### PR TITLE
Fix Relto books not remembering last open page

### DIFF
--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -1744,10 +1744,8 @@ void    pfJournalBook::IHandleCheckClick( UInt32 idx, pfBookData::WhichSide whic
 void    pfJournalBook::GoToPage( UInt32 pageNumber )
 {
     // Put us here, but only on an even page (odd pages go on the right, y'know)
-    if (pageNumber < fPageStarts.Count())
-        fCurrentPage = pageNumber & ~0x00000001;
-    else
-        fCurrentPage = 0;
+    // (no need for a range check, going past the end simply puts you on a blank page, able to go backward but not forward)
+    fCurrentPage = pageNumber & ~0x00000001;
     fVisibleLinks.Reset();
     IRenderPage( fCurrentPage, pfJournalDlgProc::kTagLeftDTMap );
     IRenderPage( fCurrentPage + 1, pfJournalDlgProc::kTagRightDTMap );
@@ -2610,7 +2608,7 @@ void    pfJournalBook::IRenderPage( UInt32 page, UInt32 whichDTMap, hsBool suppr
         }
     }
 
-    hsAssert(page < fPageStarts.GetCount(), "UnInitialized page start!");
+    hsAssert(page < fPageStarts.GetCount() || page > fLastPage, "UnInitialized page start!");
     if( page <= fLastPage 
         && page < fPageStarts.GetCount())   // Added this as a crash-prevention bandaid - MT
     {


### PR DESCRIPTION
This is the same change as discussed at https://bitbucket.org/OpenUru_org/cwe-ou/pull-request/3/fix-relto-books-not-remembering-last-open and http://foundry.openuru.org/fisheye/cru/CWE-5 and currently being tested on the Minkata shard.

Description from there:

> Based on D'Lanor’s determination that the problem lies in the C++ code, I have found and fixed the problem that causes the books on the Relto bookshelf not to remember the page on which they were last open beyond the first two spreads.
> 
> The problem was that the book only paginates its content on demand, up to the requested page. When told to go to a page that it didn’t know yet where in the content stream it started (a higher page number than the ones paginated so far), it would simply refuse to go there and go to page 0 instead. (In the Relto shelf case, the Python code would however still think it was on a higher page, which would cause the stored SDL value to go out of sync with what was shown to the user.)
> 
> That check looks like it was meant to prevent going to a higher page than there is in the book, but failed to achieve that because it was only considering already paginated pages. However, such a check is not even necessary – nothing bad happens when you go beyond the end of the book, you simply end up on a blank page from which you can flip backward (repeatedly until you’re back on pages that exist), but not forward. Since that seems no worse an outcome than going to page 0 without telling the caller, I removed the check entirely. Preventing going to a higher page than already paginated is not necessary either, because rendering any page will automatically update the pagination as required.
> 
> I also had to tweak an assertion that would trigger when going beyond the end of the book – a condition which by itself the engine handles just fine, the assertion was intended to catch a different error condition.
> 
> The reason why the Relto books worked for the first two spreads was that at the time the Python code issued the goToPage() call, the book had already been internally rendered in its initial state with the first spread (pages 0 and 1) open, therefore the start of page 2 (left page of the second spread) was already known and going to that page worked.
