### PR TITLE
Fix PageInAge ignoring the .age file

### DIFF
--- a/Sources/Plasma/Apps/plPageInfo/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plPageInfo/CMakeLists.txt
@@ -13,7 +13,7 @@ set(plPageInfo_SOURCES
 )
 
 add_executable(plPageInfo ${plPageInfo_SOURCES})
-target_link_libraries(plPageInfo CoreLib plResMgr plAudioCore pnUUID)
+target_link_libraries(plPageInfo CoreLib plAgeDescription plResMgr plAudioCore pnUUID)
 target_link_libraries(plPageInfo ${STRING_THEORY_LIBRARIES})
 
 if(USE_VLD)

--- a/Sources/Plasma/Apps/plPageOptimizer/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plPageOptimizer/CMakeLists.txt
@@ -20,6 +20,7 @@ set(plPageOptimizer_HEADERS
 add_executable(plPageOptimizer ${plPageOptimizer_SOURCES})
 
 target_link_libraries(plPageOptimizer CoreLib)
+target_link_libraries(plPageOptimizer plAgeDescription)
 target_link_libraries(plPageOptimizer plResMgr)
 target_link_libraries(plPageOptimizer pnUUID)
 target_link_libraries(plPageOptimizer ${STRING_THEORY_LIBRARIES})

--- a/Sources/Tools/plResBrowser/CMakeLists.txt
+++ b/Sources/Tools/plResBrowser/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(plResBrowser WIN32 MACOSX_BUNDLE
                ${plResBrowser_RCC} ${plResBrowser_UIC} ${plResBrowser_MOC})
 
 target_link_libraries(plResBrowser CoreLib)
+target_link_libraries(plResBrowser plAgeDescription)
 target_link_libraries(plResBrowser plResMgr)
 target_link_libraries(plResBrowser pnSceneObject)
 target_link_libraries(plResBrowser ${STRING_THEORY_LIBRARIES})


### PR DESCRIPTION
Previously, the client loaded every PRP in the global age specified. Now, we test to ensure that the requested page is listed in the age file. This is relevant considering all of the clothing PRPs going into MOULa. We don't want folks able to bring random clothing files onto Gehn. Please note this code path is only used for global ages.