### PR TITLE
Fix FindPhysx.cmake to work on linux

### DIFF
--- a/cmake/FindPhysX.cmake
+++ b/cmake/FindPhysX.cmake
@@ -6,11 +6,10 @@ endif()
 
 
 #This isn't quite right, but we'll assume they are all at the same place.
-find_path(PHYSX_SDK_PATH SDKs/Cooking/Include/NxCooking.h
+find_path(PHYSX_SDK_PATH Cooking/Include/NxCooking.h
           /usr/local/include
           /usr/include
-          PATH_SUFFIXES "PhysX/v2.6.4"
-          PATH_SUFFIXES "PhysX/v2.7.3"
+          PATH_SUFFIXES "PhysX/v2.7.3/SDKs"
 )
 
 if(PHYSX_SDK_PATH)
@@ -35,17 +34,14 @@ endif()
 
 #2.7.3 is the earliest version that can be downloaded from nVidia's archive.
 find_library(PHYSX_COOKING_LIBRARY NAMES NxCooking
-             PATH_SUFFIXES "PhysX/v2.6.4"
              PATH_SUFFIXES "PhysX/v2.7.3"
              PATHS "${PHYSX_SDK_PATH}/lib/win32"
 )
 find_library(PHYSX_CHARACTER_LIBRARY NAMES NxCharacter
-             PATH_SUFFIXES "PhysX/v2.6.4"
              PATH_SUFFIXES "PhysX/v2.7.3"
              PATHS "${PHYSX_SDK_PATH}/lib/win32"
 )
 find_library(PHYSX_EXTENSIONS_LIBRARY NAMES NxExtensions
-             PATH_SUFFIXES "PhysX/v2.6.4"
              PATH_SUFFIXES "PhysX/v2.7.3"
              PATHS "${PHYSX_SDK_PATH}/lib/win32"
 )


### PR DESCRIPTION
This is the second part of my pull request.  Sorry about submitting it this way, I should have moved to a branch before sending the first request.

It changes FindPhysx.cmake to find physx on linux (as long as it is the usual paths.)  The earliest version of PhysX for linux I could find doesn't have NxExtensions, so someone trying their hand at building on linux will most likely have to comment out that line anyone.
