### PR TITLE
Window shouldn't have a resizing border

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -2203,7 +2203,7 @@ void plClient::ResizeDisplayDevice(int Width, int Height, bool Windowed)
     if( Windowed )
     {
         // WS_VISIBLE appears necessary to avoid leaving behind framebuffer junk when going from windowed to a smaller window
-        winStyle = WS_OVERLAPPEDWINDOW | WS_VISIBLE;
+        winStyle = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_VISIBLE;
         winExStyle = WS_EX_APPWINDOW | WS_EX_WINDOWEDGE;
     } else {
         winStyle = WS_POPUP;


### PR DESCRIPTION
Resizing the window (which now that the cursor can go outside of the window is much easier to do inadvertently) distorts the image and makes the mouse cursor disappear. As long as the engine cannot properly deal with it, the window should not be resizable.

Skoader has implemented this on the OU fork, but apparently his fix has never made it here.

Of course implementing proper resizing would be nicer, but as a quick fix this will do.
