### PR TITLE
Use the UTF-8 version of Expat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,9 @@ if(CURL_IS_STATIC)
     add_definitions(-DCURL_STATICLIB)
 endif(CURL_IS_STATIC)
 
+# Same story for expat
+option(EXPAT_IS_STATIC "Using the static version of libexpat" ON)
+
 option(PLASMA_EXTERNAL_RELEASE "Is this release intended for the general public?" OFF)
 if(PLASMA_EXTERNAL_RELEASE)
     add_definitions(-DPLASMA_EXTERNAL_RELEASE)

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/CMakeLists.txt
@@ -3,9 +3,10 @@ include_directories(../../PubUtilLib)
 
 include_directories(${EXPAT_INCLUDE_DIR})
 
-add_definitions(-DXML_UNICODE_WCHAR_T)
-add_definitions(-DXML_STATIC)
 add_definitions(-DWIN32)
+if(EXPAT_IS_STATIC)
+    add_definitions(-DXML_STATIC)
+endif()
 
 set(pfLocalizationMgr_SOURCES
     pfLocalizationDataMgr.cpp

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
@@ -171,12 +171,12 @@ XML_Memory_Handling_Suite gHeapAllocator = {
 
 void XMLCALL LocalizationXMLFile::StartTag(void *userData, const XML_Char *element, const XML_Char **attributes)
 {
-    plString wElement = plString::FromWchar(element);
+    plString wElement = element;
     LocalizationXMLFile *file = (LocalizationXMLFile*)userData;
     std::map<plString, plString> wAttributes;
 
     for (int i = 0; attributes[i]; i += 2)
-        wAttributes[plString::FromWchar(attributes[i])] = plString::FromWchar(attributes[i+1]);
+        wAttributes[attributes[i]] = attributes[i+1];
 
     LocalizationXMLFile::tagInfo parentTag;
     if (!file->fTagStack.empty())
@@ -208,7 +208,7 @@ void XMLCALL LocalizationXMLFile::StartTag(void *userData, const XML_Char *eleme
 
 void XMLCALL LocalizationXMLFile::EndTag(void *userData, const XML_Char *element)
 {
-    plString wElement = plString::FromWchar(element);
+    plString wElement = element;
     LocalizationXMLFile *file = (LocalizationXMLFile*)userData;
 
     if (file->fSkipDepth != -1) // we're currently skipping
@@ -243,7 +243,7 @@ void XMLCALL LocalizationXMLFile::HandleData(void *userData, const XML_Char *dat
 
     // This gets all data between tags, including indentation and newlines
     // so we'll have to ignore data when we aren't expecting it (not in a translation tag)
-    plString contents = plString::FromWchar(data, stringLength);
+    plString contents = plString::FromUtf8(data, stringLength);
 
     // we must be in a translation tag since that's the only tag that doesn't ignore the contents
     file->fData[file->fCurrentAge][file->fCurrentSet][file->fCurrentElement][file->fCurrentTranslation] += contents;


### PR DESCRIPTION
Expat provides better support for its UTF-8 API than its "unicode" (`wchar_t` based) API. This allows us to use expat 2.1's CMake-based build system, which doesn't even support the `wchar_t` API currently. It also avoids the manual override we were previously using to tell it we were using the `wchar_t` version instead of the default.  **Please note that this does not require a change of the localization XML data itself**, as expat will still parse the data in whatever format it reads -- this only changes what format the parsed data is presented to client-side code (and our internal storage is already `plString`, which uses UTF-8 internally)

**_VERY IMPORTANT NOTE:**_  This will require a new build of your expat library!  This will NOT BE OBVIOUS, since it will still compile and link, but will give you junk localization data :(
