### PR TITLE
Copy resource.dat to output folder

### DIFF
--- a/Sources/Plasma/Apps/plClient/external/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/external/CMakeLists.txt
@@ -13,10 +13,10 @@ set(external_SOURCES
 
 if(PLASMA_EXTERNAL_RELEASE)
     set(Make_Resource_Command
-		python ${CMAKE_CURRENT_SOURCE_DIR}/makeres.py --optimize --render --package -i ${CMAKE_CURRENT_SOURCE_DIR} -o ${CMAKE_CURRENT_BINARY_DIR})
+		${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/makeres.py --optimize --render --package -i ${CMAKE_CURRENT_SOURCE_DIR} -w ${CMAKE_CURRENT_BINARY_DIR} -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 else(PLASMA_EXTERNAL_RELEASE)
 	set(Make_Resource_Command
-		python ${CMAKE_CURRENT_SOURCE_DIR}/makeres.py --render --package -i ${CMAKE_CURRENT_SOURCE_DIR} -o ${CMAKE_CURRENT_BINARY_DIR})
+		${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/makeres.py --render --package -i ${CMAKE_CURRENT_SOURCE_DIR} -w ${CMAKE_CURRENT_BINARY_DIR} -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 endif(PLASMA_EXTERNAL_RELEASE)
 
 add_custom_command(

--- a/Sources/Plasma/Apps/plClient/external/makeres.py
+++ b/Sources/Plasma/Apps/plClient/external/makeres.py
@@ -54,6 +54,7 @@ if __name__ == '__main__':
 	parser.add_option("-r", "--render", dest="render", default=False, action="store_true", help="Perform SVG Render to images")
 	parser.add_option("-p", "--package", dest="package", default=False, action="store_true", help="Perform packaging into resource container")
 	parser.add_option("-z", "--optimize", dest="optimize", default=False, action="store_true", help="Perform PNGCrush optimization on PNG resources")
+	parser.add_option("-w", "--workpath", dest="workpath", default=".", help="Sets working output path for image renders")
 	parser.add_option("-o", "--outpath", dest="outpath", default=".", help="Sets output path for resource container")
 	parser.add_option("-i", "--inpath", dest="inpath", default=".", help="Sets input path for files to add to resource file")
 
@@ -65,19 +66,20 @@ if __name__ == '__main__':
 		sys.stderr = open(os.devnull,"w")
 
 	## Compute Paths
+	workpath = os.path.expanduser(options.workpath)
 	outpath = os.path.expanduser(options.outpath)
 	inpath = os.path.expanduser(options.inpath)
 
 	## Do the work!
 	if options.render:
-		ret = subprocess.call(["python", os.path.join(inpath, "render_svg.py"), "-i", inpath, "-o", os.path.join(outpath, "render")], stdout=sys.stdout, stderr=sys.stderr)
+		ret = subprocess.call(["python", os.path.join(inpath, "render_svg.py"), "-i", inpath, "-o", os.path.join(workpath, "render")], stdout=sys.stdout, stderr=sys.stderr)
 		if ret != 0:
 			print("An error has occurred.  Aborting.")
 			exit(1)
 
 	if options.optimize:
 		print("Optimizing PNGs with pngcrush...")
-		for png in glob.glob(os.path.join("render", "*.png")):
+		for png in glob.glob(os.path.join(workpath, "render", "*.png")):
 			#print("pngcrushing - {0}".format(png))
 			ret = subprocess.call(["pngcrush", "-q", "-l 9", "-brute", png, "temp.png"], stdout=sys.stdout, stderr=sys.stderr)
 			if ret != 0:
@@ -87,7 +89,7 @@ if __name__ == '__main__':
 			os.rename("temp.png", png)
 
 	if options.package:
-		ret = subprocess.call(["python", os.path.join(inpath, "create_resource_dat.py"), "-i", os.path.join(outpath, "render"), "-o", "resource.dat"], stdout=sys.stdout, stderr=sys.stderr)
+		ret = subprocess.call(["python", os.path.join(inpath, "create_resource_dat.py"), "-i", os.path.join(workpath, "render"), "-o", os.path.join(outpath, "resource.dat")], stdout=sys.stdout, stderr=sys.stderr)
 		if ret != 0:
 			print("An error has occurred.  Aborting.")
 			exit(1)


### PR DESCRIPTION
We won't have to navigate through several source build folders just to find the resource.dat. It's copied to build/bin now.
