### PR TITLE
WIP: plCreatable modernizing

### DIFF
--- a/Sources/Plasma/NucleusLib/inc/plgDispatch.h
+++ b/Sources/Plasma/NucleusLib/inc/plgDispatch.h
@@ -51,8 +51,8 @@ class plKey;
 class plDispatchBase : public plCreatable
 {
 public:
-    CLASSNAME_REGISTER( plDispatchBase );
-    GETINTERFACE_ANY( plDispatchBase, plCreatable );
+    CLASSNAME_REGISTER(plDispatchBase);
+    GETINTERFACE_ANY(plDispatchBase, plCreatable);
 
     virtual void RegisterForType(uint16_t hClass, const plKey& receiver) = 0;
     virtual void RegisterForExactType(uint16_t hClass, const plKey& receiver) = 0;
@@ -62,21 +62,30 @@ public:
 
     virtual void UnRegisterAll(const plKey& receiver) = 0;
 
-    virtual bool    MsgSend(plMessage* msg, bool async=false) = 0;
-    virtual void    MsgQueue(plMessage* msg)=0; // Used by other thread to Send Messages, they are handled as soon as Practicable
-    virtual void    MsgQueueProcess() = 0;
-    virtual void    MsgQueueOnOff(bool) = 0;      // Turn on or off Queued Messages, if off, uses MsgSend Immediately (for plugins)
+    virtual bool MsgSend(plMessage* msg, bool async=false) = 0;
 
-    virtual bool    SetMsgBuffering(bool on) = 0; // On starts deferring msg delivery until buffering is set to off again.
+    // Used by other thread to Send Messages, they are handled as soon as
+    // Practicable
+    virtual void MsgQueue(plMessage* msg)=0;
+    virtual void MsgQueueProcess() = 0;
 
-    virtual void    BeginShutdown() = 0;
+    // Turn on or off Queued Messages, if off, uses MsgSend Immediately (for
+    // plugins)
+    virtual void MsgQueueOnOff(bool) = 0;
+
+    // On starts deferring msg delivery until buffering is set to off again.
+    virtual bool SetMsgBuffering(bool on) = 0;
+
+    virtual void BeginShutdown() = 0;
 };
 
 class plgDispatch
 {
 public:
     static plDispatchBase* Dispatch();
-    static bool MsgSend(plMessage* msg, bool async = false) { return Dispatch()->MsgSend(msg, async); }
+    static bool MsgSend(plMessage* msg, bool async = false) {
+        return Dispatch()->MsgSend(msg, async);
+    }
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnDispatch/plDispatch.h
+++ b/Sources/Plasma/NucleusLib/pnDispatch/plDispatch.h
@@ -118,42 +118,51 @@ public:
     CLASSNAME_REGISTER( plDispatch );
     GETINTERFACE_ANY( plDispatch, plCreatable );
 
-    virtual void RegisterForType(uint16_t hClass, const plKey& receiver);
-    virtual void RegisterForExactType(uint16_t hClass, const plKey& receiver);
+    void RegisterForType(uint16_t hClass, const plKey& receiver) HS_OVERRIDE;
+    void RegisterForExactType(uint16_t hClass, const plKey& receiver) HS_OVERRIDE;
 
-    virtual void UnRegisterForType(uint16_t hClass, const plKey& receiver);
-    virtual void UnRegisterForExactType(uint16_t hClass, const plKey& receiver);
+    void UnRegisterForType(uint16_t hClass, const plKey& receiver) HS_OVERRIDE;
+    void UnRegisterForExactType(uint16_t hClass, const plKey& receiver) HS_OVERRIDE;
 
-    virtual void UnRegisterAll(const plKey& receiver);
+    void UnRegisterAll(const plKey& receiver) HS_OVERRIDE;
 
-    virtual bool    MsgSend(plMessage* msg, bool async=false);
-    virtual void    MsgQueue(plMessage* msg);   // Used by other thread to Send Messages, they are handled as soon as Practicable
-    virtual void    MsgQueueProcess();
-    virtual void    MsgQueueOnOff(bool );     // Turn on or off Queued Messages, if off, uses MsgSend Immediately
+    bool MsgSend(plMessage* msg, bool async=false) HS_OVERRIDE;
 
-    virtual bool    SetMsgBuffering(bool on); // On starts deferring msg delivery until buffering is set to off again.
+    // Used by other thread to Send Messages, they are handled as soon as
+    // Practicable
+    void MsgQueue(plMessage* msg) HS_OVERRIDE;
+    void MsgQueueProcess() HS_OVERRIDE;
 
-    virtual void    BeginShutdown();
+    // Turn on or off Queued Messages, if off, uses MsgSend Immediately (for
+    // plugins)
+    void MsgQueueOnOff(bool sw) HS_OVERRIDE;
 
-    static void SetMsgRecieveCallback(MsgRecieveCallback callback) { fMsgRecieveCallback = callback; }
+    // On starts deferring msg delivery until buffering is set to off again.
+    bool SetMsgBuffering(bool on) HS_OVERRIDE;
+
+    void BeginShutdown() HS_OVERRIDE;
+
+    static void SetMsgRecieveCallback(MsgRecieveCallback callback) {
+        fMsgRecieveCallback = callback;
+    }
 };
+
 
 class plNullDispatch : public plDispatch
 {
 public:
 
-    virtual void RegisterForExactType(uint16_t hClass, const plKey& receiver) {}
-    virtual void RegisterForType(uint16_t hClass, const plKey& receiver) {}
+    void RegisterForExactType(uint16_t hClass, const plKey& receiver) HS_OVERRIDE {}
+    void RegisterForType(uint16_t hClass, const plKey& receiver) HS_OVERRIDE {}
 
-    virtual void UnRegisterForExactType(uint16_t hClass, const plKey& receiver) {}
-    virtual void UnRegisterForType(uint16_t hClass, const plKey& receiver) {}
+    void UnRegisterForExactType(uint16_t hClass, const plKey& receiver) HS_OVERRIDE {}
+    void UnRegisterForType(uint16_t hClass, const plKey& receiver) HS_OVERRIDE {}
 
+    bool MsgSend(plMessage* msg, bool async=false) HS_OVERRIDE { return true; }
+    void MsgQueue(plMessage* msg) HS_OVERRIDE {}
+    void MsgQueueProcess() HS_OVERRIDE {}
 
-    virtual bool MsgSend(plMessage* msg) { return true; }
-    virtual void MsgQueue(plMessage* msg) {}
-    virtual void MsgQueueProcess() {}
-
-    virtual void BeginShutdown() {}
+    void BeginShutdown() HS_OVERRIDE {}
 
 };
 

--- a/Sources/Plasma/NucleusLib/pnDispatch/pnDispatchCreatable.h
+++ b/Sources/Plasma/NucleusLib/pnDispatch/pnDispatchCreatable.h
@@ -46,7 +46,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnFactory/plCreatable.h"
 
 #include "plDispatch.h"
-
-REGISTER_CREATABLE( plDispatch );
+REGISTER_CREATABLE(plDispatch);
 
 #endif // pnDispatchCreatable_inc

--- a/Sources/Plasma/NucleusLib/pnFactory/plCreatable.h
+++ b/Sources/Plasma/NucleusLib/pnFactory/plCreatable.h
@@ -55,8 +55,8 @@ class plCreatable : public hsRefCnt
 {
 public:
     virtual const char*         ClassName() const = 0;
-    virtual plCreatable*        GetInterface(uint16_t hClass) { return nil; }
-    virtual const plCreatable*  GetConstInterface(uint16_t hClass) const { return nil; }
+    virtual plCreatable*        GetInterface(uint16_t hClass) { return nullptr; }
+    virtual const plCreatable*  GetConstInterface(uint16_t hClass) const { return nullptr; }
     static bool                 HasBaseClass(uint16_t hBase) { return false; }
     virtual uint16_t            ClassIndex() const = 0;
 
@@ -65,15 +65,20 @@ public:
 
     // WriteVersion writes the current version of this creatable and ReadVersion will read in
     // any previous version.
-    virtual void ReadVersion(hsStream* s, hsResMgr* mgr) { hsAssert(0, "ReadVersion not implemented!"); }
-    virtual void WriteVersion(hsStream* s, hsResMgr* mgr) {  hsAssert(0, "WriteVersion not implemented!"); }
+    virtual void ReadVersion(hsStream* s, hsResMgr* mgr) {
+        hsAssert(false, "ReadVersion not implemented!");
+    }
+    virtual void WriteVersion(hsStream* s, hsResMgr* mgr) {
+        hsAssert(false, "WriteVersion not implemented!");
+    }
 };
 
 
 // Macros:
-//  NOTE: Comfortable use of these macros assumes the compiler is comfortable eating
-//      a spurious semi-colon (;) following a curly brace. If that isn't the case, they
-//      can easily be wrapped in something like do { original macro } while(0) or the like.
+//  NOTE: Comfortable use of these macros assumes the compiler is comfortable
+//        eating a spurious semi-colon (;) following a curly brace. If that
+//        isn't the case, they can easily be wrapped in something like
+//        do { original macro } while(0) or the like.
 //
 //  Normal setup for a class:
 //  In public section of class declaration, insert the following two macros:
@@ -159,143 +164,153 @@ public:
 //
 
 
