### PR TITLE
Fix Debug Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(Plasma)
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.11.2)
 
 # Set up Product Identification parameters
 set(PRODUCT_BRANCH_ID   "1"         CACHE STRING "Branch ID")


### PR DESCRIPTION
Bump cmake minimum version to 2.8.11.2. This "fixes" the Debug build crashes in pyOutputRedirector, which were apparently caused by a flaw in cmake that was exposed by #337.
