### PR TITLE
Fix crash from Relto age journal book

### DIFF
--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -2665,7 +2665,7 @@ void    pfJournalBook::IRenderPage( uint32_t page, uint32_t whichDTMap, bool sup
                             idx--;
                         break;
                     }
-                    if( chunk->fText[ lastChar ] != 0 )
+                    if (lastChar < chunk->fText.size() && chunk->fText[lastChar] != 0)
                     {
                         // Didn't get to render the whole paragraph in this go, so we're going to cheat
                         // and split the paragraph up into two so that we can handle it properly. Note:


### PR DESCRIPTION
This fixes a crash when opening the book on the right side bookshelf looking into the Relto hut.
