### PR TITLE
Backport (and add to) fixes for latest MSVC 2015/2017 updates

### DIFF
--- a/Sources/Tests/gtest-1.8.0/cmake/internal_utils.cmake
+++ b/Sources/Tests/gtest-1.8.0/cmake/internal_utils.cmake
@@ -81,8 +81,6 @@ macro(config_compiler_and_linker)
       # Suppress "unreachable code" warning on VS 2012 and later.
       # http://stackoverflow.com/questions/3232669 explains the issue.
       set(cxx_base_flags "${cxx_base_flags} -wd4702")
-    endif()
-    if (NOT (MSVC_VERSION GREATER 1900))  # 1900 is Visual Studio 2015
       # BigObj required for tests.
       set(cxx_base_flags "${cxx_base_flags} -bigobj")
     endif()

--- a/Sources/Tests/gtest-1.8.0/include/gtest/gtest-printers.h
+++ b/Sources/Tests/gtest-1.8.0/include/gtest/gtest-printers.h
@@ -588,7 +588,7 @@ template <typename T>
 void PrintTupleTo(const T& t, ::std::ostream* os);
 #endif  // GTEST_HAS_TR1_TUPLE || GTEST_HAS_STD_TUPLE_
 
-#if GTEST_HAS_TR1_TUPLE
+#if GTEST_HAS_TR1_TUPLE && (!defined(_MSC_VER) || _MSC_VER < 1900)
 // Overload for ::std::tr1::tuple.  Needed for printing function arguments,
 // which are packed as tuples.
 
@@ -868,7 +868,7 @@ typedef ::std::vector<string> Strings;
 template <typename TupleT>
 struct TuplePolicy;
 
-#if GTEST_HAS_TR1_TUPLE
+#if GTEST_HAS_TR1_TUPLE && (!defined(_MSC_VER) || _MSC_VER < 1900)
 template <typename TupleT>
 struct TuplePolicy {
   typedef TupleT Tuple;

--- a/Sources/Tests/gtest-1.8.0/include/gtest/internal/gtest-port.h
+++ b/Sources/Tests/gtest-1.8.0/include/gtest/internal/gtest-port.h
@@ -323,7 +323,7 @@
 // -std={c,gnu}++{0x,11} is passed.  The C++11 standard specifies a
 // value for __cplusplus, and recent versions of clang, gcc, and
 // probably other compilers set that too in C++11 mode.
-# if __GXX_EXPERIMENTAL_CXX0X__ || __cplusplus >= 201103L
+# if __GXX_EXPERIMENTAL_CXX0X__ || __cplusplus >= 201103L || _MSC_VER >= 1900
 // Compiling in at least C++11 mode.
 #  define GTEST_LANG_CXX11 1
 # else
@@ -355,12 +355,16 @@
 #if GTEST_STDLIB_CXX11
 # define GTEST_HAS_STD_BEGIN_AND_END_ 1
 # define GTEST_HAS_STD_FORWARD_LIST_ 1
-# define GTEST_HAS_STD_FUNCTION_ 1
+# if !defined(_MSC_VER) || (_MSC_FULL_VER >= 190023824) // works only with VS2015U2 and better
+#   define GTEST_HAS_STD_FUNCTION_ 1
+# endif
 # define GTEST_HAS_STD_INITIALIZER_LIST_ 1
 # define GTEST_HAS_STD_MOVE_ 1
 # define GTEST_HAS_STD_SHARED_PTR_ 1
 # define GTEST_HAS_STD_TYPE_TRAITS_ 1
 # define GTEST_HAS_STD_UNIQUE_PTR_ 1
+# define GTEST_HAS_UNORDERED_MAP_ 1
+# define GTEST_HAS_UNORDERED_SET_ 1
 #endif
 
 // C++11 specifies that <tuple> provides std::tuple.
@@ -657,7 +661,8 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 // support TR1 tuple.  libc++ only provides std::tuple, in C++11 mode,
 // and it can be used with some compilers that define __GNUC__.
 # if (defined(__GNUC__) && !defined(__CUDACC__) && (GTEST_GCC_VER_ >= 40000) \
-      && !GTEST_OS_QNX && !defined(_LIBCPP_VERSION)) || _MSC_VER >= 1600
+      && !GTEST_OS_QNX && !defined(_LIBCPP_VERSION)) \
+      || (_MSC_VER >= 1600 && _MSC_VER < 1900)
 #  define GTEST_ENV_HAS_TR1_TUPLE_ 1
 # endif
 

--- a/Sources/Tests/gtest-1.8.0/test/gtest-printers_test.cc
+++ b/Sources/Tests/gtest-1.8.0/test/gtest-printers_test.cc
@@ -51,10 +51,15 @@
 #include "gtest/gtest.h"
 
 // hash_map and hash_set are available under Visual C++, or on Linux.
