### PR TITLE
Patcher fixes

### DIFF
--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
@@ -261,7 +261,7 @@ bool plClientLauncher::IApproveDownload(const plFileName& file)
     // That is: download everything that is NOT in the root directory.
     if (hsCheckBits(fFlags, kGameDataOnly)) {
         plFileName path = file.StripFileName();
-        return !path.AsString().is_empty();
+        return path.IsValid();
     }
 
     // If we have successfully self-patched, don't accept any manifest

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
@@ -70,8 +70,16 @@ private:
         kRepairGame = kHaveSelfPatched | kClientImage | kGameDataOnly,
     };
 
+    enum NetCoreState
+    {
+        kNetCoreInactive,
+        kNetCoreActive,
+        kNetCoreShutdown,
+    };
+
     uint32_t   fFlags;
     plFileName fServerIni;
+    uint8_t    fNetCoreState;
 
     plFileName fClientExecutable;
 
@@ -119,12 +127,12 @@ public:
      *  So be certain that you've thought that through!
      *  \remarks This method will cause the thread to sleep so that we don't hog the CPU.
      */
-    void PumpNetCore() const;
+    bool PumpNetCore() const;
 
     /** Shutdown eap's netcore and purge any other crap that needs to happen while the app is
      *  visible. In other words, tear down evil threaded crap.
      */
-    void ShutdownNetCore() const;
+    void ShutdownNetCore();
 
     /** Load the server configuration file. Note that you MUST parse the command
      *  arguments before calling this function!

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
@@ -77,9 +77,9 @@ private:
         kNetCoreShutdown,
     };
 
-    uint32_t   fFlags;
-    plFileName fServerIni;
-    uint8_t    fNetCoreState;
+    uint32_t    fFlags;
+    plFileName  fServerIni;
+    NetCoreState fNetCoreState;
 
     plFileName fClientExecutable;
 

--- a/Sources/Plasma/Apps/plUruLauncher/winmain.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/winmain.cpp
@@ -178,8 +178,7 @@ static void PumpMessages()
         }
 
         // Now we need to pump the netcore while we have some spare time...
-        s_launcher.PumpNetCore();
-    } while (msg.message != WM_QUIT);
+    } while (s_launcher.PumpNetCore());
 }
 
 // ===================================================


### PR DESCRIPTION
Fixes an issue in which the `-NoSelfPatch` flag is ignored if a patcher is found in the client manifest. Also addresses the issue of the patcher not exiting correctly in some situations.