### PR TITLE
Fix weird camera angles caused by 9c49b57

### DIFF
--- a/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
@@ -1565,14 +1565,13 @@ void plCameraBrain1_Fixed::Update(bool forced)
             if (fCamera->GetTarget())
             {
                 fTargetMatrix = fCamera->GetTarget()->GetCoordinateInterface()->GetLocalToWorld();
-                hsVector3 view;
                 hsVector3 up;
-                fTargetMatrix.GetAxis(0, &up, &view);
+                fTargetMatrix.GetAxis(nullptr, &up, nullptr);
                 fGoal = fTargetMatrix.GetTranslate();
                 if (fTargetPoint)
                     fPOAGoal = fTargetPoint->GetBrain()->GetGoal();
                 else
-                    fPOAGoal = fGoal - (view * 10);
+                    fPOAGoal = fGoal - (up * 10);
             }
         }
         if (fFlags.IsBitSet(kRailComponent) && fRail)


### PR DESCRIPTION
The reason for the previous commit was that coverity indicated view was being passed to up and vice versa. I don't know what they were intending, but the calculation was correct, just the argument naming was wrong. This has all been corrected now.

Test cases: Neighborhood classroom, Palace Alcove Nexus Terminal