### PR TITLE
Assorted Warning Cleanup

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -517,8 +517,8 @@ bool plClient::InitPipeline()
 
     float   yon = 500.0f;
 
-    pipe->SetFOV( 60.f, int32_t( 60.f * pipe->Height() / pipe->Width() ) );
-    pipe->SetDepth( 0.3f, yon );
+    pipe->SetFOV(60.f, 60.f * (float)pipe->Height() / (float)pipe->Width());
+    pipe->SetDepth(0.3f, yon);
 
     hsMatrix44 id;
     id.Reset();

--- a/Sources/Plasma/CoreLib/hsBitVector.h
+++ b/Sources/Plasma/CoreLib/hsBitVector.h
@@ -116,23 +116,19 @@ public:
 
 inline hsBitVector::hsBitVector(const hsBitVector& other)
 {
-    if( 0 != (fNumBitVectors = other.fNumBitVectors) )
-    {       
+    if ((fNumBitVectors = other.fNumBitVectors) != 0) {
         fBitVectors = new uint32_t[fNumBitVectors];
-        int i;
-        for( i = 0; i < fNumBitVectors; i++ )
+        for (uint32_t i = 0; i < fNumBitVectors; i++)
             fBitVectors[i] = other.fBitVectors[i];
+    } else {
+        fBitVectors = nullptr;
     }
-    else
-        fBitVectors = nil;
 }
 
 inline bool hsBitVector::Empty() const
 {
-    int i;
-    for( i = 0; i < fNumBitVectors; i++ )
-    {
-        if( fBitVectors[i] )
+    for (uint32_t i = 0; i < fNumBitVectors; i++ ) {
+        if (fBitVectors[i])
             return false;
     }
     return true;
@@ -140,13 +136,11 @@ inline bool hsBitVector::Empty() const
 
 inline bool hsBitVector::Overlap(const hsBitVector& other) const
 {
-    if( fNumBitVectors > other.fNumBitVectors )
+    if (fNumBitVectors > other.fNumBitVectors)
         return other.Overlap(*this);
 
-    int i;
-    for( i = 0; i < fNumBitVectors; i++ )
-    {
-        if( fBitVectors[i] & other.fBitVectors[i] )
+    for (uint32_t i = 0; i < fNumBitVectors; i++ ){
+        if (fBitVectors[i] & other.fBitVectors[i])
             return true;
     }
     return false;
@@ -154,21 +148,16 @@ inline bool hsBitVector::Overlap(const hsBitVector& other) const
 
 inline hsBitVector& hsBitVector::operator=(const hsBitVector& other)
 {
-    if( this != &other )
-    {
-        if( fNumBitVectors < other.fNumBitVectors )
-        {
+    if (this != &other) {
+        if (fNumBitVectors < other.fNumBitVectors) {
             Reset();
             fNumBitVectors = other.fNumBitVectors;
             fBitVectors = new uint32_t[fNumBitVectors];
-        }
-        else
-        {
+        } else {
             Clear();
         }
 
-        int i;
-        for( i = 0; i < other.fNumBitVectors; i++ )
+        for (uint32_t i = 0; i < other.fNumBitVectors; i++)
             fBitVectors[i] = other.fBitVectors[i];
     }
     return *this;
@@ -176,77 +165,65 @@ inline hsBitVector& hsBitVector::operator=(const hsBitVector& other)
 
 inline bool hsBitVector::operator==(const hsBitVector& other) const
 {
-    if( fNumBitVectors < other.fNumBitVectors )
+    if (fNumBitVectors < other.fNumBitVectors)
         return other.operator==(*this);
-    int i;
-    for( i = 0; i < other.fNumBitVectors; i++ )
-        if( fBitVectors[i] ^ other.fBitVectors[i] )
+    uint32_t i;
+    for (i = 0; i < other.fNumBitVectors; i++)
+        if (fBitVectors[i] != other.fBitVectors[i])
             return false;
-    for( ; i < fNumBitVectors; i++ )
-        if( fBitVectors[i] )
+    for (; i < fNumBitVectors; i++)
+        if (fBitVectors[i])
             return false;
     return true;
 }
 
 inline hsBitVector& hsBitVector::operator&=(const hsBitVector& other)
 {
-    if( this == &other )
+    if (this == &other)
         return *this;
 
-    if( fNumBitVectors > other.fNumBitVectors )
-    {
+    if (fNumBitVectors > other.fNumBitVectors)
         fNumBitVectors = other.fNumBitVectors;
-    }
-    int i;
-    for( i = 0; i < fNumBitVectors; i++ )
+    for (uint32_t i = 0; i < fNumBitVectors; i++)
         fBitVectors[i] &= other.fBitVectors[i];
     return *this;
 }
 
 inline hsBitVector& hsBitVector::operator|=(const hsBitVector& other)
 {
-    if( this == &other )
+    if (this == &other)
         return *this;
 
-    if( fNumBitVectors < other.fNumBitVectors )
-    {
+    if (fNumBitVectors < other.fNumBitVectors)
         IGrow(other.fNumBitVectors);
-    }
-    int i;
-    for( i = 0; i < other.fNumBitVectors; i++ )
+    for (uint32_t i = 0; i < other.fNumBitVectors; i++)
         fBitVectors[i] |= other.fBitVectors[i];
     return *this;
 }
 
 inline hsBitVector& hsBitVector::operator^=(const hsBitVector& other)
 {
-    if( this == &other )
-    {
+    if (this == &other) {
         Clear();
         return *this;
     }
 
-    if( fNumBitVectors < other.fNumBitVectors )
-    {
+    if (fNumBitVectors < other.fNumBitVectors)
         IGrow(other.fNumBitVectors);
-    }
-    int i;
-    for( i = 0; i < other.fNumBitVectors; i++ )
+    for (uint32_t i = 0; i < other.fNumBitVectors; i++)
         fBitVectors[i] ^= other.fBitVectors[i];
     return *this;
 }
 
 inline hsBitVector& hsBitVector::operator-=(const hsBitVector& other)
 {
-    if( this == &other )
-    {
+    if (this == &other) {
         Clear();
         return *this;
     }
 
-    int minNum = fNumBitVectors < other.fNumBitVectors ? fNumBitVectors : other.fNumBitVectors;
-    int i;
-    for( i = 0; i < minNum; i++ )
+    uint32_t minNum = fNumBitVectors < other.fNumBitVectors ? fNumBitVectors : other.fNumBitVectors;
+    for (uint32_t i = 0; i < minNum; i++)
         fBitVectors[i] &= ~other.fBitVectors[i];
     return *this;
 }
@@ -277,8 +254,7 @@ inline hsBitVector operator-(const hsBitVector& rhs, const hsBitVector& lhs)
 
 inline hsBitVector& hsBitVector::Clear()
 {
-    int i;
-    for( i = 0; i < fNumBitVectors; i++ )
+    for (uint32_t i = 0; i < fNumBitVectors; i++)
         fBitVectors[i] = 0;
     return *this;
 }
@@ -293,23 +269,19 @@ inline hsBitVector& hsBitVector::Clear()
 // the bits from 0 to upToBit, but won't clear any higher bits.
 inline hsBitVector& hsBitVector::Set(int upToBit)
 {
-    if( upToBit >= 0 )
-    {
+    if (upToBit >= 0) {
         uint32_t major = upToBit >> 5;
         uint32_t minor = 1 << (upToBit & 0x1f);
-        if( major >= fNumBitVectors )
+        if (major >= fNumBitVectors)
             IGrow(major+1);
 
         uint32_t i;
-        for( i = 0; i < major; i++ )
+        for (i = 0; i < major; i++)
             fBitVectors[i] = 0xffffffff;
-        for( i = 1; i <= minor && i > 0; i <<= 1 )
+        for (i = 1; i <= minor && i > 0; i <<= 1)
             fBitVectors[major] |= i;
-    }
-    else
-    {
-        int i;
-        for( i = 0; i < fNumBitVectors; i++ )
+    } else {
+        for(uint32_t i = 0; i < fNumBitVectors; i++ )
             fBitVectors[i] = 0xffffffff;
     }
     return *this;
@@ -318,21 +290,18 @@ inline hsBitVector& hsBitVector::Set(int upToBit)
 inline bool hsBitVector::IsBitSet(uint32_t which) const
 {
     uint32_t major = which >> 5;
-    return 
-        (major < fNumBitVectors)
-        && (0 != (fBitVectors[major] & 1 << (which & 0x1f)));
+    return (major < fNumBitVectors) && (0 != (fBitVectors[major] & 1 << (which & 0x1f)));
 }
 
 inline bool hsBitVector::SetBit(uint32_t which, bool on)
 {
     uint32_t major = which >> 5;
     uint32_t minor = 1 << (which & 0x1f);
-    if( major >= fNumBitVectors )
+    if (major >= fNumBitVectors)
         IGrow(major+1);
     bool ret = 0 != (fBitVectors[major] & minor);
-    if( ret != on )
-    {
-        if( on )
+    if (ret != on) {
+        if (on)
             fBitVectors[major] |= minor;
         else
             fBitVectors[major] &= ~minor;
@@ -345,10 +314,10 @@ inline bool hsBitVector::ToggleBit(uint32_t which)
 {
     uint32_t major = which >> 5;
     uint32_t minor = 1 << (which & 0x1f);
-    if( major >= fNumBitVectors )
+    if (major >= fNumBitVectors)
         IGrow(major);
     bool ret = 0 != (fBitVectors[major] & minor);
-    if( ret )
+    if (ret)
         fBitVectors[major] &= ~minor;
     else
         fBitVectors[major] |= minor;
@@ -358,18 +327,16 @@ inline bool hsBitVector::ToggleBit(uint32_t which)
 inline hsBitVector& hsBitVector::RemoveBit(uint32_t which)
 {
     uint32_t major = which >> 5;
-    if( major >= fNumBitVectors )
+    if (major >= fNumBitVectors)
         return *this;
     uint32_t minor = 1 << (which & 0x1f);
     uint32_t lowMask = minor-1;
     uint32_t hiMask = ~(lowMask);
 
-    fBitVectors[major] = (fBitVectors[major] & lowMask)
-        | ((fBitVectors[major] >> 1) & hiMask);
+    fBitVectors[major] = (fBitVectors[major] & lowMask) | ((fBitVectors[major] >> 1) & hiMask);
 
-    while( major < fNumBitVectors-1 )
-    {
-        if( fBitVectors[major+1] & 0x1 )
+    while (major < fNumBitVectors-1) {
+        if (fBitVectors[major+1] & 0x1)
             fBitVectors[major] |= 0x80000000;
         else
             fBitVectors[major] &= ~0x80000000;
@@ -393,16 +360,16 @@ protected:
     int                 fCurrVec;
     int                 fCurrBit;
 
-    int         IAdvanceBit();
-    int         IAdvanceVec();
+    int                 IAdvanceBit();
+    int                 IAdvanceVec();
 
 public:
     // Must call begin after instanciating.
     hsBitIterator(const hsBitVector& bits) : fBits(bits) {}
 
-    int         Begin();
+    int                 Begin();
     int                 Current() const { return fCurrent; }
-    int         Advance();
+    int                 Advance();
     int                 End() const { return fCurrVec < 0; }
 };
 

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -147,7 +147,7 @@ class pfPatcherStream : public plZlibStream
 
     ST::string IMakeStatusMsg() const
     {
-        float secs = hsTimer::GetSysSeconds() - fDLStartTime;
+        float secs = hsTimer::GetSeconds<float>() - fDLStartTime;
         float bytesPerSec = fBytesWritten / secs;
         return plFileSystem::ConvertFileSize(bytesPerSec) + "/s";
     }
@@ -164,14 +164,14 @@ class pfPatcherStream : public plZlibStream
 
 public:
     pfPatcherStream(pfPatcherWorker* parent, const plFileName& filename, uint64_t size)
-        : fParent(parent), fFilename(filename), fFlags(0), fBytesWritten(0), fDLStartTime(0.f), plZlibStream()
+        : fParent(parent), fFilename(filename), fFlags(), fBytesWritten(), fDLStartTime(), plZlibStream()
     {
         fParent->fTotalBytes += size;
         fOutput = new hsRAMStream;
     }
 
     pfPatcherStream(pfPatcherWorker* parent, const plFileName& reqName, const plFileName& cliName, const NetCliFileManifestEntry& entry)
-        : fParent(parent), fFilename(cliName.Normalize()), fFlags(entry.flags), fBytesWritten(0), plZlibStream()
+        : fParent(parent), fFilename(cliName.Normalize()), fFlags(entry.flags), fBytesWritten(), fDLStartTime(), plZlibStream()
     {
         // ugh. eap removed the compressed flag in his fail manifests
         if (reqName.GetFileExt().compare_i("gz") == 0) {
@@ -183,7 +183,7 @@ public:
 
     void Begin()
     {
-        fDLStartTime = hsTimer::GetSysSeconds();
+        fDLStartTime = hsTimer::GetSeconds<float>();
         if (!fOutput)
             Open(fFilename, "wb");
     }

--- a/Sources/Plasma/NucleusLib/inc/plProfileManager.cpp
+++ b/Sources/Plasma/NucleusLib/inc/plProfileManager.cpp
@@ -218,7 +218,7 @@ void plProfileBase::IPrintValue(uint64_t value, char* buf, bool printType)
             strcpy(buf, valueStr);
         }
         else
-            sprintf(buf, "%u", value);
+            sprintf(buf, "%llu", value);
     }
     else if (hsCheckBits(fDisplayFlags, kDisplayFPS))
     {

--- a/Sources/Plasma/NucleusLib/pnMessage/plMessage.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plMessage.cpp
@@ -221,7 +221,7 @@ int plMsgStdStringHelper::Poke(const std::string & stringref, hsStream* stream, 
 {
     plMessage::plStrLen strlen;
     hsAssert( stringref.length()<0xFFFF, "buf too big for plMsgStdStringHelper" );
-    strlen = stringref.length();
+    strlen = (plMessage::plStrLen)stringref.length();
     stream->WriteLE(strlen);
     if (strlen)
         stream->Write(strlen,stringref.data());
@@ -334,7 +334,7 @@ int plMsgStdStringHelper::PeekBig(ST::string & stringref, hsStream* stream, cons
 // STATIC
 int plMsgCStringHelper::Poke(const char * str, hsStream* stream, const uint32_t peekOptions)
 {
-    plMessage::plStrLen len = (str) ? strlen(str) : 0;
+    plMessage::plStrLen len = (str) ? (plMessage::plStrLen)strlen(str) : 0;
     stream->WriteLE(len);
     if (len)
         stream->Write(len,str);

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedObject.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedObject.cpp
@@ -370,8 +370,7 @@ void    plSynchedObject::Write(hsStream* stream, hsResMgr* mgr)
 
     if (fSynchFlags & kExcludePersistentState)
     {
-        int16_t num=fSDLExcludeList.size();
-        stream->WriteLE(num);
+        stream->WriteLE((uint16_t)fSDLExcludeList.size());
 
         SDLStateList::iterator it=fSDLExcludeList.begin();
         for(; it != fSDLExcludeList.end(); it++)
@@ -382,8 +381,7 @@ void    plSynchedObject::Write(hsStream* stream, hsResMgr* mgr)
 
     if (fSynchFlags & kHasVolatileState)
     {
-        int16_t num=fSDLVolatileList.size();
-        stream->WriteLE(num);
+        stream->WriteLE((uint16_t)fSDLVolatileList.size());
 
         SDLStateList::iterator it=fSDLVolatileList.begin();
         for(; it != fSDLVolatileList.end(); it++)


### PR DESCRIPTION
This changeset attempts to silence and/or fix some of the warnings emitted during compilation. When I began, 406 warnings were being emitted in my build. It is now down to 313 warnings. I avoided fixing uninitialized members to prevent conflicts with #576.