### PR TITLE
Fix Jittering Animations

### DIFF
--- a/Sources/Plasma/PubUtilLib/plInterp/hsInterp.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/hsInterp.cpp
@@ -404,7 +404,7 @@ void hsInterp::GetBoundaryKeyFrames(float time, uint32_t numKeys, void *keys, ui
 {
     hsAssert(numKeys>1, "Must have more than 1 keyframe");
     int k1, k2;
-    uint16_t frame = (uint16_t)(time * MAX_FRAMES_PER_SEC);
+    float frame = time * MAX_FRAMES_PER_SEC;
 
     // boundary case, past end
     if (frame > GetKey(numKeys-1, keys, size)->fFrame)


### PR DESCRIPTION
Casting the floating point time to an integer causes issues with boundary frame comparisons. So, actually use floats. This makes animations smoother than a baby's arse once again :smile: