### PR TITLE
Fix pySceneObject::IsHuman

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pySceneObject.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySceneObject.cpp
@@ -613,10 +613,11 @@ bool pySceneObject::IsHumanAvatar()
                 plArmatureMod* avatar = (plArmatureMod*)plArmatureMod::ConvertNoRef(mod);
                 if ( avatar )
                 {
-                    plArmatureBrain* brain = avatar->GetCurrentBrain();
-                    plAvBrainHuman* human = plAvBrainHuman::ConvertNoRef(brain);
-                    if ( human )
-                        return true;
+                    for (int i = 0; i < avatar->GetBrainCount(); ++i)
+                    {
+                        if (plAvBrainHuman::ConvertNoRef(avatar->GetBrain(i)))
+                            return true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
ptSceneObject.isHuman claims it returns the humanness of the avatar; however, the old method really checked if the current brain was human. This was fine until long-term non-human brains were added (swimming). Now, we need to check to see if there are any human brains in the armature's stack.
