### PR TITLE
fix substring negative index

### DIFF
--- a/Sources/Plasma/CoreLib/plString.cpp
+++ b/Sources/Plasma/CoreLib/plString.cpp
@@ -722,10 +722,10 @@ plString plString::Substr(int start, size_t size) const
 {
     size_t maxSize = GetSize();
 
+     if (start < 0)
+        start = 0;
     if (start > maxSize)
         return Null;
-    if (start < 0)
-        start = 0;
     if (start + size > maxSize)
         size = maxSize - start;
 


### PR DESCRIPTION
The order of the if statements made the second one useless, starting a
substring with a negative index returned Null as (start>maxSize) is
apparently true in that case.
