### PR TITLE
Remove unused platform code (MacOS9, PS2, XBox).

### DIFF
--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -39,14 +39,6 @@ if(UNIX)
         hsThread_Unix.cpp
     )
 endif(UNIX)
-
-# for now we use the Unix file on mac... I think this is Carbon code, which
-# we don't want to use. I don't think it's worth support OS9 anymore
-#if(APPLE)
-#   set(CoreLib_SOURCES ${CoreLib_SOURCES}
-#       hsThread_Mac.cpp
-#   )
-#endif(APPLE)
     
 
 set(CoreLib_HEADERS

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -46,12 +46,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsExceptions.h"
 
 
-#if HS_BUILD_FOR_MAC
-    #include <Events.h>
-    #include <ToolUtils.h>
-    #include <Windows.h>
-#endif
-
 #if HS_BUILD_FOR_WIN32
 #ifdef _MSC_VER
 # include <crtdbg.h>        /* for _RPT_BASE */
@@ -108,9 +102,7 @@ void hsDebugMessage (const char message[], long val)
     if (gHSDebugProc)
         gHSDebugProc(&s[1]);
     else
-#if HS_BUILD_FOR_MAC
-        DebugStr((unsigned char*)s);
-#elif HS_BUILD_FOR_WIN32
+#if HS_BUILD_FOR_WIN32
     {   OutputDebugString(&s[1]);
         OutputDebugString("\n");
     }
@@ -118,8 +110,6 @@ void hsDebugMessage (const char message[], long val)
     {   fprintf(stderr, "%s\n", &s[1]);
 //      hsThrow(&s[1]);
     }
-#elif HS_BUILD_FOR_PS2
-    fprintf(stderr, "%s\n", &s[1]); 
 #else
     hsThrow(&s[1]);
 #endif
@@ -160,7 +150,7 @@ void hsStatusMessage(const char message[])
   if (gHSStatusProc) {
     gHSStatusProc(message);
   } else {
-#if HS_BUILD_FOR_PS2 || HS_BUILD_FOR_UNIX
+#if HS_BUILD_FOR_UNIX
     printf("%s",message);
     int len = strlen(message);
     if (len>0 && message[len-1]!='\n')
@@ -170,7 +160,7 @@ void hsStatusMessage(const char message[])
     int len = strlen(message);
     if (len>0 && message[len-1]!='\n')
         OutputDebugString("\n");
-#endif  // MAC ??????  TODO
+#endif
   }
 }
 

--- a/Sources/Plasma/CoreLib/hsBounds.cpp
+++ b/Sources/Plasma/CoreLib/hsBounds.cpp
@@ -46,10 +46,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsFastMath.h"
 
-#if defined(__MWERKS__) && !defined(HS_DEBUGGING)
-#pragma optimization_level 2
-#endif
-
 const hsScalar hsBounds::kRealSmall = 1.0e-5f;
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/CoreLib/hsConfig.h
+++ b/Sources/Plasma/CoreLib/hsConfig.h
@@ -62,11 +62,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 ////////////////////  Specific Compiler Stuff This Section is computed  ////////////
 
-#if defined(macintosh) && defined(__POWERPC__)
-    #define HS_BUILD_FOR_MACPPC         1
-#elif defined(macintosh)
-    #define HS_BUILD_FOR_MAC68K         1
-#elif defined(_WIN32)
+#if defined(_WIN32)
     #define HS_BUILD_FOR_WIN32          1
 #elif defined(__unix__)
     #define HS_BUILD_FOR_UNIX           1

--- a/Sources/Plasma/CoreLib/hsFixedTypes.h
+++ b/Sources/Plasma/CoreLib/hsFixedTypes.h
@@ -44,11 +44,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsTypes.h"
 
-#if HS_BUILD_FOR_MAC
-    #include <ToolUtils.h>
-    #include <FixMath.h>
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -86,21 +81,12 @@ extern "C" {
     #define hsFloatToFract(x)       hsFract((x) * hsFract1)
 #endif
 
-#if HS_BUILD_FOR_MAC68K && !(HS_PIN_MATH_OVERFLOW)
-    #define hsFixMul(a, b)  FixMul(a, b)
-#else
-    hsFixed hsFixMul(hsFixed a, hsFixed b);
-#endif
 
-#if HS_BUILD_FOR_MAC && !(HS_PIN_MATH_OVERFLOW) && !(HS_MP_SAFE)
-    #define hsFixDiv(a, b)  FixDiv(a, b)
-    #define hsFracMul(a, b) FracMul(a, b)
-    #define hsFracDiv(a, b) FracDiv(a, b)
-#else
-    hsFract hsFixDiv(hsFixed a, hsFixed b);
-    hsFract hsFracMul(hsFract a, hsFract b);
-    hsFract hsFracDiv(hsFract a, hsFract b);
-#endif
+hsFixed hsFixMul(hsFixed a, hsFixed b);
+
+hsFract hsFixDiv(hsFixed a, hsFixed b);
+hsFract hsFracMul(hsFract a, hsFract b);
+hsFract hsFracDiv(hsFract a, hsFract b);
 
 hsFract hsFracSqrt(hsFract value);
 #define hsFixSqrt(value)    (hsFracSqrt(value) >> 7)

--- a/Sources/Plasma/CoreLib/hsGeometry3.h
+++ b/Sources/Plasma/CoreLib/hsGeometry3.h
@@ -196,13 +196,6 @@ struct hsVector3 : public hsScalarTriple {
 
     void            Normalize()
                 {
-#if HS_BUILD_FOR_PS2
-                    hsScalar    length = this->Magnitude();
-                     hsIfDebugMessage(length == 0, "Err: Normalizing hsVector3 of length 0", 0);
-                    if (length == 0)
-                        return;
-                    NormalizeVU0(length, (MATRIX4)this);
-#else
                     hsScalar    length = this->Magnitude();
 //                   hsIfDebugMessage(length == 0, "Err: Normalizing hsVector3 of length 0", 0);
                     if (length == 0)
@@ -212,7 +205,6 @@ struct hsVector3 : public hsScalarTriple {
                     fX = hsScalarMul(fX, invMag);
                     fY = hsScalarMul(fY, invMag);
                     fZ = hsScalarMul(fZ, invMag);
-#endif
                 }
     inline void     Renormalize()       // if the vector is already close to unit length
                 {

--- a/Sources/Plasma/CoreLib/hsMatrix44.cpp
+++ b/Sources/Plasma/CoreLib/hsMatrix44.cpp
@@ -123,9 +123,6 @@ hsMatrix44 operator*(const hsMatrix44& a, const hsMatrix44& b)
     if( b.fFlags & hsMatrix44::kIsIdent )
         return a;
 
-#if HS_BUILD_FOR_PS2
-    MulMatrixVU0(a.fMap, b.fMap, c.fMap);
-#else
     c.fMap[0][0] = hsScalarMul(a.fMap[0][0], b.fMap[0][0]) + hsScalarMul(a.fMap[0][1], b.fMap[1][0]) + hsScalarMul(a.fMap[0][2], b.fMap[2][0]) + hsScalarMul(a.fMap[0][3], b.fMap[3][0]);
     c.fMap[0][1] = hsScalarMul(a.fMap[0][0], b.fMap[0][1]) + hsScalarMul(a.fMap[0][1], b.fMap[1][1]) + hsScalarMul(a.fMap[0][2], b.fMap[2][1]) + hsScalarMul(a.fMap[0][3], b.fMap[3][1]);
     c.fMap[0][2] = hsScalarMul(a.fMap[0][0], b.fMap[0][2]) + hsScalarMul(a.fMap[0][1], b.fMap[1][2]) + hsScalarMul(a.fMap[0][2], b.fMap[2][2]) + hsScalarMul(a.fMap[0][3], b.fMap[3][2]);
@@ -145,7 +142,6 @@ hsMatrix44 operator*(const hsMatrix44& a, const hsMatrix44& b)
     c.fMap[3][1] = hsScalarMul(a.fMap[3][0], b.fMap[0][1]) + hsScalarMul(a.fMap[3][1], b.fMap[1][1]) + hsScalarMul(a.fMap[3][2], b.fMap[2][1]) + hsScalarMul(a.fMap[3][3], b.fMap[3][1]);
     c.fMap[3][2] = hsScalarMul(a.fMap[3][0], b.fMap[0][2]) + hsScalarMul(a.fMap[3][1], b.fMap[1][2]) + hsScalarMul(a.fMap[3][2], b.fMap[2][2]) + hsScalarMul(a.fMap[3][3], b.fMap[3][2]);
     c.fMap[3][3] = hsScalarMul(a.fMap[3][0], b.fMap[0][3]) + hsScalarMul(a.fMap[3][1], b.fMap[1][3]) + hsScalarMul(a.fMap[3][2], b.fMap[2][3]) + hsScalarMul(a.fMap[3][3], b.fMap[3][3]);
-#endif
 
     return c;
 }
@@ -157,13 +153,9 @@ hsVector3 operator*(const hsMatrix44& m, const hsVector3& p)
 
     hsVector3 rVal;
 
-#if HS_BUILD_FOR_PS2
-    MulVectorVU0(m.fMap, (MATRIX4) &p, (MATRIX4) &rVal);
-#else
     rVal.fX = hsScalarMul(p.fX, m.fMap[0][0]) + hsScalarMul(p.fY, m.fMap[0][1]) + hsScalarMul(p.fZ, m.fMap[0][2]);
     rVal.fY = hsScalarMul(p.fX, m.fMap[1][0]) + hsScalarMul(p.fY, m.fMap[1][1]) + hsScalarMul(p.fZ, m.fMap[1][2]);
     rVal.fZ = hsScalarMul(p.fX, m.fMap[2][0]) + hsScalarMul(p.fY, m.fMap[2][1]) + hsScalarMul(p.fZ, m.fMap[2][2]);
-#endif
 
     return rVal;
 }
@@ -183,9 +175,6 @@ hsMatrix44 hsMatrix44::operator*(const hsMatrix44& b) const
     if( b.fFlags & hsMatrix44::kIsIdent )
         return *this;
 
-#if HS_BUILD_FOR_PS2
-    MulMatrixVU0(fMap, b.fMap, c.fMap);
-#else
     c.fMap[0][0] = hsScalarMul(fMap[0][0], b.fMap[0][0]) + hsScalarMul(fMap[0][1], b.fMap[1][0]) + hsScalarMul(fMap[0][2], b.fMap[2][0]) + hsScalarMul(fMap[0][3], b.fMap[3][0]);
     c.fMap[0][1] = hsScalarMul(fMap[0][0], b.fMap[0][1]) + hsScalarMul(fMap[0][1], b.fMap[1][1]) + hsScalarMul(fMap[0][2], b.fMap[2][1]) + hsScalarMul(fMap[0][3], b.fMap[3][1]);
     c.fMap[0][2] = hsScalarMul(fMap[0][0], b.fMap[0][2]) + hsScalarMul(fMap[0][1], b.fMap[1][2]) + hsScalarMul(fMap[0][2], b.fMap[2][2]) + hsScalarMul(fMap[0][3], b.fMap[3][2]);
@@ -205,7 +194,6 @@ hsMatrix44 hsMatrix44::operator*(const hsMatrix44& b) const
     c.fMap[3][1] = hsScalarMul(fMap[3][0], b.fMap[0][1]) + hsScalarMul(fMap[3][1], b.fMap[1][1]) + hsScalarMul(fMap[3][2], b.fMap[2][1]) + hsScalarMul(fMap[3][3], b.fMap[3][1]);
     c.fMap[3][2] = hsScalarMul(fMap[3][0], b.fMap[0][2]) + hsScalarMul(fMap[3][1], b.fMap[1][2]) + hsScalarMul(fMap[3][2], b.fMap[2][2]) + hsScalarMul(fMap[3][3], b.fMap[3][2]);
     c.fMap[3][3] = hsScalarMul(fMap[3][0], b.fMap[0][3]) + hsScalarMul(fMap[3][1], b.fMap[1][3]) + hsScalarMul(fMap[3][2], b.fMap[2][3]) + hsScalarMul(fMap[3][3], b.fMap[3][3]);
-#endif
 
     return c;
 }
@@ -217,13 +205,9 @@ hsVector3 hsMatrix44::operator*(const hsVector3& p) const
 
     hsVector3 rVal;
 
-#if HS_BUILD_FOR_PS2
-    MulVectorVU0(fMap, (MATRIX4) &p, (MATRIX4) &rVal);
-#else
     rVal.fX = hsScalarMul(p.fX, fMap[0][0]) + hsScalarMul(p.fY, fMap[0][1]) + hsScalarMul(p.fZ, fMap[0][2]);
     rVal.fY = hsScalarMul(p.fX, fMap[1][0]) + hsScalarMul(p.fY, fMap[1][1]) + hsScalarMul(p.fZ, fMap[1][2]);
     rVal.fZ = hsScalarMul(p.fX, fMap[2][0]) + hsScalarMul(p.fY, fMap[2][1]) + hsScalarMul(p.fZ, fMap[2][2]);
-#endif
 
     return rVal;
 }
