### PR TITLE
Follow redirects when fetching server status.

### DIFF
--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -731,8 +731,8 @@ BOOL CALLBACK UruLoginDialogProc( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
                 // For reporting errors
                 char curlError[CURL_ERROR_SIZE];
                 curl_easy_setopt(hCurl, CURLOPT_ERRORBUFFER, curlError);
-                curl_easy_setopt(curl.get(), CURLOPT_FOLLOWLOCATION, 1);
-                curl_easy_setopt(curl.get(), CURLOPT_MAXREDIRS, 5);
+                curl_easy_setopt(hCurl, CURLOPT_FOLLOWLOCATION, 1);
+                curl_easy_setopt(hCurl, CURLOPT_MAXREDIRS, 5);
 
                 while (s_loginDlgRunning) {
                     curl_easy_setopt(hCurl, CURLOPT_URL, statusUrl.c_str());

--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -731,6 +731,8 @@ BOOL CALLBACK UruLoginDialogProc( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
                 // For reporting errors
                 char curlError[CURL_ERROR_SIZE];
                 curl_easy_setopt(hCurl, CURLOPT_ERRORBUFFER, curlError);
+                curl_easy_setopt(curl.get(), CURLOPT_FOLLOWLOCATION, 1);
+                curl_easy_setopt(curl.get(), CURLOPT_MAXREDIRS, 5);
 
                 while (s_loginDlgRunning) {
                     curl_easy_setopt(hCurl, CURLOPT_URL, statusUrl.c_str());

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
@@ -109,6 +109,8 @@ void plShardStatus::Run()
     curl_easy_setopt(curl.get(), CURLOPT_ERRORBUFFER, fCurlError);
     curl_easy_setopt(curl.get(), CURLOPT_USERAGENT, "UruClient/1.0");
     curl_easy_setopt(curl.get(), CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl.get(), CURLOPT_FOLLOWLOCATION, 1);
+    curl_easy_setopt(curl.get(), CURLOPT_MAXREDIRS, 5);
     curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, this);
     curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, ICurlCallback);
 


### PR DESCRIPTION
cURL does not follow redirects by default, meaning the Gehn launcher
is currently printing the raw HTML of a 301 response.