### PR TITLE
Patcher Patches

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -154,13 +154,13 @@ class pfPatcherStream : public plZlibStream
     uint32_t fFlags;
 
     uint64_t fBytesWritten;
-    float fDLStartTime;
+    double fDLStartTime;
 
     plString IMakeStatusMsg() const
     {
-        float secs = hsTimer::GetSysSeconds() - fDLStartTime;
-        float bytesPerSec = fBytesWritten / secs;
-        return plFileSystem::ConvertFileSize(bytesPerSec) + "/s";
+        double secs = hsTimer::GetSysSeconds() - fDLStartTime;
+        double bytesPerSec = fBytesWritten / secs;
+        return plFileSystem::ConvertFileSize(static_cast<uint64_t>(bytesPerSec)) + "/s";
     }
 
     void IUpdateProgress(uint32_t count)


### PR DESCRIPTION
This changeset addresses some common concerns and complaints with regard to the patcher:
- We now retry phailed downloads as a hack to get around spurious repair phailures against certain onery shards.
- Cleaned up `pfPatcherStream` memory management a bit.
- Made the file download error messages more useful to the end user in case a phailure still occurs.
