### PR TITLE
Fix Cloth Links

### DIFF
--- a/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.cpp
@@ -814,7 +814,7 @@ void VaultAgeLinkNode::GetSpawnPoints (plSpawnPointVec * out) const {
         if ( izer2.size() > 1)
             point.fSpawnPt = izer2[1];
         if ( izer2.size() > 2)
-            point.fSpawnPt = izer2[2];
+            point.fCameraStack = izer2[2];
 
         out->push_back(point);
     }


### PR DESCRIPTION
A typo introduced in 49dfb4e5 caused camera stacks in AgeLink nodes to overwrite spawn point names. This broke shell and journey cloth links in the Relto bookshelf.
