### PR TITLE
Fix a bug that should never happen

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -2334,7 +2334,7 @@ void plClient::IDetectAudioVideoSettings()
     plPipeline::fDefaultPipeParams.VSync = false;
 
     // card specific overrides
-    if(strstr(rec->GetDriverDesc(), "FX 5200"))
+    if(rec->GetDriverDesc() && strstr(rec->GetDriverDesc(), "FX 5200"))
     {
         plPipeline::fDefaultPipeParams.AntiAliasingAmount = 0;
     }


### PR DESCRIPTION
This fixes a crash that occurs on systems with no Direct3D device available. The device selector returns a NULL string, which is then strstr'ed for some ancient nvidia card. For now, let's wrap that in a NULL check. Eventually, when we scrub plClient.cpp and winmain.cpp, that hack should just be dropped.
