### PR TITLE
plPythonPack fixes.

### DIFF
--- a/Sources/Plasma/Apps/plPythonPack/PythonInterface.cpp
+++ b/Sources/Plasma/Apps/plPythonPack/PythonInterface.cpp
@@ -95,7 +95,7 @@ void PythonInterface::initPython(const plFileName& rootDir)
             PyList_Append(path_list, more_path3);
             temp = plFileName::Join(rootDir, "system");
             printf("%s\n\n", temp.AsString().c_str());
-            PyObject* more_path2 = PyString_FromString("system");
+            PyObject* more_path2 = PyString_FromString(temp.AsString().c_str());
             PyList_Append(path_list, more_path2);
             // set the path to be this one
             PyDict_SetItemString(sys_dict, "path", path_list);

--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -433,7 +433,7 @@ std::vector<plFileName> plFileSystem::ListSubdirs(const plFileName &path)
 
     struct dirent *de;
     while (de = readdir(dir)) {
-        if (plFileInfo(de->d_name).IsDirectory()) {
+        if (plFileInfo(plFileName::Join(path, de->d_name)).IsDirectory()) {
             plFileName name = de->d_name;
             if (name != "." && name != "..")
                 contents.push_back(plFileName::Join(path, name));


### PR DESCRIPTION
Any `path` other than "." was failing to check the correct location for sub-directory statistics, returning incorrect results.

Also includes a minor fix for using the full local system path.