### PR TITLE
OpenSSL 1.1 / Linux compile fixes

### DIFF
--- a/Sources/Plasma/Apps/plPageInfo/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plPageInfo/CMakeLists.txt
@@ -13,7 +13,7 @@ set(plPageInfo_SOURCES
 )
 
 add_executable(plPageInfo ${plPageInfo_SOURCES})
-target_link_libraries(plPageInfo CoreLib plAgeDescription plResMgr plAudioCore pnUUID)
+target_link_libraries(plPageInfo CoreLib plResMgr plAudioCore pnUUID)
 target_link_libraries(plPageInfo ${STRING_THEORY_LIBRARIES})
 
 if(USE_VLD)

--- a/Sources/Plasma/Apps/plPageOptimizer/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plPageOptimizer/CMakeLists.txt
@@ -20,7 +20,6 @@ set(plPageOptimizer_HEADERS
 add_executable(plPageOptimizer ${plPageOptimizer_SOURCES})
 
 target_link_libraries(plPageOptimizer CoreLib)
-target_link_libraries(plPageOptimizer plAgeDescription)
 target_link_libraries(plPageOptimizer plResMgr)
 target_link_libraries(plPageOptimizer pnUUID)
 target_link_libraries(plPageOptimizer ${STRING_THEORY_LIBRARIES})

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNodeGlue.cpp
@@ -88,7 +88,7 @@ PYTHON_METHOD_DEFINITION(ptVaultMarkerGameNode, setGameName, args)
     PYTHON_RETURN_NONE;
 }
 
-PYTHON_METHOD_DEFINITION(ptVaultMarkerGameNode, getReward)
+PYTHON_METHOD_DEFINITION_NOARGS(ptVaultMarkerGameNode, getReward)
 {
     return PyUnicode_FromSTString(self->fThis->GetReward());
 }

--- a/Sources/Plasma/NucleusLib/pnEncryption/plBigNum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plBigNum.cpp
@@ -58,24 +58,24 @@ static inline void byteswap(size_t size, uint8_t* data)
 
 plBigNum::plBigNum () : m_context(nil)
 {
-    BN_init(&m_number);
+    m_number = BN_new();
 }
 
 plBigNum::plBigNum(const plBigNum& a) : m_context(nil)
 {
-    BN_init(&m_number);
-    BN_copy(&m_number, &a.m_number);
+    m_number = BN_new();
+    BN_copy(m_number, a.m_number);
 }
 
 plBigNum::plBigNum(unsigned a) : m_context(nil)
 {
-    BN_init(&m_number);
-    BN_set_word(&m_number, a);
+    m_number = BN_new();
+    BN_set_word(m_number, a);
 }
 
 plBigNum::plBigNum(unsigned bytes, const void* data, bool le) : m_context(nil)
 {
-    BN_init(&m_number);
+    m_number = BN_new();
     if (le)
         FromData_LE(bytes, data);
     else
@@ -86,7 +86,7 @@ plBigNum::~plBigNum ()
 {
     if (m_context)
         BN_CTX_free(m_context);
-    BN_free(&m_number);
+    BN_free(m_number);
 }
 
 int plBigNum::Compare(uint32_t a) const
@@ -95,12 +95,12 @@ int plBigNum::Compare(uint32_t a) const
     //  0 if (this == a)
     //  1 if (this >  a)
 
-    if (BN_is_word(&m_number, a))
+    if (BN_is_word(m_number, a))
         return 0;
 
     // This returns 0xFFFFFFFFL if the number is bigger than one uint16_t, so
     // it doesn't need any size check
-    if (BN_get_word(&m_number) < a)
+    if (BN_get_word(m_number) < a)
         return -1;
 
     // Not less or equal, must be greater
@@ -112,23 +112,23 @@ void plBigNum::FromData_LE(uint32_t bytes, const void* data)
     uint8_t* buffer = new uint8_t[bytes];
     memcpy(buffer, data, bytes);
     byteswap(bytes, buffer);
-    BN_bin2bn(buffer, bytes, &m_number);
+    BN_bin2bn(buffer, bytes, m_number);
     delete[] buffer;
 }
 
 uint8_t* plBigNum::GetData_BE(uint32_t* bytes) const
 {
-    *bytes = BN_num_bytes(&m_number);
+    *bytes = BN_num_bytes(m_number);
     uint8_t* data = new uint8_t[*bytes];
-    BN_bn2bin(&m_number, data);
+    BN_bn2bin(m_number, data);
     return data;
 }
 
 uint8_t* plBigNum::GetData_LE(uint32_t* bytes) const
 {
-    *bytes = BN_num_bytes(&m_number);
+    *bytes = BN_num_bytes(m_number);
     uint8_t* data = new uint8_t[*bytes];
-    BN_bn2bin(&m_number, data);
+    BN_bn2bin(m_number, data);
     byteswap(*bytes, data);
     return data;
 }
