### PR TITLE
Added DEPR_STR macro to help plStringification.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,11 @@ if(PLASMA_USE_SSE)
     add_definitions(-DHAVE_SSE)
 endif(PLASMA_USE_SSE)
 
+option(NO_OLD_STRINGS "Disabled deprecated string functions?" OFF)
+if(NO_OLD_STRINGS)
+    add_definitions(-DDISABLE_DEPRECATED_STRINGS)
+endif(NO_OLD_STRINGS)
+
 #TODO: Make the OpenSSL includes less promiscuous so this isn't needed
 include_directories(${OPENSSL_INCLUDE_DIR})
 

--- a/Sources/Plasma/CoreLib/plString.h
+++ b/Sources/Plasma/CoreLib/plString.h
@@ -42,6 +42,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define _TEMP_CONVERT_TO_CONST_CHAR(x)      ((x).c_str())
 #define _TEMP_CONVERT_TO_WCHAR_T(x)         ((x).ToWchar().GetData())
 
+#ifdef DISABLE_DEPRECATED_STRINGS
+#define DEPR_STR void*,
+#else
+#define DEPR_STR
+#endif
+
 typedef unsigned int UniChar;
 
 template <typename _Ch>

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plLoggable.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plLoggable.cpp
@@ -84,7 +84,7 @@ void plLoggable::SetLog( plStatusLog * log, bool deleteOnDestruct/*=false */)
 }
 
 
-bool plLoggable::Log( const char * str ) const
+bool plLoggable::Log(DEPR_STR const char * str ) const
 {
     return Log(plString::FromUtf8(str));
 }
@@ -104,7 +104,7 @@ bool plLoggable::Log(const plString& str) const
     return true;
 }
 
-bool plLoggable::LogF( const char * fmt, ... ) const
+bool plLoggable::LogF(DEPR_STR const char * fmt, ... ) const
 {
     va_list args;
     va_start(args, fmt);
@@ -114,34 +114,34 @@ bool plLoggable::LogF( const char * fmt, ... ) const
     return ret;
 }
 
-bool plLoggable::LogV( const char * fmt, va_list args ) const
+bool plLoggable::LogV(DEPR_STR const char * fmt, va_list args ) const
 {
     return Log(plString::IFormat(fmt, args));
 }
 
-bool plLoggable::DebugMsgV(const char* fmt, va_list args) const
+bool plLoggable::DebugMsgV(DEPR_STR const char* fmt, va_list args) const
 {
     return Log(_TEMP_CONVERT_FROM_LITERAL("DBG: ") + plString::IFormat(fmt, args));
 }
 
-bool plLoggable::ErrorMsgV(const char* fmt, va_list args) const
+bool plLoggable::ErrorMsgV(DEPR_STR const char* fmt, va_list args) const
 {
     return Log(_TEMP_CONVERT_FROM_LITERAL("ERR: ") + plString::IFormat(fmt, args));
 }
 
-bool plLoggable::WarningMsgV(const char* fmt, va_list args) const
+bool plLoggable::WarningMsgV(DEPR_STR const char* fmt, va_list args) const
 {
     return Log(_TEMP_CONVERT_FROM_LITERAL("WRN: ") + plString::IFormat(fmt, args));
 }
 
-bool plLoggable::AppMsgV(const char* fmt, va_list args) const
+bool plLoggable::AppMsgV(DEPR_STR const char* fmt, va_list args) const
 {
     return Log(_TEMP_CONVERT_FROM_LITERAL("APP: ") + plString::IFormat(fmt, args));
 }
 
 ///////////////////////////////////////////////////////////////
 
-bool plLoggable::DebugMsg(const char* fmt, ...) const
+bool plLoggable::DebugMsg(DEPR_STR const char* fmt, ...) const
 {
     va_list args;
     va_start(args, fmt);
@@ -151,7 +151,7 @@ bool plLoggable::DebugMsg(const char* fmt, ...) const
     return ret;
 }
 
-bool plLoggable::ErrorMsg(const char* fmt, ...) const
+bool plLoggable::ErrorMsg(DEPR_STR const char* fmt, ...) const
 {
     va_list args;
     va_start(args, fmt);
@@ -161,7 +161,7 @@ bool plLoggable::ErrorMsg(const char* fmt, ...) const
     return ret;
 }
 
-bool plLoggable::WarningMsg(const char* fmt, ...) const
+bool plLoggable::WarningMsg(DEPR_STR const char* fmt, ...) const
 {
     va_list args;
     va_start(args, fmt);
@@ -171,7 +171,7 @@ bool plLoggable::WarningMsg(const char* fmt, ...) const
     return ret;
 }
 
-bool plLoggable::AppMsg(const char* fmt, ...) const
+bool plLoggable::AppMsg(DEPR_STR const char* fmt, ...) const
 {
     va_list args;
     va_start(args, fmt);

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plLoggable.h
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plLoggable.h
@@ -70,18 +70,18 @@ public:
 
     // logging
 
-    virtual bool Log( const char * str ) const;
+    virtual bool Log(DEPR_STR const char * str ) const;
     virtual bool Log(const plString& str) const;
-    virtual bool LogF( const char * fmt, ... ) const;
-    virtual bool LogV( const char * fmt, va_list args ) const;
-    virtual bool ErrorMsgV(const char* fmt, va_list args) const ;
-    virtual bool DebugMsgV(const char* fmt, va_list args) const ;
-    virtual bool WarningMsgV(const char* fmt, va_list args) const ;
-    virtual bool AppMsgV(const char* fmt, va_list args) const ;
-    virtual bool ErrorMsg(const char* fmt, ...) const ;
-    virtual bool DebugMsg(const char* fmt, ...) const ;
-    virtual bool WarningMsg(const char* fmt, ...) const ;
-    virtual bool AppMsg(const char* fmt, ...) const ;
+    virtual bool LogF(DEPR_STR const char * fmt, ... ) const;
+    virtual bool LogV(DEPR_STR const char * fmt, va_list args ) const;
+    virtual bool ErrorMsgV(DEPR_STR const char* fmt, va_list args) const ;
+    virtual bool DebugMsgV(DEPR_STR const char* fmt, va_list args) const ;
+    virtual bool WarningMsgV(DEPR_STR const char* fmt, va_list args) const ;
+    virtual bool AppMsgV(DEPR_STR const char* fmt, va_list args) const ;
+    virtual bool ErrorMsg(DEPR_STR const char* fmt, ...) const ;
+    virtual bool DebugMsg(DEPR_STR const char* fmt, ...) const ;
+    virtual bool WarningMsg(DEPR_STR const char* fmt, ...) const ;
+    virtual bool AppMsg(DEPR_STR const char* fmt, ...) const ;
 };
 
 #endif  // plLoggable_inc


### PR DESCRIPTION
You pass this as the first argument to a function that should be deprecated in favour of a plString version.

By default, the macro expands to nothing; but you can set NO_OLD_STRINGS in CMake which will cause it to add a void\* parameter, causing all calls to that function to break.
