### PR TITLE
Required link libraries for pnNetCommon.

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetCommon/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/CMakeLists.txt
@@ -34,6 +34,11 @@ set(pnNetCommon_SOURCES
 )
 
 add_library(pnNetCommon STATIC ${pnNetCommon_HEADERS} ${pnNetCommon_SOURCES})
+target_link_libraries(pnNetCommon pnNucleusInc)
+target_link_libraries(pnNetCommon pnDispatch)
+target_link_libraries(pnNetCommon pnFactory)
+target_link_libraries(pnNetCommon pnKeyedObject)
+target_link_libraries(pnNetCommon pnUUID)
 target_link_libraries(pnNetCommon plStatusLog)
 if(WIN32)
     target_link_libraries(pnNetCommon Ws2_32)


### PR DESCRIPTION
Allows it to build and link properly under gcc/clang.
