### PR TITLE
Fix age invites

### DIFF
--- a/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.cpp
@@ -97,7 +97,8 @@ void VaultTextNoteNode::SetVisitInfo (const plAgeInfoStruct & info) {
         DEFAULT_FATAL(i);
         }
 
-        str << "|";
+        if (i+1 != kNumAgeInfoFields)
+            str << "|";
     }
 
     SetNoteText(str.to_string());


### PR DESCRIPTION
We were inserting an extra separating delim, causing the tokenize to return an extra substring. This confused the note processor causing it to discard the age invite. Oops!