### PR TITLE
RefreshFOV Camera Command

### DIFF
--- a/Sources/Plasma/FeatureLib/pfCamera/plVirtualCamNeu.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plVirtualCamNeu.cpp
@@ -1370,6 +1370,11 @@ bool plVirtualCam1::MsgReceive(plMessage* msg)
                 }
             }
         }
+        else
+        if (pCam->Cmd(plCameraMsg::kRefreshFOV))
+        {
+            Refresh();
+        }
     }
     plGenRefMsg* pRefMsg = plGenRefMsg::ConvertNoRef(msg);
     if (pRefMsg )

--- a/Sources/Plasma/FeatureLib/pfPython/cyCamera.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyCamera.cpp
@@ -373,3 +373,11 @@ bool cyCamera::IsStayInFirstPerson()
     }
     return false;
 }
+
+void cyCamera::RefreshFOV()
+{
+    plCameraMsg* pMsg = new plCameraMsg();
+    pMsg->SetSender(fSender);
+    pMsg->SetCmd(plCameraMsg::kRefreshFOV);
+    pMsg->Send(fTheCam);
+}

--- a/Sources/Plasma/FeatureLib/pfPython/cyCamera.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyCamera.h
@@ -114,7 +114,7 @@ public:
 
     virtual void SetAspectRatio(float aspectratio) { plVirtualCam1::SetAspectRatio(aspectratio); }
     virtual float GetAspectRatio() const { return plVirtualCam1::GetAspectRatio(); }
-    virtual void RefreshFOV() { plVirtualCam1::Refresh(); }
+    virtual void RefreshFOV();
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plCameraMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCameraMsg.h
@@ -207,6 +207,7 @@ public:
         kNonPhysOn,
         kNonPhysOff,
         kResetPanning,
+        kRefreshFOV,
         kNumCmds
     };
 


### PR DESCRIPTION
This adds a `kRefreshFOV` command to `plCameraMsg` and changes `ptCamera.refreshFOV` to use that. This is useful when the FOV refresh needs to happen after other camera actions that are delayed by the dispatcher's recursion protection.
