### PR TITLE
Fullscreen Window

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.h
+++ b/Sources/Plasma/Apps/plClient/plClient.h
@@ -209,7 +209,9 @@ protected:
     void IRoomLoaded(plSceneNode* node, bool hold);
     void IRoomUnloaded(plSceneNode* node);
     void ISetGraphicsDefaults();
-    
+
+    void IChangeResolution(int width, int height);
+
 public:
 
     plClient();

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -1590,7 +1590,7 @@ bool plDXPipeline::ICreateDevice(bool windowed)
     }
 
     memset( &params, 0, sizeof( params ) );
-    params.Windowed = ( windowed ? TRUE : FALSE );
+    params.Windowed = TRUE; // NOTE: fullscreen is faked by changing the desktop resolution
     params.Flags = 0;//D3DPRESENTFLAG_LOCKABLE_BACKBUFFER;
     params.BackBufferCount = 1;
     params.BackBufferWidth = GetViewTransform().GetScreenWidth();
@@ -1600,15 +1600,8 @@ bool plDXPipeline::ICreateDevice(bool windowed)
     // NOTE: This was changed 5.29.2001 mcn to avoid the nasty flashing bug on nVidia's 12.60 beta drivers
 // SWAPEFFECT must be _DISCARD when using antialiasing, so we'll just go with _DISCARD for the time being. mf
     params.SwapEffect = D3DSWAPEFFECT_DISCARD;
-    params.FullScreen_RefreshRateInHz = ( windowed ? 0 : D3DPRESENT_RATE_DEFAULT );
-    if(windowed)
-    {
-        params.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;
-    }
-    else
-    {
-        params.PresentationInterval = ( fVSync ? D3DPRESENT_INTERVAL_DEFAULT : D3DPRESENT_INTERVAL_IMMEDIATE );
-    }
+    params.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;
+    params.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;
 
 #ifdef DBG_WRITE_FORMATS
     for( i = 0; i < fCurrentMode->fDepthFormats.GetCount(); i++ )
@@ -1651,7 +1644,7 @@ bool plDXPipeline::ICreateDevice(bool windowed)
 #endif
 
 
-    params.BackBufferFormat = ( windowed ? dispMode.Format : fCurrentMode->fDDmode.Format );
+    params.BackBufferFormat = dispMode.Format;
 #ifdef DBG_WRITE_FORMATS
     sprintf( msg, "-- Requesting back buffer format: %s", IGetDXFormatName( params.BackBufferFormat ) );
     hsDebugMessage( msg, 0 );
@@ -2324,7 +2317,7 @@ void plDXPipeline::ResetDisplayDevice(int Width, int Height, int ColorDepth, boo
 
     // set windowed/fullscreen mode
     fCurrentMode->fWindowed = Windowed;
-    fSettings.fPresentParams.Windowed = Windowed;
+    fSettings.fPresentParams.Windowed = TRUE;
     fSettings.fFullscreen = !Windowed;
 
     // set Antialiasing


### PR DESCRIPTION
We now use a standard window for everything and resize the display using the Win32 api for fullscreen mode instead of exclusive fullscreen mode. With the introduction of DWM in Vista, exclusive fullscreen apps are blocked when they are not focused. In other words, fullscreen exclusive mode caused the client's loading processes to be blocked while alt+tabed away. This fixes that issue. Furthermore, we can now bring back #507 without the crashing seen previously.