### PR TITLE
Fix NetCliAuthFileRequest Regression

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -3588,10 +3588,13 @@ bool FileDownloadRequestTrans::Send () {
     if (!AcquireConn())
         return false;
 
+    wchar_t filename[MAX_PATH];
+    wcsncpy(filename, m_filename.AsString().ToWchar(), arrsize(filename));
+
     const uintptr_t msg[] = {
         kCli2Auth_FileDownloadRequest,
         m_transId,
-        reinterpret_cast<uintptr_t>(m_filename.AsString().ToWchar().GetData()),
+        reinterpret_cast<uintptr_t>(filename),
     };
 
     m_conn->Send(msg, arrsize(msg));


### PR DESCRIPTION
Data fields given to the NetCli have to be the same length as they are on the wire. So a variable length filename blob fails pretty spectacularly here.