@@ -271,9 +255,6 @@ int hsMatrix44::operator==(const hsMatrix44& ss) const
 
 hsMatrix44& hsMatrix44::Scale(const hsVector3* scale)
 {
-#if HS_BUILD_FOR_PS2
-    MulScaleVU0(fMap, (MATRIX4 *) scale);
-#else
     fMap[0][0] *= scale->fX;
     fMap[0][1] *= scale->fX;
     fMap[0][2] *= scale->fX;
@@ -288,7 +269,7 @@ hsMatrix44& hsMatrix44::Scale(const hsVector3* scale)
     fMap[2][1] *= scale->fZ;
     fMap[2][2] *= scale->fZ;
     fMap[2][3] *= scale->fZ;
-#endif
+
     NotIdentity();
     return *this;
 }
@@ -318,14 +299,10 @@ hsVector3 hsMatrix44::RemoveScale()
 
 hsMatrix44& hsMatrix44::Translate(const hsVector3* pt)
 {
-#if HS_BUILD_FOR_PS2
-    TranslateVU0(fMap, (MATRIX4 *) pt);         /* SUNSOFT */
-#else
     for (int i =0; i < 3; i++)
     {
         fMap[i][3] += (*pt)[i];
     }
-#endif
     NotIdentity();
     return *this;
 }
