### PR TITLE
Fix CMake 3.1 warning regarding quoted arguments in conditionals.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(Plasma)
 cmake_minimum_required(VERSION 2.8.11.2)
+cmake_policy(SET CMP0054 NEW)
 
 # Set up Product Identification parameters
 set(PRODUCT_BRANCH_ID   "1"         CACHE STRING "Branch ID")


### PR DESCRIPTION
Fixes the warning encountered when generating build files with CMake 3.1.

See [CMP0054](http://www.cmake.org/cmake/help/v3.1/policy/CMP0054.html) for more information.