### PR TITLE
Increase allowable sequence prefix range

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.cpp
@@ -326,8 +326,8 @@ plLocation  plAgeDescription::CalcPageLocation( const char *page ) const
 
         // Now, our 32 bit number looks like the following:
         // 0xRRAAPPPP
-        // - RR is FF when reserved, and 00 when normal
-        // - AA is the one byte for age sequence prefix (FF not allowed because 0xFFFFFFFFFF is reserved for invalid sequence number)
+        // - RR is FF when reserved, and 00-FE when normal
+        // - AA is the low byte of the age sequence prefix (FF not allowed on a negative prefix because 0xFFFFFFFFFF is reserved for invalid sequence number)
         // - PPPP is the two bytes for page sequence number
 
         if( IsGlobalAge() )


### PR DESCRIPTION
This simple change allows 65279 age prefixes, instead of the 254 allowed currently. Negative pages still have a range of -254..0. This lopsided allocation makes sense, since there are so few negative pages needed.

There's really no need to maintain the concept of negative or positive sequence numbers, since there's a kReserved flag. In order to avoid conflicts, though, only kReserved pages are allowed a first byte of 0xFF. 

As far as I can tell, no code examines the bit pattern of the sequence numbers, so this shouldn't break anything.
