### PR TITLE
Fix missing include in CoreLibs

### DIFF
--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -1,3 +1,5 @@
+include_directories(${PCRE_INCLUDE_DIR})
+
 add_definitions(-D_LIB)
 
 add_definitions(-DPRODUCT_BRANCH_ID=${PRODUCT_BRANCH_ID})


### PR DESCRIPTION
The current client ignores the PCRE_INCLUDE_DIR CMake variable and does not compile. This does fix that.
