### PR TITLE
hsBounds assert fix

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDXPipeline.cpp
@@ -9019,7 +9019,10 @@ hsBool plDXPipeline::TestVisibleWorld( const hsBounds3Ext& wBnd )
 {
     if( fView.fCullTreeDirty )
         IRefreshCullTree();
-    return fView.fCullTree.BoundsVisible(wBnd);
+    if (wBnd.GetType() == kBoundsNormal)
+        return fView.fCullTree.BoundsVisible(wBnd);
+    else
+        return false;
 }
 
 hsBool plDXPipeline::TestVisibleWorld( const plSceneObject* sObj )


### PR DESCRIPTION
Code from plClothingOutfit::MsgReceive (and probably some other places) caused failed asserts in hsBounds.cpp and hsBounds.h. This fix should save lots of clicking.
