### PR TITLE
Some fixes for compiler errors found on GCC/Linux

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
@@ -544,7 +544,7 @@ PF_CONSOLE_CMD( Net,        // groupName
                "returns the age of the age" )   // helpString
 {
     PrintStringF(PrintString, "Current age is %s, elapsed time since birth = %f secs", 
-        NetCommGetAge()->ageDatasetName, plNetClientMgr::GetInstance()->GetCurrentAgeElapsedSeconds());
+        NetCommGetAge()->ageDatasetName.c_str(), plNetClientMgr::GetInstance()->GetCurrentAgeElapsedSeconds());
 }
 
 PF_CONSOLE_CMD( Net, DownloadViaManifest,

--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.cpp
@@ -49,6 +49,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <Python.h>
 #pragma hdrstop
 
+#include "pyGlueHelpers.h"
 #include "cyAccountManagement.h"
 #include "plNetClientComm/plNetClientComm.h"
 

--- a/Sources/Plasma/PubUtilLib/plGImage/plJPEG.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plJPEG.cpp
@@ -298,8 +298,10 @@ bool    plJPEG::IWrite( plMipmap *source, hsStream *outStream )
 
         jpeg_set_defaults( &cinfo );
 
+#if JPEG_LIB_VERSION >= 70
         cinfo.jpeg_width = source->GetWidth(); // default
         cinfo.jpeg_height = source->GetHeight(); // default
+#endif
         cinfo.jpeg_color_space = JCS_YCbCr; // default
         // not sure how to set 4:1:1 but supposedly it's the default
         jpeg_set_quality( &cinfo, fWriteQuality, TRUE );


### PR DESCRIPTION
Also fixes the use of libjpeg-6b (or libjpeg-turbo built with the jpeg-62 API, which is the default on Debian, sadly).