### PR TITLE
Support negative substring indexes

### DIFF
--- a/Sources/Plasma/CoreLib/plString.cpp
+++ b/Sources/Plasma/CoreLib/plString.cpp
@@ -545,7 +545,7 @@ plString plString::Format(const char *fmt, ...)
     return str;
 }
 
-int plString::Find(char ch, CaseSensitivity sense) const
+ssize_t plString::Find(char ch, CaseSensitivity sense) const
 {
     if (sense == kCaseSensitive) {
         const char *cp = strchr(c_str(), ch);
@@ -561,7 +561,7 @@ int plString::Find(char ch, CaseSensitivity sense) const
     }
 }
 
-int plString::FindLast(char ch, CaseSensitivity sense) const
+ssize_t plString::FindLast(char ch, CaseSensitivity sense) const
 {
     if (IsEmpty())
         return -1;
@@ -581,7 +581,7 @@ int plString::FindLast(char ch, CaseSensitivity sense) const
     }
 }
 
-int plString::Find(const char *str, CaseSensitivity sense) const
+ssize_t plString::Find(const char *str, CaseSensitivity sense) const
 {
     if (!str || !str[0])
         return -1;
@@ -718,14 +718,18 @@ plString plString::Trim(const char *charset) const
     return Substr(lp - c_str(), rp - lp + 1);
 }
 
-plString plString::Substr(int start, size_t size) const
+plString plString::Substr(ssize_t start, size_t size) const
 {
     size_t maxSize = GetSize();
 
-    if (start > maxSize)
+    if (start < 0) {
+        // Handle negative indexes from the right of the string
+        start += maxSize;
+        if (start < 0)
+            start = 0;
+    } else if (static_cast<size_t>(start) > maxSize) {
         return Null;
-    if (start < 0)
-        start = 0;
+    }
     if (start + size > maxSize)
         size = maxSize - start;
 

--- a/Sources/Plasma/CoreLib/plString.h
+++ b/Sources/Plasma/CoreLib/plString.h
@@ -71,6 +71,15 @@ typedef unsigned int UniChar;
 #    define strlwr      hsStrLower
 #endif
 
+// ssize_t doesn't exist in MSVC2010
+#if _MSC_VER
+#   ifdef _WIN64
+        typedef __int64 ssize_t;
+#   else
+        typedef int ssize_t;
+#   endif
+#endif
+
 /** Ref-counted string data buffer.
  *  This is used to store actual string data in any (unchecked) encoding format,
  *  including both the internal UTF-8 data of plString itself as well as the
@@ -488,22 +497,22 @@ public:
     /** Find the index of the first instance of \a ch in this string.
      *  \return -1 if the character was not found.
      */
-    int Find(char ch, CaseSensitivity sense = kCaseSensitive) const;
+    ssize_t Find(char ch, CaseSensitivity sense = kCaseSensitive) const;
 
     /** Find the index of the last instance of \a ch in this string.
      *  \return -1 if the character was not found.
      */
-    int FindLast(char ch, CaseSensitivity sense = kCaseSensitive) const;
+    ssize_t FindLast(char ch, CaseSensitivity sense = kCaseSensitive) const;
 
     /** Find the index of the first instance of \a str in this string.
      *  \return -1 if the substring was not found.
      */
-    int Find(const char *str, CaseSensitivity sense = kCaseSensitive) const;
+    ssize_t Find(const char *str, CaseSensitivity sense = kCaseSensitive) const;
 
     /** Find the index of the first instance of \a str in this string.
      *  \return -1 if the substring was not found.
      */
-    int Find(const plString &str, CaseSensitivity sense = kCaseSensitive) const
+    ssize_t Find(const plString &str, CaseSensitivity sense = kCaseSensitive) const
     { return Find(str.c_str(), sense); }
 
     /** Check that this string matches the specified regular expression.
@@ -541,7 +550,7 @@ public:
      *  number of characters left in the string after \a start, Substr will
      *  return the remainder of the string.
      */
-    plString Substr(int start, size_t size = kSizeAuto) const;
+    plString Substr(ssize_t start, size_t size = kSizeAuto) const;
 
     /** Return a substring containing at most \a size characters from the left
      *  of the string.  Equivalent to Substr(0, size).


### PR DESCRIPTION
This change makes plString::Substr's start parameter treat negative values as being from the right-hand side of the string.  As an added bonus, this also defines ssize_t on MSVC, which otherwise does not define it anywhere.  This definition should be compatible with Python's Py_ssize_t  type, at least in Python 2.7.

This PR supersedes and closes #315
