### PR TITLE
Replace hardcoded frame number in plDTProgressMgr.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/plDTProgressMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDTProgressMgr.cpp
@@ -157,7 +157,7 @@ void    plDTProgressMgr::Draw( plPipeline *p )
         if ((currentMs - fLastDraw) > 30)
         {
             fCurrentImage++;
-            if (fCurrentImage >= 18)
+            if (fCurrentImage >= plProgressMgr::NumLoadingFrames())
                 fCurrentImage = 0;
 
             fLastDraw = currentMs;

--- a/Sources/Plasma/PubUtilLib/plProgressMgr/plProgressMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plProgressMgr/plProgressMgr.cpp
@@ -246,6 +246,11 @@ char*   plProgressMgr::GetLoadingFrameID(int index)
         return fImageRotation[0];
 }
 
+uint32_t plProgressMgr::NumLoadingFrames() const
+{
+    return LOADING_RES_COUNT;
+}
+
 const char*   plProgressMgr::GetStaticTextID(StaticText staticTextType)
 {
     return fStaticTextIDs[staticTextType];

--- a/Sources/Plasma/PubUtilLib/plProgressMgr/plProgressMgr.h
+++ b/Sources/Plasma/PubUtilLib/plProgressMgr/plProgressMgr.h
@@ -236,6 +236,7 @@ class plProgressMgr
 
         static plProgressMgr* GetInstance() { return fManager; }
         static char* GetLoadingFrameID(int index);
+        uint32_t plProgressMgr::NumLoadingFrames() const;
         static const char* GetStaticTextID(StaticText staticTextType);
 
         virtual void    Draw( plPipeline *p ) { }


### PR DESCRIPTION
This was overlooked when the consolidation was done in 3027e0605c2.

With this fix, the number of frames to be loaded is entirely defined in a single place: plProgressMgr.cpp's `LOADING_RES_COUNT`.

This also further prepares the code for a future commit removing the necessity of the compile-time definition entirely.