-#define CLASSNAME_REGISTER( plClassName )                       \
-public:                                                         \
-    virtual const char* ClassName() const { return #plClassName; }  \
-private:                                                        \
-    static uint16_t plClassName##ClassIndex;                      \
-    static void SetClassIndex(uint16_t hClass) {                  \
-        plClassName##ClassIndex = hClass;                       \
-    }                                                           \
-public:                                                         \
-    virtual uint16_t ClassIndex() const {                         \
-        return plClassName::Index();                            \
-    }                                                           \
-    static uint16_t Index() {                                     \
-        return plClassName##ClassIndex;                         \
-    }                                                           \
-    static plClassName * Create() {                                         \
-        return (plClassName*)plFactory::Create(plClassName##ClassIndex);    \
+#define CLASSNAME_REGISTER(plClassName)                                     \
+public:                                                                     \
+    const char* ClassName() const override {                                \
+        return #plClassName;                                                \
     }                                                                       \
-    static plClassName * ConvertNoRef(plCreatable* c) {                     \
+private:                                                                    \
+    static uint16_t plClassName##ClassIndex;                                \
+    static void SetClassIndex(uint16_t hClass) {                            \
+        plClassName##ClassIndex = hClass;                                   \
+    }                                                                       \
+public:                                                                     \
+    uint16_t ClassIndex() const override {                                  \
+        return plClassName::Index();                                        \
+    }                                                                       \
+    static uint16_t Index() {                                               \
+        return plClassName##ClassIndex;                                     \
+    }                                                                       \
+    static plClassName* Create() {                                          \
+        return static_cast<plClassName*>(                                   \
+                plFactory::Create(plClassName##ClassIndex));                \
+    }                                                                       \
+    static plClassName* ConvertNoRef(plCreatable* c) {                      \
         plClassName* retVal = c                                             \
-            ? (plClassName *)c->GetInterface(plClassName##ClassIndex)       \
-            : nil;                                                          \
+            ? static_cast<plClassName*>(                                    \
+                    c->GetInterface(plClassName##ClassIndex))               \
+            : nullptr;                                                      \
         return retVal;                                                      \
     }                                                                       \
-    static const plClassName * ConvertNoRef(const plCreatable* c) {                     \
-        const plClassName* retVal = c                                               \
-            ? (const plClassName *)c->GetConstInterface(plClassName##ClassIndex)        \
-            : nil;                                                          \
+    static const plClassName* ConvertNoRef(const plCreatable* c) {          \
+        const plClassName* retVal = c                                       \
+            ? static_cast<const plClassName*>(                              \
+                    c->GetConstInterface(plClassName##ClassIndex))          \
+            : nullptr;                                                      \
         return retVal;                                                      \
     }                                                                       \
-    static plClassName * Convert(plCreatable* c) {                          \
+    static plClassName* Convert(plCreatable* c) {                           \
         plClassName* retVal = ConvertNoRef(c);                              \
         hsRefCnt_SafeRef(retVal);                                           \
         return retVal;                                                      \
     }                                                                       \
     static bool HasDerivedClass(uint16_t hDer) {                            \
         return plFactory::DerivesFrom(plClassName##ClassIndex, hDer);       \
-        }                                                                   \
+    }                                                                       \
     friend class plClassName##__Creator;
 
-#define GETINTERFACE_ANY( plClassName, plBaseName )                 \
-static bool HasBaseClass(uint16_t hBaseClass) {                     \
-    if( hBaseClass == plClassName##ClassIndex )                     \
-        return true;                                                \
-    else                                                            \
-        return plBaseName::HasBaseClass(hBaseClass);                \
-    }                                                               \
-virtual plCreatable* GetInterface(uint16_t hClass) {                  \
-    if( hClass == plClassName##ClassIndex )                         \
-        return this;                                                \
-    else                                                            \
-        return plBaseName::GetInterface(hClass);                    \
-}                                                                   \
-virtual const plCreatable* GetConstInterface(uint16_t hClass) const { \
-    if( hClass == plClassName##ClassIndex )                         \
-        return this;                                                \
-    else                                                            \
-        return plBaseName::GetConstInterface(hClass);               \
-}
 
-#define GETINTERFACE_EXACT( plClassName )                       \
-    static bool HasBaseClass(uint16_t hBaseClass) {             \
-        return hBaseClass == plClassName##ClassIndex;           \
-    }                                                           \
-virtual plCreatable* GetInterface(uint16_t hClass) {              \
-    return hClass == plClassName##ClassIndex ? this : nil;      \
-}                                                               \
-virtual const plCreatable* GetConstInterface(uint16_t hClass) const { \
-    return hClass == plClassName##ClassIndex ? this : nil;      \
-}
 
-#define GETINTERFACE_NONE( plClassName )                        \
-static bool HasBaseClass(uint16_t hBaseClass) { return false; } \
-virtual plCreatable* GetInterface(uint16_t hClass) {              \
-    return nil;                                                 \
-}                                                               \
-virtual const plCreatable* GetConstInterface(uint16_t hClass) const { \
-    return nil;                                                 \
-}
+#define GETINTERFACE_ANY(plClassName, plBaseName)                           \
+    static bool HasBaseClass(uint16_t hBaseClass) {                         \
+        if (hBaseClass == plClassName##ClassIndex)                          \
+            return true;                                                    \
+        else                                                                \
+            return plBaseName::HasBaseClass(hBaseClass);                    \
+    }                                                                       \
+    plCreatable* GetInterface(uint16_t hClass) override {                   \
+        if (hClass == plClassName##ClassIndex)                              \
+            return this;                                                    \
+        else                                                                \
+            return plBaseName::GetInterface(hClass);                        \
+    }                                                                       \
+    const plCreatable* GetConstInterface(uint16_t hClass) const override {  \
+        if (hClass == plClassName##ClassIndex)                              \
+            return this;                                                    \
+        else                                                                \
+            return plBaseName::GetConstInterface(hClass);                   \
+    }
+
+
+
+#define GETINTERFACE_EXACT(plClassName)                                     \
+    static bool HasBaseClass(uint16_t hBaseClass) {                         \
+        return hBaseClass == plClassName##ClassIndex;                       \
+    }                                                                       \
+    plCreatable* GetInterface(uint16_t hClass) override {                   \
+        return hClass == plClassName##ClassIndex ? this : nullptr;          \
+    }                                                                       \
+    const plCreatable* GetConstInterface(uint16_t hClass) const override {  \
+        return hClass == plClassName##ClassIndex ? this : nullptr;          \
+    }
+
+
+
+#define GETINTERFACE_NONE(plClassName)                                      \
+    static bool HasBaseClass(uint16_t hBaseClass) { return false; }         \
+    plCreatable* GetInterface(uint16_t hClass) override {                   \
+        return nullptr;                                                     \
+    }                                                                       \
+    const plCreatable* GetConstInterface(uint16_t hClass) const override {  \
+        return nullptr;                                                     \
+    }
+
 
 //
 // Macro for converting to base class OR a class member
 //
-#define GETINTERFACE_ANY_AUX( plClassName, plBaseName, plAuxClassName, plAuxClassMember )   \
-static bool HasBaseClass(uint16_t hBaseClass) {                     \
-    if( hBaseClass == plClassName##ClassIndex )                     \
-        return true;                                                \
-    else                                                            \
-        return plBaseName::HasBaseClass(hBaseClass);                \
-    }                                                               \
-virtual plCreatable* GetInterface(uint16_t hClass) {                  \
-    if( hClass == plClassName##ClassIndex )                         \
-        return this;                                                \
-    else                                                            \
-    if (hClass == plAuxClassName::Index())                      \
-        return &plAuxClassMember;                                   \
-    else                                                            \
-        return plBaseName::GetInterface(hClass);                    \
-}                                                                   \
-virtual const plCreatable* GetConstInterface(uint16_t hClass) const { \
-    if( hClass == plClassName##ClassIndex )                         \
-        return this;                                                \
-    else                                                            \
-    if (hClass == plAuxClassName::Index())                      \
-        return &plAuxClassMember;                                   \
-    else                                                            \
-        return plBaseName::GetConstInterface(hClass);               \
-}
+#define GETINTERFACE_ANY_AUX(plClassName, plBaseName, plAuxClassName, plAuxClassMember) \
+    static bool HasBaseClass(uint16_t hBaseClass) {                         \
+        if (hBaseClass == plClassName##ClassIndex)                          \
+            return true;                                                    \
+        else                                                                \
+            return plBaseName::HasBaseClass(hBaseClass);                    \
+    }                                                                       \
+    plCreatable* GetInterface(uint16_t hClass) override {                   \
+        if (hClass == plClassName##ClassIndex)                              \
+            return this;                                                    \
+        else if (hClass == plAuxClassName::Index())                         \
+            return &plAuxClassMember;                                       \
+        else                                                                \
+            return plBaseName::GetInterface(hClass);                        \
+    }                                                                       \
+    const plCreatable* GetConstInterface(uint16_t hClass) const override {  \
+        if (hClass == plClassName##ClassIndex)                              \
+            return this;                                                    \
+        else if (hClass == plAuxClassName::Index())                         \
+            return &plAuxClassMember;                                       \
+        else                                                                \
+            return plBaseName::GetConstInterface(hClass);                   \
+    }
 
-#define plBeginInterfaceMap( plClassName, plBaseName )              \
-static bool HasBaseClass(uint16_t hBaseClass) {                     \
-    if( hBaseClass == plClassName##ClassIndex )                     \
-        return true;                                                \
-    else                                                            \
-        return plBaseName::HasBaseClass(hBaseClass);                \
-    }                                                               \
-virtual plCreatable* GetInterface(uint16_t hClass) {                  \
-    /* NOTE: pulling const off the ptr should be ok, right? */      \
-    return const_cast<plCreatable*>( GetConstInterface( hClass ) ); \
-}                                                                   \
-virtual const plCreatable* GetConstInterface(uint16_t hClass) const { \
-    typedef plBaseName MyBaseClass;                                 \
-    if( hClass == plClassName##ClassIndex )                         \
-        return this
+#define plBeginInterfaceMap(plClassName, plBaseName)                        \
+    static bool HasBaseClass(uint16_t hBaseClass) {                         \
+        if (hBaseClass == plClassName##ClassIndex)                          \
+            return true;                                                    \
+        else                                                                \
+            return plBaseName::HasBaseClass(hBaseClass);                    \
+    }                                                                       \
+    plCreatable* GetInterface(uint16_t hClass) override {                   \
+        /* NOTE: pulling const off the ptr should be ok, right? */          \
+        return const_cast<plCreatable*>(GetConstInterface(hClass));         \
+    }                                                                       \
+    const plCreatable* GetConstInterface(uint16_t hClass) const override {  \
+        typedef plBaseName MyBaseClass;                                     \
+        if (hClass == plClassName##ClassIndex)                              \
+            return this
 
-#define plAddInterface( plClassName )                               \
-    else if ( hClass == plClassName::Index() )                      \
-        return plClassName::GetConstInterface(hClass)
+#define plAddInterface(plClassName)                                         \
+        else if (hClass == plClassName::Index())                            \
+            return plClassName::GetConstInterface(hClass)
 
-#define plAddInterfaceAux( plAuxClassName, plAuxClassMember )       \
-    else if ( hClass == plAuxClassName::Index() )                   \
-        return &plAuxClassMember
+#define plAddInterfaceAux(plAuxClassName, plAuxClassMember)                 \
+        else if (hClass == plAuxClassName::Index())                         \
+            return &plAuxClassMember
 
-#define plEndInterfaceMap()                                         \
-    else                                                            \
-        return MyBaseClass::GetConstInterface(hClass);              \
-}
+#define plEndInterfaceMap()                                                 \
+        else                                                                \
+            return MyBaseClass::GetConstInterface(hClass);                  \
+    }
 
 
 #endif // plCreatable_inc

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/hsKeyedObject.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/hsKeyedObject.h
@@ -65,16 +65,16 @@ public:
     plString        GetKeyName() const;
 
     virtual void Validate();
-    virtual bool IsFinal() { return true; };     // experimental; currently "is ready to process Loads"
 
-    virtual void Read(hsStream* s, hsResMgr* mgr);
-    virtual void Write(hsStream* s, hsResMgr* mgr);
+    // experimental; currently "is ready to process Loads"
+    virtual bool IsFinal() { return true; };
 
-    virtual bool MsgReceive(plMessage* msg);
+    void Read(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 
-    //----------------------
+    bool MsgReceive(plMessage* msg) HS_OVERRIDE;
+
     // Send a reference to GetKey() via enclosed message. See plKey::SendRef()
-    //----------------------
     bool SendRef(plRefMsg* refMsg, plRefFlags::Type flags);
 
     //----------------------------------------
@@ -88,9 +88,10 @@ public:
     plKey   RegisterAsManual(plUoid& uoid, const plString& p);
     void    UnRegisterAsManual(plUoid& uoid);
 
-    // If you want clone keys to share a type of object, override this function for it.
-    // (You can also return a new object that shares only some of the original's data)
-    virtual hsKeyedObject* GetSharedObject() { return nil; }
+    // If you want clone keys to share a type of object, override this function
+    // for it. (You can also return a new object that shares only some of the
+    // original's data)
+    virtual hsKeyedObject* GetSharedObject() { return nullptr; }
 
 protected:
     friend class plResManager;

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.h
@@ -68,10 +68,10 @@ public:
     CLASSNAME_REGISTER(plMsgForwarder);
     GETINTERFACE_ANY(plMsgForwarder, hsKeyedObject);
 
-    void Read(hsStream* s, hsResMgr* mgr);
-    void Write(hsStream* s, hsResMgr* mgr);
+    void Read(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 
-    bool MsgReceive(plMessage* msg);
+    bool MsgReceive(plMessage* msg) HS_OVERRIDE;
 
     void AddForwardKey(plKey key);
 };

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/pnKeyedObjectCreatable.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/pnKeyedObjectCreatable.h
@@ -46,14 +46,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnFactory/plCreator.h"
 
 #include "hsKeyedObject.h"
-REGISTER_CREATABLE( hsKeyedObject );
+REGISTER_CREATABLE(hsKeyedObject);
 
 #include "plReceiver.h"
-
-REGISTER_NONCREATABLE( plReceiver );
+REGISTER_NONCREATABLE(plReceiver);
 
 #include "plMsgForwarder.h"
 REGISTER_CREATABLE(plMsgForwarder);
 
 #endif // pnKeyedObject_inc
-

--- a/Sources/Plasma/NucleusLib/pnMessage/plAttachMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plAttachMsg.h
@@ -56,10 +56,16 @@ public:
     // flags should be either:
     //      plRefMsg::kOnRequest - I'm adding this child to the receiver
     //      plRefMsg::kOnRemove - I'm detaching this child from the receiver
-    plAttachMsg(const plKey &rcv, hsKeyedObject* child, uint8_t context, const plKey snd=nil) : plRefMsg(rcv, context) { SetSender(snd); SetRef(child); }
+    plAttachMsg(const plKey& rcv, hsKeyedObject* child, uint8_t context,
+                const plKey snd=nullptr)
+        : plRefMsg(rcv, context)
+    {
+        SetSender(snd);
+        SetRef(child);
+    }
 
-    CLASSNAME_REGISTER( plAttachMsg );
-    GETINTERFACE_ANY( plAttachMsg, plRefMsg );
+    CLASSNAME_REGISTER(plAttachMsg);
+    GETINTERFACE_ANY(plAttachMsg, plRefMsg);
 
 };
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plAudioSysMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plAudioSysMsg.h
@@ -80,8 +80,8 @@ public:
                     const double* t) : pObj(nil){SetBCastFlag(plMessage::kBCastByExactType);}
     ~plAudioSysMsg(){;}
 
-    CLASSNAME_REGISTER( plAudioSysMsg );
-    GETINTERFACE_ANY( plAudioSysMsg, plMessage );
+    CLASSNAME_REGISTER(plAudioSysMsg);
+    GETINTERFACE_ANY(plAudioSysMsg, plMessage);
     
     int GetAudFlag() { return fAudFlag; }
     plKey GetSceneObject() { return pObj; }
@@ -90,16 +90,14 @@ public:
     bool    GetBoolFlag() { return fBoolFlag; }
     void    SetBoolFlag( bool b ) { fBoolFlag = b; }
 
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgRead(stream, mgr);
         stream->WriteLE(fAudFlag);
         mgr->WriteKey(stream, pObj);
     }
 
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         stream->ReadLE(&fAudFlag);
         pObj = mgr->ReadKey(stream);

--- a/Sources/Plasma/NucleusLib/pnMessage/plCameraMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCameraMsg.h
@@ -117,11 +117,11 @@ public:
                     const plKey &r, 
                     const double* t){;}
     
-    CLASSNAME_REGISTER( plCameraTargetFadeMsg );
-    GETINTERFACE_ANY( plCameraTargetFadeMsg, plMessage );
+    CLASSNAME_REGISTER(plCameraTargetFadeMsg);
+    GETINTERFACE_ANY(plCameraTargetFadeMsg, plMessage);
 
-    void Read(hsStream* stream, hsResMgr* mgr);
-    void Write(hsStream* stream, hsResMgr* mgr);
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
 };
 
@@ -160,8 +160,8 @@ public:
                     const plKey &r, 
                     const double* t);
     
-    CLASSNAME_REGISTER( plCameraMsg );
-    GETINTERFACE_ANY( plCameraMsg, plMessage );
+    CLASSNAME_REGISTER(plCameraMsg);
+    GETINTERFACE_ANY(plCameraMsg, plMessage);
 
     enum ModCmds
     {
@@ -217,11 +217,10 @@ public:
     void SetCmd(int n) { fCmd.SetBit(n); }
     void ClearCmd() { fCmd.Clear(); }
     void ClearCmd(int n) { fCmd.ClearBit(n); }
-    
 
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr);
-    void Write(hsStream* stream, hsResMgr* mgr);
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
 };
 
@@ -251,11 +250,11 @@ public:
                     const plKey &r, 
                     const double* t): fEnable(false),fDisable(false){;}
     
-    CLASSNAME_REGISTER( plIfaceFadeAvatarMsg );
-    GETINTERFACE_ANY( plIfaceFadeAvatarMsg, plMessage );
+    CLASSNAME_REGISTER(plIfaceFadeAvatarMsg);
+    GETINTERFACE_ANY(plIfaceFadeAvatarMsg, plMessage);
 
-    void Read(hsStream* stream, hsResMgr* mgr);
-    void Write(hsStream* stream, hsResMgr* mgr);
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
 };
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plClientMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plClientMsg.h
@@ -121,16 +121,15 @@ public:
     const plLocation& GetRoomLoc(int i) const { return fRoomLocs[i]; }
     const std::vector<plLocation>& GetRoomLocs() { return fRoomLocs; }
 
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr);
-    void Write(hsStream* stream, hsResMgr* mgr);
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 class plClientRefMsg : public plRefMsg
 {
-
 public:
-    enum 
+    enum
     {
         kLoadRoom   = 0,
         kLoadRoomHold,
@@ -143,27 +142,24 @@ public:
         : plRefMsg(r, refMsgFlags), fType(type), fWhich(which) {}
 
 
-    CLASSNAME_REGISTER( plClientRefMsg );
-    GETINTERFACE_ANY( plClientRefMsg, plRefMsg );
+    CLASSNAME_REGISTER(plClientRefMsg);
+    GETINTERFACE_ANY(plClientRefMsg, plRefMsg);
 
     int8_t                    fType;
     int8_t                    fWhich;
 
     // IO - not really applicable to ref msgs, but anyway
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plRefMsg::Read(stream, mgr);
         stream->ReadLE(&fType);
         stream->ReadLE(&fWhich);
     }
 
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plRefMsg::Write(stream, mgr);
         stream->WriteLE(fType);
         stream->WriteLE(fWhich);
     }
 };
-
 
 #endif // plClientMsg

--- a/Sources/Plasma/NucleusLib/pnMessage/plCmdIfaceModMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCmdIfaceModMsg.h
@@ -61,8 +61,8 @@ public:
                     const plKey* r, 
                     const double* t) : fInterface(nil){;}
     
-    CLASSNAME_REGISTER( plCmdIfaceModMsg );
-    GETINTERFACE_ANY( plCmdIfaceModMsg, plMessage );
+    CLASSNAME_REGISTER(plCmdIfaceModMsg);
+    GETINTERFACE_ANY(plCmdIfaceModMsg, plMessage);
 
     enum 
     {
@@ -87,17 +87,14 @@ public:
     void SetCmd(int n) { fCmd.SetBit(n); }
     void ClearCmd() { fCmd.Clear(); }
     void ClearCmd(int n) { fCmd.ClearBit(n); }
-    
+
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgRead(stream, mgr);
     }
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
     }
-    
 };
 
 #endif // plCmdIfaceModMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plCorrectionMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCorrectionMsg.h
@@ -49,38 +49,35 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plCorrectionMsg : public plMessage
 {
 public:
-    plCorrectionMsg() : plMessage(nil, nil, nil) { }
-    plCorrectionMsg(plKey &r, const hsMatrix44& l2w, const hsMatrix44& w2l, bool dirtySynch = false)
-        : plMessage(nil, r, nil),
+    plCorrectionMsg() : plMessage(nullptr, nullptr, nullptr) { }
+
+    plCorrectionMsg(plKey& r, const hsMatrix44& l2w, const hsMatrix44& w2l,
+                    bool dirtySynch = false)
+        : plMessage(nullptr, r, nullptr),
           fLocalToWorld(l2w),
           fWorldToLocal(w2l),
           fDirtySynch(dirtySynch)
     { }
 
-    CLASSNAME_REGISTER( plCorrectionMsg );
-    GETINTERFACE_ANY( plCorrectionMsg, plMessage );
+    CLASSNAME_REGISTER(plCorrectionMsg);
+    GETINTERFACE_ANY(plCorrectionMsg, plMessage);
 
-    hsMatrix44      fLocalToWorld;
-    hsMatrix44      fWorldToLocal;
-    
-    bool          fDirtySynch;
+    hsMatrix44 fLocalToWorld;
+    hsMatrix44 fWorldToLocal;
 
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    bool fDirtySynch;
+
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgRead(stream, mgr);
         fLocalToWorld.Read(stream);
         fWorldToLocal.Read(stream);
     }
-    
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         fLocalToWorld.Write(stream);
         fWorldToLocal.Write(stream);
     }
-
-
 };
 
 #endif // plCorrectionMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plCursorChangeMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCursorChangeMsg.h
@@ -43,9 +43,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plCursorChangeMsg_inc
 #define plCursorChangeMsg_inc
 
-//
-// this message is to fake out a gadget to see if it would potentially trigger...
-//
 #include "pnMessage/plMessage.h"
 #include "hsBitVector.h"
 
@@ -62,11 +59,11 @@ public:
     plCursorChangeMsg(const plKey &s, 
                     const plKey &r, 
                     const double* t) : fType(0),fPriority(0){;}
-    
-    CLASSNAME_REGISTER( plCursorChangeMsg );
-    GETINTERFACE_ANY( plCursorChangeMsg, plMessage );
 
-    enum 
+    CLASSNAME_REGISTER(plCursorChangeMsg);
+    GETINTERFACE_ANY(plCursorChangeMsg, plMessage);
+
+    enum
     {
         kNoChange   = 0,
         kCursorUp,
@@ -83,25 +80,21 @@ public:
         kNullCursor
     };
 
-    int             fType;
-    int             fPriority;
+    int fType;
+    int fPriority;
 
 
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgRead(stream, mgr);
         fType = stream->ReadLE32();
         fPriority = stream->ReadLE32();
     }
-
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         stream->WriteLE32(fType);
         stream->WriteLE32(fPriority);
     }
-
 };
 
 #endif // plCursorChangeMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plDISpansMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plDISpansMsg.h
@@ -65,12 +65,12 @@ public:
 
     plDISpansMsg() : plMessage(), fType(0), fFlags(0), fIndex(-1) {}
     plDISpansMsg(const plKey &r, uint8_t type, int index, int flags) : plMessage(nil, r, nil), fType(type), fIndex(index), fFlags(flags) {}   
-    
-    CLASSNAME_REGISTER( plDISpansMsg );
-    GETINTERFACE_ANY( plDISpansMsg, plMessage );
-    
-    void Read(hsStream* stream, hsResMgr* mgr) {}
-    void Write(hsStream* stream, hsResMgr* mgr) {}
+
+    CLASSNAME_REGISTER(plDISpansMsg);
+    GETINTERFACE_ANY(plDISpansMsg, plMessage);
+
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {}
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {}
 };
 
 #endif // plDISpansMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plEnableMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plEnableMsg.h
@@ -50,9 +50,8 @@ class hsStream;
 
 class plEnableMsg : public plMessage
 {
-
 public:
-    enum 
+    enum
     {
         kDisable        = 0,
         kEnable,
@@ -62,35 +61,38 @@ public:
         kAll,
         kByType
     };
-    
-    hsBitVector     fCmd;
-    hsBitVector     fTypes;
+
+    hsBitVector fCmd;
+    hsBitVector fTypes;
 
     bool Cmd(int n) const { return fCmd.IsBitSet(n); }
     void SetCmd(int n) { fCmd.SetBit(n); }
     void ClearCmd() { fCmd.Clear(); }
-    
+
     void AddType(uint16_t t) { fTypes.SetBit(t); }
     void RemoveType(uint16_t t) { fTypes.ClearBit(t); }
     bool Type(uint16_t t) const { return fTypes.IsBitSet(t); }
     const hsBitVector& Types() const { return fTypes; }
 
     plEnableMsg() { }
-    plEnableMsg(const plKey &s, int which , int type) : plMessage() 
-    { SetCmd(which); SetCmd(type); }
 
-    CLASSNAME_REGISTER( plEnableMsg );
-    GETINTERFACE_ANY( plEnableMsg, plMessage );
-
-    void Read(hsStream* stream, hsResMgr* mgr)
+    plEnableMsg(const plKey& s, int which, int type)
+        : plMessage()
     {
+        SetCmd(which);
+        SetCmd(type);
+    }
+
+    CLASSNAME_REGISTER(plEnableMsg);
+    GETINTERFACE_ANY(plEnableMsg, plMessage);
+
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgRead(stream, mgr);
         fCmd.Read(stream);
         fTypes.Read(stream);
     }
 
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         fCmd.Write(stream);
         fTypes.Write(stream);
@@ -102,8 +104,7 @@ public:
         kTypes,
     };
 
-    void ReadVersion(hsStream* stream, hsResMgr* mgr)
-    {
+    void ReadVersion(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgReadVersion(stream, mgr);
         hsBitVector contentFlags;
         contentFlags.Read(stream);
@@ -114,14 +115,13 @@ public:
             fTypes.Read(stream);
     }
 
-    void WriteVersion(hsStream* stream, hsResMgr* mgr)
-    {
+    void WriteVersion(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWriteVersion(stream, mgr);
         hsBitVector contentFlags;
         contentFlags.SetBit(kCmd);
         contentFlags.SetBit(kTypes);
         contentFlags.Write(stream);
-        
+
         fCmd.Write(stream);
         fTypes.Write(stream);
     }

--- a/Sources/Plasma/NucleusLib/pnMessage/plEventCallbackMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plEventCallbackMsg.h
@@ -84,21 +84,19 @@ public:
 
     ~plEventCallbackMsg(){;}
 
-    CLASSNAME_REGISTER( plEventCallbackMsg );
-    GETINTERFACE_ANY( plEventCallbackMsg, plMessage );
+    CLASSNAME_REGISTER(plEventCallbackMsg);
+    GETINTERFACE_ANY(plEventCallbackMsg, plMessage);
 
-    // IO 
-    virtual void Read(hsStream* stream, hsResMgr* mgr) 
-    {
-        plMessage::IMsgRead(stream, mgr);   
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plMessage::IMsgRead(stream, mgr);
         fEventTime = stream->ReadLEFloat();
         fEvent = (CallbackEvent)stream->ReadLE16();
         fIndex = stream->ReadLE16();
         fRepeats = stream->ReadLE16();
         fUser = stream->ReadLE16();
     }
-    virtual void Write(hsStream* stream, hsResMgr* mgr) 
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         stream->WriteLEFloat(fEventTime);
         stream->WriteLE16((int16_t)fEvent);
@@ -133,11 +131,8 @@ public:
     plEventCallbackInterceptMsg() : plEventCallbackMsg(), fMsg(nil) {}
     ~plEventCallbackInterceptMsg() { hsRefCnt_SafeUnRef(fMsg); fMsg = nil; }
 
-    CLASSNAME_REGISTER( plEventCallbackInterceptMsg );
-    GETINTERFACE_ANY( plEventCallbackInterceptMsg, plEventCallbackMsg );
-
-    virtual void Read(hsStream *stream, hsResMgr *mgr) { plEventCallbackMsg::Read(stream, mgr); }
-    virtual void Write(hsStream *stream, hsResMgr *mgr) { plEventCallbackMsg::Write(stream, mgr); }
+    CLASSNAME_REGISTER(plEventCallbackInterceptMsg);
+    GETINTERFACE_ANY(plEventCallbackInterceptMsg, plEventCallbackMsg);
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plFakeOutMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plFakeOutMsg.h
@@ -57,35 +57,35 @@ class plFakeOutMsg : public plMessage
 protected:
 
 public:
-    plFakeOutMsg(){SetBCastFlag(plMessage::kPropagateToModifiers);}
-    plFakeOutMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t){SetBCastFlag(plMessage::kPropagateToModifiers);}
-    
-    CLASSNAME_REGISTER( plFakeOutMsg );
-    GETINTERFACE_ANY( plFakeOutMsg, plMessage );
+    plFakeOutMsg() {
+        SetBCastFlag(plMessage::kPropagateToModifiers);
+    }
 
-    enum 
+    plFakeOutMsg(const plKey& s, const plKey& r, const double* t) {
+        SetBCastFlag(plMessage::kPropagateToModifiers);
+    }
+
+    CLASSNAME_REGISTER(plFakeOutMsg);
+    GETINTERFACE_ANY(plFakeOutMsg, plMessage);
+
+    enum
     {
         kNumCmds = 0,
     };
 
-    hsBitVector     fCmd;
+    hsBitVector fCmd;
 
     bool Cmd(int n) const { return fCmd.IsBitSet(n); }
     void SetCmd(int n) { fCmd.SetBit(n); }
     void ClearCmd() { fCmd.Clear(); }
     void ClearCmd(int n) { fCmd.ClearBit(n); }
-    
+
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgRead(stream, mgr);
         fCmd.Read(stream);
     }
-
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         fCmd.Write(stream);
     }

--- a/Sources/Plasma/NucleusLib/pnMessage/plIntRefMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plIntRefMsg.h
@@ -67,24 +67,22 @@ public:
     plIntRefMsg() : fType(-1), fWhich(-1), fIdx(-1) {}
     plIntRefMsg(const plKey &r, uint8_t flags, int32_t which, int8_t type, int8_t idx=-1) : plRefMsg(r, flags), fWhich((int16_t)which), fType(type), fIdx(idx) {}
 
-    CLASSNAME_REGISTER( plIntRefMsg );
-    GETINTERFACE_ANY( plIntRefMsg, plRefMsg );
+    CLASSNAME_REGISTER(plIntRefMsg);
+    GETINTERFACE_ANY(plIntRefMsg, plRefMsg);
 
     int8_t        fType;
     int8_t        fIdx;
     int16_t       fWhich;
 
     // IO - not really applicable to ref msgs, but anyway
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plRefMsg::Read(stream, mgr);
         stream->ReadLE(&fType);
         stream->ReadLE(&fWhich);
         stream->ReadLE(&fIdx);
     }
 
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plRefMsg::Write(stream, mgr);
         stream->WriteLE(fType);
         stream->WriteLE(fWhich);

--- a/Sources/Plasma/NucleusLib/pnMessage/plMessage.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plMessage.h
@@ -81,8 +81,8 @@ public:
         kCCRSendToAllPlayers    = 0x10000,  // CCRs can send a plMessage to all online players.
         kNetCreatedRemotely     = 0x20000,  // kNetSent and kNetNonLocal are inherited by child messages sent off while processing a net-propped
                                             // parent. This flag ONLY gets sent on the actual message that went across the wire.
-                
     };
+
 private:
     bool dispatchBreak;
 
@@ -110,30 +110,30 @@ public:
                 const double* t);
 
     virtual ~plMessage();
-    
-    CLASSNAME_REGISTER( plMessage );
-    GETINTERFACE_ANY( plMessage, plCreatable );
+
+    CLASSNAME_REGISTER(plMessage);
+    GETINTERFACE_ANY(plMessage, plCreatable);
 
     // These must be implemented by all derived message classes (hence pure).
     // Derived classes should call the base-class default read/write implementation, 
     // so the derived Read() should call plMessage::IMsgRead().
-    virtual void Read(hsStream* stream, hsResMgr* mgr) = 0;
-    virtual void Write(hsStream* stream, hsResMgr* mgr) = 0;
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE = 0;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE = 0;
 
-    const plKey             GetSender() const { return fSender; }
-    plMessage&              SetSender(const plKey &s) { fSender = s; return *this; }
+    const plKey GetSender() const { return fSender; }
+    plMessage&  SetSender(const plKey &s) { fSender = s; return *this; }
 
-    plMessage&              SetNumReceivers(int n);
-    uint32_t                  GetNumReceivers() const ;
-    const plKey&            GetReceiver(int i) const;
-    plMessage&              RemoveReceiver(int i);
+    plMessage&   SetNumReceivers(int n);
+    uint32_t     GetNumReceivers() const ;
+    const plKey& GetReceiver(int i) const;
+    plMessage&   RemoveReceiver(int i);
 
-    plMessage&              ClearReceivers();
-    plMessage&              AddReceiver(const plKey &r);
-    plMessage&              AddReceivers(const hsTArray<plKey>& rList);
+    plMessage& ClearReceivers();
+    plMessage& AddReceiver(const plKey &r);
+    plMessage& AddReceivers(const hsTArray<plKey>& rList);
 
-    bool                    Send(const plKey r=nil, bool async=false); // Message will self-destruct after send.
-    bool                    SendAndKeep(const plKey r=nil, bool async=false); // Message won't self-destruct after send.
+    bool Send(const plKey r=nullptr, bool async=false); // Message will self-destruct after send.
+    bool SendAndKeep(const plKey r=nullptr, bool async=false); // Message won't self-destruct after send.
 
     double GetTimeStamp() const { return fTimeStamp; }
     plMessage& SetTimeStamp(double t) { fTimeStamp = t; return *this; }

--- a/Sources/Plasma/NucleusLib/pnMessage/plMessageWithCallbacks.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plMessageWithCallbacks.h
@@ -56,34 +56,34 @@ class hsResMgr;
 class plMessageWithCallbacks : public plMessage
 {
 private:
-    hsTArray<plMessage*>        fCallbacks; 
+    hsTArray<plMessage*>        fCallbacks;
 public:
     plMessageWithCallbacks() {}
     plMessageWithCallbacks(const plKey &s, const plKey &r, const double* t) : plMessage(s,r,t) {}
     ~plMessageWithCallbacks();
 
-    CLASSNAME_REGISTER( plMessageWithCallbacks );
-    GETINTERFACE_ANY( plMessageWithCallbacks, plMessage );
-    
+    CLASSNAME_REGISTER(plMessageWithCallbacks);
+    GETINTERFACE_ANY(plMessageWithCallbacks, plMessage);
+
     void Clear();
-    
+
     void                AddCallback(plMessage* e); // will RefCnt the message e.
     int                 GetNumCallbacks() const { return fCallbacks.GetCount(); }
     plMessage*          GetCallback(int i) const { return fCallbacks[i]; }
     plEventCallbackMsg* GetEventCallback(int i) const { return plEventCallbackMsg::ConvertNoRef(fCallbacks[i]); }
     void SendCallbacks();
-    
+
 #if 0
     // returns true if ok to send in a networked situations
-    static bool     NetOKToSend(plSynchedObject* sender, plEventCallbackMsg* cbmsg);    
+    static bool     NetOKToSend(plSynchedObject* sender, plEventCallbackMsg* cbmsg);
 #endif
 
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr);
-    void Write(hsStream* stream, hsResMgr* mgr);
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    void ReadVersion(hsStream* s, hsResMgr* mgr);
-    void WriteVersion(hsStream* s, hsResMgr* mgr);
+    void ReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void WriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 #endif  // plMessageWithCB_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plMultiModMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plMultiModMsg.h
@@ -61,27 +61,25 @@ public:
         : plMessage(s, r, t) {}
     ~plMultiModMsg() {}
 
-    CLASSNAME_REGISTER( plMultiModMsg );
-    GETINTERFACE_ANY( plMultiModMsg, plMessage );
+    CLASSNAME_REGISTER(plMultiModMsg);
+    GETINTERFACE_ANY(plMultiModMsg, plMessage);
 
     enum ModCmds
     {
     };
 
-    hsBitVector     fCmd;
+    hsBitVector fCmd;
 
     bool Cmd(int n) { return fCmd.IsBitSet(n); }
     void SetCmd(int n) { fCmd.SetBit(n); }
     void ClearCmd() { fCmd.Clear(); }
 
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr) 
-    {   
-        plMessage::IMsgRead(stream, mgr); 
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plMessage::IMsgRead(stream, mgr);
         fCmd.Read(stream);
     }
-    void Write(hsStream* stream, hsResMgr* mgr) 
-    {   
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         fCmd.Write(stream);
     }

--- a/Sources/Plasma/NucleusLib/pnMessage/plNodeChangeMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plNodeChangeMsg.h
@@ -55,14 +55,14 @@ public:
     plNodeChangeMsg(plKey s, plKey &r, plKey node, double* t=nil)
         :   plMessage(s, r, t), fNodeKey(node) {}
 
-    CLASSNAME_REGISTER( plNodeChangeMsg );
-    GETINTERFACE_ANY( plNodeChangeMsg, plMessage );
+    CLASSNAME_REGISTER(plNodeChangeMsg);
+    GETINTERFACE_ANY(plNodeChangeMsg, plMessage);
 
     plKey       GetNodeKey() const { return fNodeKey; }
     void        SetNodeKey(plKey &k) { fNodeKey = k; }
 
-    virtual void Read(hsStream* stream, hsResMgr* mgr);
-    virtual void Write(hsStream* stream, hsResMgr* mgr);
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 #endif //plNodeChangeMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plNodeRefMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plNodeRefMsg.h
@@ -62,8 +62,8 @@ public:
     plNodeRefMsg() {}
     plNodeRefMsg(const plKey &r, uint8_t flags, int8_t which, int8_t type) : plGenRefMsg(r, flags, which, type) {}
 
-    CLASSNAME_REGISTER( plNodeRefMsg );
-    GETINTERFACE_ANY( plNodeRefMsg, plGenRefMsg );
+    CLASSNAME_REGISTER(plNodeRefMsg);
+    GETINTERFACE_ANY(plNodeRefMsg, plGenRefMsg);
 };
 
 #endif // plNodeRefMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plNotifyMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plNotifyMsg.h
@@ -125,7 +125,15 @@ protected:
 };
 
 // The following macro makes it easy (or easier) to define new event data types
-#define proEventType(type) class pro##type##EventData : public proEventData { public: pro##type##EventData() : proEventData( k##type ) {IInit();} virtual ~pro##type##EventData(){IDestruct();}
+#define proEventType(type)                                                  \
+    class pro##type##EventData : public proEventData {                      \
+    public:                                                                 \
+        pro##type##EventData() : proEventData(k##type) {                    \
+            IInit();                                                        \
+        }                                                                   \
+        virtual ~pro##type##EventData() {                                   \
+            IDestruct();                                                    \
+        }
 
 proEventType(Collision)
     bool    fEnter;     // entering? (false is exit)
@@ -133,11 +141,11 @@ proEventType(Collision)
     plKey   fHittee;    // collision hittee (probably us)
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(Picked)
@@ -147,11 +155,11 @@ proEventType(Picked)
     hsPoint3 fHitPoint; // where on the picked object that it was picked on
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(Spawned)
@@ -159,11 +167,11 @@ proEventType(Spawned)
     plKey   fSpawnee;   // what was spawned (typically a scene object with an armature mod)
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(ControlKey)
@@ -171,11 +179,11 @@ proEventType(ControlKey)
     bool    fDown;          // was the key going down (false if going up)
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(Variable)
@@ -191,13 +199,13 @@ proEventType(Variable)
     } fNumber;
 
 protected:
