### PR TITLE
Switch plFormat's accumulator to a plStringStream for better performance

### DIFF
--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -199,7 +199,7 @@ plFileName plFileName::Join(const plFileName &base, const plFileName &path)
 
 PL_FORMAT_IMPL(const plFileName &)
 {
-    return PL_FORMAT_FORWARD(format, value.AsString());
+    PL_FORMAT_FORWARD(value.AsString());
 }
 
 

--- a/Sources/Plasma/CoreLib/plString.h
+++ b/Sources/Plasma/CoreLib/plString.h
@@ -677,6 +677,9 @@ public:
     /** Append string data to the end of the stream. */
     plStringStream &append(const char *data, size_t length);
 
+    /** Append a sequence of characters to the stream. */
+    plStringStream &appendChar(char ch, size_t count = 1);
+
     /** Append UTF-8 C-style string data to the stream. */
     plStringStream &operator<<(const char *text);
 
@@ -693,7 +696,7 @@ public:
     plStringStream &operator<<(double num);
 
     /** Append a single Latin-1 character to the stream. */
-    plStringStream &operator<<(char ch) { return append(&ch, 1); }
+    plStringStream &operator<<(char ch) { return appendChar(ch); }
 
     /** Append the contents of \a text to the stream. */
     plStringStream &operator<<(const plString &text)

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plUoid.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plUoid.cpp
@@ -119,7 +119,7 @@ plString plLocation::StringIze()  const // Format to displayable string
 
 PL_FORMAT_IMPL(const plLocation &)
 {
-    return PL_FORMAT_FORWARD(format, value.StringIze());
+    PL_FORMAT_FORWARD(value.StringIze());
 }
 
 plLocation plLocation::MakeReserved(uint32_t number)
@@ -276,5 +276,5 @@ plString plUoid::StringIze() const // Format to displayable string
 
 PL_FORMAT_IMPL(const plUoid &)
 {
-    return PL_FORMAT_FORWARD(format, value.StringIze());
+    PL_FORMAT_FORWARD(value.StringIze());
 }

--- a/Sources/Plasma/NucleusLib/pnUUID/pnUUID.cpp
+++ b/Sources/Plasma/NucleusLib/pnUUID/pnUUID.cpp
@@ -86,5 +86,5 @@ plString plUUID::AsString() const
 
 PL_FORMAT_IMPL(const plUUID &)
 {
-    return PL_FORMAT_FORWARD(format, value.AsString());
+    PL_FORMAT_FORWARD(value.AsString());
 }


### PR DESCRIPTION
I did some quick performance testing of plFormat, and discovered that it was unfortunately quite a bit slower than other formatters...  So I switched the output mechanism to a plStringStream instead of a list of buffers, and got much better performance (~1.5x-6x improvement, depending on the compiler).

For reference, these are my timings from 100k loops of a simple format test:

```
                                    GCC -O0    GCC -O3  Clang -O0  Clang -O3    VC12 Dbg    VC12 Rel

No-op                           :   1.48 ms    0.13 ms    2.24 ms    0.14 ms     0.98 ms     0.00 ms
static snprintf                 :  32.69 ms   31.57 ms   52.49 ms   30.65 ms   232.58 ms   120.21 ms
dynamic snprintf                :  63.10 ms   61.90 ms  118.53 ms   63.06 ms   497.40 ms   270.67 ms
plString::Format                :  47.72 ms   33.45 ms   82.54 ms   34.86 ms   465.15 ms   210.10 ms
plFormat (current)              : 225.26 ms   93.05 ms  360.92 ms   91.13 ms  3382.12 ms  1211.74 ms
plFormat (plStringStream)       :  86.36 ms   63.41 ms  104.45 ms   65.76 ms   571.67 ms   268.73 ms
```

The changes are non-trivial, so I did perform some basic regression testing, but any additional testing is also welcome.
