### PR TITLE
GBufferGroup hsTArray -> std::vector

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.cpp
@@ -114,7 +114,7 @@ plGBufferGroup::plGBufferGroup( uint8_t format, bool vertsVolatile, bool idxVola
 {
     fVertBuffStorage.Reset();
     fIdxBuffStorage.Reset();
-    fColorBuffStorage.Reset();
+    fColorBuffStorage.clear();
     fVertexBufferRefs.Reset();
     fIndexBufferRefs.Reset();
     fCells.clear();
@@ -216,7 +216,7 @@ void    plGBufferGroup::CleanUp( void )
         plProfile_DelMem(MemBufGrpIndex, fIdxBuffCounts[i] * sizeof(uint16_t));
         delete [] fIdxBuffStorage[ i ];
     }
-    for( i = 0; i < fColorBuffStorage.GetCount(); i++ )
+    for (size_t i = 0; i < fColorBuffStorage.size(); ++i)
     {
         plProfile_DelMem(MemBufGrpVertex, fColorBuffCounts[i] * sizeof(plGBufferColor));
         delete [] fColorBuffStorage[ i ];
@@ -233,8 +233,8 @@ void    plGBufferGroup::CleanUp( void )
     fIdxBuffCounts.Reset();
     fIdxBuffStarts.Reset();
     fIdxBuffEnds.Reset();
-    fColorBuffStorage.Reset();
-    fColorBuffCounts.Reset();
+    fColorBuffStorage.clear();
+    fColorBuffCounts.clear();
 
     fCells.clear();
 }
@@ -374,7 +374,7 @@ void    plGBufferGroup::Read( hsStream *s )
     fVertBuffSizes.Reset();
     fVertBuffStarts.Reset();
     fVertBuffEnds.Reset();
-    fColorBuffCounts.Reset();
+    fColorBuffCounts.clear();
     fIdxBuffCounts.Reset();
     fIdxBuffStarts.Reset();
     fIdxBuffEnds.Reset();
@@ -401,8 +401,8 @@ void    plGBufferGroup::Read( hsStream *s )
 
             coder.Read(s, vData, fFormat, fStride, numVerts);
 
-            fColorBuffCounts.Append(0);                     
-            fColorBuffStorage.Append(nil);
+            fColorBuffCounts.push_back(0);
+            fColorBuffStorage.push_back(nullptr);
 
         }
         else
@@ -420,7 +420,7 @@ void    plGBufferGroup::Read( hsStream *s )
             plProfile_NewMem(MemBufGrpVertex, temp);
             
             temp = s->ReadLE32();
-            fColorBuffCounts.Append( temp );
+            fColorBuffCounts.push_back( temp );
             
             if( temp > 0 )
             {
@@ -431,7 +431,7 @@ void    plGBufferGroup::Read( hsStream *s )
             else
                 cData = nil;
             
-            fColorBuffStorage.Append( cData );
+            fColorBuffStorage.push_back( cData );
         }
     }
 
@@ -753,8 +753,8 @@ bool    plGBufferGroup::ReserveVertStorage( uint32_t numVerts, uint32_t *vbIndex
         fVertBuffStarts.Append(0);
         fVertBuffEnds.Append(-1);
 
-        fColorBuffStorage.Append( nil );
-        fColorBuffCounts.Append( 0 );
+        fColorBuffStorage.push_back(nullptr);
+        fColorBuffCounts.push_back(0);
 
         fCells.push_back( new std::vector<plGBufferCell> );
     }
@@ -795,15 +795,15 @@ bool    plGBufferGroup::ReserveVertStorage( uint32_t numVerts, uint32_t *vbIndex
     }
 
     /// Switch over
-    if( storagePtr != nil )
+    if (storagePtr)
     {
         if( fVertBuffStorage[ i ] != nil )
             delete [] fVertBuffStorage[ i ];
         fVertBuffStorage[ i ] = storagePtr;
     }
