### PR TITLE
Patcher File Deletion

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -682,14 +682,14 @@ bool plClient::MsgReceive(plMessage* msg)
         case plClientMsg::kLoadAgeKeys:
             {
                 plResManager *mgr = (plResManager *)hsgResMgr::ResMgr();
-                mgr->LoadAgeKeys( pMsg->GetAgeName() );
+                mgr->LoadAgeKeys( pMsg->GetPath() );
             }
             break;
 
         case plClientMsg::kReleaseAgeKeys:
             {
                 plResManager *mgr = (plResManager *)hsgResMgr::ResMgr();
-                mgr->DropAgeKeys( pMsg->GetAgeName() );
+                mgr->DropAgeKeys( pMsg->GetPath() );
             }
             break;
             
@@ -721,6 +721,20 @@ bool plClient::MsgReceive(plMessage* msg)
         case plClientMsg::kFlashWindow:
             {
                 FlashWindow();
+            }
+            break;
+
+        case plClientMsg::kAddPage:
+            {
+                plResManager* mgr = static_cast<plResManager*>(hsgResMgr::ResMgr());
+                mgr->AddSinglePage(pMsg->GetPath());
+            }
+            break;
+
+        case plClientMsg::kDropPage:
+            {
+                plResManager* mgr = static_cast<plResManager*>(hsgResMgr::ResMgr());
+                mgr->RemoveSinglePage(pMsg->GetPath());
             }
             break;
         }

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
@@ -252,8 +252,12 @@ void plClientLauncher::IOnPatchComplete(ENetError result, const ST::string& msg)
         s_errorProc(result, msg);
 }
 
