### PR TITLE
Update Windows version identification.

### DIFF
--- a/Sources/Plasma/CoreLib/hsWindows.h
+++ b/Sources/Plasma/CoreLib/hsWindows.h
@@ -82,7 +82,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #       include <vld.h>
 #   endif // USE_VLD
 
-    const RTL_OSVERSIONINFOW& hsGetWindowsVersion();
+    const RTL_OSVERSIONINFOEXW& hsGetWindowsVersion();
 #endif // HS_BUILD_FOR_WIN32
 
 #endif // _hsWindows_inc_

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputManager.cpp
@@ -275,7 +275,7 @@ static bool INeedsWin10CursorHack()
     // According to Chromium, Microsoft will be fixing the cursor bug in the next build
     // of Windows 10, so we only need to test for the dreaded 2017 FCU...
     // Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=781182#c15
-    const RTL_OSVERSIONINFOW& version = hsGetWindowsVersion();
+    const RTL_OSVERSIONINFOEXW& version = hsGetWindowsVersion();
     return version.dwMajorVersion == 10 && version.dwBuildNumber == 16299;
 }
 


### PR DESCRIPTION
This switches over to using the recently-added `hsGetWindowsVersion` for `DisplaySystemVersion`.  I also modified `hsGetWindowsVersion` to use `RTL_OSVERSIONINFOEXW` instead of `RTL_OSVERSIONINFOW` as it contains necessary information.

`DisplaySystemVersion` no longer parses information for Win95/Win98/WinME as those are not supported and are not needed.