### PR TITLE
Fix MaxPlasmaLights for max 2012

### DIFF
--- a/Sources/Tools/MaxPlasmaLights/DLLEntry.cpp
+++ b/Sources/Tools/MaxPlasmaLights/DLLEntry.cpp
@@ -80,7 +80,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL,ULONG fdwReason,LPVOID lpvReserved)
 
 __declspec(dllexport) const TCHAR* LibDescription()
 {
-    return NULL;
+    return TEXT("MaxPlasmaLights");
 }
 
 __declspec(dllexport) int LibNumberClasses()


### PR DESCRIPTION
The issue was that MaxPlasmaLights returned a NULL description string. Apparently Max 2012 is not OK with this.
