### PR TITLE
Fix improperly calculated window size in initial Windowed mode.

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.h
+++ b/Sources/Plasma/Apps/plClient/plClient.h
@@ -276,7 +276,8 @@ public:
     virtual hsBool WindowActive() const { return fWindowActive; }
 
     void    SetMessagePumpProc( plMessagePumpProc proc ) { fMessagePumpProc = proc; }
-    void ResetDisplayDevice(int Width, int Height, int ColorDepth, hsBool Windowed, int NumAASamples, int MaxAnisotropicSamples, hsBool VSync = false, hsBool windowOnly = false);
+    void ResetDisplayDevice(int Width, int Height, int ColorDepth, hsBool Windowed, int NumAASamples, int MaxAnisotropicSamples, hsBool VSync = false);
+    void ResizeDisplayDevice(int Width, int Height, hsBool Windowed);
     void IDetectAudioVideoSettings();
     void IWriteDefaultGraphicsSettings(const wchar* destFile);
 

--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -769,11 +769,6 @@ bool    InitClient( HWND hWnd )
 
 #ifdef DETACH_EXE
     hInstance = ((LPCREATESTRUCT) lParam)->hInstance;
-#endif
-    // If in fullscreen mode, get rid of the window borders.  Note: this won't take
-    // effect until the next SetWindowPos call
-
-#ifdef DETACH_EXE
 
     // This Function loads the EXE into Virtual memory...supposedly
     HRESULT hr = DetachFromMedium(hInstance, DMDFM_ALWAYS | DMDFM_ALLPAGES);
@@ -783,34 +778,7 @@ bool    InitClient( HWND hWnd )
         gClient->SetDone(true);
     else
     {
-        if( gClient->GetPipeline()->IsFullScreen() )
-        {
-            SetWindowLong(hWnd, GWL_STYLE, WS_POPUP);
-            SetWindowLong(hWnd, GWL_EXSTYLE, WS_EX_TOPMOST);
-            SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-            gWinBorderDX = gWinBorderDY = gWinMenuDY = 0;
-        }
-        else {
-            SetWindowLong(hWnd, GWL_STYLE, WS_OVERLAPPED | WS_CAPTION);
-            SetWindowPos(hWnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-        }
-
-        int goodWidth = gClient->GetPipeline()->Width() + gWinBorderDX * 2;
-        int goodHeight = gClient->GetPipeline()->Height() + gWinBorderDY * 2 + gWinMenuDY;
-
-        SetWindowPos(
-            hWnd,
-            nil,
-            0,
-            0,
-            goodWidth,
-            goodHeight,
-            SWP_NOCOPYBITS 
-                | SWP_NOMOVE
-                | SWP_NOOWNERZORDER
-                | SWP_NOZORDER
-                | SWP_FRAMECHANGED
-        );
+        gClient->ResizeDisplayDevice(gClient->GetPipeline()->Width(), gClient->GetPipeline()->Height(), !gClient->GetPipeline()->IsFullScreen());
     }
     
     if( gPendingActivate )

--- a/Sources/Plasma/CoreLibExe/hsExeError.cpp
+++ b/Sources/Plasma/CoreLibExe/hsExeError.cpp
@@ -136,8 +136,7 @@ void ErrorMinimizeAppWindow () {
         // If the application's topmost window is a fullscreen
         // popup window, minimize it before displaying an error
         HWND appWindow = GetActiveWindow();
-        if ( ((GetWindowLong(appWindow, GWL_STYLE) & WS_POPUP) != 0) &&
-            ((GetWindowLong(appWindow, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0) )
+        if ( ((GetWindowLong(appWindow, GWL_STYLE) & WS_POPUP) != 0) )
             SetWindowPos(
                 appWindow,
                 HWND_NOTOPMOST,


### PR DESCRIPTION
Fixes window size in windowed mode being slightly too small, which was causing weird scaling issues.  Initial start-up size was calculated differently from a resized window; these have been refactored and code duplication removed.
