### PR TITLE
Fix unicode mangling in the OnPageLoad python CB

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -1749,17 +1749,14 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
         plRoomLoadNotifyMsg* pRLNMsg = plRoomLoadNotifyMsg::ConvertNoRef(msg);
         if (pRLNMsg)
         {
-            // yes...
-            // call it
-            const char* roomname = "";
-            if ( pRLNMsg->GetRoom() != nil )
-                roomname = pRLNMsg->GetRoom()->GetName().c_str();
+            PyObject* roomname = PyUnicode_FromSTString(pRLNMsg->GetRoom() ?
+                                                        pRLNMsg->GetRoom()->GetName() : ST::null);
 
             plProfile_BeginTiming(PythonUpdate);
             PyObject* retVal = PyObject_CallMethod(
                     fPyFunctionInstances[kfunc_PageLoad],
                     (char*)fFunctionNames[kfunc_PageLoad],
-                    "ls", pRLNMsg->GetWhatHappen(), roomname);
+                    "lO", pRLNMsg->GetWhatHappen(), roomname);
             if ( retVal == nil )
             {
 #ifndef PLASMA_EXTERNAL_RELEASE
@@ -1769,6 +1766,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
                 // if there was an error make sure that the stderr gets flushed so it can be seen
                 ReportError();
             }
+            Py_DECREF(roomname);
             Py_XDECREF(retVal);
             plProfile_EndTiming(PythonUpdate);
             // display any output (NOTE: this would be disabled in production)


### PR DESCRIPTION
This fixes a crash [reported](https://forum.guildofwriters.org/viewtopic.php?f=117&t=6812) to occur on Windows 7 when linking to Minkata and Ahnonay. We again see issues when reencoding the `c_str` of an `ST::string`. Please note that this changeset converts the second argument of `OnPageLoad` from an `str` to an `unicode` object.