### PR TITLE
Fix tab completion in the console

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -41,6 +41,7 @@ const Int32     pfConsoleEngine::fMaxNumParams = 16;
 static const char kTokenSeparators[] = " =\r\n\t,";
 static const char kTokenGrpSeps[] = " =\r\n._\t,";
 
+//WARNING: Potentially increments the pointer passed to it.
 static char *console_strtok( char *&line, hsBool haveCommand )
 {
     char *begin = line;
@@ -461,6 +462,7 @@ hsBool  pfConsoleEngine::FindPartialCmd( char *line, hsBool findAgain, hsBool pr
     static pfConsoleCmd         *lastCmd = nil;
     static pfConsoleCmdGroup    *lastGroup = nil, *lastParentGroup = nil;
     static char                 newStr[ 256 ];
+    static char                 *originalLine = line;
 
 
     /// Repeat search
@@ -525,13 +527,12 @@ hsBool  pfConsoleEngine::FindPartialCmd( char *line, hsBool findAgain, hsBool pr
     if( preserveParams )
     {
         /// Preserve the rest of the string after the matched command
-        ptr = strtok( nil, "\0" );
-        if( ptr != nil )
-            strcat( newStr, ptr );
+        if( line != nil )
+            strcat( newStr, line );
     }
 
     // Copy back!
-    strcpy( line, newStr );
+    strcpy( originalLine, newStr );
 
     return true;
 }


### PR DESCRIPTION
There was a bug where the Tab-completion code passed an arbitrary pointer value to strcpy.  With MSVC, that caused a stack overflow.

This then exposed a bug where a function was changing the pointer it had received without the caller knowing about it.

It seems at some point cyan changed from strtok to their own console_tok, which behaves differently.