@@ -686,9 +663,6 @@ static inline hsScalar Determinant3(hsScalar a, hsScalar b, hsScalar c,
 
 hsScalar hsMatrix44::GetDeterminant() const
 {
-#if HS_BUILD_FOR_PS2
-    return (GetDeterminantVU0(fMap));
-#else
     return (fMap[0][0]*Determinant3(fMap[1][1], fMap[2][1], fMap[3][1],
                                       fMap[1][2], fMap[2][2], fMap[3][2],
                                       fMap[1][3], fMap[2][3], fMap[3][3]) - 
@@ -701,15 +675,11 @@ hsScalar hsMatrix44::GetDeterminant() const
             fMap[3][0]*Determinant3(fMap[0][1], fMap[1][1], fMap[2][1],
                                       fMap[0][2], fMap[1][2], fMap[2][2],
                                       fMap[0][3], fMap[1][3], fMap[2][3]));
-#endif
 }
 
 
 hsMatrix44 *hsMatrix44::GetAdjoint(hsMatrix44 *adj) const
 {
-#if HS_BUILD_FOR_PS2
-    GetAdjointVU0(fMap, adj->fMap);
-#else
     float   a1, a2, a3, a4, b1, b2, b3, b4;
     float   c1, c2, c3, c4, d1, d2, d3, d4;
 /*
@@ -774,7 +744,7 @@ hsMatrix44 *hsMatrix44::GetAdjoint(hsMatrix44 *adj) const
     adj->fMap[1][3] = Determinant3(a1, a2, a3, c1, c2, c3, d1, d2, d3);
     adj->fMap[2][3] = -Determinant3(a1, a2, a3, b1, b2, b3, d1, d2, d3);
     adj->fMap[3][3] = Determinant3(a1, a2, a3, b1, b2, b3, c1, c2, c3);
-#endif
+
     adj->NotIdentity();
     return adj;
 }
@@ -792,13 +762,11 @@ hsMatrix44* hsMatrix44::GetInverse(hsMatrix44* inverse) const
 
     det = hsScalarInvert(det);
     GetAdjoint(inverse);
-#if HS_BUILD_FOR_PS2
-    MatMulVU0(inverse->fMap, det);
-#else
+
     for (i=0; i<4; i++)
         for (j=0; j<4; j++)
             inverse->fMap[i][j] *= det;
-#endif
+
     return inverse;
 }
 

--- a/Sources/Plasma/CoreLib/hsMemory.cpp
+++ b/Sources/Plasma/CoreLib/hsMemory.cpp
@@ -39,11 +39,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
       Mead, WA   99021
 
 *==LICENSE==*/
-#if HS_BUILD_FOR_MAC
-    #include <Memory.h>
-#else
-    #include <string.h>
-#endif
+
+#include <string.h>
 
 #include "hsMemory.h"
 #include "hsExceptions.h"
@@ -52,17 +49,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-#if HS_BUILD_FOR_MAC
-    void HSMemory::BlockMove(const void* src, void* dst, UInt32 length)
-    {
-        ::BlockMoveData(src, dst, length);
-    }
-#else
-    void HSMemory::BlockMove(const void* src, void* dst, UInt32 length)
-    {
-        memmove(dst, src, length);
-    }
-#endif
+void HSMemory::BlockMove(const void* src, void* dst, UInt32 length)
+{
+    memmove(dst, src, length);
+}
 
 hsBool HSMemory::EqualBlocks(const void* block1, const void* block2, UInt32 length)
 {

--- a/Sources/Plasma/CoreLib/hsMemory.h
+++ b/Sources/Plasma/CoreLib/hsMemory.h
@@ -48,11 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class HSMemory {
 public:
-#if HS_BUILD_FOR_MAC
     static void BlockMove(const void* src, void* dst, UInt32 length);
-#else
-    static void BlockMove(const void* src, void* dst, UInt32 length);
-#endif
     static void Clear(void *m, UInt32 byteLen);
     static void ClearMemory(void *m, UInt32 byteLen) { HSMemory::Clear(m, byteLen); }
 

--- a/Sources/Plasma/CoreLib/hsPoint2.h
+++ b/Sources/Plasma/CoreLib/hsPoint2.h
@@ -44,12 +44,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsScalar.h"
 
-#if __MWERKS__
-    //  This guy disables MetroWerks' desire to only include a file once, which obviously gets
-    //  in the way of our little HS_POINT2.inc trick
-    #pragma once off
-#endif
-
 #define HS_POINT2_NAME  hsIntPoint2
 #define HS_POINT2_TYPE      Int32
 #include "HS_POINT2.inc"

--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -320,17 +320,6 @@ public:
 class hsFileStream: public hsStream
 {   
     UInt32      fRef;
-#if HS_BUILD_FOR_PS2
-    enum {
-        kBufferSize = 2*1024
-    };
-    UInt32      fFileSize;
-    char        fBuffer[kBufferSize];
-    Int32       fVirtualFilePointer;
-    Int32       fBufferBase;            // offset to top of fBuffer
-    hsBool      fBufferIsEmpty;
-    hsBool      fWriteBufferUsed;       // In write mode. fBuffer must be flush, when file was closed.
-#endif
 
 public:
                 hsFileStream();

--- a/Sources/Plasma/CoreLib/hsThread.h
+++ b/Sources/Plasma/CoreLib/hsThread.h
@@ -47,9 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 typedef UInt32 hsMilliseconds;
 
 
-#if HS_BUILD_FOR_MAC
-    #include <Multiprocessing.h>
-#elif HS_BUILD_FOR_WIN32
+#if HS_BUILD_FOR_WIN32
     #include "hsWindows.h"
 #elif HS_BUILD_FOR_UNIX
     #include <pthread.h>
@@ -66,9 +64,7 @@ typedef UInt32 hsMilliseconds;
 class hsThread 
 {
 public:
-#if HS_BUILD_FOR_MAC
-    typedef MPTaskId ThreadId;
-#elif HS_BUILD_FOR_WIN32
+#if HS_BUILD_FOR_WIN32
     typedef DWORD ThreadId;
 #elif HS_BUILD_FOR_UNIX
     typedef pthread_t ThreadId;
@@ -76,10 +72,7 @@ public:
 private:
     hsBool      fQuit;
     UInt32      fStackSize;
-#if HS_BUILD_FOR_MAC
-    ThreadId    fTaskId;
-    MPQueueId   fNotifyQ;
-#elif HS_BUILD_FOR_WIN32
+#if HS_BUILD_FOR_WIN32
     ThreadId    fThreadId;
     HANDLE      fThreadH;
     HANDLE      fQuitSemaH;
@@ -94,10 +87,7 @@ protected:
 public:
     hsThread(UInt32 stackSize = 0);
     virtual     ~hsThread();    // calls Stop()
-#if HS_BUILD_FOR_MAC
-    ThreadId        GetThreadId() { return fTaskId; }
-#error "Mac is Depricated"
-#elif HS_BUILD_FOR_WIN32
+#if HS_BUILD_FOR_WIN32
     ThreadId        GetThreadId() { return fThreadId; }
     static ThreadId GetMyThreadId() { return GetCurrentThreadId(); }
 #elif HS_BUILD_FOR_UNIX
@@ -123,9 +113,7 @@ public:
 //////////////////////////////////////////////////////////////////////////////
 
 class hsMutex {
-#if HS_BUILD_FOR_MAC
-    MPCriticalRegionId  fCriticalRegion;
-#elif HS_BUILD_FOR_WIN32
+#if HS_BUILD_FOR_WIN32
     HANDLE  fMutexH;
 #elif HS_BUILD_FOR_UNIX
     pthread_mutex_t fPMutex;
@@ -159,9 +147,7 @@ public:
 //////////////////////////////////////////////////////////////////////////////
 
 class hsSemaphore {
-#if HS_BUILD_FOR_MAC
-    MPSemaphoreId   fSemaId;
-#elif HS_BUILD_FOR_WIN32
+#if HS_BUILD_FOR_WIN32
     HANDLE  fSemaH;
 #elif HS_BUILD_FOR_UNIX
 #ifdef USE_SEMA
@@ -185,7 +171,6 @@ public:
 };
 
 //////////////////////////////////////////////////////////////////////////////
-#if !HS_BUILD_FOR_MAC
 class hsEvent
 {
 #if HS_BUILD_FOR_UNIX
@@ -209,10 +194,8 @@ public:
     hsBool  Wait(hsMilliseconds timeToWait = kPosInfinity32);
     void        Signal();
 };
-#endif  // HS_BUILD_FOR_MAC
 
 //////////////////////////////////////////////////////////////////////////////
-#if !HS_BUILD_FOR_MAC
 class hsSleep
 {
 public:
@@ -224,8 +207,6 @@ public:
 
 #endif
 };
-#endif  // HS_BUILD_FOR_MAC
-
 
 //////////////////////////////////////////////////////////////////////////////
 // Allows multiple readers, locks out readers for writing.

--- a/Sources/Plasma/CoreLib/hsUtils.cpp
+++ b/Sources/Plasma/CoreLib/hsUtils.cpp
@@ -40,9 +40,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 #include "hsUtils.h"
-#if HS_BUILD_FOR_MAC
-#include <Gestalt.h>
-#endif
 #if HS_BUILD_FOR_WIN32
 extern "C" {
 #endif
@@ -50,14 +47,6 @@ extern "C" {
 #include <stdarg.h>
 #if HS_BUILD_FOR_WIN32
 };
-#endif
-#if __MWERKS__
-#include <ctype.h>
-#endif
-#if HS_BUILD_FOR_PS2
-#include <ctype.h>
-#include "eekernel.h"
-#include "sifdev.h"
 #endif
 
 #if HS_BUILD_FOR_WIN32
@@ -153,12 +142,6 @@ int hsMessageBoxWithOwner(void * owner, const char message[], const char caption
     }
 
 #endif
-#if HS_BUILD_FOR_MACPPC
-    DebugStr(message);
-#endif
-#if HS_BUILD_FOR_PS2
-    printf("Cap:%s Message:%s\n",caption, message);
-#endif
 }
 
 int hsMessageBoxWithOwner(void * owner, const wchar_t message[], const wchar_t caption[], int kind, int icon)
@@ -212,12 +195,6 @@ int hsMessageBoxWithOwner(void * owner, const wchar_t message[], const wchar_t c
     default:            return hsMBoxCancel;
     }
     
-#endif
-#if HS_BUILD_FOR_MACPPC
-    DebugStr(message);
-#endif
-#if HS_BUILD_FOR_PS2
-    printf("Cap:%s Message:%s\n",caption, message);
 #endif
 }
 
@@ -442,16 +419,6 @@ void hsCPathToMacPath(char* dst, char* fname)
 
 int hsRemove(const char * fname)
 {
-#if HS_BUILD_FOR_MACPPC
-    char buf[500];
-    hsStrcpy(buf,":");
-    hsStrcat(buf,fname);
-    int i;
-    for(i =0; i < hsStrlen(buf); i++)
-        if(buf[i] == '\\')
-            buf[i] = ':';
-    return remove(buf);
-#endif
     return remove(fname);
     
 }
@@ -464,12 +431,6 @@ UInt32 hsPhysicalMemory()
     MEMORYSTATUS ms;
     GlobalMemoryStatus(&ms);
     return (ms.dwTotalPhys / HS_ONE_MEGABYTE);
-#elif HS_BUILD_FOR_MAC
-    // Silver, figure out the physical memory here (in MB)  
-    OSErr err;
-    SInt32 TotPhysicalRAM;
-    err = Gestalt(gestaltPhysicalRAMSize, &TotPhysicalRAM);
-    return (TotPhysicalRAM / HS_ONE_MEGABYTE);
 #endif
 }
 
@@ -487,128 +448,6 @@ MemSpec hsMemorySpec()
     else
         return kOptimal;
 }
-
-#if HS_BUILD_FOR_MAC
-FILE *hsFopen(const char *fname, const char *mode)
-{
-    char buf[500];
-#if 0
-    FILE *f;
-
-    hsStrcpy(buf,":");
-    hsStrcat(buf,fname);
-    int i;
-    for(i =0; i < hsStrlen(buf); i++)
-        if(buf[i] == '\\')
-            buf[i] = ':';
-    
-#endif
-    hsCPathToMacPath(buf, (char*)fname);
-    return fopen(buf,mode);
-}
-
-#endif
-#if HS_BUILD_FOR_PS2
-int hsPS2Open(const char name[], const char mode[])
-{
-  char buf[500];
-  int newMode;
-  int i;
-  hsStrcpy(buf,"sim:");
-//hsStrcpy(buf,"");
-  hsStrcat(buf,name);
-  for(i =0; i < hsStrlen(buf); i++)
-    if(buf[i] == '\\')
-        buf[i] = '/';
-  printf("Opening File %s\n",buf);
-  if(mode[0] == 'r')
-    newMode = SCE_RDONLY;
-  else if(mode[0] == 'w')
-    newMode = SCE_WRONLY|SCE_CREAT;
-  else
-    hsAssert(0,"Bad mode in hsPS2Open\n");
-
-  printf("Opening File %s mode =%d\n",buf,newMode);
-   return  sceOpen(buf,newMode);
-}
-
-void hsPS2Close( int file )
-{
-    if( file != -1 )
-        sceClose( file );
-}
-
-//FILE *hsFopen(const char *fname, const char *mode)
-//{ 
-//  FILE *f;
-//  char buf[500];
-//  char newMode[10];
-//  hsStrcpy(buf,"sim:");
-//  //hsStrcpy(buf,"");
-//  hsStrcat(buf,fname);
-//  int i;
-//  for(i =0; i < hsStrlen(buf); i++)
-//      if(buf[i] == '\\')
-//          buf[i] = '/';
-//  printf("Opening File %s\n",buf);
-//  if(!strcmp("rt",mode))
-//    {
-//      strcpy(newMode, "r");
-//    }
-//  else
-//    strcpy(newMode, mode);
-//
-//  printf("Opening File %s mode =%s\n",buf,newMode);
-//  f= fopen(buf,newMode);
-//  if(f)
-//      return f;
-//  else
-//      return nil;
-//}
-#endif
-
-// Compare lexigraphically two strings
-
-#if !(HS_BUILD_FOR_WIN32 || HS_BUILD_FOR_UNIX)
-
-int hsStrcasecmp(const char *s1, const char *s2)
-{
-    if (s1 && s2)
-    {
-        char c1, c2;
-        while (1)
-        {
-            c1 = tolower(*s1++);
-            c2 = tolower(*s2++);
-            if (c1 < c2) return -1;
-            if (c1 > c2) return 1;
-            if (c1 == '\0') return 0;
-        }
-    }
-    return !s1 ? -1 : 1;
-}
-
-// Compare lexigraphically two strings up to a max length
-
-int hsStrncasecmp(const char *s1, const char *s2, int n)
-{
-    if (s1 && s2)
-    {
-        int i;
-        char c1, c2;
-        for (i=0; i<n; i++)
-        {
-            c1 = tolower(*s1++);
-            c2 = tolower(*s2++);
-            if (c1 < c2) return -1;
-            if (c1 > c2) return 1;
-            if (!c1) return 0;
-        }
-        return 0;
-    }
-    return !s1 ? -1 : 1;
-}
-#endif
 
 //
 // Microsoft SAMPLE CODE

--- a/Sources/Plasma/CoreLib/hsUtils.h
+++ b/Sources/Plasma/CoreLib/hsUtils.h
@@ -185,20 +185,7 @@ inline float hsRandNorm() { return 1.f / 32767.f; } // multiply by hsRand to get
 int hsRand(void);
 void hsRandSeed(int seed);
 
-
-#if HS_BUILD_FOR_MAC
-FILE* hsFopen(const char name[], const char mode[]);    // handles path names with /s
-
-#elif HS_BUILD_FOR_PS2 // HS_BUILD_FOR_MAC
-
-int hsPS2Open(const char name[], const char mode[]);
-void hsPS2Close( int file );
-
-#else // HS_BUILD_FOR_MAC
-
 #define hsFopen(name, mode) fopen(name, mode)
-
-#endif // HS_BUILD_FOR_MAC
 
 char** DisplaySystemVersion();
 

--- a/Sources/Plasma/CoreLib/hsWindowHndl.h
+++ b/Sources/Plasma/CoreLib/hsWindowHndl.h
@@ -45,17 +45,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 
 // decide what hsWindowHndl is
-#if HS_BUILD_FOR_MAC
-#include <QuickDraw.h>
-#ifdef HS_MAC_CARBON
-typedef WindowPtr hsWindowHndl;
-#else
-typedef GrafPtr hsWindowHndl;
-#endif
-#endif
 #if HS_BUILD_FOR_WIN32
 typedef struct HWND__ * hsWindowHndl;
-#elif HS_BUILD_FOR_PS2 || HS_BUILD_FOR_UNIX
+#elif HS_BUILD_FOR_UNIX
 typedef int* hsWindowHndl;
 #endif
 

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
@@ -62,10 +62,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <stack>
 
-#if HS_BUILD_FOR_MAC
-#include <bxwchar.h>
-#endif
-
 // MinGW sucks
 #if defined(_WIN32) && !defined(_MSC_VER)
 #   define swprintf _snwprintf
@@ -183,28 +179,12 @@ XML_Memory_Handling_Suite gHeapAllocator = {
 //metmet remove static
 void XMLCALL LocalizationXMLFile::StartTag(void *userData, const XML_Char *element, const XML_Char **attributes)
 {
-#if !HS_BUILD_FOR_MAC
     std::wstring wElement = element;
-#else
-    // jfim
-    wchar_t buf[2048], buf2[2048];
-    BX_Char16ToWchar(element, buf);
-    std::wstring wElement = buf;    // jfim: element;
-#endif
     LocalizationXMLFile *file = (LocalizationXMLFile*)userData;
     std::map<std::wstring, std::wstring> wAttributes;
 
     for (int i = 0; attributes[i]; i += 2)
-#if !HS_BUILD_FOR_MAC
         wAttributes[attributes[i]] = attributes[i+1];
-#else
-    {
-        // jfim
-        BX_Char16ToWchar(attributes[i], buf);
-        BX_Char16ToWchar(attributes[i+1], buf2);
-        wAttributes[buf] = buf2;
-    }
-#endif
 
     LocalizationXMLFile::tagInfo parentTag;
     if (!file->fTagStack.empty())
@@ -236,14 +216,7 @@ void XMLCALL LocalizationXMLFile::StartTag(void *userData, const XML_Char *eleme
 //metmet remove static and include the function inside LocalizationXMLFile
 void XMLCALL LocalizationXMLFile::EndTag(void *userData, const XML_Char *element)
 {
-#if !HS_BUILD_FOR_MAC
     std::wstring wElement = element;
-#else
-    // jfim
-    wchar_t buf[2048], buf2[2048];
-    BX_Char16ToWchar(element, buf);
-    std::wstring wElement = buf;    // jfim: element;
-#endif
     LocalizationXMLFile *file = (LocalizationXMLFile*)userData;
 
     if (file->fSkipDepth != -1) // we're currently skipping
@@ -447,14 +420,7 @@ bool LocalizationXMLFile::Parse(const std::string & fileName)
             fLastError += L"ERROR: Parse error at line ";
             fLastError += lineNumber;
             fLastError += L": ";
-#if !HS_BUILD_FOR_MAC
             fLastError += XML_ErrorString(XML_GetErrorCode(fParser));
-#else
-            // jfim
-            wchar_t buf[2048];
-            BX_Utf8ToWchar(XML_ErrorString(XML_GetErrorCode(fParser)), buf);
-            fLastError += buf;
-#endif
             fLastError += L"\n";
             XML_ParserFree(fParser);
             fParser = nil;

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.cpp
@@ -52,10 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pfLocalizedString.h"
 
-#if HS_BUILD_FOR_MAC
-#include <bxwchar.h>
-#endif
-
 // MinGW sucks
 #if defined(_WIN32) && !defined(_MSC_VER)
 #   define swprintf _snwprintf

--- a/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
@@ -53,11 +53,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "structmember.h"
 #include "pyGlueHelpers.h"
 
-#if HS_BUILD_FOR_MAC
-#include <stdio.h>
-#include <bxString.h>
-#endif
-
 struct EnumValue {
     PyObject_HEAD
     long value;

--- a/Sources/Plasma/FeatureLib/pfSurface/plLayerBink.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plLayerBink.cpp
@@ -201,23 +201,6 @@ hsBool plLayerBink::IGetCurrentFrame()
             0, 0,
             BINKSURFACE32A | BINKCOPYALL
     );
-
-#if HS_BUILD_FOR_MAC
-    UInt32  numPix = GetTexture()->GetBitmap()->GetWidth() * GetTexture()->GetBitmap()->GetHeight(); 
-    UInt32  h = GetTexture()->GetBitmap()->GetHeight(); 
-    UInt32* pix = (UInt32*)GetTexture()->GetBitmap()->GetImage();
-    UInt32  i = 0;
-    while( i < numPix )
-    {
-        unsigned char r = (*pix >> 0);  unsigned char g = (*pix >> 8);
-        unsigned char b = (*pix >> 16); unsigned char a = (*pix >> 24);
-            
-        *pix = ((b << 24) | (g << 16) | (r << 8) | a);
-        
-        pix++;
-        i++;
-    }
-#endif
 #endif /* BINK_SDK_AVAILABLE */
 
     return false;

--- a/Sources/Plasma/NucleusLib/pnTimer/hsTimer.cpp
+++ b/Sources/Plasma/NucleusLib/pnTimer/hsTimer.cpp
@@ -42,10 +42,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsTimer.h"
 #include "hsUtils.h"
 
-#if HS_BUILD_FOR_MAC
-#include <Timer.h>
-#endif
-
 #include "plTweak.h"
 
 //
@@ -241,34 +237,6 @@ hsWide hsTimer::IInitRawBase()
     return base;
 }
 
-#elif HS_BUILD_FOR_MAC
-
-#include <Events.h>
-#include <DriverServices.h>
-
-//#define HS_USE_TICKCOUNT
-hsWide* plTimerShare::GetRawTicks(hsWide* ticks)
-{   
-#ifndef HS_USE_TICKCOUNT
-    UnsignedWide ns = AbsoluteToNanoseconds(UpTime());
-    ticks->Set(ns.hi, ns.lo);
-#else
-    ticks->Set(0, TickCount());
-#endif
-    return FactorInTimeZero(ticks);
-}
-
-hsWide plTimerShare::IInitRawBase()
-{
-    hsWide base;
-#ifndef HS_USE_TICKCOUNT
-    base.Set(0, 1000000000L);
-#else
-    base.Set(0, 60);
-#endif
-    return base;
-}
-
 #elif HS_BUILD_FOR_UNIX
 
 #include <sys/time.h>
@@ -292,29 +260,6 @@ hsWide hsTimer::IInitRawBase()
 {
     hsWide base;
     base.Set(0, kMicroSecondsUnit);
-    return base;
-}
-
-
-#elif HS_BUILD_FOR_PS2
-
-extern unsigned long psTimerGetCount();
-//#define kTickMul (150000000)      // kTickMul/kTickDiv :: 4577.636719
-#define kTickMul (100000000)    // kTickMul/kTickDiv :: 3051.757813 // for debugger
-#define kTickDiv (256*128)
-
-
-hsWide* plTimerShare::GetRawTicks(hsWide* ticks)
-{
-    unsigned long t= psTimerGetCount();
-    ticks->Set( (Int32)(t>>32), (Int32)(t&((1ul<<32)-1)));
-    return ticks;
-}
-
-hsWide plTimerShare::IInitRawBase()
-{
-    hsWide base;
-    base.Set(0, kTickMul/kTickDiv );
     return base;
 }
 
@@ -351,12 +296,6 @@ double hsTimer::GetPrecTicksPerSec()
     }
     return ((double) freq.LowPart);
 #endif
-#if HS_BUILD_FOR_MAC
-    return 1000.f;
-#endif
-#if HS_BUILD_FOR_PS2
-    return 1000.f;
-#endif
     
     return 1;
 }
@@ -369,13 +308,6 @@ UInt32 hsTimer::GetPrecTickCount()
         return GetTickCount();
 
     return ti.LowPart;
-#endif
-#if HS_BUILD_FOR_MACPPC
-    return hsTimer::GetMSeconds();
-#endif
-
-#if HS_BUILD_FOR_PS2
-    return hsTimer::GetMSeconds();
 #endif
 }
 UInt32 hsTimer::PrecSecsToTicks(hsScalar secs)

--- a/Sources/Plasma/PubUtilLib/plContainer/hsStringTable.cpp
+++ b/Sources/Plasma/PubUtilLib/plContainer/hsStringTable.cpp
@@ -41,7 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 #include "hsStringTable.h"
 #include <stdlib.h>
-#if HS_BUILD_FOR_PS2 || __MWERKS__ || HS_BUILD_FOR_UNIX
+#if HS_BUILD_FOR_UNIX
 #include <ctype.h>
 #endif
 //

--- a/Sources/Plasma/PubUtilLib/plFile/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plFile/CMakeLists.txt
@@ -16,10 +16,6 @@ set(plFile_SOURCES
 
 if(WIN32)
     set(plFile_SOURCES ${plFile_SOURCES} hsFiles_Win.cpp)
-elseif(APPLE)
-    set(plFile_SOURCES ${plFile_SOURCES} hsFiles_Mac.cpp)
-#elseif(PS2)
-#   set(plFile_SOURCES ${plFile_SOURCES} hsFiles_PS2.cpp)
 else(WIN32)
     set(plFile_SOURCES ${plFile_SOURCES} hsFiles_Unix.cpp)
 endif(WIN32)

--- a/Sources/Plasma/PubUtilLib/plFile/hsFiles.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/hsFiles.cpp
@@ -45,9 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsExceptions.h"
 
-#if HS_BUILD_FOR_MAC
-    #define kDirChar        ':'
-#elif HS_BUILD_FOR_WIN32
+#if HS_BUILD_FOR_WIN32
     #define kDirChar        '\\'
 #else
     #define kDirChar        '/'
@@ -64,7 +62,6 @@ static const char* FindNameInPath(const char path[])
 }
 
 ///////////////////////////////////////////////////////////////////////
-#if !HS_BUILD_FOR_PS2
 
 hsFile::hsFile() : fPathAndName(nil), fFILE(nil)
 {
@@ -141,7 +138,6 @@ void hsFile::Close()
         fFILE = nil;
     }
 }
-#endif
 
 ///////////////////////////////////////////////////////////////////////
 

--- a/Sources/Plasma/PubUtilLib/plFile/hsFiles.h
+++ b/Sources/Plasma/PubUtilLib/plFile/hsFiles.h
@@ -50,15 +50,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     #define kFolderIterator_MaxPath     PATH_MAX
     #include <unistd.h>
     #define SetCurrentDirectory chdir
-#elif !HS_BUILD_FOR_PS2
-    #define kFolderIterator_MaxPath     _MAX_PATH
 #else
-    #define kFolderIterator_MaxPath     255
-#endif
-
-#if HS_BUILD_FOR_MAC
-    #include <Files.h>
-    #include <Script.h>
+    #define kFolderIterator_MaxPath     _MAX_PATH
 #endif
 
 
@@ -76,7 +69,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 
 ///////////////////////////////////////////////////////////////////////
-#if !HS_BUILD_FOR_PS2
 
 class hsFile {
     hsFile&     operator=(const hsFile&);       // disallow assignment
@@ -98,41 +90,8 @@ public:
     virtual void    Close();    // called automatically in the destructor
 };
 typedef hsFile  hsUnixFile; // for compatibility
+typedef hsFile  hsOSFile;
 
-#if HS_BUILD_FOR_MAC
-    class hsMacFile : public hsFile {
-        enum {
-            kRefNum_Dirty,
-            kPathName_Dirty
-        };
-        FSSpec      fSpec;
-        Int16       fRefNum;
-        UInt16      fFlags;
-
-        void            SetSpecFromName();
-        void            SetNameFromSpec();
-    public:
-                    hsMacFile();
-                    hsMacFile(const FSSpec* spec);
-                    hsMacFile(const char pathAndName[]);
-        virtual     ~hsMacFile();
-
-        const FSSpec*   GetSpec() const { return &fSpec; }
-        void            SetSpec(const FSSpec* spec);
-        hsBool      Create(OSType creator, OSType fileType, ScriptCode scriptCode = smSystemScript);
-        hsBool      OpenDataFork(SInt8 permission, Int16* refnum);
-
-        //  Overrides
-        virtual const char* GetPathAndName();
-        virtual void    SetPathAndName(const char pathAndName[]);
-        virtual hsStream* OpenStream(const char mode[], hsBool throwIfFailure = false);
-        virtual void    Close();
-    };
-    typedef hsMacFile   hsOSFile;
-#else
-    typedef hsFile      hsOSFile;
-#endif
-#endif // HS_BUILD_FOR_PS2
 ///////////////////////////////////////////////////////////////////////
 
 class hsFolderIterator {
@@ -160,15 +119,7 @@ public:
 
     FILE*       OpenFILE(const char mode[]);
 
-#if HS_BUILD_FOR_MAC
-    void            SetMacFolder(const char path[]);
-    void            SetMacFolder(OSType folderType);
-    void            SetMacFolder(Int16 vRefNum, Int32 dirID);
-    hsBool      NextMacFile(OSType targetFileType, OSType targetCreator);
-    const struct FSSpec* GetMacSpec() const;
-    OSType      GetMacFileType() const;
-    OSType      GetMacCreator() const;
-#elif HS_BUILD_FOR_WIN32
+#if HS_BUILD_FOR_WIN32
     void        SetWinSystemDir(const char subdir[]);   // e.g. "Fonts"
     void        SetFileFilterStr(const char filterStr[]);   // e.g. "*.*"
 #endif

--- a/Sources/Plasma/PubUtilLib/plGImage/hsDXTSoftwareCodec.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/hsDXTSoftwareCodec.cpp
@@ -667,13 +667,8 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT5To16( plMipmap *destBMap, plMip
         colors[ 2 ] = IMixTwoThirdsRGB4444( colors[ 0 ], colors[ 1 ] );
         colors[ 3 ] = IMixTwoThirdsRGB4444( colors[ 1 ], colors[ 0 ] );
         
-        cBitSrc1 = srcData[ 2 ];
-        cBitSrc2 = srcData[ 3 ];
-
-#ifdef HS_BUILD_FOR_MAC
-        cBitSrc1 = ISwapWordOrder( cBitSrc1 );
-        cBitSrc2 = ISwapWordOrder( cBitSrc2 );
-#endif
+        cBitSrc1 = hsToLE16( srcData[ 2 ] );
+        cBitSrc2 = hsToLE16( srcData[ 3 ] );
         
         for( j = 0; j < 8; j++ )
         {
@@ -683,10 +678,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT5To16( plMipmap *destBMap, plMip
             destBlock[ j + 8 ] = alphas[ aBitSrc2 & 0x07 ] | colors[ cBitSrc2 & 0x03 ];
             aBitSrc2 >>= 3;
             cBitSrc2 >>= 2;
-#ifdef HS_BUILD_FOR_MAC
-            destBlock[ j ] = ISwapWordOrder( destBlock[ j ] );
-            destBlock[ j + 8 ] = ISwapWordOrder( destBlock[ j + 8 ] );
-#endif
+
+            destBlock[ j ] = hsToLE16( destBlock[ j ] );
+            destBlock[ j + 8 ] = hsToLE16( destBlock[ j + 8 ] );
         }
         
         /// Now copy the block to the destination bitmap
@@ -828,13 +822,8 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT5To16Weird( plMipmap *destBMap, 
         colors[ 2 ] = IMixTwoThirdsRGB4444( colors[ 0 ], colors[ 1 ] );
         colors[ 3 ] = IMixTwoThirdsRGB4444( colors[ 1 ], colors[ 0 ] );
         
-        cBitSrc1 = srcData[ 2 ];
-        cBitSrc2 = srcData[ 3 ];
-
-#ifdef HS_BUILD_FOR_MAC
-        cBitSrc1 = ISwapWordOrder( cBitSrc1 );
-        cBitSrc2 = ISwapWordOrder( cBitSrc2 );
-#endif
+        cBitSrc1 = hsToLE16( srcData[ 2 ] );
+        cBitSrc2 = hsToLE16( srcData[ 3 ] );
         
         for( j = 0; j < 8; j++ )
         {
@@ -844,10 +833,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT5To16Weird( plMipmap *destBMap, 
             destBlock[ j + 8 ] = alphas[ aBitSrc2 & 0x07 ] | colors[ cBitSrc2 & 0x03 ];
             aBitSrc2 >>= 3;
             cBitSrc2 >>= 2;
-#ifdef HS_BUILD_FOR_MAC
-            destBlock[ j ] = ISwapWordOrder( destBlock[ j ] );
-            destBlock[ j + 8 ] = ISwapWordOrder( destBlock[ j + 8 ] );
-#endif
+
+            destBlock[ j ] = hsToLE16( destBlock[ j ] );
+            destBlock[ j + 8 ] = hsToLE16( destBlock[ j + 8 ] );
         }
         
         /// Now copy the block to the destination bitmap
@@ -1000,13 +988,8 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT5To32( plMipmap *destBMap, plMip
         colors[ 2 ] = IMixTwoThirdsRGB32( colors[ 0 ], colors[ 1 ] );
         colors[ 3 ] = IMixTwoThirdsRGB32( colors[ 1 ], colors[ 0 ] );
         
-        cBitSrc1 = srcData[ 2 ];
-        cBitSrc2 = srcData[ 3 ];
-
-#ifdef HS_BUILD_FOR_MAC
-        cBitSrc1 = ( cBitSrc1 >> 8 ) | ( ( cBitSrc1 & 0xff ) << 8 );
-        cBitSrc2 = ( cBitSrc2 >> 8 ) | ( ( cBitSrc2 & 0xff ) << 8 );
-#endif
+        cBitSrc1 = hsToLE16( srcData[ 2 ] );
+        cBitSrc2 = hsToLE16( srcData[ 3 ] );
         
         for( j = 0; j < 8; j++ )
         {
@@ -1016,10 +999,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT5To32( plMipmap *destBMap, plMip
             destBlock[ j + 8 ] = alphas[ aBitSrc2 & 0x07 ] | colors[ cBitSrc2 & 0x03 ];
             aBitSrc2 >>= 3;
             cBitSrc2 >>= 2;
-#ifdef HS_BUILD_FOR_MAC
-            destBlock[ j ] = ISwapDwordOrder( destBlock[ j ] );
-            destBlock[ j + 8 ] = ISwapDwordOrder( destBlock[ j + 8 ] );
-#endif
+
+            destBlock[ j ] = hsToLE32( destBlock[ j ] );
+            destBlock[ j + 8 ] = hsToLE32( destBlock[ j + 8 ] );
         }
         
         /// Now copy the block to the destination bitmap
@@ -1153,13 +1135,8 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT5ToAInten( plMipmap *destBMap, p
         colors[ 2 ] = IMixTwoThirdsInten( colors[ 0 ], colors[ 1 ] );
         colors[ 3 ] = IMixTwoThirdsInten( colors[ 1 ], colors[ 0 ] );
         
-        cBitSrc1 = srcData[ 2 ];
-        cBitSrc2 = srcData[ 3 ];
-
-#ifdef HS_BUILD_FOR_MAC
-        cBitSrc1 = ( cBitSrc1 >> 8 ) | ( ( cBitSrc1 & 0xff ) << 8 );
-        cBitSrc2 = ( cBitSrc2 >> 8 ) | ( ( cBitSrc2 & 0xff ) << 8 );
-#endif
+        cBitSrc1 = hsToLE16( srcData[ 2 ] );
+        cBitSrc2 = hsToLE16( srcData[ 3 ] );
         
         for( j = 0; j < 8; j++ )
         {
@@ -1169,10 +1146,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT5ToAInten( plMipmap *destBMap, p
             destBlock[ j + 8 ] = alphas[ aBitSrc2 & 0x07 ] | (UInt16)colors[ cBitSrc2 & 0x03 ];
             aBitSrc2 >>= 3;
             cBitSrc2 >>= 2;
-#ifdef HS_BUILD_FOR_MAC
-            destBlock[ j ] = ISwapWordOrder( destBlock[ j ] );
-            destBlock[ j + 8 ] = ISwapWordOrder( destBlock[ j + 8 ] );
-#endif
+
+            destBlock[ j ] = hsToLE16( destBlock[ j ] );
+            destBlock[ j + 8 ] = hsToLE16( destBlock[ j + 8 ] );
         }
         
         /// Now copy the block to the destination bitmap
@@ -1246,13 +1222,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1To16( plMipmap *destBMap, plMip
         colors[ 0 ] = IRGB565To1555( srcData[ 0 ] ) | 0x8000;       // Make sure alpha is set
         colors[ 1 ] = IRGB565To1555( srcData[ 1 ] ) | 0x8000;       // Make sure alpha is set
 
-#ifdef HS_BUILD_FOR_MAC
-        tempW1 = ISwapWordOrder( srcData[ 0 ] );
-        tempW2 = ISwapWordOrder( srcData[ 1 ] );
-#else 
-        tempW1 = srcData[ 0 ]; 
-        tempW2 = srcData[ 1 ];
-#endif      
+        tempW1 = hsToLE16( srcData[ 0 ] );
+        tempW2 = hsToLE16( srcData[ 1 ] );
+
         if( tempW1 > tempW2 )
         {
             /// Four-color block--mix the other two
@@ -1266,13 +1238,8 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1To16( plMipmap *destBMap, plMip
             colors[ 3 ] = 0;
         }
 
-        bitSource = srcData[ 2 ];
-        bitSource2 = srcData[ 3 ];
-
-#ifdef HS_BUILD_FOR_MAC
-        bitSource = ( bitSource >> 8 ) | ( ( bitSource & 0xff ) << 8 );
-        bitSource2 = ( bitSource2 >> 8 ) | ( ( bitSource2 & 0xff ) << 8 );      
-#endif
+        bitSource = hsToLE16( srcData[ 2 ] );
+        bitSource2 = hsToLE16( srcData[ 3 ] );
 
         for( j = 0; j < 8; j++ )
         {
@@ -1280,10 +1247,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1To16( plMipmap *destBMap, plMip
             bitSource >>= 2;
             destBlock[ j + 8 ] = colors[ bitSource2 & 0x03 ];
             bitSource2 >>= 2;
-#ifdef HS_BUILD_FOR_MAC
-            destBlock[ j ] = ISwapWordOrder( destBlock[ j ] );
-            destBlock[ j + 8 ] = ISwapWordOrder( destBlock[ j + 8 ] );
-#endif
+
+            destBlock[ j ] = hsToLE16( destBlock[ j ] );
+            destBlock[ j + 8 ] = hsToLE16( destBlock[ j + 8 ] );
         }
         
         /// Now copy the block to the destination bitmap
@@ -1358,13 +1324,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1To16Weird( plMipmap *destBMap,
         colors[ 0 ] = IRGB565To5551( srcData[ 0 ] ) | 0x0001;       // Make sure alpha is set
         colors[ 1 ] = IRGB565To5551( srcData[ 1 ] ) | 0x0001;       // Make sure alpha is set
 
-#ifdef HS_BUILD_FOR_MAC
-        tempW1 = ISwapWordOrder( srcData[ 0 ] );
-        tempW2 = ISwapWordOrder( srcData[ 1 ] );
-#else 
-        tempW1 = srcData[ 0 ]; 
-        tempW2 = srcData[ 1 ];
-#endif      
+        tempW1 = hsToLE16( srcData[ 0 ] );
+        tempW2 = hsToLE16( srcData[ 1 ] );
+
         if( tempW1 > tempW2 )
         {
             /// Four-color block--mix the other two
@@ -1378,13 +1340,8 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1To16Weird( plMipmap *destBMap,
             colors[ 3 ] = 0;
         }
 
-        bitSource = srcData[ 2 ];
-        bitSource2 = srcData[ 3 ];
-
-#ifdef HS_BUILD_FOR_MAC
-        bitSource = ( bitSource >> 8 ) | ( ( bitSource & 0xff ) << 8 );
-        bitSource2 = ( bitSource2 >> 8 ) | ( ( bitSource2 & 0xff ) << 8 );      
-#endif
+        bitSource = hsToLE16( srcData[ 2 ] );
+        bitSource2 = hsToLE16( srcData[ 3 ] );
 
         for( j = 0; j < 8; j++ )
         {
@@ -1392,10 +1349,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1To16Weird( plMipmap *destBMap,
             bitSource >>= 2;
             destBlock[ j + 8 ] = colors[ bitSource2 & 0x03 ];
             bitSource2 >>= 2;
-#ifdef HS_BUILD_FOR_MAC
-            destBlock[ j ] = ISwapWordOrder( destBlock[ j ] );
-            destBlock[ j + 8 ] = ISwapWordOrder( destBlock[ j + 8 ] );
-#endif
+
+            destBlock[ j ] = hsToLE16( destBlock[ j ] );
+            destBlock[ j + 8 ] = hsToLE16( destBlock[ j + 8 ] );
         }
         
         /// Now copy the block to the destination bitmap
@@ -1470,13 +1426,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1To32( plMipmap *destBMap,
         colors[ 0 ] = IRGB16To32Bit( srcData[ 0 ] ) | 0xff000000;
         colors[ 1 ] = IRGB16To32Bit( srcData[ 1 ] ) | 0xff000000;
 
-#ifdef HS_BUILD_FOR_MAC
-        tempW1 = ISwapWordOrder( srcData[ 0 ] );
-        tempW2 = ISwapWordOrder( srcData[ 1 ] );
-#else 
-        tempW1 = srcData[ 0 ]; 
-        tempW2 = srcData[ 1 ];
-#endif      
+        tempW1 = hsToLE16( srcData[ 0 ] );
+        tempW2 = hsToLE16( srcData[ 1 ] );
+
         if( tempW1 > tempW2 )
         {
             /// Four-color block--mix the other two
@@ -1490,13 +1442,8 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1To32( plMipmap *destBMap,
             colors[ 3 ] = 0;
         }
 
-        bitSource = srcData[ 2 ];
-        bitSource2 = srcData[ 3 ];
-
-#ifdef HS_BUILD_FOR_MAC
-        bitSource = ( bitSource >> 8 ) | ( ( bitSource & 0xff ) << 8 );
-        bitSource2 = ( bitSource2 >> 8 ) | ( ( bitSource2 & 0xff ) << 8 );      
-#endif
+        bitSource = hsToLE16( srcData[ 2 ] );
+        bitSource2 = hsToLE16( srcData[ 3 ] );
 
         for( j = 0; j < 8; j++ )
         {
@@ -1504,10 +1451,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1To32( plMipmap *destBMap,
             bitSource >>= 2;
             destBlock[ j + 8 ] = colors[ bitSource2 & 0x03 ];
             bitSource2 >>= 2;
-#ifdef HS_BUILD_FOR_MAC
-            destBlock[ j ] = ISwapDwordOrder( destBlock[ j ] );
-            destBlock[ j + 8 ] = ISwapDwordOrder( destBlock[ j + 8 ] );
-#endif
+
+            destBlock[ j ] = hsToLE32( destBlock[ j ] );
+            destBlock[ j + 8 ] = hsToLE32( destBlock[ j + 8 ] );
         }
         
         /// Now copy the block to the destination bitmap
@@ -1580,13 +1526,9 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1ToInten( plMipmap *destBMap,
         colors[ 0 ] = (UInt8)IRGB16To32Bit( srcData[ 0 ] );
         colors[ 1 ] = (UInt8)IRGB16To32Bit( srcData[ 1 ] );
 
-#ifdef HS_BUILD_FOR_MAC
-        tempW1 = ISwapWordOrder( srcData[ 0 ] );
-        tempW2 = ISwapWordOrder( srcData[ 1 ] );
-#else 
-        tempW1 = srcData[ 0 ]; 
-        tempW2 = srcData[ 1 ];
-#endif      
+        tempW1 = hsToLE16( srcData[ 0 ] );
+        tempW2 = hsToLE16( srcData[ 1 ] );
+
         if( tempW1 > tempW2 )
         {
             /// Four-color block--mix the other two
@@ -1600,13 +1542,8 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1ToInten( plMipmap *destBMap,
             colors[ 3 ] = 0;
         }
 
-        bitSource = srcData[ 2 ];
-        bitSource2 = srcData[ 3 ];
-
-#ifdef HS_BUILD_FOR_MAC
-        bitSource = ( bitSource >> 8 ) | ( ( bitSource & 0xff ) << 8 );
-        bitSource2 = ( bitSource2 >> 8 ) | ( ( bitSource2 & 0xff ) << 8 );      
-#endif
+        bitSource = hsToLE16( srcData[ 2 ] );
+        bitSource2 = hsToLE16( srcData[ 3 ] );
 
         for( j = 0; j < 8; j++ )
         {
@@ -1650,27 +1587,6 @@ void    hsDXTSoftwareCodec::IUncompressMipmapDXT1ToInten( plMipmap *destBMap,
     }
 }
 
-//// ISwapDwordOrder //////////////////////////////////////////////////////////
-
-UInt32  hsDXTSoftwareCodec::ISwapDwordOrder( UInt32 color )
-{
-    UInt8   a, r, g, b;
-
-
-    a = (UInt8)( color >> 24 );
-    r = (UInt8)( color >> 16 ) & 0xff;
-    g = (UInt8)( color >> 8 ) & 0xff;
-    b = (UInt8)( color & 0xff );
-    return( ( b << 24 ) | ( g << 16 ) | ( r << 8 ) | a );
-}
-
-//// ISwapWordOrder ///////////////////////////////////////////////////////////
-
-UInt16  hsDXTSoftwareCodec::ISwapWordOrder( UInt16 color )
-{
-    return( ( color >> 8 ) | ( color << 8 ) );
-}
-
 //// IRGB16To32Bit ////////////////////////////////////////////////////////////
 //
 //  Converts a RGB565 16-bit color into a RGB888 32-bit color. Alpha (upper 8
@@ -1681,9 +1597,7 @@ UInt32  hsDXTSoftwareCodec::IRGB16To32Bit( UInt16 color )
 {
     UInt32      r, g, b;
 
-#ifdef HS_BUILD_FOR_MAC
-    color = ( ( color >> 8 ) | ( ( color & 0xff ) << 8 ) );
-#endif
+    color = hsToLE16(color);
     
     b = ( color & 31 ) << 3;
     color >>= 5;
@@ -1706,9 +1620,7 @@ UInt16  hsDXTSoftwareCodec::IRGB565To4444( UInt16 color )
 {
     UInt16      r, g, b;
 
-#ifdef HS_BUILD_FOR_MAC
-    color = ISwapWordOrder( color );
-#endif
+    color = hsToLE16( color );
     
     b = ( color & 31 ) >> 1;
     color >>= 5;
@@ -1733,9 +1645,7 @@ UInt16  hsDXTSoftwareCodec::IRGB565To4444Rev( UInt16 color )
 {
     UInt16      r, g, b;
 
-#ifdef HS_BUILD_FOR_MAC
-    color = ISwapWordOrder( color );
-#endif
+    color = hsToLE16( color );
     
     r = ( color & 31 ) >> 1;
     color >>= 5;
@@ -1760,9 +1670,7 @@ UInt16  hsDXTSoftwareCodec::IRGB565To1555( UInt16 color )
 {
     UInt16      r, g, b;
 
-#ifdef HS_BUILD_FOR_MAC
-    color = ISwapWordOrder( color );
-#endif
+    color = hsToLE16( color );
     
     b = ( color & 31 );
     color >>= 5;
@@ -1787,9 +1695,7 @@ UInt16  hsDXTSoftwareCodec::IRGB565To5551( UInt16 color )
 {
     UInt16      rg, b;
 
-#ifdef HS_BUILD_FOR_MAC
-    color = ISwapWordOrder( color );
-#endif
+    color = hsToLE16( color );
     
     rg = color & 0xffc0;        /// Masks off red and green
     b = ( color & 31 );
@@ -2418,13 +2324,8 @@ hsBool hsDXTSoftwareCodec::ColorizeCompMipmap( plMipmap *bMap, const UInt8 *colo
     {
         /// Get the two colors to colorize (our decompression scheme will do the rest...
         /// handy, eh? :)
-#if HS_BUILD_FOR_MAC
-        color1 = ISwapWordOrder( srcData[ 0 ] );
-        color2 = ISwapWordOrder( srcData[ 1 ] );
-#else
-        color1 = srcData[ 0 ];
-        color2 = srcData[ 1 ];
-#endif
+        color1 = hsToLE16( srcData[ 0 ] );
+        color2 = hsToLE16( srcData[ 1 ] );
 
         /// Now colorize using our age-old formula (see hsGMipmap::ColorLevel for details)
         gray = ( ( color1 >> 11 ) & 0x1f ) + ( ( color1 >> 6 ) & 0x1f ) + ( color1 & 0x1f );
@@ -2484,13 +2385,9 @@ hsBool hsDXTSoftwareCodec::ColorizeCompMipmap( plMipmap *bMap, const UInt8 *colo
         }
 
         /// Write back and go!
-#if HS_BUILD_FOR_MAC
-        srcData[ 0 ] = ISwapWordOrder( color1 );
-        srcData[ 1 ] = ISwapWordOrder( color2 );
-#else
-        srcData[ 0 ] = color1;
-        srcData[ 1 ] = color2;
-#endif
+        srcData[ 0 ] = hsToLE16( color1 );
+        srcData[ 1 ] = hsToLE16( color2 );
+
         srcData += blockSize;
     }
 

--- a/Sources/Plasma/PubUtilLib/plGImage/hsDXTSoftwareCodec.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/hsDXTSoftwareCodec.h
@@ -146,11 +146,6 @@ private:
     // Converts a color from RGB565 to RGB4444 reversed format, with alpha=0
     UInt16 inline IRGB565To4444Rev( UInt16 color );
 
-    // Swaps the bytes in a doubleword
-    UInt32 inline ISwapDwordOrder( UInt32 color );
-    // Swaps the bytes in a word
-    UInt16 inline ISwapWordOrder( UInt16 color );
-
     static hsBool Register();
     static hsBool fRegistered;
 };

--- a/Sources/Plasma/PubUtilLib/plGImage/hsRect.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/hsRect.h
@@ -44,32 +44,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsPoint2.h"
 
-#if HS_BUILD_FOR_MAC
-    //  This guy disables MetroWerks' desire to only include a file once, which obviously gets
-    //  in the way of our little HS_RECT.inc trick
-    #pragma once off
-#endif
-
 #define HS_RECT_NAME        hsIntRect
 #define HS_RECT_POINT       hsIntPoint2
 #define HS_RECT_TYPE        Int32
 #define HS_RECT_EXTEND      1
 #include "HS_RECT.inc"
 
-#if HS_BUILD_FOR_MAC
-    Rect*       ToRect(Rect* r) const
-                {
-                    r->left = (Int16)this->fLeft;
-                    r->top = (Int16)this->fTop;
-                    r->right = (Int16)this->fRight;
-                    r->bottom = (Int16)this->fBottom;
-                    return r;
-                }
-    hsIntRect*  Set(const Rect* r)
-                {
-                    return this->Set(r->left, r->top, r->right, r->bottom);
-                }
-#endif
 #ifdef _WINDOWS_
     RECT*       ToRECT(RECT* r) const
                 {

--- a/Sources/Plasma/PubUtilLib/plPipeline/hsWinRef.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/hsWinRef.h
@@ -49,10 +49,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsWindows.h"
 typedef HWND hsWinRef;
 
-#elif HS_BUILD_FOR_MACPPC
-
-typedef WindowRef hsWinRef;
-
 #else // Whatever
 
 typedef void* hsWinRef;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDXEnumerate.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDXEnumerate.cpp
@@ -217,7 +217,6 @@ HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultDriver( DWORD dwFlags )
                 }
                 else
                 {
-#if !HS_BUILD_FOR_XBOX
                     if( dwFlags & D3DENUM_CANWINDOW )
                     {
                         if( (pDriver == &fDrivers[0])
@@ -229,7 +228,6 @@ HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultDriver( DWORD dwFlags )
                         }
                     }
                     else
-#endif
                         if( dwFlags & D3DENUM_PRIMARYHAL )
                         {
                             if( pDriver == &fDrivers[0] )
@@ -292,7 +290,6 @@ hsGDirect3DTnLEnumerate::hsGDirect3DTnLEnumerate()
     /// New DX Enumeration
 
     // Get a pointer to the creation function
-#if !HS_BUILD_FOR_XBOX
     if( hsGDDrawDllLoad::GetD3DDll() == nil )
     {
         strcpy( fEnumeErrorStr, "Cannot load Direct3D driver!" );
@@ -308,10 +305,7 @@ hsGDirect3DTnLEnumerate::hsGDirect3DTnLEnumerate()
     }
 
     // Create a D3D object to use
-    IDirect3D9      *pD3D = procPtr( D3D_SDK_VERSION );
-#else
-    IDirect3D9      *pD3D = Direct3DCreate9( D3D_SDK_VERSION );
-#endif
+    IDirect3D9 *pD3D = procPtr( D3D_SDK_VERSION );
     if( pD3D == nil )
     {
         strcpy( fEnumeErrorStr, "Cannot load DirectX!" );
@@ -519,12 +513,8 @@ void    hsGDirect3DTnLEnumerate::IEnumAdapterDevices( IDirect3D9 *pD3D, UINT iAd
 hsBool  hsGDirect3DTnLEnumerate::IFindDepthFormats( IDirect3D9 *pD3D, UINT iAdapter, D3DDEVTYPE deviceType,
                                                    D3DEnum_ModeInfo *modeInfo )
 {
-#if HS_BUILD_FOR_XBOX
-    D3DFORMAT       formats[] = { D3DFMT_D16, D3DFMT_D24S8, D3DFMT_UNKNOWN };
-#else
     D3DFORMAT       formats[] = { D3DFMT_D16, D3DFMT_D24X8, D3DFMT_D32,
         D3DFMT_D15S1, D3DFMT_D24X4S4, D3DFMT_D24S8, D3DFMT_UNKNOWN };
-#endif
 
     /// Try 'em
     for( int i = 0; formats[ i ] != D3DFMT_UNKNOWN; i++ )

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDXPipeline.cpp
@@ -5367,13 +5367,11 @@ void plDXPipeline::ISetFogParameters(const plSpan* span, const plLayerInterface*
     bool forceLoad = false;
     D3DRENDERSTATETYPE  d3dFogType = D3DRS_FOGTABLEMODE;        // Use VERTEXMODE for vertex fog
 
-#if !HS_BUILD_FOR_XBOX
     if (!(fSettings.fD3DCaps & kCapsPixelFog) || isShader)
     {
         d3dFogType = D3DRS_FOGVERTEXMODE;
         isVertex = true;
     }
-#endif
 
     // Quick check
     if ((fCurrFog.fEnvPtr == fog) && (fCurrFog.fIsVertex == isVertex) && (fCurrFog.fIsShader == isShader))

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDXTextFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDXTextFont.cpp
@@ -57,10 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <ddraw.h>
 #include <d3dx9mesh.h>
 
-#if HS_BUILD_FOR_MAC
-#include <QuickDraw.h>
-#endif
-
 #include "hsWinRef.h"
 #include "hsTypes.h"
 #include "plDXTextFont.h"

--- a/Sources/Plasma/PubUtilLib/plTransform/mat_decomp.cpp
+++ b/Sources/Plasma/PubUtilLib/plTransform/mat_decomp.cpp
@@ -46,9 +46,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 #include <math.h>
 #include "mat_decomp.h"
-#ifdef __MWERKS__ 
-//#pragma optimization_level 0
-#endif
 
 /******* Matrix Preliminaries *******/
 


### PR DESCRIPTION
This commit removes obsolete code that was ifdef'd for 68k Macs running OS9, PS2, and XBox.  Also fixed was code that used ifdefs to work around endian issues for PowerPC and other big-endian architectures; those have been folded in and updated to use the appropriate functions from hsTypes.h.
