### PR TITLE
Fix for exclusive cursor

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -1286,6 +1286,8 @@ void plClient::IIncProgress (hsScalar byHowMuch, const char * text)
 //============================================================================
 void    plClient::IStartProgress( const char *title, hsScalar len )
 {
+    plInputManager::SetRecenterMouse(false);
+
     if (fProgressBar)
     {
         fProgressBar->SetLength(fProgressBar->GetMax()+len);
@@ -2191,7 +2193,6 @@ void plClient::ResetDisplayDevice(int Width, int Height, int ColorDepth, hsBool 
     else
     {
         SetWindowPos( fWindowHndl, HWND_TOP, 0, 0, Width, Height, flags );
-        ::ClipCursor(nil);
     }
 
     WindowActivate(true);

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
@@ -795,7 +795,6 @@ void plMouseDevice::HandleWindowActivate(bool bActive, HWND hWnd)
 //      rect.bottom /= plInputManager::GetInstance()->GetMouseScale();
 
         ::MapWindowPoints( hWnd, NULL, (POINT *)&rect, 2 );
-        ::ClipCursor(&rect);
         ::ShowCursor( FALSE );
         SetCapture(hWnd);
 
@@ -803,7 +802,6 @@ void plMouseDevice::HandleWindowActivate(bool bActive, HWND hWnd)
     else
     {
         ReleaseCapture();
-        ::ClipCursor(nil);
         ::ShowCursor( TRUE );
     }   
 }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputManager.cpp
@@ -547,7 +547,6 @@ void plDInputMgr::AddDevice(IDirectInputDevice8* device)
 
 void plDInputMgr::ConfigureDevice()
 {
-    ::ClipCursor(nil);
     ::ShowCursor( TRUE );
     ReleaseCapture();
         
@@ -571,10 +570,6 @@ void plDInputMgr::ConfigureDevice()
     for (int i = 0; i < fDI->fSticks.Count(); i++)
         fDI->fSticks[i]->fDevice->SetActionMap( fDI->fActionFormat, NULL, DIDSAM_FORCESAVE );
 
-    RECT rect;
-    ::GetClientRect(fhWnd,&rect);
-    ::ClientToScreen(fhWnd,(LPPOINT)&rect);
-    ::ClipCursor(&rect);
     ::ShowCursor( FALSE );
     SetCapture(fhWnd);
 


### PR DESCRIPTION
This patch removes the calls to ClipCursor which prevent the cursor from leaving the client window.  It doesn't affect first-person-mode's mouse-look, the telescopes, or anything else which emulates the infinite client area by warping the cursor back to the center of the screen.

I also disabled warping of the cursor during the progress screen, which would otherwise prevent the mouse from leaving the application while loading even in the absence of ClipCursor.
