### PR TITLE
Don’t modify tuples that others may already have references to

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -208,6 +208,22 @@ void plPythonSDLModifier::SetItemIdx(const char* key, int idx, PyObject* value, 
         return;
     }
 
+    if (pyTuple && pyTuple->ob_refcnt != 1)
+    {
+        // others already have references to the tuple and expect it to be immutable, must make a copy
+        int n = PyTuple_Size(pyTuple);
+        PyObject* newTuple = PyTuple_New(n);
+        for (int j = 0; j < n; j++)
+        {
+            PyObject* item = PyTuple_GetItem(pyTuple, j);
+            Py_INCREF(item);
+            PyTuple_SetItem(newTuple, j, item);
+        }
+        Py_DECREF(pyTuple);
+        pyTuple = newTuple;
+        it->second.obj = newTuple;
+    }
+
     if (pyTuple)
     {
         if (PyTuple_Size(pyTuple) <= idx)
@@ -221,6 +237,8 @@ void plPythonSDLModifier::SetItemIdx(const char* key, int idx, PyObject* value, 
                 Py_INCREF(Py_None);
                 PyTuple_SetItem(pyTuple, j, Py_None);
             }
+            // _PyTuple_Resize may have changed pyTuple
+            it->second.obj = pyTuple;
         }
     }
     else


### PR DESCRIPTION
### Short Version

Due to a bug in Cyan’s code, setting individual entries of a multi-value SDL variable from Python (ptSDL.setIndex()) has only ever worked by chance. All current uses of it happened to work with Python 2.3, but some break with Python 2.7. Symptoms fixed by the attached commit include broken private chat functionality in the neighborhood egg room and inability to enter Teledahn buckets.
### Long Version

As D'Lanor discovered, entering an egg room cubicle with the H-uru client (Python 2.7) causes the following error log, and chat is not made private as it should be:

```
(10/25 14:49:32) cPythConeOfSilence01 - Traceback (most recent call last):
(10/25 14:49:32)   File ".\python\xChatChannelRegion.py", line 130, in OnNotify
(10/25 14:49:32)     self.IAddMember(event[2])
(10/25 14:49:32)   File ".\python\xChatChannelRegion.py", line 149, in IAddMember
(10/25 14:49:32)     PtDebugPrint("xChatChannel: memberID=%d added to SDL." % (memberID),level=kDebugDumpLevel)
(10/25 14:49:32)   File "PlasmaTypes", line 138, in PtDebugPrint
(10/25 14:49:32) SystemError: ..\Objects\tupleobject.c:142: bad argument to internal function
```

It turns out this backtrace is a bit misleading, the error does not happen in PtDebugPrint(). What fails is the middle one of these lines:

``` python
            if self.SDL["intSDLChatMembers"][count] == -1:
                self.SDL.setIndex("intSDLChatMembers",count,memberID)
                PtDebugPrint("xChatChannel: memberID=%d added to SDL." % (memberID),level=kDebugDumpLevel)
```

_SDL["intSDLChatMembers"]_ is a tuple (8-tuple in this case), and _SDL.setIndex()_ (_plPythonSDLModifier::SetItemIdx()_) modifies that tuple directly. This is a big no-no, because tuples are supposed to be immutable. The C API to modify tuples only exists because there must be a way to build tuples in the first place, but once they’re out in the wild and someone else might already have references to them, it mustn’t be used anymore. This is Cyan’s code and unchanged between CWE, CWE-ou, and H-uru/Plasma.

The attempt to modify the tuple can have three outcomes, according to my observations. Which one is taken is deterministic but unpredictably dependent on various seemingly unrelated circumstances:
1. It can work: When nobody else has a reference to the tuple, modifying it succeeds, and everything works as intended.
2. It can fail spectacularly: When the tuple has a reference count greater than 1, Python notices the error and refuses to modify it. The error bubbles up through the Python interpreter until it arrives in the Python script, where it appears as an exception (SystemError), causing the observed backtrace, and terminates execution of the script.
3. It can fail silently: When the tuple has a reference count greater than 1, Python notices the error and refuses to modify it. The error, for some reason that I haven’t investigated yet, is somehow swallowed somewhere before it reaches the Python script. The script continues executing and it looks like everything went well, but the SDL value has actually not been changed.

With CWE-ou with Python 2.3 (and probably also the original Cyan MOULa client), normally outcome 1 happens. I can easily provoke outcome 3 however by adding a variable that keeps a reference to the tuple – the added PtDebugPrint confirms that the SDL setting has not taken effect:

``` python
            if self.SDL["intSDLChatMembers"][count] == -1:
                s = self.SDL["intSDLChatMembers"]
                self.SDL.setIndex("intSDLChatMembers",count,memberID)
                del s
                PtDebugPrint("SDL after: " + repr(self.SDL["intSDLChatMembers"]))
                PtDebugPrint("xChatChannel: memberID=%d added to SDL." % (memberID),level=kDebugDumpLevel)
```

There may be a way to provoke outcome 2 too, I haven’t tried that.

With H-uru/Plasma with Python 2.7, normally outcome 2 happens. I can easily provoke outcome 3 however by various seemingly innocuous changes to the Python code, e.g. adding another PtDebugPrint (yes, this is after where the error occurs):

``` python
            if self.SDL["intSDLChatMembers"][count] == -1:
                self.SDL.setIndex("intSDLChatMembers",count,memberID)
                PtDebugPrint("")
                PtDebugPrint("xChatChannel: memberID=%d added to SDL." % (memberID),level=kDebugDumpLevel)
```

There may be a way to provoke outcome 1, but I doubt it – the fact that the tuple has reference count 2 in this case probably comes from differences in Python’s garbage collection between 2.3 and 2.7.

The way to fix this is making plPythonSDLModifier::SetItemIdx() create a new tuple rather than modify an existing one. I have checked all uses of ptSDL.setIndex() and unless I missed anything they don’t mind if it replaces the tuple. I have also verified that the egg room SDL setting works now (I didn’t do any multiplayer testing to see if it has the intended effect though), and found that it also fixes entering the Teledahn buckets. The other two uses of ptSDL.setIndex(), the Gahreesen gear niche and remembering the last opened page of every book on the Relto bookshelf, already appear to work without the fix (tuple refcount is 1).

I’ve also found the following comment that seems to refer to this issue:
_tldnBucketBrain.py:417:_

``` python
        riders = None   #Need to release variable otherwise the SDL refuses to update (thus why I've moved it ouside of the 'for' loop)
        ageSDL.setIndex(kStringAgeSDLRiders,index,-1)
```
