### PR TITLE
Allow setting the G values in server.ini

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCommandsCore.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCommandsCore.cpp
@@ -178,6 +178,16 @@ PF_CONSOLE_CMD(
                  kNetDiffieHellmanKeyBits / 8, kAuthDhXData);
 }
 
+//============================================================================
+PF_CONSOLE_CMD(
+    Server_Auth,
+    G,
+    "int GValue",
+    "Set the Auth Server G value"
+    ) {
+    kAuthDhGValue = (int)params[0];
+}
+
 
 //============================================================================
 // Server.Game group
@@ -217,6 +227,16 @@ PF_CONSOLE_CMD(
 
     Base64Decode(strlen((const char *)params[0]), (const char *)params[0],
                  kNetDiffieHellmanKeyBits / 8, kGameDhXData);
+}
+
+//============================================================================
+PF_CONSOLE_CMD(
+    Server_Game,
+    G,
+    "int GValue",
+    "Set the Game Server G value"
+    ) {
+    kGameDhGValue = (int)params[0];
 }
 
 
@@ -268,4 +288,14 @@ PF_CONSOLE_CMD(
 
     Base64Decode(strlen((const char *)params[0]), (const char *)params[0],
                  kNetDiffieHellmanKeyBits / 8, kGateKeeperDhXData);
+}
+
+//============================================================================
+PF_CONSOLE_CMD(
+    Server_Gate,
+    G,
+    "int GValue",
+    "Set the GateKeeper Server G value"
+    ) {
+    kGateKeeperDhGValue = (int)params[0];
 }

--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbKeys.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbKeys.cpp
@@ -43,13 +43,16 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnNbKeys.h"
 
 // Auth Server
+uint32_t kAuthDhGValue = 41;
 uint8_t kAuthDhNData[kNetDiffieHellmanKeyBits / 8] = {0};
 uint8_t kAuthDhXData[kNetDiffieHellmanKeyBits / 8] = {0};
 
 // Game Server
+uint32_t kGameDhGValue = 73;
 uint8_t kGameDhNData[kNetDiffieHellmanKeyBits / 8] = {0};
 uint8_t kGameDhXData[kNetDiffieHellmanKeyBits / 8] = {0};
 
 // GateKeeper Server
+uint32_t kGateKeeperDhGValue = 4;
 uint8_t kGateKeeperDhNData[kNetDiffieHellmanKeyBits / 8] = {0};
 uint8_t kGateKeeperDhXData[kNetDiffieHellmanKeyBits / 8] = {0};

--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbKeys.h
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbKeys.h
@@ -47,17 +47,17 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnNbConst.h"
 
 // Auth Server
-static const unsigned kAuthDhGValue = 41;
+extern uint32_t kAuthDhGValue;
 extern uint8_t kAuthDhNData[kNetDiffieHellmanKeyBits / 8];
 extern uint8_t kAuthDhXData[kNetDiffieHellmanKeyBits / 8];
 
 // Game Server
-static const unsigned kGameDhGValue = 73;
+extern uint32_t kGameDhGValue;
 extern uint8_t kGameDhNData[kNetDiffieHellmanKeyBits / 8];
 extern uint8_t kGameDhXData[kNetDiffieHellmanKeyBits / 8];
 
 // GateKeeper Server
-static const unsigned kGateKeeperDhGValue = 4;
+extern uint32_t kGateKeeperDhGValue;
 extern uint8_t kGateKeeperDhNData[kNetDiffieHellmanKeyBits / 8];
 extern uint8_t kGateKeeperDhXData[kNetDiffieHellmanKeyBits / 8];
 


### PR DESCRIPTION
Using UruLauncher's repair mode with a client that is using different G values led to being unable to connect to MOULa. This allows us to optionally set them in the server.ini.