-    virtual void IInit();
-    virtual void IDestruct();
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IInit() HS_OVERRIDE;
+    void IDestruct() HS_OVERRIDE;
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 
     virtual void IReadNumber(hsStream * stream);
     virtual void IWriteNumber(hsStream * stream);
@@ -210,11 +218,11 @@ proEventType(Facing)
     bool        enabled; // Now meets facing requirement (true) or no longer meets requirement (false)
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(Contained)
@@ -223,11 +231,11 @@ proEventType(Contained)
     bool    fEntering;  // entering volume (true) or exiting (false)
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(Activate)
@@ -235,57 +243,57 @@ proEventType(Activate)
     bool fActivate;   // the data
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
-};      
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+};
 
 proEventType(Callback)
     int32_t   fEventType;  // enumerated in plEventCallbackMsg.h
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(ResponderState)
     int32_t   fState;     // what state the responder should be switched to before triggering
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(MultiStage)
-    int32_t   fStage; 
+    int32_t   fStage;
     int32_t   fEvent;
     plKey   fAvatar;    // who was running the stage
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(Coop)
     uint32_t  fID;        // player ID of the initiator
     uint16_t  fSerial;    // serial number for the initiator
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 
@@ -300,33 +308,33 @@ proEventType(OfferLinkingBook)
     int targetAge; // the age the book is for - taken from konstant list of age buttons in xLinkingBookPopupGUI.py
     int offeree; // who we are offering the book to
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(Book)
     uint32_t  fEvent;     // The type of event. See pfJournalBook.h for enumsu
     uint32_t  fLinkID;    // The link ID of the image clicked, if an image link event, otherwise unused
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 proEventType(ClimbingBlockerHit)
     plKey   fBlockerKey;    // collision hittee (probably us)
 
 protected:
