### PR TITLE
Add basic regex functionality to plString

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ find_package(Ogg REQUIRED)    #TODO: Not required if we aren't building the clie
 find_package(Vorbis REQUIRED) #TODO: Not required if we aren't building the client
 find_package(Speex REQUIRED)  #TODO: Not required if we aren't building the client
 find_package(CURL REQUIRED)
+find_package(PCRE REQUIRED)
 
 if(WIN32)
     find_package(PhysX REQUIRED)  #TODO: Not required if we aren't building the client

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Plasma currently utilizes the following third-party libraries:
 - libPNG  - http://www.libpng.org/
 - speex  - http://www.speex.org/downloads/
 - zlib  - http://zlib.net/
+- PCRE  - http://www.pcre.org/
 
 - PyGTK  - http://www.pygtk.org/downloads.html
 - PIL  - http://www.pythonware.com/products/pil/

--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -172,10 +172,6 @@ target_link_libraries(plClient ${Vorbis_LIBRARIES})
 target_link_libraries(plClient ${DirectX_LIBRARIES})
 target_link_libraries(plClient ${CURL_LIBRARY})
 
-if(Bink_SDK_AVAILABLE)
-    target_link_libraries(plClient ${Bink_LIBRARIES})
-endif()
-
 if(USE_VLD)
     target_link_libraries(plClient ${VLD_LIBRARY})
 endif()

--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -97,6 +97,8 @@ set(CoreLib_HEADERS
 )
 
 add_library(CoreLib STATIC ${CoreLib_SOURCES} ${CoreLib_HEADERS})
+target_link_libraries(CoreLib ${PCRE_LIBRARY})
+
 if(UNIX)
     target_link_libraries(CoreLib pthread)
 endif(UNIX)

--- a/Sources/Plasma/CoreLib/plString.h
+++ b/Sources/Plasma/CoreLib/plString.h
@@ -479,6 +479,20 @@ public:
     int Find(const plString &str, CaseSensitivity sense = kCaseSensitive) const
     { return Find(str.c_str(), sense); }
 
+    /** Check that this string matches the specified regular expression.
+     *  This with only return true if the whole string can be matched
+     *  by \a pattern.
+     */
+    bool REMatch(const char *pattern, CaseSensitivity sense = kCaseSensitive) const;
+
+    /** Search for substrings which match the specified regular expression.
+     *  If capture groups are specified in the pattern, they will be
+     *  returned as additional strings in the returned vector, starting at
+     *  index 1 (index 0 contains the whole match).  If the pattern was not
+     *  found, this returns an empty vector.
+     */
+    std::vector<plString> RESearch(const char *pattern, CaseSensitivity sense = kCaseSensitive) const;
+
     /** Trim any characters in the supplied \a charset from the left of
      *  this string.
      */

--- a/cmake/FindPCRE.cmake
+++ b/cmake/FindPCRE.cmake
@@ -1,0 +1,21 @@
+if(PCRE_INCLUDE_DIR AND PCRE_LIBRARY)
+    set(PCRE_FIND_QUIETLY TRUE)
+endif()
+
+find_path(PCRE_INCLUDE_DIR pcre.h)
+find_library(PCRE_LIBRARY NAMES pcre)
+set(PCRE_LIBRARIES ${PCRE_LIBRARY})
+
+if(PCRE_INCLUDE_DIR AND PCRE_LIBRARY)
+    set(PCRE_FOUND TRUE)
+endif()
+
+if(PCRE_FOUND)
+    if(NOT PCRE_FIND_QUIETLY)
+        message(STATUS "Found Perl Compatible Regular Expressions library: ${PCRE_INCLUDE_DIR}")
+    endif()
+else()
+    if(PCRE_FIND_REQUIRED)
+        message(FATAL_ERROR "Could not find Perl Compatible Regular Expressions library")
+    endif()
+endif()


### PR DESCRIPTION
Adds a REMatch (match whole string against regular expression) and RESearch (search for regular expression and return match and all sub-matches) to plString.  Note that this PR adds a new dependency on pcre.
