### PR TITLE
Let ptVault.setAgePublic accept ptVaultAgeInfoNode in addition to ptAgeInfoStruct

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
@@ -641,6 +641,11 @@ bool pyVault::SetAgePublic( const pyAgeInfoStruct * ageInfo, bool makePublic )
     return VaultSetOwnedAgePublicAndWait(ageInfo->GetAgeInfo(), makePublic);
 }
 
+bool pyVault::SetAgePublic( const pyVaultAgeInfoNode * ageInfoNode, bool makePublic )
+{
+    return VaultSetAgePublicAndWait(ageInfoNode->GetNode(), makePublic);
+}
+
 
 PyObject* pyVault::GetGlobalInbox()
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.h
@@ -174,6 +174,8 @@ public:
     void CreateNeighborhood();
     // set an age's public status. will fail if you aren't czar of age.
     bool SetAgePublic( const pyAgeInfoStruct * ageInfo, bool makePublic );
+    // set an age's public status, also works for non-owners
+    bool SetAgePublic( const pyVaultAgeInfoNode * ageInfoNode, bool makePublic );
 
     PyObject* GetGlobalInbox( void ); // returns pyVaultFolderNode
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultGlue.cpp
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyEnum.h"
 #include "pyAgeInfoStruct.h"
 #include "pyVaultNode.h"
+#include "pyVaultAgeInfoNode.h"
 #include "pySDL.h"
 #include "pyAgeLinkStruct.h"
 
@@ -455,16 +456,21 @@ PYTHON_METHOD_DEFINITION(ptVault, setAgePublic, args)
     char makePublic;
     if (!PyArg_ParseTuple(args, "Ob", &ageInfoObj, &makePublic))
     {
-        PyErr_SetString(PyExc_TypeError, "setAgePublic expects a ptAgeInfoStruct and a boolean");
+        PyErr_SetString(PyExc_TypeError, "setAgePublic expects a ptAgeInfoStruct or ptVaultAgeInfoNode and a boolean");
         PYTHON_RETURN_ERROR;
     }
-    if (!pyAgeInfoStruct::Check(ageInfoObj))
+    if (pyAgeInfoStruct::Check(ageInfoObj))
     {
-        PyErr_SetString(PyExc_TypeError, "setAgePublic expects a ptAgeInfoStruct and a boolean");
-        PYTHON_RETURN_ERROR;
+        pyAgeInfoStruct* ageInfo = pyAgeInfoStruct::ConvertFrom(ageInfoObj);
+        PYTHON_RETURN_BOOL(self->fThis->SetAgePublic(ageInfo, makePublic != 0));
     }
-    pyAgeInfoStruct* ageInfo = pyAgeInfoStruct::ConvertFrom(ageInfoObj);
-    PYTHON_RETURN_BOOL(self->fThis->SetAgePublic(ageInfo, makePublic != 0));
+    else if (pyVaultAgeInfoNode::Check(ageInfoObj))
+    {
+        pyVaultAgeInfoNode* ageInfoNode = pyVaultAgeInfoNode::ConvertFrom(ageInfoObj);
+        PYTHON_RETURN_BOOL(self->fThis->SetAgePublic(ageInfoNode, makePublic != 0));
+    }
+    PyErr_SetString(PyExc_TypeError, "setAgePublic expects a ptAgeInfoStruct or ptVaultAgeInfoNode and a boolean");
+    PYTHON_RETURN_ERROR;
 }
 
 PYTHON_START_METHODS_TABLE(ptVault)

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -2477,22 +2477,28 @@ bool VaultAddOwnedAgeSpawnPoint (const plUUID& ageInstId, const plSpawnPointInfo
 bool VaultSetOwnedAgePublicAndWait (const plAgeInfoStruct * info, bool publicOrNot) {
     if (hsRef<RelVaultNode> rvnLink = VaultGetOwnedAgeLink(info)) {
         if (hsRef<RelVaultNode> rvnInfo = rvnLink->GetChildNode(plVault::kNodeType_AgeInfo, 1)) {
-            NetCliAuthSetAgePublic(rvnInfo->GetNodeId(), publicOrNot);
-
-            VaultAgeInfoNode access(rvnInfo);
-            char ageName[MAX_PATH];
-            StrToAnsi(ageName, access.GetAgeFilename(), arrsize(ageName));
-            
-            plVaultNotifyMsg * msg = new plVaultNotifyMsg;
-            if (publicOrNot)
-                msg->SetType(plVaultNotifyMsg::kPublicAgeCreated);
-            else
-                msg->SetType(plVaultNotifyMsg::kPublicAgeRemoved);
-            msg->SetResultCode(true);
-            msg->GetArgs()->AddString(plNetCommon::VaultTaskArgs::kAgeFilename, ageName);
-            msg->Send();
+            VaultSetAgePublicAndWait(rvnInfo, publicOrNot);
         }
     }
+    return true;
+}
+
+//============================================================================
+bool VaultSetAgePublicAndWait (NetVaultNode * ageInfoNode, bool publicOrNot) {
+    NetCliAuthSetAgePublic(ageInfoNode->GetNodeId(), publicOrNot);
+
+    VaultAgeInfoNode access(ageInfoNode);
+    char ageName[MAX_PATH];
+    StrToAnsi(ageName, access.GetAgeFilename(), arrsize(ageName));
+    
+    plVaultNotifyMsg * msg = new plVaultNotifyMsg;
+    if (publicOrNot)
+        msg->SetType(plVaultNotifyMsg::kPublicAgeCreated);
+    else
+        msg->SetType(plVaultNotifyMsg::kPublicAgeRemoved);
+    msg->SetResultCode(true);
+    msg->GetArgs()->AddString(plNetCommon::VaultTaskArgs::kAgeFilename, ageName);
+    msg->Send();
     return true;
 }
 

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -345,6 +345,7 @@ hsRef<RelVaultNode> VaultGetOwnedAgeInfo(const plAgeInfoStruct * info);
 bool                VaultGetOwnedAgeLink(const plAgeInfoStruct * info, plAgeLinkStruct * link);
 bool                VaultAddOwnedAgeSpawnPoint(const plUUID& ageInstId, const plSpawnPointInfo & spawnPt);
 bool                VaultSetOwnedAgePublicAndWait(const plAgeInfoStruct * info, bool publicOrNot);
+bool                VaultSetAgePublicAndWait(NetVaultNode * ageInfoNode, bool publicOrNot);
 hsRef<RelVaultNode> VaultGetVisitAgeLink(const plAgeInfoStruct * info);
 bool                VaultGetVisitAgeLink(const plAgeInfoStruct * info, class plAgeLinkStruct * link);
 bool                VaultRegisterOwnedAgeAndWait(const plAgeLinkStruct * link);


### PR DESCRIPTION
In this case it now also works for non-owners of the age. Previously it only worked for owners because the ageInfoStruct does not contain the vault node ID, so it needed to be looked up somewhere, and that was in the AgesIOwnFolder.

Prerequisite for hood auto-bump (moul-scripts PR forthcoming).
