### PR TITLE
Ensure OpenSSL EVP digests are initialized

### DIFF
--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -1005,6 +1005,7 @@ bool WinInit(HINSTANCE hInst)
 #include "plResMgr/plVersion.h"
 int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nCmdShow)
 {
+    OpenSSL_add_all_algorithms();
     PF_CONSOLE_INIT_ALL()
 
     // Set global handle
@@ -1230,6 +1231,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
 
     gClient.ShutdownEnd();
     DeInitNetClientComm();
+    EVP_cleanup();
 
     // Exit WinMain and terminate the app....
     return PARABLE_NORMAL_EXIT;

--- a/Sources/Plasma/Apps/plUruLauncher/winmain.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/winmain.cpp
@@ -55,6 +55,7 @@ Mead, WA   99021
 #include <commctrl.h>
 #include <shellapi.h>
 #include <shlobj.h>
+#include <openssl/evp.h>
 
 // ===================================================
 
@@ -373,6 +374,9 @@ static pfPatcher* IPatcherFactory()
 
 int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLink, int nCmdShow)
 {
+    // OpenSSL sucks
+    OpenSSL_add_all_algorithms();
+
     // Let's initialize our plClientLauncher friend
     s_launcher.ParseArguments();
     s_launcher.SetErrorProc(IOnNetError);
@@ -420,6 +424,7 @@ int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdL
     //       awhile (it can... dang eap...)
     ReleaseMutex(_onePatcherMut);
     CloseHandle(_onePatcherMut);
+    EVP_cleanup();
 
     // kthxbai
     return s_error.is_empty() ? PLASMA_OK : PLASMA_PHAILURE;


### PR DESCRIPTION
If we don't do this, `EVP_get_digestbyname` returns null and the game crashes on startup.