### PR TITLE
Fix inappropriate UnRefing in VaultCreateNodeTrans

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -779,13 +779,14 @@ struct VaultCreateNodeTrans : NetAuthTrans {
     void *                          m_param;
     
     unsigned                        m_nodeId;
-    
+
     VaultCreateNodeTrans (
         NetVaultNode *                  templateNode,
         FNetCliAuthVaultNodeCreated     callback,
         void *                          param
     );
-    
+    ~VaultCreateNodeTrans();
+
     bool Send ();
     void Post ();
     bool Recv (
@@ -4056,7 +4057,13 @@ VaultCreateNodeTrans::VaultCreateNodeTrans (
 ,   m_param(param)
 ,   m_nodeId(0)
 {
-    m_templateNode->Ref();
+    m_templateNode->Ref("VaultCreateNodeTrans");
+}
+
+//============================================================================
+VaultCreateNodeTrans::~VaultCreateNodeTrans()
+{
+    m_templateNode->UnRef("VaultCreateNodeTrans");
 }
 
 //============================================================================
@@ -4086,7 +4093,6 @@ void VaultCreateNodeTrans::Post () {
         m_param,
         m_nodeId
     );
-    m_templateNode->UnRef();
 }
 
 //============================================================================


### PR DESCRIPTION
This caused an intermittent crash when creating a new avatar.
