### PR TITLE
Fix Patcher Progress

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
@@ -183,7 +183,8 @@ static void ManifestDownloaded(
             PatcherLog(kInfo, "    Enqueueing %s: File Sizes Differ", fileName);
 
         // If we're still here, then we need to update the file.
-        patcher->GetProgress()->SetLength((float)mfs.fileSize + patcher->GetProgress()->GetMax());
+        float size = mfs.zipSize ? (float)mfs.zipSize : (float)mfs.fileSize;
+        patcher->GetProgress()->SetLength(size + patcher->GetProgress()->GetMax());
         patcher->RequestFile(mfs.downloadName, mfs.clientName);
     }
 


### PR DESCRIPTION
Previously, the uncompressed size was always used as a maximum value. This would be acceptable, but download stream only increments the progress by the number of bytes read from the stream. This changeset fixes the maximum progress size to be the compressed size if the file is compressed; otherwise, we fall back to using the uncompressed size.
