### PR TITLE
Make hsAssert useful on Linux / Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,19 @@ include(cmake/CompilerChecks.cmake)
 if(WIN32 AND NOT CYGWIN)
     add_definitions(-DHS_BUILD_FOR_WIN32)
 endif(WIN32 AND NOT CYGWIN)
+
 if(UNIX)
+    # This is set for both Linux and Mac builds
     add_definitions(-DHS_BUILD_FOR_UNIX)
 endif(UNIX)
+
 if(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     add_definitions(-DHS_BUILD_FOR_OSX)
 endif(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    add_definitions(-DHS_BUILD_FOR_LINUX)
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 # End HeadSpin Configuration
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -118,17 +118,20 @@ void ErrorAssert(int line, const char* file, const char* fmt, ...)
     va_list args;
     va_start(args, fmt);
     vsnprintf(msg, arrsize(msg), fmt, args);
-#if defined(HS_DEBUGGING) && defined(_MSC_VER)
+#if defined(HS_DEBUGGING)
+#if defined(_MSC_VER)
     if (s_GuiAsserts)
     {
-        if(_CrtDbgReport(_CRT_ASSERT, file, line, NULL, msg))
+        if (_CrtDbgReport(_CRT_ASSERT, file, line, NULL, msg))
             DebugBreak();
     } else
-#endif // HS_DEBUGGING
-      if (DebugIsDebuggerPresent()) {
+#endif // _MSC_VER
+    {
         char str[] = "-------\nASSERTION FAILED:\nFile: %s   Line: %i\nMessage: %s\n-------";
         DebugMsg(str, file, line, msg);
+        abort();
     }
+#endif // HS_DEBUGGING
 #else
     DebugBreakIfDebuggerPresent();
 #endif // defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
@@ -164,13 +167,14 @@ void DebugMsg(const char* fmt, ...)
     va_start(args, fmt);
     vsnprintf(msg, arrsize(msg), fmt, args);
 
+#ifdef _MSC_VER
     if (DebugIsDebuggerPresent())
     {
-#ifdef _MSC_VER
         OutputDebugStringA(msg);
         OutputDebugStringA("\n");
+    } else
 #endif
-    } else {
+    {
         fprintf(stderr, "%s\n", msg);
     }
 }

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -53,6 +53,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   include <fcntl.h>
 #   include <unistd.h>
 #endif
+
+#if defined(HS_BUILD_FOR_UNIX)
+#   include <signal.h>
+#endif
+
 #pragma hdrstop
 
 #include "hsTemplates.h"
@@ -136,6 +141,9 @@ void ErrorAssert(int line, const char* file, const char* fmt, ...)
     {
         char str[] = "-------\nASSERTION FAILED:\nFile: %s   Line: %i\nMessage: %s\n-------";
         DebugMsg(str, file, line, msg);
+        DebugBreakIfDebuggerPresent();
+
+        // In case the debug trap is ignored
         abort();
     }
 #endif // HS_DEBUGGING
@@ -175,7 +183,7 @@ bool DebugIsDebuggerPresent()
 
 void DebugBreakIfDebuggerPresent()
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
     __try
     {
         __debugbreak();
@@ -183,6 +191,8 @@ void DebugBreakIfDebuggerPresent()
         // Debugger not present or some such shwiz.
         // Whatever. Don't crash here.
     }
+#elif defined(HS_BUILD_FOR_UNIX)
+    raise(SIGTRAP);
 #endif // _MSC_VER
 }
 

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -47,7 +47,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   include <crtdbg.h>
 #endif
 
-#if defined(HS_DEBUGGING) && defined(HS_BUILD_FOR_LINUX)
+#pragma hdrstop
+
+#if defined(HS_DEBUGGING) && defined(HS_BUILD_FOR_UNIX)
 #   include <cstring>
 #   include <sys/stat.h>
 #   include <fcntl.h>
@@ -57,8 +59,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #if defined(HS_BUILD_FOR_UNIX)
 #   include <signal.h>
 #endif
-
-#pragma hdrstop
 
 #include "hsTemplates.h"
 #include "plFormat.h"

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -135,16 +135,13 @@ void ErrorAssert(int line, const char* file, const char* fmt, ...)
     if (s_GuiAsserts)
     {
         if (_CrtDbgReport(_CRT_ASSERT, file, line, NULL, msg))
-            DebugBreak();
+            DebugBreakAlways();
     } else
 #endif // _MSC_VER
     {
         char str[] = "-------\nASSERTION FAILED:\nFile: %s   Line: %i\nMessage: %s\n-------";
         DebugMsg(str, file, line, msg);
-        DebugBreakIfDebuggerPresent();
-
-        // In case the debug trap is ignored
-        abort();
+        DebugBreakAlways();
     }
 #endif // HS_DEBUGGING
 #else
@@ -192,7 +189,22 @@ void DebugBreakIfDebuggerPresent()
         // Whatever. Don't crash here.
     }
 #elif defined(HS_BUILD_FOR_UNIX)
+    if (DebugIsDebuggerPresent())
+        raise(SIGTRAP);
+#else
+    // FIXME
+#endif // _MSC_VER
+}
+
+void DebugBreakAlways()
+{
+#if defined(_MSC_VER)
+    DebugBreak();
+#elif defined(HS_BUILD_FOR_UNIX)
     raise(SIGTRAP);
+#else
+    // FIXME
+    abort();
 #endif // _MSC_VER
 }
 

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -374,8 +374,9 @@ hsDebugMessageProc hsSetStatusMessageProc(hsDebugMessageProc newProc);
 void ErrorEnableGui (bool enabled);
 void ErrorAssert (int line, const char* file, const char* fmt, ...);
 
-bool DebugIsDebuggerPresent ();
-void DebugBreakIfDebuggerPresent ();
+bool DebugIsDebuggerPresent();
+void DebugBreakIfDebuggerPresent();
+void DebugBreakAlways();
 void DebugMsg(const char* fmt, ...);
 
 #ifdef HS_DEBUGGING


### PR DESCRIPTION
Previously, `hsAssert()` would be completely ignored on anything other than Windows, even when `HS_DEBUGGING` was properly defined.  This makes it actually print the error message, and then abort afterwards for `HS_DEBUGGING` mode.  Release mode will still silently ignore asserts as before.

EDIT: Also included @dpogue's `DebugIsDebuggerPresent` fix for Linux, and a `DebugBreak` equivalent for all Unixes.