### PR TITLE
Fix plKeyCollector key trashing...

### DIFF
--- a/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
+++ b/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
 class plSoundBufferCollector : public plRegistryPageIterator, public plKeyCollector
 {
 public:
-    plSoundBufferCollector(hsTArray<plKey>& keyArray) 
+    plSoundBufferCollector(std::set<plKey>& keyArray)
                 : plKeyCollector(keyArray) {}
 
     bool EatPage(plRegistryPageNode* page)
@@ -159,14 +159,14 @@ public:
 
 bool DumpSounds()
 {
-    hsTArray<plKey> soundKeys;
+    std::set<plKey> soundKeys;
 
     plSoundBufferCollector soundCollector(soundKeys);
     gResMgr->IterateAllPages(&soundCollector);
 
-    for (int i = 0; i < soundKeys.GetCount(); i++)
+    for (auto it = soundKeys.begin(); it != soundKeys.end(); ++it)
     {
-        plSoundBuffer* buffer = plSoundBuffer::ConvertNoRef(soundKeys[i]->VerifyLoaded());
+        plSoundBuffer* buffer = plSoundBuffer::ConvertNoRef((*it)->VerifyLoaded());
         if (buffer)
         {
             // Ref it...
@@ -197,7 +197,7 @@ bool DumpSounds()
         }
     }
 
-    soundKeys.Reset();
+    soundKeys.clear();
     plIndirectUnloadIterator iter;
     gResMgr->IterateAllPages(&iter);
 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
@@ -162,7 +162,7 @@ public:
             if (pageNode->GetPageInfo().GetAge().CompareI(fAgeName) == 0)
             {
                 // Try loading and searching thru this page
-                hsTArray<plKey> keyRefs;
+                std::set<plKey> keyRefs;
 
                 IGetResMgr()->LoadPageKeys( pageNode );
                 plKeyCollector coll( keyRefs );

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryHelpers.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryHelpers.cpp
@@ -42,16 +42,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plRegistryHelpers.h"
 #include "plRegistryNode.h"
 
-plKeyCollector::plKeyCollector( hsTArray<plKey> &keys ) : fKeys( keys )
-{
-}
-
-bool plKeyCollector::EatKey(const plKey& key)
-{
-    fKeys.Append(key);
-    return true;
-}
-
 bool plIndirectUnloadIterator::EatPage(plRegistryPageNode* page)
 {
     page->IterateKeys(this);

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryHelpers.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryHelpers.h
@@ -53,8 +53,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define _plRegistryHelpers_h
 
 #include "HeadSpin.h"
-#include "hsTemplates.h"
 #include "pnKeyedObject/plKey.h"
+#include <set>
 
 class plKey;
 class plRegistryPageNode;
@@ -76,16 +76,19 @@ public:
 };
 
 
-//// plKeyCollector //////////////////////////////////////////////////////////
-//  Helper key iterator that collects the given keys into the given hsTArray
+/** Helper key iterator that collects keys into an std::set. */
 class plKeyCollector : public plRegistryKeyIterator
 {
 protected:
-    hsTArray<plKey> &fKeys;
+    std::set<plKey>& fKeys;
 
 public:
-    plKeyCollector(hsTArray<plKey>& keys);
-    virtual bool EatKey(const plKey& key);
+    plKeyCollector(std::set<plKey>& keys) : fKeys(keys) { }
+    virtual bool EatKey(const plKey& key)
+    {
+        fKeys.insert(key);
+        return true;
+    }
 };
 
 // If you loaded keys with another iterator, this will ensure that they're unloaded

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
@@ -990,12 +990,11 @@ void plResManager::SetProgressBarProc(plProgressProc proc)
 class plResAgeHolder : public hsRefCnt
 {
     public:
-        hsTArray<plKey> fKeys;
+        std::set<plKey> fKeys;
         plString        fAge;
 
         plResAgeHolder() {}
         plResAgeHolder( const plString& age ) : fAge( age ) {}
-        ~plResAgeHolder() { fKeys.Reset(); }
 };
 
 //// plResHolderIterator /////////////////////////////////////////////////////
@@ -1003,12 +1002,12 @@ class plResAgeHolder : public hsRefCnt
 class plResHolderIterator : public plRegistryPageIterator
 {
 protected:
-    hsTArray<plKey>& fKeys;
+    std::set<plKey>& fKeys;
     plString fAgeName;
     plResManager* fResMgr;
 
 public:
-    plResHolderIterator(const plString& age, hsTArray<plKey>& keys, plResManager* resMgr)
+    plResHolderIterator(const plString& age, std::set<plKey>& keys, plResManager* resMgr)
             : fAgeName(age), fKeys(keys), fResMgr(resMgr) {}
 
     virtual bool EatPage(plRegistryPageNode* page)

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.h
@@ -135,12 +135,11 @@ class plResPageKeyRefList : public plKeyCollector
 {
     protected:
 
-        hsTArray<plKey>     fKeyList;
+        std::set<plKey>     fKeyList;
 
     public:
 
         plResPageKeyRefList() : plKeyCollector( fKeyList ) {}
-        virtual ~plResPageKeyRefList() { fKeyList.Reset(); }
 };
 
 #endif // _plResManagerHelper_h


### PR DESCRIPTION
It appears that the hsTArray memory management really sucks for smart pointers like plKey. The crash mentioned at http://forum.guildofwriters.org/viewtopic.php?f=117&t=6291 went away immediately after switching plKeyCollector to an std::set.

Removing the rest of the hsTArray<plKey> is pending. That's a lot of spidery work that (unfortunately) goes deep inside the Max plugin. Let's go ahead and get this in.
