### PR TITLE
Allow python scripts to supress MLEdit updates

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -174,6 +174,7 @@ pfGUIMultiLineEditCtrl::pfGUIMultiLineEditCtrl()
     fFontSize = 0;
     fFontStyle = 0;
     fFontFlagsSet = 0;
+    fCanUpdate = true;
 }
 
 pfGUIMultiLineEditCtrl::~pfGUIMultiLineEditCtrl()
@@ -383,7 +384,7 @@ void    pfGUIMultiLineEditCtrl::IUpdate( int32_t startLine, int32_t endLine )
     int32_t       numVisibleLines, lastVisibleLine;
 
 
-    if( !fReadyToRender )
+    if (!fReadyToRender || !fCanUpdate)
         return;
 
     // Detect whether we need to recalc all of our dimensions entirely

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -123,6 +123,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         pfMLScrollProc  *fScrollProc;
         int32_t           fScrollPos;
         int32_t           fBufferLimit;
+        bool              fCanUpdate;
 
         pfGUIMultiLineEditCtrl *fNextCtrl; // used for linking multiple controls together to share a buffer
         pfGUIMultiLineEditCtrl *fPrevCtrl;
@@ -282,6 +283,17 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         bool    ShowingEndOfBuffer();
 
         void    DeleteLinesFromTop(int numLines); // cursor and scroll position might be off after this call, not valid on connected controls
+
+        /** Signifies that the control will be updated heavily starting now, so suppress all redraws. */
+        void BeginUpdate() { fCanUpdate = false; }
+
+        /** Signifies that the massive updates are over. We can now redraw. */
+        void EndUpdate(bool redraw=true)
+        {
+            fCanUpdate = true;
+            if (redraw)
+                IUpdate();
+        }
 };
 
 #endif // _pfGUIMultiLineEditCtrl_h

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
@@ -581,3 +581,21 @@ void pyGUIControlMultiLineEdit::SetFontSize( uint32_t fontsize )
             pbmod->SetFontSize((uint8_t)fontsize);
     }
 }
+
+void pyGUIControlMultiLineEdit::BeginUpdate()
+{
+    if (fGCkey) {
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if (pbmod)
+            pbmod->BeginUpdate();
+    }
+}
+
+void pyGUIControlMultiLineEdit::EndUpdate(bool redraw)
+{
+    if (fGCkey) {
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if (pbmod)
+            pbmod->EndUpdate(redraw);
+    }
+}

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
@@ -113,6 +113,9 @@ public:
 
     virtual uint32_t  GetFontSize() const;
     virtual void    SetFontSize( uint32_t fontsize );
+
+    void BeginUpdate();
+    void EndUpdate(bool redraw);
 };
 
 #endif // _pyGUIControlMultiLineEdit_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
@@ -403,6 +403,19 @@ PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, setFontSize, args)
     PYTHON_RETURN_NONE;
 }
 
+PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlMultiLineEdit, beginUpdate, BeginUpdate)
+
+PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, endUpdate, args)
+{
+    bool redraw = true;
+    if (!PyArg_ParseTuple(args, "|b", &redraw)) {
+        PyErr_SetString(PyExc_TypeError, "endUpdate expects an optional boolean");
+        PYTHON_RETURN_ERROR;
+    }
+    self->fThis->EndUpdate(redraw);
+    PYTHON_RETURN_NONE;
+}
+
 PYTHON_START_METHODS_TABLE(ptGUIControlMultiLineEdit)
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, clickable, "Sets this listbox to be clickable by the user."),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, unclickable, "Makes this listbox not clickable by the user.\n"
@@ -439,6 +452,8 @@ PYTHON_START_METHODS_TABLE(ptGUIControlMultiLineEdit)
     PYTHON_METHOD(ptGUIControlMultiLineEdit, deleteLinesFromTop, "Params: numLines\nDeletes the specified number of lines from the top of the text buffer"),
     PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, getFontSize, "Returns the current default font size"),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, setFontSize, "Params: fontSize\nSets the default font size for the edit control"),
+    PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, beginUpdate, "Signifies that the control will be updated heavily starting now, so suppress all redraws"),
+    PYTHON_METHOD(ptGUIControlMultiLineEdit, endUpdate, "Signifies that the massive updates are over. We can now redraw."),
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition


### PR DESCRIPTION
Refreshing multiline edit controls is expensive, and there are lots of implicit updates in common operations, such as adding strings, adding colors, and deleting lines. This allows the scripter to manually suppress expensive updates until (s)he is done doing evil things.