### PR TITLE
Add Truncate() method to plStringStream

### DIFF
--- a/Sources/Plasma/CoreLib/plString.cpp
+++ b/Sources/Plasma/CoreLib/plString.cpp
@@ -822,17 +822,16 @@ plString operator+(const char *left, const plString &right)
 
 plStringStream &plStringStream::append(const char *data, size_t length)
 {
-    size_t bufSize = ICanHasHeap() ? fBufSize : STRING_STACK_SIZE;
     char *bufp = ICanHasHeap() ? fBuffer : fShort;
 
-    if (fLength + length > bufSize) {
-        size_t bigSize = bufSize;
+    if (fLength + length > fBufSize) {
+        size_t bigSize = fBufSize;
         do {
             bigSize *= 2;
         } while (fLength + length > bigSize);
 
         char *bigger = new char[bigSize];
-        memcpy(bigger, GetRawBuffer(), bufSize);
+        memcpy(bigger, GetRawBuffer(), fBufSize);
         if (ICanHasHeap())
             delete [] fBuffer;
         fBuffer = bufp = bigger;


### PR DESCRIPTION
Truncates a plStringStream without freeing or reducing the size of the internal buffer (handy for accumulating several large but independent string buffers without unnecessary memory allocations).
