### PR TITLE
Cleanup VolumeSensorConditionalObject

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConditional/plObjectInBoxConditionalObject.cpp
+++ b/Sources/Plasma/FeatureLib/pfConditional/plObjectInBoxConditionalObject.cpp
@@ -49,8 +49,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnNetCommon/plNetApp.h"
 #include "plAvatar/plArmatureMod.h"
 #include "pnSceneObject/plSceneObject.h"
-
-bool plVolumeSensorConditionalObject::makeBriceHappyVar = true;
+#include "pnMessage/plPlayerPageMsg.h"
+#include "plgDispatch.h"
 
 plObjectInBoxConditionalObject::plObjectInBoxConditionalObject() :
 fCurrentTrigger(nil)
@@ -79,7 +79,7 @@ bool plObjectInBoxConditionalObject::MsgReceive(plMessage* msg)
                     if (pActivateMsg->fHitterObj == fCurrentTrigger && fCurrentTrigger && fLogicMod->HasFlag(plLogicModBase::kTriggered) && !IsToggle())
                     {
                         fCurrentTrigger = nil;
-                        fLogicMod->GetNotify()->AddContainerEvent( pActivateMsg->fHiteeObj, pActivateMsg->fHitterObj, false );
+                        fLogicMod->GetNotify()->AddContainerEvent(pActivateMsg->fHiteeObj, pActivateMsg->fHitterObj, false);
                         fLogicMod->RequestUnTrigger();
                     }
                 }
