### PR TITLE
Skip the Thumbs.db files that Windows likes to add

### DIFF
--- a/Sources/Plasma/Apps/plClient/external/create_resource_dat.py
+++ b/Sources/Plasma/Apps/plClient/external/create_resource_dat.py
@@ -18,6 +18,10 @@ def create_resource_dat(resfilepath, inrespath):
 	## Get list of files to archive
 	resourceList = glob.glob(os.path.join(inrespath, "*"))
 	resourceList.sort()
+	try:
+		resourceList.remove(os.path.join(inrespath, "Thumbs.db")) # likely to be there on Windows and likely to be unwanted
+	except ValueError:
+		pass
 	if len(resourceList) == 0:
 		print("No files found in '{0}'.  Quitting.\n".format(inrespath))
 		return False


### PR DESCRIPTION
Rebase of cwalther@84a97b42532d7b905a1402d178178f30cb217b88. As discussed there, the problem could also be solved in a more general way, but in the meantime here's a reminder so this isn't lost.
