### PR TITLE
Display Cursors Pixel-by-Pixel

### DIFF
--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
@@ -39,13 +39,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plPipeline/plPlates.h"
 #include "plPipeline/plDebugText.h"
+#include "plGImage/plMipmap.h"
 
 #include "hsWindows.h"
 #include "plPipeline.h"
-
-// base size of the cursor 
-#define CURSOR_SIZE_X 0.0675f   
-#define CURSOR_SIZE_Y 0.09f
 
 // The resolution that uses the base size of the cursor. 
 // All other resolutions will scale the cursor size to keep the same physical size.
@@ -322,7 +319,7 @@ void plMouseDevice::IUpdateCursorSize()
     if(fCursor)
     {
         // set the size of the cursor based on resolution.
-        fCursor->SetSize( CURSOR_SIZE_X * BASE_WIDTH / fWidth, CURSOR_SIZE_Y * BASE_HEIGHT / fHeight );
+        fCursor->SetSize( 2*fCursor->GetMipmap()->GetWidth()/fWidth, 2*fCursor->GetMipmap()->GetHeight()/fHeight );
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDXPipeline.cpp
@@ -11673,7 +11673,11 @@ void    plDXPlateManager::IDrawToDevice( plPipeline *pipe )
     fD3DDevice->SetFVF(dxPipe->fSettings.fCurrFVFFormat = PLD3D_PLATEFVF);
     fD3DDevice->SetStreamSource( 0, fVertBuffer, 0, sizeof( plPlateVertex ) );  
     plProfile_Inc(VertexChange);
-    fD3DDevice->SetTransform( D3DTS_VIEW, &d3dIdentityMatrix );
+    // To get plates properly pixel-aligned, we need to compensate for D3D9's weird half-pixel
+    // offset (see http://drilian.com/2008/11/25/understanding-half-pixel-and-half-texel-offsets/
+    // or http://msdn.microsoft.com/en-us/library/bb219690(VS.85).aspx).
+    D3DXMatrixTranslation(&mat, -0.5f/scrnWidthDiv2, -0.5f/scrnHeightDiv2, 0.0f);
+    fD3DDevice->SetTransform( D3DTS_VIEW, &mat );
     oldCullMode = dxPipe->fCurrCullMode;
 
     for( plate = fPlates; plate != nil; plate = plate->GetNext() )

--- a/Sources/Plasma/PubUtilLib/plPipeline/plPlates.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plPlates.h
@@ -110,6 +110,7 @@ class plPlate
         hsMatrix44      &GetTransform( void ) { return fXformMatrix; }
         const char      *GetTitle( void ) { return fTitle; }
         UInt32          GetFlags( void ) { return fFlags; }
+        const plMipmap  *GetMipmap( void ) { return fMipmap; }
 
         void    SetVisible( hsBool vis ) { if( vis ) fFlags |= kFlagVisible; else fFlags &= ~kFlagVisible; }
         hsBool  IsVisible( void );


### PR DESCRIPTION
As discussed in #45: Port of only the pixel-alignment fixes from my cursor improvements.

One thing to keep in mind: when not coupled with new bitmaps that compensate for that (as mine do), the cursors will now be slightly smaller than before.

When you say “just for the code changes”, I assume you’re excluding the code changes of 760606d979b6150ceb161dae420ba3af86efad3d that deal with loading raw bitmap resources and that will be obsoleted by PNG loading.
