### PR TITLE
Convert NetCommPlayer to std::vector

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.cpp
@@ -61,22 +61,21 @@ bool cyAccountManagement::IsSubscriptionActive()
 
 PyObject* cyAccountManagement::GetPlayerList()
 {
-    const ARRAY(NetCommPlayer)& playerList = NetCommGetPlayerList();
-    int numPlayers = NetCommGetPlayerCount();
+    const std::vector<NetCommPlayer>& playerList = NetCommGetPlayerList();
     PyObject* pList = PyList_New(0);
 
     PyObject* visitor = nil;
 
-    for (int i = 0; i < numPlayers; ++i)
+    for (Py_ssize_t i = 0; i < playerList.size(); ++i)
     {
         PyObject* playerTuple   = PyTuple_New(3);
         PyObject* playerName    = PyUnicode_FromStringEx(playerList[i].playerName);
         PyObject* playerId      = PyInt_FromLong(playerList[i].playerInt);
         PyObject* avatarShape   = PyString_FromPlString(playerList[i].avatarDatasetName);
 
-        PyTuple_SetItem(playerTuple, 0, playerName);
-        PyTuple_SetItem(playerTuple, 1, playerId);
-        PyTuple_SetItem(playerTuple, 2, avatarShape);
+        PyTuple_SET_ITEM(playerTuple, 0, playerName);
+        PyTuple_SET_ITEM(playerTuple, 1, playerId);
+        PyTuple_SET_ITEM(playerTuple, 2, avatarShape);
 
         if (visitor || playerList[i].explorer)
             PyList_Append(pList, playerTuple);

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.h
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.h
@@ -76,6 +76,11 @@ struct NetCommPlayer {
     plString    playerName;
     plString    avatarDatasetName;
     unsigned    explorer;
+
+    NetCommPlayer() { }
+    NetCommPlayer(unsigned id, const plString& name, const plString& shape, unsigned ex)
+        : playerInt(id), playerName(name), avatarDatasetName(shape), explorer(ex)
+    { }
 };
 
 struct NetCommAccount {
@@ -102,7 +107,7 @@ const NetCommAge *                  NetCommGetAge ();
 const NetCommAge *                  NetCommGetStartupAge ();
 const NetCommAccount *              NetCommGetAccount ();
 const NetCommPlayer *               NetCommGetPlayer ();
-const ARRAY(NetCommPlayer) &        NetCommGetPlayerList ();
+const std::vector<NetCommPlayer> &  NetCommGetPlayerList ();
 unsigned                            NetCommGetPlayerCount ();
 bool                                NetCommIsLoginComplete ();
 void                                NetCommSetIniPlayerId(unsigned playerId);


### PR DESCRIPTION
This fixes a crash observed when creating a new avatar. `ARRAY` and friends do not run constructors when the `New` method is used. `ARRAY` is evil anyway, so here's my fix.