### PR TITLE
Cope with unknown resource name extensions

### DIFF
--- a/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.cpp
@@ -101,6 +101,9 @@ void plClientResMgr::ILoadResources(const char* resfile)
                         // Original Myst5 format only is known to support Targa,
                         // so default fallback is targa
                         // TODO - Add plTarga::ReadFromStream()
+                        // for now, just skip the unknown resource and put NULL into the map
+                        res_size = in.ReadSwap32();
+                        in.Skip(res_size);
                     }
 
                     (*this->ClientResources)[res_name] = res_data;


### PR DESCRIPTION
(E.g. a mistakenly included Thumbs.db)

Rebase of [c170b50](https://github.com/cwalther/Plasma/commit/c170b50337bbc30e8fe26941ee728c2d081e89aa) and already discussed there.