-    virtual void IRead(hsStream* stream, hsResMgr* mgr);
-    virtual void IWrite(hsStream* stream, hsResMgr* mgr);
+    void IRead(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void IWrite(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    virtual void IReadVersion(hsStream* s, hsResMgr* mgr);
-    virtual void IWriteVersion(hsStream* s, hsResMgr* mgr);
+    void IReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void IWriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 
@@ -346,11 +354,11 @@ protected:
 
 public:
     plNotifyMsg() { IInit(); }
-    plNotifyMsg(const plKey &s, const plKey &r);
+    plNotifyMsg(const plKey& s, const plKey& r);
     ~plNotifyMsg();
 
-    CLASSNAME_REGISTER( plNotifyMsg );
-    GETINTERFACE_ANY( plNotifyMsg, plMessage );
+    CLASSNAME_REGISTER(plNotifyMsg);
+    GETINTERFACE_ANY(plNotifyMsg, plMessage);
 
     // data area
     enum notificationType
@@ -402,12 +410,12 @@ public:
     // Searches the event records for an event triggered by an avatar, and returns that key
     plKey GetAvatarKey();
 
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr);
-    void Write(hsStream* stream, hsResMgr* mgr);
-    
-    void ReadVersion(hsStream* s, hsResMgr* mgr);
-    void WriteVersion(hsStream* s, hsResMgr* mgr);
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+
+    void ReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void WriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plObjRefMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plObjRefMsg.h
@@ -51,7 +51,6 @@ class hsResMgr;
 
 class plObjRefMsg : public plRefMsg
 {
-
 public:
     enum {
         kModifier       = 0,
@@ -60,26 +59,23 @@ public:
 
     plObjRefMsg(): fType(-1), fWhich(-1) {};
 
-    plObjRefMsg(const plKey &r, uint8_t refMsgFlags, int8_t which , int8_t type)
+    plObjRefMsg(const plKey& r, uint8_t refMsgFlags, int8_t which, int8_t type)
         : plRefMsg(r, refMsgFlags), fType(type), fWhich(which) {}
 
+    CLASSNAME_REGISTER(plObjRefMsg);
+    GETINTERFACE_ANY(plObjRefMsg, plRefMsg);
 
-    CLASSNAME_REGISTER( plObjRefMsg );
-    GETINTERFACE_ANY( plObjRefMsg, plRefMsg );
-
-    int8_t                    fType;
-    int8_t                    fWhich;
+    int8_t fType;
+    int8_t fWhich;
 
     // IO - not really applicable to ref msgs, but anyway
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plRefMsg::Read(stream, mgr);
         stream->ReadLE(&fType);
         stream->ReadLE(&fWhich);
     }
 
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plRefMsg::Write(stream, mgr);
         stream->WriteLE(fType);
         stream->WriteLE(fWhich);

--- a/Sources/Plasma/NucleusLib/pnMessage/plPipeResMakeMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plPipeResMakeMsg.h
@@ -57,14 +57,18 @@ public:
     plPipeResMakeMsg(plPipeline* pipe) : plMessage(nil, nil, nil), fPipe(pipe) { SetBCastFlag(kBCastByExactType); }
 
     ~plPipeResMakeMsg() {}
-    
-    CLASSNAME_REGISTER( plPipeResMakeMsg );
-    GETINTERFACE_ANY( plPipeResMakeMsg, plMessage );
+
+    CLASSNAME_REGISTER(plPipeResMakeMsg);
+    GETINTERFACE_ANY(plPipeResMakeMsg, plMessage);
 
     plPipeline* Pipeline() const { return fPipe; }
 
-    virtual void Read(hsStream* s, hsResMgr* mgr) { plMessage::IMsgRead(s, mgr); }
-    virtual void Write(hsStream* s, hsResMgr* mgr) { plMessage::IMsgWrite(s, mgr); }
+    void Read(hsStream* s, hsResMgr* mgr) HS_OVERRIDE {
+        plMessage::IMsgRead(s, mgr);
+    }
+    void Write(hsStream* s, hsResMgr* mgr) HS_OVERRIDE {
+        plMessage::IMsgWrite(s, mgr);
+    }
 };
 
 class plPipeRTMakeMsg : public plPipeResMakeMsg
@@ -74,9 +78,9 @@ public:
     plPipeRTMakeMsg(plPipeline* pipe) : plPipeResMakeMsg(pipe) { }
 
     ~plPipeRTMakeMsg() {}
-    
-    CLASSNAME_REGISTER( plPipeRTMakeMsg );
-    GETINTERFACE_ANY( plPipeRTMakeMsg, plPipeResMakeMsg );
+
+    CLASSNAME_REGISTER(plPipeRTMakeMsg);
+    GETINTERFACE_ANY(plPipeRTMakeMsg, plPipeResMakeMsg);
 };
 
 class plPipeGeoMakeMsg : public plPipeResMakeMsg
