### PR TITLE
Add PNG support to plBitmap and plMipmap.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plGImage/plBitmap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plBitmap.cpp
@@ -113,7 +113,8 @@ uint32_t  plBitmap::Read( hsStream *s )
     fFlags = s->ReadLE16();
     fCompressionType = s->ReadByte();
 
-    if(( fCompressionType == kUncompressed )||( fCompressionType == kJPEGCompression ))
+    if( fCompressionType == kUncompressed || fCompressionType == kJPEGCompression ||
+        fCompressionType == kPNGCompression )
     {
         fUncompressedInfo.fType = s->ReadByte();
         read++;
@@ -145,7 +146,8 @@ uint32_t  plBitmap::Write( hsStream *s )
     s->WriteLE16( fFlags );
     s->WriteByte( fCompressionType );
 
-    if(( fCompressionType == kUncompressed )||(fCompressionType == kJPEGCompression ))
+    if( fCompressionType == kUncompressed || fCompressionType == kJPEGCompression ||
+        fCompressionType == kPNGCompression )
     {
         s->WriteByte( fUncompressedInfo.fType );
         written++;

--- a/Sources/Plasma/PubUtilLib/plGImage/plBitmap.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plBitmap.h
@@ -105,7 +105,8 @@ class plBitmap : public hsKeyedObject
         {
             kUncompressed       = 0x0,
             kDirectXCompression = 0x1,
-            kJPEGCompression    = 0x2
+            kJPEGCompression    = 0x2,
+            kPNGCompression     = 0x3
         };
 
         struct DirectXInfo

--- a/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
@@ -60,6 +60,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plPipeline/hsGDeviceRef.h"
 #include "plProfile.h"
 #include "plJPEG.h"
+#include "plPNG.h"
 #include <cmath>
 #include <algorithm>
 
@@ -124,11 +125,8 @@ void    plMipmap::Create( uint32_t width, uint32_t height, unsigned config, uint
     }
     
     fCompressionType = compType;
-    if( compType == kUncompressed )
-    {
-        fUncompressedInfo.fType = format;
-    }
-    else if( compType == kJPEGCompression )
+    if( compType == kUncompressed || compType == kJPEGCompression ||
+        compType == kPNGCompression )
     {
         fUncompressedInfo.fType = format;
     }
@@ -271,6 +269,10 @@ uint32_t  plMipmap::Read( hsStream *s )
             case kJPEGCompression:
                 IReadJPEGImage( s );
                 break;
+
+            case kPNGCompression:
+                IReadPNGImage( s );
+                break;
                 
             default:
                 hsAssert( false, "Unknown compression type in plMipmap::Read()" );
@@ -309,6 +311,10 @@ uint32_t  plMipmap::Write( hsStream *s )
 
             case kJPEGCompression:
                 IWriteJPEGImage( s );
+                break;
+
+            case kPNGCompression:
+                IWritePNGImage( s );
                 break;
 
             default:
@@ -578,6 +584,23 @@ void plMipmap::IWriteJPEGImage( hsStream *stream )
     delete alpha;
 }
 
+void plMipmap::IReadPNGImage(hsStream* stream)
+{
+    plMipmap* temp = nullptr;
+
+    temp = plPNG::Instance().ReadFromStream(stream);
+
+    if (temp) {
+        CopyFrom(temp);
+        delete temp;
+    }
+}
+
+void plMipmap::IWritePNGImage(hsStream* stream)
+{
+    plPNG::Instance().WriteToStream(stream, this);
+}
+
 //// GetLevelSize /////////////////////////////////////////////////////////////
 //  Get the size of a single mipmap level (0 is the largest)
 
@@ -615,6 +638,7 @@ void    plMipmap::IBuildLevelSizes()
 
             case kUncompressed:
             case kJPEGCompression:
+            case kPNGCompression:
                 fLevelSizes[ level ] = height * rowBytes;
                 break;
 
@@ -1588,6 +1612,7 @@ void    plMipmap::CopyFrom( const plMipmap *source )
             break;
         case kUncompressed:
         case kJPEGCompression:
+        case kPNGCompression:
             fUncompressedInfo.fType = source->fUncompressedInfo.fType;
             break;
         default:

--- a/Sources/Plasma/PubUtilLib/plGImage/plMipmap.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plMipmap.h
@@ -311,6 +311,8 @@ class plMipmap : public plBitmap
         void    IWriteRLEImage( hsStream *stream, plMipmap *mipmap );
         void    IReadJPEGImage( hsStream *stream );
         void    IWriteJPEGImage( hsStream *stream );
+        void    IReadPNGImage( hsStream *stream );
+        void    IWritePNGImage( hsStream *stream );
         void    IBuildLevelSizes();
 
         void    IColorLevel( uint8_t level, const uint8_t *colorMask );

--- a/Sources/Tools/MaxComponent/plMiscComponents.cpp
+++ b/Sources/Tools/MaxComponent/plMiscComponents.cpp
@@ -2539,7 +2539,7 @@ bool pfImageLibComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
                     flags |= plBitmap::kForceNonCompressed;
                     bMap = plLayerConverter::Instance().CreateSimpleTexture( texture->bi.Name(), lib->GetKey()->GetUoid().GetLocation(), 0, flags );
                 }
