### PR TITLE
Refactor RegistryKeyList

### DIFF
--- a/Sources/Plasma/NucleusLib/pnKeyedObject/hsKeyedObject.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/hsKeyedObject.cpp
@@ -107,6 +107,10 @@ plKey hsKeyedObject::RegisterAs(plFixedKeyId fixedKey)
     if (key == nil)
     {
         key = hsgResMgr::ResMgr()->NewKey(meUoid, this);
+
+        //  the key list "helpfully" assigns us an object id.
+        // we don't want one for fixed keys however (initialization order might bite us in the ass)
+        static_cast<plKeyImp*>(key)->SetObjectID(0);
     }
     else
     {

--- a/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
@@ -438,15 +438,9 @@ plKey plKeyFinder::IFindSceneNodeKey(plRegistryPageNode* page) const
     plRegistryKeyList* keyList = page->IGetKeyList(CLASS_INDEX_SCOPED(plSceneNode));
     if (keyList)
     {
-        if (keyList->fStaticKeys.size() == 1)
+        if (keyList->fKeys.size() == 1)
         {
-            return plKey::Make((plKeyData*)keyList->fStaticKeys[0]);
-        }
-        else if (keyList->fDynamicKeys.size() == 1) // happens during export
-        {
-            plRegistryKeyList::DynSet::const_iterator it = keyList->fDynamicKeys.begin();
-            plKeyImp* keyImp = *it;
-            return plKey::Make(keyImp);
+            return plKey::Make((plKeyData*)keyList->fKeys[0]);
         }
     }
 
@@ -459,9 +453,9 @@ plKey plKeyFinder::IFindSceneNodeKey(plRegistryPageNode* page) const
     // Get the list of all sceneNodes
     plKey retVal(nil);
     keyList = page->IGetKeyList(CLASS_INDEX_SCOPED(plSceneNode));
-    if (keyList && keyList->fStaticKeys.size() == 1)
+    if (keyList && keyList->fKeys.size() == 1)
     {
-        retVal = plKey::Make((plKeyData*)keyList->fStaticKeys[0]);
+        retVal = plKey::Make((plKeyData*)keyList->fKeys[0]);
     }
     // If we just loaded up all the keys for this page, then we
     // may have a bunch of keys with a refcount of 0. For any of 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.h
@@ -74,8 +74,7 @@ protected:
     // Map from class type to a list of keys of that type
     typedef std::map<uint16_t, plRegistryKeyList*> KeyMap;
     KeyMap fKeyLists;
-    int fDynLoadedTypes;    // The number of key types that have dynamic keys loaded
-    int fStaticLoadedTypes; // The number of key types that have all their keys loaded
+    uint32_t fLoadedTypes;      // The number of key types that have dynamic keys loaded
 
     PageCond    fValid;         // Condition of the page
     plFileName  fPath;          // Path to the page file
@@ -104,9 +103,9 @@ public:
     PageCond GetPageCondition() { return fValid; }
 
     // True if we have any static or dynamic keys loaded
-    bool IsLoaded() const     { return fDynLoadedTypes > 0 || fStaticLoadedTypes > 0; }
+    bool IsLoaded() const     { return fLoadedTypes > 0; }
     // True if all of our static keys are loaded
-    bool IsFullyLoaded() const    { return (fStaticLoadedTypes == fKeyLists.size() && !fKeyLists.empty()) || fIsNewPage; }
+    bool IsFullyLoaded() const    { return (fLoadedTypes == fKeyLists.size() && !fKeyLists.empty()) || fIsNewPage; }
 
     // Export time only.  If we want to reuse a page, load the keys we want then
     // call SetNewPage, so it will be considered a new page from now on.  That


### PR DESCRIPTION
This is in preparation for page patching. The old code kept dynamic (programatically created) and serialized keys separate. This had the potential to reorder the key list during the application of a patch.

This is separate from the prp-patches branch to facillitate review.
