### PR TITLE
Fixes for plFormat on GCC/Clang

### DIFF
--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -8,16 +8,25 @@ add_definitions(-DPRODUCT_SHORT_NAME="${PRODUCT_SHORT_NAME}")
 add_definitions(-DPRODUCT_LONG_NAME="${PRODUCT_LONG_NAME}")
 add_definitions(-DPRODUCT_UUID="${PRODUCT_UUID}")
 
-if(NOT WCHAR_BYTES)
-    include(CheckTypeSize)
+include(CheckTypeSize)
 
+if(NOT WCHAR_BYTES)
     check_type_size("wchar_t" WCHAR_BYTES)
     if(NOT WCHAR_BYTES)
         message(FATAL_ERROR "Could not determine sizeof(wchar_t)")
         set(WCHAR_BYTES 0)
-    endif(NOT WCHAR_BYTES)
-endif(NOT WCHAR_BYTES)
+    endif()
+endif()
 add_definitions(-DWCHAR_BYTES=${WCHAR_BYTES})
+
+if(NOT SIZEOF_LONG)
+    check_type_size("long" SIZEOF_LONG)
+    if(NOT SIZEOF_LONG)
+        message(FATAL_ERROR "Could not determine sizeof(long)")
+        set(SIZEOF_LONG 0)
+    endif()
+endif()
+add_definitions(-DSIZEOF_LONG=${SIZEOF_LONG})
 
 try_compile(HAVE_CPUID ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_cpuid.cpp

--- a/Sources/Plasma/CoreLib/plFormat.cpp
+++ b/Sources/Plasma/CoreLib/plFormat.cpp
@@ -338,7 +338,7 @@ static plStringBuffer<char> _formatChar(const plFormat_Private::FormatSpec &form
 #define _PL_FORMAT_IMPL_INT_TYPE(_stype, _utype) \
     PL_FORMAT_IMPL(_stype) \
     { \
-        /* Note:  The use of unsigned here is not a typo -- we only format decimal
+        /* Note:  The use of unsigned here is not a typo -- we only format decimal \
            values with a sign, so we can convert everything else to unsigned. */ \
         switch (format.fDigitClass) { \
         case plFormat_Private::kDigitBin: \
@@ -388,7 +388,9 @@ _PL_FORMAT_IMPL_INT_TYPE(signed char, unsigned char)
 _PL_FORMAT_IMPL_INT_TYPE(short, unsigned short)
 _PL_FORMAT_IMPL_INT_TYPE(int, unsigned)
 _PL_FORMAT_IMPL_INT_TYPE(long, unsigned long)
+#if (SIZEOF_LONG == 4)
 _PL_FORMAT_IMPL_INT_TYPE(int64_t, uint64_t)
+#endif
 
 PL_FORMAT_IMPL(char)
 {

--- a/Sources/Plasma/CoreLib/plFormat.h
+++ b/Sources/Plasma/CoreLib/plFormat.h
@@ -132,6 +132,12 @@ namespace plFormat_Private
     };
 
     extern FormatSpec _FetchNextFormat(_IFormatDataObject &data);
+
+    template <typename _type, typename... _Args>
+    plString _IFormat(_IFormatDataObject &data, _type, _Args...);
+
+    // End of the chain -- emits the last piece (if any) and builds the final string
+    plString _IFormat(_IFormatDataObject &data);
 }
 
 /** Declare a formattable type for `plFormat`.
@@ -201,8 +207,10 @@ PL_FORMAT_TYPE(int)
 PL_FORMAT_TYPE(unsigned)
 PL_FORMAT_TYPE(long)
 PL_FORMAT_TYPE(unsigned long)
+#if (SIZEOF_LONG == 4)
 PL_FORMAT_TYPE(int64_t)
 PL_FORMAT_TYPE(uint64_t)
+#endif
 PL_FORMAT_TYPE(const char *)
 PL_FORMAT_TYPE(const wchar_t *)
 PL_FORMAT_TYPE(const plString &)
@@ -217,11 +225,5 @@ PL_FORMAT_TYPE(const std::wstring &)
 // Formats as "true" or "false", following normal string formatting rules.
 // To use other formats, don't pass us a bool directly...
 PL_FORMAT_TYPE(bool)
-
-namespace plFormat_Private
-{
-    // End of the chain -- emits the last piece (if any) and builds the final string
-    plString _IFormat(_IFormatDataObject &data);
-}
 
 #endif // plFormat_Defined


### PR DESCRIPTION
- `int64_t` is a `typedef` of `long` on Linux/x86_64 -- don't redefine its specialization
- Properly forward-declare the unspecialized variadic template form of `_IFormat`
