### PR TITLE
Fix forward declarations for ALSoft

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.h
@@ -59,8 +59,8 @@ class plgAudioSys;
 class plStatusLog;
 class plEAXListenerMod;
 
-typedef struct ALCdevice_struct ALCdevice;
-typedef struct ALCcontext_struct ALCcontext;
+struct ALCdevice;
+struct ALCcontext;
 
 
 class DeviceDescriptor

--- a/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.h
@@ -65,8 +65,6 @@ struct hsVector3;
 class  plWinAudible;
 class  plPlate;
 class  plStatusLog;
-class  plSpeex;
-typedef struct ALCdevice_struct ALCdevice;
 class plVoiceDecoder;
 class plVoiceEncoder;
 


### PR DESCRIPTION
In OpenAL Soft master, the delcarations of `ALdevice` and `ALcontext` do not match the declarations found in the Creative OpenAL 1.1 SDK, resulting in a compile error. This should fix our forward declarations to match both.