### PR TITLE
Fix #106

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetMsgScreener.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetMsgScreener.cpp
@@ -127,6 +127,7 @@ plNetMsgScreener::Answer plNetMsgScreener::IAllowMessageType(Int16 classIndex, c
     case CLASS_INDEX_SCOPED(plClothingMsg):
     case CLASS_INDEX_SCOPED(plEnableMsg):
     case CLASS_INDEX_SCOPED(plLinkToAgeMsg):
+    case CLASS_INDEX_SCOPED(plSubWorldMsg):
         return kYes;
         
         // definitely yes or no (based on whether sender is a CCR)


### PR DESCRIPTION
Allow plSubWorldMsg to be sent over the network, allowing players to exit
the elevator on the second floor of the Teledahn shroom without falling
through the floor.
