### PR TITLE
Implement chat history browsing (Client and Python)

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogNotifyProc.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogNotifyProc.cpp
@@ -105,6 +105,14 @@ void pfGUIDialogNotifyProc::HandleExtendedEvent( pfGUIControlMod *ctrl, uint32_t
         //send notify, somebody will do something with that (like python script)
         ISendNotify( ctrl->GetKey(), pfGUINotifyMsg::kSpecialAction );
     }
+    else if(edit && event == pfGUIEditBoxMod::kWantMessageHistoryUp)
+    {
+        ISendNotify( ctrl->GetKey(), pfGUINotifyMsg::kMessageHistoryUp );
+    }
+    else if(edit && event == pfGUIEditBoxMod::kWantMessageHistoryDown)
+    {
+        ISendNotify( ctrl->GetKey(), pfGUINotifyMsg::kMessageHistoryDown );
+    }
 }
 
 void pfGUIDialogNotifyProc::OnInit( void )

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -335,11 +335,11 @@ bool    pfGUIEditBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
         {
             fFirstHalfExitKeyPushed = false;
             // Use arrow keys to do our dirty work
-            if( key == KEY_UP || key == KEY_HOME )
+            if( key == KEY_HOME )
             {
                 SetCursorToHome();
             }
-            else if( key == KEY_DOWN || key == KEY_END )
+            else if( key == KEY_END )
             {
                 SetCursorToEnd();
             }
@@ -381,8 +381,18 @@ bool    pfGUIEditBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
             }
             else if (key == KEY_TAB) 
             {
-                //Send notify for python scripts
+                // Send notify for python scripts
                 HandleExtendedEvent(kWantAutocomplete);
+            }
+            else if (key == KEY_UP)
+            {
+                // Send notify for python scripts
+                HandleExtendedEvent(kWantMessageHistoryUp);
+            }
+            else if (key == KEY_DOWN)
+            {
+                // Send notify for python scripts
+                HandleExtendedEvent(kWantMessageHistoryDown);
             }
             else if (modifiers & pfGameGUIMgr::kCtrlDown) 
             {

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
@@ -129,7 +129,9 @@ class pfGUIEditBoxMod : public pfGUIControlMod
         enum ExtendedEvents
         {
             kValueChanging,
-            kWantAutocomplete
+            kWantAutocomplete,
+            kWantMessageHistoryUp,
+            kWantMessageHistoryDown
         };
 };
 

--- a/Sources/Plasma/FeatureLib/pfMessage/pfGUINotifyMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfGUINotifyMsg.h
@@ -84,6 +84,8 @@ public:
         kExitMode,          // GUI Exit Mode key was pressed
         kInterestingEvent,  // GUI interesting-ness has changed
         kSpecialAction,     // meaning depends on control functionality (see below) 
+        kMessageHistoryUp,  // up key to scroll back in history
+        kMessageHistoryDown,// down key to scroll forward in history
         kEndEventList
     };
 
@@ -99,6 +101,8 @@ public:
 // kEditBox
 //    kAction           - enter key hit
 //    kSpecialAction    - tab key hit (for autocompletion on Python side)
+//    kMessageHistoryUp - up key hit
+//    kMessageHistoryDown - down key hit
 // kUpDownPair
 //    kValueChanged     - the value of the pair has been changed
 // kKnob


### PR DESCRIPTION
This enables GUI notifications when the up and down keys are pressed in the chat editor. Based on this, we can implement chat history browsing in the Python scripts.
 H-uru/moul-scripts#81
