### PR TITLE
plString fixes

### DIFF
--- a/Sources/Plasma/CoreLib/plFormat.cpp
+++ b/Sources/Plasma/CoreLib/plFormat.cpp
@@ -530,9 +530,7 @@ PL_FORMAT_IMPL(const std::string &)
 
 PL_FORMAT_IMPL(const std::wstring &)
 {
-    plStringBuffer<char> utf8 = plString::FromWchar(value.c_str()).ToUtf8();
-    _formatString(format, output, utf8.GetData(), utf8.GetSize(),
-                  plFormat_Private::kAlignLeft);
+    PL_FORMAT_FORWARD(value.c_str());
 }
 
 PL_FORMAT_IMPL(bool)

--- a/Sources/Plasma/CoreLib/plString.cpp
+++ b/Sources/Plasma/CoreLib/plString.cpp
@@ -838,7 +838,7 @@ std::vector<plString> plString::Split(const char *split, size_t maxSplits) const
 plString plString::Fill(size_t count, char c)
 {
     plStringBuffer<char> buf;
-    char *data = buf.CreateWritableBuffer(count + 1);
+    char *data = buf.CreateWritableBuffer(count);
     memset(data, c, count);
     data[count] = 0;
     return buf;

--- a/Sources/Plasma/CoreLib/plString.h
+++ b/Sources/Plasma/CoreLib/plString.h
@@ -279,7 +279,7 @@ public:
      *        conversion from ISO-8859-1 8-bit data, use FromIso8859_1().
      */
     template <size_t _Sz>
-    plString(const char (&literal)[_Sz]) { IConvertFromUtf8(literal, _Sz); }
+    plString(const char (&literal)[_Sz]) { IConvertFromUtf8(literal, _Sz - 1); }
 
     /** Copy constructor. */
     plString(const plString &copy) : fUtf8Buffer(copy.fUtf8Buffer) { }
@@ -304,7 +304,7 @@ public:
 
     /** Assignment operator.  Same as plString(const char (&)[_Sz]). */
     template <size_t _Sz>
-    plString &operator=(const char (&literal)[_Sz]) { IConvertFromUtf8(literal, _Sz); return *this; }
+    plString &operator=(const char (&literal)[_Sz]) { IConvertFromUtf8(literal, _Sz - 1); return *this; }
 
     /** Assignment operator.  Same as plString(const plString &). */
     plString &operator=(const plString &copy) { fUtf8Buffer = copy.fUtf8Buffer; return *this; }


### PR DESCRIPTION
The important one here is the fix for the string literal constructors.  A string literal's size includes its nul-terminator :(