### PR TITLE
Add a SHA-0 implementation to work around its removal in OpenSSL 1.1.

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -156,6 +156,15 @@ typedef int32_t   hsError;
 //======================================
 // Endian swap funcitions
 //======================================
+#ifdef _MSC_VER
+    #define hsSwapEndian16(val) _byteswap_ushort(val)
+    #define hsSwapEndian32(val) _byteswap_ulong(val)
+    #define hsSwapEndian64(val) _byteswap_uint64(val)
+#elif defined(__llvm__) || (defined(__GNUC__) && ((__GNUC__ * 100) + __GNUC_MINOR__) >= 408)
+    #define hsSwapEndian16(val) __builtin_bswap16(val)
+    #define hsSwapEndian32(val) __builtin_bswap32(val)
+    #define hsSwapEndian64(val) __builtin_bswap64(val)
+#else
 inline uint16_t hsSwapEndian16(uint16_t value)
 {
     return (value >> 8) | (value << 8);
@@ -178,6 +187,8 @@ inline uint64_t hsSwapEndian64(uint64_t value)
             ((value & 0x00ff000000000000) >> 40) |
             ((value)                      >> 56);
 }
+#endif
+
 inline float hsSwapEndianFloat(float fvalue)
 {
     union {

--- a/Sources/Plasma/NucleusLib/pnEncryption/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnEncryption/CMakeLists.txt
@@ -6,12 +6,14 @@ set(pnEncryption_SOURCES
     plBigNum.cpp
     plChallengeHash.cpp
     plChecksum.cpp
+    plSha0.cpp
 )
 
 set(pnEncryption_HEADERS
     plBigNum.h
     plChallengeHash.h
     plChecksum.h
+    plSha0.h
     plRandom.h
 )
 

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChallengeHash.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChallengeHash.cpp
@@ -49,7 +49,6 @@ ShaDigest fSeed;
 
 void CryptCreateRandomSeed(size_t length, uint8_t* data)
 {
-#ifdef OPENSSL_HAVE_SHA0
     uint32_t seedIdx = 0;
     uint32_t dataIdx = 0;
     size_t cur = 0;
@@ -92,14 +91,10 @@ void CryptCreateRandomSeed(size_t length, uint8_t* data)
     for (size_t i = 0; i < sizeof(ShaDigest); i++) {
         fSeed[i] ^= digest[i];
     }
-#else
-    FATAL("OpenSSL 1.1+ does not include SHA0 support");
-#endif
 }
 
 void CryptHashPassword(const ST::string& username, const ST::string& password, ShaDigest dest)
 {
-#ifdef OPENSSL_HAVE_SHA0
     ST::string_stream buf;
     buf << password.left(password.size() - 1) << '\0';
     buf << username.to_lower().left(username.size() - 1) << '\0';
@@ -107,14 +102,10 @@ void CryptHashPassword(const ST::string& username, const ST::string& password, S
     plSHAChecksum sum(result.size() * sizeof(char16_t), (uint8_t*)result.data());
 
     memcpy(dest, sum.GetValue(), sizeof(ShaDigest));
-#else
-    FATAL("OpenSSL 1.1+ does not include SHA0 support");
-#endif
 }
 
 void CryptHashPasswordChallenge(uint32_t clientChallenge, uint32_t serverChallenge, ShaDigest namePassHash, ShaDigest challengeHash)
 {
-#ifdef OPENSSL_HAVE_SHA0
     plSHAChecksum sum;
 
     sum.Start();
@@ -124,7 +115,4 @@ void CryptHashPasswordChallenge(uint32_t clientChallenge, uint32_t serverChallen
     sum.Finish();
 
     memcpy(challengeHash, sum.GetValue(), sizeof(ShaDigest));
-#else
-    FATAL("OpenSSL 1.1+ does not include SHA0 support");
-#endif
 }

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -104,7 +104,7 @@ plChecksum::plChecksum(unsigned int bufsize, const char* buffer)
 
 //============================================================================
 
-plMD5Checksum::plMD5Checksum(size_t size, uint8_t* buffer)
+plMD5Checksum::plMD5Checksum(size_t size, const uint8_t* buffer)
 {
     fValid = false;
     Start();
@@ -233,7 +233,7 @@ bool plMD5Checksum::operator==(const plMD5Checksum& rhs) const
 
 //============================================================================
 #ifdef OPENSSL_HAVE_SHA0
-plSHAChecksum::plSHAChecksum(size_t size, uint8_t* buffer)
+plSHAChecksum::plSHAChecksum(size_t size, const uint8_t* buffer)
 {
     fValid = false;
     Start();

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -43,13 +43,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define PL_CHECKSUM_H
 
 #include "HeadSpin.h"
-#include <openssl/md5.h>
-#include <openssl/sha.h>
-#include <openssl/opensslv.h>
+#include <openssl/evp.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define OPENSSL_HAVE_SHA0 1
-#endif
+#define MD5_DIGEST_LENGTH 16
+#define SHA_DIGEST_LENGTH 20
 
 class plChecksum
 {
@@ -70,9 +67,9 @@ class plFileName;
 class plMD5Checksum
 {
     protected:
-        bool    fValid;
-        MD5_CTX fContext;
-        uint8_t fChecksum[MD5_DIGEST_LENGTH];
+        bool        fValid;
+        EVP_MD_CTX* fContext;
+        uint8_t     fChecksum[MD5_DIGEST_LENGTH];
 
     public:
         plMD5Checksum(size_t size, const uint8_t* buffer);
@@ -80,6 +77,7 @@ class plMD5Checksum
         plMD5Checksum(const plMD5Checksum& rhs);
         plMD5Checksum(const plFileName& fileName);
         plMD5Checksum(hsStream* stream);
+        ~plMD5Checksum() { Clear(); }
 
         bool IsValid() const { return fValid; }
         void Clear();
@@ -111,13 +109,12 @@ class plMD5Checksum
  */
 typedef uint8_t ShaDigest[SHA_DIGEST_LENGTH];
 
-#ifdef OPENSSL_HAVE_SHA0
 class plSHAChecksum
 {
     protected:
-        bool      fValid;
-        SHA_CTX   fContext;
-        ShaDigest fChecksum;
+        bool        fValid;
+        EVP_MD_CTX* fContext;
+        ShaDigest   fChecksum;
 
     public:
         plSHAChecksum(size_t size, const uint8_t* buffer);
@@ -125,6 +122,7 @@ class plSHAChecksum
         plSHAChecksum(const plSHAChecksum& rhs);
         plSHAChecksum(const plFileName& fileName);
         plSHAChecksum(hsStream* stream);
+        ~plSHAChecksum() { Clear(); }
 
         bool IsValid() const { return fValid; }
         void Clear();
@@ -150,14 +148,13 @@ class plSHAChecksum
         bool operator==(const plSHAChecksum& rhs) const;
         bool operator!=(const plSHAChecksum& rhs) const { return !operator==(rhs); }
 };
-#endif
 
 class plSHA1Checksum
 {
     protected:
-        bool      fValid;
-        SHA_CTX   fContext;
-        ShaDigest fChecksum;
+        bool        fValid;
+        EVP_MD_CTX* fContext;
+        ShaDigest   fChecksum;
 
     public:
         plSHA1Checksum(size_t size, const uint8_t* buffer);
@@ -165,6 +162,7 @@ class plSHA1Checksum
         plSHA1Checksum(const plSHA1Checksum& rhs);
         plSHA1Checksum(const plFileName& fileName);
         plSHA1Checksum(hsStream* stream);
+        ~plSHA1Checksum() { Clear(); }
 
         bool IsValid() const { return fValid; }
         void Clear();

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define PL_CHECKSUM_H
 
 #include "HeadSpin.h"
+#include "plSha0.h"
 #include <openssl/evp.h>
 
 #define MD5_DIGEST_LENGTH 16
@@ -113,7 +114,8 @@ class plSHAChecksum
 {
     protected:
         bool        fValid;
-        EVP_MD_CTX* fContext;
+        EVP_MD_CTX* fOpenSSLContext;
+        plSha0      fPlasmaContext;
         ShaDigest   fChecksum;
 
     public:

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -75,7 +75,7 @@ class plMD5Checksum
         uint8_t fChecksum[MD5_DIGEST_LENGTH];
 
     public:
-        plMD5Checksum(size_t size, uint8_t* buffer);
+        plMD5Checksum(size_t size, const uint8_t* buffer);
         plMD5Checksum();
         plMD5Checksum(const plMD5Checksum& rhs);
         plMD5Checksum(const plFileName& fileName);
@@ -120,7 +120,7 @@ class plSHAChecksum
         ShaDigest fChecksum;
 
     public:
-        plSHAChecksum(size_t size, uint8_t* buffer);
+        plSHAChecksum(size_t size, const uint8_t* buffer);
         plSHAChecksum();
         plSHAChecksum(const plSHAChecksum& rhs);
         plSHAChecksum(const plFileName& fileName);

--- a/Sources/Plasma/NucleusLib/pnEncryption/plSha0.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plSha0.cpp
@@ -1,0 +1,160 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+#include "plSha0.h"
+
+#include "HeadSpin.h"
+#include <functional>
+#include <cstring>
+
+static const uint32_t K[] = {
+    0x5a827999,
+    0x6ed9eba1,
+    0x8f1bbcdc,
+    0xca62c1d6
+};
+
+static const std::function<uint32_t (uint32_t*)> F[] = {
+    [](uint32_t* hv) { return (hv[1] & hv[2]) | (~hv[1] & hv[3]); },
+    [](uint32_t* hv) { return (hv[1] ^ hv[2] ^ hv[3]); },
+    [](uint32_t* hv) { return (hv[1] & hv[2]) | (hv[1] & hv[3]) | (hv[2] & hv[3]); },
+    [](uint32_t* hv) { return (hv[1] ^ hv[2] ^ hv[3]); }
+};
+
+void plSha0::Start()
+{
+    fHash[0] = 0x67452301;
+    fHash[1] = 0xefcdab89;
+    fHash[2] = 0x98badcfe;
+    fHash[3] = 0x10325476;
+    fHash[4] = 0xc3d2e1f0;
+
+    fIndex = 0;
+    fSize = 0;
+}
+
+void plSha0::AddTo(size_t size, const uint8_t* buffer)
+{
+    while (size > 0) {
+        size_t count = size;
+        if (fIndex + count > sizeof(fData))
+            count = sizeof(fData) - fIndex;
+        memcpy(fData + fIndex, buffer, count);
+        fIndex += count;
+        fSize += count;
+        buffer += count;
+        size -= count;
+
+        if (fIndex == sizeof(fData)) {
+            ProcessChunk();
+            fIndex = 0;
+        }
+    }
+}
+
+void plSha0::Finish(uint8_t* digest)
+{
+    fData[fIndex++] = 0x80;   // Append '1' bit to the end of the message
+    if (fIndex == sizeof(fData)) {
+        ProcessChunk();
+        fIndex = 0;
+    }
+
+    if (fIndex + sizeof(uint64_t) > sizeof(fData)) {
+        // Not enough space to write the size -- we need another chunk.
+        memset(fData + fIndex, 0, sizeof(fData) - fIndex);
+        ProcessChunk();
+        fIndex = 0;
+    }
+
+    memset(fData + fIndex, 0, sizeof(fData) - fIndex);
+    uint64_t msg_size_bits = hsToBE64(static_cast<uint64_t>(fSize) * 8);
+    memcpy(fData + sizeof(fData) - sizeof(msg_size_bits),
+           &msg_size_bits, sizeof(msg_size_bits));
+    ProcessChunk();
+
+    // Bring the output back to host endian
+    for (size_t i = 0; i < 5; ++i)
+        fHash[i] = hsToBE32(fHash[i]);
+
+    memcpy(digest, fHash, sizeof(fHash));
+}
+
+uint32_t rol32(uint32_t value, unsigned int n)
+{
+    // Many compilers will optimize this to a single rol instruction on x86
+    return (value << n) | (value >> (32 - n));
+}
+
+void plSha0::ProcessChunk()
+{
+    uint32_t work[80];
+    memcpy(work, fData, sizeof(fData));
+
+    for (size_t i = 0; i < 16; ++i)
+        work[i] = hsToBE32(work[i]);
+
+    for (size_t i = 16; i < 80; ++i) {
+        // SHA-1 difference: no rol32(work[i], 1)
+        work[i] = work[i-3] ^ work[i-8] ^ work[i-14] ^ work[i-16];
+    }
+
+    uint32_t hv[5];
+    memcpy(hv, fHash, sizeof(hv));
+
+    // Main SHA loop
+    for (size_t i = 0; i < 80; ++i) {
+        const size_t stage = i / 20;
+        const uint32_t f = F[stage](hv);
+        const uint32_t temp = rol32(hv[0], 5) + f + hv[4] + K[stage] + work[i];
+        hv[4] = hv[3];
+        hv[3] = hv[2];
+        hv[2] = rol32(hv[1], 30);
+        hv[1] = hv[0];
+        hv[0] = temp;
+    }
+
+    fHash[0] += hv[0];
+    fHash[1] += hv[1];
+    fHash[2] += hv[2];
+    fHash[3] += hv[3];
+    fHash[4] += hv[4];
+}

--- a/Sources/Plasma/NucleusLib/pnEncryption/plSha0.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plSha0.h
@@ -1,0 +1,63 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+#ifndef PL_SHA0_H
+#define PL_SHA0_H
+
+#include <cstdint>
+#include <cstddef>
+
+class plSha0
+{
+public:
+    void Start();
+    void AddTo(size_t size, const uint8_t* buffer);
+    void Finish(uint8_t* digest);
+
+private:
+    uint8_t fData[64];
+    uint32_t fHash[5];
+    size_t fIndex, fSize;
+
+    void ProcessChunk();
+};
+
+#endif // PL_SHA0_H

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/CMakeLists.txt
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(../../../Plasma/NucleusLib)
 
 set(pnEncryptionTest_SOURCES
     test_plMD5Checksum.cpp
+    test_plSHAChecksum.cpp
     test_plSHA1Checksum.cpp
     )
 

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
@@ -1,0 +1,134 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <cstring>
+#include <gtest/gtest.h>
+#include "pnEncryption/plChecksum.h"
+
+TEST(plSHAChecksum, ctor_with_buffer)
+{
+    const char buffer[] = "Hello World";
+    const char hexStr[] = "45d579c3582a30e6ec0cc15e7ebd586838b0f7fb";
+    const ShaDigest value = {0x45, 0xd5, 0x79, 0xc3,
+                             0x58, 0x2a, 0x30, 0xe6,
+                             0xec, 0x0c, 0xc1, 0x5e,
+                             0x7e, 0xbd, 0x58, 0x68,
+                             0x38, 0xb0, 0xf7, 0xfb};
+
+    plSHAChecksum sum(strlen(buffer), (const uint8_t*)buffer);
+
+    EXPECT_EQ(sizeof(value), sum.GetSize());
+    EXPECT_EQ(0, memcmp(sum.GetValue(), value, 20));
+    EXPECT_STREQ(hexStr, sum.GetAsHexString());
+}
+
+TEST(plSHAChecksum, update)
+{
+    const char* buffer[] = {"Hello ", "World"};
+    const char hexStr[] = "45d579c3582a30e6ec0cc15e7ebd586838b0f7fb";
+    const ShaDigest value = {0x45, 0xd5, 0x79, 0xc3,
+                             0x58, 0x2a, 0x30, 0xe6,
+                             0xec, 0x0c, 0xc1, 0x5e,
+                             0x7e, 0xbd, 0x58, 0x68,
+                             0x38, 0xb0, 0xf7, 0xfb};
+
+    plSHAChecksum sum;
+    sum.Start();
+    sum.AddTo(strlen(buffer[0]), (const uint8_t*)buffer[0]);
+    sum.AddTo(strlen(buffer[1]), (const uint8_t*)buffer[1]);
+    sum.Finish();
+
+    EXPECT_EQ(sizeof(value), sum.GetSize());
+    EXPECT_EQ(0, memcmp(sum.GetValue(), value, 20));
+    EXPECT_STREQ(hexStr, sum.GetAsHexString());
+}
+
+TEST(plSHAChecksum, well_known_hashes)
+{
+    // From NIST FIPS-180
+    const char case0_text[] = "";
+    const char case0_digest[] = "f96cea198ad1dd5617ac084a3d92c6107708c0ef";
+    plSHAChecksum case0(strlen(case0_text), (const uint8_t*)case0_text);
+    EXPECT_STREQ(case0_digest, case0.GetAsHexString());
+
+    const char case1_text[] = "abc";
+    const char case1_digest[] = "0164b8a914cd2a5e74c4f7ff082c4d97f1edf880";
+    plSHAChecksum case1(strlen(case1_text), (const uint8_t*)case1_text);
+    EXPECT_STREQ(case1_digest, case1.GetAsHexString());
+
+    const char case2_text[] = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    const char case2_digest[] = "d2516ee1acfa5baf33dfc1c471e438449ef134c8";
+    plSHAChecksum case2(strlen(case2_text), (const uint8_t*)case2_text);
+    EXPECT_STREQ(case2_digest, case2.GetAsHexString());
+
+    const char case3_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+                              "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
+    const char case3_digest[] = "459f83b95db2dc87bb0f5b513a28f900ede83237";
+    plSHAChecksum case3(strlen(case3_text), (const uint8_t*)case3_text);
+    EXPECT_STREQ(case3_digest, case3.GetAsHexString());
+
+    // 1,000,000 copies of 'a'
+    uint8_t onek_a[1000];
+    memset(onek_a, 'a', sizeof(onek_a));
+    const char case4_digest[] = "3232affa48628a26653b5aaa44541fd90d690603";
+    plSHAChecksum case4;
+    case4.Start();
+    for (size_t i = 0; i < 1000; ++i)
+        case4.AddTo(sizeof(onek_a), onek_a);
+    case4.Finish();
+    EXPECT_STREQ(case4_digest, case4.GetAsHexString());
+
+#if 0
+    // case5_text repeated 16,777,216 times
+    // This test is too slow (~40 sec) with the built-in SHA0, but it can be
+    // enabled if more conformance testing is desired.
+    const char case5_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno";
+    const size_t case5_text_len = strlen(case5_text);
+    const char case5_digest[] = "bd18f2e7736c8e6de8b5abdfdeab948f5171210c";
+    plSHAChecksum case5;
+    case5.Start();
+    for (size_t i = 0; i < 16777216; ++i)
+        case5.AddTo(case5_text_len, (const uint8_t*)case5_text);
+    case5.Finish();
+    EXPECT_STREQ(case5_digest, case5.GetAsHexString());
+#endif
+}

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
@@ -119,7 +119,7 @@ TEST(plSHAChecksum, well_known_hashes)
 
 #if 0
     // case5_text repeated 16,777,216 times
-    // This test is too slow (~40 sec) with the built-in SHA0, but it can be
+    // This test is too slow (~12 sec) with the built-in SHA0, but it can be
     // enabled if more conformance testing is desired.
     const char case5_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno";
     const size_t case5_text_len = strlen(case5_text);


### PR DESCRIPTION
Based on H-uru/dirtsand#130 and H-uru/libhsplasma#120, but reworked to fit the stream-based hashing style that Plasma uses for its checksums.