### PR TITLE
NaN animation time == kaboom

### DIFF
--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
@@ -508,8 +508,13 @@ float plAnimTimeConvert::WorldToAnimTime(double wSecs)
             {
                 if (secs > fLoopEnd)
                 {
-                    secs = fmodf(secs - fLoopBegin, fLoopEnd - fLoopBegin) + fLoopBegin;
-                    wrapped = true;
+                    float result = fmodf(secs - fLoopBegin, fLoopEnd - fLoopBegin) + fLoopBegin;
+                    // are they a dumb ass?
+                    if (!isnan(result))
+                    {
+                        secs = result;
+                        wrapped = true;
+                    }
                 }
             }   
         }
@@ -527,11 +532,16 @@ float plAnimTimeConvert::WorldToAnimTime(double wSecs)
             {
                 if (secs < fLoopBegin)
                 {
-                    secs = fLoopEnd - fmodf(fLoopEnd - secs, fLoopEnd - fLoopBegin);
-                    wrapped = true;
+                    float result  = fLoopEnd - fmodf(fLoopEnd - secs, fLoopEnd - fLoopBegin);
+                    // are they a dumb ass?
+                    if (!isnan(result))
+                    {
+                        secs = result;
+                        wrapped = true;
+                    }
                 }
-            }               
-        }       
+            }
+        }
 
         if (fFlags & kWrap)
         {


### PR DESCRIPTION
Some dumb ass artist has a LayerAnimation set to `kLoop` with `fLoopBegin` == 0 and `fLoopEnd` == 0. This worked in MOUL, but now we use that in our keyframe calculations now. Whoops. Most of the data should be fine since Plasma checked frame times until MOUL. This is just an edge case in Ahnoying, really.