### PR TITLE
Don't use CPUID call on targets that don't support it

### DIFF
--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -21,6 +21,16 @@ if(NOT WCHAR_BYTES)
 endif(NOT WCHAR_BYTES)
 add_definitions(-DWCHAR_BYTES=${WCHAR_BYTES})
 
+try_compile(HAVE_CPUID ${PROJECT_BINARY_DIR}
+            ${PROJECT_SOURCE_DIR}/cmake/check_cpuid.cpp
+            OUTPUT_VARIABLE OUTPUT)
+if(HAVE_CPUID)
+    add_definitions(-DHAVE_CPUID)
+    message("CPUID header found -- using hardware math acceleration when available")
+else()
+    message("CPUID header not found -- using software math")
+endif()
+
 set(CoreLib_SOURCES
     HeadSpin.cpp
     hsBitVector.cpp

--- a/Sources/Plasma/CoreLib/hsCpuID.cpp
+++ b/Sources/Plasma/CoreLib/hsCpuID.cpp
@@ -40,12 +40,18 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#if defined(_MSC_VER) || ((defined(_WIN32) || defined(_WIN64)) && defined(__INTEL_COMPILER))
-#  include <intrin.h>
-#  define MSC_COMPATIBLE
-#elif defined(__GNUC__)
-#  include <cpuid.h>
-#  define GCC_COMPATIBLE
+#if defined(HAVE_CPUID)
+#  if defined(_MSC_VER) || ((defined(_WIN32) || defined(_WIN64)) && defined(__INTEL_COMPILER))
+#    include <intrin.h>
+#    define MSC_COMPATIBLE
+#  elif defined(__GNUC__)
+#    include <cpuid.h>
+#    define GCC_COMPATIBLE
+#  else
+#    define SOFTWARE_ONLY
+#  endif
+#else
+#  define SOFTWARE_ONLY
 #endif
 
 #include "hsCpuID.h"
@@ -57,7 +63,7 @@ hsCpuId::hsCpuId() {
     const unsigned int ssse3_flag = 1<<9;
     const unsigned int sse41_flag = 1<<19;
     const unsigned int sse42_flag = 1<<20;
-    const unsigned int avx_flag = 1 << 28;
+    const unsigned int avx_flag = 1<<28;
 
     unsigned int ax = 0, bx = 0, cx = 0, dx = 0;
 

--- a/cmake/check_cpuid.cpp
+++ b/cmake/check_cpuid.cpp
@@ -1,0 +1,11 @@
+#if defined(_MSC_VER) || ((defined(_WIN32) || defined(_WIN64)) && defined(__INTEL_COMPILER))
+#  include <intrin.h>
+#elif defined(__GNUC__)
+#  include <cpuid.h>
+#endif
+
+/* Just needed to look for the headers -- this just makes the compiler happy. */
+int main(int argc, char *argv[])
+{
+    return 0;
+}


### PR DESCRIPTION
This fixes the inability to compile hsCpuID.cpp on ARM (as well as other non-x86 platforms).  Tested against Win32/VS2010, GCC/Linux_x86-64 (Debian), GCC/Linux_armv6h (Arch on Raspberry Pi).
