### PR TITLE
PyUnicode

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.cpp
@@ -69,7 +69,7 @@ PyObject* cyAccountManagement::GetPlayerList()
     for (Py_ssize_t i = 0; i < playerList.size(); ++i)
     {
         PyObject* playerTuple   = PyTuple_New(3);
-        PyObject* playerName    = PyUnicode_FromStringEx(playerList[i].playerName);
+        PyObject* playerName    = PyUnicode_FromPlString(playerList[i].playerName);
         PyObject* playerId      = PyInt_FromLong(playerList[i].playerInt);
         PyObject* avatarShape   = PyString_FromPlString(playerList[i].avatarDatasetName);
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagementGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagementGlue.cpp
@@ -61,7 +61,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetAccountPlayerList, "Returns list of 
 
 PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetAccountName, "Returns the account name for the current account")
 {
-    return PyUnicode_FromStringEx(cyAccountManagement::GetAccountName());
+    return PyUnicode_FromPlString(cyAccountManagement::GetAccountName());
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtCreatePlayer, args, "Params: playerName, avatarShape, invitation\nCreates a new player")

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
@@ -115,10 +115,10 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtGetClientName, args, "Params: avatarKey=None\n
             PYTHON_RETURN_ERROR;
         }
         pyKey* key = pyKey::ConvertFrom(keyObj);
-        return PyString_FromString(cyMisc::GetClientName(*key).c_str());
+        return PyString_FromPlString(cyMisc::GetClientName(*key));
     }
     else
-        return PyString_FromString(cyMisc::GetLocalClientName().c_str());
+        return PyString_FromPlString(cyMisc::GetLocalClientName());
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetLocalAvatar, "This will return a ptSceneobject of the local avatar\n"
@@ -446,7 +446,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtGetLocalizedString, args, "Params: name, argum
         }
     }
 
-    return PyUnicode_FromStringEx(cyMisc::GetLocalizedString(name, argList));
+    return PyUnicode_FromPlString(cyMisc::GetLocalizedString(name, argList));
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtDumpLogs, args, "Params: folder\nDumps all current log files to the specified folder (a sub-folder to the log folder)")

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
@@ -678,12 +678,12 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtCreateDir, args, "Params: directory\nCreates t
 
 PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetUserPath, "Returns the unicode path to the client's root user directory. Do NOT convert to a standard string.")
 {
-    return PyUnicode_FromStringEx(cyMisc::GetUserPath().AsString());
+    return PyUnicode_FromPlString(cyMisc::GetUserPath().AsString());
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetInitPath, "Returns the unicode path to the client's init directory. Do NOT convert to a standard string.")
 {
-    return PyUnicode_FromStringEx(cyMisc::GetInitPath().AsString());
+    return PyUnicode_FromPlString(cyMisc::GetInitPath().AsString());
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBoxGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBoxGlue.cpp
@@ -159,7 +159,7 @@ PYTHON_METHOD_DEFINITION(ptGUIControlListBox, getElementW, args)
         PyErr_SetString(PyExc_TypeError, "getElementW expects an unsigned short");
         PYTHON_RETURN_ERROR;
     }
-    return PyUnicode_FromStringEx(self->fThis->GetElement(index));
+    return PyUnicode_FromPlString(self->fThis->GetElement(index));
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, setStringJustify, args)

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameScoreGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameScoreGlue.cpp
@@ -74,7 +74,7 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptGameScore, getGameType)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGameScore, getName)
 {
-    return PyUnicode_FromStringEx(self->fThis->GetGameName());
+    return PyUnicode_FromPlString(self->fThis->GetGameName());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGameScore, remove)

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameScoreMsgGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameScoreMsgGlue.cpp
@@ -88,7 +88,7 @@ PYTHON_NO_INIT_DEFINITION(ptGameScoreListMsg);
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGameScoreListMsg, getName)
 {
-    return PyUnicode_FromStringEx(self->fThis->GetName());
+    return PyUnicode_FromPlString(self->fThis->GetName());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGameScoreListMsg, getOwnerID)

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.cpp
@@ -68,7 +68,7 @@ bool PyString_CheckEx(PyObject* obj)
     return (PyString_Check(obj) || PyUnicode_Check(obj));
 }
 
