### PR TITLE
Remove PhysX plModifier

### DIFF
--- a/Sources/Plasma/PubUtilLib/plModifier/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plModifier/CMakeLists.txt
@@ -4,7 +4,6 @@ include_directories("../../NucleusLib/inc")
 include_directories("../../NucleusLib")
 include_directories("../../PubUtilLib")
 
-include_directories(${PHYSX_INCLUDE_DIRS})
 include_directories(${OPENAL_INCLUDE_DIR})
 
 set(plModifier_SOURCES

--- a/Sources/Plasma/PubUtilLib/plModifier/plExcludeRegionModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plExcludeRegionModifier.cpp
@@ -62,7 +62,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //for hack
 #include "plPhysX/plPXPhysical.h"
 #include "plPhysX/plPXPhysicalControllerCore.h"
-#include <NxCapsule.h>
+
 static plPhysical* GetPhysical(plSceneObject* obj)
 {
     if (obj)
@@ -309,10 +309,8 @@ void plExcludeRegionModifier::IMoveAvatars()
             int actualCount = plPXPhysicalControllerCore::GetControllersInThisSubWorld(phys->GetWorldKey(), numControllers, controllers);
             
             for (int i=0;i<actualCount;i++)
-            {   
-                NxCapsule cap;
-                controllers[i]->GetWorldSpaceCapsule(cap);
-                if(phys->OverlapWithCapsule(cap))
+            {
+                if (phys->OverlapWithController(controllers[i]))
                 {
                     plSceneObject* so = plSceneObject::ConvertNoRef(controllers[i]->GetOwner()->ObjectIsLoaded());
                     const plArmatureMod* constAvMod = (plArmatureMod*)so->GetModifierByType(plArmatureMod::Index());

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
@@ -1080,8 +1080,10 @@ void plPXPhysical::ExcludeRegionHack(bool cleared)
     plPXPhysicalControllerCore::RebuildCache();
 
 }
-bool plPXPhysical::OverlapWithCapsule(NxCapsule& cap)
+bool plPXPhysical::OverlapWithController(const plPXPhysicalControllerCore* controller)
 {
+    NxCapsule cap;
+    controller->GetWorldSpaceCapsule(cap);
     NxShape* shape = fActor->getShapes()[0];
     return shape->checkOverlapCapsule(cap);
 }

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.h
@@ -182,9 +182,8 @@ public:
     // This weeds those out.
     bool IsDynamic() const;
     
-    //Hack to check if there is an overlap with the capsule
-    //this partially for exclude regions vs avatar capsule
-    virtual bool OverlapWithCapsule(NxCapsule& cap);
+    //Hack to check if there is an overlap with the avatar controller
+    bool OverlapWithController(const class plPXPhysicalControllerCore* controller);
 
     virtual float GetMass() {return fMass;}
 protected:


### PR DESCRIPTION
Fix original MOUL physics programmer stupid by moving PhysX SDK usage into plPhysX where it belongs.
