### PR TITLE
Use Windows themes for the Win32 GUI executables

### DIFF
--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -1564,3 +1564,7 @@ static void GetCryptKey(uint32_t* cryptKey, unsigned numElements)
     }
 }
 
+/* Enable themes in Windows XP and later */
+#pragma comment(linker,"\"/manifestdependency:type='win32' \
+name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
+processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")

--- a/Sources/Plasma/Apps/plUruLauncher/SelfPatcher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/SelfPatcher.cpp
@@ -337,3 +337,8 @@ bool SelfPatch (bool noSelfPatch, bool * abort, ENetError * result, plLauncherIn
     return patched;
 }
 
+
+/* Enable themes in Windows XP and later */
+#pragma comment(linker,"\"/manifestdependency:type='win32' \
+name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
+processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")

--- a/Sources/Tools/plFontConverter/plFontConverter.cpp
+++ b/Sources/Tools/plFontConverter/plFontConverter.cpp
@@ -87,3 +87,8 @@ int WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 
     return 0;
 }
+
+/* Enable themes in Windows XP and later */
+#pragma comment(linker,"\"/manifestdependency:type='win32' \
+name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
+processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")

--- a/Sources/Tools/plLocalizationEditor/plLocalizationEditor.cpp
+++ b/Sources/Tools/plLocalizationEditor/plLocalizationEditor.cpp
@@ -390,3 +390,8 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
     return DefWindowProc(hWnd, msg, wParam, lParam);
 }
+
+/* Enable themes in Windows XP and later */
+#pragma comment(linker,"\"/manifestdependency:type='win32' \
+name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
+processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")

--- a/Sources/Tools/plResBrowser/plResBrowser.cpp
+++ b/Sources/Tools/plResBrowser/plResBrowser.cpp
@@ -126,3 +126,8 @@ BOOL WinInit(HINSTANCE hInst, int nCmdShow)
 
     return TRUE;
 }
+
+/* Enable themes in Windows XP and later */
+#pragma comment(linker,"\"/manifestdependency:type='win32' \
+name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
+processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")


### PR DESCRIPTION
This adds the necessary ComCtl manifests to allow the Win32 GUI executables to be styled using the system theme in Windows XP and later (at least until they are ported to a cross-platform toolkit).

Currently, I've enabled the following executables (let me know if I'm missing any):
- plClient
- UruLauncher
- plFontConverter
- plLocalizationEditor
- plResBrowser
