### PR TITLE
Move OpenSSL initialization closer to point of use

### DIFF
--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -1004,7 +1004,6 @@ bool WinInit(HINSTANCE hInst)
 #include "plResMgr/plVersion.h"
 int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nCmdShow)
 {
-    OpenSSL_add_all_algorithms();
     PF_CONSOLE_INIT_ALL()
 
     // Set global handle
@@ -1230,7 +1229,6 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
 
     gClient.ShutdownEnd();
     DeInitNetClientComm();
-    EVP_cleanup();
 
     // Exit WinMain and terminate the app....
     return PARABLE_NORMAL_EXIT;

--- a/Sources/Plasma/Apps/plUruLauncher/winmain.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/winmain.cpp
@@ -55,7 +55,6 @@ Mead, WA   99021
 #include <commctrl.h>
 #include <shellapi.h>
 #include <shlobj.h>
-#include <openssl/evp.h>
 
 // ===================================================
 
@@ -374,9 +373,6 @@ static pfPatcher* IPatcherFactory()
 
 int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLink, int nCmdShow)
 {
-    // OpenSSL sucks
-    OpenSSL_add_all_algorithms();
-
     // Let's initialize our plClientLauncher friend
     s_launcher.ParseArguments();
     s_launcher.SetErrorProc(IOnNetError);
@@ -424,7 +420,6 @@ int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdL
     //       awhile (it can... dang eap...)
     ReleaseMutex(_onePatcherMut);
     CloseHandle(_onePatcherMut);
-    EVP_cleanup();
 
     // kthxbai
     return s_error.empty() ? PLASMA_OK : PLASMA_PHAILURE;

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -44,6 +44,21 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <cstring>
 
+struct _InitOpenSSL
+{
+    _InitOpenSSL()
+    {
+        // This ensures algorithms used by the EVP APIs are available,
+        // regardless of the entry point to this code.
+        OpenSSL_add_all_algorithms();
+    }
+
+    ~_InitOpenSSL()
+    {
+        EVP_cleanup();
+    }
+
+} s_initOpenSSL;
 
 static uint8_t IHexCharToInt(char c)
 {


### PR DESCRIPTION
In particular, this fixes running the pnEncryption unit tests, which currently do not do the mandatory OpenSSL initialization dance routine.