-                else // compress using JPEG compression scheme
+                else // compress using PNG compression scheme
                     bMap = plLayerConverter::Instance().CreateSimpleTexture( texture->bi.Name(), lib->GetKey()->GetUoid().GetLocation(), 0, flags, true );
                 if( bMap != nil )
                 {

--- a/Sources/Tools/MaxConvert/plBitmapCreator.cpp
+++ b/Sources/Tools/MaxConvert/plBitmapCreator.cpp
@@ -234,19 +234,12 @@ plMipmap *plBitmapCreator::ICreateBitmap(plBitmapData *bd)
         flagsToSet |= plMipmap::kDontThrowAwayImage;
 
     hBitmap->SetFlags( hBitmap->GetFlags() | flagsToSet );
-    if (bd->useJPEG)
-        hBitmap->fCompressionType = plMipmap::kJPEGCompression;
+    if (bd->usePNG)
+        hBitmap->fCompressionType = plMipmap::kPNGCompression;
 
-    // FIXME
-    if (/*fSave &&*/ !(bd->texFlags & plMipmap::kForceNonCompressed) && !bd->useJPEG)
-    {
-        // Are we on?  Check Plasma Util panel
-//      SwitchUtil *pu = (SwitchUtil *)CreateInstance(UTILITY_CLASS_ID, PlasmaUtilClassID);
-//      if (!pu || pu->TextureCompressionEnabled()) 
+    if (!(bd->texFlags & plMipmap::kForceNonCompressed) && !bd->usePNG)
         {
             plMipmap *compressed = hsCodecManager::Instance().CreateCompressedMipmap(plMipmap::kDirectXCompression, hBitmap);
-//              hsDXTSoftwareCodec::Instance().CreateCompressedBitmap(hBitmap);
-//              hsDXTDirectXCodec::Instance().CreateCompressedBitmap(hBitmap);
 
             if (compressed)
             {
@@ -255,7 +248,6 @@ plMipmap *plBitmapCreator::ICreateBitmap(plBitmapData *bd)
                 hBitmap->SetFlags( hBitmap->GetFlags() | flagsToSet );
             }
         }
-    }
 
     return hBitmap;
     hsGuardEnd; 

--- a/Sources/Tools/MaxConvert/plBitmapCreator.h
+++ b/Sources/Tools/MaxConvert/plBitmapCreator.h
@@ -74,7 +74,7 @@ public:
     const char  *faceNames[ 6 ];
     uint32_t  maxDimension;
     uint8_t   clampFlags;
-    bool    useJPEG;
+    bool    usePNG;
 
     plBitmapData()
     {
@@ -88,7 +88,7 @@ public:
         faceNames[ 0 ] = faceNames[ 1 ] = faceNames[ 2 ] = faceNames[ 3 ] = faceNames[ 4 ] = faceNames[ 5 ] = nil;
         maxDimension = 0;
         clampFlags = 0;
-        useJPEG = false;
+        usePNG = false;
     }
 };
 