-    if( cStoragePtr != nil )
+    if (cStoragePtr)
     {
-        if( fColorBuffStorage[ i ] != nil )
+        if (fColorBuffStorage[ i ])
             delete [] fColorBuffStorage[ i ];
         fColorBuffStorage[ i ] = cStoragePtr;
         fColorBuffCounts[ i ] += numVerts;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.cpp
@@ -850,7 +850,7 @@ void    plGBufferGroup::AppendToColorStorage( plGeometrySpan *srcSpan, uint32_t 
 
 void    plGBufferGroup::IGetStartVtxPointer( uint32_t vbIndex, uint32_t cell, uint32_t offset, uint8_t *&tempPtr, plGBufferColor *&cPtr )
 {
-    hsAssert( vbIndex < fVertBuffStorage.GetCount(), "Invalid vbIndex in StuffToVertStorage()" );
+    hsAssert( vbIndex < fVertBuffStorage.size(), "Invalid vbIndex in StuffToVertStorage()" );
     hsAssert( cell < fCells[ vbIndex ]->size(), "Invalid cell in StuffToVertStorage()" );
 
     tempPtr = fVertBuffStorage[ vbIndex ];
@@ -880,7 +880,7 @@ uint32_t  plGBufferGroup::GetVertStartFromCell( uint32_t vbIndex, uint32_t cell,
     uint32_t  i, numVerts;
 
 
-    hsAssert( vbIndex < fVertBuffStorage.GetCount(), "Invalid vbIndex in StuffToVertStorage()" );
+    hsAssert( vbIndex < fVertBuffStorage.size(), "Invalid vbIndex in StuffToVertStorage()" );
     hsAssert( cell <= fCells[ vbIndex ]->size(), "Invalid cell in StuffToVertStorage()" );
 
     numVerts = 0;
@@ -904,7 +904,7 @@ void    plGBufferGroup::StuffToVertStorage( plGeometrySpan *srcSpan, uint32_t vb
     plGBufferCell   *cellPtr;
 
 
-    hsAssert( vbIndex < fVertBuffStorage.GetCount(), "Invalid vbIndex in StuffToVertStorage()" );
+    hsAssert( vbIndex < fVertBuffStorage.size(), "Invalid vbIndex in StuffToVertStorage()" );
     hsAssert( cell < fCells[ vbIndex ]->size(), "Invalid cell in StuffToVertStorage()" );
 
     IGetStartVtxPointer( vbIndex, cell, offset, tempPtr, cPtr );
@@ -1196,7 +1196,7 @@ void    plGBufferGroup::StuffFromTriList( uint32_t which, uint32_t start, uint32
 void    plGBufferGroup::StuffTri( uint32_t iBuff, uint32_t iTri, uint16_t idx0, uint16_t idx1, uint16_t idx2 )
 {
     /// Sanity checks
-    hsAssert( iBuff < fIdxBuffStorage.GetCount(), "Invalid index buffer ID to StuffFromTriList()" );
+    hsAssert( iBuff < fIdxBuffStorage.size(), "Invalid index buffer ID to StuffFromTriList()" );
     hsAssert( iTri < fIdxBuffCounts[ iBuff ], "Invalid start index to StuffFromTriList()" );
 
     fIdxBuffStorage[ iBuff ][ iTri + 0 ] = idx0;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.cpp
@@ -360,8 +360,15 @@ void    plGBufferGroup::Read( hsStream *s )
     fIdxBuffStorage.clear();
 
     plVertCoder coder;
+
     /// Create buffers and read in as we go
     count = s->ReadLE32();
+    fVertBuffSizes.reserve(count);
+    fVertBuffStarts.reserve(count);
+    fVertBuffEnds.reserve(count);
+    fVertBuffStorage.reserve(count);
+    fColorBuffCounts.reserve(count);
+    fColorBuffStorage.reserve(count);
     for( i = 0; i < count; i++ )
     {
         if( fFormat & kEncoded )
@@ -414,6 +421,10 @@ void    plGBufferGroup::Read( hsStream *s )
     }
 
     count = s->ReadLE32();
+    fIdxBuffCounts.reserve(count);
+    fIdxBuffStarts.reserve(count);
+    fIdxBuffEnds.reserve(count);
+    fIdxBuffStorage.reserve(count);
     for( i = 0; i < count; i++ )
     {
         temp = s->ReadLE32();
@@ -429,6 +440,7 @@ void    plGBufferGroup::Read( hsStream *s )
     }
 
     /// Read in cell arrays, one per vBuffer
+    fCells.reserve(fVertBuffStorage.size());
     for( i = 0; i < fVertBuffStorage.size(); i++ )
     {
         temp = s->ReadLE32();

--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.cpp
@@ -115,8 +115,8 @@ plGBufferGroup::plGBufferGroup( uint8_t format, bool vertsVolatile, bool idxVola
     fVertBuffStorage.clear();
     fIdxBuffStorage.clear();
     fColorBuffStorage.clear();
-    fVertexBufferRefs.Reset();
-    fIndexBufferRefs.Reset();
+    fVertexBufferRefs.clear();
+    fIndexBufferRefs.clear();
     fCells.clear();
     fNumVerts = fNumIndices = 0;
 
@@ -131,29 +131,25 @@ plGBufferGroup::plGBufferGroup( uint8_t format, bool vertsVolatile, bool idxVola
 
 plGBufferGroup::~plGBufferGroup()
 {
-    uint32_t   i;
-
     CleanUp();
 
-    for( i = 0; i < fVertexBufferRefs.GetCount(); i++ )
-        hsRefCnt_SafeUnRef( fVertexBufferRefs[ i ] );
-
-    for( i = 0; i < fIndexBufferRefs.GetCount(); i++ )
-        hsRefCnt_SafeUnRef( fIndexBufferRefs[ i ] );
-
-    fVertexBufferRefs.Reset();
-    fIndexBufferRefs.Reset();
+    for (auto i : fVertexBufferRefs) {
+        hsRefCnt_SafeUnRef(i);
+    }
+    for (auto i : fIndexBufferRefs) {
+        hsRefCnt_SafeUnRef(i);
+    }
 }
 
-void plGBufferGroup::DirtyVertexBuffer(int i)
+void plGBufferGroup::DirtyVertexBuffer(size_t i)
 {
-    if( (i < fVertexBufferRefs.GetCount()) && fVertexBufferRefs[i] )
+    if( (i < fVertexBufferRefs.size()) && fVertexBufferRefs[i] )
         fVertexBufferRefs[i]->SetDirty(true);
 }
 
-void plGBufferGroup::DirtyIndexBuffer(int i)
+void plGBufferGroup::DirtyIndexBuffer(size_t i)
 {
-    if( (i < fIndexBufferRefs.GetCount()) && fIndexBufferRefs[i] )
+    if( (i < fIndexBufferRefs.size()) && fIndexBufferRefs[i] )
         fIndexBufferRefs[i]->SetDirty(true);
 }
 
@@ -240,11 +236,11 @@ void    plGBufferGroup::CleanUp( void )
 
 void    plGBufferGroup::SetVertexBufferRef( uint32_t index, hsGDeviceRef *vb )
 {
-    hsAssert( index < fVertexBufferRefs.GetCount() + 1, "Vertex buffers must be assigned linearly!" );
+    hsAssert( index < fVertexBufferRefs.size() + 1, "Vertex buffers must be assigned linearly!" );
 
-    if( (int)index > (int)fVertexBufferRefs.GetCount() - 1 )
+    if (index > fVertexBufferRefs.size() - 1)
     {
-        fVertexBufferRefs.Append( vb );
+        fVertexBufferRefs.push_back( vb );
         hsRefCnt_SafeRef( vb );
     }
     else
@@ -258,11 +254,11 @@ void    plGBufferGroup::SetVertexBufferRef( uint32_t index, hsGDeviceRef *vb )
 
 void    plGBufferGroup::SetIndexBufferRef( uint32_t index, hsGDeviceRef *ib ) 
 {
-    hsAssert( index < fIndexBufferRefs.GetCount() + 1, "Index buffers must be assigned linearly!" );
+    hsAssert( index < fIndexBufferRefs.size() + 1, "Index buffers must be assigned linearly!" );
 
-    if( (int)index > (int)fIndexBufferRefs.GetCount() - 1 )
+    if(index > fIndexBufferRefs.size() - 1)
     {
-        fIndexBufferRefs.Append( ib );
+        fIndexBufferRefs.push_back( ib );
         hsRefCnt_SafeRef( ib );
     }
     else
@@ -285,16 +281,16 @@ void    plGBufferGroup::PrepForRendering( plPipeline *pipe, bool adjustForNvidia
 
 hsGDeviceRef* plGBufferGroup::GetVertexBufferRef(uint32_t i) 
 { 
-    if( i >= fVertexBufferRefs.GetCount() )
-        fVertexBufferRefs.ExpandAndZero(i+1);
+    if( i >= fVertexBufferRefs.size() )
+        fVertexBufferRefs.resize(i+1);
 
     return fVertexBufferRefs[i]; 
 }
 
 hsGDeviceRef* plGBufferGroup::GetIndexBufferRef(uint32_t i) 
 { 
-    if( i >= fIndexBufferRefs.GetCount() )
-        fIndexBufferRefs.ExpandAndZero(i+1);
+    if( i >= fIndexBufferRefs.size() )
+        fIndexBufferRefs.resize(i+1);
 
     return fIndexBufferRefs[i]; 
 }
@@ -580,10 +576,10 @@ void    plGBufferGroup::DeleteVertsFromStorage( uint32_t which, uint32_t start, 
     fVertBuffSizes[ which ] -= length;
     plProfile_DelMem(MemBufGrpVertex, length);
 
-    if( fVertexBufferRefs.GetCount() > which && fVertexBufferRefs[ which ] != nil )
+    if (fVertexBufferRefs.size() > which && fVertexBufferRefs[which])
     {
         hsRefCnt_SafeUnRef(fVertexBufferRefs[which]);
-        fVertexBufferRefs[which] = nil;
+        fVertexBufferRefs[which] = nullptr;
     }
 
 }
@@ -603,8 +599,8 @@ void    plGBufferGroup::AdjustIndicesInStorage( uint32_t which, uint16_t threshh
             fIdxBuffStorage[ which ][ i ] += delta;
     }
 
-    if( fIndexBufferRefs.GetCount() > which && fIndexBufferRefs[ which ] != nil )
-        fIndexBufferRefs[ which ]->SetDirty( true );
+    if (fIndexBufferRefs.size() > which && fIndexBufferRefs[which])
+        fIndexBufferRefs[which]->SetDirty( true );
 
 }
 
@@ -633,10 +629,10 @@ void    plGBufferGroup::DeleteIndicesFromStorage( uint32_t which, uint32_t start
     fIdxBuffCounts[ which ] -= length;
     plProfile_DelMem(MemBufGrpIndex, length * sizeof(uint16_t));
 
-    if( fIndexBufferRefs.GetCount() > which && fIndexBufferRefs[ which ] != nil )
+    if (fIndexBufferRefs.size() > which && fIndexBufferRefs[which])
     {
         hsRefCnt_SafeUnRef(fIndexBufferRefs[which]);
-        fIndexBufferRefs[which] = nil;
+        fIndexBufferRefs[which] = nullptr;
     }
 
 }
@@ -802,10 +798,10 @@ bool    plGBufferGroup::ReserveVertStorage( uint32_t numVerts, uint32_t *vbIndex
         plProfile_NewMem(MemBufGrpVertex, numVerts * sizeof(plGBufferColor));
     }
 
-    if( fVertexBufferRefs.GetCount() > i && fVertexBufferRefs[ i ] != nil )
+    if (fVertexBufferRefs.size() > i && fVertexBufferRefs[i])
     {
         hsRefCnt_SafeUnRef(fVertexBufferRefs[i]);
-        fVertexBufferRefs[i] = nil;
+        fVertexBufferRefs[i] = nullptr;
     }
 
     /// Append a cell entry
@@ -1015,7 +1011,7 @@ void    plGBufferGroup::StuffToVertStorage( plGeometrySpan *srcSpan, uint32_t vb
         cPtr++;
     }
 
-    if( ( vbIndex < fVertexBufferRefs.GetCount() ) && fVertexBufferRefs[ vbIndex ] )
+    if( ( vbIndex < fVertexBufferRefs.size() ) && fVertexBufferRefs[ vbIndex ] )
         fVertexBufferRefs[ vbIndex ]->SetDirty( true );
 }
 
@@ -1071,10 +1067,10 @@ bool    plGBufferGroup::ReserveIndexStorage( uint32_t numIndices, uint32_t *ibIn
     plProfile_NewMem(MemBufGrpIndex, numIndices * sizeof(uint16_t));
 
     /// All done!
-    if( fIndexBufferRefs.GetCount() > i && fIndexBufferRefs[ i ] != nil )
+    if ( fIndexBufferRefs.size() > i && fIndexBufferRefs[i])
     {
         hsRefCnt_SafeUnRef(fIndexBufferRefs[i]);
-        fIndexBufferRefs[i] = nil;
+        fIndexBufferRefs[i] = nullptr;
     }
 
     return true;
@@ -1200,8 +1196,8 @@ void    plGBufferGroup::StuffFromTriList( uint32_t which, uint32_t start, uint32
 #endif // MF_SPEED_THIS_UP
 
     /// All done! Just make sure we refresh before we render...
-    if( fIndexBufferRefs.GetCount() > which && fIndexBufferRefs[ which ] != nil )
-        fIndexBufferRefs[ which ]->SetDirty( true );
+    if (fIndexBufferRefs.size() > which && fIndexBufferRefs[which])
+        fIndexBufferRefs[which]->SetDirty(true);
 
 }
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.cpp
@@ -110,21 +110,11 @@ void    plGBufferCell::Write( hsStream *s )
 
 //// Constructor //////////////////////////////////////////////////////////////
 
-plGBufferGroup::plGBufferGroup( uint8_t format, bool vertsVolatile, bool idxVolatile, int LOD ) 
+plGBufferGroup::plGBufferGroup(uint8_t format, bool vertsVolatile, bool idxVolatile, int LOD)
+    : fNumVerts(0), fNumIndices(0), fFormat(format), fVertsVolatile(vertsVolatile),
+      fIdxVolatile(idxVolatile), fLOD(LOD)
 {
-    fVertBuffStorage.clear();
-    fIdxBuffStorage.clear();
-    fColorBuffStorage.clear();
-    fVertexBufferRefs.clear();
-    fIndexBufferRefs.clear();
-    fCells.clear();
-    fNumVerts = fNumIndices = 0;
-
-    fFormat = format;
-    fStride = ICalcVertexSize( fLiteStride );
-    fVertsVolatile = vertsVolatile;
-    fIdxVolatile = idxVolatile;
-    fLOD = LOD;
+    fStride = ICalcVertexSize(fLiteStride);
 }
 
 //// Destructor ///////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
@@ -138,7 +138,7 @@ class plGBufferGroup
 
         std::vector<plGBufferColor*>  fColorBuffStorage;
 
-        std::vector<std::vector<plGBufferCell>*> fCells;
+        std::vector<std::vector<plGBufferCell>> fCells;
 
         virtual void    ISendStorageToBuffers( plPipeline *pipe, bool adjustForNvidiaLighting );
 
@@ -241,8 +241,8 @@ class plGBufferGroup
         hsGDeviceRef    *GetVertexBufferRef( uint32_t i );
         hsGDeviceRef    *GetIndexBufferRef( uint32_t i );
 
-        size_t          GetNumCells( size_t idx ) const { return fCells[ idx ]->size(); }
-        plGBufferCell   *GetCell( size_t idx, size_t cell ) { return &( (*fCells[ idx ])[ cell ] ); }
+        size_t          GetNumCells( size_t idx ) const { return fCells[ idx ].size(); }
+        plGBufferCell   *GetCell( size_t idx, size_t cell ) { return &(fCells[ idx ][ cell ]); }
 
         void    SetVertexBufferRef( uint32_t index, hsGDeviceRef *vb );
         void    SetIndexBufferRef( uint32_t index, hsGDeviceRef *ib );

--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
@@ -126,15 +126,15 @@ class plGBufferGroup
         hsTArray<hsGDeviceRef *>        fIndexBufferRefs;
 
         std::vector<uint32_t>  fVertBuffSizes;
-        hsTArray<uint32_t>     fIdxBuffCounts;
+        std::vector<uint32_t>  fIdxBuffCounts;
         std::vector<uint32_t>  fColorBuffCounts;
         std::vector<uint8_t *> fVertBuffStorage;
-        hsTArray<uint16_t *>   fIdxBuffStorage;
+        std::vector<uint16_t*> fIdxBuffStorage;
 
         std::vector<uint32_t> fVertBuffStarts;
         std::vector<int32_t>  fVertBuffEnds;
-        hsTArray<uint32_t>    fIdxBuffStarts;
-        hsTArray<int32_t>     fIdxBuffEnds;
+        std::vector<uint32_t> fIdxBuffStarts;
+        std::vector<int32_t>  fIdxBuffEnds;
 
         std::vector<plGBufferColor*>  fColorBuffStorage;
 
@@ -232,7 +232,7 @@ class plGBufferGroup
         ///////////////////////////////////////////////////////////////////////////////
 
         uint32_t  GetNumVertexBuffers( void ) const { return fVertBuffStorage.size(); }
-        uint32_t  GetNumIndexBuffers( void ) const { return fIdxBuffStorage.GetCount(); }
+        uint32_t  GetNumIndexBuffers( void ) const { return fIdxBuffStorage.size(); }
 
         uint8_t           *GetVertBufferData( uint32_t idx ) { return fVertBuffStorage[ idx ]; }
         uint16_t          *GetIndexBufferData( uint32_t idx ) { return fIdxBuffStorage[ idx ]; }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
@@ -125,18 +125,18 @@ class plGBufferGroup
         hsTArray<hsGDeviceRef *>        fVertexBufferRefs;
         hsTArray<hsGDeviceRef *>        fIndexBufferRefs;
 
-        hsTArray<uint32_t>    fVertBuffSizes;
-        hsTArray<uint32_t>    fIdxBuffCounts;
-        hsTArray<uint32_t>    fColorBuffCounts;
-        hsTArray<uint8_t *>   fVertBuffStorage;
-        hsTArray<uint16_t *>  fIdxBuffStorage;
+        hsTArray<uint32_t>     fVertBuffSizes;
+        hsTArray<uint32_t>     fIdxBuffCounts;
+        std::vector<uint32_t>  fColorBuffCounts;
+        hsTArray<uint8_t *>    fVertBuffStorage;
+        hsTArray<uint16_t *>   fIdxBuffStorage;
 
         hsTArray<uint32_t>    fVertBuffStarts;
         hsTArray<int32_t>     fVertBuffEnds;
         hsTArray<uint32_t>    fIdxBuffStarts;
         hsTArray<int32_t>     fIdxBuffEnds;
 
-        hsTArray<plGBufferColor *>  fColorBuffStorage;
+        std::vector<plGBufferColor*>  fColorBuffStorage;
 
         std::vector<std::vector<plGBufferCell>*> fCells;
 
@@ -236,7 +236,7 @@ class plGBufferGroup
 
         uint8_t           *GetVertBufferData( uint32_t idx ) { return fVertBuffStorage[ idx ]; }
         uint16_t          *GetIndexBufferData( uint32_t idx ) { return fIdxBuffStorage[ idx ]; }
-        plGBufferColor  *GetColorBufferData( uint32_t idx ) { return fColorBuffStorage[ idx ]; }
+        plGBufferColor  *GetColorBufferData( size_t idx ) { return fColorBuffStorage[ idx ]; }
 
         hsGDeviceRef    *GetVertexBufferRef( uint32_t i );
         hsGDeviceRef    *GetIndexBufferRef( uint32_t i );

--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
@@ -138,7 +138,7 @@ class plGBufferGroup
 
         hsTArray<plGBufferColor *>  fColorBuffStorage;
 
-        hsTArray<hsTArray<plGBufferCell> *> fCells;
+        std::vector<std::vector<plGBufferCell>*> fCells;
 
         virtual void    ISendStorageToBuffers( plPipeline *pipe, bool adjustForNvidiaLighting );
 
@@ -241,8 +241,8 @@ class plGBufferGroup
         hsGDeviceRef    *GetVertexBufferRef( uint32_t i );
         hsGDeviceRef    *GetIndexBufferRef( uint32_t i );
 
-        uint32_t          GetNumCells( uint32_t idx ) const { return fCells[ idx ]->GetCount(); }
-        plGBufferCell   *GetCell( uint32_t idx, uint32_t cell ) { return &( (*fCells[ idx ])[ cell ] ); }
+        size_t          GetNumCells( size_t idx ) const { return fCells[ idx ]->size(); }
+        plGBufferCell   *GetCell( size_t idx, size_t cell ) { return &( (*fCells[ idx ])[ cell ] ); }
 
         void    SetVertexBufferRef( uint32_t index, hsGDeviceRef *vb );
         void    SetIndexBufferRef( uint32_t index, hsGDeviceRef *ib );

--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
@@ -125,14 +125,14 @@ class plGBufferGroup
         hsTArray<hsGDeviceRef *>        fVertexBufferRefs;
         hsTArray<hsGDeviceRef *>        fIndexBufferRefs;
 
-        hsTArray<uint32_t>     fVertBuffSizes;
+        std::vector<uint32_t>  fVertBuffSizes;
         hsTArray<uint32_t>     fIdxBuffCounts;
         std::vector<uint32_t>  fColorBuffCounts;
-        hsTArray<uint8_t *>    fVertBuffStorage;
+        std::vector<uint8_t *> fVertBuffStorage;
         hsTArray<uint16_t *>   fIdxBuffStorage;
 
-        hsTArray<uint32_t>    fVertBuffStarts;
-        hsTArray<int32_t>     fVertBuffEnds;
+        std::vector<uint32_t> fVertBuffStarts;
+        std::vector<int32_t>  fVertBuffEnds;
         hsTArray<uint32_t>    fIdxBuffStarts;
         hsTArray<int32_t>     fIdxBuffEnds;
 
@@ -231,7 +231,7 @@ class plGBufferGroup
         void    SetIndexBufferEnd(uint32_t idx, uint32_t e) { fIdxBuffEnds[idx] = e; }
         ///////////////////////////////////////////////////////////////////////////////
 
-        uint32_t  GetNumVertexBuffers( void ) const { return fVertBuffStorage.GetCount(); }
+        uint32_t  GetNumVertexBuffers( void ) const { return fVertBuffStorage.size(); }
         uint32_t  GetNumIndexBuffers( void ) const { return fIdxBuffStorage.GetCount(); }
 
         uint8_t           *GetVertBufferData( uint32_t idx ) { return fVertBuffStorage[ idx ]; }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plGBufferGroup.h
@@ -121,9 +121,9 @@ class plGBufferGroup
         bool    fVertsVolatile;
         bool    fIdxVolatile;
         int     fLOD;
-        
-        hsTArray<hsGDeviceRef *>        fVertexBufferRefs;
-        hsTArray<hsGDeviceRef *>        fIndexBufferRefs;
+
+        std::vector<hsGDeviceRef*> fVertexBufferRefs;
+        std::vector<hsGDeviceRef*> fIndexBufferRefs;
 
         std::vector<uint32_t>  fVertBuffSizes;
         std::vector<uint32_t>  fIdxBuffCounts;
@@ -188,10 +188,10 @@ class plGBufferGroup
         static uint8_t    CalcNumUVs( uint8_t format ) { return ( format & kUVCountMask ); }
         static uint8_t    UVCountToFormat( uint8_t numUVs ) { return numUVs & kUVCountMask; }
 
-        void    DirtyVertexBuffer(int i);
-        void    DirtyIndexBuffer(int i);
-        bool    VertexReady(int i) const { return (i < fVertexBufferRefs.GetCount()) && fVertexBufferRefs[i]; }
-        bool    IndexReady(int i) const { return  (i < fIndexBufferRefs.GetCount()) && fIndexBufferRefs[i]; }
+        void    DirtyVertexBuffer(size_t i);
+        void    DirtyIndexBuffer(size_t i);
+        bool    VertexReady(size_t i) const { return (i < fVertexBufferRefs.size()) && fVertexBufferRefs[i]; }
+        bool    IndexReady(size_t i) const { return  (i < fIndexBufferRefs.size()) && fIndexBufferRefs[i]; }
         uint8_t   GetVertexSize( void ) const { return fStride; }
         uint8_t   GetVertexLiteStride( void ) const { return fLiteStride; }
         uint8_t   GetVertexFormat( void ) const { return fFormat; }


### PR DESCRIPTION
Does what it says. `std::vector` is just better than `hsTArray`.