### PR TITLE
Fix Clone Race Condition

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrLoad.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrLoad.cpp
@@ -105,6 +105,12 @@ plKey plNetClientMgr::ILoadClone(plLoadCloneMsg *pCloneMsg)
 
     if(pCloneMsg->GetIsLoading())
     {
+        if (!cloneKey)
+        {
+            DebugMsg("ILoadClone: got a null clone key... either a loading race or someone is being naughty.");
+            return nullptr;
+        }
+
         if (cloneKey->ObjectIsLoaded())
         {
             DebugMsg("ILoadClone: object %s is already loaded, ignoring", cloneKey->GetUoid().StringIze().c_str());


### PR DESCRIPTION
This happens on DirtSand shards when two avatars are loading the same age at once. LoadCloneMsgs are dispatched to the clients before they have loaded the original keys. The server has no way of knowing that however, so this is the correct place to fix the problem.
