### PR TITLE
Fix buddy-add stutter

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
@@ -93,31 +93,37 @@ bool pyVaultPlayerInfoListNode::HasPlayer( uint32_t playerID )
     return (rvn != nil);
 }
 
-bool pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
+//==================================================================
+
+static void IAddPlayer_NodesFound(ENetError result, void* param, unsigned nodeIdCount, const unsigned nodeIds[])
 {
-    if (HasPlayer(playerID))
-        return true;
-        
-    if (!fNode)
-        return false;
-        
-    NetVaultNode * templateNode = new NetVaultNode;
+    NetVaultNode* parent = static_cast<NetVaultNode*>(param);
+    if (nodeIdCount)
+        VaultAddChildNode(parent->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr, nullptr);
+    parent->DecRef();
+}
+
+void pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
+{
+    if (HasPlayer(playerID) || !fNode)
+        return;
+
+    NetVaultNode* templateNode = new NetVaultNode();
     templateNode->IncRef();
     templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
     VaultPlayerInfoNode access(templateNode);
     access.SetPlayerId(playerID);
 
-    ARRAY(unsigned) nodeIds;
+    ARRAY(uint32_t) nodeIds;
     VaultLocalFindNodes(templateNode, &nodeIds);
-    
-    if (!nodeIds.Count())
-        VaultFindNodesAndWait(templateNode, &nodeIds);
-        
+
+    // So, if we know about this node, we can take it easy. If not, we lazy load it.
     if (nodeIds.Count())
-        VaultAddChildNodeAndWait(fNode->GetNodeId(), nodeIds[0], VaultGetPlayerId());
-        
-    templateNode->DecRef();
-    return nodeIds.Count() != 0;
+        VaultAddChildNode(fNode->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr, nullptr);
+    else {
+        fNode->IncRef();
+        VaultFindNodes(templateNode, IAddPlayer_NodesFound, fNode);
+    }
 }
 
 void pyVaultPlayerInfoListNode::RemovePlayer( uint32_t playerID )

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.h
@@ -78,8 +78,8 @@ public:
 //==================================================================
 // class RelVaultNode : public plVaultFolderNode
 //
-    virtual bool  HasPlayer( uint32_t playerID );
-    bool    AddPlayer( uint32_t playerID );
+    bool    HasPlayer( uint32_t playerID );
+    void    AddPlayer( uint32_t playerID );
     void    RemovePlayer( uint32_t playerID );
     PyObject * GetPlayer( uint32_t playerID ); // returns pyVaultPlayerInfoNode
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNodeGlue.cpp
@@ -83,7 +83,8 @@ PYTHON_METHOD_DEFINITION(ptVaultPlayerInfoListNode, playerlistAddPlayer, args)
         PyErr_SetString(PyExc_TypeError, "playerlistAddPlayer expects an unsigned long");
         PYTHON_RETURN_ERROR;
     }
-    PYTHON_RETURN_BOOL(self->fThis->AddPlayer(playerID));
+    self->fThis->AddPlayer(playerID);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION(ptVaultPlayerInfoListNode, playerlistRemovePlayer, args)
@@ -128,7 +129,8 @@ PYTHON_METHOD_DEFINITION(ptVaultPlayerInfoListNode, addPlayer, args)
         PyErr_SetString(PyExc_TypeError, "addPlayer expects an unsigned long");
         PYTHON_RETURN_ERROR;
     }
-    PYTHON_RETURN_BOOL(self->fThis->AddPlayer(playerID));
+    self->fThis->AddPlayer(playerID);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION(ptVaultPlayerInfoListNode, removePlayer, args)


### PR DESCRIPTION
This fixes the stutter when adding a buddy to the KI by making pyVaultPlayerListNode::AddPlayer async. The return value was never used according to grep. There is a delay between hitting enter and the player being added, but that's acceptable.
