### PR TITLE
Fix plDrawable compilation on *nix

### DIFF
--- a/Sources/Plasma/NucleusLib/pnInputCore/plOSMsg.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plOSMsg.h
@@ -51,6 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 
 // for Win32:
+#ifdef HS_BUILD_FOR_WIN32
 
 enum plOSMsg
 {
@@ -70,6 +71,12 @@ enum plOSMsg
     M_BUTTONUP      = WM_MBUTTONUP,
     CHAR_MSG        = WM_CHAR,
 };
+
+#else
+
+enum plOSMsg { };
+
+#endif
 
 
 //

--- a/Sources/Plasma/PubUtilLib/plDrawable/plVisLOSMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plVisLOSMgr.cpp
@@ -432,18 +432,18 @@ hsBool plVisLOSMgr::CursorCheck(plVisHit& hit)
 /////////////////////////////////////////////////////////////////
 
 static plSceneObject* marker = nil;
-static plPipeline* pipe = nil;
+static plPipeline* fPipe = nil;
 
 
 void VisLOSHackBegin(plPipeline* p, plSceneObject* m)
 {
     marker = m;
-    pipe = p;
+    fPipe = p;
 }
 
 void VisLOSHackPulse()
 {
-    if( !pipe )
+    if( !fPipe )
         return;
 
     plVisHit hit;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
@@ -46,6 +46,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include "hsWindows.h"
+#include "hsWindowHndl.h"
 //#include "pnInputCore/plControlDefinition.h"
 #include "pnInputCore/plOSMsg.h"
 #include "pnInputCore/plKeyDef.h"
@@ -75,7 +76,7 @@ public:
     void SetFlags(UInt32 f) { fFlags = f; }
     virtual void HandleKeyEvent(plOSMsg message, plKeyDef key, bool bKeyDown, hsBool bKeyRepeat, wchar_t c = nil) {;}
     virtual void HandleMouseEvent(plOSMsg message, plMouseState state)  {;}
-    virtual void HandleWindowActivate(bool bActive, HWND hWnd) {;}
+    virtual void HandleWindowActivate(bool bActive, hsWindowHndl hWnd) {;}
     virtual hsBool MsgReceive(plMessage* msg) {return false;}
     virtual void Shutdown() {;}
 
@@ -116,7 +117,7 @@ public:
 
     const char* GetInputName() { return "keyboard"; }
     void HandleKeyEvent(plOSMsg message, plKeyDef key, bool bKeyDown, hsBool bKeyRepeat, wchar_t c = nil);
-    virtual void HandleWindowActivate(bool bActive, HWND hWnd);
+    virtual void HandleWindowActivate(bool bActive, hsWindowHndl hWnd);
     virtual hsBool IsCapsLockKeyOn();
     virtual void Shutdown();
 
@@ -159,7 +160,7 @@ public:
     ~plMouseDevice();
 
     const char* GetInputName() { return "mouse"; }
-    void HandleWindowActivate(bool bActive, HWND hWnd);
+    void HandleWindowActivate(bool bActive, hsWindowHndl hWnd);
 
     hsBool  HasControlFlag(int f) const { return fControlFlags.IsBitSet(f); }
     void    SetControlFlag(int f) 


### PR DESCRIPTION
Fairly simple change that #ifdefs some Win32-specific constants.

Also renames a global variable so that it doesn't conflict with a system global (pipe).
