### PR TITLE
Fix date formatting on systems where time_t is 64-bit (e.g. MSVC10)

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -602,7 +602,7 @@ UInt32 cyMisc::GetAgeTime( void )
 
 
 
-UInt32 cyMisc::GetDniTime(void)
+time_t cyMisc::GetDniTime(void)
 {
     const plUnifiedTime utime = plNetClientMgr::GetInstance()->GetServerTime();
     if ( utime.GetSecs() != 0)
@@ -611,7 +611,7 @@ UInt32 cyMisc::GetDniTime(void)
         return 0;
 }
 
-UInt32 cyMisc::GetServerTime(void)
+time_t cyMisc::GetServerTime(void)
 {
     const plUnifiedTime utime = plNetClientMgr::GetInstance()->GetServerTime();
     return utime.GetSecs();
@@ -626,10 +626,10 @@ float cyMisc::GetAgeTimeOfDayPercent(void)
 #define kOneHour (UInt32)3600
 #define kOneDay (UInt32)86400
 
-UInt32 cyMisc::ConvertGMTtoDni(UInt32 gtime)
+time_t cyMisc::ConvertGMTtoDni(time_t gtime)
 {
     // convert to mountain time
-    UInt32 dtime = gtime - kMST;
+    time_t dtime = gtime - kMST;
     plUnifiedTime utime = plUnifiedTime();
     utime.SetSecs(dtime);
     // check for daylight savings time in New Mexico and adjust
@@ -638,10 +638,10 @@ UInt32 cyMisc::ConvertGMTtoDni(UInt32 gtime)
         plUnifiedTime dstStart = plUnifiedTime();
         dstStart.SetGMTime(utime.GetYear(),4,1,2,0,0);
         // find first Sunday after 4/1 (first sunday of April)
-        UInt32 days_to_go = 7 - dstStart.GetDayOfWeek();
+        int days_to_go = 7 - dstStart.GetDayOfWeek();
         if (days_to_go == 7)
             days_to_go = 0;
-        UInt32 dstStartSecs = dstStart.GetSecs() + days_to_go * kOneDay;
+        time_t dstStartSecs = dstStart.GetSecs() + days_to_go * kOneDay;
 
         plUnifiedTime dstEnd = plUnifiedTime();
         dstEnd.SetGMTime(utime.GetYear(),10,25,1,0,0);
@@ -649,7 +649,7 @@ UInt32 cyMisc::ConvertGMTtoDni(UInt32 gtime)
         days_to_go = 7 - dstEnd.GetDayOfWeek();
         if (days_to_go == 7)
             days_to_go = 0;
-        UInt32 dstEndSecs = dstEnd.GetSecs() + days_to_go * kOneDay;
+        time_t dstEndSecs = dstEnd.GetSecs() + days_to_go * kOneDay;
 
         if ( dtime > dstStartSecs && dtime < dstEndSecs )
             // add hour for daylight savings time

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -274,9 +274,9 @@ public:
     static PyObject* GetPrevAgeInfo();
     // current time in current age
     static UInt32 GetAgeTime( void );
-    static UInt32 GetDniTime(void);
-    static UInt32 ConvertGMTtoDni(UInt32 time);
-    static UInt32 GetServerTime( void ); // returns the current server time in GMT
+    static time_t GetDniTime(void);
+    static time_t ConvertGMTtoDni(time_t time);
+    static time_t GetServerTime( void ); // returns the current server time in GMT
     static float GetAgeTimeOfDayPercent(void);
 
     /////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
@@ -59,12 +59,12 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetPrevAgeInfo, "Returns ptAgeInfoStruc
 
 PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetDniTime, "Returns current D'Ni time")
 {
-    return PyLong_FromUnsignedLong(cyMisc::GetDniTime());
+    return PyLong_FromUnsignedLong((unsigned long)cyMisc::GetDniTime());
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetServerTime, "Returns the current time on the server (which is GMT)")
 {
-    return PyLong_FromUnsignedLong(cyMisc::GetServerTime());
+    return PyLong_FromUnsignedLong((unsigned long)cyMisc::GetServerTime());
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtGMTtoDniTime, args, "Params: gtime\nConverts GMT time (passed in) to D'Ni time")
@@ -75,7 +75,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtGMTtoDniTime, args, "Params: gtime\nConverts G
         PyErr_SetString(PyExc_TypeError, "PtGMTtoDniTime expects a long");
         PYTHON_RETURN_ERROR;
     }
-    return PyLong_FromUnsignedLong(cyMisc::ConvertGMTtoDni(gtime));
+    return PyLong_FromUnsignedLong((unsigned long)cyMisc::ConvertGMTtoDni(gtime));
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtGetClientName, args, "Params: avatarKey=None\nThis will return the name of the client that is owned by the avatar\n"

