### PR TITLE
Fix Teledahn and Kemo Camera Issues

### DIFF
--- a/Sources/Plasma/FeatureLib/pfCamera/plVirtualCamNeu.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plVirtualCamNeu.cpp
@@ -1680,19 +1680,9 @@ void plVirtualCam1::PushCamera(plCameraModifier1* pCam, bool bDefault)
 
 void plVirtualCam1::PopCamera(plCameraModifier1* pCam)
 {
-        // sanity / new default camera check
+    // sanity / new default camera check
     if (fCameraStack.size() <= 1)
         return;
-    
-    // Crazy Special Casing Turd: [based on some Cyan crap]
-    // is it the current camera AND the same camera we would otherwise switch to?
-    // if so, pop off the dupe if we're going to the age default... otherwise, go crazy.
-    if (fCameraStack.size() > 2 && pCam == GetCurrentStackCamera())
-    {
-        int theDupe = fCameraStack.size() - 1;
-        if (pCam == fCameraStack[theDupe] && theDupe == 2)
-            fCameraStack.pop_back();
-    }
 
     // are we mouse-looking?
     bool mLook = false;

--- a/Sources/Plasma/PubUtilLib/plPhysX/plSimulationMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plSimulationMgr.cpp
@@ -248,10 +248,7 @@ void plSimulationMgr::Init()
     hsAssert(!gTheInstance, "Initializing the sim when it's already been done");
     gTheInstance = new plSimulationMgr();
     if (gTheInstance->InitSimulation())
-    {
         gTheInstance->RegisterAs(kSimulationMgr_KEY);
-        plgDispatch::Dispatch()->RegisterForExactType(plAgeLoadedMsg::Index(), gTheInstance->GetKey());
-    }
     else
     {
         // There was an error when creating the PhysX simulation
@@ -267,7 +264,6 @@ void plSimulationMgr::Shutdown()
     hsAssert(gTheInstance, "Simulation manager missing during shutdown.");
     if (gTheInstance)
     {
-        plgDispatch::Dispatch()->UnRegisterForExactType(plAgeLoadedMsg::Index(), gTheInstance->GetKey());
         gTheInstance->UnRegisterAs(kSimulationMgr_KEY);     // this will destroy the instance
         gTheInstance = nil;
     }
@@ -622,18 +618,6 @@ void plSimulationMgr::ISendUpdates()
 //          fNeedLOSCullPhase = false;
 //      }
     }
-}
-
-bool plSimulationMgr::MsgReceive(plMessage *msg)
-{
-    // Suspend/resume the simulation based on whether or not we're in an age...
-    if (plAgeLoadedMsg* aMsg = plAgeLoadedMsg::ConvertNoRef(msg))
-    {
-        fSuspended = !aMsg->fLoaded;
-        return true;
-    }
-
-    return hsKeyedObject::MsgReceive(msg);
 }
 
 /////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plPhysX/plSimulationMgr.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plSimulationMgr.h
@@ -75,8 +75,6 @@ public:
     // Advance the simulation by the given number of seconds
     void Advance(float delSecs);
 
-    bool MsgReceive(plMessage* msg);
-
     // The simulation won't run at all if it is suspended
     void Suspend() { fSuspended = true; }
     void Resume() { fSuspended = false; }


### PR DESCRIPTION
This fixes the camera getting stuck in the Teledahn upper shroom and avoids introducing a regression in the Kemo journey cloth link-in cameras.

Turns out, it was an artifact of us suspending the simulation during links and partly because of Cyan's late adding of the avatar controller to the sim. Previously, the avatar would be added to the sim after xJourneyClothsGen2 fixed the camera stack, so PhysX would brick it for us. Now, we add the avatar as soon as the age data is loaded. This causes the camera stack to be populated with whatever garbage PhysX decides on, then xJourneyClothsGen2 is free to set the real stack after we get all the SDL from the server.