@@ -96,12 +96,12 @@ bool plObjectInBoxConditionalObject::Verify(plMessage* msg)
 {
     plActivatorMsg* pActivateMsg = plActivatorMsg::ConvertNoRef(msg);
     if (pActivateMsg)
-    {   
+    {
         for (int i = 0; i < fInside.Count(); i++)
         {
             if (pActivateMsg->fHitterObj == fInside[i])
             {
-                fLogicMod->GetNotify()->AddContainerEvent( pActivateMsg->fHiteeObj, pActivateMsg->fHitterObj, true );
+                fLogicMod->GetNotify()->AddContainerEvent(pActivateMsg->fHiteeObj, pActivateMsg->fHitterObj, true);
                 fCurrentTrigger = pActivateMsg->fHiteeObj;
                 return true;
             }
@@ -125,134 +125,139 @@ bool plObjectInBoxConditionalObject::Verify(plMessage* msg)
 // volume sensor conditional 
 //
 plVolumeSensorConditionalObject::plVolumeSensorConditionalObject() :
-fTrigNum(-1),
-fType(0),
-fFirst(false),
-fTriggered(false),
-fIgnoreExtraEnters(true)
+    fTrigNum(-1),
+    fType(0),
+    fFirst(false),
+    fTriggered(false),
+    fFlags(kIgnoreExtraEnters)
 {
     SetSatisfied(true);
 }
 
+void plVolumeSensorConditionalObject::IgnoreExtraEnters(bool ignore)
+{
+    if (ignore)
+        fFlags |= kIgnoreExtraEnters;
+    else
+        fFlags &= ~kIgnoreExtraEnters;
+}
+
+void plVolumeSensorConditionalObject::NoServerArbitration(bool noArbitration)
+{
+    if (noArbitration) {
+        plgDispatch::Dispatch()->RegisterForExactType(plPlayerPageMsg::Index(), GetKey());
+        fFlags |= kNoServerArbitration;
+    } else {
+        plgDispatch::Dispatch()->UnRegisterForExactType(plPlayerPageMsg::Index(), GetKey());
+        fFlags &= ~kNoServerArbitration;
+    }
+}
+
+bool plVolumeSensorConditionalObject::IIsLocal(const plKey& key) const
+{
+    if (key == plNetClientApp::GetInstance()->GetLocalPlayerKey())
+        return true;
+
+    const plSceneObject* hitter = plSceneObject::ConvertNoRef(key->ObjectIsLoaded());
+    if (hitter) {
+        for (size_t i = 0; i < hitter->GetNumModifiers(); ++i) {
+            const plArmatureMod* am = plArmatureMod::ConvertNoRef(hitter->GetModifier(i));
+            if (am && !am->IsLocalAI())
+                return false;
+        }
+        if (hitter->IsLocallyOwned() != plSynchedObject::kYes)
+            return false;
+    }
+
+    // Yes, I know that we're saying YES for not loaded objects. This matches the previous behavior.
+    return true;
+}
 
 bool plVolumeSensorConditionalObject::MsgReceive(plMessage* msg)
 {
     plActivatorMsg* pActivateMsg = plActivatorMsg::ConvertNoRef(msg);
-    if (pActivateMsg)
-    {
+    if (pActivateMsg) {
         // single player hack
         if (!fLogicMod->HasFlag(plLogicModBase::kRequestingTrigger))
             fLogicMod->GetNotify()->ClearEvents();
 
-        if (pActivateMsg->fTriggerType == plActivatorMsg::kVolumeEnter)
-        {
-            int i;
-            for (i = 0; i < fInside.Count(); i++)
-            {
-                if (fInside[i] == pActivateMsg->fHitterObj)
-                {
-                    if (fIgnoreExtraEnters)
-                        return false; // this is the "correct" way to handle this situation
-                    break; // this is for those special situations where, due to some physics oddity, we need to allow the avatar to enter without exiting
-                }
-            }
-            if (i == fInside.Count())
-                fInside.Append(pActivateMsg->fHitterObj);
-            if (makeBriceHappyVar)
-            {
-                plSceneObject *pObj = plSceneObject::ConvertNoRef( pActivateMsg->fHitterObj->ObjectIsLoaded() );
-                if( pObj )
-                {
-                    //need to check for human vs quabish type things in here                
-                    int i;
-                    for( i = 0; i < pObj->GetNumModifiers(); i++ )
-                    {
-                        if (plArmatureMod::ConvertNoRef( pObj->GetModifier(i)))
-                        {   
-                            if (plNetClientApp::GetInstance()->GetLocalPlayerKey() != pActivateMsg->fHitterObj)
-                            {
-                                plArmatureMod *am=const_cast<plArmatureMod*>( plArmatureMod::ConvertNoRef(pObj->GetModifier(i)));
-                                if (!am->IsLocalAI())
-                                {
-                                    return false;
-                                }
-                            }
-                        }
-                    }
-                    plSynchedObject* syncObj = (plSynchedObject*)pObj;
-                    if (syncObj->IsLocallyOwned() != plSynchedObject::kYes) 
-                    {
-                        return false;
-                    }
-                }
-            }
+        // Track the hittee for the NoArbitration case so we can trigger the exit volume on link out
+        fHittee = pActivateMsg->fHiteeObj;
 
-            if (fType == kTypeEnter)
-            {
-                fLogicMod->GetNotify()->AddCollisionEvent(true, pActivateMsg->fHitterObj, pActivateMsg->fHiteeObj, false);
-                fLogicMod->RequestTrigger(false);
+        // Track the enters/exits on all clients
+        if (pActivateMsg->fTriggerType == plActivatorMsg::kVolumeEnter) {
+            auto it = fInside.find(pActivateMsg->fHitterObj);
+            if (it != fInside.end() && fFlags & kIgnoreExtraEnters) {
+                // This is normally what we should do. You're already inside the region,
+                // so we don't care about a dupe enter. However, PhysX is weird, so sometimes
+                // we might want to allow dupe enters.
+                return false;
             }
-            else
-            {
+            fInside.insert(pActivateMsg->fHitterObj);
+
+            // From here on out, we only care about local avatars
+            if (!IIsLocal(pActivateMsg->fHitterObj))
+                return false;
+
+            if (fType == kTypeEnter) {
+                fLogicMod->GetNotify()->AddCollisionEvent(true, pActivateMsg->fHitterObj, pActivateMsg->fHiteeObj, false);
+                if ((fFlags & kNoServerArbitration)) {
+                    if (Satisfied())
+                        fLogicMod->Trigger(false);
+                } else {
+                    fLogicMod->RequestTrigger(false);
+                }
+            } else if (fType == kTypeExit && !(fFlags & kNoServerArbitration)) {
                 fLogicMod->GetNotify()->AddCollisionEvent(false, pActivateMsg->fHitterObj, pActivateMsg->fHiteeObj, false);
                 fLogicMod->RequestUnTrigger();
             }
             return false;
+        } else if (pActivateMsg->fTriggerType == plActivatorMsg::kVolumeExit) {
+            auto it = fInside.find(pActivateMsg->fHitterObj);
+            if (it == fInside.end())
+                return false;
+            fInside.erase(it);
+
+            // From here on out, we only care about local avatars
+            if (!IIsLocal(pActivateMsg->fHitterObj))
+                return false;
+
+            if (fType == kTypeExit) {
+                fLogicMod->GetNotify()->AddCollisionEvent(false, pActivateMsg->fHitterObj, pActivateMsg->fHiteeObj, false);
+                if (fFlags & kNoServerArbitration) {
+                    if (Satisfied())
+                        fLogicMod->Trigger(false);
+                } else {
+                    fLogicMod->RequestTrigger(false);
+                }
+            } else if (fType == kTypeEnter && !(fFlags & kNoServerArbitration)) {
+                fLogicMod->GetNotify()->AddCollisionEvent(true, pActivateMsg->fHitterObj, pActivateMsg->fHiteeObj, false);
+                fLogicMod->RequestUnTrigger();
+            }
+            return true;
         }
-        else
-        if (pActivateMsg->fTriggerType == plActivatorMsg::kVolumeExit)
-        {
-            for (int i = 0; i < fInside.Count(); i++)
-            {
-                if (fInside[i] == pActivateMsg->fHitterObj)
-                {
-                    fInside.Remove(i);
-                    if (makeBriceHappyVar)
-                    {
-                    //need to check for human vs quabish type things in here    
-                        plSceneObject *pObj = plSceneObject::ConvertNoRef( pActivateMsg->fHitterObj->ObjectIsLoaded() );
-                        if( pObj )
-                        {
-                            int i;
-                            for( i = 0; i < pObj->GetNumModifiers(); i++ )
-                            {
-                                if (plArmatureMod::ConvertNoRef( pObj->GetModifier(i)))
-                                {   
-                                    if (plNetClientApp::GetInstance()->GetLocalPlayerKey() != pActivateMsg->fHitterObj)
-                                    {
-                                        plArmatureMod *am=const_cast<plArmatureMod*>( plArmatureMod::ConvertNoRef(pObj->GetModifier(i)));
-                                        if (!am->IsLocalAI())
-                                        {
-                                            return false;
-                                        }
-                                    }
-                                }
-                            }
-                            plSynchedObject* syncObj = (plSynchedObject*)pObj;
-                            if (syncObj->IsLocallyOwned() != plSynchedObject::kYes) 
-                            {
-                                return false;
-                            }
-                        }
-                    }
-                    if (fType == kTypeExit)
-                    {
-                        fLogicMod->GetNotify()->AddCollisionEvent(false, pActivateMsg->fHitterObj, pActivateMsg->fHiteeObj, false);
-                        fLogicMod->RequestTrigger(false);
-    
-                    }
-                    else
-                    {
-                        fLogicMod->GetNotify()->AddCollisionEvent(true, pActivateMsg->fHitterObj, pActivateMsg->fHiteeObj, false);
-                        fLogicMod->RequestUnTrigger();
-                    }
-                    return false;
+        return true;
+    }
+
+    plPlayerPageMsg* page = plPlayerPageMsg::ConvertNoRef(msg);
+    if (page && page->fUnload) {
+        hsAssert(fFlags & kNoServerArbitration, "WTF -- should only get here if the VSCO skips arbitration!");
+
+        auto it = fInside.find(page->fPlayer);
+        if (it != fInside.end()) {
+            fInside.erase(it);
+            if (fHittee && fType == kTypeExit) {
+                const plSceneObject* hitteeSO = plSceneObject::ConvertNoRef(fHittee->ObjectIsLoaded());
+                if (hitteeSO && hitteeSO->IsLocallyOwned() == plSynchedObject::kYes) {
+                    fLogicMod->GetNotify()->AddCollisionEvent(false, pActivateMsg->fHitterObj, pActivateMsg->fHiteeObj, false);
+                    if (Satisfied())
+                        fLogicMod->Trigger(false);
                 }
             }
         }
-
-        return false;
+        return true;
     }
+
     return plConditionalObject::MsgReceive(msg);
 }
 
@@ -260,20 +265,20 @@ bool plVolumeSensorConditionalObject::Satisfied()
 {
     if (fType == kTypeExit && fFirst && !fTriggered)
     {
-        if (fInside.Count())
+        if (!fInside.empty())
             fTriggered = true;
         return true;
     }
-    if (fTriggered) 
+    if (fTriggered)
     {
-        if (fInside.Count() == 0)
+        if (fInside.empty())
             fTriggered = false;
         return false;
     }
 
     if (fTrigNum == -1)
         return true;
-    if (fInside.Count() == fTrigNum)
+    if (fInside.size() == fTrigNum)
         return true;
     else
         return false;
@@ -286,6 +291,7 @@ void plVolumeSensorConditionalObject::Read(hsStream* stream, hsResMgr* mgr)
     fType = stream->ReadLE32();
     fFirst = stream->ReadBool();
 }
+
 void plVolumeSensorConditionalObject::Write(hsStream* stream, hsResMgr* mgr)
 {
     plConditionalObject::Write(stream, mgr);
@@ -293,156 +299,11 @@ void plVolumeSensorConditionalObject::Write(hsStream* stream, hsResMgr* mgr)
     stream->WriteLE32(fType);
     stream->WriteBool(fFirst);
 }
-#include "pnMessage/plPlayerPageMsg.h"
-#include "plgDispatch.h"
-bool plVolumeSensorConditionalObjectNoArbitration::MsgReceive(plMessage* msg)
-{
-    plActivatorMsg* pActivateMsg = plActivatorMsg::ConvertNoRef(msg);
-    if (pActivateMsg)
-    {
-        // single player hack
-        if (!fLogicMod->HasFlag(plLogicModBase::kRequestingTrigger))
-            fLogicMod->GetNotify()->ClearEvents();
-        fHittee= pActivateMsg->fHiteeObj;
-        if (pActivateMsg->fTriggerType == plActivatorMsg::kVolumeEnter)
-        {
-            int i;
-            for (i = 0; i < fInside.Count(); i++)
-            {
-                if (fInside[i] == pActivateMsg->fHitterObj)
-                {
-                    if (fIgnoreExtraEnters)
-                        return false; // this is the "correct" way to handle this situation
-                    break; // this is for those special situations where, due to some physics oddity, we need to allow the avatar to enter without exiting
-                }
-            }
-            if (i == fInside.Count())
-                fInside.Append(pActivateMsg->fHitterObj);
-            if (makeBriceHappyVar)
-            {
-                plSceneObject *pObj = plSceneObject::ConvertNoRef( pActivateMsg->fHitterObj->ObjectIsLoaded() );
-                if( pObj )
-                {
-                    //need to check for human vs quabish type things in here                
-                    int i;
-                    for( i = 0; i < pObj->GetNumModifiers(); i++ )
-                    {
-                        if (plArmatureMod::ConvertNoRef( pObj->GetModifier(i)))
-                        {   
-                            if (plNetClientApp::GetInstance()->GetLocalPlayerKey() != pActivateMsg->fHitterObj)
-                            {
-                                plArmatureMod *am=const_cast<plArmatureMod*>( plArmatureMod::ConvertNoRef(pObj->GetModifier(i)));
-                                if (!am->IsLocalAI())
-                                {
-                                    return false;
-                                }
-                            }
-                        }
-                    }
-                    plSynchedObject* syncObj = (plSynchedObject*)pObj;
-                    if (syncObj->IsLocallyOwned() != plSynchedObject::kYes) 
-                    {
-                        return false;
-                    }
-                }
-            }
 
-            if (fType == kTypeEnter)
-            {
-                fLogicMod->GetNotify()->AddCollisionEvent(true, pActivateMsg->fHitterObj, pActivateMsg->fHiteeObj, false);
-                //fLogicMod->RequestTrigger(false);
-                
-                if (!Satisfied())
-                    return false;
-                
-                fLogicMod->Trigger(false);
-            }
-        
-            return false;
-        }
-        else
-        if (pActivateMsg->fTriggerType == plActivatorMsg::kVolumeExit)
-        {
-            for (int i = 0; i < fInside.Count(); i++)
-            {
-                if (fInside[i] == pActivateMsg->fHitterObj)
-                {
-                    fInside.Remove(i);
-                    if (makeBriceHappyVar)
-                    {
-                    //need to check for human vs quabish type things in here    
-                        plSceneObject *pObj = plSceneObject::ConvertNoRef( pActivateMsg->fHitterObj->ObjectIsLoaded() );
-                        if( pObj )
-                        {
-                            int i;
-                            for( i = 0; i < pObj->GetNumModifiers(); i++ )
-                            {
-                                if (plArmatureMod::ConvertNoRef( pObj->GetModifier(i)))
-                                {   
-                                    if (plNetClientApp::GetInstance()->GetLocalPlayerKey() != pActivateMsg->fHitterObj)
-                                    {
-                                        plArmatureMod *am=const_cast<plArmatureMod*>( plArmatureMod::ConvertNoRef(pObj->GetModifier(i)));
-                                        if (!am->IsLocalAI())
-                                        {
-                                            return false;
-                                        }
-                                    }
-                                }
-                            }
-                            plSynchedObject* syncObj = (plSynchedObject*)pObj;
-                            if (syncObj->IsLocallyOwned() != plSynchedObject::kYes) 
-                            {
-                                return false;
-                            }
-                        }
-                    }
-                    if (fType == kTypeExit)
-                    {
-                        fLogicMod->GetNotify()->AddCollisionEvent(false, pActivateMsg->fHitterObj, pActivateMsg->fHiteeObj, false);
-                        //fLogicMod->RequestTrigger(false);
-                        if (!Satisfied())
-                            return false;
-                    
-                        fLogicMod->Trigger(false);
-                    }
-                    return false;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    plPlayerPageMsg* page = plPlayerPageMsg::ConvertNoRef(msg);
-    if(page && page->fUnload)
-    {
-        for(int j= 0; j< fInside.Count(); j++)
-        {
-            if(fInside[j] == page->fPlayer)
-            {//this is the one inside
-                if(fHittee)
-                {
-                    plSceneObject *so = plSceneObject::ConvertNoRef(fHittee->ObjectIsLoaded());
-                    if(so && so->IsLocallyOwned())
-                    {
-                        if (fType == kTypeExit)
-                        {
-                            fLogicMod->GetNotify()->AddCollisionEvent(false, page->fPlayer, fHittee, false);
-                            //fLogicMod->RequestTrigger(false);
-                            if (!Satisfied())
-                                return false;
-                            fLogicMod->Trigger(false);
-                        }
-                    }
-                }
-                fInside.Remove(j);
-            }
-        }
-    }
-        return plConditionalObject::MsgReceive(msg);
-}
 void plVolumeSensorConditionalObjectNoArbitration::Read(hsStream* stream, hsResMgr* mgr)
 {
     plVolumeSensorConditionalObject::Read(stream, mgr);
-    plgDispatch::Dispatch()->RegisterForExactType(plPlayerPageMsg::Index(), GetKey());
+
+    // We must have a valid fpKey before we do this, hence why this is not in the constructor
+    NoServerArbitration(true);
 }

--- a/Sources/Plasma/FeatureLib/pfConditional/plObjectInBoxConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plObjectInBoxConditionalObject.h
@@ -45,6 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnModifier/plConditionalObject.h"
 #include "hsTemplates.h"
+#include <set>
 
 class plKey;
 
@@ -76,56 +77,61 @@ class plVolumeSensorConditionalObject : public plConditionalObject
 {
 
 protected:
-
-    hsTArray<plKey> fInside;
+    std::set<plKey>     fInside;
     int                 fTrigNum;
     int                 fType;
     bool                fFirst;
     bool                fTriggered;
-    bool                fIgnoreExtraEnters;
+
+    plKey               fHittee;
+    uint32_t            fFlags;
+
+    enum
+    {
+        /** */
+        kIgnoreExtraEnters = (1<<0),
+        kNoServerArbitration = (1<<1),
+    };
+
+    bool IIsLocal(const plKey& key) const;
+
 public:
-
-    static bool makeBriceHappyVar;
-
-
     enum
     {
         kTypeEnter  = 1,
         kTypeExit,
     };
+
     plVolumeSensorConditionalObject();
     ~plVolumeSensorConditionalObject(){;}
-    
-    CLASSNAME_REGISTER( plVolumeSensorConditionalObject );
-    GETINTERFACE_ANY( plVolumeSensorConditionalObject, plConditionalObject );
-    
-    virtual bool MsgReceive(plMessage* msg);
 
-    void Evaluate(){;}
+    CLASSNAME_REGISTER(plVolumeSensorConditionalObject);
+    GETINTERFACE_ANY(plVolumeSensorConditionalObject, plConditionalObject);
+
+    bool MsgReceive(plMessage* msg) HS_OVERRIDE;
+
+    void Evaluate() { }
     void Reset() { SetSatisfied(false); }
-    virtual bool Satisfied();
-    void    SetType(int i) { fType = i; }
+    bool Satisfied() HS_OVERRIDE;
+    void SetType(int i) { fType = i; }
 
     void SetTrigNum(int i) { fTrigNum = i; }
     void SetFirst(bool b) { fFirst = b; }
 
-    void IgnoreExtraEnters(bool ignore = true) {fIgnoreExtraEnters = ignore;}
+    void IgnoreExtraEnters(bool ignore = true);
+    void NoServerArbitration(bool noArbitration = true);
 
-    virtual void Read(hsStream* stream, hsResMgr* mgr); 
-    virtual void Write(hsStream* stream, hsResMgr* mgr);
+    void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
+    void Write(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 
 };
 class plVolumeSensorConditionalObjectNoArbitration : public plVolumeSensorConditionalObject
 {
 public:
-    plVolumeSensorConditionalObjectNoArbitration ():plVolumeSensorConditionalObject(){;}
-    ~plVolumeSensorConditionalObjectNoArbitration (){;}
-    CLASSNAME_REGISTER( plVolumeSensorConditionalObjectNoArbitration );
-    GETINTERFACE_ANY( plVolumeSensorConditionalObjectNoArbitration, plConditionalObject );
-    virtual bool MsgReceive(plMessage* msg);
-    virtual void Read(hsStream* stream, hsResMgr* mgr); 
-protected:
-    plKey fHittee;
+    CLASSNAME_REGISTER(plVolumeSensorConditionalObjectNoArbitration);
+    GETINTERFACE_ANY( plVolumeSensorConditionalObjectNoArbitration, plVolumeSensorConditionalObject);
+
+    virtual void Read(hsStream* stream, hsResMgr* mgr) HS_OVERRIDE;
 };
 
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -3193,6 +3193,15 @@ PF_CONSOLE_CMD(Logic, WriteDetectorLog, "", "Write detector log to logfile")
     DetectorDoLogfile();
 }
 
+PF_CONSOLE_CMD(Logic,
+               DelayArbitration,
+               "int millis",
+               "Simulates network delay for LogicMod arbitration")
+{
+    int ms = params[0];
+    plLogicModBase::SetArbitrationDelay(ms);
+}
+
 #endif // LIMIT_CONSOLE_COMMANDS
 
 ////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfConsole/pfGameConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfGameConsoleCommands.cpp
@@ -421,11 +421,3 @@ PF_CONSOLE_CMD( Game, SetLocalClientAsAdmin, "bool enable", "Makes chat messages
     plgDispatch::MsgSend( msg );
 }
 #endif
-
-#include "pfConditional/plObjectInBoxConditionalObject.h"
-
-PF_CONSOLE_CMD( Game, BreakVolumeSensors, "bool break", "reverts to old broken volume sensor logic" )
-{
-    bool b =  params[ 0 ];
-    plVolumeSensorConditionalObject::makeBriceHappyVar = !b;
-}

--- a/Sources/Plasma/FeatureLib/pfPython/pySceneObject.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySceneObject.cpp
@@ -995,3 +995,17 @@ void pySceneObject::VolumeSensorIgnoreExtraEnters(bool ignore)
         }
     }
 }
+
+void pySceneObject::VolumeSensorNoArbitration(bool noArbitration)
+{
+    if (fSceneObjects.Count() > 0) {
+        plSceneObject* obj = plSceneObject::ConvertNoRef(fSceneObjects[0]->ObjectIsLoaded());
+        if (obj) {
+            for (size_t i = 0; i < obj->GetNumModifiers(); ++i) {
+                plLogicModifier* logic = const_cast<plLogicModifier*>(plLogicModifier::ConvertNoRef(obj->GetModifier(i)));
+                if (logic)
+                    logic->VolumeNoArbitration(noArbitration);
+            }
+        }
+    }
+}

--- a/Sources/Plasma/FeatureLib/pfPython/pySceneObject.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pySceneObject.h
@@ -194,6 +194,9 @@ public:
 
     // hack for garrison
     void VolumeSensorIgnoreExtraEnters(bool ignore);
+
+    /** More SubWorld hacks */
+    void VolumeSensorNoArbitration(bool noArbitration);
 };
 
 #endif // _pySceneObject_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pySceneObjectGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySceneObjectGlue.cpp
@@ -455,6 +455,17 @@ PYTHON_METHOD_DEFINITION(ptSceneobject, volumeSensorIgnoreExtraEnters, args)
     PYTHON_RETURN_NONE;
 }
 
+PYTHON_METHOD_DEFINITION(ptSceneobject, volumeSensorNoArbitration, args)
+{
+    bool noArbitration = true;
+    if (!PyArg_ParseTuple(args, "|b", &noArbitration)) {
+        PyErr_SetString(PyExc_TypeError, "volumeSensorNoArbitration expects an optional boolean");
+        PYTHON_RETURN_ERROR;
+    }
+    self->fThis->VolumeSensorNoArbitration(noArbitration);
+    PYTHON_RETURN_NONE;
+}
+
 PYTHON_START_METHODS_TABLE(ptSceneobject)
     PYTHON_METHOD(ptSceneobject, addKey, "Params: key\nMostly used internally.\n"
                 "Add another sceneobject ptKey"),
@@ -513,6 +524,7 @@ PYTHON_START_METHODS_TABLE(ptSceneobject)
     PYTHON_METHOD(ptSceneobject, getSoundIndex, "Params: sndComponentName\nGet the index of the requested sound component"),
 
     PYTHON_METHOD(ptSceneobject, volumeSensorIgnoreExtraEnters, "Params: ignore\nTells the volume sensor attached to this object to ignore extra enters (default), or not (hack for garrison)."),
+    PYTHON_METHOD(ptSceneobject, volumeSensorNoArbitration, "Params: noArbitration\nTells the volume sensor attached to this object whether or not to negotiate exclusive locks with the server."),
 PYTHON_END_METHODS_TABLE;
 
 PYTHON_GET_DEFINITION(ptSceneobject, draw)

--- a/Sources/Plasma/NucleusLib/pnMessage/plServerReplyMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plServerReplyMsg.h
@@ -57,6 +57,7 @@ class hsResMgr;
 class plServerReplyMsg : public plMessage
 {
     int fType;
+    bool fWasDelayed;
 public:
 
     enum
@@ -67,10 +68,13 @@ public:
     };
 
     void SetType(int t) { fType = t; }
-    int GetType() { return fType; }
+    int GetType() const { return fType; }
 
-    plServerReplyMsg() : fType(kUnInit) { }
-    plServerReplyMsg(const plKey &s, const plKey &r, const double* t) : plMessage(s,r,t), fType(kUnInit) { }
+    void SetWasDelayed(bool v) { fWasDelayed = v; }
+    bool GetWasDelayed() const { return fWasDelayed; }
+
+    plServerReplyMsg() : fType(kUnInit), fWasDelayed(false) { }
+    plServerReplyMsg(const plKey &s, const plKey &r, const double* t) : plMessage(s,r,t), fType(kUnInit), fWasDelayed(false) { }
 
     CLASSNAME_REGISTER(plServerReplyMsg);
     GETINTERFACE_ANY(plServerReplyMsg, plMessage);

--- a/Sources/Plasma/NucleusLib/pnModifier/plLogicModBase.cpp
+++ b/Sources/Plasma/NucleusLib/pnModifier/plLogicModBase.cpp
@@ -173,7 +173,7 @@ void plLogicModBase::IHandleArbitration(plServerReplyMsg* pSMsg)
 {
     hsAssert(pSMsg->GetType() != plServerReplyMsg::kUnInit, "uninit server reply msg");
     plNetClientApp::GetInstance()->DebugMsg("LM: LogicModifier {} recvd trigger request reply:{}, wasRequesting={}, t={f}\n",
-                                            GetKeyName().c_str(),
+                                            GetKeyName(),
                                             pSMsg->GetType() == plServerReplyMsg::kDeny ? "denied" : "confirmed",
                                             HasFlag(kRequestingTrigger), hsTimer::GetSysSeconds());
 

--- a/Sources/Plasma/NucleusLib/pnModifier/plLogicModBase.h
+++ b/Sources/Plasma/NucleusLib/pnModifier/plLogicModBase.h
@@ -66,6 +66,8 @@ public:
     };
 
 protected:
+    static uint32_t sArbitrationDelayMs;
+
     hsTArray<plMessage*>            fCommandList;
     hsTArray<plKey>                 fReceiverList;
     uint32_t                          fCounterLimit;
@@ -77,13 +79,14 @@ protected:
 
     virtual bool IEval(double secs, float del, uint32_t dirty) {return false;}
     void IUpdateSharedState(bool triggered) const;
+    void IHandleArbitration(class plServerReplyMsg* msg);
     bool IEvalCounter();
     virtual void PreTrigger(bool netRequest);
     virtual void Trigger(bool netRequest);
     virtual void UnTrigger();
     
     void CreateNotifyMsg();
-    
+
 public:
     friend class plVolumeSensorConditionalObjectNoArbitration;
     plLogicModBase();
@@ -121,6 +124,9 @@ public:
     // for debug purposes only!
     void ConsoleTrigger(plKey playerKey);
     void ConsoleRequestTrigger();
+
+    /** Specifies an amount of time (in milliseconds) to delay processing server arbitration responses */
+    static void SetArbitrationDelay(uint32_t ms) { sArbitrationDelayMs = ms; }
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnModifier/plLogicModBase.h
+++ b/Sources/Plasma/NucleusLib/pnModifier/plLogicModBase.h
@@ -88,7 +88,7 @@ protected:
     void CreateNotifyMsg();
 
 public:
-    friend class plVolumeSensorConditionalObjectNoArbitration;
+    friend class plVolumeSensorConditionalObject;
     plLogicModBase();
     ~plLogicModBase();
     CLASSNAME_REGISTER( plLogicModBase );

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -1946,7 +1946,7 @@ bool plArmatureMod::IsLocalAvatar()
     return plAvatarMgr::GetInstance()->GetLocalAvatar() == this;
 }
 
-bool plArmatureMod::IsLocalAI()
+bool plArmatureMod::IsLocalAI() const
 {
     // Formerly a lot of silly cached rigamaroll... Now, we'll just rely
     // on the fact that one player is the game master. HACK TURD if net groups

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
@@ -221,7 +221,7 @@ public:
     void GetPositionAndRotationSim(hsPoint3* position, hsQuat* rotation);
 
     bool IsLocalAvatar();
-    bool IsLocalAI();
+    bool IsLocalAI() const;
     virtual const plSceneObject *FindBone(const ST::string & name) const;
     virtual const plSceneObject *FindBone(uint32_t id) const; // use an id from an appropriate taxonomy, such as plAvBrainHuman::BoneID
     virtual void AddBoneMapping(uint32_t id, const plSceneObject *bone);

--- a/Sources/Plasma/PubUtilLib/plModifier/plLogicModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plLogicModifier.cpp
@@ -279,3 +279,12 @@ void plLogicModifier::VolumeIgnoreExtraEnters(bool ignore /* = true */)
             condition->IgnoreExtraEnters(ignore);
     }
 }
+
+void plLogicModifier::VolumeNoArbitration(bool noArbitration)
+{
+    for (size_t i = 0; i < fConditionList.Count(); ++i) {
+        plVolumeSensorConditionalObject* condition = plVolumeSensorConditionalObject::ConvertNoRef(fConditionList[i]);
+        if (condition)
+            condition->NoServerArbitration(noArbitration);
+    }
+}

--- a/Sources/Plasma/PubUtilLib/plModifier/plLogicModifier.h
+++ b/Sources/Plasma/PubUtilLib/plModifier/plLogicModifier.h
@@ -70,6 +70,7 @@ public:
     virtual void Reset(bool bCounterReset);
 
     void VolumeIgnoreExtraEnters(bool ignore = true); // hack for garrison
+    void VolumeNoArbitration(bool noArbitration = true);
 
     int fMyCursor;
 };


### PR DESCRIPTION
The goal behind this changeset is to fix the intermittent issues seen in ages such as Gahreesen and Teledahn in which the avatar falls through the floor when leaving a subworld. This generally happens when the player's ping time is unsatisfactorily high. `plVolumeSensorConditionalObject` acquires an exclusive server lock before triggering the transition, and if this lock takes too long... the player has fallen through the floor. At some point, Cyan introduced the special case `plVolumeSensorConditionalObjectNoArbitration` exactly for this purpose, but it appears to never have been used.

This changeset refactors both VolumeSensor classes and moves the logic into the base class. The NoArbitration variant just sets a flag on the base class. This enables us to toggle which behavior we want in Python, allowing us to silently upgrade Cyan's VSCOs to VSCONAs and therefore fix the falling through the floor issue. A console command `Logic.DelayArbitration` was introduced to model both the problem and solution. This can be removed from the changeset if it is deemed inappropriate.

--code_duplication
--bugs
++code_quality