### PR TITLE
Fix crashes caused by poor iterator usage in pfLocalizationDataMgr.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
@@ -640,7 +640,9 @@ void LocalizationDatabase::IVerifySet(const std::wstring &ageName, const std::ws
 {
     LocalizationXMLFile::set& theSet = fData[ageName][setName];
     LocalizationXMLFile::set::iterator curElement = theSet.begin();
-    std::wstring defaultLanguage = hsStringToWString(plLocalization::GetLanguageName((plLocalization::Language)0));
+    wchar_t *wDefLang = hsStringToWString(plLocalization::GetLanguageName((plLocalization::Language)0));
+    std::wstring defaultLanguage = wDefLang;
+    delete [] wDefLang;
 
     while (curElement != theSet.end())
     {


### PR DESCRIPTION
The existing error-logging sections crash if they're ever called thanks to poor use of iterators.  This allows the game to continue along with localization XML files containing errors and properly reports them in the log.
