### PR TITLE
Fix a typo from way back when

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientGroup.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientGroup.h
@@ -100,7 +100,7 @@ public:
         std::set<OwnedGroup>::iterator it=IFind(grpId);
         if (it != fGroups.end())
         {
-            OwnedGroup grp(it->fGroup, it->fOwnIt);
+            OwnedGroup grp(grpId, ownIt);
             fGroups.erase(it);
             fGroups.insert(grp);
         }


### PR DESCRIPTION
As pointed out at bitbucket here: https://bitbucket.org/cwalther/cwe/changeset/140e56cf20c9
This line was likely a typo, and may have been causing fOwnIt to have an inconsistent state for all builds since the initial commit (fa6d5057).  This new commit fixes that.
