### PR TITLE
Add support for saving optional text chunks to PNG images.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pyImage.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyImage.cpp
@@ -189,10 +189,9 @@ void pyImage::SaveAsJPEG(const plFileName& fileName, uint8_t quality)
     plJPEG::Instance().WriteToFile(fileName, this->GetImage());
 }
 
-void pyImage::SaveAsPNG(const plFileName& fileName)
+void pyImage::SaveAsPNG(const plFileName& fileName, const std::multimap<ST::string, ST::string>& textFields)
 {
-
-    plPNG::Instance().WriteToFile(fileName, this->GetImage());
+    plPNG::Instance().WriteToFile(fileName, this->GetImage(), textFields);
 }
 
 PyObject* pyImage::LoadJPEGFromDisk(const plFileName& filename, uint16_t width, uint16_t height)

--- a/Sources/Plasma/FeatureLib/pfPython/pyImage.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyImage.h
@@ -51,6 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pyGlueHelpers.h"
 #include <vector>
+#include <map>
 
 #include "pnKeyedObject/plKey.h"
 #include "pyColor.h"
@@ -144,7 +145,7 @@ public:
     uint32_t GetWidth(); // returns the width of the image
     uint32_t GetHeight(); // returns the height of the image
     void SaveAsJPEG(const plFileName& fileName, uint8_t quality = 75);
-    void SaveAsPNG(const plFileName& fileName);
+    void SaveAsPNG(const plFileName& fileName, const std::multimap<ST::string, ST::string>& textFields = std::multimap<ST::string, ST::string>());
     static PyObject* LoadJPEGFromDisk(const plFileName& filename, uint16_t width, uint16_t height); // returns pyImage
     static PyObject* LoadPNGFromDisk(const plFileName& filename, uint16_t width, uint16_t height); // returns pyImage
 #endif

--- a/Sources/Plasma/FeatureLib/pfPython/pyImageGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyImageGlue.cpp
@@ -165,21 +165,33 @@ PYTHON_METHOD_DEFINITION(ptImage, saveAsJPEG, args)
 
 PYTHON_METHOD_DEFINITION(ptImage, saveAsPNG, args)
 {
-    PyObject* filenameObj;
-    if (!PyArg_ParseTuple(args, "O", &filenameObj))
+    PyObject* filenameObj, *optionalText = nullptr;
+    if (!PyArg_ParseTuple(args, "O|O", &filenameObj, &optionalText))
     {
-        PyErr_SetString(PyExc_TypeError, "saveAsPNG expects a string");
+        PyErr_SetString(PyExc_TypeError, "saveAsPNG expects a string, and an optional dict of key-value string pairs");
         PYTHON_RETURN_ERROR;
     }
 
     if (PyString_CheckEx(filenameObj))
     {
-        self->fThis->SaveAsPNG(PyString_AsStringEx(filenameObj));
+        if (optionalText && PyDict_Check(optionalText)) {
+            std::multimap<ST::string, ST::string> textFields;
+            PyObject *key, *value;
+            Py_ssize_t pos = 0;
+            while (PyDict_Next(optionalText, &pos, &key, &value)) {
+                if (PyString_CheckEx(key) && PyString_CheckEx(value)) {
+                    textFields.emplace(PyString_AsStringEx(key), PyString_AsStringEx(value));
+                }
+            }
+            self->fThis->SaveAsPNG(PyString_AsStringEx(filenameObj), textFields);
+        }
+        else
+            self->fThis->SaveAsPNG(PyString_AsStringEx(filenameObj));
         PYTHON_RETURN_NONE;
     }
     else
     {
-        PyErr_SetString(PyExc_TypeError, "saveAsPNG expects a string");
+        PyErr_SetString(PyExc_TypeError, "saveAsPNG expects a string, and an optional dict of key-value string pairs");
         PYTHON_RETURN_ERROR;
     }
 }

--- a/Sources/Plasma/PubUtilLib/plGImage/plPNG.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plPNG.cpp
@@ -44,6 +44,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsStream.h"
 #include "hsExceptions.h"
 
+#include "plProduct.h"
+#include <ctime>
+
 #include "plPNG.h"
 #include "plGImage/plMipmap.h"
 
@@ -189,7 +192,7 @@ plMipmap* plPNG::ReadFromFile(const plFileName& fileName)
     return ret;
 }
 
-bool plPNG::IWrite(plMipmap* source, hsStream* outStream)
+bool plPNG::IWrite(plMipmap* source, hsStream* outStream, const std::multimap<ST::string, ST::string>& textFields)
 {
     bool result = true;
 
@@ -226,11 +229,46 @@ bool plPNG::IWrite(plMipmap* source, hsStream* outStream)
             row_ptrs[i] = (png_bytep)srcp + (i * stride);
         }
 
