### PR TITLE
plString constructor enhancements

### DIFF
--- a/Sources/Plasma/CoreLib/plString.cpp
+++ b/Sources/Plasma/CoreLib/plString.cpp
@@ -88,14 +88,12 @@ void plString::IConvertFromUtf8(const char *utf8, size_t size)
     operator=(plStringBuffer<char>(utf8, size));
 }
 
-plString &plString::operator=(const plStringBuffer<char> &init)
-{
-    fUtf8Buffer = init;
-
 #ifdef _DEBUG
     // Check to make sure the string is actually valid UTF-8
-    const char *sp = fUtf8Buffer.GetData();
-    while (sp < fUtf8Buffer.GetData() + fUtf8Buffer.GetSize()) {
+static void _check_utf8_buffer(const plStringBuffer<char> &buffer)
+{
+    const char *sp = buffer.GetData();
+    while (sp < buffer.GetData() + buffer.GetSize()) {
         unsigned char unichar = *sp++;
         if ((unichar & 0xF8) == 0xF0) {
             // Four bytes
@@ -115,8 +113,22 @@ plString &plString::operator=(const plStringBuffer<char> &init)
             hsAssert(0, "UTF-8 character out of range");
         }
     }
+}
+#else
+#   define _check_utf8_buffer(buffer)  NULL_STMT
 #endif
 
+plString &plString::operator=(const plStringBuffer<char> &init)
+{
+    fUtf8Buffer = init;
+    _check_utf8_buffer(fUtf8Buffer);
+    return *this;
+}
+
+plString &plString::operator=(plStringBuffer<char> &&init)
+{
+    fUtf8Buffer = std::move(init);
+    _check_utf8_buffer(fUtf8Buffer);
     return *this;
 }
 


### PR DESCRIPTION
- Add move constructors/operators to plString and friends
- Add a constructor/assignment operator to plString for string literals, to avoid a `strlen` call (and thereby hopefully reduce the number of Coverity false positives)
