### PR TITLE
Fix patcher brokenness from filesystem PR

### DIFF
--- a/Sources/Plasma/Apps/plClientPatcher/UruPlayer.cpp
+++ b/Sources/Plasma/Apps/plClientPatcher/UruPlayer.cpp
@@ -472,9 +472,9 @@ static void ProcessManifestEntry (void * param, ENetError error) {
         StrPrintf(text, arrsize(text), "Checking for updates...  %S", p->mr->manifest[p->index].clientName);
         p->mr->info->SetText(text);
 #endif
-    plFileName path = plFileName::Join(s_workingDir, p->mr->manifest[p->index].clientName);
+    plFileName path = plFileName::Join(s_workingDir, plString::FromWchar(p->mr->manifest[p->index].clientName));
     uint32_t start = (uint32_t)(TimeGetTime() / kTimeIntervalsPerMs);
-    if (!MD5Check(path, p->mr->manifest[p->index].md5.c_str())) {
+    if (!MD5Check(path, plString::FromWchar(p->mr->manifest[p->index].md5, 32).c_str())) {
         p->mr->critsect.Lock();
         p->mr->indices.Add(p->index);
         p->mr->critsect.Unlock();
@@ -547,7 +547,7 @@ static void ProcessManifest (void * param) {
         p->index = i;
         p->mr = mr;
         p->exists = false;
-        plFileName path = plFileName::Join(s_workingDir, mr->manifest[i].clientName);
+        plFileName path = plFileName::Join(s_workingDir, plString::FromWchar(mr->manifest[i].clientName));
         fd = plFileSystem::Open(path, "r");
         if (fd)
         {
@@ -589,13 +589,13 @@ static void ProcessManifest (void * param) {
                 if(s_running)
                 {
                     unsigned index = mr->indices[i];
-                    plFileName path = plFileName::Join(s_workingDir, manifest[index].clientName);
+                    plFileName path = plFileName::Join(s_workingDir, plString::FromWchar(manifest[index].clientName));
                     plFileSystem::CreateDir(path.StripFileName(), true);
 
                     ManifestFile* mf = new ManifestFile(
-                        manifest[index].clientName,
-                        manifest[index].downloadName,
-                        manifest[index].md5,
+                        plString::FromWchar(manifest[index].clientName),
+                        plString::FromWchar(manifest[index].downloadName),
+                        plString::FromWchar(manifest[index].md5),
                         manifest[index].flags,
                         mr->info
                     );
@@ -733,8 +733,8 @@ static void ThinManifestCallback (
         if (!s_running)
             return;
 
-        plFileName path = plFileName::Join(s_workingDir, manifest[i].clientName);
-        if (!MD5Check(path, manifest[i].md5.c_str())) {
+        plFileName path = plFileName::Join(s_workingDir, plString::FromWchar(manifest[i].clientName));
+        if (!MD5Check(path, plString::FromWchar(manifest[i].md5, 32).c_str())) {
             s_patchComplete = false;
             NetCliFileManifestRequest(ManifestCallback, info, s_manifest, info->buildId);
             break;
@@ -746,7 +746,7 @@ static void ThinManifestCallback (
         info->progressCallback(kStatusPending, &patchInfo);
 #ifndef PLASMA_EXTERNAL_RELEASE
         char text[256];
-        StrPrintf(text, arrsize(text), "Checking for updates...  %s", manifest[i].clientName.AsString().c_str());
+        StrPrintf(text, arrsize(text), "Checking for updates...  %S", manifest[i].clientName);
         info->SetText(text);
 #endif
     }

--- a/Sources/Plasma/Apps/plUruLauncher/SelfPatcher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/SelfPatcher.cpp
@@ -184,7 +184,7 @@ static void ManifestCallback (
     // MD5 check current patcher against value in manifest
     ASSERT(entryCount == 1);
     plFileName curPatcherFile = plFileSystem::GetCurrentAppPath();
-    if (!MD5Check(curPatcherFile, manifest[0].md5.c_str())) {
+    if (!MD5Check(curPatcherFile, plString::FromWchar(manifest[0].md5, 32).c_str())) {
 //      MessageBox(GetTopWindow(nil), "MD5 failed", "Msg", MB_OK);
         SelfPatcherStream::totalBytes += manifest[0].zipSize;
 
@@ -195,7 +195,7 @@ static void ManifestCallback (
         if (!stream->Open(s_newPatcherFile, "wb"))
             ErrorAssert(__LINE__, __FILE__, "Failed to create file: %s, errno: %u", s_newPatcherFile.AsString().c_str(), errno);
 
-        NetCliFileDownloadRequest(manifest[0].downloadName, stream, DownloadCallback, nil);
+        NetCliFileDownloadRequest(plString::FromWchar(manifest[0].downloadName), stream, DownloadCallback, nil);
     }
     else {
         s_downloadComplete = true;
@@ -272,7 +272,8 @@ static bool SelfPatcherProc (bool * abort, plLauncherInfo *info) {
         si.cb = sizeof(si);
 
         wchar_t cmdline[MAX_PATH];
-        StrPrintf(cmdline, arrsize(cmdline), L"%s %s", s_newPatcherFile.AsString().ToWchar(), info->cmdLine);
+        StrPrintf(cmdline, arrsize(cmdline), L"%s %s",
+                  s_newPatcherFile.AsString().ToWchar().GetData(), info->cmdLine);
 
         // we have only successfully patched if we actually launch the new version of the patcher
         patched = CreateProcessW(

--- a/Sources/Plasma/FeatureLib/pfSecurePreloader/pfSecurePreloader.cpp
+++ b/Sources/Plasma/FeatureLib/pfSecurePreloader/pfSecurePreloader.cpp
@@ -345,8 +345,8 @@ void pfSecurePreloader::PreloadManifest(const NetCliFileManifestEntry manifestEn
         const NetCliFileManifestEntry mfs = manifestEntries[i];
         bool fetchMe = true;
         hsRAMStream* s = nil;
-        plFileName clientName = mfs.clientName;
-        plFileName downloadName = mfs.downloadName;
+        plFileName clientName = plString::FromWchar(mfs.clientName);
+        plFileName downloadName = plString::FromWchar(mfs.downloadName);
 
         if (plFileInfo(clientName).Exists())
         {
@@ -355,7 +355,7 @@ void pfSecurePreloader::PreloadManifest(const NetCliFileManifestEntry manifestEn
             {
                 // Damn this
                 plMD5Checksum srvHash;
-                srvHash.SetFromHexString(mfs.md5.c_str());
+                srvHash.SetFromHexString(plString::FromWchar(mfs.md5, 32).c_str());
 
                 // Now actually copare the hashes
                 plMD5Checksum lclHash;

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
@@ -150,8 +150,8 @@ static void ManifestDownloaded(
     for (uint32_t i = 0; i < entryCount; ++i)
     {
         const NetCliFileManifestEntry mfs = manifest[i];
-        plFileName fileName = mfs.clientName;
-        plFileName downloadName = mfs.downloadName;
+        plFileName fileName = plString::FromWchar(mfs.clientName);
+        plFileName downloadName = plString::FromWchar(mfs.downloadName);
 
         // See if the files are the same
         // 1. Check file size before we do time consuming md5 operations
@@ -160,7 +160,7 @@ static void ManifestDownloaded(
         {
             plMD5Checksum cliMD5(fileName);
             plMD5Checksum srvMD5;
-            srvMD5.SetFromHexString(mfs.md5.c_str());
+            srvMD5.SetFromHexString(plString::FromWchar(mfs.md5, 32).c_str());
 
             if (cliMD5 == srvMD5)
                 continue;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
@@ -97,10 +97,10 @@ void NetCliFileRegisterBuildIdUpdate (FNetCliFileBuildIdUpdateCallback callback)
 // Manifest
 //============================================================================
 struct NetCliFileManifestEntry {
-    plFileName  clientName; // path and file on client side (for comparison)
-    plFileName  downloadName; // path and file on server side (for download)
-    plString    md5;
-    plString    md5compressed; // md5 for the compressed file
+    wchar_t     clientName[MAX_PATH]; // path and file on client side (for comparison)
+    wchar_t     downloadName[MAX_PATH]; // path and file on server side (for download)
+    wchar_t     md5[32];
+    wchar_t     md5compressed[32]; // md5 for the compressed file
     unsigned    fileSize;
     unsigned    zipSize;
     unsigned    flags;


### PR DESCRIPTION
This fixes some bugs from my already-merged filesystem PR; most notably, it restores the manifest structure to using wchar_t arrays, since ARRAY(T) allocates memory for itself in chunks, allocated with a single malloc call (thereby bypassing constructors).  The long-term fix is probably to re-evaluate the necessity of this non-obvious design implementation, but the short-term fix is to restore the old design.