+        // Write image data
         png_write_image(png_ptr, row_ptrs);
+
+        // Prepare Textual Metadata
+        char time_string[50]; // RFC-1123: "Day, DD-Mon-YYYY hh:mm:ss";
+        time_t rawtime = time(nullptr);
+        strftime(time_string, sizeof(time_string), "%a, %d-%b-%Y %T", gmtime(&rawtime));
+
+        // Add our standard fields, then combine with the custom fields
+        std::multimap<ST::string, ST::string> all_fields;
+        all_fields.emplace("Software", plProduct::ProductString());
+        all_fields.emplace("Creation Time", time_string);
+        for (auto field : textFields)
+            all_fields.insert(field);
+
+        png_text* text = new png_text[all_fields.size()];
+        size_t num_txtfields = 0;
+        for (auto it = all_fields.begin(); it != all_fields.end(); it++, num_txtfields++) {
+            // The PNG specification requires Latin-1 in the 'key' field
+            text[num_txtfields].key = (png_charp)(strdup(it->first.left(PNG_KEYWORD_MAX_LENGTH).trim().to_latin_1().data()));
+            text[num_txtfields].text = (png_charp)(it->second.c_str());
+            text[num_txtfields].lang = "en-us";  //  Language used in 'text' and 'lang_key'.
+            text[num_txtfields].lang_key = "";   //  Translation of 'key' into 'lang', if needed.
+            text[num_txtfields].compression = PNG_ITXT_COMPRESSION_NONE;
+        }
+
+        // Write Textual Metadata
+        png_set_text(png_ptr, info_ptr, text, num_txtfields);
+
+        // Finish Up
         png_write_end(png_ptr, info_ptr);
+
+        //  Clean up text buffers
+        for (size_t i = 0; i < num_txtfields; i++)
+            free(text[i].key);
+
         //  Clean up allocated structs
         png_destroy_write_struct(&png_ptr, &info_ptr);
         delete [] row_ptrs;
+        delete [] text;
     } catch (...) {
         result = false;
     }
@@ -238,7 +276,7 @@ bool plPNG::IWrite(plMipmap* source, hsStream* outStream)
     return result;
 }
 
-bool plPNG::WriteToFile(const plFileName& fileName, plMipmap* sourceData)
+bool plPNG::WriteToFile(const plFileName& fileName, plMipmap* sourceData, const std::multimap<ST::string, ST::string>& textFields)
 {
     hsUNIXStream out;
 
@@ -246,7 +284,7 @@ bool plPNG::WriteToFile(const plFileName& fileName, plMipmap* sourceData)
         return false;
     }
 
-    bool ret = IWrite(sourceData, &out);
+    bool ret = IWrite(sourceData, &out, textFields);
     out.Close();
     return ret;
 }

--- a/Sources/Plasma/PubUtilLib/plGImage/plPNG.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plPNG.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef _plPNG_h
 #define _plPNG_h
 
+#include <map>
 
 //// Class Definition /////////////////////////////////////////////////////////
 
@@ -53,15 +54,16 @@ class plPNG {
 protected:
 
     plMipmap* IRead(hsStream* inStream);
-    bool IWrite(plMipmap* source, hsStream* outStream);
+    bool IWrite(plMipmap* source, hsStream* outStream, const std::multimap<ST::string, ST::string>& textFields = std::multimap<ST::string, ST::string>());
 
 public:
 
     plMipmap* ReadFromStream(hsStream* inStream) { return IRead(inStream); }
     plMipmap* ReadFromFile(const plFileName& fileName);
 
-    bool WriteToStream(hsStream* outStream, plMipmap* sourceData) { return IWrite(sourceData, outStream); }
-    bool WriteToFile(const plFileName& fileName, plMipmap* sourceData);
+    bool WriteToStream(hsStream* outStream, plMipmap* sourceData,
+        const std::multimap<ST::string, ST::string>& textFields = std::multimap<ST::string, ST::string>()) { return IWrite(sourceData, outStream, textFields); }
+    bool WriteToFile(const plFileName& fileName, plMipmap* sourceData, const std::multimap<ST::string, ST::string>& textFields = std::multimap<ST::string, ST::string>());
 
     static plPNG& Instance(void);
 };


### PR DESCRIPTION
By default, this addition inserts the client version and a timestamp into every image saved.  Other fields such as Explorer, Current Age, etc. are context-dependent and can be added by the caller.

Localized strings are possible, but as we don't have any translations for them I did not implement it in this changeset.