### PR TITLE
Add workaround for mouse handling bug in Win10 FCU

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -631,3 +631,30 @@ std::vector<ST::string> DisplaySystemVersion()
     return std::vector<ST::string>();
 #endif
 }
+
+#ifdef HS_BUILD_FOR_WIN32
+static RTL_OSVERSIONINFOW s_WinVer;
+
+const RTL_OSVERSIONINFOW& hsGetWindowsVersion()
+{
+    static bool done = false;
+    if (!done) {
+        memset(&s_WinVer, 0, sizeof(RTL_OSVERSIONINFOW));
+        HMODULE ntdll = LoadLibraryW(L"ntdll.dll");
+        hsAssert(ntdll, "Failed to LoadLibrary on ntdll???");
+
+        if (ntdll) {
+            s_WinVer.dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOW);
+            typedef LONG(WINAPI* RtlGetVersionPtr)(RTL_OSVERSIONINFOW*);
+            RtlGetVersionPtr getVersion = (RtlGetVersionPtr)GetProcAddress(ntdll, "RtlGetVersion");
+            hsAssert(getVersion, "Could not find RtlGetVersion in ntdll");
+            if (getVersion) {
+                getVersion(&s_WinVer);
+                done = true;
+            }
+        }
+        FreeLibrary(ntdll);
+    }
+    return s_WinVer;
+}
+#endif

--- a/Sources/Plasma/CoreLib/hsWindows.h
+++ b/Sources/Plasma/CoreLib/hsWindows.h
@@ -81,6 +81,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   ifdef USE_VLD
 #       include <vld.h>
 #   endif // USE_VLD
+
+    const RTL_OSVERSIONINFOW& hsGetWindowsVersion();
 #endif // HS_BUILD_FOR_WIN32
 
 #endif // _hsWindows_inc_


### PR DESCRIPTION
Quoth @Deledrius 

Windows 10 Fall Creators Update changed the behavior of SetCursorPos, which no longer sends the expected WM_MOUSEMOVE message when recentering the cursor.  This adds a function to detect affected versions of Windows and flags the necessity to manually send our own message.

This workaround currently only detects the known affected version of Win10, in the hope that it will be fixed and no further attention will be required.  If this regression is not fixed, additional Win10 versions can be added.