### PR TITLE
Implement a generic hull/trimesh collider format

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.h
@@ -187,6 +187,9 @@ public:
 
     virtual float GetMass() {return fMass;}
 protected:
+    class NxConvexMesh* IReadHull(hsStream* s);
+    class NxTriangleMesh* IReadTriMesh(hsStream* s);
+
     void IGetPositionSim(hsPoint3& pos) const;
     void IGetRotationSim(hsQuat& rot) const;
     void ISetPositionSim(const hsPoint3& pos);


### PR DESCRIPTION
PhysX requires all of its actors to have cooked mesh data. This cooked data is unfortunately not compatible with other versions of PhysX outside of the minor branch. The format is also largely unknown. Therefore, it is relevant to allow CWE prps to include an engine agnostic physical format to reduce our dependencies on proprietary libraries.

All PhysX blobs thankfully begin with the magic string NXS\x01, so we now abuse that by adding our own format that begins with the magic string HSP\x01. These blobs are cooked on the fly while already cooked blobs are passed directly on to PhysX.