### PR TITLE
Login fixes

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -1037,7 +1037,7 @@ void NetCommSetMsgPreHandler (
 
 //============================================================================
 void NetCommSetAccountUsernamePassword (
-    wchar_t               username[],
+    const wchar_t       username[],
     const ShaDigest &   namePassHash
 ) {
     StrCopy(s_iniAccountUsername, username, arrsize(s_iniAccountUsername));

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.h
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.h
@@ -102,7 +102,7 @@ const ARRAY(NetCommPlayer) &        NetCommGetPlayerList ();
 unsigned                            NetCommGetPlayerCount ();
 bool                                NetCommIsLoginComplete ();
 void                                NetCommSetReadIniAccountInfo (bool readFromIni);
-void                                NetCommSetAccountUsernamePassword (wchar_t username[], const ShaDigest &  namePassHash);
+void                                NetCommSetAccountUsernamePassword (const wchar_t username[], const ShaDigest &  namePassHash);
 void                                NetCommSetAuthTokenAndOS (wchar_t authToken[], wchar_t os[]);
 ENetError                           NetCommGetAuthResult ();
 


### PR DESCRIPTION
Fixes logins with the "regular" SHA-1 hashing by reintroducing eap's bug. Evidently, eap was too stupid to understand endianness, or he just enjoyed doing stupid stuff. I think both are true.
