### PR TITLE
Refactor Pending Loads

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
@@ -124,14 +124,12 @@ public:
         // must be set by user
         plStateDataRecord* fSDRec;  // the sdl data record
         plUoid  fUoid;              // the object it's meant for
-        uint32_t  fPlayerID;          // the player that originally sent the state
+        uint32_t  fPlayerID;        // the player that originally sent the state
 
         // set by NetClient
         plKey fKey;                 // the key of the object it's meant for
-        double fQueuedTime;
-        int     fQueueTimeResets;
 
-        PendingLoad() : fSDRec(nil),fPlayerID(0),fKey(nil),fQueuedTime(0.0),fQueueTimeResets(0) {}
+        PendingLoad() : fSDRec(nullptr), fPlayerID(0), fKey(nullptr) { }
         ~PendingLoad();
     };
 


### PR DESCRIPTION
I noticed in my Relto on MOULa that I have stale physical SDL variables from the Neighborhood ("OrangeCone15") hanging around in the game server blob. This is all well and good except for the fact that the old pending load code would attempt to deliver pending SDL states long after all the pages that are actually in an age are actually loaded. This causes the game to load all the Neighborhood_nb01 keys every second.

So, I have refactored the state delivery code to make more sense and to only attempt to deliver state once when the age is fully loaded. If the age is still loading, states are allowed to remain queued until the age is fully loaded. Anything that fails after the age is fully loaded is tossed out.
