### PR TITLE
Fix a major plStringStream bug, and add an SSO-like optimization to it

### DIFF
--- a/Sources/Plasma/CoreLib/plString.cpp
+++ b/Sources/Plasma/CoreLib/plString.cpp
@@ -501,11 +501,11 @@ double plString::ToDouble() const
 
 plString plString::IFormat(const char *fmt, va_list vptr)
 {
-    char buffer[256];
+    char buffer[STRING_STACK_SIZE];
     va_list vptr_save;
     va_copy(vptr_save, vptr);
 
-    int chars = vsnprintf(buffer, 256, fmt, vptr);
+    int chars = vsnprintf(buffer, STRING_STACK_SIZE, fmt, vptr);
     if (chars < 0) {
         // We will need to try this multiple times until we get a
         // large enough buffer :(
@@ -522,9 +522,8 @@ plString plString::IFormat(const char *fmt, va_list vptr)
             }
 
             size *= 2;
-            hsAssert(size > 0, "Formatted string output is waaaaay too long");
         }
-    } else if (chars >= 256) {
+    } else if (chars >= STRING_STACK_SIZE) {
         va_copy(vptr, vptr_save);
         plStringBuffer<char> bigbuffer;
         char *data = bigbuffer.CreateWritableBuffer(chars);
@@ -800,13 +799,12 @@ plString operator+(const char *left, const plString &right)
 
 plStringStream &plStringStream::append(const char *data, size_t length)
 {
-    size_t bufSize = ICanHasHeap() ? fBufSize : 256;
+    size_t bufSize = ICanHasHeap() ? fBufSize : STRING_STACK_SIZE;
     char *bufp = ICanHasHeap() ? fBuffer : fShort;
 
     if (fLength + length > bufSize) {
         size_t bigSize = bufSize;
         do {
-            hsAssert(bigSize * 2, "plStringStream buffer too large");
             bigSize *= 2;
         } while (fLength + length > bigSize);
 

--- a/Sources/Plasma/CoreLib/plString.h
+++ b/Sources/Plasma/CoreLib/plString.h
@@ -49,6 +49,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 typedef unsigned int UniChar;
 
 #define SSO_CHARS (16)
+#define STRING_STACK_SIZE (256)
 #define WHITESPACE_CHARS " \t\n\r"
 
 template <typename _Ch>
@@ -341,10 +342,7 @@ plString operator+(const char *left, const plString &right);
 class plStringStream
 {
 public:
-    plStringStream() : fLength(0)
-    {
-        fShort[0] = 0;
-    }
+    plStringStream() : fLength(0) { }
     ~plStringStream() { if (ICanHasHeap()) delete [] fBuffer; }
 
     plStringStream &append(const char *data, size_t length);
@@ -375,11 +373,11 @@ private:
             char *fBuffer;
             size_t fBufSize;
         };
-        char fShort[256];
+        char fShort[STRING_STACK_SIZE];
     };
     size_t fLength;
 
-    bool ICanHasHeap() const { return fLength > 256; }
+    bool ICanHasHeap() const { return fLength > STRING_STACK_SIZE; }
 };
 
 size_t ustrlen(const UniChar *ustr, size_t max = plString::kSizeAuto);


### PR DESCRIPTION
While cleaning C string uses around Plasma, I discovered a major bug in plStringStream that could cause it to crash if the appended content size exceeded a single buffer size increase.  This fixes that, while also keeping the first buffer (256 chars) in the stack to improve performance when replacing many of the static buffers currently being strcatted.
