### PR TITLE
Re-add GateSrvHostnameOverride

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetBase/Private/pnNbSrvs.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetBase/Private/pnNbSrvs.cpp
@@ -145,6 +145,11 @@ void SetGateKeeperSrvHostname (const wchar addr[]) {
     StrCopy(s_gateKeeperAddrConsole, addr, arrsize(s_gateKeeperAddrConsole));
 }
 
+//============================================================================
+bool GateKeeperSrvHostnameOverride () {
+    return s_gateKeeperAddrConsole[0];
+}
+
 
 //============================================================================
 // User-visible Server

--- a/Sources/Plasma/NucleusLib/pnNetBase/Private/pnNbSrvs.h
+++ b/Sources/Plasma/NucleusLib/pnNetBase/Private/pnNbSrvs.h
@@ -86,6 +86,7 @@ void SetCsrSrvHostname (const wchar addr[]);
 
 unsigned GetGateKeeperSrvHostnames (const wchar *** addrs); // returns addrCount
 void SetGateKeeperSrvHostname (const wchar addr[]);
+bool GateKeeperSrvHostnameOverride ();
 
 const wchar *GetServerStatusUrl ();
 void SetServerStatusUrl (const wchar url[]);


### PR DESCRIPTION
Since the latest commit, it's not possible to compile an external client anymore. This should fix it.
