### PR TITLE
Infinite loop fix

### DIFF
--- a/Sources/Plasma/CoreLib/plString.cpp
+++ b/Sources/Plasma/CoreLib/plString.cpp
@@ -556,6 +556,7 @@ int plString::Find(char ch, CaseSensitivity sense) const
         while (*cp) {
             if (tolower(*cp) == tolower(ch))
                 return cp - c_str();
+            cp++;
         }
         return -1;
     }


### PR DESCRIPTION
When using plString::Find with kCaseInSensivity it gets stuck in an infinite loop. This should fix that. 

Found while working on an unit test and tested with it. 
