### PR TITLE
Smoother Spinning Dots

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
@@ -190,6 +190,8 @@ void plNCAgeJoiner::IResMgrProgressBarCallback (plKey key) {
     if (s_instance)
         s_instance->progressBar->SetStatusText(key->GetName());
 #endif
+    if (s_instance)
+        s_instance->progressBar->Increment(1);
 }
 
 //============================================================================


### PR DESCRIPTION
Calling `plOperationProgress:Increment` has the side effect of firing off progress callbacks, which ends up redrawing the spinning dots at a maximum of 60fps. It'll still stutter a bit, but not as badly as before. This will make the experience more pleasant for shards with shiny branding.
