### PR TITLE
Fix shadowed text fading

### DIFF
--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -1108,6 +1108,8 @@ void    plFont::IRenderChar8To32AlphaPremShadow( const plFont::plCharacter &c )
         xstart = -2;
 
     srcA = (uint8_t)(( fRenderInfo.fColor >> 24 ) & 0x000000ff);
+    if (srcA == 0)
+        return;
     srcR = (uint8_t)(( fRenderInfo.fColor >> 16 ) & 0x000000ff);
     srcG = (uint8_t)(( fRenderInfo.fColor >> 8  ) & 0x000000ff);
     srcB = (uint8_t)(( fRenderInfo.fColor       ) & 0x000000ff);
@@ -1149,7 +1151,10 @@ void    plFont::IRenderChar8To32AlphaPremShadow( const plFont::plCharacter &c )
                 sa = clamp;
             uint32_t a = IGetCharPixel(c, x, y);
             if (srcA != 0xff)
+            {
                 a = (srcA * a + 127) / 255;
+                sa = (srcA * sa + 127) / 255;
+            }
             uint32_t ta = a + sa - ((a*sa + 127) / 255);
             if (ta > (destPtr[ x ] >> 24))
                 destPtr[ x ] = ( ta << 24 ) | (((srcR * a + 127) / 255) << 16) |


### PR DESCRIPTION
Apparently fading the player list is done by re-rendering the text with a different alpha of the text color at every step. The shadow strength wasn’t modulated by that alpha, so the shadow didn’t fade. Now it is.

Also, the text of the faded-out player list is re-rendered with alpha == 0 every time the mouse enters its area, do a little less needless work in that case.
