### PR TITLE
Fix the Relto panic link weird stuff

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
@@ -395,7 +395,10 @@ void plPXPhysicalControllerCore::IMatchKinematicToController()
         kinPos.z = (NxReal)cPos.z;
         if (plSimulationMgr::fExtraProfile)
             SimLog("Match setting kinematic from %f,%f,%f to %f,%f,%f",prevKinPos.x,prevKinPos.y,prevKinPos.z,kinPos.x,kinPos.y,kinPos.z );
-        fKinematicActor->moveGlobalPosition(kinPos);
+        if (fBehavingLikeAnimatedPhys && fKinematic) // if NX_BF_KINEMATIC && (avatar is on a ladder or something)
+            fKinematicActor->moveGlobalPosition(kinPos);
+        else
+            fKinematicActor->setGlobalPosition(kinPos);
     }
 }
 void plPXPhysicalControllerCore::UpdateControllerAndPhysicalRep()
@@ -406,7 +409,7 @@ void plPXPhysicalControllerCore::UpdateControllerAndPhysicalRep()
         {//this means we are moving the controller and then synchnig the kin
             NxExtendedVec3 ControllerPos= fController->getPosition();
             NxVec3 NewKinPos((NxReal)ControllerPos.x, (NxReal)ControllerPos.y, (NxReal)ControllerPos.z);
-            if (fEnabled && fKinematicActor->readBodyFlag(NX_BF_KINEMATIC))
+            if (fEnabled || fKinematic)
             {
                 if (plSimulationMgr::fExtraProfile)
                     SimLog("Moving kinematic to %f,%f,%f",NewKinPos.x, NewKinPos.y, NewKinPos.z );
@@ -414,7 +417,7 @@ void plPXPhysicalControllerCore::UpdateControllerAndPhysicalRep()
                 fKinematicActor->moveGlobalPosition(NewKinPos);
 
             }
-            else if (fEnabled)
+            else
             {
                 if (plSimulationMgr::fExtraProfile)
                     SimLog("Setting kinematic to %f,%f,%f", NewKinPos.x, NewKinPos.y, NewKinPos.z );
@@ -446,14 +449,14 @@ void plPXPhysicalControllerCore::MoveKinematicToController(hsPoint3& pos)
             newPos.x = (NxReal)pos.fX;
             newPos.y = (NxReal)pos.fY;
             newPos.z = (NxReal)pos.fZ+kPhysZOffset;
-            if (fEnabled && fKinematicActor->readBodyFlag(NX_BF_KINEMATIC))
+            if ((fEnabled || fKinematic) && fBehavingLikeAnimatedPhys)
             {
                 if (plSimulationMgr::fExtraProfile)
                     SimLog("Moving kinematic from %f,%f,%f to %f,%f,%f",pos.fX,pos.fY,pos.fZ+kPhysZOffset,kinPos.x,kinPos.y,kinPos.z );
                 // use the position
                 fKinematicActor->moveGlobalPosition(newPos);
             }
-            else if (fEnabled)
+            else
             {
                 if (plSimulationMgr::fExtraProfile)
                     SimLog("Setting kinematic from %f,%f,%f to %f,%f,%f",pos.fX,pos.fY,pos.fZ+kPhysZOffset,kinPos.x,kinPos.y,kinPos.z );
@@ -488,9 +491,9 @@ void plPXPhysicalControllerCore::ISetKinematicLoc(const hsMatrix44& l2w)
     // add z offset
     kPos.fZ += kPhysZOffset;
     // Update the physical position of kinematic
-    if (fEnabled && fKinematicActor->readBodyFlag(NX_BF_KINEMATIC))
+    if (fEnabled || fBehavingLikeAnimatedPhys)
         fKinematicActor->moveGlobalPosition(plPXConvert::Point(kPos));
-    else if (fEnabled)
+    else
         fKinematicActor->setGlobalPosition(plPXConvert::Point(kPos));
 }
 void plPXPhysicalControllerCore::IGetPositionSim(hsPoint3& pos) const


### PR DESCRIPTION
The ladder region fixes introduced the panic link. Now we should always
verify the following when changing anything related to the stupid kinematic
actor turd:
- Linking to any Ahnoying Sphere's main LIP does not result in a panic link
- The Teledahn hatch ladder camera works as expected
- That the game doesn't crash on anything stupid, like a nil SceneNode
