### PR TITLE
Don't error on a clean CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,6 @@ if(PLASMA_TARGETS STREQUAL "Ethereal")
 endif(PLASMA_TARGETS STREQUAL "Ethereal")
 
 
-set_property(CACHE PLASMA_PIPELINE PROPERTY STRINGS "DirectX" "OpenGL")
 if(WIN32)
     set(PLASMA_PIPELINE "DirectX"
                         CACHE STRING "Which graphics backend to use")
@@ -235,6 +234,7 @@ else(WIN32)
     set(PLASMA_PIPELINE "OpenGL"
                         CACHE STRING "Which graphics backend to use")
 endif(WIN32)
+set_property(CACHE PLASMA_PIPELINE PROPERTY STRINGS "DirectX" "OpenGL")
 
 if(PLASMA_PIPELINE STREQUAL "DirectX")
     find_package(DirectX REQUIRED)


### PR DESCRIPTION
`set_property(CACHE ...)` must refer to an existing cache variable. This
means it must be created before the properties are set on it. Without
this change, running `cmake` the first time fails on my machine, and
then succeeds when run the second time.