### PR TITLE
Add functions to fix KI Chat scrolling issue.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -249,6 +249,14 @@ void    pfGUIMultiLineEditCtrl::SetScrollPosition( int32_t topLine )
         fDialog->GetHandler()->DoSomething(this);
 }
 
+//// GetScrollPosition ///////////////////////////////////////////////////////
+
+int32_t   pfGUIMultiLineEditCtrl::GetScrollPosition()
+{
+
+    return fScrollPos;
+}
+
 //// MoveCursor - by direction command////////////////////////////////////////////////
 void    pfGUIMultiLineEditCtrl::MoveCursor( Direction dir )
 {

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -220,6 +220,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         };
 
         void    SetScrollPosition( int32_t topLine );
+        int32_t GetScrollPosition();
         void    MoveCursor( Direction dir );
 
         void    InsertChar( char c );

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
@@ -78,6 +78,30 @@ void pyGUIControlMultiLineEdit::SetScrollPosition( int32_t topLine )
     }
 }
 
+int32_t pyGUIControlMultiLineEdit::GetScrollPosition()
+{
+    if ( fGCkey )
+    {
+        // get the pointer to the modifier
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if ( pbmod )
+            return pbmod->GetScrollPosition();
+    }
+    return 0;
+}
+
+bool pyGUIControlMultiLineEdit::IsAtEnd()
+{
+    if ( fGCkey )
+    {
+        // get the pointer to the modifier
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if ( pbmod )
+            return pbmod->ShowingEndOfBuffer();
+    }
+    return false;
+}
+
 void pyGUIControlMultiLineEdit::MoveCursor( int32_t dir)
 {
     if ( fGCkey )

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
@@ -77,6 +77,8 @@ public:
     virtual void    Clickable( void );
     virtual void    Unclickable( void );
     virtual void    SetScrollPosition( int32_t topLine );
+    virtual int32_t GetScrollPosition();
+    virtual bool    IsAtEnd();
     virtual void    MoveCursor( int32_t dir );
     virtual void    ClearBuffer( void );
     virtual void    SetText( const char *asciiText );

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
@@ -91,6 +91,16 @@ PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, setScrollPosition, args)
     PYTHON_RETURN_NONE;
 }
 
+PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, getScrollPosition)
+{
+    return PyLong_FromLong(self->fThis->GetScrollPosition());
+}
+
+PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, isAtEnd)
+{
+    PYTHON_RETURN_BOOL(self->fThis->IsAtEnd());
+}
+
 PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, moveCursor, args)
 {
     long dir;
@@ -398,6 +408,8 @@ PYTHON_START_METHODS_TABLE(ptGUIControlMultiLineEdit)
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, unclickable, "Makes this listbox not clickable by the user.\n"
                 "Useful when just displaying a list that is not really selectable."),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, setScrollPosition, "Params: topLine\nSets the what line is the top line."),
+    PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, getScrollPosition, "Gets what line is the top line."),
+    PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, isAtEnd, "Returns true if the end of the buffer has been reached."),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, moveCursor, "Params: direction\nMove the cursor in the specified direction (see PtGUIMultiLineDirection)"),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, clearBuffer, "Clears all text from the multi-line edit control."),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, setString, "Params: asciiText\nSets the multi-line edit control string."),


### PR DESCRIPTION
Fixes #180 (if combined with the moul-scripts commit). These two Python/Plasma functions are used in the moul-scripts fix for the scrolling KI Chat issue.
