### PR TITLE
Avoid truncated window size after going from fullscreen to a window of the same size

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -2181,9 +2181,9 @@ void plClient::ResetDisplayDevice(int Width, int Height, int ColorDepth, hsBool 
 
     WindowActivate(false);
 
-    ResizeDisplayDevice(Width, Height, Windowed);
-
     fPipeline->ResetDisplayDevice(Width, Height, ColorDepth, Windowed, NumAASamples, MaxAnisotropicSamples, VSync);
+
+    ResizeDisplayDevice(Width, Height, Windowed);
 
     WindowActivate(true);
 }
@@ -2202,7 +2202,8 @@ void plClient::ResizeDisplayDevice(int Width, int Height, hsBool Windowed)
     uint32_t winStyle, winExStyle;
     if( Windowed )
     {
-        winStyle = WS_OVERLAPPEDWINDOW;
+        // WS_VISIBLE appears necessary to avoid leaving behind framebuffer junk when going from windowed to a smaller window
+        winStyle = WS_OVERLAPPEDWINDOW | WS_VISIBLE;
         winExStyle = WS_EX_APPWINDOW | WS_EX_WINDOWEDGE;
     } else {
         winStyle = WS_POPUP;


### PR DESCRIPTION
As discussed at https://bitbucket.org/OpenUru_org/cwe-ou/pull-request/18/fix-improperly-calculated-window-size-in#comment-8535 :

When going from fullscreen to windowed without changing the resolution, the window would end up smaller than intended, because the display resolution was still small (not reset to the full desktop resolution yet) at the time the window size was set, and Windows would clamp the total window size to slightly larger than the display resolution.

The display resolution must be reset before setting the window size (as the old Cyan code did).

I also found that on Windows XP, for whatever reason, setting window style WS_VISIBLE appears necessary to prevent the contents of the previous window from staying behind when going from windowed to a smaller window.

Tested on Windows XP (in CWE-ou only) and Windows 7 (CWE-ou and H-uru/Plasma).
