### PR TITLE
Fix compiling with OpenGL

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLDevice.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLDevice.h
@@ -68,6 +68,11 @@ public:
     void SetProjectionMatrix(const hsMatrix44& src);
     void SetWorldToCameraMatrix(const hsMatrix44& src);
     void SetLocalToWorldMatrix(const hsMatrix44& src);
+
+    struct VertexBufferRef;
+    struct IndexBufferRef;
+
+    const char* GetErrorString();
 };
 
 #endif


### PR DESCRIPTION
This adds the necessary declarations needed for successful compilation
with OpenGL. It doesn't define them - none of the declarations in this
class are defined, it looks like this is all unfinished stub code.