-PyObject* PyUnicode_FromStringEx(const plString& str)
+PyObject* PyUnicode_FromPlString(const plString& str)
 {
     plStringBuffer<wchar_t> buf = str.ToWchar();
     return PyUnicode_FromWideChar(buf.GetData(), buf.GetSize());

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -51,8 +51,8 @@ typedef struct PyMethodDef PyMethodDef;
 // Useful string functions
 plString PyString_AsStringEx(PyObject* obj);
 bool PyString_CheckEx(PyObject* obj);
-PyObject* PyUnicode_FromStringEx(const plString& str);
 
+PyObject* PyUnicode_FromPlString(const plString& str);
 #define PyString_FromPlString(x) PyString_FromString((x).c_str())
 
 // A set of macros to take at least some of the tediousness out of creating straight python glue code

--- a/Sources/Plasma/FeatureLib/pfPython/pyPlayerGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyPlayerGlue.cpp
@@ -140,6 +140,11 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptPlayer, getPlayerName)
     return PyString_FromPlString(self->fThis->GetPlayerName());
 }
 
+PYTHON_METHOD_DEFINITION_NOARGS(ptPlayer, getPlayerNameW)
+{
+    return PyUnicode_FromPlString(self->fThis->GetPlayerName());
+}
+
 PYTHON_METHOD_DEFINITION_NOARGS(ptPlayer, getPlayerID)
 {
     return PyLong_FromUnsignedLong(self->fThis->GetPlayerID());

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNodeGlue.cpp
@@ -96,7 +96,7 @@ PYTHON_METHOD_DEFINITION(ptVaultFolderNode, folderSetName, args)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultFolderNode, folderGetName)
 {
-    return PyString_FromString(self->fThis->Folder_GetName().c_str());
+    return PyString_FromPlString(self->fThis->Folder_GetName());
 }
 
 PYTHON_METHOD_DEFINITION(ptVaultFolderNode, setFolderType, args)
@@ -159,12 +159,12 @@ PYTHON_METHOD_DEFINITION(ptVaultFolderNode, setFolderNameW, args)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultFolderNode, getFolderName)
 {
-    return PyString_FromString(self->fThis->Folder_GetName().c_str());
+    return PyString_FromPlString(self->fThis->Folder_GetName());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultFolderNode, getFolderNameW)
 {
-    return PyUnicode_FromStringEx(self->fThis->Folder_GetName());
+    return PyUnicode_FromPlString(self->fThis->Folder_GetName());
 }
 
 PYTHON_START_METHODS_TABLE(ptVaultFolderNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNodeGlue.cpp
@@ -71,7 +71,7 @@ PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, noteSetTitle, args)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultTextNoteNode, noteGetTitle)
 {
-    return PyString_FromString(self->fThis->Note_GetTitle().c_str());
+    return PyString_FromPlString(self->fThis->Note_GetTitle());
 }
 
 PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, noteSetText, args)
@@ -88,7 +88,7 @@ PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, noteSetText, args)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultTextNoteNode, noteGetText)
 {
-    return PyString_FromString(self->fThis->Note_GetText().c_str());
+    return PyString_FromPlString(self->fThis->Note_GetText());
 }
 
 PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, noteSetType, args)
@@ -168,12 +168,12 @@ PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, setTitleW, args)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultTextNoteNode, getTitle)
 {
-    return PyString_FromString(self->fThis->Note_GetTitle().c_str());
+    return PyString_FromPlString(self->fThis->Note_GetTitle());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultTextNoteNode, getTitleW)
 {
-    return PyUnicode_FromStringEx(self->fThis->Note_GetTitle());
+    return PyUnicode_FromPlString(self->fThis->Note_GetTitle());
 }
 
 PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, setText, args)
@@ -219,12 +219,12 @@ PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, setTextW, args)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultTextNoteNode, getText)
 {
-    return PyString_FromString(self->fThis->Note_GetText().c_str());
+    return PyString_FromPlString(self->fThis->Note_GetText());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultTextNoteNode, getTextW)
 {
-    return PyUnicode_FromStringEx(self->fThis->Note_GetText());
+    return PyUnicode_FromPlString(self->fThis->Note_GetText());
 }
 
 PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, setType, args)


### PR DESCRIPTION
This renames `PyUnicode_FromStringEx` to `PyUnicode_FromPlString` for consistency with the `PyString_FromPlString` macro (and because it's a more descriptive name anyway), and adds a unicode version of `ptPlayer.getPlayerName`.

I decided on this approach because `getPlayerName` is used in many places in moul-scripts, so this change allows the old API to not break while allowing `getPlayerNameW` to be used when necessary (e.g. as an alternative to H-uru/moul-scripts#101).