### PR TITLE
Re-define nil as nullptr, cleaning up some potential issues along the way

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -116,7 +116,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #endif
 
 #ifndef nil
-#   define nil (0)
+#   define nil (nullptr)
 #endif
 
 typedef int32_t   hsError;

--- a/Sources/Plasma/CoreLib/hsTemplates.h
+++ b/Sources/Plasma/CoreLib/hsTemplates.h
@@ -734,7 +734,7 @@ template <class T> void hsTArray<T>::SetCountAndZero(int count)
     }
     int i;
     for( i = 0; i < fTotalCount; i++ )
-        fArray[i] = nil;
+        fArray[i] = 0;
     fUseCount = count;
 }
 
@@ -746,7 +746,7 @@ template <class T> void hsTArray<T>::ExpandAndZero(int count)
         Expand(count);
         int i;
         for( i = n; i < count; i++ )
-            fArray[i] = nil;
+            fArray[i] = 0;
     }
     if( fUseCount < count )
         fUseCount = count;

--- a/Sources/Plasma/CoreLib/plString.cpp
+++ b/Sources/Plasma/CoreLib/plString.cpp
@@ -88,7 +88,7 @@ size_t wcsnlen(const wchar_t *s, size_t maxlen)
 
 void plString::IConvertFromUtf8(const char *utf8, size_t size)
 {
-    if (utf8 == nil) {
+    if (!utf8) {
         fUtf8Buffer = plStringBuffer<char>();
         return;
     }
@@ -134,7 +134,7 @@ plString &plString::operator=(const plStringBuffer<char> &init)
 void plString::IConvertFromUtf16(const uint16_t *utf16, size_t size)
 {
     fUtf8Buffer = plStringBuffer<char>();
-    if (utf16 == nil)
+    if (!utf16)
         return;
 
     if ((int32_t)size < 0)
@@ -213,7 +213,7 @@ void plString::IConvertFromWchar(const wchar_t *wstr, size_t size)
 void plString::IConvertFromUtf32(const UniChar *ustr, size_t size)
 {
     fUtf8Buffer = plStringBuffer<char>();
-    if (ustr == nil)
+    if (!ustr)
         return;
 
     if ((int32_t)size < 0)
@@ -271,7 +271,7 @@ void plString::IConvertFromUtf32(const UniChar *ustr, size_t size)
 void plString::IConvertFromIso8859_1(const char *astr, size_t size)
 {
     fUtf8Buffer = plStringBuffer<char>();
-    if (astr == nil)
+    if (!astr)
         return;
 
     if ((int32_t)size < 0)
@@ -477,23 +477,23 @@ plUnicodeBuffer plString::GetUnicodeArray() const
 
 int plString::ToInt(int base) const
 {
-    return static_cast<int>(strtol(c_str(), nil, base));
+    return static_cast<int>(strtol(c_str(), nullptr, base));
 }
 
 unsigned int plString::ToUInt(int base) const
 {
-    return static_cast<unsigned int>(strtoul(c_str(), nil, base));
+    return static_cast<unsigned int>(strtoul(c_str(), nullptr, base));
 }
 
 float plString::ToFloat() const
 {
     // strtof is C99, which MS doesn't support...
-    return (float)strtod(c_str(), nil);
+    return (float)strtod(c_str(), nullptr);
 }
 
 double plString::ToDouble() const
 {
-    return strtod(c_str(), nil);
+    return strtod(c_str(), nullptr);
 }
 
 // Microsoft doesn't provide this for us

--- a/Sources/Plasma/CoreLib/plString.h
+++ b/Sources/Plasma/CoreLib/plString.h
@@ -215,6 +215,15 @@ private:
     void IConvertFromUtf32(const UniChar *ustr, size_t size);
     void IConvertFromIso8859_1(const char *astr, size_t size);
 
+    // Constructing and comparing with nil or nullptr won't break plString,
+    // but it's preferred not to do so with the constants.  That is to say,
+    // you can construct with a const char * which points to null, but
+    // don't actually write `plString foo = nil;`
+    plString(std::nullptr_t) { }
+    void operator=(std::nullptr_t) { }
+    void operator==(std::nullptr_t) const { }
+    void operator!=(std::nullptr_t) const { }
+
 public:
     /** Construct a valid, empty string. */
     plString() { }

--- a/Sources/Plasma/FeatureLib/pfConditional/plObjectInBoxConditionalObject.cpp
+++ b/Sources/Plasma/FeatureLib/pfConditional/plObjectInBoxConditionalObject.cpp
@@ -172,7 +172,7 @@ bool plVolumeSensorConditionalObject::MsgReceive(plMessage* msg)
                             if (plNetClientApp::GetInstance()->GetLocalPlayerKey() != pActivateMsg->fHitterObj)
                             {
                                 plArmatureMod *am=const_cast<plArmatureMod*>( plArmatureMod::ConvertNoRef(pObj->GetModifier(i)));
-                                if((am->IsLocalAI())==nil)
+                                if (!am->IsLocalAI())
                                 {
                                     return false;
                                 }
@@ -221,7 +221,7 @@ bool plVolumeSensorConditionalObject::MsgReceive(plMessage* msg)
                                     if (plNetClientApp::GetInstance()->GetLocalPlayerKey() != pActivateMsg->fHitterObj)
                                     {
                                         plArmatureMod *am=const_cast<plArmatureMod*>( plArmatureMod::ConvertNoRef(pObj->GetModifier(i)));
-                                        if((am->IsLocalAI())==nil)
+                                        if (!am->IsLocalAI())
                                         {
                                             return false;
                                         }
@@ -332,7 +332,7 @@ bool plVolumeSensorConditionalObjectNoArbitration::MsgReceive(plMessage* msg)
                             if (plNetClientApp::GetInstance()->GetLocalPlayerKey() != pActivateMsg->fHitterObj)
                             {
                                 plArmatureMod *am=const_cast<plArmatureMod*>( plArmatureMod::ConvertNoRef(pObj->GetModifier(i)));
-                                if((am->IsLocalAI())==nil)
+                                if (!am->IsLocalAI())
                                 {
                                     return false;
                                 }
@@ -382,7 +382,7 @@ bool plVolumeSensorConditionalObjectNoArbitration::MsgReceive(plMessage* msg)
                                     if (plNetClientApp::GetInstance()->GetLocalPlayerKey() != pActivateMsg->fHitterObj)
                                     {
                                         plArmatureMod *am=const_cast<plArmatureMod*>( plArmatureMod::ConvertNoRef(pObj->GetModifier(i)));
-                                        if((am->IsLocalAI())==nil)
+                                        if (!am->IsLocalAI())
                                         {
                                             return false;
                                         }

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -844,7 +844,7 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
     {
         fWorkingCursor = 0;
     }
-    else if (msg->GetKeyChar() != nil)
+    else if (msg->GetKeyChar())
     {
         key = msg->GetKeyChar();
         // do they want to go into help mode?

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
@@ -615,7 +615,7 @@ bool    pfGameGUIMgr::IHandleKeyPress( wchar_t key, uint8_t modifiers )
     pfGUIDialogMod  *dlg;
 
     // Really... Don't handle any nil keypresses
-    if (key == nil)
+    if (!key)
         return false;
 
     for( dlg = fActiveDialogs; dlg != nil; dlg = dlg->GetNext() )

--- a/Sources/Plasma/FeatureLib/pfPython/pyPlayerGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyPlayerGlue.cpp
@@ -103,7 +103,7 @@ PYTHON_INIT_DEFINITION(ptPlayer, args, keywords)
         PYTHON_RETURN_INIT_ERROR;
     }
 
-    self->fThis->Init(key, name.c_str(), pid, distSeq);
+    self->fThis->Init(key->getKey(), name.c_str(), pid, distSeq);
     PYTHON_RETURN_INIT_OK;
 }
 

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Nt/pnAceNtSocket.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Nt/pnAceNtSocket.cpp
@@ -770,7 +770,7 @@ static unsigned THREADCALL ListenThreadProc (AsyncThread *) {
     for (NtOpConnAttempt * op; (op = s_connectList.Head()) != nil; s_connectList.Unlink(op)) {
         if (op->hSocket != INVALID_SOCKET) {
             closesocket(op->hSocket);
-            op->hSocket = nil;
+            op->hSocket = 0;
         }
         INtConnPostOperation(nil, op, 0);
     }

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Win32/pnAceW32Dns.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Win32/pnAceW32Dns.cpp
@@ -306,7 +306,7 @@ void AsyncAddressLookupName (
             sizeof(lookup->buffer)
         );
         if (!lookup->cancelHandle) {
-            PostMessage(s_lookupWindow, WM_LOOKUP_FOUND_HOST, nil, (unsigned) -1);
+            PostMessage(s_lookupWindow, WM_LOOKUP_FOUND_HOST, 0, (unsigned) -1);
         }
     }
     s_critsect.Leave();
@@ -356,7 +356,7 @@ void AsyncAddressLookupAddr (
             sizeof(lookup->buffer)
         );
         if (!lookup->cancelHandle) {
-            PostMessage(s_lookupWindow, WM_LOOKUP_FOUND_HOST, nil, (unsigned) -1);
+            PostMessage(s_lookupWindow, WM_LOOKUP_FOUND_HOST, 0, (unsigned) -1);
         }
     }
     s_critsect.Leave();
@@ -381,7 +381,7 @@ void AsyncAddressLookupCancel (
         lookup->cancelHandle = nil;
 
         // initiate user callback
-        PostMessage(s_lookupWindow, WM_LOOKUP_FOUND_HOST, nil, (unsigned) -1);
+        PostMessage(s_lookupWindow, WM_LOOKUP_FOUND_HOST, 0, (unsigned) -1);
     }
     s_critsect.Leave();
 }

--- a/Sources/Plasma/NucleusLib/pnFactory/plFactory.cpp
+++ b/Sources/Plasma/NucleusLib/pnFactory/plFactory.cpp
@@ -154,7 +154,7 @@ void plFactory::IUnRegister(uint16_t hClass)
 uint16_t plFactory::Register(uint16_t hClass, plCreator* worker)
 {
     if( !theFactory && !ICreateTheFactory() )
-            return nil;
+        return 0;
 
     hsRefCnt_SafeRef(theFactory);
     return theFactory->IRegister(hClass, worker);

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.cpp
@@ -120,15 +120,6 @@ static const char* CloneString(const plKeyData* keyData)
 #endif
 
 
-plKey::plKey() : fKeyData(nil)
-{
-}
-
-plKey::plKey(void* ptr) : fKeyData(nil)
-{
-    hsAssert(!ptr, "Attempting to publically construct a non-nil key");
-}
-
 plKey::plKey(const plKey& rhs) : fKeyData(rhs.fKeyData)
 {
 #if TRACK_REFS  // FOR DEBUGGING ONLY
@@ -143,13 +134,13 @@ plKey::plKey(const plKey& rhs) : fKeyData(rhs.fKeyData)
     IIncRef();
 }
 
-plKey::plKey(plKeyData* data, bool ignore) : fKeyData(data)
+plKey::plKey(plKeyData* data) : fKeyData(data)
 {
 #if TRACK_REFS  // FOR DEBUGGING ONLY
     if( IsTracked(fKeyData) )
     {
         char msg[ 512 ];
-        sprintf( msg, "C: Key %s %s is being constructed using the plKey(plKeyData*, bool) constructor", keyNameToLookFor, CloneString(fKeyData) );
+        sprintf( msg, "C: Key %s %s is being constructed using the plKey(plKeyData*) constructor", keyNameToLookFor, CloneString(fKeyData) );
         //hsAssert( false, msg );
         hsStatusMessageF(msg);
     }

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
@@ -61,9 +61,9 @@ class plKey
 {
 public:
     // Constructors and destructors and copy stuff
-    plKey();
+    plKey() : fKeyData(nullptr) { }
+    plKey(std::nullptr_t) : fKeyData(nullptr) { }
     plKey(const plKey& rhs);
-    plKey(void* ptr);   // For constructing a nil key
     ~plKey();
     plKey& operator=(const plKey& rhs);
 
@@ -77,7 +77,7 @@ public:
 
     operator plKeyImp*() const { return (plKeyImp*)fKeyData; }
 
-    static plKey Make(plKeyData* data) { return plKey(data, false); }
+    static plKey Make(plKeyData* data) { return plKey(data); }
 
 protected:
     // Pointer to our real key
@@ -86,7 +86,7 @@ protected:
     void IDecRef();
 
     // Internal constructor, extra param is to distinguish it from the void* constructor
-    plKey(plKeyData* data, bool ignore);
+    plKey(plKeyData* data);
 };
 
 //// plKeyData ///////////////////////////////////////////////////////////////

--- a/Sources/Plasma/NucleusLib/pnMessage/plCameraMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCameraMsg.cpp
@@ -53,13 +53,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 //
 
-plCameraMsg::plCameraMsg() : 
+plCameraMsg::plCameraMsg() :
 fNewCam(nil),
 fTriggerer(nil),
 fTransTime(0),
 fSubject(nil),
 fPipe(nil),
-fConfig(nil),
 fActivated(false)
 {
 }
@@ -70,7 +69,6 @@ fTriggerer(nil),
 fTransTime(0),
 fSubject(nil),
 fPipe(nil),
-fConfig(nil),
 fActivated(false),
 plMessage(s, r, t)
 {

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plCoordinateInterface.cpp
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plCoordinateInterface.cpp
@@ -333,7 +333,7 @@ uint16_t plCoordinateInterface::GetReasons()
 
 void plCoordinateInterface::ClearReasons()
 {
-    fReason = nil;
+    fReason = 0;
 }
 
 void plCoordinateInterface::SetLocalToParent(const hsMatrix44& l2p, const hsMatrix44& p2l)

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
@@ -198,7 +198,7 @@ void plAudioSystem::IEnumerateDevices()
     char *devices = (char *)alcGetString(nil, ALC_DEVICE_SPECIFIER);
     int major, minor;
 
-    while(*devices != nil)
+    while (*devices)
     {
         ALCdevice *device = alcOpenDevice(devices);
         if (device) 

--- a/Sources/Plasma/PubUtilLib/plAudio/plDSoundBuffer.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plDSoundBuffer.cpp
@@ -125,7 +125,7 @@ void    plDSoundBuffer::IRelease( void )
 
     // Release stuff
     fEAXSource.Release();
-    alSourcei(source, AL_BUFFER, nil);
+    alSourcei(source, AL_BUFFER, 0);
     alDeleteSources(1, &source);
     if(buffer)
         alDeleteBuffers( 1, &buffer );
@@ -173,7 +173,7 @@ bool plDSoundBuffer::FillBuffer(void *data, unsigned bytes, plWAVHeader *header)
 {
     if(source)
     {
-        alSourcei(source, AL_BUFFER, nil);
+        alSourcei(source, AL_BUFFER, 0);
         alDeleteSources(1, &source);
     }
     if(buffer)
@@ -278,7 +278,7 @@ bool plDSoundBuffer::SetupStreamingSource(plAudioFileReader *stream)
         plStatusLog::AddLineS("audio.log", "Failed to create audio source %d %d", error, source);
         return false;
     }
-    alSourcei(source, AL_BUFFER, nil);
+    alSourcei(source, AL_BUFFER, 0);
     SetScalarVolume(0);
     
     
@@ -344,7 +344,7 @@ bool plDSoundBuffer::SetupStreamingSource(void *data, unsigned bytes)
         plStatusLog::AddLineS("audio.log", "Failed to create audio source %d %d", error, source);
         return false;
     }
-    alSourcei(source, AL_BUFFER, nil);
+    alSourcei(source, AL_BUFFER, 0);
     SetScalarVolume(0);
     
     alSourcef(source, AL_ROLLOFF_FACTOR, 0.3048);
@@ -512,7 +512,7 @@ bool plDSoundBuffer::SetupVoiceSource()
     {
         return false;
     }
-    alSourcei(source, AL_BUFFER, nil);
+    alSourcei(source, AL_BUFFER, 0);
     alGetError();
     //alSourcei(source, AL_PITCH, 0);
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plWinMicLevel.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWinMicLevel.cpp
@@ -149,9 +149,9 @@ plWinMicLevel::plWinMicLevel()
     if( sNumMixers == 0 )
         return;
 
-    if( ::mixerOpen( &sMixerHandle, 0, 
-                                    nil,    // Window handle to receive callback messages
-                                    nil, MIXER_OBJECTF_MIXER ) != MMSYSERR_NOERROR )
+    if( ::mixerOpen( &sMixerHandle, 0,
+                     0,    // Window handle to receive callback messages
+                     0, MIXER_OBJECTF_MIXER ) != MMSYSERR_NOERROR )
     {
         sMixerHandle = nil; // Just to be sure
         return;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -1339,7 +1339,7 @@ bool plArmatureMod::MsgReceive(plMessage* msg)
         }
         else
         {
-            if (cloneMsg->GetCloneKey() == GetFollowerParticleSystemSO())
+            if (cloneMsg->GetCloneKey() == GetFollowerParticleSystemSO()->GetKey())
             {
                 SetFollowerParticleSystemSO(nil);
                 return true;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
@@ -159,10 +159,10 @@ void plAvTask::IUndoLimitPlayersInput(plArmatureMod *avatar)
 plAvSeekTask::plAvSeekTask()
 : fAnimName(nil),
   fAlign(kAlignHandle),
-  fDuration(0.25f),
+  fDuration(0.25),
   fTarget(nil),
   fAnimInstance(nil),
-  fTargetTime(nil),
+  fTargetTime(0),
   fPhysicalAtStart(false),
   fCleanup(false)
 {
@@ -171,10 +171,10 @@ plAvSeekTask::plAvSeekTask()
 // CTOR target, align, animName
 plAvSeekTask::plAvSeekTask(plKey target, plAvAlignment align, const char *animName)
 : fAlign(align),
-  fDuration(0.25f),
+  fDuration(0.25),
   fTarget(target),
   fAnimInstance(nil),
-  fTargetTime(nil),
+  fTargetTime(0),
   fPhysicalAtStart(false),
   fCleanup(false)
 {
@@ -185,10 +185,10 @@ plAvSeekTask::plAvSeekTask(plKey target, plAvAlignment align, const char *animNa
 plAvSeekTask::plAvSeekTask(plKey target)
 : fAnimName(nil),
 fAlign(kAlignHandle),
-fDuration(0.25f),
+fDuration(0.25),
 fTarget(target),
 fAnimInstance(nil),
-fTargetTime(nil),
+fTargetTime(0),
 fPhysicalAtStart(false),
 fCleanup(false)
 {

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
@@ -74,7 +74,7 @@ public:
 
     uint32_t GetFlags() { return fFlags; }
     void SetFlags(uint32_t f) { fFlags = f; }
-    virtual void HandleKeyEvent(plOSMsg message, plKeyDef key, bool bKeyDown, bool bKeyRepeat, wchar_t c = nil) {;}
+    virtual void HandleKeyEvent(plOSMsg message, plKeyDef key, bool bKeyDown, bool bKeyRepeat, wchar_t c = 0) {;}
     virtual void HandleMouseEvent(plOSMsg message, plMouseState state)  {;}
     virtual void HandleWindowActivate(bool bActive, hsWindowHndl hWnd) {;}
     virtual bool MsgReceive(plMessage* msg) {return false;}
@@ -116,7 +116,7 @@ public:
     void SetControlMode(int i) { fControlMode = i; }
 
     const char* GetInputName() { return "keyboard"; }
-    void HandleKeyEvent(plOSMsg message, plKeyDef key, bool bKeyDown, bool bKeyRepeat, wchar_t c = nil);
+    void HandleKeyEvent(plOSMsg message, plKeyDef key, bool bKeyDown, bool bKeyRepeat, wchar_t c = 0);
     virtual void HandleWindowActivate(bool bActive, hsWindowHndl hWnd);
     virtual bool IsCapsLockKeyOn();
     virtual void Shutdown();

--- a/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
@@ -335,12 +335,12 @@ bool plAxisAnimModifier::MsgReceive(plMessage* msg)
                 hsRefCnt_SafeUnRef( pCall1 );
                 hsRefCnt_SafeUnRef( pCall2 );
 
-                plgDispatch::MsgSend(pMsg);     
+                plgDispatch::MsgSend(pMsg);
             }
             else 
             if (pRefMsg->fType == kTypeLogic)
             {
-                SetNotificationKey(pRefMsg->GetRef());
+                SetNotificationKey(pRefMsg->GetRef()->GetKey());
             }
         }
         else

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -279,7 +279,7 @@ const char* ProcessTab(const char* fmt)
 //
 bool plNetClientMgr::Log(const char* str) const
 {
-    if (strlen(str)==nil)
+    if (strlen(str) == 0)
         return true;
 
     // prepend raw time

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
@@ -403,11 +403,9 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgVoice)
     const char* buf = m->GetVoiceData();
     uint8_t flags = m->GetFlags();
     uint8_t numFrames = m->GetNumFrames();
-    plKey key = NULL;
+    plKey key;
 
     // plKey key=hsgResMgr::ResMgr()->FindKey(m->ObjectInfo()->GetUoid());
-
-    
 
     // Filter ignored sender
     if ( VaultAmIgnoringPlayer( m->GetPlayerID() ) )

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -1719,15 +1719,15 @@ void CliAuConn::StopAutoPing () {
 void CliAuConn::TimerPing () {
     // Send a ping request
     pingSendTimeMs = GetNonZeroTimeMs();
-        
+
     const uintptr_t msg[] = {
         kCli2Auth_PingRequest,
         pingSendTimeMs,
         0,      // not a transaction
         0,      // no payload
-        nil
+        reinterpret_cast<uintptr_t>(nullptr)
     };
-        
+
     Send(msg, arrsize(msg));
 }
 
@@ -5093,8 +5093,7 @@ bool AuthQueryConnected () {
     bool result;
     s_critsect.Enter();
     {
-        if (nil != (result = s_active))
-            result &= (nil != s_active->cli);
+        result = (s_active && s_active->cli);
     }
     s_critsect.Leave();
     return result;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
@@ -756,8 +756,7 @@ bool GameQueryConnected () {
     bool result;
     s_critsect.Enter();
     {
-        if (nil != (result = s_active))
-            result &= (nil != s_active->cli);
+        result = (s_active && s_active->cli);
     }
     s_critsect.Leave();
     return result;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -655,15 +655,15 @@ void CliGkConn::StopAutoPing () {
 void CliGkConn::TimerPing () {
     // Send a ping request
     pingSendTimeMs = GetNonZeroTimeMs();
-        
+
     const uintptr_t msg[] = {
         kCli2GateKeeper_PingRequest,
         pingSendTimeMs,
         0,      // not a transaction
         0,      // no payload
-        nil
+        reinterpret_cast<uintptr_t>(nullptr)
     };
-        
+
     Send(msg, arrsize(msg));
 }
 
@@ -1032,8 +1032,7 @@ bool GateKeeperQueryConnected () {
     bool result;
     s_critsect.Enter();
     {
-        if (nil != (result = s_active))
-            result &= (nil != s_active->cli);
+        result = (s_active && s_active->cli);
     }
     s_critsect.Leave();
     return result;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDXPipeline.cpp
@@ -752,7 +752,7 @@ void    plDXPipeline::IClearMembers()
     fULutTextureRef = nil;
     for( i = 0; i < kMaxRenderTargetNext; i++ )
         fBlurVBuffers[i] = nil;
-    fBlurVSHandle = nil;
+    fBlurVSHandle = 0;
 
     fD3DObject = nil;
     fD3DDevice = nil;
@@ -4352,7 +4352,7 @@ bool  plDXPipeline::CaptureScreen( plMipmap *dest, bool flipVertical, uint16_t d
     surface->UnlockRect();
     ReleaseObject( surface );
 
-    if( desiredWidth != 0 && desiredHeight != nil )
+    if( desiredWidth != 0 && desiredHeight != 0 )
     {
         // Rescale to the right size
         dest->ResizeNicely( desiredWidth, desiredHeight, plMipmap::kDefaultFilter );
@@ -11889,7 +11889,7 @@ void    plDXPipeline::ISetErrorMessage( char *errStr )
         plStatusLog::AddLineS("pipeline.log", fSettings.fErrorStr);
     }
     else
-        fSettings.fErrorStr[ 0 ] = nil;
+        fSettings.fErrorStr[ 0 ] = 0;
 }
 
 // IGetD3DError /////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDXTextFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDXTextFont.cpp
@@ -120,7 +120,7 @@ void    plDXTextFont::ICreateTexture( uint16_t *data )
     // Lock the texture and write our values out
     fD3DTexture->LockRect( 0, &lockInfo, 0, 0 );
     memcpy( lockInfo.pBits, data, fTextureWidth * fTextureHeight * sizeof( uint16_t ) );
-    fD3DTexture->UnlockRect( nil );
+    fD3DTexture->UnlockRect( 0 );
 }
 
 void plDXTextFont::CreateShared(IDirect3DDevice9* device)

--- a/Sources/Plasma/PubUtilLib/plResMgr/plPageInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plPageInfo.cpp
@@ -61,7 +61,7 @@ plPageInfo::plPageInfo( const plLocation &loc )
 
 void plPageInfo::IInit()
 {
-    fAge = fPage = nil;
+    fAge = fPage = "";
     fLocation.Invalidate();
     SetMajorVersion(plVersion::GetMajorVersion());
     fClassVersions.clear();
@@ -71,7 +71,7 @@ void plPageInfo::IInit()
 
 plPageInfo::~plPageInfo()
 {
-    SetStrings( nil, nil );
+    SetStrings("", "");
 }
 
 plPageInfo::plPageInfo( const plPageInfo &src )

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
@@ -1715,7 +1715,7 @@ public:
 bool plResManager::IterateKeys(plRegistryKeyIterator* iterator)
 {
     plKeyIterEater myEater(iterator);
-    return IteratePages(&myEater, nil);
+    return IteratePages(&myEater);
 }
 
 bool plResManager::IterateKeys(plRegistryKeyIterator* iterator, const plLocation& pageToRestrictTo)

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDLParser.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDLParser.cpp
@@ -67,7 +67,7 @@ void plSDLParser::DebugMsg(const char* fmt, ...) const
 
 void plSDLParser::DebugMsgV(const char* fmt, va_list args) const
 {
-    if (strlen(fmt)==nil)
+    if (strlen(fmt) == 0)
         return;
     hsStatusMessage(plString::IFormat(fmt,args).c_str());
 }

--- a/Sources/Tools/MaxComponent/plClimbComponent.cpp
+++ b/Sources/Tools/MaxComponent/plClimbComponent.cpp
@@ -243,7 +243,7 @@ bool plClimbTriggerComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     plKey nilKey = nil;
     plKey target = node->GetSceneObject()->GetKey();
     plClimbMsg *enterMsg = nil;
-    if(enterCommand != plClimbMsg::kNoCommand)
+    if (enterCommand != plClimbMsg::kNoCommand)
     {
         enterMsg = new plClimbMsg(nilKey, nilKey, enterCommand, direction, enterStatus, target);
         enterMsg->SetBCastFlag(plMessage::kPropagateToModifiers);
@@ -252,7 +252,7 @@ bool plClimbTriggerComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     }
 
     plClimbMsg *exitMsg = nil;
-    if(exitCommand != nil)
+    if (exitCommand != plClimbMsg::kNoCommand)
     {
         exitMsg = new plClimbMsg(nilKey, nilKey, exitCommand, direction, exitStatus, target);
         exitMsg->SetBCastFlag(plMessage::kPropagateToModifiers);

--- a/Sources/Tools/MaxMain/plMaxNodeBase.cpp
+++ b/Sources/Tools/MaxMain/plMaxNodeBase.cpp
@@ -130,45 +130,45 @@ plMaxNodeData *plMaxNodeBase::GetMaxNodeData()
 
 plKey           plMaxNodeBase::GetKey()             { GetMD; return (pMD) ? pMD->GetKey() : nil;        }
 plSceneObject*  plMaxNodeBase::GetSceneObject()     { GetMD; return (pMD) ? pMD->GetSceneObject() : nil;}
-bool            plMaxNodeBase::GetForceLocal()          { GetMD; return (pMD) ? pMD->GetForceLocal() : nil; }
-bool            plMaxNodeBase::GetReverseSort()         { GetMD; return (pMD) ? pMD->GetReverseSort() : nil;}
-bool            plMaxNodeBase::GetSortAsOpaque()        { GetMD; return (pMD) ? pMD->GetSortAsOpaque() : nil;}
-bool            plMaxNodeBase::GetVS()                  { GetMD; return (pMD) ? pMD->GetVS() : nil;}
-bool            plMaxNodeBase::GetHasWaterHeight()      { GetMD; return (pMD) ? pMD->GetHasWaterHeight() : nil; }
-float           plMaxNodeBase::GetWaterHeight()         { GetMD; return (pMD) ? pMD->GetWaterHeight() : nil; }
-bool            plMaxNodeBase::GetSmoothAll()           { GetMD; return (pMD) ? pMD->GetSmoothAll() : nil;}
-bool            plMaxNodeBase::GetForceSortable()       { GetMD; return (pMD) ? pMD->GetForceSortable() : nil;}
-bool            plMaxNodeBase::GetConcave()             { GetMD; return (pMD) ? pMD->GetConcave() : nil;}
-bool            plMaxNodeBase::GetCalcEdgeLens()        { GetMD; return (pMD) ? pMD->GetCalcEdgeLens() : nil;}
-bool            plMaxNodeBase::GetRunTimeLight()        { GetMD; return (pMD) ? pMD->GetRunTimeLight() : nil;}
-bool            plMaxNodeBase::GetForceMatShade()       { GetMD; return (pMD) ? pMD->GetForceMatShade() : nil;}
-bool            plMaxNodeBase::GetForceVisLOS()         { GetMD; return (pMD) ? pMD->GetForceVisLOS() : nil;}
-bool            plMaxNodeBase::GetEnviron()     { GetMD; return (pMD) ? pMD->GetEnviron() : nil;}
-bool            plMaxNodeBase::GetEnvironOnly()     { GetMD; return (pMD) ? pMD->GetEnvironOnly() : nil;}
-bool            plMaxNodeBase::GetWaterDecEnv()         { GetMD; return (pMD) ? pMD->GetWaterDecEnv() : nil; }
-bool            plMaxNodeBase::GetNoPreShade()          { GetMD; return (pMD) ? pMD->GetNoPreShade() && !pMD->GetForcePreShade() : nil;}
-bool            plMaxNodeBase::GetForcePreShade()       { GetMD; return (pMD) ? pMD->GetForcePreShade() : nil;}
+bool            plMaxNodeBase::GetForceLocal()          { GetMD; return (pMD) ? pMD->GetForceLocal() : false; }
+bool            plMaxNodeBase::GetReverseSort()         { GetMD; return (pMD) ? pMD->GetReverseSort() : false;}
+bool            plMaxNodeBase::GetSortAsOpaque()        { GetMD; return (pMD) ? pMD->GetSortAsOpaque() : false;}
+bool            plMaxNodeBase::GetVS()                  { GetMD; return (pMD) ? pMD->GetVS() : false;}
+bool            plMaxNodeBase::GetHasWaterHeight()      { GetMD; return (pMD) ? pMD->GetHasWaterHeight() : false; }
+float           plMaxNodeBase::GetWaterHeight()         { GetMD; return (pMD) ? pMD->GetWaterHeight() : 0; }
+bool            plMaxNodeBase::GetSmoothAll()           { GetMD; return (pMD) ? pMD->GetSmoothAll() : false;}
+bool            plMaxNodeBase::GetForceSortable()       { GetMD; return (pMD) ? pMD->GetForceSortable() : false;}
+bool            plMaxNodeBase::GetConcave()             { GetMD; return (pMD) ? pMD->GetConcave() : false;}
+bool            plMaxNodeBase::GetCalcEdgeLens()        { GetMD; return (pMD) ? pMD->GetCalcEdgeLens() : false;}
+bool            plMaxNodeBase::GetRunTimeLight()        { GetMD; return (pMD) ? pMD->GetRunTimeLight() : false;}
+bool            plMaxNodeBase::GetForceMatShade()       { GetMD; return (pMD) ? pMD->GetForceMatShade() : false;}
+bool            plMaxNodeBase::GetForceVisLOS()         { GetMD; return (pMD) ? pMD->GetForceVisLOS() : false;}
+bool            plMaxNodeBase::GetEnviron()     { GetMD; return (pMD) ? pMD->GetEnviron() : false;}
+bool            plMaxNodeBase::GetEnvironOnly()     { GetMD; return (pMD) ? pMD->GetEnvironOnly() : false;}
+bool            plMaxNodeBase::GetWaterDecEnv()         { GetMD; return (pMD) ? pMD->GetWaterDecEnv() : false; }
+bool            plMaxNodeBase::GetNoPreShade()          { GetMD; return (pMD) ? pMD->GetNoPreShade() && !pMD->GetForcePreShade() : false;}
+bool            plMaxNodeBase::GetForcePreShade()       { GetMD; return (pMD) ? pMD->GetForcePreShade() : false;}
 plKey           plMaxNodeBase::GetRoomKey()         { GetMD; return (pMD) ? pMD->GetRoomKey() : nil;    }
-bool            plMaxNodeBase::GetDrawable()            { GetMD; return (pMD) ? pMD->GetDrawable() : nil;   }
-bool            plMaxNodeBase::GetPhysical()            { GetMD; return (pMD) ? pMD->GetPhysical() : nil;   }
-bool            plMaxNodeBase::GetItinerant()           { GetMD; return (pMD) ? pMD->GetItinerant() : nil;  }
-bool            plMaxNodeBase::GetUnBounded()           { GetMD; return (pMD) ? pMD->GetUnBounded() : nil;  }
-bool            plMaxNodeBase::GetDisableNormal()       { GetMD; return (pMD) ? pMD->GetDisableNormal() : nil;  }
-uint32_t        plMaxNodeBase::GetDecalLevel()          { GetMD; return (pMD) ? pMD->GetDecalLevel() : nil; }
-bool            plMaxNodeBase::GetMovable()         { GetMD; return (pMD) ? pMD->GetMovable() : nil;    }
-bool            plMaxNodeBase::GetIsBarney()            { GetMD; return (pMD) ? pMD->GetIsBarney() : nil;   }
-bool            plMaxNodeBase::GetForceShadow()         { GetMD; return (pMD) ? pMD->GetForceShadow() : nil;    }
-bool            plMaxNodeBase::GetAlphaTestHigh()       { GetMD; return (pMD) ? pMD->GetAlphaTestHigh() : nil;  }
-bool            plMaxNodeBase::GetFilterInherit()           { GetMD; return (pMD) ? pMD->GetFilterInherit() : nil;  }
-bool            plMaxNodeBase::GetNoShadow()            { GetMD; return (pMD) ? pMD->GetNoShadow() : nil;   }
-bool            plMaxNodeBase::GetNoSpanSort()          { GetMD; return (pMD) ? pMD->GetNoSpanSort() : nil; }
-bool            plMaxNodeBase::GetNoSpanReSort()        { GetMD; return (pMD) ? pMD->GetNoSpanReSort() : nil; }
-bool            plMaxNodeBase::GetNoFaceSort()          { GetMD; return (pMD) ? pMD->GetNoFaceSort() : nil; }
-bool            plMaxNodeBase::GetNoDeferDraw()     { GetMD; return (pMD) ? pMD->GetNoDeferDraw() : nil; }
-bool            plMaxNodeBase::GetBlendToFB()       { GetMD; return (pMD) ? pMD->GetBlendToFB() : nil; }
-bool            plMaxNodeBase::GetForceMaterialCopy()   { GetMD; return (pMD) ? pMD->GetForceMaterialCopy() : nil; }
-bool            plMaxNodeBase::GetInstanced()           { GetMD; return (pMD) ? pMD->GetInstanced() : nil; }
-bool            plMaxNodeBase::GetParticleRelated() { GetMD; return (pMD) ? pMD->GetParticleRelated() : nil; }
+bool            plMaxNodeBase::GetDrawable()            { GetMD; return (pMD) ? pMD->GetDrawable() : false;   }
+bool            plMaxNodeBase::GetPhysical()            { GetMD; return (pMD) ? pMD->GetPhysical() : false;   }
+bool            plMaxNodeBase::GetItinerant()           { GetMD; return (pMD) ? pMD->GetItinerant() : false;  }
+bool            plMaxNodeBase::GetUnBounded()           { GetMD; return (pMD) ? pMD->GetUnBounded() : false;  }
+bool            plMaxNodeBase::GetDisableNormal()       { GetMD; return (pMD) ? pMD->GetDisableNormal() : false;  }
+uint32_t        plMaxNodeBase::GetDecalLevel()          { GetMD; return (pMD) ? pMD->GetDecalLevel() : 0; }
+bool            plMaxNodeBase::GetMovable()         { GetMD; return (pMD) ? pMD->GetMovable() : false;    }
+bool            plMaxNodeBase::GetIsBarney()            { GetMD; return (pMD) ? pMD->GetIsBarney() : false;   }
+bool            plMaxNodeBase::GetForceShadow()         { GetMD; return (pMD) ? pMD->GetForceShadow() : false;    }
+bool            plMaxNodeBase::GetAlphaTestHigh()       { GetMD; return (pMD) ? pMD->GetAlphaTestHigh() : false;  }
+bool            plMaxNodeBase::GetFilterInherit()           { GetMD; return (pMD) ? pMD->GetFilterInherit() : false;  }
+bool            plMaxNodeBase::GetNoShadow()            { GetMD; return (pMD) ? pMD->GetNoShadow() : false;   }
+bool            plMaxNodeBase::GetNoSpanSort()          { GetMD; return (pMD) ? pMD->GetNoSpanSort() : false; }
+bool            plMaxNodeBase::GetNoSpanReSort()        { GetMD; return (pMD) ? pMD->GetNoSpanReSort() : false; }
+bool            plMaxNodeBase::GetNoFaceSort()          { GetMD; return (pMD) ? pMD->GetNoFaceSort() : false; }
+bool            plMaxNodeBase::GetNoDeferDraw()     { GetMD; return (pMD) ? pMD->GetNoDeferDraw() : false; }
+bool            plMaxNodeBase::GetBlendToFB()       { GetMD; return (pMD) ? pMD->GetBlendToFB() : false; }
+bool            plMaxNodeBase::GetForceMaterialCopy()   { GetMD; return (pMD) ? pMD->GetForceMaterialCopy() : false; }
+bool            plMaxNodeBase::GetInstanced()           { GetMD; return (pMD) ? pMD->GetInstanced() : false; }
+bool            plMaxNodeBase::GetParticleRelated() { GetMD; return (pMD) ? pMD->GetParticleRelated() : false; }
 uint32_t        plMaxNodeBase::GetSoundIdxCounter() { GetMD; return (pMD) ? pMD->GetSoundIdxCounter() : 0; }
 plSceneObject*  plMaxNodeBase::GetAvatarSO()            { GetMD; return (pMD) ? pMD->GetAvatarSO() : nil; }
 BOOL            plMaxNodeBase::HasFade()                { GetMD; return (pMD) ? pMD->HasFade() : false; }

--- a/Sources/Tools/plFontConverter/plFontConverterProc.cpp
+++ b/Sources/Tools/plFontConverter/plFontConverterProc.cpp
@@ -344,12 +344,12 @@ BOOL CALLBACK ResListWndProc( HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
 
         case WM_COMMAND:
             if( wParam == IDCANCEL )
-                EndDialog( hWnd, nil );
+                EndDialog( hWnd, 0 );
             else
             {
                 int idx = SendDlgItemMessage( hWnd, IDC_RESLIST, LB_GETCURSEL, 0, 0 );
                 if( idx == LB_ERR )
-                    EndDialog( hWnd, nil );
+                    EndDialog( hWnd, 0 );
                 else
                 {
                     ResRecord *rec = (ResRecord *)SendDlgItemMessage( hWnd, IDC_RESLIST, LB_GETITEMDATA, idx, 0 );
@@ -719,7 +719,7 @@ BOOL CALLBACK WndProc( HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam )
 
         case WM_DROPFILES:
             {
-                int     i, fileCount = DragQueryFile( (HDROP)wParam, -1, nil, nil );
+                int     i, fileCount = DragQueryFile( (HDROP)wParam, -1, nil, 0 );
                 char    path[ MAX_PATH ];
 
 

--- a/Sources/Tools/plResBrowser/plResBrowserWndProc.cpp
+++ b/Sources/Tools/plResBrowser/plResBrowserWndProc.cpp
@@ -375,7 +375,7 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam 
 
         case WM_DROPFILES:
             {
-                int     i, j, fileCount = DragQueryFile( (HDROP)wParam, -1, nil, nil );
+                int     i, j, fileCount = DragQueryFile( (HDROP)wParam, -1, nil, 0 );
                 char    path[ MAX_PATH ];
 
                 plWaitCursor    myWaitCursor;


### PR DESCRIPTION
With nil defined as 0, there were several parts of the code that were using nil incorrectly...  And with plKey's "nil" constructor taking a void*, there were a few places where a random pointer was being accepted as a valid constructor argument, even though they shouldn't have (and would have caused an assert at runtime anyway).  Using nullptr makes these types of misuse compile-time errors.
