### PR TITLE
Only dirty changed states...

### DIFF
--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -4243,10 +4243,10 @@ bool VaultAgeGetAgeSDL (plStateDataRecord * out) {
     if (RelVaultNode * rvn = VaultGetAgeInfoNodeIncRef()) {
         if (RelVaultNode * rvnSdl = rvn->GetChildNodeIncRef(plVault::kNodeType_SDL, 1)) {
             VaultSDLNode sdl(rvnSdl);
-            result = sdl.GetStateDataRecord(out, plSDL::kKeepDirty);
+            result = sdl.GetStateDataRecord(out);
             if (!result) {
                 sdl.InitStateDataRecord(sdl.GetSDLName());
-                result = sdl.GetStateDataRecord(out, plSDL::kKeepDirty);
+                result = sdl.GetStateDataRecord(out);
             }
             rvnSdl->DecRef();
         }
@@ -4260,7 +4260,7 @@ void VaultAgeUpdateAgeSDL (const plStateDataRecord * rec) {
     if (RelVaultNode * rvn = VaultGetAgeInfoNodeIncRef()) {
         if (RelVaultNode * rvnSdl = rvn->GetChildNodeIncRef(plVault::kNodeType_SDL, 1)) {
             VaultSDLNode sdl(rvnSdl);
-            sdl.SetStateDataRecord(rec, plSDL::kDirtyOnly | plSDL::kTimeStampOnRead);
+            sdl.SetStateDataRecord(rec, plSDL::kTimeStampOnRead);
             rvnSdl->DecRef();
         }
         rvn->DecRef();


### PR DESCRIPTION
So the big idea for dirtying a state is that we need to send it to the server, because, well, we changed it. So, let's not keep everything dirty.We can figure out if it's changed from the default regardless of the dirty
flag.

This change specifically fixes problems with dirtied-but-not-modified variables overriding global states (AllAgeGlobalSDL) just because they happened to be read in at a later time than the global state. Whew.

This addresses a global-SDL override bug uncovered in the Neighborhood using H-uru/dirtsand#95
