### PR TITLE
Implement Leaderboards

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameScoreMgr/pfGameScoreMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameScoreMgr/pfGameScoreMgr.cpp
@@ -149,7 +149,7 @@ static void OnScoreCreate(
     delete p;
 }
 
-void pfGameScore::Create(uint32_t ownerId, const plString& name, uint32_t type, int32_t value, plKey rcvr)
+void pfGameScore::Create(uint32_t ownerId, const plString& name, uint32_t type, int32_t value, const plKey& rcvr)
 {
     NetCliAuthScoreCreate(ownerId, name, type, value, OnScoreCreate, new ScoreUpdateParam(nil, rcvr));
 }
@@ -174,7 +174,12 @@ static void OnScoreFound(
     delete p;
 }
 
-void pfGameScore::Find(uint32_t ownerId, const plString& name, plKey rcvr)
+void pfGameScore::Find(uint32_t ownerId, const plString& name, const plKey& rcvr)
 {
-    NetCliAuthScoreGetScores(ownerId, name.c_str(), OnScoreFound, new ScoreFindParam(ownerId, name, rcvr));
+    NetCliAuthScoreGetScores(ownerId, name, OnScoreFound, new ScoreFindParam(ownerId, name, rcvr));
+}
+
+void pfGameScore::FindHighScores(uint32_t ageId, uint32_t maxScores, const plString& name, const plKey& rcvr)
+{
+    NetCliAuthScoreGetHighScores(ageId, maxScores, name, OnScoreFound, new ScoreFindParam(ageId, name, rcvr));
 }

--- a/Sources/Plasma/FeatureLib/pfGameScoreMgr/pfGameScoreMgr.h
+++ b/Sources/Plasma/FeatureLib/pfGameScoreMgr/pfGameScoreMgr.h
@@ -84,8 +84,9 @@ public:
     void TransferPoints(pfGameScore* to, plKey rcvr = nil) { TransferPoints(to, fValue, rcvr); }
     void TransferPoints(pfGameScore* to, int32_t points, plKey rcvr = nil);
 
-    static void Create(uint32_t ownerId, const plString& name, uint32_t type, int32_t value, plKey rcvr);
-    static void Find(uint32_t ownerId, const plString& name, plKey rcvr);
+    static void Create(uint32_t ownerId, const plString& name, uint32_t type, int32_t value, const plKey& rcvr);
+    static void Find(uint32_t ownerId, const plString& name, const plKey& rcvr);
+    static void FindHighScores(uint32_t ageId, uint32_t maxScores, const plString& name, const plKey& rcvr);
 };
 
 #endif // _pfGameScoreMgr_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameScore.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameScore.cpp
@@ -183,3 +183,17 @@ void pyGameScore::FindScores(uint32_t ownerId, const plString& name, pyKey& rcvr
 {
     pfGameScore::Find(ownerId, name, rcvr.getKey());
 }
+
+void pyGameScore::FindAgeHighScores(const plString& name, uint32_t maxScores, pyKey& rcvr)
+{
+    if (hsRef<RelVaultNode> ageInfo = VaultGetAgeInfoNode()) {
+        pfGameScore::FindHighScores(ageInfo->GetNodeId(), maxScores, name, rcvr.getKey());
+    }
+    else
+        hsAssert(false, "Age has no vault... Need to rewrite score python script?");
+}
+
+void pyGameScore::FindGlobalHighScores(const plString& name, uint32_t maxScores, pyKey& rcvr)
+{
+    pfGameScore::FindHighScores(0, maxScores, name, rcvr.getKey());
+}

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameScore.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameScore.h
@@ -93,6 +93,9 @@ public:
     static void     FindGlobalScores(const plString& name, pyKey& rcvr);
     static void     FindPlayerScores(const plString& name, pyKey& rcvr);
     static void     FindScores(uint32_t ownerId, const plString& name, pyKey& rcvr);
+
+    static void     FindAgeHighScores(const plString& name, uint32_t maxScores, pyKey& rcvr);
+    static void     FindGlobalHighScores(const plString& name, uint32_t maxScores, pyKey& rcvr);
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameScoreGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameScoreGlue.cpp
@@ -331,6 +331,40 @@ PYTHON_METHOD_DEFINITION_STATIC(ptGameScore, findScores, args)
     PYTHON_RETURN_NONE; // get result in callback
 }
 