-#if GTEST_HAS_HASH_MAP_
+#if GTEST_HAS_UNORDERED_MAP_
+# include <unordered_map>
+#elif GTEST_HAS_HASH_MAP_
 # include <hash_map>            // NOLINT
 #endif  // GTEST_HAS_HASH_MAP_
-#if GTEST_HAS_HASH_SET_
+
+#if GTEST_HAS_UNORDERED_SET_
+# include <unordered_set>
+#elif GTEST_HAS_HASH_SET_
 # include <hash_set>            // NOLINT
 #endif  // GTEST_HAS_HASH_SET_
 
@@ -217,16 +222,44 @@ using ::testing::internal::string;
 // The hash_* classes are not part of the C++ standard.  STLport
 // defines them in namespace std.  MSVC defines them in ::stdext.  GCC
 // defines them in ::.
+#if GTEST_HAS_UNORDERED_MAP_
+
+#define GTEST_HAS_HASH_MAP_ 1
+template<class Key, class T>
+using hash_map = ::std::unordered_map<Key, T>;
+template<class Key, class T>
+using hash_multimap = ::std::unordered_multimap<Key, T>;
+
+#elif GTEST_HAS_HASH_MAP_
+
 #ifdef _STLP_HASH_MAP  // We got <hash_map> from STLport.
 using ::std::hash_map;
-using ::std::hash_set;
 using ::std::hash_multimap;
-using ::std::hash_multiset;
 #elif _MSC_VER
 using ::stdext::hash_map;
-using ::stdext::hash_set;
 using ::stdext::hash_multimap;
+#endif
+
+#endif
+
+#if GTEST_HAS_UNORDERED_SET_
+
+#define GTEST_HASH_HASH_SET_ 1
+template<class Key>
+using hash_set = ::std::unordered_set<Key>;
+template<class Key>
+using hash_multiset = ::std::unordered_multiset<Key>;
+
+#elif GTEST_HAS_HASH_SET_
+
+#ifdef _STLP_HASH_MAP  // We got <hash_map> from STLport.
+using ::std::hash_set;
+using ::std::hash_multiset;
+#elif _MSC_VER
+using ::stdext::hash_set;
 using ::stdext::hash_multiset;
+#endif
+
 #endif
 
 // Prints a value to a string using the universal value printer.  This
@@ -1036,7 +1069,7 @@ TEST(PrintTr1TupleTest, VariousSizes) {
   // an explicit type cast of NULL to be used.
   ::std::tr1::tuple<bool, char, short, testing::internal::Int32,  // NOLINT
       testing::internal::Int64, float, double, const char*, void*, string>
-      t10(false, 'a', 3, 4, 5, 1.5F, -2.5, str,
+      t10(false, 'a', static_cast<short>(3), 4, 5, 1.5F, -2.5, str,
           ImplicitCast_<void*>(NULL), "10");
   EXPECT_EQ("(false, 'a' (97, 0x61), 3, 4, 5, 1.5, -2.5, " + PrintPointer(str) +
             " pointing to \"8\", NULL, \"10\")",
@@ -1095,7 +1128,7 @@ TEST(PrintStdTupleTest, VariousSizes) {
   // an explicit type cast of NULL to be used.
   ::std::tuple<bool, char, short, testing::internal::Int32,  // NOLINT
       testing::internal::Int64, float, double, const char*, void*, string>
-      t10(false, 'a', 3, 4, 5, 1.5F, -2.5, str,
+      t10(false, 'a', static_cast<short>(3), 4, 5, 1.5F, -2.5, str,
           ImplicitCast_<void*>(NULL), "10");
   EXPECT_EQ("(false, 'a' (97, 0x61), 3, 4, 5, 1.5, -2.5, " + PrintPointer(str) +
             " pointing to \"8\", NULL, \"10\")",

--- a/Sources/Tests/gtest-1.8.0/test/gtest_catch_exceptions_test_.cc
+++ b/Sources/Tests/gtest-1.8.0/test/gtest_catch_exceptions_test_.cc
@@ -138,7 +138,7 @@ TEST_F(CxxExceptionInConstructorTest, ThrowsExceptionInConstructor) {
 }
 
 // Exceptions in destructors are not supported in C++11.
-#if !defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __cplusplus < 201103L
+#if !GTEST_LANG_CXX11
 class CxxExceptionInDestructorTest : public Test {
  public:
   static void TearDownTestCase() {


### PR DESCRIPTION
This change is ported/copied from zrax/string_theory@2c49e9ce353dd04bd1837c614ec7db7faf53e1f2, and should resolve #556.