### PR TITLE
Added new SDL descriptor syntax STATEDIFF

### DIFF
--- a/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
@@ -514,6 +514,7 @@ private:
     bool IParseVarDesc(const char* fileName, hsStream* stream, char token[], plStateDescriptor*& curDesc, 
         plVarDescriptor*& curVar) const;
     bool IParseStateDesc(const char* fileName, hsStream* stream, char token[], plStateDescriptor*& curDesc) const;
+    bool IParseStateDiff(const char* fileName, hsStream* stream, char token[], plStateDescriptor*& curDesc) const;
 
     void DebugMsg(const char* fmt, ...) const;
     void DebugMsgV(const char* fmt, va_list args) const;

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDLDescriptor.h
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDLDescriptor.h
@@ -244,6 +244,7 @@ public:
     void SetVersion(int v) { fVersion=v; }
     void SetName(const char* n) { delete [] fName; fName=hsStrcpy(n); }
     void AddVar(plVarDescriptor* v) { fVarsList.push_back(v); }
+    void DelVar( const char * n );
     void SetFilename( const char * n ) { fFilename=n;}
     
     plVarDescriptor* FindVar(const char* name, int* idx=nil) const;

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateDescriptor.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateDescriptor.cpp
@@ -63,6 +63,17 @@ void plStateDescriptor::IDeInit()
     fVarsList.clear();
 }
 
+void plStateDescriptor::DelVar(const char* n)  { 
+    for(VarsList::iterator it = fVarsList.begin(); it != fVarsList.end(); it++)
+    {
+        if(!stricmp((*it)->GetName(), n))
+        {
+            fVarsList.erase(it);
+            break;
+        }
+    }
+}
+
 plVarDescriptor* plStateDescriptor::FindVar(const char* name, int* idx) const
 {
     VarsList::const_iterator it;


### PR DESCRIPTION
Allows SDL changes to be more readable. STATEDIFFS contain
VERSION, ADD, REMOVE, and UPDATE entries

This isn't really complete, as the server will need to support the new SDL syntax as well, but the client doesn't asplode, so this part is okay at least.
