### PR TITLE
Use SSPI when building curl in AppVeyor config.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ install:
         git pull 2> $null
         bootstrap-vcpkg.bat
         vcpkg integrate install
-        vcpkg install curl expat freetype libjpeg-turbo libogg libpng libtheora libvorbis libvpx opus pcre speex string-theory zlib --triplet x86-windows-static-dyncrt 2> $null
+        vcpkg install curl[sspi] expat freetype libjpeg-turbo libogg libpng libtheora libvorbis libvpx opus pcre speex string-theory zlib --triplet x86-windows-static-dyncrt 2> $null
         Write-Host "OK" -foregroundColor Green
 
         Set-Location $path


### PR DESCRIPTION
As suggested by @Hoikas, this causes curl to be built using SSPI on Windows instead of OpenSSL for supporting HTTPS connections.