-bool plClientLauncher::IApproveDownload(const plFileName& file)
+bool plClientLauncher::IApproveDownload(const plFileName& file, bool deleting)
 {
+    // No deletions allowed!
+    if (deleting)
+        return false;
+
     // So, for a repair, what we want to do is quite simple.
     // That is: download everything that is NOT in the root directory.
     plFileName path = file.StripFileName();
@@ -284,7 +288,7 @@ void plClientLauncher::PatchClient()
 
     // If this is a repair, we need to approve the downloads...
     if (hsCheckBits(fFlags, kGameDataOnly))
-        patcher->OnFileDownloadDesired(std::bind(&plClientLauncher::IApproveDownload, this, std::placeholders::_1));
+        patcher->OnFileDownloadDesired(std::bind(&plClientLauncher::IApproveDownload, this, std::placeholders::_1, std::placeholders::_2));
 
     // Let's get 'er done.
     if (hsCheckBits(fFlags, kHaveSelfPatched)) {

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
@@ -85,7 +85,7 @@ private:
     ST::string GetAppArgs() const;
 
     void IOnPatchComplete(ENetError result, const ST::string& msg);
-    bool IApproveDownload(const plFileName& file);
+    bool IApproveDownload(const plFileName& file, bool deleting);
 
 public:
     plClientLauncher();

--- a/Sources/Plasma/FeatureLib/pfCharacter/pfMarkerInfo.cpp
+++ b/Sources/Plasma/FeatureLib/pfCharacter/pfMarkerInfo.cpp
@@ -68,7 +68,7 @@ void pfMarkerInfo::Init()
 
     // Force the client to keep the GlobalMarkers keys loaded, so we don't load them every time we clone
     plClientMsg* loadAgeKeysMsg = new plClientMsg(plClientMsg::kLoadAgeKeys);
-    loadAgeKeysMsg->SetAgeName("GlobalMarkers");
+    loadAgeKeysMsg->SetPath("GlobalMarkers");
     loadAgeKeysMsg->Send(resMgr->FindKey(kClient_KEY));
 
     //

--- a/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.cpp
@@ -304,7 +304,7 @@ static bool DumpSpecificMsgInfo(plMessage* msg, ST::string& info)
 
         case plClientMsg::kLoadAgeKeys:
         case plClientMsg::kReleaseAgeKeys:
-            info += ST::format(" - Age: {}", clientMsg->GetAgeName());
+            info += ST::format(" - Age: {}", clientMsg->GetPath());
             break;
         }
         return true;

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.h
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.h
@@ -71,8 +71,11 @@ public:
     /** Represents a function that takes the status and an optional message on completion. */
     typedef std::function<void(ENetError, const ST::string&)> CompletionFunc;
 
-    /** Represents a function that takes (const plFileName&) and approves it. */
-    typedef std::function<bool(const plFileName&)> FileDesiredFunc;
+    /**
+     * Represents a function that takes the filename and whether or not the file is being deleted
+     * and either approves or disapproves the patch operation.
+     */
+    typedef std::function<bool(const plFileName&, bool)> FileDesiredFunc;
 
     /** Represents a function that takes (const plFileName&) on an interesting file operation. */
     typedef std::function<void(const plFileName&)> FileDownloadFunc;
@@ -94,13 +97,18 @@ public:
      */
     void OnCompletion(CompletionFunc cb);
 
+    /** Sets a callback that will be fired when the patcher deletes a file.
+     * \remarks This will be called from the patcher thread.
+     */
+    void OnFileDeleted(FileDownloadFunc cb);
+
     /** Set a callback that will be fired when the patcher issues a download request to the server.
      *  \remarks This will be called from the network thread.
      */
     void OnFileDownloadBegin(FileDownloadFunc cb);
 
     /** Set a callback that will be fired when the patcher wants to download a file. You are
-     *  given the ability to approve or veto the download. With great power comes great responsibility...
+     *  given the ability to approve or veto the patch. With great power comes great responsibility...
      *  \remarks This will be called from the patcher thread.
      */
     void OnFileDownloadDesired(FileDesiredFunc cb);

--- a/Sources/Plasma/NucleusLib/pnMessage/plClientMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plClientMsg.cpp
@@ -45,7 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 void plClientMsg::IReset()
 { 
     fMsgFlag = 0;
-    fAgeName = "";
+    fPath = "";
 }
 
 void plClientMsg::AddRoomLoc(plLocation loc)

--- a/Sources/Plasma/NucleusLib/pnMessage/plClientMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plClientMsg.h
@@ -56,7 +56,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plClientMsg : public plMessage
 {
     int fMsgFlag;
-    ST::string fAgeName;
+    ST::string fPath;
     std::vector<plLocation> fRoomLocs;
 
     void IReset();
@@ -95,6 +95,9 @@ public:
         kSetGraphicsDefaults,
 
         kFlashWindow,
+
+        kAddPage,  // adds a page to the registry
+        kDropPage, // drops a page from the registry
     };
 
     // graphics settings fields
@@ -105,6 +108,7 @@ public:
     plClientMsg(const plKey &s) { IReset();}  
     plClientMsg(int i) { IReset(); fMsgFlag = i; }  
     plClientMsg(const plKey &s, const plKey &r, const double* t) { IReset(); }
+    ~plClientMsg() { }
 
     CLASSNAME_REGISTER(plClientMsg);
     GETINTERFACE_ANY(plClientMsg, plMessage);
@@ -113,9 +117,9 @@ public:
 
     void AddRoomLoc(plLocation loc);
 
-    // Used for kLoadAgeKeys, kLetGoOfAgeKeys only
-    ST::string  GetAgeName() const { return fAgeName; }
-    void        SetAgeName(const ST::string& age) { fAgeName = age; }
+    // Used for kLoadAgeKeys, kLetGoOfAgeKeys, kAddPage, and kDropPage
+    const ST::string& GetPath() const { return fPath; }
+    void              SetPath(const ST::string& path) { fPath = path; }
 
     int GetNumRoomLocs() { return fRoomLocs.size(); }
     const plLocation& GetRoomLoc(int i) const { return fRoomLocs[i]; }

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
@@ -266,7 +266,7 @@ bool plAgeLoader::ILoadAge(const ST::string& ageName)
 
     // Tell the client to load-and-hold all the keys for this age, to make the loading process work better
     plClientMsg *loadAgeKeysMsg = new plClientMsg( plClientMsg::kLoadAgeKeys );
-    loadAgeKeysMsg->SetAgeName( fAgeName);
+    loadAgeKeysMsg->SetPath(fAgeName);
     loadAgeKeysMsg->Send( clientKey );
 
     //
@@ -281,7 +281,7 @@ bool plAgeLoader::ILoadAge(const ST::string& ageName)
     int nPages = 0;
 
     plClientMsg* pMsg1 = new plClientMsg(plClientMsg::kLoadRoom);
-    pMsg1->SetAgeName(fAgeName);
+    pMsg1->SetPath(fAgeName);
 
     // Loop and ref!
     while( ( page = ad.GetNextPage() ) != nil )
@@ -302,7 +302,7 @@ bool plAgeLoader::ILoadAge(const ST::string& ageName)
 
     // Send the client a message to let go of the extra keys it was holding on to
     plClientMsg *dumpAgeKeys = new plClientMsg( plClientMsg::kReleaseAgeKeys );
-    dumpAgeKeys->SetAgeName( fAgeName);
+    dumpAgeKeys->SetPath(fAgeName);
     dumpAgeKeys->Send( clientKey );
 
     if ( nPages==0 )

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.h
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.h
@@ -62,6 +62,7 @@ class plResPatcher
     friend class plAgeLoader;
 
     void OnCompletion(ENetError, const ST::string& msg);
+    void OnFileDeleted(const plFileName& file);
     void OnFileDownloadBegin(const plFileName& file);
     void OnFileDownloaded(const plFileName& file);
     bool OnGameCodeDiscovered(const plFileName& file, class hsStream* stream);

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
@@ -1264,7 +1264,7 @@ void plResManager::PageInAge(const ST::string &age)
 
     // Tell the client to load all the keys for this age, to make the loading process work better
     plClientMsg *loadAgeKeysMsg = new plClientMsg(plClientMsg::kLoadAgeKeys);
-    loadAgeKeysMsg->SetAgeName(age);
+    loadAgeKeysMsg->SetPath(age);
     loadAgeKeysMsg->Send(clientKey);
 
     // Then iterate through each room in the age. The iterator will send the load message


### PR DESCRIPTION
Implements the ability for the FileSrv to instruct the patcher to delete files. Also, we ensure that pfPatcher can only operate inside the client directory to prevent mischief. This will be useful considering we don't want the stupid clothing files from MOULa.