### PR TITLE
Hor+ Fixes

### DIFF
--- a/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
@@ -677,7 +677,7 @@ bool plCameraBrain1::MsgReceive(plMessage* msg)
             {
                 fFlags.SetBit(kAnimateFOV);
                 fFOVhGoal = fZoomMax;
-                fFOVwGoal = IMakeFOVwZoom(fZoomMin);
+                fFOVwGoal = IMakeFOVwZoom(fZoomMax);
                 fFOVwAnimRate = fFOVhAnimRate = fZoomRate;
                 fFOVEndTime = hsTimer::GetSysSeconds() + 60;
                 return true;


### PR DESCRIPTION
Fixes the issues seen in zoomable telescopes that aren't the Teledahn gun.

Yes, the bug was caused by a typo.
