### PR TITLE
pySimpleStateVariable IsUsed Binding

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pySDL.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySDL.cpp
@@ -284,3 +284,10 @@ bool pySimpleStateVariable::IsAlwaysNew() const
     plVarDescriptor *varDesc = fVar->GetVarDescriptor();
     return varDesc->IsAlwaysNew();
 }
+
+bool pySimpleStateVariable::IsUsed() const
+{
+    if (fVar)
+        return fVar->IsUsed();
+    return false;
+}

--- a/Sources/Plasma/FeatureLib/pfPython/pySDL.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pySDL.h
@@ -141,6 +141,7 @@ public:
     const char *GetDefault() const;
     bool    IsAlwaysNew() const;
     bool    IsInternal() const;
+    bool    IsUsed() const;
 
 };
 

--- a/Sources/Plasma/FeatureLib/pfPython/pySDLGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySDLGlue.cpp
@@ -264,6 +264,11 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptSimpleStateVariable, isInternal)
     PYTHON_RETURN_BOOL(self->fThis->IsInternal());
 }
 
+PYTHON_METHOD_DEFINITION_NOARGS(ptSimpleStateVariable, isUsed)
+{
+    PYTHON_RETURN_BOOL(self->fThis->IsUsed());
+}
+
 PYTHON_START_METHODS_TABLE(ptSimpleStateVariable)
     PYTHON_METHOD(ptSimpleStateVariable, setByte, "Params: val,idx=0\nSets a byte variable's value"),
     PYTHON_METHOD(ptSimpleStateVariable, setShort, "Params: val,idx=0\nSets a short variable's value"),
@@ -285,6 +290,7 @@ PYTHON_START_METHODS_TABLE(ptSimpleStateVariable)
     PYTHON_METHOD_NOARGS(ptSimpleStateVariable, getDefault, "Returns the variable's default"),
     PYTHON_METHOD_NOARGS(ptSimpleStateVariable, isAlwaysNew, "Is this variable always new?"),
     PYTHON_METHOD_NOARGS(ptSimpleStateVariable, isInternal, "Is this an internal variable?"),
+    PYTHON_METHOD_NOARGS(ptSimpleStateVariable, isUsed, "Is this variable used?"),
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition


### PR DESCRIPTION
This lets python scripts determine if variables in SDL blobs are used (at the default).

H-uru/moul-scripts#42 depends on this PR.
