### PR TITLE
Port PtDebugPrint to C++

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -2599,6 +2599,33 @@ void cyMisc::DebugAssert( bool cond, const char * msg )
     hsAssert( cond, msg );
 }
 
+void cyMisc::DebugPrint(const plString& msg, uint32_t level)
+{
+    if (level < fPythonLoggingLevel)
+        return;
+    plStatusLog* log = plStatusLogMgr::GetInstance().FindLog("python.log", false);
+    if (!log)
+        return;
+
+    switch (level) {
+    case kDebugDump:
+        log->AddLine(msg.c_str(), plStatusLog::kGreen);
+        break;
+    case kWarningLevel:
+        log->AddLine(msg.c_str(), plStatusLog::kYellow);
+        break;
+    case kAssertLevel:
+        hsAssert(false, msg.c_str());
+        // ... fall thru to the actual log-print
+    case kErrorLevel:
+        log->AddLine(msg.c_str(), plStatusLog::kRed);
+        break;
+    default:
+        log->AddLine(msg.c_str(), plStatusLog::kWhite);
+        break;
+    }
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // Function   : Set a python object to be called back after a certain amount of time.

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -853,6 +853,7 @@ public:
     // PURPOSE    : debugging
     //
     static void DebugAssert( bool cond, const char * msg );
+    static void DebugPrint(const plString& msg, uint32_t level);
 
 
     //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This has a couple of benefits:
- We should theoretically no longer run into UnicodeDecodeErrors from the plString-based implementation
- By doing things engine side, we can use the logging API to colorize log messages.

This should be merged alongside H-uru/moul-scripts#72
