### PR TITLE
Remove unnecessary assertion.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.cpp
@@ -196,7 +196,7 @@ bool plMoviePlayer::IOpenMovie()
 {
 #ifdef MOVIE_AVAILABLE
     if (!plFileInfo(fMoviePath).Exists()) {
-        hsAssert(false, "Tried to play a movie that doesn't exist");
+        plStatusLog::AddLineS("movie.log", "%s: Tried to play a movie that doesn't exist.", fMoviePath.AsString().c_str());
         return false;
     }
 


### PR DESCRIPTION
As I've removed the intro videos in my testing installation to reduce startup time, this is a really irritating assertion and isn't especially useful.  If there's any utility to be had, it's as a notice in the `movie.log` file.