--- a/Sources/Tools/MaxConvert/plLayerConverter.cpp
+++ b/Sources/Tools/MaxConvert/plLayerConverter.cpp
@@ -1029,7 +1029,7 @@ plDynamicTextMap    *plLayerConverter::ICreateDynTextMap( const plString &layerN
 ///////////////////////////////////////////////////////////////////////////////
 
 plBitmap *plLayerConverter::CreateSimpleTexture(const char *fileName, const plLocation &loc, 
-                                                uint32_t clipID /* = 0 */, uint32_t texFlags /* = 0 */, bool useJPEG /* = false */)
+                                                uint32_t clipID /* = 0 */, uint32_t texFlags /* = 0 */, bool usePNG /* = false */)
 {
     plBitmapData bd;
     bd.fileName = fileName;
@@ -1043,7 +1043,7 @@ plBitmap *plLayerConverter::CreateSimpleTexture(const char *fileName, const plLo
     bd.isStaticCubicEnvMap = false;
     bd.invertAlpha = false;
     bd.clampFlags = 0;
-    bd.useJPEG = useJPEG;
+    bd.usePNG = usePNG;
 
     return plBitmapCreator::Instance().CreateTexture(&bd, loc, clipID);
 }

--- a/Sources/Tools/MaxConvert/plLayerConverter.h
+++ b/Sources/Tools/MaxConvert/plLayerConverter.h
@@ -90,7 +90,7 @@ class plLayerConverter
 
         plLayerInterface    *ConvertTexmap( Texmap *texmap, plMaxNode *maxNode,
                                             uint32_t blendFlags, bool preserveUVOffset, bool upperLayer );
-        plBitmap *CreateSimpleTexture(const char *fileName, const plLocation &loc, uint32_t clipID = 0, uint32_t texFlags = 0, bool useJPEG = false);
+        plBitmap *CreateSimpleTexture(const char *fileName, const plLocation &loc, uint32_t clipID = 0, uint32_t texFlags = 0, bool usePNG = false);
         
         void    MuteWarnings( void );
         void    UnmuteWarnings( void );

--- a/Sources/Tools/MaxConvert/plLightMapGen.cpp
+++ b/Sources/Tools/MaxConvert/plLightMapGen.cpp
@@ -362,33 +362,8 @@ bool plLightMapGen::ICompressLightMaps()
                 DumpMipmap(orig, orig->GetKeyName());
 #endif // MIPMAP_LOG
 
-                plMipmap *compressed = 
-                    hsCodecManager::Instance().CreateCompressedMipmap(plMipmap::kDirectXCompression, orig);
-
-                if( compressed )
-                {
-                    const plLocation &textureLoc = plPluginResManager::ResMgr()->GetCommonPage(orig->GetKey()->GetUoid().GetLocation(),
-                                                                                    plAgeDescription::kTextures );
-                    plString name = plFormat("{}_DX", orig->GetKey()->GetName());
-
-                    plKey compKey = hsgResMgr::ResMgr()->FindKey(plUoid(textureLoc, plMipmap::Index(), name));
-                    if( compKey )
-                        plBitmapCreator::Instance().DeleteExportedBitmap(compKey);
-
-                    hsgResMgr::ResMgr()->NewKey( name, compressed, textureLoc );
-
-                    int j;
-                    for( j = 0; j < fCreatedLayers.GetCount(); j++ )
-                    {
-                        if( orig == fCreatedLayers[j]->GetTexture() )
-                        {
-                            fCreatedLayers[j]->GetKey()->Release(orig->GetKey());
-                            hsgResMgr::ResMgr()->AddViaNotify(compressed->GetKey(), new plLayRefMsg(fCreatedLayers[j]->GetKey(), plRefMsg::kOnReplace, 0, plLayRefMsg::kTexture), plRefFlags::kActiveRef);
-                        }
-                    }
-
-                    plBitmapCreator::Instance().DeleteExportedBitmap(orig->GetKey());
-                }
+                // Use lossless compression on LightMaps.  We don't want ugly, muddy edges.
+                orig->fCompressionType = plMipmap::kPNGCompression;
             }
         }
     }


### PR DESCRIPTION
Using the existing PNG library support, this allows PNG-compressed images as plBitmaps and plMipmaps
