### PR TITLE
Fix plUnifiedTime::SetGMTime

### DIFF
--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.cpp
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.cpp
@@ -257,9 +257,9 @@ void plUnifiedTime::ToCurrentTime()
     SetToUTC();
 }
 
-hsBool plUnifiedTime::SetGMTime(short year, short month, short day, short hour, short minute, short second, unsigned long usec, int dst)
+hsBool plUnifiedTime::SetGMTime(short year, short month, short day, short hour, short minute, short second, unsigned long usec)
 {
-    if( !SetTime( year, month, day, hour, minute, second, usec, dst ) )
+    if( !SetTime( year, month, day, hour, minute, second, usec, 0 ) )
         return false;
 
     fSecs -= IGetLocalTimeZoneOffset();

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.h
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.h
@@ -128,7 +128,7 @@ public:
     void SetSecsDouble(double secs);
     void SetMicros(const uint32_t micros) { fMicros = micros; }
     hsBool SetTime(short year, short month, short day, short hour, short minute, short second, unsigned long usec=0, int dst=-1);
-    hsBool SetGMTime(short year, short month, short day, short hour, short minute, short second, unsigned long usec=0, int dst=-1);
+    hsBool SetGMTime(short year, short month, short day, short hour, short minute, short second, unsigned long usec=0);
     hsBool SetToUTC();
     void ToCurrentTime();
     void ToEpoch() { fSecs = 0; fMicros = 0;}


### PR DESCRIPTION
The default value of the "dst" argument must be 0, because -1 leads to incorrect results when the given time falls into local DST. However, a "dst" argument makes no sense on a method that deals with GMT anyway, so remove it entirely.

An alternative and somewhat more elegant fix would be to implement SetGMTime using the timegm() function where available (at least Mac OS X and Linux), but since this fix appears to work I didn’t bother figuring out how to have CMake detect that.

Here’s the trivial test that fails in the current implementation and succeeds after the fix – if anyone ever feels like setting up a unit test framework, that could be integrated there:

``` c++
// test with two dates, one at the beginning and one in the middle of the year, so that one of them falls into local DST (if present)
plUnifiedTime t1;
t1.SetGMTime(1984, 1, 24, 18, 27, 43, 123456);
assert(t1.GetYear() == 1984);
assert(t1.GetMonth() == 1);
assert(t1.GetDay() == 24);
assert(t1.GetHour() == 18);
assert(t1.GetMinute() == 27);
assert(t1.GetSecond() == 43);
assert(t1.GetMicros() == 123456);

plUnifiedTime t2;
t2.SetGMTime(2003, 7, 10, 5, 46, 14, 654321);
assert(t2.GetYear() == 2003);
assert(t2.GetMonth() == 7);
assert(t2.GetDay() == 10);
assert(t2.GetHour() == 5);
assert(t2.GetMinute() == 46);
assert(t2.GetSecond() == 14);
assert(t2.GetMicros() == 654321);
```
