### PR TITLE
Fix static initialization order dependency in MSVC2015

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcChannel.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcChannel.cpp
@@ -204,8 +204,8 @@ static unsigned MaxMsgId (const T msgs[], unsigned count) {
     unsigned maxMsgId = 0;
 
     for (unsigned i = 0; i < count; i++) {
-        ASSERT(msgs[i].msg.count);
-        maxMsgId = std::max(msgs[i].msg.messageId, maxMsgId);
+        ASSERT(msgs[i].msg->count);
+        maxMsgId = std::max(msgs[i].msg->messageId, maxMsgId);
     }
     return maxMsgId;
 }
@@ -219,13 +219,13 @@ static void AddSendMsgs_CS (
     channel->m_sendMsgs.GrowToFit(MaxMsgId(src, count), true);
 
     for (const NetMsgInitSend * term = src + count; src < term; ++src) {
-        NetMsgInitSend * const dst = &channel->m_sendMsgs[src[0].msg.messageId];
+        NetMsgInitSend * const dst = &channel->m_sendMsgs[src[0].msg->messageId];
 
         // check to ensure that the message id isn't already used
-        ASSERT(!dst->msg.count);
+        ASSERT(!dst->msg);
 
         *dst = *src;
-        ValidateMsg(dst->msg);
+        ValidateMsg(*dst->msg);
     }
 }
 
@@ -239,15 +239,15 @@ static void AddRecvMsgs_CS (
 
     for (const NetMsgInitRecv * term = src + count; src < term; ++src) {
         ASSERT(src->recv);
-        NetMsgInitRecv * const dst = &channel->m_recvMsgs[src[0].msg.messageId];
+        NetMsgInitRecv * const dst = &channel->m_recvMsgs[src[0].msg->messageId];
 
         // check to ensure that the message id isn't already used
-        ASSERT(!dst->msg.count);
+        ASSERT(!dst->msg);
 
         // copy the message handler
         *dst = *src;
 
-        const uint32_t bytes = ValidateMsg(dst->msg);
+        const uint32_t bytes = ValidateMsg(*dst->msg);
         channel->m_largestRecv = std::max(channel->m_largestRecv, bytes);
     }
 }