@@ -140,6 +140,6 @@ void plBigNum::Rand(uint32_t bits, plBigNum* seed)
     uint32_t seedbytes;
     uint8_t* seedData = seed->GetData_BE(&seedbytes);
     RAND_seed(seedData, seedbytes);
-    BN_rand(&m_number, bits, 0, 0);
+    BN_rand(m_number, bits, 0, 0);
     delete[] seedData;
 }

--- a/Sources/Plasma/NucleusLib/pnEncryption/plBigNum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plBigNum.h
@@ -55,7 +55,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plBigNum
 {
 private:
-    BIGNUM m_number;
+    BIGNUM* m_number;
     mutable BN_CTX* m_context;
 
     BN_CTX* GetContext() const
@@ -74,7 +74,7 @@ public:
 
     plBigNum& operator=(const plBigNum& a)
     {
-        BN_copy(&m_number, &a.m_number);
+        BN_copy(m_number, a.m_number);
         return *this;
     }
 
@@ -84,46 +84,46 @@ public:
     void Add(const plBigNum& a, uint32_t b)
     {
         // this = a + b
-        BN_copy(&m_number, &a.m_number);
-        BN_add_word(&m_number, b);
+        BN_copy(m_number, a.m_number);
+        BN_add_word(m_number, b);
     }
 
     void Add(const plBigNum& a, const plBigNum& b)
     {
         // this = a + b
-        BN_add(&m_number, &a.m_number, &b.m_number);
+        BN_add(m_number, a.m_number, b.m_number);
     }
 
     int Compare(uint32_t a) const;
 
     int Compare(const plBigNum& a) const
     {
-        return BN_cmp(&m_number, &a.m_number);
+        return BN_cmp(m_number, a.m_number);
     }
 
     bool isZero() const
     {
-        return BN_is_zero(&m_number);
+        return BN_is_zero(m_number);
     }
 
     void Div(const plBigNum& a, uint32_t b, uint32_t* remainder)
     {
         // this = a / b, remainder = a % b
-        BN_copy(&m_number, &a.m_number);
-        *remainder = (uint32_t)BN_div_word(&m_number, b);
+        BN_copy(m_number, a.m_number);
+        *remainder = (uint32_t)BN_div_word(m_number, b);
     }
 
     void Div(const plBigNum& a, const plBigNum& b, plBigNum* remainder)
     {
         // this = a / b, remainder = a % b
         // either this or remainder may be nil
-        BN_div(this ? &m_number : nil, remainder ? &remainder->m_number : nil,
-               &a.m_number, &b.m_number, GetContext());
+        BN_div(this ? m_number : nil, remainder ? remainder->m_number : nil,
+               a.m_number, b.m_number, GetContext());
     }
 
     void FromData_BE(uint32_t bytess, const void* data)
     {
-        BN_bin2bn((const uint8_t*)data, bytess, &m_number);
+        BN_bin2bn((const uint8_t*)data, bytess, m_number);
     }
 
     void FromData_LE(uint32_t bytess, const void* data);
@@ -135,26 +135,26 @@ public:
     {
         // Cyan's code uses 3 checks, so we'll follow suit.
         // This provides an accurate answer to p < 0.015625
-        return BN_is_prime_fasttest(&m_number, 3, nil, GetContext(), nil, 1) > 0;
+        return BN_is_prime_fasttest(m_number, 3, nil, GetContext(), nil, 1) > 0;
     }
 
     void Mod(const plBigNum& a, const plBigNum& b)
     {
         // this = a % b
-        BN_div(nil, &m_number, &a.m_number, &b.m_number, GetContext());
+        BN_div(nil, m_number, a.m_number, b.m_number, GetContext());
     }
 
     void Mul(const plBigNum& a, uint32_t b)
     {
         // this = a * b
-        BN_copy(&m_number, &a.m_number);
-        BN_mul_word(&m_number, b);
+        BN_copy(m_number, a.m_number);
+        BN_mul_word(m_number, b);
     }
 
     void Mul(const plBigNum& a, const plBigNum& b)
     {
         // this = a * b
-        BN_mul(&m_number, &a.m_number, &b.m_number, GetContext());
+        BN_mul(m_number, a.m_number, b.m_number, GetContext());
     }
 
     void PowMod(uint32_t a, const plBigNum& b, const plBigNum& c)
@@ -166,13 +166,13 @@ public:
     void PowMod(const plBigNum& a, const plBigNum& b, const plBigNum& c)
     {
         // this = a ^ b % c
-        BN_mod_exp(&m_number, &a.m_number, &b.m_number, &c.m_number, GetContext());
+        BN_mod_exp(m_number, a.m_number, b.m_number, c.m_number, GetContext());
     }
 
     void Rand(const plBigNum& a, plBigNum* seed)
     {
         // this = random number less than a
-        int bits = BN_num_bits(&a.m_number);
+        int bits = BN_num_bits(a.m_number);
         do
             Rand(bits, seed);
         while (Compare(a) >= 0);
@@ -182,17 +182,17 @@ public:
 
     void RandPrime(uint32_t bits, plBigNum* seed)
     {
-        BN_generate_prime(&m_number, bits, 1, nil, nil, nil, nil);
+        BN_generate_prime(m_number, bits, 1, nil, nil, nil, nil);
     }
 
     void Set(const plBigNum& a)
     {
-        BN_copy(&m_number, &a.m_number);
+        BN_copy(m_number, a.m_number);
     }
 
     void Set(uint32_t a)
     {
-        BN_set_word(&m_number, a);
+        BN_set_word(m_number, a);
     }
 
     void SetOne() { Set(1); }
@@ -201,26 +201,26 @@ public:
     void Shl(const plBigNum& a, uint32_t b)
     {
         // this = a << b
-        BN_lshift(&m_number, &a.m_number, b);
+        BN_lshift(m_number, a.m_number, b);
     }
 
     void Shr(const plBigNum& a, uint32_t b)
     {
         // this = a >> b
-        BN_rshift(&m_number, &a.m_number, b);
+        BN_rshift(m_number, a.m_number, b);
     }
 
     void Sub(const plBigNum& a, uint32_t b)
     {
         // this = a - b
-        BN_copy(&m_number, &a.m_number);
-        BN_sub_word(&m_number, b);
+        BN_copy(m_number, a.m_number);
+        BN_sub_word(m_number, b);
     }
 
     void Sub(const plBigNum& a, const plBigNum& b)
     {
         // this = a - b
-        BN_sub(&m_number, &a.m_number, &b.m_number);
+        BN_sub(m_number, a.m_number, b.m_number);
     }
 };
 #endif // plBigNum_inc

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChallengeHash.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChallengeHash.cpp
@@ -49,6 +49,7 @@ ShaDigest fSeed;
 
 void CryptCreateRandomSeed(size_t length, uint8_t* data)
 {
+#ifdef OPENSSL_HAVE_SHA0
     uint32_t seedIdx = 0;
     uint32_t dataIdx = 0;
     size_t cur = 0;
@@ -91,10 +92,14 @@ void CryptCreateRandomSeed(size_t length, uint8_t* data)
     for (size_t i = 0; i < sizeof(ShaDigest); i++) {
         fSeed[i] ^= digest[i];
     }
+#else
+    FATAL("OpenSSL 1.1+ does not include SHA0 support");
+#endif
 }
 
 void CryptHashPassword(const ST::string& username, const ST::string& password, ShaDigest dest)
 {
+#ifdef OPENSSL_HAVE_SHA0
     ST::string_stream buf;
     buf << password.left(password.size() - 1) << '\0';
     buf << username.to_lower().left(username.size() - 1) << '\0';
@@ -102,10 +107,14 @@ void CryptHashPassword(const ST::string& username, const ST::string& password, S
     plSHAChecksum sum(result.size() * sizeof(char16_t), (uint8_t*)result.data());
 
     memcpy(dest, sum.GetValue(), sizeof(ShaDigest));
+#else
+    FATAL("OpenSSL 1.1+ does not include SHA0 support");
+#endif
 }
 
 void CryptHashPasswordChallenge(uint32_t clientChallenge, uint32_t serverChallenge, ShaDigest namePassHash, ShaDigest challengeHash)
 {
+#ifdef OPENSSL_HAVE_SHA0
     plSHAChecksum sum;
 
     sum.Start();
@@ -115,4 +124,7 @@ void CryptHashPasswordChallenge(uint32_t clientChallenge, uint32_t serverChallen
     sum.Finish();
 
     memcpy(challengeHash, sum.GetValue(), sizeof(ShaDigest));
+#else
+    FATAL("OpenSSL 1.1+ does not include SHA0 support");
+#endif
 }

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -232,7 +232,7 @@ bool plMD5Checksum::operator==(const plMD5Checksum& rhs) const
 }
 
 //============================================================================
-
+#ifdef OPENSSL_HAVE_SHA0
 plSHAChecksum::plSHAChecksum(size_t size, uint8_t* buffer)
 {
     fValid = false;
@@ -359,6 +359,7 @@ bool plSHAChecksum::operator==(const plSHAChecksum& rhs) const
 {
     return (fValid && rhs.fValid && memcmp(fChecksum, rhs.fChecksum, sizeof(fChecksum)) == 0);
 }
+#endif /* OPENSSL_HAVE_SHA0 */
 
 //============================================================================
 

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -45,6 +45,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include <openssl/md5.h>
 #include <openssl/sha.h>
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define OPENSSL_HAVE_SHA0 1
+#endif
 
 class plChecksum
 {
@@ -106,6 +111,7 @@ class plMD5Checksum
  */
 typedef uint8_t ShaDigest[SHA_DIGEST_LENGTH];
 
+#ifdef OPENSSL_HAVE_SHA0
 class plSHAChecksum
 {
     protected:
@@ -144,6 +150,7 @@ class plSHAChecksum
         bool operator==(const plSHAChecksum& rhs) const;
         bool operator!=(const plSHAChecksum& rhs) const { return !operator==(rhs); }
 };
+#endif
 
 class plSHA1Checksum
 {

--- a/Sources/Plasma/PubUtilLib/plResMgr/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plResMgr/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(plResMgr pnFactory)
 target_link_libraries(plResMgr pnKeyedObject)
 target_link_libraries(plResMgr pnMessage)
 target_link_libraries(plResMgr pnTimer)
+target_link_libraries(plResMgr plAgeDescription)
 target_link_libraries(plResMgr plFile)
 target_link_libraries(plResMgr plStatusLog)
 

--- a/Sources/Tools/plFontConverter/CMakeLists.txt
+++ b/Sources/Tools/plFontConverter/CMakeLists.txt
@@ -48,7 +48,6 @@ add_executable(plFontConverter WIN32 MACOSX_BUNDLE
 target_link_libraries(plFontConverter CoreLib)
 target_link_libraries(plFontConverter pnKeyedObject)
 target_link_libraries(plFontConverter pnSceneObject)
-target_link_libraries(plFontConverter plAgeDescription)
 target_link_libraries(plFontConverter plGImage)
 target_link_libraries(plFontConverter plPipeline)
 target_link_libraries(plFontConverter plResMgr)

--- a/Sources/Tools/plResBrowser/CMakeLists.txt
+++ b/Sources/Tools/plResBrowser/CMakeLists.txt
@@ -49,7 +49,6 @@ add_executable(plResBrowser WIN32 MACOSX_BUNDLE
                ${plResBrowser_RCC} ${plResBrowser_UIC} ${plResBrowser_MOC})
 
 target_link_libraries(plResBrowser CoreLib)
-target_link_libraries(plResBrowser plAgeDescription)
 target_link_libraries(plResBrowser plResMgr)
 target_link_libraries(plResBrowser pnSceneObject)
 target_link_libraries(plResBrowser ${STRING_THEORY_LIBRARIES})


### PR DESCRIPTION
Using OpenSSL 1.1 for the client is still not an option with this change, but this allows us to once again build the tools on Linux systems with newer system OpenSSL libraries.