### PR TITLE
Restore minimum resolution 800x600.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue4.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue4.cpp
@@ -583,11 +583,13 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetSupportedDisplayModes, "Returns a li
     PyObject *retVal = PyList_New(0);
     for (std::vector<plDisplayMode>::iterator curArg = res.begin(); curArg != res.end(); ++curArg)
     {
-        PyObject* tup = PyTuple_New(2);
-        PyTuple_SetItem(tup, 0, PyInt_FromLong((long)(*curArg).Width));
-        PyTuple_SetItem(tup, 1, PyInt_FromLong((long)(*curArg).Height));
+        if ((*curArg).Width >= 800 && (*curArg).Height >= 600) {
+            PyObject* tup = PyTuple_New(2);
+            PyTuple_SetItem(tup, 0, PyInt_FromLong((long)(*curArg).Width));
+            PyTuple_SetItem(tup, 1, PyInt_FromLong((long)(*curArg).Height));
 
-        PyList_Append(retVal, tup);
+            PyList_Append(retVal, tup);
+        }
     }
     return retVal;
 }


### PR DESCRIPTION
While the game appears to work fine in smaller resolutions such as 640x480, the clutter they add makes the slider harder to use, so restoring the limitation to 800x600 and above, previously enforced by the hardcoded resolution lists in xOptionsMenu.py, seems justified.

This is intended for http://foundry.openuru.org/fisheye/cru/MOULSCRIPT-20, but I thought I’d run it by here first for feedback.