@@ -332,7 +332,7 @@ const NetMsgInitRecv * NetMsgChannelFindRecvMessage (
 
     // Is message defined?
     const NetMsgInitRecv * recvMsg = &channel->m_recvMsgs[messageId];
-    if (!recvMsg->msg.count)
+    if (!recvMsg->msg->count)
         return nil;
 
     // Success!
@@ -349,7 +349,7 @@ const NetMsgInitSend * NetMsgChannelFindSendMessage (
 
     // Is message defined?
     const NetMsgInitSend * sendMsg = &channel->m_sendMsgs[messageId];
-    ASSERTMSG(sendMsg->msg.count, "NetMsg not found for send");
+    ASSERTMSG(sendMsg->msg->count, "NetMsg not found for send");
 
     return sendMsg;
 }

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -283,8 +283,8 @@ static void BufferedSendData (
     uintptr_t const * const msgEnd = msg + fieldCount;
 
     const NetMsgInitSend * sendMsg = NetMsgChannelFindSendMessage(cli->channel, msg[0]);
-    ASSERT(msg[0] == sendMsg->msg.messageId);
-    ASSERT(fieldCount-1 == sendMsg->msg.count);
+    ASSERT(msg[0] == sendMsg->msg->messageId);
+    ASSERT(fieldCount-1 == sendMsg->msg->count);
 
     // insert messageId into command stream
     const uint16_t msgId = hsToLE16((uint16_t)msg[0]);
@@ -295,8 +295,8 @@ static void BufferedSendData (
     // insert fields into command stream
     uint32_t varCount  = 0;
     uint32_t varSize   = 0;
-    const NetMsgField * cmd     = sendMsg->msg.fields;
-    const NetMsgField * cmdEnd  = cmd + sendMsg->msg.count;
+    const NetMsgField * cmd     = sendMsg->msg->fields;
+    const NetMsgField * cmdEnd  = cmd + sendMsg->msg->count;
     for (; cmd < cmdEnd; ++msg, ++cmd) {
         switch (cmd->type) {
             case kNetMsgFieldInteger: {
@@ -429,7 +429,7 @@ static bool DispatchData (NetCli * cli, void * param) {
             // prepare to start decompressing new fields
             ASSERT(!cli->recvField);
             ASSERT(!cli->recvFieldBytes);
-            cli->recvField = cli->recvMsg->msg.fields;
+            cli->recvField = cli->recvMsg->msg->fields;
             cli->recvBuffer.ZeroCount();
             cli->recvBuffer.Reserve(kAsyncSocketBufferSize);
 
@@ -439,7 +439,7 @@ static bool DispatchData (NetCli * cli, void * param) {
         }
 
         for (
-            const NetMsgField * end = cli->recvMsg->msg.fields + cli->recvMsg->msg.count;
+            const NetMsgField * end = cli->recvMsg->msg->fields + cli->recvMsg->msg->count;
             cli->recvField < end;
             ++cli->recvField
         ) {
@@ -574,7 +574,7 @@ static bool DispatchData (NetCli * cli, void * param) {
         }
 
         // dispatch message to handler function
-        NCCLI_LOG(kLogPerf, L"pnNetCli: Dispatching. msg: %S. cli: %p", cli->recvMsg ? cli->recvMsg->msg.name : "(unknown)", cli);
+        NCCLI_LOG(kLogPerf, L"pnNetCli: Dispatching. msg: %S. cli: %p", cli->recvMsg ? cli->recvMsg->msg->name : "(unknown)", cli);
         if (!cli->recvMsg->recv(cli->recvBuffer.Ptr(), cli->recvBuffer.Count(), param))
             goto ERR_DISPATCH_FAILED;
         
@@ -592,19 +592,19 @@ static bool DispatchData (NetCli * cli, void * param) {
 
 // these are used for convenience in setting breakpoints
 NEED_MORE_DATA:
-    NCCLI_LOG(kLogPerf, L"pnNetCli: NEED_MORE_DATA. msg: %S (%u). cli: %p", cli->recvMsg ? cli->recvMsg->msg.name : "(unknown)", msgId, cli);
+    NCCLI_LOG(kLogPerf, L"pnNetCli: NEED_MORE_DATA. msg: %S (%u). cli: %p", cli->recvMsg ? cli->recvMsg->msg->name : "(unknown)", msgId, cli);
     return true;
 
 ERR_BAD_COUNT:
-    LogMsg(kLogError, L"pnNetCli: ERR_BAD_COUNT. msg: %S (%u). cli: %p", cli->recvMsg ? cli->recvMsg->msg.name : "(unknown)", msgId, cli);
+    LogMsg(kLogError, L"pnNetCli: ERR_BAD_COUNT. msg: %S (%u). cli: %p", cli->recvMsg ? cli->recvMsg->msg->name : "(unknown)", msgId, cli);
     return false;
 
 ERR_NO_HANDLER:
-    LogMsg(kLogError, L"pnNetCli: ERR_NO_HANDLER. msg: %S (%u). cli: %p", cli->recvMsg ? cli->recvMsg->msg.name : "(unknown)", msgId, cli);
+    LogMsg(kLogError, L"pnNetCli: ERR_NO_HANDLER. msg: %S (%u). cli: %p", cli->recvMsg ? cli->recvMsg->msg->name : "(unknown)", msgId, cli);
     return false;
 
 ERR_DISPATCH_FAILED:
-    LogMsg(kLogError, L"pnNetCli: ERR_DISPATCH_FAILED. msg: %S (%u). cli: %p", cli->recvMsg ? cli->recvMsg->msg.name : "(unknown)", msgId, cli);
+    LogMsg(kLogError, L"pnNetCli: ERR_DISPATCH_FAILED. msg: %S (%u). cli: %p", cli->recvMsg ? cli->recvMsg->msg->name : "(unknown)", msgId, cli);
     return false;
 }
 

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
@@ -311,10 +311,10 @@ struct NetCliQueue;
 ***/
 
 struct NetMsgInitSend {
-    NetMsg  msg;
+    const NetMsg  *msg;
 };
 struct NetMsgInitRecv {
-    NetMsg  msg;
+    const NetMsg  *msg;
     bool (* recv)(const uint8_t msg[], unsigned bytes, void * param);
 };
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -2345,7 +2345,7 @@ static bool Recv_ScoreGetRanksReply (
 *
 ***/
 
-#define MSG(s)  kNetMsg_Cli2Auth_##s
+#define MSG(s)  &kNetMsg_Cli2Auth_##s
 static NetMsgInitSend s_send[] = {
     { MSG(PingRequest)              },
     { MSG(ClientRegisterRequest)    },
@@ -2396,7 +2396,7 @@ static NetMsgInitSend s_send[] = {
 };
 #undef MSG
 
-#define MSG(s)  kNetMsg_Auth2Cli_##s, Recv_##s
+#define MSG(s)  &kNetMsg_Auth2Cli_##s, Recv_##s
 static NetMsgInitRecv s_recv[] = {
     { MSG(PingReply)                },
     { MSG(ClientRegisterReply)      },

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
@@ -550,7 +550,7 @@ static bool Recv_GameMgrMsg (
 //============================================================================
 // Send/Recv protocol handler init
 //============================================================================
-#define MSG(s)  kNetMsg_Cli2Game_##s
+#define MSG(s)  &kNetMsg_Cli2Game_##s
 static NetMsgInitSend s_send[] = {
     { MSG(PingRequest),         },
     { MSG(JoinAgeRequest),      },
@@ -559,7 +559,7 @@ static NetMsgInitSend s_send[] = {
 };
 #undef MSG
 
-#define MSG(s)  kNetMsg_Game2Cli_##s, Recv_##s
+#define MSG(s)  &kNetMsg_Game2Cli_##s, Recv_##s
 static NetMsgInitRecv s_recv[] = {
     { MSG(PingReply)            },
     { MSG(JoinAgeReply),        },

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -732,7 +732,7 @@ static bool Recv_AuthSrvIpAddressReply (
 *
 ***/
 
-#define MSG(s)  kNetMsg_Cli2GateKeeper_##s
+#define MSG(s)  &kNetMsg_Cli2GateKeeper_##s
 static NetMsgInitSend s_send[] = {
     { MSG(PingRequest)              },
     { MSG(FileSrvIpAddressRequest)  },
@@ -740,7 +740,7 @@ static NetMsgInitSend s_send[] = {
 };
 #undef MSG
 
-#define MSG(s)  kNetMsg_GateKeeper2Cli_##s, Recv_##s
+#define MSG(s)  &kNetMsg_GateKeeper2Cli_##s, Recv_##s
 static NetMsgInitRecv s_recv[] = {
     { MSG(PingReply)                },
     { MSG(FileSrvIpAddressReply)    },


### PR DESCRIPTION
This changes the message object to a pointer within the initialization structs.  Since initialization order is not guaranteed, the messages were getting copied to the init struct before it was fully initialized, even though it got initialized later.  This ensures that the data is always up-to-date by the time it is used, by pointing to the original struct instead of copying it.