@@ -86,11 +90,11 @@ public:
     plPipeGeoMakeMsg(plPipeline* pipe, bool def) : plPipeResMakeMsg(pipe), fDefault(def) { }
 
     ~plPipeGeoMakeMsg() {}
-    
-    CLASSNAME_REGISTER( plPipeGeoMakeMsg );
-    GETINTERFACE_ANY( plPipeGeoMakeMsg, plPipeResMakeMsg );
 
-    bool            fDefault;
+    CLASSNAME_REGISTER(plPipeGeoMakeMsg);
+    GETINTERFACE_ANY(plPipeGeoMakeMsg, plPipeResMakeMsg);
+
+    bool fDefault;
 };
 
 class plPipeTexMakeMsg : public plPipeResMakeMsg
@@ -100,9 +104,9 @@ public:
     plPipeTexMakeMsg(plPipeline* pipe) : plPipeResMakeMsg(pipe) { }
 
     ~plPipeTexMakeMsg() {}
-    
-    CLASSNAME_REGISTER( plPipeTexMakeMsg );
-    GETINTERFACE_ANY( plPipeTexMakeMsg, plPipeResMakeMsg );
+
+    CLASSNAME_REGISTER(plPipeTexMakeMsg);
+    GETINTERFACE_ANY(plPipeTexMakeMsg, plPipeResMakeMsg);
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plPlayerPageMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plPlayerPageMsg.h
@@ -59,8 +59,8 @@ public:
                     const plKey &r, 
                     const double* t) : fPlayer(nil),fLocallyOriginated(false),fUnload(false),fLastOut(false),fClientID(-1){;}
     
-    CLASSNAME_REGISTER( plPlayerPageMsg );
-    GETINTERFACE_ANY( plPlayerPageMsg, plMessage );
+    CLASSNAME_REGISTER(plPlayerPageMsg);
+    GETINTERFACE_ANY(plPlayerPageMsg, plMessage);
 
 
     plKey           fPlayer;
@@ -70,8 +70,7 @@ public:
     bool            fLastOut;
 
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgRead(stream, mgr);
         fPlayer = mgr->ReadKey(stream);
         fLocallyOriginated = stream->ReadBool();
@@ -79,8 +78,7 @@ public:
         fUnload = stream->ReadBool();
         fClientID = stream->ReadLE32();
     }
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         mgr->WriteKey(stream, fPlayer);
         stream->WriteBool(fLocallyOriginated);

--- a/Sources/Plasma/NucleusLib/pnMessage/plProxyDrawMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plProxyDrawMsg.h
@@ -64,8 +64,8 @@ public:
     plProxyDrawMsg(plKey &rcv, uint16_t flags); // send yourself an ack
     ~plProxyDrawMsg();
 
-    CLASSNAME_REGISTER( plProxyDrawMsg );
-    GETINTERFACE_ANY( plProxyDrawMsg, plMessage );
+    CLASSNAME_REGISTER(plProxyDrawMsg);
+    GETINTERFACE_ANY(plProxyDrawMsg, plMessage);
 
     enum {
         kCreate         = 0x1,
@@ -80,8 +80,8 @@ public:
         kCoordinate     = 0x100,
         kCamera         = 0x200,
 
-        kAllTypes       = kLight 
-                        | kPhysical 
+        kAllTypes       = kLight
+                        | kPhysical
                         | kOccluder
                         | kAudible
                         | kCoordinate
@@ -91,8 +91,8 @@ public:
     uint16_t  GetProxyFlags() const { return fProxyFlags; }
     void    SetProxyFlags(uint16_t f) { fProxyFlags = f; }
 
-    virtual void Read(hsStream* stream, hsResMgr* mgr);
-    virtual void Write(hsStream* stream, hsResMgr* mgr);
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 #endif // plProxyDrawMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plRefMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plRefMsg.h
@@ -70,8 +70,8 @@ public:
 
     virtual ~plRefMsg();
 
-    CLASSNAME_REGISTER( plRefMsg );
-    GETINTERFACE_ANY( plRefMsg, plMessage );
+    CLASSNAME_REGISTER(plRefMsg);
+    GETINTERFACE_ANY(plRefMsg, plMessage);
 
     plRefMsg&       SetRef(hsKeyedObject* ref);
     hsKeyedObject*  GetRef() { return fRef; }
@@ -79,11 +79,11 @@ public:
     plRefMsg&       SetOldRef(hsKeyedObject* oldRef);
     hsKeyedObject*  GetOldRef() { return fOldRef; }
 
-    plRefMsg&   SetContext(uint8_t c) { fContext = c; return *this; }
-    uint8_t       GetContext() { return fContext; }
+    plRefMsg& SetContext(uint8_t c) { fContext = c; return *this; }
+    uint8_t   GetContext() { return fContext; }
 
-    void Read(hsStream* stream, hsResMgr* mgr);
-    void Write(hsStream* stream, hsResMgr* mgr);
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 
@@ -102,8 +102,8 @@ public:
     int8_t    fType;
     int32_t   fWhich;
 
-    void Read(hsStream* stream, hsResMgr* mgr);
-    void Write(hsStream* stream, hsResMgr* mgr);
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 #endif // plRefMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plRemoteAvatarInfoMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plRemoteAvatarInfoMsg.h
@@ -62,22 +62,19 @@ public:
     plRemoteAvatarInfoMsg(const plKey &s, 
                     const plKey &r, 
                     const double* t) : fAvatar(nil){SetBCastFlag(plMessage::kBCastByExactType);}
-    
-    CLASSNAME_REGISTER( plRemoteAvatarInfoMsg );
-    GETINTERFACE_ANY( plRemoteAvatarInfoMsg, plMessage );
-    
+
+    CLASSNAME_REGISTER(plRemoteAvatarInfoMsg);
+    GETINTERFACE_ANY(plRemoteAvatarInfoMsg, plMessage);
+
     void SetAvatarKey(plKey p) { fAvatar = p; }
     plKey GetAvatarKey() { return fAvatar; }
-        
+
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgRead(stream, mgr);
         fAvatar = mgr->ReadKey(stream);
     }
