### PR TITLE
Proper SetClipboardData usage

### DIFF
--- a/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
+++ b/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
@@ -107,8 +107,7 @@ void plClipboard::SetClipboardText(const plString& text)
     target[len] = '\0';
     ::GlobalUnlock(copy); 
 
-    // Place the handle on the clipboard. 
-    ::SetClipboardData(CF_UNICODETEXT, target);
+    ::SetClipboardData(CF_UNICODETEXT, copy);
     ::CloseClipboard();
 #endif
 }


### PR DESCRIPTION
Previously, pointer to buffer was passed as parameter. That worked, but there is nothing in documentation about this and I'm not sure about side effects (may be anything, from memory leak to occasional crash). So just to be safe, it is changed to windows handle. Also, obvious comment is obvious.
