### PR TITLE
Fixes for Max plugin compilation when not using PCH

### DIFF
--- a/Sources/Tools/MaxComponent/plMultistageStage.cpp
+++ b/Sources/Tools/MaxComponent/plMultistageStage.cpp
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "hsStream.h"
 #include "hsWindows.h"
+#include "MaxMain/MaxCompat.h"
 
 #include <iparamb2.h>
 #include <max.h>

--- a/Sources/Tools/MaxMain/plComponentDlg.cpp
+++ b/Sources/Tools/MaxMain/plComponentDlg.cpp
@@ -51,6 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <algorithm>
 #include <notify.h>
 #include <utilapi.h>
+#include <notify.h>
 #include <vector>
 #pragma hdrstop
 

--- a/Sources/Tools/MaxMain/plComponentPanel.cpp
+++ b/Sources/Tools/MaxMain/plComponentPanel.cpp
@@ -47,6 +47,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "MaxComponent/plComponent.h"
 #include "MaxComponent/plComponentMgr.h"
 #include "resource.h"
+
+#include <notify.h>
 #pragma hdrstop
 
 #include "plComponentPanel.h"


### PR DESCRIPTION
This should be a better fix than previous attempts, since the breakages were due to PCH usage, not header differences.
