### PR TITLE
Dyanmic Cam Map stuff

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/plDynamicEnvMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDynamicEnvMap.cpp
@@ -753,13 +753,13 @@ void plDynamicCamMap::IPrepTextureLayers()
             {
                 fMatLayers[i]->SetUVWSrc(plLayerInterface::kUVWPosition);
                 fMatLayers[i]->SetMiscFlags(hsGMatState::kMiscCam2Screen | hsGMatState::kMiscPerspProjection);
-                hsgResMgr::ResMgr()->SendRef(GetKey(), new plGenRefMsg(fMatLayers[i]->GetKey(), plRefMsg::kOnRequest, 0, plLayRefMsg::kTexture), plRefFlags::kActiveRef);
+                hsgResMgr::ResMgr()->SendRef(GetKey(), new plLayRefMsg(fMatLayers[i]->GetKey(), plRefMsg::kOnRequest, 0, plLayRefMsg::kTexture), plRefFlags::kActiveRef);
             }
             else
             {
                 fMatLayers[i]->SetUVWSrc(0);
                 fMatLayers[i]->SetMiscFlags(0);
-                hsgResMgr::ResMgr()->SendRef(fDisableTexture->GetKey(), new plGenRefMsg(fMatLayers[i]->GetKey(), plRefMsg::kOnRequest, 0, plLayRefMsg::kTexture), plRefFlags::kActiveRef);
+                hsgResMgr::ResMgr()->SendRef(fDisableTexture->GetKey(), new plLayRefMsg(fMatLayers[i]->GetKey(), plRefMsg::kOnRequest, 0, plLayRefMsg::kTexture), plRefFlags::kActiveRef);
             }
         }
     }


### PR DESCRIPTION
This fixes a crash bug in `plDynamicCamMap::IPrepTextureLayers()`. Cyan was sending the wrong kind of ref message to the layer, so we kept resending the texture over and over until the heap was corrupted.
