### PR TITLE
Fix sound debug

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -3426,6 +3426,30 @@ PF_CONSOLE_CMD( Audio, NextDebugPlate, "", "Cycles through the volume displays f
     plgAudioSys::NextDebugSound();
 }
 
+PF_CONSOLE_CMD(Audio, ShowDebugPlate, "string object, int soundIdx", "Shows the volume display for a registered sound")
+{
+    plKey key = FindSceneObjectByName(plString::FromUtf8(params[0]), "", nullptr);
+    if (!key) {
+        plSound::SetCurrDebugPlate(nullptr);
+        return;
+    }
+
+    plSceneObject* so = plSceneObject::ConvertNoRef(key->GetObjectPtr());
+    if (!so) {
+        PrintString("Invalid SceneObject");
+        return;
+    }
+
+    const plAudioInterface* ai = so->GetAudioInterface();
+    if (ai) {
+        plSound* sound = ai->GetSound(params[1]);
+        // sue me
+        plSound::SetCurrDebugPlate(sound->GetKey());
+    } else {
+        PrintString("SceneObject has no AudioInterface");
+    }
+}
+
 #endif // LIMIT_CONSOLE_COMMANDS
 
 PF_CONSOLE_CMD( Audio, SetLoadOnDemand, "bool on", "Enable or disable load-on-demand for sounds")

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
@@ -163,10 +163,10 @@ void plSound::IUpdateDebugPlate( void )
             fDebugPlate->SetPosition( -0.5, 0 );
             fDebugPlate->SetDataRange( 0, 100, 100 );
             fDebugPlate->SetColors( 0x80202000 );
-            fDebugPlate->SetTitle( GetKeyName().c_str() );      // Bleah
             fDebugPlate->SetLabelText( "Desired", "Curr", "Soft", "Dist" );
         }
 
+        fDebugPlate->SetTitle(GetKeyName().c_str());      // Bleah
         fDebugPlate->SetVisible( true );
         fDebugPlate->AddData( (int32_t)( fDesiredVol * 100.f ), 
                               (int32_t)( fCurrVolume * 100.f ),
@@ -175,7 +175,7 @@ void plSound::IUpdateDebugPlate( void )
     }
 }
 
-void plSound::SetCurrDebugPlate( const plKey soundKey )
+void plSound::SetCurrDebugPlate( const plKey& soundKey )
 {
     if( soundKey == nil )
     {
@@ -186,12 +186,7 @@ void plSound::SetCurrDebugPlate( const plKey soundKey )
     else
     {
         fCurrDebugPlateSound = plSound::ConvertNoRef( soundKey->GetObjectPtr() );
-        if( fDebugPlate != nil )
-        {
-            fDebugPlate->ClearData();
-            fDebugPlate->SetVisible( true );
-            fDebugPlate->SetTitle( fCurrDebugPlateSound->GetKeyName().c_str() );        // Bleah
-        }
+        fCurrDebugPlateSound->IUpdateDebugPlate();
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.h
@@ -260,7 +260,7 @@ public:
     virtual void        ForceUnload( void );
 
     // Note: ONLY THE AUDIOSYS SHOULD CALL THIS. If you're not the audioSys, get lost.
-    static void         SetCurrDebugPlate( const plKey soundKey );
+    static void         SetCurrDebugPlate( const plKey& soundKey );
 
     void                RegisterOnAudioSys( void );
     void                UnregisterOnAudioSys( void );
@@ -343,7 +343,7 @@ protected:
     void            IUpdateDebugPlate( void );
     void            IPrintDbgMessage( const char *msg, bool isErr = false );
 
-    virtual void    ISetActualVolume(const float v) = 0;
+    virtual void    ISetActualVolume(float v) = 0;
     virtual void    IActuallyStop( void );
     virtual bool    IActuallyPlaying( void ) = 0;
     virtual void    IActuallyPlay( void ) = 0;

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
@@ -274,7 +274,7 @@ void plWin32Sound::SetPosition( const hsPoint3 pos )
     }
 }
 
-void plWin32Sound::ISetActualVolume(const float volume)
+void plWin32Sound::ISetActualVolume(float volume)
 {
     float vol = IAttenuateActualVolume( volume ) * IGetChannelVolume();
     if( fDSoundBuffer )

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.h
@@ -111,7 +111,7 @@ protected:
 
     hsTArray<plSoundEvent *>    fSoundEvents;
 
-    virtual void    ISetActualVolume(const float v);
+    virtual void    ISetActualVolume(float v);
     virtual void    IActuallyStop( void );
     virtual bool    IActuallyPlaying( void ) { return fReallyPlaying; }
     virtual void    IActuallyPlay( void );


### PR DESCRIPTION
Some fixes and additions to the audio console commands that I'm using to debug why the heek table sound is so loud. Previously, the `Audio.NextDebugPlate` command did not work. I also added `Audio.ShowDebugPlate` so that we wouldn't have to step through tons of useless crap before we get to the one we want.