### PR TITLE
Remove some checks from AvatarPhysical updates

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarSDLModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarSDLModifier.cpp
@@ -116,12 +116,8 @@ void plAvatarPhysicalSDLModifier::ISetCurrentStateFrom(const plStateDataRecord* 
     {
         const plArmatureMod* kAvMod = (plArmatureMod*)sObj->GetModifierByType(plArmatureMod::Index());
         plArmatureMod * avMod = const_cast<plArmatureMod *>(kAvMod);
-        if(avMod && !avMod->GetCurrentBrain()->IsRunningTask())
+        if(avMod)
         {
-            plAvBrainGeneric* genBrain = plAvBrainGeneric::ConvertNoRef(avMod->GetCurrentBrain());
-            if (genBrain && (genBrain->GetType() == plAvBrainGeneric::kLadder || genBrain->GetType() == plAvBrainGeneric::kSit || genBrain->GetType() == plAvBrainGeneric::kSitOnGround))
-                return;
-
             plSimpleStateVariable* worldVar = srcState->FindVar(kStrSubworld);
             if (worldVar->IsDirty() && avMod->fController)
             {


### PR DESCRIPTION
These checks introduced a hidden race condition. If the initial avatar physical update comes in after the initial avatar update (always happens on DirtSand, never happens on MOUL), then the physical update could be rejected if the avatar is sitting on the ground or on a sitting modifier (this adds stages, which count as a task). This results in seeing an avatar sitting at the link in point. Whoops!

I can think of no cases where these checks are actually useful. It's also difficult to determine if we are linking in due to the fact that we're in the grey area between loading the entire age and fading the screen. All flags indicate we're in the age. This is just the best way to fix it(TM)