### PR TITLE
Fix MaxPlasmaMtls to not require missing Bink files

### DIFF
--- a/Sources/Tools/MaxPlasmaMtls/CMakeLists.txt
+++ b/Sources/Tools/MaxPlasmaMtls/CMakeLists.txt
@@ -8,12 +8,7 @@ include_directories("../../Plasma/PubUtilLib")
 include_directories("../../Plasma/PubUtilLib/inc")
 include_directories(${3dsm_INCLUDE_DIR})
 
-if(Bink_SDK_AVAILABLE)
-    include_directories(${Bink_INCLUDE_DIR})
-endif()
-
 set(MaxPlasmaMtls_HEADERS
-    plBinkBitmap.h
     plBMSampler.h
     plDetailCurveCtrl.h
     plMaterialRefMsg.h
@@ -85,7 +80,6 @@ set(MaxPlasmaMtls_RESOURCES
 )
 
 set(MaxPlasmaMtls_SOURCES
-    plBinkBitmap.cpp
     plBMSampler.cpp
     plDetailCurveCtrl.cpp
     plDrawCurve.cpp

--- a/Sources/Tools/MaxPlasmaMtls/plMtlImport.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/plMtlImport.cpp
@@ -54,7 +54,6 @@ extern ClassDesc2* GetDynamicTextLayerDesc();
 extern ClassDesc2* GetClothingMtlDesc();
 extern ClassDesc2* GetAngleAttenLayerDesc();
 extern ClassDesc2* GetStealthClassDesc();
-extern ClassDesc2* GetBinkClassDesc();
 extern ClassDesc2* GetMAXCameraLayerDesc();
 
 int         plPlasmaMtlImport::GetNumMtlDescs( void )
@@ -79,7 +78,7 @@ ClassDesc2  *plPlasmaMtlImport::GetMtlDesc( int i )
         case 10: return GetClothingMtlDesc();
         case 11: return GetAngleAttenLayerDesc();
         case 12: return GetStealthClassDesc();
-        case 13: return GetBinkClassDesc();
+        case 13: return NULL;
         case 14: return GetMAXCameraLayerDesc();
         default: return 0;
     }


### PR DESCRIPTION
This apparently got missed when fixing Plasma to compile without the missing Bink files (probably because others don't have the Max SDK components enabled in their build).  Note that this just fixes compilation and linking -- the plugin functionality is completely untested.
