### PR TITLE
Use std::regex instead of PCRE.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ find_package(Ogg REQUIRED)    #TODO: Not required if we aren't building the clie
 find_package(Vorbis REQUIRED) #TODO: Not required if we aren't building the client
 find_package(Speex REQUIRED)  #TODO: Not required if we aren't building the client
 find_package(CURL REQUIRED)
-find_package(PCRE REQUIRED)
 
 if(WIN32)
     find_package(PhysX REQUIRED)  #TODO: Not required if we aren't building the client
@@ -62,12 +61,6 @@ option(CURL_IS_STATIC "Using the static version of libcurl?" ON)
 if(CURL_IS_STATIC)
     add_definitions(-DCURL_STATICLIB)
 endif(CURL_IS_STATIC)
-
-#libpcre isn't smart enough to detect this either
-option(PCRE_IS_STATIC "Using the static version of libpcre?" ON)
-if(PCRE_IS_STATIC)
-    add_definitions(-DPCRE_STATIC)
-endif(PCRE_IS_STATIC)
 
 option(PLASMA_EXTERNAL_RELEASE "Is this release intended for the general public?" OFF)
 if(PLASMA_EXTERNAL_RELEASE)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Plasma currently requires the following third-party libraries:
 - libPNG - http://www.libpng.org/
 - speex - http://www.speex.org/downloads/
 - zlib - http://zlib.net/
-- PCRE - http://www.pcre.org/
 - libcurl - http://curl.haxx.se/
 
 The following libraries are optional:

--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${PCRE_INCLUDE_DIR})
-
 add_definitions(-D_LIB)
 
 add_definitions(-DPRODUCT_BRANCH_ID=${PRODUCT_BRANCH_ID})
@@ -111,7 +109,6 @@ set(CoreLib_HEADERS
 
 use_precompiled_header(_CoreLibPch.h Pch.cpp CoreLib_HEADERS CoreLib_SOURCES)
 add_library(CoreLib STATIC ${CoreLib_SOURCES} ${CoreLib_HEADERS})
-target_link_libraries(CoreLib ${PCRE_LIBRARY})
 
 if(UNIX)
     target_link_libraries(CoreLib pthread)


### PR DESCRIPTION
This removes the project's dependence on the PCRE library and instead uses C++11's std::regex to provide an engine for plString's Regular Expression functions.
