### PR TITLE
Fix out of bounds crash in GetNPC()

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -784,7 +784,9 @@ plSynchedObject* plNetClientMgr::GetLocalPlayer(bool forceLoad) const
 
 plSynchedObject* plNetClientMgr::GetNPC(uint32_t i) const
 {
-    return fNPCKeys[i] ? plSynchedObject::ConvertNoRef(fNPCKeys[i]->ObjectIsLoaded()) : nil; 
+    if (i >= fNPCKeys.size())
+        return nullptr;
+    return plSynchedObject::ConvertNoRef(fNPCKeys[i]->ObjectIsLoaded()); 
 }
 
 void plNetClientMgr::AddNPCKey(const plKey& npc)


### PR DESCRIPTION
Silly me tried to start with index number 1, today. Unfortunately, there was just one NPC and I killed the whole world.
Let's prevent silly me from killing the whole world...
