### PR TITLE
plPXConvert::Validate to compile time

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXConvert.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXConvert.cpp
@@ -39,44 +39,20 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
       Mead, WA   99021
 
 *==LICENSE==*/
+
 #include "plPXConvert.h"
 
-bool plPXConvert::Validate()
-{
-    NxVec3 nxVec;
-    hsVector3 plVec;
+#define CHECK_OFFSET(NxCls, NxMem, hsCls, hsMem) \
+    static_assert(offsetof(NxCls, NxMem) == offsetof(hsCls, hsMem), \
+    "PhysX Conversion Failure: "#NxCls " and " #hsCls " offsets do not match for " #NxMem "!");
 
-    int nxVecXOffset = ((char*)&nxVec.x) - ((char*)&nxVec);
-    int nxVecYOffset = ((char*)&nxVec.y) - ((char*)&nxVec);
-    int nxVecZOffset = ((char*)&nxVec.z) - ((char*)&nxVec);
+CHECK_OFFSET(NxVec3, x, hsScalarTriple, fX);
+CHECK_OFFSET(NxVec3, y, hsScalarTriple, fY);
+CHECK_OFFSET(NxVec3, z, hsScalarTriple, fZ);
 
-    int plVecXOffset = ((char*)&plVec.fX) - ((char*)&plVec);
-    int plVecYOffset = ((char*)&plVec.fY) - ((char*)&plVec);
-    int plVecZOffset = ((char*)&plVec.fZ) - ((char*)&plVec);
+CHECK_OFFSET(NxQuat, x, hsQuat, fX);
+CHECK_OFFSET(NxQuat, y, hsQuat, fY);
+CHECK_OFFSET(NxQuat, z, hsQuat, fZ);
+CHECK_OFFSET(NxQuat, w, hsQuat, fW);
+#undef CHECK_OFFSET
 
-    NxQuat nxQuat;
-    hsQuat plQuat;
-
-    int nxQuatXOffset = ((char*)&nxQuat.x) - ((char*)&nxQuat);
-    int nxQuatYOffset = ((char*)&nxQuat.y) - ((char*)&nxQuat);
-    int nxQuatZOffset = ((char*)&nxQuat.z) - ((char*)&nxQuat);
-    int nxQuatWOffset = ((char*)&nxQuat.w) - ((char*)&nxQuat);
-
-    int plQuatXOffset = ((char*)&plQuat.fX) - ((char*)&plQuat);
-    int plQuatYOffset = ((char*)&plQuat.fY) - ((char*)&plQuat);
-    int plQuatZOffset = ((char*)&plQuat.fZ) - ((char*)&plQuat);
-    int plQuatWOffset = ((char*)&plQuat.fW) - ((char*)&plQuat);
-
-    bool offsetsOK =
-        nxVecXOffset == plVecXOffset &&
-        nxVecYOffset == plVecYOffset &&
-        nxVecZOffset == plVecZOffset &&
-        nxQuatXOffset == plQuatXOffset &&
-        nxQuatYOffset == plQuatYOffset &&
-        nxQuatZOffset == plQuatZOffset &&
-        nxQuatWOffset == plQuatWOffset;
-
-    hsAssert(offsetsOK, "PhysX or Plasma offsets have changed, need to rewrite conversion code");
-
-    return offsetsOK;
-}

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXConvert.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXConvert.h
@@ -73,7 +73,6 @@ namespace plPXConvert
     inline void Matrix(const hsMatrix44& fromMat, NxMat34& toMat) { toMat.setRowMajor44(&fromMat.fMap[0][0]); }
     inline void Matrix(const NxMat34& fromMat, hsMatrix44& toMat) { toMat.NotIdentity(); fromMat.getRowMajor44(&toMat.fMap[0][0]); }
 
-    bool Validate();
 };
 
 #endif // plPXConvert_h_inc

--- a/Sources/Plasma/PubUtilLib/plPhysX/plSimulationMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plSimulationMgr.cpp
@@ -301,14 +301,6 @@ bool plSimulationMgr::InitSimulation()
     fSDK->getFoundationSDK().getRemoteDebugger()->connect("localhost", 5425);
 #endif
 
-    if ( !plPXConvert::Validate() )
-    {
-#ifndef PLASMA_EXTERNAL_RELEASE
-        hsMessageBox("Ageia's PhysX or Plasma offsets have changed, need to rewrite conversion code.","PhysX Error",hsMBoxOk);
-#endif
-        return false; // client will handle this and ask user to install
-    }
-
     return true;
 }
 


### PR DESCRIPTION
Refactor plPXConvert::Validate to be compile-time checks. I am saddened by the fact that this was a runtime check, especially given the availability of offsetof (and an alternative in CoreLib) and eap's old compiler_assert.
