### PR TITLE
Fix loading localized sound files

### DIFF
--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
@@ -95,7 +95,7 @@ plFileName plLocalization::IGetLocalized(const plFileName& name, Language lang)
         plString langTag = name.AsString().Substr(underscore, kLangTagLen);
 
         if (langTag == fLangTags[kEnglish])
-            return name.AsString().Left(underscore) + fLangTags[lang];
+            return name.AsString().Replace(fLangTags[kEnglish], fLangTags[lang]);
     }
 
     return "";


### PR DESCRIPTION
This bug was caused by ignoring possible file extensions like ".ogg" after the "_eng" language tag, when localizing the object name.