-
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         mgr->WriteKey(stream, fAvatar);
     }

--- a/Sources/Plasma/NucleusLib/pnMessage/plSDLModifierMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSDLModifierMsg.h
@@ -74,8 +74,8 @@ public:
     plSDLModifierMsg(const plString& sdlName="", Action a=kActionNone);
     ~plSDLModifierMsg();
 
-    CLASSNAME_REGISTER( plSDLModifierMsg );
-    GETINTERFACE_ANY( plSDLModifierMsg, plMessage );
+    CLASSNAME_REGISTER(plSDLModifierMsg);
+    GETINTERFACE_ANY(plSDLModifierMsg, plMessage);
 
     uint32_t GetFlags() const { return fFlags; }
     void SetFlags(uint32_t f) { fFlags = f; }
@@ -88,13 +88,17 @@ public:
 
     plString GetSDLName() const { return fSDLName; }
     void SetSDLName(const plString& s) { fSDLName=s; }
-        
+
     uint32_t GetPlayerID() const { return fPlayerID;  }
     void SetPlayerID(uint32_t p) { fPlayerID=p;   }
-    
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr) { hsAssert(false, "local only msg"); }
-    void Write(hsStream* stream, hsResMgr* mgr) { hsAssert(false, "local only msg"); }
+
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        hsAssert(false, "local only msg");
+    }
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        hsAssert(false, "local only msg");
+    }
 };
 
 #endif  // plSDLModifierMsg_INC

--- a/Sources/Plasma/NucleusLib/pnMessage/plSDLNotificationMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSDLNotificationMsg.h
@@ -53,16 +53,20 @@ public:
     plString fSDLName;          // name of state descriptor
     int fPlayerID;              // pid of the player who changed the data
     plString fHintString;       // hint from the player who changed the data
-    
+
     plSDLNotificationMsg() : fDelta(0), fVar(nil), fPlayerID(0) {}
     ~plSDLNotificationMsg() { }
 
-    CLASSNAME_REGISTER( plSDLNotificationMsg );
-    GETINTERFACE_ANY( plSDLNotificationMsg, plMessage );
+    CLASSNAME_REGISTER(plSDLNotificationMsg);
+    GETINTERFACE_ANY(plSDLNotificationMsg, plMessage);
 
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr) { hsAssert(false, "NA: LocalOnly msg");  }
-    void Write(hsStream* stream, hsResMgr* mgr) { hsAssert(false, "NA: LocalOnly msg"); }
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        hsAssert(false, "NA: LocalOnly msg");
+    }
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        hsAssert(false, "NA: LocalOnly msg");
+    }
 };
 
 #endif  // plSDLNotificationMsg_in

--- a/Sources/Plasma/NucleusLib/pnMessage/plSatisfiedMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSatisfiedMsg.h
@@ -49,13 +49,17 @@ class plSatisfiedMsg : public plMessage
 {
 public:
     plSatisfiedMsg() {}
-    plSatisfiedMsg(const plKey &s) : plMessage(s, s, nil) {}
+    plSatisfiedMsg(const plKey &s) : plMessage(s, s, nullptr) {}
 
-    CLASSNAME_REGISTER( plSatisfiedMsg );
-    GETINTERFACE_ANY( plSatisfiedMsg, plMessage );
+    CLASSNAME_REGISTER(plSatisfiedMsg);
+    GETINTERFACE_ANY(plSatisfiedMsg, plMessage);
 
-    virtual void Read(hsStream* stream, hsResMgr* mgr) { IMsgRead(stream, mgr); }
-    virtual void Write(hsStream* stream, hsResMgr* mgr) { IMsgWrite(stream, mgr); }
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        IMsgRead(stream, mgr);
+    }
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        IMsgWrite(stream, mgr);
+    }
 
 };
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plSelfDestructMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSelfDestructMsg.h
@@ -48,19 +48,22 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plSelfDestructMsg : public plMessage
 {
 protected:
-    plSelfDestructMsg(plKey &victim) : plMessage(victim, victim, nil) {}
+    plSelfDestructMsg(plKey& victim) : plMessage(victim, victim, nullptr) {}
 
     friend class plKeyImp;
-public:
 
+public:
     plSelfDestructMsg() { hsAssert(false, "For system use only"); }
 
-    CLASSNAME_REGISTER( plSelfDestructMsg );
-    GETINTERFACE_ANY( plSelfDestructMsg, plMessage );
+    CLASSNAME_REGISTER(plSelfDestructMsg);
+    GETINTERFACE_ANY(plSelfDestructMsg, plMessage);
 
-    virtual void Read(hsStream* stream, hsResMgr* mgr) { IMsgRead(stream, mgr); }
-    virtual void Write(hsStream* stream, hsResMgr* mgr) { IMsgWrite(stream, mgr); }
-    
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        IMsgRead(stream, mgr);
+    }
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        IMsgWrite(stream, mgr);
+    }
 };
 
 #endif // plSelfDestructMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plServerReplyMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plServerReplyMsg.h
@@ -72,15 +72,15 @@ public:
     plServerReplyMsg() : fType(kUnInit) { }
     plServerReplyMsg(const plKey &s, const plKey &r, const double* t) : plMessage(s,r,t), fType(kUnInit) { }
 
-    CLASSNAME_REGISTER( plServerReplyMsg );
-    GETINTERFACE_ANY( plServerReplyMsg, plMessage );
+    CLASSNAME_REGISTER(plServerReplyMsg);
+    GETINTERFACE_ANY(plServerReplyMsg, plMessage);
 
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr);
-    void Write(hsStream* stream, hsResMgr* mgr);
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
-    void ReadVersion(hsStream* s, hsResMgr* mgr);
-    void WriteVersion(hsStream* s, hsResMgr* mgr);
+    void ReadVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void WriteVersion(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 #endif // plServerReplyMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plSetNetGroupIDMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSetNetGroupIDMsg.h
@@ -54,8 +54,14 @@ public:
 
     plNetGroupId fId;
 
-    void Read(hsStream* stream, hsResMgr* mgr)  { plMessage::IMsgRead(stream, mgr);  fId.Read(stream); }
-    void Write(hsStream* stream, hsResMgr* mgr) { plMessage::IMsgWrite(stream, mgr); fId.Write(stream); }
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plMessage::IMsgRead(stream, mgr);
+        fId.Read(stream);
+    }
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plMessage::IMsgWrite(stream, mgr);
+        fId.Write(stream);
+    }
 };
 
 #endif // plSetNetGroupIDMsg_h_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plSharedStateMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSharedStateMsg.h
@@ -59,15 +59,21 @@ public:
     plSharedStateMsg() {}
     plSharedStateMsg(const plKey &s, const plKey &r, const double* t) : plMessage(s,r,t) {}
 
-    CLASSNAME_REGISTER( plSharedStateMsg );
-    GETINTERFACE_ANY( plSharedStateMsg, plMessage );
+    CLASSNAME_REGISTER(plSharedStateMsg);
+    GETINTERFACE_ANY(plSharedStateMsg, plMessage);
 
     void CopySharedState(plNetSharedState* ss) { fSharedState.Copy(ss); }
     plNetSharedState* GetSharedState() { return &fSharedState; }
 
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr)  { plMessage::IMsgRead(stream, mgr); fSharedState.Write(stream); }
-    void Write(hsStream* stream, hsResMgr* mgr) { plMessage::IMsgWrite(stream, mgr); fSharedState.Read(stream); }
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plMessage::IMsgRead(stream, mgr);
+        fSharedState.Write(stream);
+    }
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plMessage::IMsgWrite(stream, mgr);
+        fSharedState.Read(stream);
+    }
 };
 
 #endif // plSharedStateMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plSimulationMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSimulationMsg.h
@@ -57,11 +57,11 @@ public:
     plSimulationMsg() : plMessage() {};
     plSimulationMsg(const plKey &sender, const plKey &receiver, const double *time) : plMessage(sender, receiver, time) {};
 
-CLASSNAME_REGISTER( plSimulationMsg );
-    GETINTERFACE_ANY( plSimulationMsg, plMessage );
+    CLASSNAME_REGISTER(plSimulationMsg);
+    GETINTERFACE_ANY(plSimulationMsg, plMessage);
 
-    virtual void Read(hsStream *stream, hsResMgr *mgr);
-    virtual void Write(hsStream *stream, hsResMgr *mgr);
+    void Read(hsStream *stream, hsResMgr *mgr) HS_OVERRIDE;
+    void Write(hsStream *stream, hsResMgr *mgr) HS_OVERRIDE;
 };
 
 #endif // PLSIMULATIONMSG_H

--- a/Sources/Plasma/NucleusLib/pnMessage/plSimulationSynchMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSimulationSynchMsg.h
@@ -55,13 +55,13 @@ public:
     // ???
     // This message is not really creatable: it's abstract. It's designed to sneak
     // havok-specific data through the generalized simulation logic
-    CLASSNAME_REGISTER( plSimulationSynchMsg );
-    GETINTERFACE_ANY( plSimulationSynchMsg, plMessage );
+    CLASSNAME_REGISTER(plSimulationSynchMsg);
+    GETINTERFACE_ANY(plSimulationSynchMsg, plMessage);
 
     // Don't be fooled: this class is *not* to be instantiated.
 
-    void Read(hsStream *stream, hsResMgr *mgr);
-    void Write(hsStream *stream, hsResMgr *mgr);
+    void Read(hsStream *stream, hsResMgr *mgr) HS_OVERRIDE;
+    void Write(hsStream *stream, hsResMgr *mgr) HS_OVERRIDE;
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plSingleModMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSingleModMsg.h
@@ -61,27 +61,25 @@ public:
         : plMessage(s, r, t) {}
     ~plSingleModMsg() {}
 
-    CLASSNAME_REGISTER( plSingleModMsg );
-    GETINTERFACE_ANY( plSingleModMsg, plMessage );
+    CLASSNAME_REGISTER(plSingleModMsg);
+    GETINTERFACE_ANY(plSingleModMsg, plMessage);
 
     enum ModCmds
     {
     };
 
-    hsBitVector     fCmd;
+    hsBitVector fCmd;
 
     bool Cmd(int n) { return fCmd.IsBitSet(n); }
     void SetCmd(int n) { fCmd.SetBit(n); }
     void ClearCmd() { fCmd.Clear(); }
 
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr) 
-    {   
-        plMessage::IMsgRead(stream, mgr); 
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plMessage::IMsgRead(stream, mgr);
         fCmd.Read(stream);
     }
-    void Write(hsStream* stream, hsResMgr* mgr) 
-    {   
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         fCmd.Write(stream);
     }

--- a/Sources/Plasma/NucleusLib/pnMessage/plSoundMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSoundMsg.cpp
@@ -50,10 +50,10 @@ plSoundMsg::~plSoundMsg()
 }
 
 
