### PR TITLE
plgAudioSys doesn't need to take hsWindowHndl.

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -1385,10 +1385,9 @@ bool plClient::StartInit()
 
     // the dx8 audio system MUST be initialized
     // before the database is loaded
-    HWND hWnd = fWindowHndl;
     SetForegroundWindow(fWindowHndl);
 
-    plgAudioSys::Init(hWnd);
+    plgAudioSys::Init();
     gAudio = plgAudioSys::Sys();
 
     RegisterAs( kClient_KEY );

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
@@ -264,7 +264,7 @@ void plAudioSystem::IEnumerateDevices()
 }
 
 //// Init ////////////////////////////////////////////////////////////////////
-bool    plAudioSystem::Init( hsWindowHndl hWnd )
+bool    plAudioSystem::Init()
 {
     plgAudioSys::fRestarting = false;
     static bool firstTimeInit = true; 
@@ -996,7 +996,6 @@ bool            plgAudioSys::fUseHardware = false;
 bool            plgAudioSys::fMuted = true;
 bool            plgAudioSys::fDelayedActivate = false;
 bool            plgAudioSys::fEnableEAX = false;
-hsWindowHndl    plgAudioSys::fWnd = nil;
 float        plgAudioSys::fChannelVolumes[ kNumChannels ] = { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f };
 float        plgAudioSys::f2D3DBias = 0.75f;
 uint32_t          plgAudioSys::fDebugFlags = 0;
@@ -1010,13 +1009,12 @@ std::string     plgAudioSys::fDeviceName;
 bool            plgAudioSys::fRestarting = false;
 bool            plgAudioSys::fMutedStateChange = false;
 
-void plgAudioSys::Init(hsWindowHndl hWnd)
+void plgAudioSys::Init()
 {
     fSys = new plAudioSystem;
     fSys->RegisterAs( kAudioSystem_KEY );
     plgDispatch::Dispatch()->RegisterForExactType( plAudioSysMsg::Index(), fSys->GetKey() );
     plgDispatch::Dispatch()->RegisterForExactType( plRenderMsg::Index(), fSys->GetKey() );
-    fWnd = hWnd;
 
     if(fMuted)
         SetGlobalFadeVolume(0.0f);
@@ -1143,7 +1141,7 @@ void plgAudioSys::Activate(bool b)
     if( b )
     {
         plStatusLog::AddLineS( "audio.log", plStatusLog::kBlue, "ASYS: -- Attempting audio system init --" );
-        if( !fSys->Init( fWnd ) )
+        if( !fSys->Init() )
         {
             // Cannot init audio system. Don't activate
             return; 

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.h
@@ -94,7 +94,7 @@ public:
         kRefEAXRegion
     };
 
-    bool    Init(hsWindowHndl hWnd);
+    bool    Init();
     void    Shutdown();
 
     void    SetActive( bool b );
@@ -189,7 +189,7 @@ public:
         kHardware,
         kHardwarePlusEAX,
     };
-    static void Init(hsWindowHndl hWnd);
+    static void Init();
     static bool Hardware() { return fUseHardware; }
     static void SetUseHardware(bool b);
     static void SetActive(bool b);
@@ -199,7 +199,6 @@ public:
     static void Shutdown();
     static void Activate(bool b);
     static bool     IsMuted( void ) { return fMuted; }
-    static hsWindowHndl hWnd() { return fWnd; }
     static plAudioSystem* Sys() { return fSys; }
     static void Restart( void );
     static bool     UsingEAX( void ) { return fSys->fUsingEAX; }
@@ -259,7 +258,6 @@ private:
     static bool                 fInit;
     static bool                 fActive;
     static bool                 fMuted;
-    static hsWindowHndl         fWnd;
     static bool                 fUseHardware;
     static bool                 fDelayedActivate;
     static float             fChannelVolumes[ kNumChannels ];

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.cpp
@@ -447,7 +447,7 @@ unsigned plWin32StreamingSound::GetByteOffset()
         unsigned offset = fDSoundBuffer->GetByteOffset();
         long byteoffset = ((fDataStream->GetDataSize() - fDataStream->NumBytesLeft()) - bytesQueued) + offset;
         
-        return byteoffset < 0 ? fDataStream->GetDataSize() - abs(byteoffset) : byteoffset;
+        return byteoffset < 0 ? fDataStream->GetDataSize() - std::abs(byteoffset) : byteoffset;
     }
     return 0;
 }


### PR DESCRIPTION
The window handle is no longer used by the audio system after the switch to OpenAL.
