### PR TITLE
Automatic Mipmapping for DynamicTextMaps

### DIFF
--- a/Sources/Plasma/PubUtilLib/plGImage/plBitmap.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plBitmap.h
@@ -90,6 +90,7 @@ class plBitmap : public hsKeyedObject
             kUserOwnsBitmap     = 0x0200,
             kForceRewrite       = 0x0400,
             kForceNonCompressed = 0x0800,
+            kAutoGenMipmap      = 0x1000,   // prompts DirectX to generate mipmaps for us automagically
             // For renderTargets:
             kIsTexture          = 0x1000,
             kIsOffscreen        = 0x2000,

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
@@ -75,20 +75,12 @@ plProfile_Extern(MemMipmaps);
 
 //// Constructor & Destructor /////////////////////////////////////////////////
 
-plDynamicTextMap::plDynamicTextMap() : plMipmap()
+plDynamicTextMap::plDynamicTextMap()
+    : fVisWidth(0), fVisHeight(0), fHasAlpha(false), fJustify(kLeftJustify),
+      fInitBuffer(nullptr), fFontFace(nullptr), fFontSize(0), fFontFlags(0),
+      fFontAntiAliasRGB(false), fFontBlockRGB(false), fHasCreateBeenCalled(false)
 {
-    fVisWidth = fVisHeight = 0;
-    fHasAlpha = false;
-    fJustify = kLeftJustify;
-    fInitBuffer = nil;
-    fFontFace = nil;
-    fFontSize = 0;
-    fFontFlags = 0;
-    fFontAntiAliasRGB = false;
-    fFontColor.Set( 0, 0, 0, 1 );
-    fFontBlockRGB = false;
-    fHasCreateBeenCalled = false;
-
+    fFontColor.Set(0, 0, 0, 1);
 }
 
 plDynamicTextMap::~plDynamicTextMap()
@@ -96,10 +88,9 @@ plDynamicTextMap::~plDynamicTextMap()
     Reset();
 }
 
-plDynamicTextMap::plDynamicTextMap( uint32_t width, uint32_t height, bool hasAlpha, uint32_t extraWidth, uint32_t extraHeight ) : plMipmap()
+plDynamicTextMap::plDynamicTextMap( uint32_t width, uint32_t height, bool hasAlpha, uint32_t extraWidth, uint32_t extraHeight )
+    : fInitBuffer(nullptr), fFontFace(nullptr)
 {
-    fInitBuffer = nil;
-    fFontFace = nil;
     Create( width, height, hasAlpha, extraWidth, extraHeight );
 }
 
@@ -139,7 +130,7 @@ void    plDynamicTextMap::Create( uint32_t width, uint32_t height, bool hasAlpha
 
     fRowBytes = fWidth << 2;
     fNumLevels = 1;
-    fFlags |= plMipmap::kDontThrowAwayImage;
+    fFlags |= plMipmap::kDontThrowAwayImage | plMipmap::kAutoGenMipmap;
     fCompressionType = plMipmap::kUncompressed;
     fUncompressedInfo.fType = plMipmap::UncompressedInfo::kRGB8888;
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDXDeviceRefs.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDXDeviceRefs.cpp
@@ -209,17 +209,9 @@ plDXTextureRef& plDXTextureRef::Set( D3DFORMAT ft, uint32_t ml, uint32_t mw, uin
 //// Constructor & Destructor /////////////////////////////////////////////////
 
 plDXTextureRef::plDXTextureRef( D3DFORMAT ft, uint32_t ml, uint32_t mw, uint32_t mh, uint32_t np, 
-                                                uint32_t sz, uint32_t manSize, uint32_t* lSz, void* pd, bool ed, bool renderTarget )
+                                uint32_t sz, uint32_t manSize, uint32_t* lSz, void* pd, bool ed, bool renderTarget )
+                                : fD3DTexture(nullptr), fLevelSizes(nullptr), fOwner(nullptr)
 {
-    fLevelSizes = nil;
-    fOwner = nil;
-    fD3DTexture = nil;
-    fDataSize = 0;
-    fFlags = 0;
-    fFormatType = D3DFMT_UNKNOWN;
-    fMMLvs = 0;
-    fMaxWidth = 0;
-    fMaxHeight = 0;
     Set( ft, ml, mw, mh, np, sz, manSize, lSz, pd, ed, renderTarget );
 }
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDXPipeline.cpp
@@ -8292,6 +8292,14 @@ void    plDXPipeline::IReloadTexture( plDXTextureRef *ref )
     }
 }
 
+static uint32_t IGetD3DTextureUsage(const plDXTextureRef* ref)
+{
+    uint32_t usage = 0;
+    if (ref->GetFlags() & plDXTextureRef::kAutoGenMipmap)
+        usage |= D3DUSAGE_AUTOGENMIPMAP;
+    return usage;
+}
+
 //// IMakeD3DTexture //////////////////////////////////////////////////////////
 //  Makes a DX Texture object based on the ref given.
 
@@ -8302,7 +8310,7 @@ IDirect3DTexture9   *plDXPipeline::IMakeD3DTexture( plDXTextureRef *ref, D3DFORM
     fManagedAlloced = true;
     if( FAILED( fSettings.fDXError = fD3DDevice->CreateTexture( ref->fMaxWidth, ref->fMaxHeight, 
                                           ref->fMMLvs,
-                                          0,
+                                          IGetD3DTextureUsage(ref),
                                           formatType,
                                           poolType,
                                           &texPtr, NULL ) ) )
@@ -8473,6 +8481,11 @@ hsGDeviceRef    *plDXPipeline::MakeTextureRef( plLayerInterface* layer, plMipmap
         // Re-linking
         ref->Link( &fTextureRefList );
     }
+
+    // NOTE: This is just a hint, so setting it on a device with no support for it
+    //       or mipmaps in general won't do any damage.
+    if (original->GetFlags() & plMipmap::kAutoGenMipmap)
+        ref->SetFlags(ref->GetFlags() | plDXTextureRef::kAutoGenMipmap);
 
     /// Copy the data into the ref
     IReloadTexture( ref );

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDXTextureRef.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDXTextureRef.h
@@ -76,7 +76,8 @@ class plDXTextureRef : public plDXDeviceRef
             kProjection         = kPerspProjection | kOrthoProjection,
             kOffscreenRT        = 0x00000040,   // Offscreen renderTarget. Never used as an actual texture,
                                                 // but handy to still have it as a textureRef
-            kUVWNormal          = 0x00000080    // Use the normal as the UVW src
+            kUVWNormal          = 0x00000080,   // Use the normal as the UVW src
+            kAutoGenMipmap      = 0x00000100    // DirectX should generate mip levels for us
         };
 
         IDirect3DBaseTexture9   *fD3DTexture;
@@ -94,7 +95,7 @@ class plDXTextureRef : public plDXDeviceRef
 
         void*       fData;          // for reloading
 
-        uint32_t      GetFlags( void ) { return fFlags; }
+        uint32_t      GetFlags() const { return fFlags; }
         void        SetFlags( uint32_t flag ) { fFlags = flag; }
 
         plDXTextureRef& Set( D3DFORMAT tp, uint32_t ml, uint32_t mw, uint32_t mh, uint32_t np, uint32_t sz, uint32_t manSize, uint32_t* lSz, void* pd, bool ed=false, bool renderTarget = false );


### PR DESCRIPTION
This makes DynamicTextMaps not look quite so awful. Mostly noticeable for text notes on imagers and Neighborhood easels.
