### PR TITLE
Fix some bugs in plStatusLog, take two

### DIFF
--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
@@ -97,7 +97,9 @@ plStatusLogMgr::plStatusLogMgr()
 //#elif HS_BUILD_FOR_DARWIN
 // Do some Mac specific thing here eventually
 #else
-    wchar* temp = hsStringToWString(getenv("HOME"));
+    const char* home = getenv("HOME");
+    if (!home) home = "";
+    wchar* temp = hsStringToWString(home);
     swprintf(fBasePath, MAX_PATH, L"%S/.cache", temp);
     delete[] temp;
 #endif


### PR DESCRIPTION
Put log output back into the AppData folder where other logs are and fix truncation of log lines. Fixes some shortcomings of #100 and closes #99.