--- a/Sources/Plasma/FeatureLib/pfPython/pyDniInfoSource.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDniInfoSource.cpp
@@ -55,10 +55,10 @@ UInt32 pyDniInfoSource::GetAgeTime( void ) const
     if (!node)
         return 0;
     
-    unsigned result;
+    UInt32 result;
     VaultAgeInfoNode ageInfo(node);
     if (const plUnifiedTime * utime = ageInfo.GetAgeTime())
-        result = utime->GetSecs();
+        result = (UInt32)utime->GetSecs();
     else
         result = 0;
     node->DecRef();

--- a/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.cpp
@@ -338,7 +338,7 @@ void plAgeDescription::Write(hsStream* stream) const
     char buf[256];
 
     // Write the date/time
-    sprintf(buf, "StartDateTime=%010u\n", fStart.GetSecs());
+    sprintf(buf, "StartDateTime=%010lu\n", (unsigned long)fStart.GetSecs());
     stream->WriteString(buf);
 
     // Write the day length

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
@@ -786,7 +786,7 @@ bool plStatusLog::IPrintLineToFile( const char *line, UInt32 count )
             }
             if ( fFlags & kTimeInSeconds )
             {
-                StrPrintf(work, arrsize(work), "(%u) ", plUnifiedTime(kNow).GetSecs());
+                StrPrintf(work, arrsize(work), "(%lu) ", (unsigned long)plUnifiedTime(kNow).GetSecs());
                 StrPack(buf, work, arrsize(buf));
             }
             if ( fFlags & kTimeAsDouble )

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plTimeSpan.cpp
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plTimeSpan.cpp
@@ -28,22 +28,22 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 long plTimeSpan::GetTotalDays() const
 {
-    return fSecs / (24*3600L);
+    return (long)(fSecs / (24*3600L));
 }
 
 long plTimeSpan::GetTotalHours() const
 {
-    return fSecs / 3600;
+    return (long)(fSecs / 3600);
 }
 
 long plTimeSpan::GetTotalMinutes() const
 {
-    return fSecs / 60;
+    return (long)(fSecs / 60);
 }
 
 long plTimeSpan::GetTotalSeconds() const
 {
-    return fSecs;
+    return (long)fSecs;
 }
 
 

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.h
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.h
@@ -59,7 +59,7 @@ public:
     };
 
 protected:
-    UInt32  fSecs;
+    time_t  fSecs;
     UInt32  fMicros;
     Mode    fMode;
 
@@ -92,7 +92,7 @@ public:
     const plUnifiedTime & operator=(const struct tm & src);
 
     // getters
-    UInt32 GetSecs() const { return fSecs; }
+    time_t GetSecs() const { return fSecs; }
     UInt32 GetMicros() const { return fMicros; }
     double GetSecsDouble() const;  // get the secs and micros as a double floating point value
     hsBool GetTime(short &year, short &month, short &day, short &hour, short &minute, short &second) const;
@@ -106,10 +106,9 @@ public:
     int GetMillis() const;
     int GetDayOfWeek() const;
     int GetMode() const {return fMode;} // local or gmt.
-    UInt32 AsMillis();
 
     // setters
-    void SetSecs(const UInt32 secs) { fSecs = secs; }
+    void SetSecs(const time_t secs) { fSecs = secs; }
     void SetSecsDouble(double secs);
     void SetMicros(const UInt32 micros) { fMicros = micros; }
     hsBool SetTime(short year, short month, short day, short hour, short minute, short second, unsigned long usec=0, int dst=-1);
@@ -118,7 +117,6 @@ public:
     void ToCurrentTime();
     void ToEpoch() { fSecs = 0; fMicros = 0;}
     void SetMode(Mode mode) { fMode=mode;}
-    void FromMillis(UInt32 millis);
 #if HS_BUILD_FOR_WIN32
     hsBool SetFromWinFileTime(const FILETIME ft);
 #endif


### PR DESCRIPTION
The attached commit changes the fSecs field of plUnifiedTime from UInt32 to time_t. This fixes various date formatting problems, e.g. missing log timestamps or output of the Net.GetServerTime console command, when building on a system where time_t is 64-bit (e.g. Visual Studio 2010, and possibly also 2008, though I didn’t test that), and, as a bonus, extends the range past 2038 on such systems.

The wire protocol is left at 32 bit for now, we might change that to 64 when other reasons to break compatibility have accumulated.

Avoiding unnecessary back-and-forth type conversions makes the change ripple out into several other files. Changes have been tested as far as I easily could, and introduce no new compiler warnings.

The minimal-invasive way of fixing only the date formatting, should you prefer that, is in branch [cwalther:timet-minimal](https://github.com/cwalther/Plasma/branches/timet-minimal) (9b54fb05c9471c1b3317a5f8ed6cd4c11977e9e1).
