### PR TITLE
Show notification when missing required resource data file.

### DIFF
--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -709,6 +709,11 @@ bool    InitClient( HWND hWnd )
     resMgr->SetDataPath("dat");
     hsgResMgr::Init(resMgr);
 
+    if(!plFileUtils::FileExists("resource.dat"))
+    {
+        hsMessageBox("Required file 'resource.dat' not found.", "Error", hsMessageBoxNormal);
+        return false;
+    }
     plClientResMgr::Instance().ILoadResources("resource.dat");
 
     gClient = TRACKED_NEW plClient;


### PR DESCRIPTION
Adds a simple dialog to be shown to the user when required resources are unavailable and then gracefully exits the client.  

Addresses Issue #110.
