### PR TITLE
Don't link against legacy library in older versions of Visual Studio.

### DIFF
--- a/cmake/FindDirectX.cmake
+++ b/cmake/FindDirectX.cmake
@@ -58,9 +58,13 @@ set(DirectX_LIBRARIES
     ${DirectX_dsound}
     ${DirectX_dxguid}
     ${DirectX_dxerr}
-    legacy_stdio_definitions.lib
 )
 
+if(MSVC AND NOT (MSVC_VERSION LESS 1900))
+    # MSVC 2015 (v14) or newer need this library for backwards-compatibility
+    # For more information: https://msdn.microsoft.com/en-us/library/bb531344.aspx
+    list(APPEND DirectX_LIBRARIES "legacy_stdio_definitions.lib")
+endif()
 
 if(DirectX_INCLUDE_DIR AND DirectX_d3d9 AND DirectX_d3dx9 AND DirectX_dinput8
                        AND DirectX_dsound AND DirectX_dxguid AND DirectX_dxerr)


### PR DESCRIPTION
Older versions of Visual Studio neither provide nor need the wrapper for stdio backwards-compatibility.  This fixes a link error on pre-2015 VS introduced by 0df2b8b98b052e880c3e.

See also:
https://stackoverflow.com/a/32418900
https://msdn.microsoft.com/en-us/library/bb531344.aspx