-void plSoundMsg::ClearCmd() 
-{ 
+void plSoundMsg::ClearCmd()
+{
     plMessageWithCallbacks::Clear();
-    fCmd.Clear(); 
+    fCmd.Clear();
 }
 
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plSoundMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSoundMsg.h
@@ -49,18 +49,31 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plSoundMsg : public plMessageWithCallbacks
 {
 private:
-    void IInit() { fLoop=false; fPlaying = false; fBegin=fEnd=fTime=fRepeats=0; fSpeed = 0.f; fVolume = 0.f; fIndex = -1; fNameStr = 0; fFadeType = kLinear; }
+    void IInit() {
+        fLoop = false;
+        fPlaying = false;
+        fBegin = fEnd = fTime = fRepeats = 0;
+        fSpeed = 0.f;
+        fVolume = 0.f;
+        fIndex = -1;
+        fNameStr = 0;
+        fFadeType = kLinear;
+    }
 public:
-    plSoundMsg()
-        : plMessageWithCallbacks(nil, nil, nil) { IInit(); }
-    plSoundMsg(const plKey &s, 
-                const plKey &r, 
-                const double* t)
-        : plMessageWithCallbacks(s, r, t) { IInit(); }
+    plSoundMsg() : plMessageWithCallbacks(nullptr, nullptr, nullptr) {
+        IInit();
+    }
+
+    plSoundMsg(const plKey& s, const plKey& r, const double* t)
+        : plMessageWithCallbacks(s, r, t)
+    {
+        IInit();
+    }
+
     ~plSoundMsg();
 
-    CLASSNAME_REGISTER( plSoundMsg );
-    GETINTERFACE_ANY( plSoundMsg, plMessageWithCallbacks );
+    CLASSNAME_REGISTER(plSoundMsg);
+    GETINTERFACE_ANY(plSoundMsg, plMessageWithCallbacks);
 
     enum ModCmds
     {
@@ -89,22 +102,22 @@ public:
         kSynchedPlay,
     };
 
-    hsBitVector     fCmd;
+    hsBitVector fCmd;
 
     bool Cmd(int n) const { return fCmd.IsBitSet(n); }
     void SetCmd(int n) { fCmd.SetBit(n); }
     void ClearCmd();
 
-    double   fBegin;
-    double   fEnd;
-    bool     fLoop;
-    float fSpeed;
-    double   fTime;
-    int      fIndex;
-    int      fRepeats;
-    bool     fPlaying;
-    uint32_t   fNameStr;  
-    float fVolume;   // Range: 0 - silence, 1.f - loudest
+    double      fBegin;
+    double      fEnd;
+    bool        fLoop;
+    float       fSpeed;
+    double      fTime;
+    int         fIndex;
+    int         fRepeats;
+    bool        fPlaying;
+    uint32_t    fNameStr;
+    float       fVolume;   // Range: 0 - silence, 1.f - loudest
 
     enum FadeType
     {
@@ -114,8 +127,8 @@ public:
     } fFadeType;
 
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr);
-    void Write(hsStream* stream, hsResMgr* mgr);
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plTimeMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plTimeMsg.h
@@ -59,8 +59,8 @@ public:
                     const double* t, const float* del);
     ~plTimeMsg();
 
-    CLASSNAME_REGISTER( plTimeMsg );
-    GETINTERFACE_ANY( plTimeMsg, plMessage );
+    CLASSNAME_REGISTER(plTimeMsg);
+    GETINTERFACE_ANY(plTimeMsg, plMessage);
 
     plTimeMsg& SetSeconds(double s) { fSeconds = s; return *this; }
     plTimeMsg& SetDelSeconds(float d) { fDelSecs = d; return *this; }
@@ -69,15 +69,13 @@ public:
     float        DelSeconds() { return fDelSecs; }
 
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgRead(stream, mgr);
         stream->ReadLE(&fSeconds);
         stream->ReadLE(&fDelSecs);
     }
 
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         stream->WriteLE(fSeconds);
         stream->WriteLE(fDelSecs);
@@ -93,12 +91,17 @@ public:
                     const double* t, const float* del);
     ~plEvalMsg();
 
-    CLASSNAME_REGISTER( plEvalMsg );
-    GETINTERFACE_ANY( plEvalMsg, plTimeMsg );
+    CLASSNAME_REGISTER(plEvalMsg);
+    GETINTERFACE_ANY(plEvalMsg, plTimeMsg);
 
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr)  {   plTimeMsg::Read(stream, mgr);   }
-    void Write(hsStream* stream, hsResMgr* mgr) {   plTimeMsg::Write(stream, mgr);  }
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plTimeMsg::Read(stream, mgr);
+    }
+
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plTimeMsg::Write(stream, mgr);
+    }
 };
 
 class plTransformMsg : public plTimeMsg
@@ -110,12 +113,16 @@ public:
                     const double* t, const float* del);
     ~plTransformMsg();
 
-    CLASSNAME_REGISTER( plTransformMsg );
-    GETINTERFACE_ANY( plTransformMsg, plTimeMsg );
+    CLASSNAME_REGISTER(plTransformMsg);
+    GETINTERFACE_ANY(plTransformMsg, plTimeMsg);
 
     // IO
-    void Read(hsStream* stream, hsResMgr* mgr)  {   plTimeMsg::Read(stream, mgr);   }
-    void Write(hsStream* stream, hsResMgr* mgr) {   plTimeMsg::Write(stream, mgr);  }
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plTimeMsg::Read(stream, mgr);
+    }
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
+        plTimeMsg::Write(stream, mgr);
+    }
 };
 
 // Does the same thing as plTransformMsg, but as you might guess from the name, it's sent later.
@@ -126,9 +133,9 @@ class plDelayedTransformMsg : public plTransformMsg
 public:
     plDelayedTransformMsg() : plTransformMsg() {}
     plDelayedTransformMsg(const plKey &s, const plKey &r, const double* t, const float* del) : plTransformMsg(s, r, t, del) {}
-    
-    CLASSNAME_REGISTER( plDelayedTransformMsg );
-    GETINTERFACE_ANY( plDelayedTransformMsg, plTransformMsg );
+
+    CLASSNAME_REGISTER(plDelayedTransformMsg);
+    GETINTERFACE_ANY(plDelayedTransformMsg, plTransformMsg);
 };
 
 #endif // plTimeMsg_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/plWarpMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plWarpMsg.h
@@ -50,8 +50,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plWarpMsg : public plMessage
 {
 private:
-    uint32_t  fWarpFlags;
+    uint32_t fWarpFlags;
     hsMatrix44 fTransform;
+
 public:
     enum WarpFlags
     {
@@ -59,38 +60,42 @@ public:
         kZeroVelocity   = 0x2
     };
 
-    plWarpMsg() { Clear(); }
-    plWarpMsg(const hsMatrix44& mat ){ Clear(); fTransform = mat; }
-    plWarpMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t) { Clear(); }
-    plWarpMsg(const plKey &s, const plKey &r, uint32_t flags, const hsMatrix44 &mat)
-        : fWarpFlags(flags), fTransform(mat), plMessage(s, r, nil)
-    {  };
-    
-    ~plWarpMsg(){}
+    plWarpMsg() {
+        Clear();
+    }
 
-    CLASSNAME_REGISTER( plWarpMsg );
-    GETINTERFACE_ANY( plWarpMsg, plMessage );
+    plWarpMsg(const hsMatrix44& mat) {
+        Clear();
+        fTransform = mat;
+    }
 
-    void Clear() { fWarpFlags=0; }
+    plWarpMsg(const plKey& s, const plKey& r, const double* t) {
+        Clear();
+    }
+
+    plWarpMsg(const plKey& s, const plKey& r, uint32_t flags, const hsMatrix44& mat)
+        : fWarpFlags(flags), fTransform(mat), plMessage(s, r, nullptr) { };
+
+    ~plWarpMsg() {}
+
+    CLASSNAME_REGISTER(plWarpMsg);
+    GETINTERFACE_ANY(plWarpMsg, plMessage);
+
+    void Clear() { fWarpFlags = 0; }
 
     uint32_t GetWarpFlags() { return fWarpFlags; }
-    void SetWarpFlags(uint32_t f) { fWarpFlags=f; }
+    void SetWarpFlags(uint32_t f) { fWarpFlags = f; }
 
-    void SetTransform(const hsMatrix44& mat) { fTransform=mat;  }
     hsMatrix44& GetTransform() { return fTransform; }
+    void SetTransform(const hsMatrix44& mat) { fTransform = mat; }
 
-    // IO 
-    void Read(hsStream* stream, hsResMgr* mgr)
-    {
+    // IO
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgRead(stream, mgr);
         fTransform.Read(stream);
         stream->ReadLE(&fWarpFlags);
     }
