### PR TITLE
Add missing std headers for compilation with VisualStudio 2013.

### DIFF
--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -46,6 +46,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <direct.h>     // windows directory handling fxns (for chdir)
 #include <process.h>
 #include <shellapi.h>   // ShellExecuteA
+#include <algorithm>
 
 //#define DETACH_EXE  // Microsoft trick to force loading of exe to memory 
 #ifdef DETACH_EXE

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAGAnimInstance.cpp
@@ -45,6 +45,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
+
 // singular
 #include "plAGAnimInstance.h"
 


### PR DESCRIPTION
Additional C++11 support in VS12 requires inclusion of the proper headers.  This allows all projects to be built using the new compiler, at least under the recent Preview Release.
