### PR TITLE
Fix loud sound issue

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StaticSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StaticSound.cpp
@@ -134,6 +134,15 @@ bool plWin32StaticSound::LoadSound( bool is3D )
         }
         uint32_t bufferSize = buffer->GetDataLength();
 
+        if( header.fNumChannels > 1 && is3D )
+        {
+            // We can only do a single channel of 3D sound. So copy over one (later)
+            bufferSize              /= header.fNumChannels;
+            header.fBlockAlign      /= header.fNumChannels;
+            header.fAvgBytesPerSec  /= header.fNumChannels;
+            header.fNumChannels = 1;
+        }
+
         bool tryStatic = true;
         // If we want FX, we can't use a static voice, but EAX doesn't fit under that limitation :)
         if( 0 )

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.cpp
@@ -269,6 +269,15 @@ bool plWin32StreamingSound::LoadSound( bool is3D )
         return false;
     }
 
+    if( header.fNumChannels > 1 && is3D )
+    {
+        // We can only do a single channel of 3D sound. So copy over one (later)
+        bufferSize              /= header.fNumChannels;
+        header.fBlockAlign      /= header.fNumChannels;
+        header.fAvgBytesPerSec  /= header.fNumChannels;
+        header.fNumChannels = 1;
+    }
+
     // Actually create the buffer now (always looping)
     fDSoundBuffer = new plDSoundBuffer( bufferSize, header, is3D, IsPropertySet(kPropLooping), false, true );
     if( !fDSoundBuffer->IsValid() )


### PR DESCRIPTION
This pull request fixes problems with certain sounds being entirely too loud, for example, the ayoheek drone sound. This reverts commit b3d6afc1c1436f94c7a1591f9aa156dd49948712.

As best as I can remember, that commit was originally intended to fix some crashing issues present in transfused versions of Doobes' Guild of Messengers Pub. We determined that sounds exported in PyPRP ages would cause issues if they were shorter than 4 seconds in length. The real problem here was PyPRP bugs. For future reference: PyPRP should only be pointed to `.wav` files (not `.ogg`). Anything 4 seconds or shorter MUST be a plWin32StaticSound.