### PR TITLE
Fix #169

### DIFF
--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -1472,6 +1472,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
         tempConsole.ExecuteFile(gipath);
     }
 
+#ifdef PLASMA_EXTERNAL_RELEASE
     // If another instance is running, exit.  We'll automatically release our
     // lock on the mutex when our process exits
     HANDLE hOneInstance = CreateMutex(nil, FALSE, "UruExplorer");
@@ -1498,6 +1499,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
         }
         return PARABLE_NORMAL_EXIT;
     }
+#endif
 
     FILE *serverIniFile = _wfopen(serverIni, L"rb");
     if (serverIniFile)


### PR DESCRIPTION
Allow the execution of multiple internal clients. The crash that was observed before was fixed with the removal of pnAcLog.

This is how I tested the Ahnoying Quabs.