-
-    void Write(hsStream* stream, hsResMgr* mgr)
-    {
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE {
         plMessage::IMsgWrite(stream, mgr);
         fTransform.Write(stream);
         stream->WriteLE(fWarpFlags);

--- a/Sources/Plasma/NucleusLib/pnMessage/pnMessageCreatable.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/pnMessageCreatable.h
@@ -46,143 +46,128 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnFactory/plCreator.h"
 
 #include "plMessage.h"
-
-REGISTER_NONCREATABLE( plMessage );
+REGISTER_NONCREATABLE(plMessage);
 
 #include "plRefMsg.h"
-
-REGISTER_CREATABLE( plRefMsg );
-REGISTER_CREATABLE( plGenRefMsg );
+REGISTER_CREATABLE(plRefMsg);
+REGISTER_CREATABLE(plGenRefMsg);
 
 #include "plObjRefMsg.h"
-
-REGISTER_CREATABLE( plObjRefMsg );
+REGISTER_CREATABLE(plObjRefMsg);
 
 #include "plIntRefMsg.h"
-
-REGISTER_CREATABLE( plIntRefMsg );
+REGISTER_CREATABLE(plIntRefMsg);
 
 #include "plNodeRefMsg.h"
+REGISTER_CREATABLE(plNodeRefMsg);
 
-REGISTER_CREATABLE( plNodeRefMsg );
-
+// Probably UNUSED
 #include "plSatisfiedMsg.h"
+REGISTER_CREATABLE(plSatisfiedMsg);
 
-REGISTER_CREATABLE( plSatisfiedMsg );
-
+// UNUSED
 #include "plSingleModMsg.h"
+REGISTER_CREATABLE(plSingleModMsg);
 
-REGISTER_CREATABLE( plSingleModMsg );
-
+// UNUSED
 #include "plMultiModMsg.h"
-
-REGISTER_CREATABLE( plMultiModMsg );
+REGISTER_CREATABLE(plMultiModMsg);
 
 #include "plTimeMsg.h"
-
-REGISTER_CREATABLE( plTimeMsg );
-REGISTER_CREATABLE( plEvalMsg );
-REGISTER_CREATABLE( plTransformMsg );
-REGISTER_CREATABLE( plDelayedTransformMsg );
+REGISTER_CREATABLE(plTimeMsg);
+REGISTER_CREATABLE(plEvalMsg);
+REGISTER_CREATABLE(plTransformMsg);
+REGISTER_CREATABLE(plDelayedTransformMsg);
 
 #include "plWarpMsg.h"
-
-REGISTER_CREATABLE( plWarpMsg );
+REGISTER_CREATABLE(plWarpMsg);
 
 #include "plAttachMsg.h"
-
-REGISTER_CREATABLE( plAttachMsg );
+REGISTER_CREATABLE(plAttachMsg);
 
 #include "plCorrectionMsg.h"
-
-REGISTER_CREATABLE( plCorrectionMsg );
+REGISTER_CREATABLE(plCorrectionMsg);
 
 #include "plSoundMsg.h"
-
-REGISTER_CREATABLE( plSoundMsg );
+REGISTER_CREATABLE(plSoundMsg);
 
 #include "plAudioSysMsg.h"
-
-REGISTER_CREATABLE( plAudioSysMsg );
+REGISTER_CREATABLE(plAudioSysMsg);
 
 #include "plEnableMsg.h"
-
-REGISTER_CREATABLE( plEnableMsg );
+REGISTER_CREATABLE(plEnableMsg);
 
 #include "plServerReplyMsg.h"
-
-REGISTER_CREATABLE( plServerReplyMsg );
+REGISTER_CREATABLE(plServerReplyMsg);
 
 #include "plSharedStateMsg.h"
-REGISTER_CREATABLE( plSharedStateMsg );
+REGISTER_CREATABLE(plSharedStateMsg);
 
+// -> PubUtilLib
 #include "plClientMsg.h"
-REGISTER_CREATABLE( plClientMsg );
-REGISTER_CREATABLE( plClientRefMsg );
+REGISTER_CREATABLE(plClientMsg);
+REGISTER_CREATABLE(plClientRefMsg);
 
 #include "plSimulationMsg.h"
+REGISTER_NONCREATABLE(plSimulationMsg);
 
-REGISTER_NONCREATABLE( plSimulationMsg );
-
+// UNUSED
 #include "plSimulationSynchMsg.h"
-
-REGISTER_NONCREATABLE( plSimulationSynchMsg );
+REGISTER_NONCREATABLE(plSimulationSynchMsg);
 
 #include "plProxyDrawMsg.h"
-
-REGISTER_CREATABLE( plProxyDrawMsg );
+REGISTER_CREATABLE(plProxyDrawMsg);
 
 #include "plEventCallbackMsg.h"
-
-REGISTER_CREATABLE( plEventCallbackMsg );
-REGISTER_CREATABLE( plEventCallbackInterceptMsg );
+REGISTER_CREATABLE(plEventCallbackMsg);
+REGISTER_CREATABLE(plEventCallbackInterceptMsg);
 
 #include "plSelfDestructMsg.h"
+REGISTER_CREATABLE(plSelfDestructMsg);
 
-REGISTER_CREATABLE( plSelfDestructMsg );
-
+// -> PubUtilLib
 #include "plCameraMsg.h"
+REGISTER_CREATABLE(plCameraMsg);
+REGISTER_CREATABLE(plCameraTargetFadeMsg);
+REGISTER_CREATABLE(plIfaceFadeAvatarMsg);
 
-REGISTER_CREATABLE( plCameraMsg );
-REGISTER_CREATABLE( plCameraTargetFadeMsg );
-REGISTER_CREATABLE( plIfaceFadeAvatarMsg );
-
+// -> PubUtilLib
 #include "plPlayerPageMsg.h"
+REGISTER_CREATABLE(plPlayerPageMsg);
 
-REGISTER_CREATABLE( plPlayerPageMsg );
-
+// -> PubUtilLib
 #include "plCmdIfaceModMsg.h"
-
-REGISTER_CREATABLE( plCmdIfaceModMsg );
+REGISTER_CREATABLE(plCmdIfaceModMsg);
 
 #include "plNotifyMsg.h"
-
-REGISTER_CREATABLE( plNotifyMsg );
+REGISTER_CREATABLE(plNotifyMsg);
 
 #include "plFakeOutMsg.h"
+REGISTER_CREATABLE(plFakeOutMsg);
 
-REGISTER_CREATABLE( plFakeOutMsg );
-
+// -> PubUtilLib
 #include "plCursorChangeMsg.h"
-
-REGISTER_CREATABLE( plCursorChangeMsg );
+REGISTER_CREATABLE(plCursorChangeMsg);
 
 #include "plNodeChangeMsg.h"
-
-REGISTER_CREATABLE( plNodeChangeMsg );
+REGISTER_CREATABLE(plNodeChangeMsg);
 
 #include "plMessageWithCallbacks.h"
-REGISTER_CREATABLE( plMessageWithCallbacks );
+REGISTER_CREATABLE(plMessageWithCallbacks);
 
+// -> PubUtilLib
 #include "plRemoteAvatarInfoMsg.h"
-REGISTER_CREATABLE( plRemoteAvatarInfoMsg );
+REGISTER_CREATABLE(plRemoteAvatarInfoMsg);
 
 #include "plSDLModifierMsg.h"
 REGISTER_CREATABLE(plSDLModifierMsg);
 
+// -> PubUtilLib
+// possibly unused
 #include "plSDLNotificationMsg.h"
 REGISTER_CREATABLE(plSDLNotificationMsg);
 
+// -> PubUtilLib
 #include "plPipeResMakeMsg.h"
 REGISTER_CREATABLE(plPipeResMakeMsg);
 REGISTER_CREATABLE(plPipeRTMakeMsg);

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plCreatableUuid.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plCreatableUuid.h
@@ -47,15 +47,19 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plCreatableUuid : public plUUID, public plCreatable {
 public:
-    CLASSNAME_REGISTER( plCreatableUuid );
-    GETINTERFACE_ANY( plCreatableUuid, plCreatable );
+    CLASSNAME_REGISTER(plCreatableUuid);
+    GETINTERFACE_ANY(plCreatableUuid, plCreatable);
 
     plCreatableUuid() { }
     plCreatableUuid(const plCreatableUuid& other) : plUUID(other) { }
     plCreatableUuid(const plUUID& other) : plUUID(other) { }
 
-    void    Read( hsStream * s, hsResMgr* ) { plUUID::Read(s); }
-    void    Write( hsStream * s, hsResMgr* ) { plUUID::Write(s); }
+    void Read(hsStream* s, hsResMgr*) HS_OVERRIDE {
+        plUUID::Read(s);
+    }
+    void Write(hsStream* s, hsResMgr*) HS_OVERRIDE {
+        plUUID::Write(s);
+    }
 };
 
 #endif //pnCreatableUUID_h_inc

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.h
@@ -169,13 +169,21 @@ public:
 class plCreatableGenericValue : public plCreatable
 {
 public:
-    plGenericType   fValue;
-    CLASSNAME_REGISTER( plCreatableGenericValue );
-    GETINTERFACE_ANY( plCreatableGenericValue, plCreatable );
-    void    Read(hsStream* s, hsResMgr* mgr) { fValue.Read(s);}
-    void    Write(hsStream* s, hsResMgr* mgr) { fValue.Write(s);}
+    plGenericType fValue;
+
+    CLASSNAME_REGISTER(plCreatableGenericValue);
+    GETINTERFACE_ANY(plCreatableGenericValue, plCreatable);
+
+    void Read(hsStream* s, hsResMgr*) HS_OVERRIDE {
+        fValue.Read(s);
+    }
+    void Write(hsStream* s, hsResMgr*) HS_OVERRIDE {
+        fValue.Write(s);
+    }
+
     plGenericType& Value() { return fValue; }
     const plGenericType& Value() const { return fValue; }
+
     operator int32_t() const { return (int32_t)fValue; }
     operator uint32_t() const { return (uint32_t)fValue; }
     operator float() const { return (float)fValue; }

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetApp.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetApp.h
@@ -173,8 +173,8 @@ public:
         kLinkingToOfflineAge,               // set if we're linking to the startup age
     };
 
-    CLASSNAME_REGISTER( plNetClientApp );
-    GETINTERFACE_ANY( plNetClientApp, plNetApp);
+    CLASSNAME_REGISTER(plNetClientApp);
+    GETINTERFACE_ANY(plNetClientApp, plNetApp);
 
     plNetClientApp();
     
@@ -244,8 +244,8 @@ public:
         kProcessedPendingMsgs,              // Used by front-end server
     };
 
-    CLASSNAME_REGISTER( plNetServerApp );
-    GETINTERFACE_ANY( plNetServerApp, plNetApp);
+    CLASSNAME_REGISTER(plNetServerApp);
+    GETINTERFACE_ANY(plNetServerApp, plNetApp);
 
     virtual int SendMsg(plNetMessage* msg) = 0;
 };

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedObject.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedObject.h
@@ -121,11 +121,11 @@ public:
     plSynchedObject();
     virtual ~plSynchedObject();
 
-    CLASSNAME_REGISTER( plSynchedObject );
-    GETINTERFACE_ANY( plSynchedObject, hsKeyedObject);
+    CLASSNAME_REGISTER(plSynchedObject);
+    GETINTERFACE_ANY(plSynchedObject, hsKeyedObject);
 
-    virtual bool MsgReceive(plMessage* msg);
-    
+    bool MsgReceive(plMessage* msg) HS_OVERRIDE;
+
     // getters
     int GetSynchFlags() const { return fSynchFlags; }
     plNetGroupId GetNetGroup() const { return fNetGroup; };
@@ -155,11 +155,11 @@ public:
 //  void SendCreationMsg(double secs);
 //  void SendDestructionMsg(double secs) ;
 
-    virtual void    Read(hsStream* s, hsResMgr* mgr);
-    virtual void    Write(hsStream* s, hsResMgr* mgr);
+    void Read(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* s, hsResMgr* mgr) HS_OVERRIDE;
 
     int IsLocallyOwned() const;     // returns yes/no/maybe
-    
+
     // disable net synching only
     bool IsNetSynched() const { return (fSynchFlags & kDontSynchGameMessages)==0; }
     void SetNetSynched(bool b) { if (!b) fSynchFlags |= kDontSynchGameMessages; else fSynchFlags &= ~kDontSynchGameMessages;    }

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
@@ -92,12 +92,15 @@ namespace pnNetCommon
 class plCreatableStream : public plCreatable
 {
     hsRAMStream fStream;
+
 public:
-    CLASSNAME_REGISTER( plCreatableStream );
-    GETINTERFACE_ANY( plCreatableStream, plCreatable );
-    void Read( hsStream* stream, hsResMgr* mgr=nil );
-    void Write( hsStream* stream, hsResMgr* mgr=nil );
-    hsStream * GetStream( void ) { return &fStream;}
+    CLASSNAME_REGISTER(plCreatableStream);
+    GETINTERFACE_ANY(plCreatableStream, plCreatable);
+
+    void Read(hsStream* stream, hsResMgr* mgr=nullptr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr=nullptr) HS_OVERRIDE;
+
+    hsStream* GetStream(void) { return &fStream;}
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommonCreatable.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommonCreatable.h
@@ -45,22 +45,20 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnFactory/plCreator.h"
 
 #include "plSynchedObject.h"
-REGISTER_CREATABLE( plSynchedObject );
+REGISTER_CREATABLE(plSynchedObject);
 
 #include "plNetApp.h"
-REGISTER_NONCREATABLE( plNetApp );
-REGISTER_NONCREATABLE( plNetClientApp );
-REGISTER_NONCREATABLE( plNetServerApp );
+REGISTER_NONCREATABLE(plNetApp);
+REGISTER_NONCREATABLE(plNetClientApp);
+REGISTER_NONCREATABLE(plNetServerApp);
 
 #include "plGenericVar.h"
-REGISTER_CREATABLE( plCreatableGenericValue );
+REGISTER_CREATABLE(plCreatableGenericValue);
+
 #include "pnNetCommon.h"
-REGISTER_CREATABLE( plCreatableStream );
+REGISTER_CREATABLE(plCreatableStream);
 
 #include "plCreatableUuid.h"
-REGISTER_CREATABLE( plCreatableUuid );
-
+REGISTER_CREATABLE(plCreatableUuid);
 
 #endif // pnNetCommonCreatable_inc
-
-

--- a/Sources/Plasma/NucleusLib/pnTimer/plTimerCallbackManager.h
+++ b/Sources/Plasma/NucleusLib/pnTimer/plTimerCallbackManager.h
@@ -48,13 +48,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plMessage;
 
-class plTimerCallback 
+class plTimerCallback
 {
 public:
-    
+
     plTimerCallback(double time, plMessage* pMsg);
     ~plTimerCallback();
-    
+
     virtual void Read(hsStream* stream, hsResMgr* mgr);
     virtual void Write(hsStream* stream, hsResMgr* mgr);
 
@@ -65,25 +65,23 @@ public:
 class plTimerCallbackManager : public hsKeyedObject
 {
 public:
-    
     plTimerCallbackManager();
     ~plTimerCallbackManager();
 
-    CLASSNAME_REGISTER( plTimerCallbackManager );
-    GETINTERFACE_ANY( plTimerCallbackManager, hsKeyedObject );
+    CLASSNAME_REGISTER(plTimerCallbackManager);
+    GETINTERFACE_ANY(plTimerCallbackManager, hsKeyedObject);
 
     virtual plTimerCallback* NewTimer(float time, plMessage* pMsg);
     bool CancelCallback(plTimerCallback* pTimer);
     bool CancelCallbacksToKey(const plKey& key);
 
 
-    virtual bool MsgReceive(plMessage* msg);
-        
-    virtual void Read(hsStream* stream, hsResMgr* mgr);
-    virtual void Write(hsStream* stream, hsResMgr* mgr);
+    bool MsgReceive(plMessage* msg) HS_OVERRIDE;
+
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
 private:
-    
     hsTArray<plTimerCallback*>  fCallbacks;
 };
 
@@ -91,8 +89,8 @@ class plgTimerCallbackMgr
 {
 private:
     static plTimerCallbackManager*      fMgr;
-public:
 
+public:
     static void Init();
     static void Shutdown();
     static plTimerCallbackManager* Mgr() { return fMgr; }
@@ -105,7 +103,4 @@ public:
     static bool CancelCallbacksToKey(const plKey& key);
 };
 
-
 #endif
-
-

--- a/Sources/Plasma/NucleusLib/pnTimer/pnTimerCreatable.h
+++ b/Sources/Plasma/NucleusLib/pnTimer/pnTimerCreatable.h
@@ -45,10 +45,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnFactory/plCreator.h"
 
-
 #include "plTimerCallbackManager.h"
-
-REGISTER_CREATABLE( plTimerCallbackManager );
+REGISTER_CREATABLE(plTimerCallbackManager);
 
 #endif // pnTimerCreatable_inc
 


### PR DESCRIPTION
Mostly just changing the creatable macros to properly use C++-style casts, and the creatable types to use the `override` keyword properly.

I started in NucleusLib, and then got distracted with investigating some of the old plKey loading stuff. Eventually we'll want all creatable classes in all libs to properly use `override`.

Clang (and gcc) warn about missing overrides, so the goal is to have no override warnings.