### PR TITLE
Deprecate and remove NEWZERO macro

### DIFF
--- a/Sources/Plasma/Apps/plClientPatcher/UruPlayer.cpp
+++ b/Sources/Plasma/Apps/plClientPatcher/UruPlayer.cpp
@@ -631,8 +631,7 @@ static void ProcessManifest (void * param) {
                     );
 
                     if (i < kMaxManifestFileRequests) {
-                        ProgressStream * stream;
-                        stream = NEWZERO(ProgressStream);
+                        ProgressStream * stream = new ProgressStream;
                         if (!stream->Open(path, "wb")) {
 #ifdef PLASMA_EXTERNAL_RELEASE
                             MessageBox(nil, s_fileOpenError, "URU Launcher", MB_ICONERROR);

--- a/Sources/Plasma/Apps/plUruLauncher/SelfPatcher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/SelfPatcher.cpp
@@ -198,7 +198,7 @@ static void ManifestCallback (
         SetText("Downloading new patcher...");
 
         StrToAnsi(ansi, s_newPatcherFile, arrsize(ansi));
-        SelfPatcherStream * stream = NEWZERO(SelfPatcherStream);
+        SelfPatcherStream * stream = new SelfPatcherStream;
         if (!stream->Open(ansi, "wb"))
             ErrorAssert(__LINE__, __FILE__, "Failed to create file: %s, errno: %u", ansi, errno);
 

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -446,9 +446,6 @@ inline float hsDegreesToRadians(float deg) { return float(deg * (M_PI / 180)); }
 inline float hsRadiansToDegrees(float rad) { return float(rad * (180 / M_PI)); }
 #define hsInvert(a) (1 / (a))
 
-#include <new>
-#define NEWZERO(t)              new(calloc(sizeof(t), 1)) t
-
 #ifdef _MSC_VER
 #   define ALIGN(n) __declspec(align(n))
 #else

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -1223,7 +1223,7 @@ void pfConsole::AddLineF(const char * fmt, ...) {
 //============================================================================
 void pfConsole::RunCommandAsync (const char cmd[]) {
 
-    plConsoleMsg * consoleMsg = NEWZERO(plConsoleMsg);
+    plConsoleMsg * consoleMsg = new plConsoleMsg;
     consoleMsg->SetCmd(plConsoleMsg::kExecuteLine);
     consoleMsg->SetString(cmd);
 //  consoleMsg->SetBreakBeforeDispatch(true);

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -6036,7 +6036,7 @@ PF_CONSOLE_GROUP( Age )
 
 PF_CONSOLE_CMD(Age, ShowSDL, "", "Prints the age SDL values")
 {
-    plStateDataRecord * rec = NEWZERO(plStateDataRecord);
+    plStateDataRecord * rec = new plStateDataRecord;
     if (!VaultAgeGetAgeSDL(rec)) {
         PrintString("Age SDL not found");
         delete rec;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
@@ -796,7 +796,7 @@ bool    pfGameUIInputInterface::InterpretInputEvent( plInputEventMsg *pMsg )
                 if ((keymap->GetKey1().IsSatisfiedBy(combo)) || (keymap->GetKey2().IsSatisfiedBy(combo)))
                 {
                     // tell the KI to take the shot
-                    plConsoleMsg * consoleMsg = NEWZERO(plConsoleMsg);
+                    plConsoleMsg * consoleMsg = new plConsoleMsg;
                     consoleMsg->SetCmd(plConsoleMsg::kExecuteLine);
                     consoleMsg->SetString("Game.KITakePicture");
                     consoleMsg->Send(nil, true);

--- a/Sources/Plasma/FeatureLib/pfGameMgr/BlueSpiral/pfGmBlueSpiral.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/BlueSpiral/pfGmBlueSpiral.cpp
@@ -58,8 +58,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 struct IBlueSpiral {
     pfGmBlueSpiral * gameCli;
-    
-    IBlueSpiral (pfGmBlueSpiral * gameCli);
+
+    IBlueSpiral (pfGmBlueSpiral * gameCli) : gameCli(gameCli) { }
 
     // pfGameCli event notification handlers
     void Recv           (GameMsgHeader * msg, void * param);
@@ -88,7 +88,7 @@ static pfGameCli * BlueSpiralFactory (
     unsigned    gameId,
     plKey       receiver
 ) {
-    return NEWZERO(pfGmBlueSpiral)(gameId, receiver);
+    return new pfGmBlueSpiral(gameId, receiver);
 }
 
 //============================================================================
@@ -111,15 +111,9 @@ AUTO_INIT_FUNC(RegisterBlueSpiralFactory) {
 ***/
 
 //============================================================================
-IBlueSpiral::IBlueSpiral (pfGmBlueSpiral * gameCli)
-:   gameCli(gameCli)
-{
-}
-
-//============================================================================
 void IBlueSpiral::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -127,7 +121,7 @@ void IBlueSpiral::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
 //============================================================================
 void IBlueSpiral::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -135,7 +129,7 @@ void IBlueSpiral::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
 //============================================================================
 void IBlueSpiral::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
     
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -143,42 +137,42 @@ void IBlueSpiral::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
 //============================================================================
 void IBlueSpiral::OnOwnerChange (const Srv2Cli_Game_OwnerChange & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IBlueSpiral::RecvClothOrder (const Srv2Cli_BlueSpiral_ClothOrder & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IBlueSpiral::RecvSuccessfulHit (const Srv2Cli_BlueSpiral_SuccessfulHit & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IBlueSpiral::RecvGameWon (const Srv2Cli_BlueSpiral_GameWon & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IBlueSpiral::RecvGameOver (const Srv2Cli_BlueSpiral_GameOver & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IBlueSpiral::RecvGameStarted (const Srv2Cli_BlueSpiral_GameStarted & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -197,7 +191,7 @@ pfGmBlueSpiral::pfGmBlueSpiral (
 )
 :   pfGameCli(gameId, receiver)
 {
-    internal = NEWZERO(IBlueSpiral)(this);
+    internal = new IBlueSpiral(this);
 }
 
 //============================================================================

--- a/Sources/Plasma/FeatureLib/pfGameMgr/ClimbingWall/pfGmClimbingWall.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/ClimbingWall/pfGmClimbingWall.cpp
@@ -57,9 +57,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 ***/
 
 struct IClimbingWall {
-    pfGmClimbingWall *  gameCli;
-    
-    IClimbingWall (pfGmClimbingWall *   gameCli);
+    pfGmClimbingWall * gameCli;
+
+    IClimbingWall (pfGmClimbingWall * gameCli) : gameCli(gameCli) { }
 
     // pfGameCli event notification handlers
     void Recv           (GameMsgHeader * msg, void * param);
@@ -89,7 +89,7 @@ static pfGameCli * ClimbingWallFactory (
     unsigned    gameId,
     plKey       receiver
 ) {
-    return NEWZERO(pfGmClimbingWall)(gameId, receiver);
+    return new pfGmClimbingWall(gameId, receiver);
 }
 
 //============================================================================
@@ -112,15 +112,9 @@ AUTO_INIT_FUNC(RegisterClimbingWallFactory) {
 ***/
 
 //============================================================================
-IClimbingWall::IClimbingWall (pfGmClimbingWall * gameCli)
-:   gameCli(gameCli)
-{
-}
-
-//============================================================================
 void IClimbingWall::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -128,7 +122,7 @@ void IClimbingWall::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
 //============================================================================
 void IClimbingWall::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -136,7 +130,7 @@ void IClimbingWall::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
 //============================================================================
 void IClimbingWall::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
     
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -144,49 +138,49 @@ void IClimbingWall::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
 //============================================================================
 void IClimbingWall::OnOwnerChange (const Srv2Cli_Game_OwnerChange & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IClimbingWall::RecvNumBlockersChanged (const Srv2Cli_ClimbingWall_NumBlockersChanged & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IClimbingWall::RecvReady (const Srv2Cli_ClimbingWall_Ready & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IClimbingWall::RecvBlockersChanged (const Srv2Cli_ClimbingWall_BlockersChanged & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IClimbingWall::RecvPlayerEntered (const Srv2Cli_ClimbingWall_PlayerEntered & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IClimbingWall::RecvSuitMachineLocked (const Srv2Cli_ClimbingWall_SuitMachineLocked & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IClimbingWall::RecvGameOver (const Srv2Cli_ClimbingWall_GameOver & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -205,7 +199,7 @@ pfGmClimbingWall::pfGmClimbingWall (
 )
 :   pfGameCli(gameId, receiver)
 {
-    internal = NEWZERO(IClimbingWall)(this);
+    internal = new IClimbingWall(this);
 }
 
 //============================================================================

--- a/Sources/Plasma/FeatureLib/pfGameMgr/Heek/pfGmHeek.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/Heek/pfGmHeek.cpp
@@ -57,9 +57,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 ***/
 
 struct IHeek {
-    pfGmHeek *      gameCli;
+    pfGmHeek * gameCli;
 
-    IHeek (pfGmHeek * gameCli);
+    IHeek (pfGmHeek * gameCli) : gameCli(gameCli) { }
 
     // pfGameCli event notification handlers
     void Recv           (GameMsgHeader * msg, void * param);
@@ -94,7 +94,7 @@ static pfGameCli * HeekFactory (
 unsigned    gameId,
 plKey       receiver
 ) {
-    return NEWZERO(pfGmHeek)(gameId, receiver);
+    return new pfGmHeek(gameId, receiver);
 }
 
 //============================================================================
@@ -116,112 +116,106 @@ AUTO_INIT_FUNC(RegisterHeek) {
 ***/
 
 //============================================================================
-IHeek::IHeek (pfGmHeek * gameCli)
-:   gameCli(gameCli)
-{
-}
-
-//============================================================================
 void IHeek::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::OnOwnerChange (const Srv2Cli_Game_OwnerChange & msg) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvPlayGame (const Srv2Cli_Heek_PlayGame & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvGoodbye (const Srv2Cli_Heek_Goodbye & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvWelcome (const Srv2Cli_Heek_Welcome & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvDrop (const Srv2Cli_Heek_Drop & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvSetup (const Srv2Cli_Heek_Setup & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvLightState (const Srv2Cli_Heek_LightState & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvInterfaceState (const Srv2Cli_Heek_InterfaceState & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvCountdownState (const Srv2Cli_Heek_CountdownState & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvWinLose (const Srv2Cli_Heek_WinLose & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvGameWin (const Srv2Cli_Heek_GameWin & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IHeek::RecvPointUpdate (const Srv2Cli_Heek_PointUpdate & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -240,7 +234,7 @@ pfGmHeek::pfGmHeek (
 )
 :   pfGameCli(gameId, receiver)
 {
-    internal = NEWZERO(IHeek)(this);
+    internal = new IHeek(this);
 }
 
 //============================================================================

--- a/Sources/Plasma/FeatureLib/pfGameMgr/Marker/pfGmMarker.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/Marker/pfGmMarker.cpp
@@ -57,9 +57,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 ***/
 
 struct IMarker {
-    pfGmMarker *    gameCli;
-    
-    IMarker (pfGmMarker *   gameCli);
+    pfGmMarker * gameCli;
+
+    IMarker (pfGmMarker * gameCli) : gameCli(gameCli) { }
 
     // pfGameCli event notification handlers
     void Recv           (GameMsgHeader * msg, void * param);
@@ -97,7 +97,7 @@ static pfGameCli * MarkerFactory (
     unsigned    gameId,
     plKey       receiver
 ) {
-    return NEWZERO(pfGmMarker)(gameId, receiver);
+    return new pfGmMarker(gameId, receiver);
 }
 
 //============================================================================
@@ -120,15 +120,9 @@ AUTO_INIT_FUNC(RegisterMarkerFactory) {
 ***/
 
 //============================================================================
-IMarker::IMarker (pfGmMarker * gameCli)
-:   gameCli(gameCli)
-{
-}
-
-//============================================================================
 void IMarker::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -136,7 +130,7 @@ void IMarker::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
 //============================================================================
 void IMarker::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -144,7 +138,7 @@ void IMarker::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
 //============================================================================
 void IMarker::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
     
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -152,7 +146,7 @@ void IMarker::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
 //============================================================================
 void IMarker::OnOwnerChange (const Srv2Cli_Game_OwnerChange & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -160,7 +154,7 @@ void IMarker::OnOwnerChange (const Srv2Cli_Game_OwnerChange & msg) {
 //============================================================================
 void IMarker::RecvTemplateCreated (const Srv2Cli_Marker_TemplateCreated & msg, void * param) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -168,63 +162,63 @@ void IMarker::RecvTemplateCreated (const Srv2Cli_Marker_TemplateCreated & msg, v
 //============================================================================
 void IMarker::RecvTeamAssigned (const Srv2Cli_Marker_TeamAssigned & msg, void * param) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvGameType (const Srv2Cli_Marker_GameType & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvGameStarted (const Srv2Cli_Marker_GameStarted & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvGamePaused (const Srv2Cli_Marker_GamePaused & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvGameReset (const Srv2Cli_Marker_GameReset & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvGameOver (const Srv2Cli_Marker_GameOver & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvGameNameChanged (const Srv2Cli_Marker_GameNameChanged & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvTimeLimitChanged (const Srv2Cli_Marker_TimeLimitChanged & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvGameDeleted (const Srv2Cli_Marker_GameDeleted & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 
@@ -234,28 +228,28 @@ void IMarker::RecvGameDeleted (const Srv2Cli_Marker_GameDeleted & msg, void * pa
 
 //============================================================================
 void IMarker::RecvMarkerAdded (const Srv2Cli_Marker_MarkerAdded & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvMarkerDeleted (const Srv2Cli_Marker_MarkerDeleted & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvMarkerNameChanged (const Srv2Cli_Marker_MarkerNameChanged & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IMarker::RecvMarkerCaptured (const Srv2Cli_Marker_MarkerCaptured & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -274,7 +268,7 @@ pfGmMarker::pfGmMarker (
 )
 :   pfGameCli(gameId, receiver)
 {
-    internal = NEWZERO(IMarker)(this);
+    internal = new IMarker(this);
 }
 
 //============================================================================

--- a/Sources/Plasma/FeatureLib/pfGameMgr/TicTacToe/pfGmTicTacToe.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/TicTacToe/pfGmTicTacToe.cpp
@@ -61,7 +61,7 @@ struct ITicTacToe {
     char            board[3][3];
     char            myself;
     char            other;
-    
+
     ITicTacToe (pfGmTicTacToe * gameCli);
 
     // pfGameCli event notification handlers
@@ -89,7 +89,7 @@ static pfGameCli * TicTacToeFactory (
     unsigned    gameId,
     plKey       receiver
 ) {
-    return NEWZERO(pfGmTicTacToe)(gameId, receiver);
+    return new pfGmTicTacToe(gameId, receiver);
 }
 
 //============================================================================
@@ -113,7 +113,7 @@ AUTO_INIT_FUNC(RegisterTicTacToeFactory) {
 
 //============================================================================
 ITicTacToe::ITicTacToe (pfGmTicTacToe * gameCli)
-:   gameCli(gameCli)
+:   gameCli(gameCli), myself(0), other(0)
 {
     // Fill the board with space chars
     memset(board, ' ', sizeof(board));
@@ -122,7 +122,7 @@ ITicTacToe::ITicTacToe (pfGmTicTacToe * gameCli)
 //============================================================================
 void ITicTacToe::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -130,7 +130,7 @@ void ITicTacToe::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
 //============================================================================
 void ITicTacToe::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -138,7 +138,7 @@ void ITicTacToe::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
 //============================================================================
 void ITicTacToe::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
     
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -146,7 +146,7 @@ void ITicTacToe::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
 //============================================================================
 void ITicTacToe::OnOwnerChange (const Srv2Cli_Game_OwnerChange & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -163,14 +163,14 @@ void ITicTacToe::RecvGameStarted (const Srv2Cli_TTT_GameStarted & msg, void * pa
         other   = 'X';
     }
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void ITicTacToe::RecvGameOver (const Srv2Cli_TTT_GameOver & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 
@@ -185,11 +185,11 @@ void ITicTacToe::RecvMoveMade (const Srv2Cli_TTT_MoveMade & msg, void * param) {
     else
         board[msg.row][msg.col] = other;
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
-                                                                
+
 
 /*****************************************************************************
 *
@@ -204,7 +204,7 @@ pfGmTicTacToe::pfGmTicTacToe (
 )
 :   pfGameCli(gameId, receiver)
 {
-    internal = NEWZERO(ITicTacToe)(this);
+    internal = new ITicTacToe(this);
 }
 
 //============================================================================

--- a/Sources/Plasma/FeatureLib/pfGameMgr/VarSync/pfGmVarSync.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/VarSync/pfGmVarSync.cpp
@@ -57,9 +57,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 ***/
 
 struct IVarSync {
-    pfGmVarSync *   gameCli;
-    
-    IVarSync (pfGmVarSync * gameCli);
+    pfGmVarSync * gameCli;
+
+    IVarSync (pfGmVarSync * gameCli) : gameCli(gameCli) { }
 
     // pfGameCli event notification handlers
     void Recv           (GameMsgHeader * msg, void * param);
@@ -88,7 +88,7 @@ static pfGameCli * VarSyncFactory (
     unsigned    gameId,
     plKey       receiver
 ) {
-    return NEWZERO(pfGmVarSync)(gameId, receiver);
+    return new pfGmVarSync(gameId, receiver);
 }
 
 //============================================================================
@@ -111,15 +111,9 @@ AUTO_INIT_FUNC(RegisterVarSyncFactory) {
 ***/
 
 //============================================================================
-IVarSync::IVarSync (pfGmVarSync * gameCli)
-:   gameCli(gameCli)
-{
-}
-
-//============================================================================
 void IVarSync::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -127,7 +121,7 @@ void IVarSync::OnPlayerJoined (const Srv2Cli_Game_PlayerJoined & msg) {
 //============================================================================
 void IVarSync::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -135,7 +129,7 @@ void IVarSync::OnPlayerLeft (const Srv2Cli_Game_PlayerLeft & msg) {
 //============================================================================
 void IVarSync::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
     
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
@@ -143,42 +137,42 @@ void IVarSync::OnInviteFailed (const Srv2Cli_Game_InviteFailed & msg) {
 //============================================================================
 void IVarSync::OnOwnerChange (const Srv2Cli_Game_OwnerChange & msg) {
 
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IVarSync::RecvStringVarChanged (const Srv2Cli_VarSync_StringVarChanged & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IVarSync::RecvNumericVarChanged (const Srv2Cli_VarSync_NumericVarChanged & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IVarSync::RecvAllVarsSent (const Srv2Cli_VarSync_AllVarsSent & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IVarSync::RecvStringVarCreated (const Srv2Cli_VarSync_StringVarCreated & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }
 
 //============================================================================
 void IVarSync::RecvNumericVarCreated (const Srv2Cli_VarSync_NumericVarCreated & msg, void * param) {
-    pfGameCliMsg * gameCliMsg = NEWZERO(pfGameCliMsg);
+    pfGameCliMsg * gameCliMsg = new pfGameCliMsg;
     gameCliMsg->Set(gameCli, msg);
     gameCliMsg->Send(gameCli->GetReceiver());
 }                   
@@ -196,7 +190,7 @@ pfGmVarSync::pfGmVarSync (
 )
 :   pfGameCli(gameId, receiver)
 {
-    internal = NEWZERO(IVarSync)(this);
+    internal = new IVarSync(this);
 }
 
 //============================================================================

--- a/Sources/Plasma/FeatureLib/pfGameMgr/pfGameMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/pfGameMgr.cpp
@@ -76,7 +76,7 @@ struct IGameCli : THashKeyVal<unsigned> {
     Factory *           factory;
     plKey               receiver;
     unsigned            playerCount;
-    
+
     IGameCli (
         pfGameCli * gameCli,
         unsigned    gameId,
@@ -209,7 +209,7 @@ void IGameMgr::RecvGameInstance (const Srv2Cli_GameMgr_GameInstance & msg, void 
 
 //============================================================================
 void IGameMgr::RecvInviteReceived (const Srv2Cli_GameMgr_InviteReceived & msg, void * param) {
-    pfGameMgrMsg * gameMgrMsg = NEWZERO(pfGameMgrMsg);
+    pfGameMgrMsg * gameMgrMsg = new pfGameMgrMsg;
     gameMgrMsg->Set(msg);
     for (unsigned i = 0; i < s_receivers.Count(); ++i)
         gameMgrMsg->AddReceiver(s_receivers[i]);
@@ -218,7 +218,7 @@ void IGameMgr::RecvInviteReceived (const Srv2Cli_GameMgr_InviteReceived & msg, v
 
 //============================================================================
 void IGameMgr::RecvInviteRevoked (const Srv2Cli_GameMgr_InviteRevoked & msg, void * param) {
-    pfGameMgrMsg * gameMgrMsg = NEWZERO(pfGameMgrMsg);
+    pfGameMgrMsg * gameMgrMsg = new pfGameMgrMsg;
     gameMgrMsg->Set(msg);
     for (unsigned i = 0; i < s_receivers.Count(); ++i)
         gameMgrMsg->AddReceiver(s_receivers[i]);
@@ -276,12 +276,6 @@ void IGameMgr::StaticRecv (GameMsgHeader * msg) {
 ***/
 
 //============================================================================
-pfGameMgrMsg::pfGameMgrMsg () {
-
-    netMsg = nil;
-}
-
-//============================================================================
 pfGameMgrMsg::~pfGameMgrMsg () {
 
     free(netMsg);
@@ -300,13 +294,6 @@ void pfGameMgrMsg::Set (const GameMsgHeader & msg) {
 *   pfGameCliMsg
 *
 ***/
-
-//============================================================================
-pfGameCliMsg::pfGameCliMsg () {
-
-    gameCli = nil;
-    netMsg  = nil;
-}
 
 //============================================================================
 pfGameCliMsg::~pfGameCliMsg () {
@@ -403,7 +390,7 @@ void pfGameMgr::JoinGame (
         
     msg.messageBytes    = msgBytes;
 
-    GameMgrSend(&msg, NEWZERO(JoinTransState)(receiver));
+    GameMgrSend(&msg, new JoinTransState(receiver));
 }
 
 //============================================================================
@@ -431,7 +418,7 @@ void pfGameMgr::CreateGame (
     msg->createDataBytes    = initBytes;
     memcpy(msg->createData, initData, initBytes);
 
-    GameMgrSend(msg, NEWZERO(JoinTransState)(receiver));
+    GameMgrSend(msg, new JoinTransState(receiver));
 
     free(msg);
 }
@@ -462,7 +449,7 @@ void pfGameMgr::JoinCommonGame (
     msg->createDataBytes    = initBytes;
     memcpy(msg->createData, initData, initBytes);
 
-    GameMgrSend(msg, NEWZERO(JoinTransState)(receiver));
+    GameMgrSend(msg, new JoinTransState(receiver));
 
     free(msg);
 }
@@ -479,7 +466,7 @@ pfGameCli::pfGameCli (
     unsigned    gameId,
     plKey       receiver
 ) {
-    internal = NEWZERO(IGameCli)(this, gameId, receiver);
+    internal = new IGameCli(this, gameId, receiver);
 }
 
 //============================================================================
@@ -567,7 +554,9 @@ IGameCli::IGameCli (
     plKey       receiver
 ) : THashKeyVal<unsigned>(gameId)
 ,   gameCli(gameCli)
+,   factory(nil)
 ,   receiver(receiver)
+,   playerCount(0)
 {
     s_games.Add(this);
 }
@@ -651,7 +640,7 @@ TransState::TransState (unsigned transId, void * param)
 //============================================================================
 void GameMgrRegisterGameType (const GameTypeReg & reg) {
 
-    (void)NEWZERO(Factory)(reg);
+    (void)new Factory(reg);
 }
 
 //============================================================================

--- a/Sources/Plasma/FeatureLib/pfGameMgr/pfGameMgr.h
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/pfGameMgr.h
@@ -86,7 +86,7 @@ public:
     void Read(hsStream *, hsResMgr *) { FATAL("not impl"); }
     void Write(hsStream *, hsResMgr *) { FATAL("not impl"); }
 
-    pfGameMgrMsg ();
+    pfGameMgrMsg () : netMsg(nil) { }
     ~pfGameMgrMsg ();
     
     void Set (const GameMsgHeader & msg);
@@ -108,8 +108,8 @@ public:
     CLASSNAME_REGISTER(pfGameCliMsg);
     GETINTERFACE_ANY(pfGameCliMsg, plMessage);
     #pragma warning(pop)
-    
-    pfGameCliMsg ();
+
+    pfGameCliMsg () : gameCli(nil), netMsg(nil) { }
     ~pfGameCliMsg ();
 
     void Read(hsStream *, hsResMgr *) { FATAL("not impl"); }

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.cpp
@@ -229,7 +229,7 @@ void pyAgeVault::AddChronicleEntry( const char * name, uint32_t type, const char
 // Add a new device.
 void pyAgeVault::AddDevice( const char * deviceName, PyObject * cbObject, uint32_t cbContext )
 {
-    pyVaultNode::pyVaultNodeOperationCallback * cb = NEWZERO(pyVaultNode::pyVaultNodeOperationCallback)( cbObject );
+    pyVaultNode::pyVaultNodeOperationCallback * cb = new pyVaultNode::pyVaultNodeOperationCallback( cbObject );
     cb->VaultOperationStarted( cbContext );
 
     wchar_t wStr[MAX_PATH];
@@ -278,7 +278,7 @@ PyObject * pyAgeVault::GetDevice( const char * deviceName )
 // Sets the inbox associated with a device.
 void pyAgeVault::SetDeviceInbox( const char * deviceName, const char * inboxName, PyObject * cbObject, uint32_t cbContext )
 {
-    pyVaultNode::pyVaultNodeOperationCallback * cb = NEWZERO(pyVaultNode::pyVaultNodeOperationCallback)( cbObject );
+    pyVaultNode::pyVaultNodeOperationCallback * cb = new pyVaultNode::pyVaultNodeOperationCallback( cbObject );
     cb->VaultOperationStarted( cbContext );
 
     wchar_t wDev[MAX_PATH];
@@ -310,7 +310,7 @@ PyObject * pyAgeVault::GetDeviceInbox( const char * deviceName )
 
 PyObject * pyAgeVault::GetAgeSDL() const
 {
-    plStateDataRecord * rec = NEWZERO(plStateDataRecord);
+    plStateDataRecord * rec = new plStateDataRecord;
     if (!VaultAgeGetAgeSDL(rec)) {
         delete rec;
         PYTHON_RETURN_NONE;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
@@ -431,7 +431,7 @@ PyObject* pyVault::GetInviteFolder(void)
 PyObject* pyVault::GetPsnlAgeSDL() const
 {
     PyObject * result = nil;
-    NetVaultNode * templateNode = NEWZERO(NetVaultNode);
+    NetVaultNode * templateNode = new NetVaultNode;
     templateNode->IncRef();
     
     if (RelVaultNode * rvnFldr = VaultGetAgesIOwnFolderIncRef()) {
@@ -450,7 +450,7 @@ PyObject* pyVault::GetPsnlAgeSDL() const
 
             if (RelVaultNode * rvnSdl = rvnInfo->GetChildNodeIncRef(templateNode, 1)) {
                 VaultSDLNode sdl(rvnSdl);
-                plStateDataRecord * rec = NEWZERO(plStateDataRecord);
+                plStateDataRecord * rec = new plStateDataRecord;
                 if (sdl.GetStateDataRecord(rec, plSDL::kKeepDirty))
                     result = pySDLStateDataRecord::New(rec);
                 else
@@ -476,7 +476,7 @@ void pyVault::UpdatePsnlAgeSDL( pySDLStateDataRecord & pyrec )
     if ( !rec )
         return;
 
-    NetVaultNode * templateNode = NEWZERO(NetVaultNode);
+    NetVaultNode * templateNode = new NetVaultNode;
     templateNode->IncRef();
     
     if (RelVaultNode * rvnFldr = VaultGetAgesIOwnFolderIncRef()) {
@@ -589,7 +589,7 @@ void _InvitePlayerToAge(ENetError result, void* state, void* param, RelVaultNode
 
 void pyVault::InvitePlayerToAge( const pyAgeLinkStruct & link, uint32_t playerID )
 {
-    NetVaultNode * templateNode = NEWZERO(NetVaultNode);
+    NetVaultNode * templateNode = new NetVaultNode;
     templateNode->IncRef();
     templateNode->SetNodeType(plVault::kNodeType_TextNote);
     VaultTextNoteNode visitAcc(templateNode);
@@ -622,7 +622,7 @@ void pyVault::UnInvitePlayerToAge( const char * str, uint32_t playerID )
         rvnLink->DecRef();
     }
 
-    NetVaultNode * templateNode = NEWZERO(NetVaultNode);
+    NetVaultNode * templateNode = new NetVaultNode;
     templateNode->IncRef();
     templateNode->SetNodeType(plVault::kNodeType_TextNote);
     VaultTextNoteNode visitAcc(templateNode);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
@@ -69,7 +69,7 @@ pyVaultAgeInfoNode::pyVaultAgeInfoNode(RelVaultNode* nfsNode)
 
 //create from the Python side
 pyVaultAgeInfoNode::pyVaultAgeInfoNode(int n)
-: pyVaultNode(NEWZERO(RelVaultNode))
+: pyVaultNode(new RelVaultNode)
 {
     fNode->SetNodeType(plVault::kNodeType_AgeInfo);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.cpp
@@ -66,7 +66,7 @@ pyVaultAgeLinkNode::pyVaultAgeLinkNode(RelVaultNode* nfsNode)
 
 //create from the Python side
 pyVaultAgeLinkNode::pyVaultAgeLinkNode(int n)
-: pyVaultNode(NEWZERO(RelVaultNode))
+: pyVaultNode(new RelVaultNode)
 {
     fNode->SetNodeType(plVault::kNodeType_AgeLink);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.cpp
@@ -63,7 +63,7 @@ pyVaultChronicleNode::pyVaultChronicleNode(RelVaultNode* nfsNode)
 
 //create from the Python side
 pyVaultChronicleNode::pyVaultChronicleNode(int n)
-: pyVaultNode(NEWZERO(RelVaultNode))
+: pyVaultNode(new RelVaultNode)
 , ansiName(nil)
 , ansiValue(nil)
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.cpp
@@ -58,7 +58,7 @@ pyVaultFolderNode::pyVaultFolderNode( RelVaultNode* nfsNode )
 
 //create from the Python side
 pyVaultFolderNode::pyVaultFolderNode(int n)
-: pyVaultNode(NEWZERO(RelVaultNode))
+: pyVaultNode(new RelVaultNode)
 {
     fNode->SetNodeType(plVault::kNodeType_Folder);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.cpp
@@ -96,7 +96,7 @@ pyVaultImageNode::pyVaultImageNode(RelVaultNode* nfsNode)
 
 //create from the Python side
 pyVaultImageNode::pyVaultImageNode(int n)
-: pyVaultNode(NEWZERO(RelVaultNode))
+: pyVaultNode(new RelVaultNode)
 , fMipmapKey(nil)
 , fMipmap(nil)
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNode.cpp
@@ -59,7 +59,7 @@ pyVaultMarkerGameNode::pyVaultMarkerGameNode(RelVaultNode* nfsNode)
 
 //create from the Python side
 pyVaultMarkerGameNode::pyVaultMarkerGameNode(int n)
-: pyVaultNode(NEWZERO(RelVaultNode))
+: pyVaultNode(new RelVaultNode)
 {
     fNode->SetNodeType(plVault::kNodeType_MarkerGame);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -96,6 +96,7 @@ pyVaultNode::pyVaultNodeOperationCallback::pyVaultNodeOperationCallback(PyObject
 : fCbObject( cbObject )
 , fNode(nil)
 , fPyNodeRef(nil)
+, fContext(0)
 {
     Py_XINCREF( fCbObject );
 }
@@ -269,7 +270,7 @@ PyObject* pyVaultNode::GetCreatorNode( void )
     PyObject * result = nil;
     if (fNode)
     {
-        RelVaultNode * templateNode = NEWZERO(RelVaultNode);
+        RelVaultNode * templateNode = new RelVaultNode;
         templateNode->IncRef();
         templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
         VaultPlayerInfoNode plrInfo(templateNode);
@@ -403,7 +404,7 @@ void _AddNodeCallback(ENetError result, void* param) {
 
 PyObject* pyVaultNode::AddNode(pyVaultNode* pynode, PyObject* cbObject, uint32_t cbContext)
 {
-    pyVaultNodeOperationCallback * cb = NEWZERO(pyVaultNodeOperationCallback)(cbObject);
+    pyVaultNodeOperationCallback * cb = new pyVaultNodeOperationCallback(cbObject);
 
     if ( fNode && pynode && pynode->GetNode() )
     {
@@ -460,7 +461,7 @@ PyObject* pyVaultNode::AddNode(pyVaultNode* pynode, PyObject* cbObject, uint32_t
 // Link a node to this one
 void pyVaultNode::LinkToNode(int nodeID, PyObject* cbObject, uint32_t cbContext)
 {
-    pyVaultNodeOperationCallback * cb = NEWZERO(pyVaultNodeOperationCallback)( cbObject );
+    pyVaultNodeOperationCallback * cb = new pyVaultNodeOperationCallback( cbObject );
 
     if (fNode && nodeID)
     {
@@ -491,7 +492,7 @@ void pyVaultNode::LinkToNode(int nodeID, PyObject* cbObject, uint32_t cbContext)
 // Remove child node
 bool pyVaultNode::RemoveNode( pyVaultNode& pynode, PyObject* cbObject, uint32_t cbContext )
 {
-    pyVaultNodeOperationCallback * cb = NEWZERO(pyVaultNodeOperationCallback)( cbObject );
+    pyVaultNodeOperationCallback * cb = new pyVaultNodeOperationCallback( cbObject );
 
     if (fNode && pynode.fNode)
     {
@@ -539,7 +540,7 @@ void pyVaultNode::Save(PyObject* cbObject, uint32_t cbContext)
             fNode = node;
         }
     }
-    pyVaultNodeOperationCallback * cb = NEWZERO(pyVaultNodeOperationCallback)( cbObject );
+    pyVaultNodeOperationCallback * cb = new pyVaultNodeOperationCallback( cbObject );
     cb->SetNode(fNode);
     cb->VaultOperationStarted( cbContext );
     cb->VaultOperationComplete( cbContext, hsOK );
@@ -549,7 +550,7 @@ void pyVaultNode::Save(PyObject* cbObject, uint32_t cbContext)
 void pyVaultNode::SaveAll(PyObject* cbObject, uint32_t cbContext)
 {
     // Nodes are now auto-saved
-    pyVaultNodeOperationCallback * cb = NEWZERO(pyVaultNodeOperationCallback)( cbObject );
+    pyVaultNodeOperationCallback * cb = new pyVaultNodeOperationCallback( cbObject );
     cb->VaultOperationStarted( cbContext );
     cb->VaultOperationComplete( cbContext, hsOK );
 }
@@ -570,7 +571,7 @@ void pyVaultNode::ForceSave()
 // Send this node to the destination client node. will be received in it's inbox folder.
 void pyVaultNode::SendTo(uint32_t destClientNodeID, PyObject* cbObject, uint32_t cbContext )
 {
-    pyVaultNodeOperationCallback * cb = NEWZERO(pyVaultNodeOperationCallback)( cbObject );
+    pyVaultNodeOperationCallback * cb = new pyVaultNodeOperationCallback( cbObject );
 
     if (fNode)
     {
@@ -655,7 +656,7 @@ PyObject * pyVaultNode::GetNode2( uint32_t nodeID ) const
     PyObject * result = nil;
     if ( fNode )
     {
-        RelVaultNode * templateNode = NEWZERO(RelVaultNode);
+        RelVaultNode * templateNode = new RelVaultNode;
         templateNode->IncRef();
         templateNode->SetNodeId(nodeID);
         if (RelVaultNode * rvn = fNode->GetChildNodeIncRef(templateNode, 1)) {
@@ -693,7 +694,7 @@ PyObject * pyVaultNode::GetChildNode (unsigned nodeId) {
     if (!fNode)
         PYTHON_RETURN_NONE;
         
-    RelVaultNode * templateNode = NEWZERO(RelVaultNode);
+    RelVaultNode * templateNode = new RelVaultNode;
     templateNode->IncRef();
     templateNode->SetNodeId(nodeId);
     RelVaultNode * rvn = fNode->GetChildNodeIncRef(templateNode, 1);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
@@ -84,7 +84,7 @@ public:
         PyObject *          fCbObject;
         RelVaultNode *      fNode;
         PyObject *          fPyNodeRef;
-        uint32_t              fContext;
+        uint32_t            fContext;
 
         pyVaultNodeOperationCallback(PyObject * cbObject);
         ~pyVaultNodeOperationCallback();

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.cpp
@@ -128,7 +128,7 @@ PyObject * pyVaultNodeRef::GetSaver () {
     if (RelVaultNode * child = VaultGetNodeIncRef(fChild->nodeId)) {
         if (unsigned saverId = child->GetRefOwnerId(fParent->nodeId)) {
             // Find the player info node representing the saver
-            NetVaultNode * templateNode = NEWZERO(NetVaultNode);
+            NetVaultNode * templateNode = new NetVaultNode;
             templateNode->IncRef();
             templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
             VaultPlayerInfoNode access(templateNode);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
@@ -79,7 +79,7 @@ bool pyVaultPlayerInfoListNode::HasPlayer( uint32_t playerID )
     if (!fNode)
         return false;
 
-    NetVaultNode * templateNode = NEWZERO(NetVaultNode);
+    NetVaultNode * templateNode = new NetVaultNode;
     templateNode->IncRef();
     templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
     VaultPlayerInfoNode access(templateNode);
@@ -101,7 +101,7 @@ bool pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
     if (!fNode)
         return false;
         
-    NetVaultNode * templateNode = NEWZERO(NetVaultNode);
+    NetVaultNode * templateNode = new NetVaultNode;
     templateNode->IncRef();
     templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
     VaultPlayerInfoNode access(templateNode);
@@ -125,7 +125,7 @@ void pyVaultPlayerInfoListNode::RemovePlayer( uint32_t playerID )
     if (!fNode)
         return;
 
-    NetVaultNode * templateNode = NEWZERO(NetVaultNode);
+    NetVaultNode * templateNode = new NetVaultNode;
     templateNode->IncRef();
     templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
     VaultPlayerInfoNode access(templateNode);
@@ -144,7 +144,7 @@ PyObject * pyVaultPlayerInfoListNode::GetPlayer( uint32_t playerID )
     if (!fNode)
         PYTHON_RETURN_NONE;
 
-    NetVaultNode * templateNode = NEWZERO(NetVaultNode);
+    NetVaultNode * templateNode = new NetVaultNode;
     templateNode->IncRef();
     templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
     VaultPlayerInfoNode access(templateNode);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.cpp
@@ -64,7 +64,7 @@ pyVaultPlayerInfoNode::pyVaultPlayerInfoNode(RelVaultNode* nfsNode)
 
 //create from the Python side
 pyVaultPlayerInfoNode::pyVaultPlayerInfoNode()
-: pyVaultNode(NEWZERO(RelVaultNode))
+: pyVaultNode(new RelVaultNode)
 , ansiPlayerName(nil)
 , ansiAgeInstName(nil)
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.cpp
@@ -61,7 +61,7 @@ pyVaultSDLNode::pyVaultSDLNode(RelVaultNode* nfsNode)
 
 //create from the Python side
 pyVaultSDLNode::pyVaultSDLNode()
-: pyVaultNode(NEWZERO(RelVaultNode))
+: pyVaultNode(new RelVaultNode)
 {
     fNode->SetNodeType(plVault::kNodeType_SDL);
 }
@@ -94,7 +94,7 @@ PyObject * pyVaultSDLNode::GetStateDataRecord() const
         PYTHON_RETURN_NONE;
         
     VaultSDLNode sdl(fNode);
-    plStateDataRecord * rec = NEWZERO(plStateDataRecord);
+    plStateDataRecord * rec = new plStateDataRecord;
     if (sdl.GetStateDataRecord(rec))
         return pySDLStateDataRecord::New(rec);
     else

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
@@ -64,7 +64,7 @@ pyVaultTextNoteNode::pyVaultTextNoteNode(RelVaultNode* nfsNode)
 
 //create from the Python side
 pyVaultTextNoteNode::pyVaultTextNoteNode()
-: pyVaultNode(NEWZERO(RelVaultNode))
+: pyVaultNode(new RelVaultNode)
 {
     fNode->SetNodeType(plVault::kNodeType_TextNote);
 }
@@ -222,7 +222,7 @@ void pyVaultTextNoteNode::SetDeviceInbox( const char * devName, PyObject * cbObj
     if (!fNode)
         return;
 
-    pyVaultNode::pyVaultNodeOperationCallback * cb = NEWZERO(pyVaultNode::pyVaultNodeOperationCallback)( cbObject );
+    pyVaultNode::pyVaultNodeOperationCallback * cb = new pyVaultNode::pyVaultNodeOperationCallback( cbObject );
     cb->VaultOperationStarted( cbContext );
 
     wchar_t wDev[MAX_PATH];

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
@@ -103,12 +103,16 @@ enum EAsyncNotifySocket {
 struct AsyncNotifySocket {
     void *          param;
     AsyncId         asyncId;
+
+    AsyncNotifySocket() : param(nil), asyncId(nil) { }
 };
 
 struct AsyncNotifySocketConnect : AsyncNotifySocket {
     plNetAddress    localAddr;
     plNetAddress    remoteAddr;
     unsigned        connType;
+
+    AsyncNotifySocketConnect() : connType(0) { }
 };
 
 struct AsyncNotifySocketListen : AsyncNotifySocketConnect {
@@ -120,12 +124,18 @@ struct AsyncNotifySocketListen : AsyncNotifySocketConnect {
     uint8_t *       buffer;
     unsigned        bytes;
     unsigned        bytesProcessed;
+
+    AsyncNotifySocketListen()
+        : buildId(0), buildType(0), branchId(0), buffer(nil), bytes(0),
+          bytesProcessed(0) { }
 };
 
 struct AsyncNotifySocketRead : AsyncNotifySocket {
     uint8_t *       buffer;
     unsigned        bytes;
     unsigned        bytesProcessed;
+
+    AsyncNotifySocketRead() : buffer(nil), bytes(0), bytesProcessed(0) { }
 };
 
 typedef AsyncNotifySocketRead AsyncNotifySocketWrite;

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcThread.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcThread.h
@@ -83,7 +83,7 @@ struct AsyncThread {
     void *              handle;
     void *              argument;
     unsigned            workTimeMs;
-    wchar_t               name[16];
+    wchar_t             name[16];
 };
 
 /*****************************************************************************
@@ -95,7 +95,7 @@ struct AsyncThread {
 void * AsyncThreadCreate (
     FAsyncThreadProc    proc,
     void *              argument,
-    const wchar_t         name[]
+    const wchar_t       name[]
 );
 
 // This function should ONLY be called during shutdown while waiting for things to expire

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Nt/pnAceNtInt.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Nt/pnAceNtInt.h
@@ -108,12 +108,19 @@ struct Operation {
     unsigned        pending;
     CNtWaitHandle * signalComplete;
     LINK(Operation) link;
-    
+
+    Operation()
+        : opType((EOpType)0), asyncId(nil), notify(false), pending(0),
+          signalComplete(nil)
+    {
+        memset(&overlapped, 0, sizeof(overlapped));
+    }
+
     #ifdef HS_DEBUGGING
     ~Operation () {
         ASSERT(!signalComplete);
     }
-    #endif    
+    #endif
 };
 
 struct NtObject {
@@ -126,6 +133,11 @@ struct NtObject {
     long                        nextStartSequence;
     long                        ioCount;
     bool                        closed;
+
+    NtObject()
+        : ioType((EIoType)0), handle(nil), userState(nil),
+          nextCompleteSequence(0), nextStartSequence(0),
+          ioCount(0), closed(false) { }
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -130,13 +130,13 @@ struct NetCli {
     const NetMsgField *     recvField;
     unsigned                recvFieldBytes;
     bool                    recvDispatch;
-    uint8_t *                  sendCurr;       // points into sendBuffer
+    uint8_t *               sendCurr;       // points into sendBuffer
     CInputAccumulator       input;
 
     // Message encryption
     ENetCliMode             mode;
     FNetCliEncrypt          encryptFcn;
-    uint8_t                    seed[kNetMaxSymmetricSeedBytes];
+    uint8_t                 seed[kNetMaxSymmetricSeedBytes];
     CryptKey *              cryptIn; // nil if encrytpion is disabled
     CryptKey *              cryptOut; // nil if encrytpion is disabled
     void *                  encryptParam;
@@ -144,6 +144,16 @@ struct NetCli {
     // Message buffers
     uint8_t                    sendBuffer[kAsyncSocketBufferSize];
     ARRAY(uint8_t)             recvBuffer;
+
+    NetCli()
+        : sock(nil), protocol((ENetProtocol)0), channel(nil), server(false)
+        , queue(nil), recvMsg(nil), recvField(nil), recvFieldBytes(0)
+        , recvDispatch(false), sendCurr(nil), mode((ENetCliMode)0)
+        , encryptFcn(nil), cryptIn(nil), cryptOut(nil), encryptParam(nil)
+    {
+        memset(seed, 0, sizeof(seed));
+        memset(sendBuffer, 0, sizeof(sendBuffer));
+    }
 };
 
 struct NetCliQueue {
@@ -913,7 +923,7 @@ static NetCli * ConnCreate (
     if (!channel)
         return nil;
 
-    NetCli * const cli  = NEWZERO(NetCli);
+    NetCli * const cli  = new NetCli;
     cli->sock           = sock;
     cli->protocol       = (ENetProtocol) protocol;
     cli->channel        = channel;

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.cpp
@@ -363,9 +363,18 @@ static void DeallocNodeFields (NetVaultNode * node) {
 }
 
 //============================================================================
-NetVaultNode::NetVaultNode () {
-    ASSERTMSG(!fieldFlags, "NetVaultNode instances must be allocated with NEWZERO");
-}
+NetVaultNode::NetVaultNode ()
+    : fieldFlags(0), dirtyFlags(0)
+    , nodeId(0), createTime(0), modifyTime(0)
+    , createAgeName(nil), creatorId(0)
+    , nodeType(0)
+    , int32_1(0), int32_2(0), int32_3(0), int32_4(0)
+    , uint32_1(0), uint32_2(0), uint32_3(0), uint32_4(0)
+    , string64_1(nil), string64_2(nil), string64_3(nil), string64_4(nil)
+    , string64_5(nil), string64_6(nil)
+    , istring64_1(nil), istring64_2(nil)
+    , text_1(nil), text_2(nil)
+    , blob_1(nil), blob_1Length(0), blob_2(nil), blob_2Length(0) { }
 
 //============================================================================
 NetVaultNode::~NetVaultNode () {

--- a/Sources/Plasma/NucleusLib/pnUtils/pnUtHash.h
+++ b/Sources/Plasma/NucleusLib/pnUtils/pnUtHash.h
@@ -163,6 +163,8 @@ private:
     LINK(T)  m_linkToSlot;
 
 public:
+    THashLink() : m_hash(0) { }
+
     inline bool IsLinked () const;
     inline T * Next ();
     inline const T * Next () const;

--- a/Sources/Plasma/NucleusLib/pnUtils/pnUtList.h
+++ b/Sources/Plasma/NucleusLib/pnUtils/pnUtList.h
@@ -105,7 +105,7 @@ class CBaseLink {
 
 protected:
     CBaseLink * volatile m_prevLink;
-    uint8_t * volatile      m_next;
+    uint8_t   * volatile m_next;
 
     inline int  CalcLinkOffset () const;
     inline void InitializeLinks ();

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
@@ -934,7 +934,7 @@ void plClothingOutfit::WriteToVault(const ARRAY(plStateDataRecord*) & SDRs)
                 node->DecRef(); // REF: Find
             }
             else {
-                RelVaultNode * templateNode = NEWZERO(RelVaultNode);
+                RelVaultNode * templateNode = new RelVaultNode;
                 templateNode->SetNodeType(plVault::kNodeType_SDL);
                 templates.Add(templateNode);
                 node = templateNode;
@@ -1571,7 +1571,7 @@ void plClothingMgr::AddItemsToCloset(hsTArray<plClosetItem> &items)
         plStateDataRecord rec(plClothingSDLModifier::GetClothingItemSDRName());
         plClothingSDLModifier::PutSingleItemIntoSDR(&items[i], &rec);
         
-        RelVaultNode * templateNode = NEWZERO(RelVaultNode);
+        RelVaultNode * templateNode = new RelVaultNode;
         templateNode->IncRef();
         templateNode->SetNodeType(plVault::kNodeType_SDL);
         
@@ -1609,7 +1609,7 @@ void plClothingMgr::GetClosetItems(hsTArray<plClosetItem> &out)
     
     for (unsigned i = 0; i < nodes.Count(); ++i) {
         VaultSDLNode sdl(nodes[i]);
-        plStateDataRecord * rec = NEWZERO(plStateDataRecord);
+        plStateDataRecord * rec = new plStateDataRecord;
         if (sdl.GetStateDataRecord(rec, 0))
             plClothingSDLModifier::HandleSingleSDR(rec, nil, &out[i]);
         delete rec;

--- a/Sources/Plasma/PubUtilLib/plMessage/plNetClientMgrMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plNetClientMgrMsg.h
@@ -57,14 +57,25 @@ public:
         kNotifyRcvdAllSDLStates,
         kCmdDisableNet,
     };
-    
+
     unsigned type;
     char str[256];
     bool yes;
 
     CLASSNAME_REGISTER(plNetClientMgrMsg);
     GETINTERFACE_ANY(plNetClientMgrMsg, plMessage);
-    
+
+    plNetClientMgrMsg(unsigned _type = 0, bool _yes = false, const char * _str = nil)
+        : type(_type), yes(_yes)
+    {
+        if (_str) {
+            strncpy(str, _str, arrsize(str));
+            str[arrsize(str)-1] = 0;
+        } else {
+            memset(str, 0, sizeof(str));
+        }
+    }
+
     void Read (hsStream *, hsResMgr *) { FATAL("plNetClientMgrMsg::Read"); }
     void Write (hsStream *, hsResMgr *) { FATAL("plNetClientMgrMsg::Write"); }
 };

--- a/Sources/Plasma/PubUtilLib/plMessage/plVaultNotifyMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plVaultNotifyMsg.h
@@ -48,9 +48,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plVaultNotifyMsg : public plMessage
 {
-    uint16_t                  fType;
+    uint16_t                fType;
     plCreatableListHelper   fArgs;
-    int8_t                    fResultCode;
+    int8_t                  fResultCode;
 
 public:
     enum VaultNotifyTypes
@@ -73,9 +73,9 @@ public:
     GETINTERFACE_ANY_AUX( plVaultNotifyMsg, plMessage, plCreatableListHelper, fArgs );
 
     uint16_t  GetType() const { return fType; }
-    void    SetType( uint16_t v ) { fType=v; }
+    void      SetType( uint16_t v ) { fType=v; }
 
-    int8_t    GetResultCode() const { return fResultCode; }
+    int8_t  GetResultCode() const { return fResultCode; }
     void    SetResultCode( int8_t v ) { fResultCode=v; }
 
     plCreatableListHelper * GetArgs() { return &fArgs; }

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
@@ -102,7 +102,7 @@ struct plNCAgeJoiner {
     bool                    complete;
 
     plOperationProgress*    progressBar;
-    
+
     plNCAgeJoiner (
         const NetCommAge &      age,
         FNCAgeJoinerCallback    callback,
@@ -163,6 +163,7 @@ plNCAgeJoiner::plNCAgeJoiner (
 ,   age(age)
 ,   callback(callback)
 ,   userState(userState)
+,   complete(false)
 ,   progressBar(nil)
 {
 }
@@ -475,7 +476,7 @@ void NCAgeJoinerCreate (
     ASSERT(callback);
     
     plNCAgeJoiner * joiner;
-    *pjoiner = joiner = NEWZERO(plNCAgeJoiner)(
+    *pjoiner = joiner = new plNCAgeJoiner(
         age,
         callback,
         userState

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeLeaver.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeLeaver.cpp
@@ -78,13 +78,13 @@ struct plNCAgeLeaver {
         kUnloadAge,
         kNotifyAgeUnloaded,
     };
-    
+
     NextOp                  nextOp;
     bool                    quitting;
     bool                    complete;
     FNCAgeLeaverCallback    callback;
     void *                  userState;
-    
+
     plNCAgeLeaver (
         bool                    quitting,
         FNCAgeLeaverCallback    callback,
@@ -271,7 +271,7 @@ void NCAgeLeaverCreate (
     ASSERT(callback);
     
     plNCAgeLeaver * leaver;
-    *pleaver = leaver = NEWZERO(plNCAgeLeaver)(
+    *pleaver = leaver = new plNCAgeLeaver(
         quitting,
         callback,
         userState

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -1139,8 +1139,7 @@ void plNetClientMgr::IncNumInitialSDLStates()
 
 void plNetClientMgr::NotifyRcvdAllSDLStates() {
     DebugMsg( "Got all initial SDL states" );
-    plNetClientMgrMsg * msg = new plNetClientMgrMsg();
-    msg->type = plNetClientMgrMsg::kNotifyRcvdAllSDLStates;
+    plNetClientMgrMsg * msg = new plNetClientMgrMsg(plNetClientMgrMsg::kNotifyRcvdAllSDLStates);
     msg->SetBCastFlag(plMessage::kBCastByType);
     msg->Send();
 }
@@ -1303,11 +1302,8 @@ void plNetClientMgr::MakeCCRInvisible(plKey avKey, int level)
 
 void plNetClientMgr::QueueDisableNet (bool showDlg, const char str[]) {
 
-    plNetClientMgrMsg * msg = NEWZERO(plNetClientMgrMsg);
-    msg->type   = plNetClientMgrMsg::kCmdDisableNet;
-    msg->yes    = showDlg;
-    if (str)
-        StrCopy(msg->str, str, arrsize(msg->str));
+    plNetClientMgrMsg * msg = new plNetClientMgrMsg(plNetClientMgrMsg::kCmdDisableNet,
+                                                    showDlg, str);
 
 #if 0
     msg->Send(GetKey());

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
@@ -109,7 +109,7 @@ struct NlmJoinAgeOp : NlmOp {
 struct NlmLeaveAgeOp : NlmOp {
     bool    quitting;
     NlmLeaveAgeOp ()
-    : NlmOp(kNlmOpLeaveAgeOp)
+    : NlmOp(kNlmOpLeaveAgeOp), quitting(false)
     { }
 };
 
@@ -231,7 +231,7 @@ void plNetLinkingMgr::ExecNextOp () {
             ASSERT(!s_ageLeaver);
 
             // Insert a wait operation into the exec queue
-            NlmOpWaitOp * waitOp = NEWZERO(NlmOpWaitOp);
+            NlmOpWaitOp * waitOp = new NlmOpWaitOp;
             QueueOp(waitOp, true);
 
             NlmJoinAgeOp * joinAgeOp = (NlmJoinAgeOp *)op;
@@ -249,7 +249,7 @@ void plNetLinkingMgr::ExecNextOp () {
             ASSERT(!s_ageLeaver);
 
             // Insert a wait operation into the exec queue
-            NlmOpWaitOp * waitOp = NEWZERO(NlmOpWaitOp);
+            NlmOpWaitOp * waitOp = new NlmOpWaitOp;
             QueueOp(waitOp, true);
 
             lm->SetEnabled(false);
@@ -413,12 +413,12 @@ void plNetLinkingMgr::IDoLink(plLinkToAgeMsg* msg)
             avMod->SetLinkInAnim(msg->GetLinkInAnimName());
         }
         // Queue leave op
-        NlmLeaveAgeOp * leaveAgeOp = NEWZERO(NlmLeaveAgeOp);
+        NlmLeaveAgeOp * leaveAgeOp = new NlmLeaveAgeOp;
         QueueOp(leaveAgeOp);
     }
 
-    // Queue join op        
-    NlmJoinAgeOp * joinAgeOp = NEWZERO(NlmJoinAgeOp);
+    // Queue join op
+    NlmJoinAgeOp * joinAgeOp = new NlmJoinAgeOp;
     joinAgeOp->age.ageInstId = *GetAgeLink()->GetAgeInfo()->GetAgeInstanceGuid();
     StrCopy(
         joinAgeOp->age.ageDatasetName,
@@ -1118,7 +1118,7 @@ uint8_t plNetLinkingMgr::IPreProcessLink(void)
 ////////////////////////////////////////////////////////////////////
 void plNetLinkingMgr::LeaveAge (bool quitting) {
     // Queue leave op
-    NlmLeaveAgeOp * leaveAgeOp = NEWZERO(NlmLeaveAgeOp);
+    NlmLeaveAgeOp * leaveAgeOp = new NlmLeaveAgeOp;
     leaveAgeOp->quitting = quitting;
     QueueOp(leaveAgeOp);
 

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -158,9 +158,8 @@ static void INetErrorCallback (
 ) {
     NetClientDestroy(false);
     
-    plNetClientMgrMsg * msg = NEWZERO(plNetClientMgrMsg);
-    msg->type   = plNetClientMgrMsg::kCmdDisableNet;
-    msg->yes    = true;
+    plNetClientMgrMsg * msg = new plNetClientMgrMsg(plNetClientMgrMsg::kCmdDisableNet,
+                                                    true, nil);
     msg->AddReceiver(plNetClientApp::GetInstance()->GetKey());
 
     switch (error)
@@ -259,7 +258,7 @@ static void INotifyAuthConnectedCallback () {
     if (!hsgResMgr::ResMgr())
         return;
         
-    plNetCommAuthConnectedMsg * msg = NEWZERO(plNetCommAuthConnectedMsg);
+    plNetCommAuthConnectedMsg * msg = new plNetCommAuthConnectedMsg;
     msg->Send();
 }
 
@@ -535,7 +534,7 @@ static void INetCliAuthGetPublicAgeListCallback (
 ) {
     NetCommParam * cp = (NetCommParam *) param;
     
-    plNetCommPublicAgeListMsg * msg = NEWZERO(plNetCommPublicAgeListMsg);
+    plNetCommPublicAgeListMsg * msg = new plNetCommPublicAgeListMsg;
     msg->result     = result;
     msg->param      = cp->param;
     msg->ptype      = cp->type;

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.h
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.h
@@ -80,7 +80,7 @@ struct NetCommPlayer {
 
 struct NetCommAccount {
     plUUID      accountUuid;
-    wchar_t       accountName[kMaxAccountNameLength];
+    wchar_t     accountName[kMaxAccountNameLength];
     ShaDigest   accountNamePassHash;
     char        accountNameAnsi[kMaxAccountNameLength];
     unsigned    accountFlags;
@@ -92,6 +92,12 @@ struct NetCommAge {
     unsigned    ageVaultId;
     char        ageDatasetName[kMaxAgeNameLength];
     char        spawnPtName[64];
+
+    NetCommAge() : ageVaultId(0)
+    {
+        memset(ageDatasetName, 0, sizeof(ageDatasetName));
+        memset(spawnPtName, 0, sizeof(spawnPtName));
+    }
 };
 
 const NetCommAge *                  NetCommGetAge ();

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.h
@@ -91,8 +91,8 @@ class plCreatableListHelper : public plCreatable
         kCompressed         = 1<<1,
         kWritten            = 1<<2,
     };
-    uint8_t                               fFlags;
-    std::map<uint16_t,plCreatable*>       fItems;
+    uint8_t                             fFlags;
+    std::map<uint16_t,plCreatable*>     fItems;
     mutable std::vector<plCreatable*>   fManagedItems;
     uint32_t  fCompressionThreshold;  // NOT WRITTEN
     std::string fWritten;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -67,7 +67,7 @@ struct CliFileConn : AtomicRef {
     char                name[MAX_PATH];
     plNetAddress        addr;
     unsigned            seq;
-    ARRAY(uint8_t)         recvBuffer;
+    ARRAY(uint8_t)      recvBuffer;
     AsyncCancelId       cancelId;
     bool                abandoned;
     unsigned            buildId;
@@ -544,7 +544,7 @@ static void Connect (
 ) {
     ASSERT(s_running);
     
-    CliFileConn * conn = NEWZERO(CliFileConn);
+    CliFileConn * conn = new CliFileConn;
     strncpy(conn->name, name, arrsize(conn->name));
     conn->addr          = addr;
     conn->buildId       = s_connectBuildId;
@@ -580,7 +580,13 @@ static void AsyncLookupCallback (
 ***/
 
 //============================================================================
-CliFileConn::CliFileConn () {
+CliFileConn::CliFileConn ()
+    : sock(nil), seq(0), cancelId(nil), abandoned(false), buildId(0), serverType(0)
+    , reconnectTimer(nil), reconnectStartMs(0), connectStartMs(0)
+    , numImmediateDisconnects(0), numFailedConnects(0)
+    , pingTimer(nil), pingSendTimeMs(0), lastHeardTimeMs(0)
+{
+    memset(name, 0, sizeof(name));
     AtomicAdd(&s_perf[kPerfConnCount], 1);
 }
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -63,7 +63,7 @@ struct CliGkConn : AtomicRef {
     // Reconnection
     AsyncTimer *        reconnectTimer;
     unsigned            reconnectStartMs;
-    
+
     // Ping
     AsyncTimer *        pingTimer;
     unsigned            pingSendTimeMs;
@@ -77,12 +77,12 @@ struct CliGkConn : AtomicRef {
     void StopAutoReconnect (); // call before destruction
     void StartAutoReconnect ();
     void TimerReconnect ();
-    
+
     // ping
     void AutoPing ();
     void StopAutoPing ();
     void TimerPing ();
-    
+
     void Send (const uintptr_t fields[], unsigned count);
 
     CCritSect       critsect;
@@ -468,7 +468,7 @@ static void Connect (
 ) {
     ASSERT(s_running);
     
-    CliGkConn * conn        = NEWZERO(CliGkConn);
+    CliGkConn * conn        = new CliGkConn;
     conn->addr              = addr;
     conn->seq               = ConnNextSequence();
     conn->lastHeardTimeMs   = GetNonZeroTimeMs();   // used in connect timeout, and ping timeout
@@ -524,7 +524,14 @@ static unsigned CliGkConnPingTimerProc (void * param) {
 }
 
 //============================================================================
-CliGkConn::CliGkConn () {
+CliGkConn::CliGkConn ()
+    : reconnectTimer(nil), reconnectStartMs(0)
+    , pingTimer(nil), pingSendTimeMs(0), lastHeardTimeMs(0)
+    , sock(nil), cli(nil), seq(0), serverChallenge(0)
+    , cancelId(nil), abandoned(false)
+{
+    memset(name, 0, sizeof(name));
+
     AtomicAdd(&s_perf[kPerfConnCount], 1);
 }
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglTrans.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglTrans.cpp
@@ -123,6 +123,7 @@ NetTrans::NetTrans (ENetProtocol protocol, ETransType transType)
 ,   m_connId(0)
 ,   m_protocol(protocol)
 ,   m_hasSubTrans(false)
+,   m_timeoutAtMs(0)
 ,   m_transType(transType)
 {
     AtomicAdd(&s_perf[kPerfCurrTransactions], 1);

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
@@ -433,9 +433,9 @@ public:
     plStateDataRecord(const plString& sdName, int version=plSDL::kLatestVersion);
     plStateDataRecord(plStateDescriptor* sd);
     plStateDataRecord(const plStateDataRecord &other, uint32_t writeOptions=0 ):fFlags(0) { CopyFrom(other, writeOptions); }
-    plStateDataRecord():fFlags(0) {}
+    plStateDataRecord() : fDescriptor(nil), fFlags(0) {}
     ~plStateDataRecord();
-    
+
     bool ConvertTo(plStateDescriptor* other, bool force=false );
     bool operator==(const plStateDataRecord &other) const;  // assumes matching state descriptors
 

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.cpp
@@ -579,7 +579,7 @@ void VaultSDLNode::SetStateDataRecord (const plStateDataRecord * rec, unsigned w
 #ifdef CLIENT
 void VaultSDLNode::InitStateDataRecord (const wchar_t sdlRecName[], unsigned writeOptions) {
     {
-        plStateDataRecord * rec = NEWZERO(plStateDataRecord);
+        plStateDataRecord * rec = new plStateDataRecord;
         bool exists = GetStateDataRecord(rec, 0);
         delete rec;
         if (exists)


### PR DESCRIPTION
NEWZERO uses calloc on pointers that are expected to be deleted with operator delete...  This is generally bad news for MSVC.  Also, NEWZERO creates inconsistent constructor behavior with C++'s default operator new, which can create confusion and lead to faulty assumptions.

Depends on #248