+PYTHON_METHOD_DEFINITION_STATIC(ptGameScore, findAgeHighScores, args)
+{
+    PyObject* nameObj;
+    uint32_t maxScores;
+    PyObject* keyObj;
+    if (!PyArg_ParseTuple(args, "OIO", &nameObj, &maxScores, &keyObj) ||
+        !PyString_CheckEx(nameObj) || !pyKey::Check(keyObj)) {
+        PyErr_SetString(PyExc_TypeError, "findAgeHighScores expects a string, an int, and a ptKey");
+        PYTHON_RETURN_ERROR;
+    }
+
+    plString name = PyString_AsStringEx(nameObj);
+    pyKey*   rcvr = pyKey::ConvertFrom(keyObj);
+    pyGameScore::FindAgeHighScores(name, maxScores, *rcvr);
+    PYTHON_RETURN_NONE; // get result in callback
+}
+
+PYTHON_METHOD_DEFINITION_STATIC(ptGameScore, findGlobalHighScores, args)
+{
+    PyObject* nameObj;
+    uint32_t maxScores;
+    PyObject* keyObj;
+    if (!PyArg_ParseTuple(args, "OIO", &nameObj, &maxScores, &keyObj) ||
+        !PyString_CheckEx(nameObj) || !pyKey::Check(keyObj)) {
+        PyErr_SetString(PyExc_TypeError, "findGlobalHighScores expects a string, an int, and a ptKey");
+        PYTHON_RETURN_ERROR;
+    }
+
+    plString name = PyString_AsStringEx(nameObj);
+    pyKey*   rcvr = pyKey::ConvertFrom(keyObj);
+    pyGameScore::FindGlobalHighScores(name, maxScores, *rcvr);
+    PYTHON_RETURN_NONE; // get result in callback
+}
+
 PYTHON_START_METHODS_TABLE(ptGameScore)
     PYTHON_METHOD_NOARGS(ptGameScore, getGameType, "Returns the score game type."),
     PYTHON_METHOD_NOARGS(ptGameScore, getName, "Returns the score game name."),
@@ -348,6 +382,8 @@ PYTHON_START_METHODS_TABLE(ptGameScore)
     PYTHON_METHOD_STATIC(ptGameScore, findGlobalScores, "Params: scoreName, key\nFinds matching global scores"),
     PYTHON_METHOD_STATIC(ptGameScore, findPlayerScores, "Params: scoreName, key\nFinds matching player scores"),
     PYTHON_METHOD_STATIC(ptGameScore, findScores, "Params: ownerID, scoreName, key\nFinds matching scores for an arbitrary owner"),
+    PYTHON_METHOD_STATIC(ptGameScore, findAgeHighScores, "Params: name, maxScores, key\nFinds the highest matching scores for the current age's owners"),
+    PYTHON_METHOD_STATIC(ptGameScore, findGlobalHighScores, "Params: name, maxScores, key\nFinds the highest matching scores"),
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
@@ -335,6 +335,13 @@ static const NetMsgField kScoreGetRanksFields[] = {
     NET_MSG_FIELD_DWORD(),                          // sortDesc
 };
 
