### PR TITLE
Improve cubemap console commands

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -1560,7 +1560,7 @@ PF_CONSOLE_CMD( Graphics_Renderer, GrabCubeCam,
     hsPoint3 pos = pfConsole::GetPipeline()->GetViewPositionWorld();
 
     hsColorRGBA clearColor = plClient::GetInstance()->GetClearColor();
-    const char* pref = params[1];
+    const char* pref = params[0];
     plGrabCubeMap grabCube;
     grabCube.GrabCube(pfConsole::GetPipeline(), pos, pref, clearColor);
 }

--- a/Sources/Plasma/FeatureLib/pfSurface/plGrabCubeMap.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plGrabCubeMap.cpp
@@ -56,60 +56,51 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnSceneObject/plDrawInterface.h"
 
 #include "plGImage/plMipmap.h"
-#include "plGImage/plJPEG.h"
+#include "plGImage/plPNG.h"
 
 #include "plMessage/plRenderRequestMsg.h"
 
-plGrabCubeRenderRequest::plGrabCubeRenderRequest()
-:   fQuality(75)
+class plGrabCubeRenderRequest : public plRenderRequest
 {
-}
+public:
+    plFileName fFileName;
 
-void plGrabCubeRenderRequest::Render(plPipeline* pipe, plPageTreeMgr* pageMgr)
-{
-    if( !fFileName[0] )
-        return;
-
-    plRenderRequest::Render(pipe, pageMgr);
-
-    pipe->EndRender();
-
-    plMipmap        mipmap;
-    if( pipe->CaptureScreen(&mipmap) )
+    // This function is called after the render request is processed by the client
+    void Render(plPipeline* pipe, plPageTreeMgr* pageMgr) HS_OVERRIDE
     {
-        plJPEG::Instance().SetWriteQuality(fQuality);
+        if (!fFileName.IsValid())
+            return;
 
-        plJPEG::Instance().WriteToFile(fFileName, &mipmap);
+        plRenderRequest::Render(pipe, pageMgr);
+        pipe->EndRender();
+
+        plMipmap mipmap;
+        if (pipe->CaptureScreen(&mipmap))
+            plPNG::Instance().WriteToFile(fFileName, &mipmap);
+        pipe->BeginRender();
     }
+};
 
-    pipe->BeginRender();
-}
+// ==============================================================================================
 
-
-void plGrabCubeMap::GrabCube(plPipeline* pipe, plSceneObject* obj, const char* pref, const hsColorRGBA& clearColor, uint8_t q)
+void plGrabCubeMap::GrabCube(plPipeline* pipe, plSceneObject* obj, const char* pref, const hsColorRGBA& clearColor)
 {
     hsPoint3 center;
-    if( obj && !(obj->GetLocalToWorld().fFlags & hsMatrix44::kIsIdent) )
-    {
+    if (obj && !(obj->GetLocalToWorld().fFlags & hsMatrix44::kIsIdent))
         center = obj->GetLocalToWorld().GetTranslate();
-    }
-    else if( obj && obj->GetDrawInterface() )
-    {
+    else if (obj && obj->GetDrawInterface())
         center = obj->GetDrawInterface()->GetWorldBounds().GetCenter();
-    }
     else
-    {
         center = pipe->GetCameraToWorld().GetTranslate();
-    }
-    ISetupRenderRequests(pipe, center, pref, clearColor, q);
+    ISetupRenderRequests(pipe, center, pref, clearColor);
 }
 
-void plGrabCubeMap::GrabCube(plPipeline* pipe, const hsPoint3& center, const char* pref, const hsColorRGBA& clearColor, uint8_t q)
+void plGrabCubeMap::GrabCube(plPipeline* pipe, const hsPoint3& center, const char* pref, const hsColorRGBA& clearColor)
 {
-    ISetupRenderRequests(pipe, center, pref, clearColor, q);
+    ISetupRenderRequests(pipe, center, pref, clearColor);
 }
 
-void plGrabCubeMap::ISetupRenderRequests(plPipeline* pipe, const hsPoint3& center, const char* pref, const hsColorRGBA& clearColor, uint8_t q) const
+void plGrabCubeMap::ISetupRenderRequests(plPipeline* pipe, const hsPoint3& center, const char* pref, const hsColorRGBA& clearColor) const
 {
     hsMatrix44 worldToCameras[6];
     hsMatrix44 cameraToWorlds[6];
@@ -132,9 +123,10 @@ void plGrabCubeMap::ISetupRenderRequests(plPipeline* pipe, const hsPoint3& cente
         "UP",
         "DN" };
 
-    int i;
-    for( i = 0; i < 6; i++ )
-    {
+    plFileName cubedir = plFileName::Join(plFileSystem::GetUserDataPath(), "CubeMaps");
+    plFileSystem::CreateDir(cubedir, false); // just in case...
+
+    for (int i = 0; i < 6; i++) {
         plGrabCubeRenderRequest* req = new plGrabCubeRenderRequest;
         req->SetRenderState(renderState);
 
@@ -155,8 +147,7 @@ void plGrabCubeMap::ISetupRenderRequests(plPipeline* pipe, const hsPoint3& cente
 
         req->SetCameraTransform(worldToCameras[i], cameraToWorlds[i]);
 
-        req->fQuality = q;
-        sprintf(req->fFileName, "%s_%s.jpg", pref, suff[i]);
+        req->fFileName = plFileName::Join(cubedir, ST::format("{}_{}.png", pref, suff[i]));
 
         plRenderRequestMsg* reqMsg = new plRenderRequestMsg(nil, req);
         reqMsg->Send();

--- a/Sources/Plasma/FeatureLib/pfSurface/plGrabCubeMap.h
+++ b/Sources/Plasma/FeatureLib/pfSurface/plGrabCubeMap.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plGrabCubeMap_inc
 #define plGrabCubeMap_inc
 
+#include <string_theory/string>
 #include "plScene/plRenderRequest.h"
 
 class plSceneObject;
@@ -53,27 +54,15 @@ struct hsMatrix44;
 struct hsPoint3;
 struct hsColorRGBA;
 
-class plGrabCubeRenderRequest : public plRenderRequest
-{
-public:
-    plGrabCubeRenderRequest();
-
-    char            fFileName[256];
-    uint8_t           fQuality;
-
-    // This function is called after the render request is processed by the client
-    virtual void    Render(plPipeline* pipe, plPageTreeMgr* pageMgr);
-};
-
 class plGrabCubeMap
 {
 protected:
-    void ISetupRenderRequests(plPipeline* pipe, const hsPoint3& center, const char* pref, const hsColorRGBA& clearColor, uint8_t q) const;
+    void ISetupRenderRequests(plPipeline* pipe, const hsPoint3& center, const char* pref, const hsColorRGBA& clearColor) const;
 
 public:
     plGrabCubeMap() {}
-    void GrabCube(plPipeline* pipe, plSceneObject* obj, const char* pref, const hsColorRGBA& clearColor, uint8_t q=75);
-    void GrabCube(plPipeline* pipe, const hsPoint3& pos, const char* pref, const hsColorRGBA& clearColor, uint8_t q=75);
+    void GrabCube(plPipeline* pipe, plSceneObject* obj, const char* pref, const hsColorRGBA& clearColor);
+    void GrabCube(plPipeline* pipe, const hsPoint3& pos, const char* pref, const hsColorRGBA& clearColor);
 };
 
 


### PR DESCRIPTION
Previously, the console command Graphics.Renderer.GrabCubeCam would use the prefix "(null)" due to a copypasta error. Saved cubemaps are now stored in their own directory in the game app data directory and compressed as PNGs instead of lossy JPEGs.