### PR TITLE
Proper detection for G++ and Clang for the C++11 flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,16 @@
 project(Plasma)
 cmake_minimum_required(VERSION 2.8)
 
+# Detect Clang compiler
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_COMPILER_IS_CLANGXX 1)
+endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+
+# Require C++11
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+endif()
+
 # HeadSpin Configuration
 if(WIN32 AND NOT CYGWIN)
     add_definitions(-DHS_BUILD_FOR_WIN32)
@@ -8,10 +18,6 @@ endif(WIN32 AND NOT CYGWIN)
 if(UNIX)
     add_definitions(-DHS_BUILD_FOR_UNIX)
 endif(UNIX)
-
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-    add_definitions(-std=c++0x)
-endif()
 # End HeadSpin Configuration
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")


### PR DESCRIPTION
This correctly adds `-std=c++0x` to the build when the compiler is g++ or clang.
