### PR TITLE
Fix fake deleted methods in pnUtList

### DIFF
--- a/Sources/Plasma/NucleusLib/pnUtils/pnUtList.h
+++ b/Sources/Plasma/NucleusLib/pnUtils/pnUtList.h
@@ -121,9 +121,9 @@ protected:
 
 public:
     inline CBaseLink ();
-    inline CBaseLink (const CBaseLink & source);
+    inline CBaseLink (const CBaseLink & source) = delete;
     inline ~CBaseLink ();
-    inline CBaseLink & operator= (const CBaseLink & source);
+    CBaseLink & operator= (const CBaseLink & source) = delete;
     inline bool IsLinked () const;
     inline void Unlink ();
 
@@ -135,25 +135,8 @@ CBaseLink::CBaseLink () {
 }
 
 //===========================================================================
-CBaseLink::CBaseLink (const CBaseLink & source) {
-#ifdef HS_DEBUGGING
-    if (source.IsLinked())
-        FATAL("No copy constructor");
-#endif
-    InitializeLinks();
-}
-
-//===========================================================================
 CBaseLink::~CBaseLink () {
     UnlinkFromNeighbors();
-}
-
-//===========================================================================
-CBaseLink & CBaseLink::operator= (const CBaseLink & source) {
-#ifdef HS_DEBUGGING
-    FATAL("No assignment operator");
-#endif
-    return *this;
 }
 
 //===========================================================================


### PR DESCRIPTION
Intrusive linked lists should never be copied. The copy constructor and operator were effectively disabled previously, but this is a more correct way to ensure copy code is never generated for list elements.