+static const NetMsgField kScoreGetHighScoresFields[] = {
+    kNetMsgFieldTransId,                            // transId
+    NET_MSG_FIELD_DWORD(),                          // ageId
+    NET_MSG_FIELD_DWORD(),                          // maxScores
+    NET_MSG_FIELD_STRING(kMaxGameScoreNameLength),  // gameName
+};
+
 
 /*****************************************************************************
 *
@@ -617,6 +624,14 @@ static const NetMsgField kScoreGetRanksReplyFields[] = {
     NET_MSG_FIELD_VAR_PTR(),                                // nodeBuffer
 };
 
+static const NetMsgField kScoreGetHighScoresReplyFields[] = {
+    kNetMsgFieldTransId,                                    // transId
+    kNetMsgFieldENetError,                                  // result
+    NET_MSG_FIELD_DWORD(),                                  // scoreCount
+    NET_MSG_FIELD_VAR_COUNT(1, 1024 * 1024),                // scoreBytes
+    NET_MSG_FIELD_VAR_PTR(),                                // scoreBuffer
+};
+
 } using namespace Cli2Auth;
 
 
@@ -673,6 +688,7 @@ const NetMsg kNetMsg_Cli2Auth_ScoreAddPoints            = NET_MSG(kCli2Auth_Scor
 const NetMsg kNetMsg_Cli2Auth_ScoreTransferPoints       = NET_MSG(kCli2Auth_ScoreTransferPoints,        kScoreTransferPointsFields);
 const NetMsg kNetMsg_Cli2Auth_ScoreSetPoints            = NET_MSG(kCli2Auth_ScoreSetPoints,             kScoreSetPointsFields);
 const NetMsg kNetMsg_Cli2Auth_ScoreGetRanks             = NET_MSG(kCli2Auth_ScoreGetRanks,              kScoreGetRanksFields);
+const NetMsg kNetMsg_Cli2Auth_ScoreGetHighScores        = NET_MSG(kCli2Auth_ScoreGetHighScores,         kScoreGetHighScoresFields);
 
 const NetMsg kNetMsg_Auth2Cli_PingReply                 = NET_MSG(kAuth2Cli_PingReply,                  kPingReplyFields);
 const NetMsg kNetMsg_Auth2Cli_ClientRegisterReply       = NET_MSG(kAuth2Cli_ClientRegisterReply,        kClientRegisterReplyFields);
@@ -719,3 +735,4 @@ const NetMsg kNetMsg_Auth2Cli_ScoreAddPointsReply       = NET_MSG(kAuth2Cli_Scor
 const NetMsg kNetMsg_Auth2Cli_ScoreTransferPointsReply  = NET_MSG(kAuth2Cli_ScoreTransferPointsReply,   kScoreTransferPointsReplyFields);
 const NetMsg kNetMsg_Auth2Cli_ScoreSetPointsReply       = NET_MSG(kAuth2Cli_ScoreSetPointsReply,        kScoreSetPointsReplyFields);
 const NetMsg kNetMsg_Auth2Cli_ScoreGetRanksReply        = NET_MSG(kAuth2Cli_ScoreGetRanksReply,         kScoreGetRanksReplyFields);
+const NetMsg kNetMsg_Auth2Cli_ScoreGetHighScoresReply   = NET_MSG(kAuth2Cli_ScoreGetHighScoresReply,    kScoreGetHighScoresReplyFields);

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.h
@@ -119,7 +119,7 @@ enum {
     kCli2Auth_LogPythonTraceback,
     kCli2Auth_LogStackDump,
     kCli2Auth_LogClientDebuggerConnect,
-    
+
     // Score
     kCli2Auth_ScoreCreate,
     kCli2Auth_ScoreDelete,
@@ -130,6 +130,10 @@ enum {
     kCli2Auth_ScoreGetRanks,
 
     kCli2Auth_AccountExistsRequest,
+
+    // Extension messages
+    kCli2Auth_AgeRequestEx = 0x1000,
+    kCli2Auth_ScoreGetHighScores,
 
     kNumCli2AuthMessages
 };
@@ -209,6 +213,10 @@ enum {
     kAuth2Cli_ScoreGetRanksReply,
 
     kAuth2Cli_AccountExistsReply,
+
+    // Extension messages
+    kAuth2Cli_AgeReplyEx = 0x1000,
+    kAuth2Cli_ScoreGetHighScoresReply,
 
     kNumAuth2CliMessages
 };
@@ -641,6 +649,15 @@ struct Cli2Auth_ScoreGetRanks {
     uint32_t sortDesc;
 };
 
+extern const NetMsg kNetMsg_Cli2Auth_ScoreGetHighScores;
+struct Cli2Auth_ScoreGetHighScores {
+    uint32_t messageId;
+    uint32_t transId;
+    uint32_t ageId;
+    uint32_t maxScores;
+    wchar_t gameName[kMaxGameScoreNameLength];
+};
+
 
 /*****************************************************************************
 *
@@ -1038,6 +1055,18 @@ struct Auth2Cli_ScoreGetRanksReply {
     uint32_t           transId;
     ENetError       result;
     uint32_t           rankCount;
+    uint32_t           byteCount;
+    uint8_t            buffer[1];  // [byteCount], actually
+    // no more fields
+};
+
+// ScoreGetHighScoresReply
+extern const NetMsg kNetMsg_Auth2Cli_ScoreGetHighScoresReply;
+struct Auth2Cli_ScoreGetHighScoresReply {
+    uint32_t           messageId;
+    uint32_t           transId;
+    ENetError          result;
+    uint32_t           scoreCount;
     uint32_t           byteCount;
     uint8_t            buffer[1];  // [byteCount], actually
     // no more fields

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Intern.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Intern.h
@@ -181,20 +181,21 @@ enum ETransType {
     kScoreSetPointsTrans,
     kScoreGetRanksTrans,
     kSendFriendInviteTrans,
-    
+    kScoreGetHighScoresTrans,
+
     //========================================================================
     // NglGame.cpp transactions
     kJoinAgeRequestTrans,
     kGmRcvdPropagatedBufferTrans,
     kGmRcvdGameMgrMsgTrans,
-    
+
     //========================================================================
     // NglFile.cpp transactions
     kBuildIdRequestTrans,
     kManifestRequestTrans,
     kDownloadRequestTrans,
     kFileRcvdFileDownloadChunkTrans,
-    
+
     //========================================================================
     // NglCore.cpp transactions
     kReportNetErrorTrans,
@@ -251,6 +252,7 @@ static const char * s_transTypes[] = {
     "ScoreSetPointsTrans",
     "ScoreGetRanksTrans",
     "SendFriendInviteTrans",
+    "ScoreGetHighScoresTrans",
     
     // NglGame.cpp
     "JoinAgeRequestTrans",

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
@@ -715,3 +715,12 @@ void NetCliAuthScoreGetRankList(
     FNetCliAuthGetRanksCallback callback,
     void *                      param
 );
+
+//============================================================================
+void NetCliAuthScoreGetHighScores(
+    unsigned                        ageId,
+    unsigned                        maxScores,
+    const plString&                 gameName,
+    FNetCliAuthGetScoresCallback    callback,
+    void *                          param
+);


### PR DESCRIPTION
Implements a new message and python bindings for retrieving score leaders from the server. See H-uru/dirtsand#103 for a sample implementation. H-uru/moul-scripts#94 should be merged concurrently.

Required for non-eap Ayoheek.