### PR TITLE
pfPython Cleanups

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
@@ -154,6 +154,7 @@ set(pfPython_HEADERS
     pyNetLinkingMgr.h
     pyNetServerSessionInfo.h
     pyNotify.h
+    pyObjectRef.h
     pyPlayer.h
     pySceneObject.h
     pySDL.h

--- a/Sources/Plasma/FeatureLib/pfPython/Pch.h
+++ b/Sources/Plasma/FeatureLib/pfPython/Pch.h
@@ -88,5 +88,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGlueHelpers.h"
 #include "pyKey.h"
 #include "pyMatrix44.h"
+#include "pyObjectRef.h"
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.cpp
@@ -99,18 +99,9 @@ ST::string cyAccountManagement::GetAccountName()
         return ST::null;
 }
 
-void cyAccountManagement::CreatePlayer(const char* playerName, const char* avatar, const char* invitationCode)
+void cyAccountManagement::CreatePlayer(const ST::string& playerName, const ST::string& avatar, const ST::string& invitationCode)
 {
     NetCommCreatePlayer(playerName, avatar, invitationCode, 0, nil);
-}
-
-void cyAccountManagement::CreatePlayerW(const wchar_t* playerName, const wchar_t* avatar, const wchar_t* invitationCode)
-{
-    NetCommCreatePlayer(ST::string::from_wchar(playerName),
-        ST::string::from_wchar(avatar),
-        ST::string::from_wchar(invitationCode),
-        0,
-        nullptr);
 }
 
 void cyAccountManagement::DeletePlayer(unsigned playerId)

--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.h
@@ -63,8 +63,7 @@ public:
 
     static PyObject*    GetPlayerList();
     static ST::string   GetAccountName();
-    static void         CreatePlayer(const char* playerName, const char* avatar, const char* invitationCode);
-    static void         CreatePlayerW(const wchar_t* playerName, const wchar_t* avatar, const wchar_t* invitationCode);
+    static void         CreatePlayer(const ST::string& playerName, const ST::string& avatar, const ST::string& invitationCode);
     static void         DeletePlayer(unsigned playerId);
     static void         SetActivePlayer(unsigned playerId);
     static bool         IsActivePlayerSet();

--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagementGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagementGlue.cpp
@@ -61,102 +61,18 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetAccountName, "Returns the account na
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtCreatePlayer, args, "Params: playerName, avatarShape, invitation\nCreates a new player")
 {
-    char* playerName;
-    char* avatarShape;
-    char* invitation;
-    if (!PyArg_ParseTuple(args, "ssz", &playerName, &avatarShape, &invitation))
+    PyObject* playerName;
+    PyObject* avatarShape;
+    PyObject* invitation;
+    if (!PyArg_ParseTuple(args, "OOO", &playerName, &avatarShape, &invitation) ||
+        !PyString_CheckEx(playerName) || !PyString_CheckEx(avatarShape) || !PyString_CheckEx(invitation))
     {
         PyErr_SetString(PyExc_TypeError, "PtCreatePlayer expects three strings");
         PYTHON_RETURN_ERROR;
     }
 
-    cyAccountManagement::CreatePlayer(playerName, avatarShape, invitation);
-    PYTHON_RETURN_NONE;
-}
-
-PYTHON_GLOBAL_METHOD_DEFINITION(PtCreatePlayerW, args, "Params: playerName, avatarShape, invitation\nUnicode version of PtCreatePlayer")
-{
-    PyObject* playerNameObj;
-    PyObject* avatarShapeObj;
-    PyObject* invitationObj;
-    if (!PyArg_ParseTuple(args, "OOO", &playerNameObj, &avatarShapeObj, &invitationObj))
-    {
-        PyErr_SetString(PyExc_TypeError, "PtCreatePlayerW expects three unicode strings");
-        PYTHON_RETURN_ERROR;
-    }
-
-    std::wstring playerName, avatarShape, invitation;
-
-    if (PyUnicode_Check(playerNameObj))
-    {
-        int strLen = PyUnicode_GetSize(playerNameObj);
-        wchar_t* text = new wchar_t[strLen + 1];
-        PyUnicode_AsWideChar((PyUnicodeObject*)playerNameObj, text, strLen);
-        text[strLen] = L'\0';
-        playerName = text;
-        delete [] text;
-    }
-    else if (PyString_Check(playerNameObj))
-    {
-        // we'll allow this, just in case something goes weird
-        char* text = PyString_AsString(playerNameObj);
-        wchar_t* temp = hsStringToWString(text);
-        playerName = temp;
-        delete [] temp;
-    }
-    else
-    {
-        PyErr_SetString(PyExc_TypeError, "PtCreatePlayerW expects three unicode strings");
-        PYTHON_RETURN_ERROR;
-    }
-
-    if (PyUnicode_Check(avatarShapeObj))
-    {
-        int strLen = PyUnicode_GetSize(avatarShapeObj);
-        wchar_t* text = new wchar_t[strLen + 1];
-        PyUnicode_AsWideChar((PyUnicodeObject*)avatarShapeObj, text, strLen);
-        text[strLen] = L'\0';
-        avatarShape = text;
-        delete [] text;
-    }
-    else if (PyString_Check(avatarShapeObj))
-    {
-        // we'll allow this, just in case something goes weird
-        char* text = PyString_AsString(avatarShapeObj);
-        wchar_t* temp = hsStringToWString(text);
-        avatarShape = temp;
-        delete [] temp;
-    }
-    else
-    {
-        PyErr_SetString(PyExc_TypeError, "PtCreatePlayerW expects three unicode strings");
-        PYTHON_RETURN_ERROR;
-    }
-
-    if (PyUnicode_Check(invitationObj))
-    {
-        int strLen = PyUnicode_GetSize(invitationObj);
-        wchar_t* text = new wchar_t[strLen + 1];
-        PyUnicode_AsWideChar((PyUnicodeObject*)invitationObj, text, strLen);
-        text[strLen] = L'\0';
-        invitation = text;
-        delete [] text;
-    }
-    else if (PyString_Check(invitationObj))
-    {
-        // we'll allow this, just in case something goes weird
-        char* text = PyString_AsString(invitationObj);
-        wchar_t* temp = hsStringToWString(text);
-        invitation = temp;
-        delete [] temp;
-    }
-    else
-    {
-        PyErr_SetString(PyExc_TypeError, "PtCreatePlayerW expects three unicode strings");
-        PYTHON_RETURN_ERROR;
-    }
-
-    cyAccountManagement::CreatePlayerW(playerName.c_str(), avatarShape.c_str(), invitation.c_str());
+    cyAccountManagement::CreatePlayer(PyString_AsStringEx(playerName), PyString_AsStringEx(avatarShape),
+                                      PyString_AsStringEx(invitation));
     PYTHON_RETURN_NONE;
 }
 
@@ -193,14 +109,14 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtIsActivePlayerSet, "Returns whether or 
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtChangePassword, args, "Params: password\nChanges the current account's password")
 {
-    char* password = nil;
-    if (!PyArg_ParseTuple(args, "s", &password))
+    PyObject* password;
+    if (!PyArg_ParseTuple(args, "O", &password) || !PyString_CheckEx(password))
     {
         PyErr_SetString(PyExc_TypeError, "PtChangePassword expects a string");
         PYTHON_RETURN_ERROR;
     }
 
-    cyAccountManagement::ChangePassword(password);
+    cyAccountManagement::ChangePassword(PyString_AsStringEx(password));
     PYTHON_RETURN_NONE;
 }
 
@@ -209,7 +125,6 @@ void cyAccountManagement::AddPlasmaMethods(std::vector<PyMethodDef> &methods)
     PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetAccountPlayerList);
     PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetAccountName);
     PYTHON_GLOBAL_METHOD(methods, PtCreatePlayer);
-    PYTHON_GLOBAL_METHOD(methods, PtCreatePlayerW);
     PYTHON_GLOBAL_METHOD(methods, PtDeletePlayer);
     PYTHON_GLOBAL_METHOD(methods, PtSetActivePlayer);
     PYTHON_GLOBAL_METHOD(methods, PtIsActivePlayerSet);

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -1290,7 +1290,7 @@ void cyMisc::SendKIRegisterImagerMsg(const char* imagerName, pyKey& sender)
 //  RETURNS    : nothing
 //
 
-void cyMisc::YesNoDialog(pyKey& sender, const char* thestring)
+void cyMisc::YesNoDialog(pyKey& sender, const ST::string& thestring)
 {
     // create the mesage to send
     pfKIMsg *msg = new pfKIMsg( pfKIMsg::kYesNoDialog );
@@ -1299,13 +1299,6 @@ void cyMisc::YesNoDialog(pyKey& sender, const char* thestring)
     msg->SetString(thestring);
     // send it off
     plgDispatch::MsgSend( msg );
-}
-
-void cyMisc::YesNoDialog(pyKey& sender, std::wstring thestring)
-{
-    char *temp = hsWStringToString(thestring.c_str());
-    YesNoDialog(sender,temp);
-    delete [] temp;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -2755,7 +2748,7 @@ void cyMisc::FakeLinkToObjectNamed(const ST::string& name)
     plgDispatch::MsgSend(msg);
 }
 
-PyObject* cyMisc::LoadAvatarModel(const char* modelName, pyKey& spawnPoint, const char* userStr)
+PyObject* cyMisc::LoadAvatarModel(const char* modelName, pyKey& spawnPoint, const ST::string& userStr)
 {
     plKey SpawnedKey = plAvatarMgr::GetInstance()->LoadAvatar(modelName, "", false, spawnPoint.getKey(), nil, userStr);
     return pyKey::New(SpawnedKey);
@@ -2841,12 +2834,9 @@ void cyMisc::SetGraphicsOptions(int Width, int Height, int ColorDepth, bool Wind
     //plClient::GetInstance()->ResetDisplayDevice(Width, Height, ColorDepth, Windowed, NumAASamples, MaxAnisotropicSamples);
 }
 
-bool cyMisc::DumpLogs(const std::wstring & folder)
+bool cyMisc::DumpLogs(const ST::string& folder)
 {
-    char* temp = hsWStringToString(folder.c_str());
-    bool retVal = plStatusLogMgr::GetInstance().DumpLogs(temp);
-    delete [] temp;
-    return retVal;
+    return plStatusLogMgr::GetInstance().DumpLogs(folder);
 }
 
 bool cyMisc::FileExists(const plFileName & filename)

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -514,8 +514,7 @@ public:
     //
     //  RETURNS    : nothing
     //
-    static void YesNoDialog(pyKey& sender, const char* thestring);
-    static void YesNoDialog(pyKey& sender, std::wstring thestring);
+    static void YesNoDialog(pyKey& sender, const ST::string& thestring);
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -912,7 +911,7 @@ public:
     // PURPOSE    : takes the name of an avatar model and a sceneobject key and
     //              spawns the avatar at that point
     //
-    static PyObject* LoadAvatarModel(const char* modelName, pyKey& object, const char* userStr); // returns pyKey
+    static PyObject* LoadAvatarModel(const char* modelName, pyKey& object, const ST::string& userStr); // returns pyKey
     static void UnLoadAvatarModel(pyKey& avatar);
     
     ///////////////////////////////////////////////////////////////////////////////
@@ -943,7 +942,7 @@ public:
     static int GetDesktopColorDepth();
     static PipelineParams *GetDefaultDisplayParams();
 
-    static bool DumpLogs(const std::wstring & folder);
+    static bool DumpLogs(const ST::string& folder);
 
     static bool FileExists(const plFileName & filename);
     static bool CreateDir(const plFileName & directory);

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
@@ -60,37 +60,16 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtYesNoDialog, args, "Params: selfkey,dialogMess
             "This dialog _has_ to be answered by the user.\n"
             "And their answer will be returned in a Notify message.")
 {
-    PyObject* keyObj = NULL;
-    PyObject* dialogMsgObj = NULL;
-    if (!PyArg_ParseTuple(args, "OO", &keyObj, &dialogMsgObj))
-    {
-        PyErr_SetString(PyExc_TypeError, "PtYesNoDialog expects a ptKey and a string or unicode string");
-        PYTHON_RETURN_ERROR;
-    }
-    if (!pyKey::Check(keyObj))
-    {
-        PyErr_SetString(PyExc_TypeError, "PtYesNoDialog expects a ptKey and a string or unicode string");
+    PyObject* keyObj = nullptr;
+    PyObject* text;
+    if (!PyArg_ParseTuple(args, "OO", &keyObj, &text) || !pyKey::Check(keyObj) ||
+        !PyString_CheckEx(text)) {
+        PyErr_SetString(PyExc_TypeError, "PtYesNoDialog expects a ptKey and a string");
         PYTHON_RETURN_ERROR;
     }
     pyKey* key = pyKey::ConvertFrom(keyObj);
-    if (PyUnicode_Check(dialogMsgObj))
-    {
-        int len = PyUnicode_GetSize(dialogMsgObj);
-        wchar_t* text = new wchar_t[len + 1];
-        PyUnicode_AsWideChar((PyUnicodeObject*)dialogMsgObj, text, len);
-        text[len] = L'\0';
-        cyMisc::YesNoDialog(*key, text);
-        delete [] text;
-        PYTHON_RETURN_NONE;
-    }
-    else if (PyString_Check(dialogMsgObj))
-    {
-        char* text = PyString_AsString(dialogMsgObj);
-        cyMisc::YesNoDialog(*key, text);
-        PYTHON_RETURN_NONE;
-    }
-    PyErr_SetString(PyExc_TypeError, "PtYesNoDialog expects a ptKey and a string or unicode string");
-    PYTHON_RETURN_ERROR;
+    cyMisc::YesNoDialog(*key, PyString_AsStringEx(text));
+    PYTHON_RETURN_NONE
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtRateIt, args, "Params: chronicleName,dialogPrompt,onceFlag\nShows a dialog with dialogPrompt and stores user input rating into chronicleName")

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -1846,7 +1846,7 @@ void PythonInterface::CheckModuleForFunctions(PyObject* module, char** funcNames
 //  PURPOSE    : checks to see if a specific function is defined in this instance of a class
 //             : and will fill out the funcTable with object instances of where the funciton is
 //
-void PythonInterface::CheckInstanceForFunctions(PyObject* instance, char** funcNames, PyObject** funcTable)
+void PythonInterface::CheckInstanceForFunctions(PyObject* instance, const char** funcNames, PyObject** funcTable)
 {
     // start looking for the functions
     int i=0;

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -52,6 +52,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGeometry3.h"
 #include "pyKey.h"
 #include "pyMatrix44.h"
+#include "pyObjectRef.h"
 #pragma hdrstop
 
 #include "cyPythonInterface.h"
@@ -1844,25 +1845,17 @@ void PythonInterface::CheckModuleForFunctions(PyObject* module, char** funcNames
 //  PARAMETERS : instance    - instance of a class to check
 //
 //  PURPOSE    : checks to see if a specific function is defined in this instance of a class
-//             : and will fill out the funcTable with object instances of where the funciton is
+//             : and will fill out the funcTable with pointers to the function objects
 //
 void PythonInterface::CheckInstanceForFunctions(PyObject* instance, const char** funcNames, PyObject** funcTable)
 {
     // start looking for the functions
-    int i=0;
-    while ( funcNames[i] != nil )
-    {
-        PyObject* func = PyObject_GetAttrString(instance, funcNames[i]);
-        if ( func != NULL )
-        {
-            if ( PyCallable_Check(func)>0 )
-            {
-                // if it is defined then mark the funcTable
-                funcTable[i] = instance;
-            }
-            Py_DECREF(func);
+    for (size_t i = 0; funcNames[i] != nullptr; ++i) {
+        pyObjectRef func = PyObject_GetAttrString(instance, funcNames[i]);
+        if (func && PyCallable_Check(func.Get())) {
+            // if it is defined then mark the funcTable
+            funcTable[i] = func.Release();
         }
-        i++;
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -1663,7 +1663,7 @@ int PythonInterface::getOutputAndReset(std::string *output)
     return 0;
 }
 
-void PythonInterface::WriteToLog(const char* text)
+void PythonInterface::WriteToLog(const ST::string& text)
 {
     dbgLog->AddLine(text);
 }
@@ -1974,15 +1974,14 @@ bool PythonInterface::RunStringInteractive(const char *command, PyObject* module
 //
 //  PURPOSE    : run a python string in a specific module name
 //
-bool PythonInterface::RunString(const char *command, PyObject* module)
+bool PythonInterface::RunString(const char* command, PyObject* module)
 {
     PyObject *d, *v;
     // make sure that we're given a good module... or at least one with an address
-    if ( !module )
-    {
+    if (!module) {
         // if no module was given then use just use the main module
         module = PyImport_AddModule("__main__");
-        if (module == NULL)
+        if (!module)
             return false;
     }
     // get the dictionaries for this module
@@ -1990,8 +1989,7 @@ bool PythonInterface::RunString(const char *command, PyObject* module)
     // run the string
     v = PyRun_String(command, Py_file_input, d, d);
     // check for errors and print them
-    if (v == NULL)
-    {
+    if (!v) {
         // Yikes! errors!
         PyErr_Print();
         return false;

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
@@ -154,7 +154,7 @@ public:
     //  checks to see if a specific function is defined in this instance of a class
     //  and will fill out the funcTable with object instances of where the funciton is
     //
-    static void CheckInstanceForFunctions(PyObject* instance, char** funcNames, PyObject** funcTable);
+    static void CheckInstanceForFunctions(PyObject* instance, const char** funcNames, PyObject** funcTable);
 
     //  run a python string in a specific module name
     //  PARAMETERS : command       - string of commands to execute in the...

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
@@ -152,7 +152,7 @@ public:
     static void CheckModuleForFunctions(PyObject* module, char** funcNames, PyObject** funcTable);
 
     //  checks to see if a specific function is defined in this instance of a class
-    //  and will fill out the funcTable with object instances of where the funciton is
+    //  and will fill out the funcTable with pointers to the function objects
     //
     static void CheckInstanceForFunctions(PyObject* instance, const char** funcNames, PyObject** funcTable);
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
@@ -126,7 +126,7 @@ public:
     static int getOutputAndReset(std::string* output = nil);
 
     // Writes 'text' to the Python log
-    static void WriteToLog(const char* text);
+    static void WriteToLog(const ST::string& text);
 
     // Writes 'text' to stderr specified in the python interface
     static void WriteToStdErr(const char* text);

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -421,36 +421,29 @@ plPythonFileMod::~plPythonFileMod()
 
 bool plPythonFileMod::ILoadPythonCode()
 {
-
 #ifndef PLASMA_EXTERNAL_RELEASE
     // get code from file and execute in module
     // see if the file exists first before trying to import it
     plFileName pyfile = plFileName::Join(".", "python", ST::format("{}.py", fPythonFile));
-    if (plFileInfo(pyfile).Exists())
-    {
-        char fromLoad[256];
-        //sprintf(fromLoad,"from %s import *", fPythonFile.c_str());
+    if (plFileInfo(pyfile).Exists()) {
         // ok... we can't really use import because Python remembers too much where global variables came from
         // ...and using execfile make it sure that globals are defined in this module and not in the imported module
-        sprintf(fromLoad,"execfile('.\\\\python\\\\%s.py')", fPythonFile.c_str());
-        if ( PythonInterface::RunString( fromLoad, fModule) )
-        {
+        ST::string fromLoad = ST::format(R"(execfile('.\\python\\{}.py'))", fPythonFile);
+        if (PythonInterface::RunString(fromLoad.c_str(), fModule)) {
             // we've loaded the code into our module
             // now attach the glue python code to the end
-            if ( !PythonInterface::RunString("execfile('.\\\\python\\\\plasma\\\\glue.py')", fModule) )
-            {
+            if (!PythonInterface::RunString(R"(execfile('.\\python\\plasma\\glue.py'))", fModule)) {
                 // display any output (NOTE: this would be disabled in production)
                 DisplayPythonOutput();
                 return false;
-            }
-            else
+            } else {
                 return true;
+            }
         }
         DisplayPythonOutput();
-        char errMsg[256];
-        snprintf(errMsg, arrsize(errMsg), "Python file %s.py had errors!!! Could not load.", fPythonFile.c_str());
+
+        ST::string errMsg = ST::format("Python file {}.py had errors!!! Could not load.", fPythonFile);
         PythonInterface::WriteToLog(errMsg);
-        hsAssert(0,errMsg);
         return false;
     }
 #endif  //PLASMA_EXTERNAL_RELEASE
@@ -462,10 +455,9 @@ bool plPythonFileMod::ILoadPythonCode()
         return true;
 
     DisplayPythonOutput();
-    char errMsg[256];
-    snprintf(errMsg, arrsize(errMsg), "Python file %s.py was not found.", fPythonFile.c_str());
+
+    ST::string errMsg = ST::format("Python file {}.py was not found.", fPythonFile);
     PythonInterface::WriteToLog(errMsg);
-    hsAssert(0,errMsg);
     return false;
 }
 
@@ -525,13 +517,10 @@ void plPythonFileMod::AddTarget(plSceneObject* sobj)
                 }
                 // display any output
                 DisplayPythonOutput();
-                if ( fInstance == nil )     // then there was an error
-                {
+                if (!fInstance) {
                     // display any output (NOTE: this would be disabled in production)
-                    char errMsg[256];
-                    snprintf(errMsg, arrsize(errMsg), "Python file %s.py, instance not found.", fPythonFile.c_str());
+                    ST::string errMsg = ST::format("Python file {}.py, instance not found.", fPythonFile);
                     PythonInterface::WriteToLog(errMsg);
-                    hsAssert(0, errMsg);
                     return;         // if we can't create the instance then there is nothing to do here
                 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.h
@@ -65,6 +65,8 @@ typedef struct _object PyObject;
 class plPythonFileMod : public plMultiModifier
 {
 private:
+    friend class PythonVaultCallback;
+
     enum func_num
     {
         kfunc_FirstUpdate = 0,
@@ -108,7 +110,30 @@ private:
     };
 
     template<typename T>
-    T* IScriptWantsMsg(func_num methodId, plMessage* msg);
+    T* IScriptWantsMsg(func_num methodId, plMessage* msg) const;
+
+    /**
+     * \brief Calls a bound method in this Python script.
+     * \detail Calls the bound method in this Python script specified by methodId with the arguments
+     *         provided as variadic template arugments.
+     * \note Calling a method that is not a member of the script instance is a no-op.
+     * \remarks Instance methods are resolved at initialization; therefore, Python metaprogramming
+     *          hacks such as `OnNotify = new_callable` will not actually override the OnNotify
+     *          method called when the plPythonFileMod receives a plNotifyMsg.
+     */
+    template<typename... Args>
+    void ICallScriptMethod(func_num methodId, Args&&... args);
+
+    /**
+     * \brief Calls a bound method in this Python script.
+     * \detail Calls the bound method in this Python script specified by methodId. This overload
+     *         is used when there are no arguments to pass to the method.
+     * \note Calling a method that is not a member of the script instance is a no-op.
+     * \remarks Instance methods are resolved at initialization; therefore, Python metaprogramming
+     *          hacks such as `OnNotify = new_callable` will not actually override the OnNotify
+     *          method called when the plPythonFileMod receives a plNotifyMsg.
+     */
+    void ICallScriptMethod(func_num methodId);
 
 protected:
     friend class plPythonSDLModifier;

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.h
@@ -62,8 +62,54 @@ class plPipeline;
 
 typedef struct _object PyObject;
 
-class plPythonFileMod   : public plMultiModifier
+class plPythonFileMod : public plMultiModifier
 {
+private:
+    enum func_num
+    {
+        kfunc_FirstUpdate = 0,
+        kfunc_Update,
+        kfunc_Notify,
+        kfunc_AtTimer,
+        kfunc_OnKeyEvent,
+        kfunc_Load,
+        kfunc_Save,
+        kfunc_GUINotify,
+        kfunc_PageLoad,
+        kfunc_ClothingUpdate,
+        kfunc_KIMsg,
+        kfunc_MemberUpdate,
+        kfunc_RemoteAvatarInfo,
+        kfunc_RTChat,
+        kfunc_VaultEvent,
+        kfunc_AvatarPage,
+        kfunc_SDLNotify,
+        kfunc_OwnershipNotify,
+        kfunc_AgeVaultEvent,
+        kfunc_Init,
+        kfunc_OnCCRMsg,
+        kfunc_OnServerInitComplete,
+        kfunc_OnVaultNotify,
+        kfunc_OnDefaultKeyCaught,
+        kfunc_OnMarkerMsg,
+        kfunc_OnBackdoorMsg,
+        kfunc_OnBehaviorNotify,
+        kfunc_OnLOSNotify,
+        kfunc_OnBeginAgeLoad,
+        kfunc_OnMovieEvent,
+        kfunc_OnScreenCaptureDone,
+        kfunc_OnClimbBlockerEvent,
+        kfunc_OnAvatarSpawn,
+        kfunc_OnAccountUpdate,
+        kfunc_gotPublicAgeList,
+        kfunc_OnAIMsg,
+        kfunc_OnGameScoreMsg,
+        kfunc_lastone
+    };
+
+    template<typename T>
+    T* IScriptWantsMsg(func_num methodId, plMessage* msg);
+
 protected:
     friend class plPythonSDLModifier;
 
@@ -157,49 +203,6 @@ public:
     virtual void Read(hsStream* stream, hsResMgr* mgr);
     virtual void Write(hsStream* stream, hsResMgr* mgr);
 
-    // this is to keep track of what python functions are available and working,
-    // so there is no need to keep trying and banging our head until its bloody
-    enum func_num
-    {
-        kfunc_FirstUpdate = 0,      // these enums _have_ to match the static names in fEventFunctionNames
-        kfunc_Update,
-        kfunc_Notify,       // OnNotify
-        kfunc_AtTimer,
-        kfunc_OnKeyEvent,
-        kfunc_Load,
-        kfunc_Save,
-        kfunc_GUINotify,
-        kfunc_PageLoad,
-        kfunc_ClothingUpdate,
-        kfunc_KIMsg,
-        kfunc_MemberUpdate,
-        kfunc_RemoteAvatarInfo,
-        kfunc_RTChat,
-        kfunc_VaultEvent,
-        kfunc_AvatarPage,
-        kfunc_SDLNotify,
-        kfunc_OwnershipNotify,
-        kfunc_AgeVaultEvent,
-        kfunc_Init,
-        kfunc_OnCCRMsg,
-        kfunc_OnServerInitComplete,
-        kfunc_OnVaultNotify,
-        kfunc_OnDefaultKeyCaught,
-        kfunc_OnMarkerMsg,
-        kfunc_OnBackdoorMsg,
-        kfunc_OnBehaviorNotify,
-        kfunc_OnLOSNotify,
-        kfunc_OnBeginAgeLoad,
-        kfunc_OnMovieEvent,
-        kfunc_OnScreenCaptureDone,
-        kfunc_OnClimbBlockerEvent,
-        kfunc_OnAvatarSpawn,
-        kfunc_OnAccountUpdate,
-        kfunc_gotPublicAgeList,
-        kfunc_OnAIMsg,
-        kfunc_OnGameScoreMsg,
-        kfunc_lastone
-    };
     // array of matching Python instance where the functions are, if defined
     PyObject* fPyFunctionInstances[kfunc_lastone];
     // array of the names of the standard functions that can be called

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -66,8 +66,8 @@ plStateDataRecord * GetAgeSDL()
 }
 
 
-#define PyLoggedAssert(cond, text)                  \
-    if (!cond) PythonInterface::WriteToLog(text);   \
+#define PyLoggedAssert(cond, text)                              \
+    if (!cond) PythonInterface::WriteToLog(ST_LITERAL(text));   \
     hsAssert(cond, text);
 
 plPythonSDLModifier::plPythonSDLModifier(plPythonFileMod* owner) : fOwner(owner)

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -313,26 +313,7 @@ void plPythonSDLModifier::ISetCurrentStateFrom(const plStateDataRecord* srcState
     }
 
     // Notify the Python code that we updated the SDL record
-    if (fOwner->fPyFunctionInstances[plPythonFileMod::kfunc_Load] != nil)
-    {
-        PyObject* retVal = PyObject_CallMethod(
-                fOwner->fPyFunctionInstances[plPythonFileMod::kfunc_Load],
-                (char*)fOwner->fFunctionNames[plPythonFileMod::kfunc_Load],
-                nil);
-        if (retVal == nil)
-        {
-#ifndef PLASMA_EXTERNAL_RELEASE
-            // for some reason this function didn't, remember that and not call it again
-            fOwner->fPyFunctionInstances[plPythonFileMod::kfunc_Load] = nil;
-#endif //PLASMA_EXTERNAL_RELEASE
-            // if there was an error make sure that the stderr gets flushed so it can be seen
-            fOwner->ReportError();
-        }
-        Py_XDECREF(retVal);
-    }
-
-    // display any output
-    fOwner->DisplayPythonOutput();
+    fOwner->ICallScriptMethod(plPythonFileMod::kfunc_Load);
 }
 
 void plPythonSDLModifier::IPutCurrentStateIn(plStateDataRecord* dstState)

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -73,84 +73,71 @@ plStateDataRecord * GetAgeSDL()
 plPythonSDLModifier::plPythonSDLModifier(plPythonFileMod* owner) : fOwner(owner)
 {
     plStateDescriptor* desc = plSDLMgr::GetInstance()->FindDescriptor(fOwner->fPythonFile, plSDL::kLatestVersion);
-    if (desc)
-    {
+    if (desc) {
         // Create a Python SDL record with no values set
-        int numVars = desc->GetNumVars();
-        for (int i = 0; i < numVars; i++)
-        {
+        for (int i = 0; i < desc->GetNumVars(); i++) {
             plVarDescriptor* var = desc->GetVar(i);
 
             ST::string name = var->GetName();
             int count = var->GetCount();
 
-            fMap[name] = SDLObj(nil, count, false);
+            fMap[name] = SDLObj(nullptr, count, false);
         }
     }
 }
 
 plPythonSDLModifier::~plPythonSDLModifier()
 {
-    SDLMap::iterator it;
-    for (it = fMap.begin(); it != fMap.end(); it++)
-    {
-        PyObject* obj = it->second.obj;
-        Py_XDECREF(obj);
+    for (auto it : fMap) {
+        Py_XDECREF(it.second.obj);
     }
 }
 
 PyObject* plPythonSDLModifier::GetItem(const ST::string& key)
 {
-    SDLMap::iterator it = fMap.find(key);
+    auto it = fMap.find(key);
 
-    if (it == fMap.end())
-    {
+    if (it == fMap.end()) {
         ST::string errmsg = ST::format("SDL key {} not found", key);
         PyErr_SetString(PyExc_KeyError, errmsg.c_str());
         PYTHON_RETURN_ERROR;
     }
 
     PyObject* val = it->second.obj;
-    if (!val)
+    if (val)
+        Py_INCREF(val);
+    else
         val = PyTuple_New(0);
-
-    Py_INCREF(val);
     return val;
 }
 
 void plPythonSDLModifier::ISetItem(const ST::string& key, PyObject* value)
 {
-    if (!value || !PyTuple_Check(value))
-    {
+    if (!value || !PyTuple_Check(value)) {
         PyLoggedAssert(0, "[SDL] Trying to set a tuple value to something that isn't a tuple");
         return;
     }
 
-    SDLMap::iterator it = fMap.find(key);
-
-    if (it == fMap.end())
-    {
+    auto it = fMap.find(key);
+    if (it == fMap.end()) {
         PyLoggedAssert(0, "[SDL] Tried to set a nonexistent SDL value");
         return;
     }
 
     SDLObj& oldObj = it->second;
-
-    if (oldObj.size != 0 && PyTuple_Size(value) != oldObj.size)
-    {
+    if (oldObj.size != 0 && PyTuple_Size(value) != oldObj.size) {
         PyLoggedAssert(0, "[SDL] Wrong size for a fixed size SDL value");
         return;
     }
 
     Py_XDECREF(oldObj.obj);
-
-    Py_XINCREF(value);
+    Py_INCREF(value);
     oldObj.obj = value;
 }
 
 void plPythonSDLModifier::SendToClients(const ST::string& key)
 {
-    SDLMap::iterator it = fMap.find(key);
+    auto it = fMap.find(key);
     if (it != fMap.end())
         it->second.sendToClients = true;
 }
@@ -191,77 +178,65 @@ void plPythonSDLModifier::SetDefault(const ST::string& key, PyObject* value)
 
 void plPythonSDLModifier::SetItemIdx(const ST::string& key, int idx, PyObject* value, bool sendImmediate)
 {
-    if (!value)
-    {
+    if (!value) {
         PyLoggedAssert(0, "[SDL] Trying to set a value to nil");
         return;
     }
 
-    SDLMap::iterator it = fMap.find(key);
-
-    if (it == fMap.end())
-    {
+    auto it = fMap.find(key);
+    if (it == fMap.end()) {
         PyLoggedAssert(0, "[SDL] Tried to set a nonexistent SDL value");
         return;
     }
 
     PyObject* pyTuple = it->second.obj;
     int size = it->second.size;
-
-    if (size != 0 && idx >= size)
-    {
+    if (size != 0 && idx >= size) {
         PyLoggedAssert(0, "[SDL] Trying to resize a SDL value that can't be");
         return;
     }
 
-    if (pyTuple && pyTuple->ob_refcnt != 1)
-    {
+    if (pyTuple && pyTuple->ob_refcnt != 1) {
         // others already have references to the tuple and expect it to be immutable, must make a copy
-        int n = PyTuple_Size(pyTuple);
+        Py_ssize_t n = PyTuple_Size(pyTuple);
         PyObject* newTuple = PyTuple_New(n);
-        for (int j = 0; j < n; j++)
-        {
+        for (Py_ssize_t j = 0; j < n; j++) {
             PyObject* item = PyTuple_GetItem(pyTuple, j);
             Py_INCREF(item);
-            PyTuple_SetItem(newTuple, j, item);
+            PyTuple_SET_ITEM(newTuple, j, item);
         }
         Py_DECREF(pyTuple);
         pyTuple = newTuple;
         it->second.obj = newTuple;
-    }
+    } else if (pyTuple) {
+        // The item tuple already exists but only we have a reference to it, so we can change it
+        // if needed.
+        if (PyTuple_Size(pyTuple) <= idx) {
+            Py_ssize_t oldsize = PyTuple_Size(pyTuple);
+            _PyTuple_Resize(&pyTuple, idx + 1);
 
-    if (pyTuple)
-    {
-        if (PyTuple_Size(pyTuple) <= idx)
-        {
-            int oldsize = PyTuple_Size(pyTuple);
-            _PyTuple_Resize(&pyTuple, idx+1);
             // initialize the tuple elements to None, because Python don't like NULLs
-            int j;
-            for ( j=oldsize; j<idx+1; j++ )
-            {
+            for (Py_ssize_t j = oldsize; j < (idx + 1); j++) {
                 Py_INCREF(Py_None);
                 PyTuple_SetItem(pyTuple, j, Py_None);
             }
-            // _PyTuple_Resize may have changed pyTuple
+
+            // _PyTuple_Resize may have recreated pyTuple
             it->second.obj = pyTuple;
         }
-    }
-    else
-    {
-        int newSize = (size == 0) ? idx+1 : size;
+    } else {
+        int newSize = (size == 0) ? idx + 1 : size;
         pyTuple = PyTuple_New(newSize);
+
         // initialize the tuple elements to None, because Python don't like NULLs
-        int j;
-        for ( j=0; j<newSize; j++ )
-        {
+        for (int j = 0; j < newSize; j++) {
             Py_INCREF(Py_None);
-            PyTuple_SetItem(pyTuple, j, Py_None);
+            PyTuple_SET_ITEM(pyTuple, j, Py_None);
         }
         it->second.obj = pyTuple;
     }
 
-    Py_XINCREF(value);  // PyTuple_SetItem doesn't increment the ref count
+    Py_INCREF(value);  // PyTuple_SetItem doesn't increment the ref count
     PyTuple_SetItem(pyTuple, idx, value);
 
     IDirtySynchState(key, sendImmediate);
@@ -277,9 +252,8 @@ const char* plPythonSDLModifier::GetSDLName() const
 
 void plPythonSDLModifier::SetFlags(const ST::string& name, bool sendImmediate, bool skipOwnershipCheck)
 {
-    SDLMap::iterator it = fMap.find(name);
-    if (it != fMap.end())
-    {
+    auto it = fMap.find(name);
+    if (it != fMap.end()) {
         it->second.sendImmediate = sendImmediate;
         it->second.skipLocalCheck = skipOwnershipCheck;
     }
@@ -287,11 +261,9 @@ void plPythonSDLModifier::SetFlags(const ST::string& name, bool sendImmediate, b
 
 void plPythonSDLModifier::SetTagString(const ST::string& name, const ST::string& tag)
 {
-    SDLMap::iterator it = fMap.find(name);
+    auto it = fMap.find(name);
     if (it != fMap.end())
-    {
         it->second.hintString = tag;
-    }
 }
 
 void plPythonSDLModifier::ISetCurrentStateFrom(const plStateDataRecord* srcState)
@@ -299,8 +271,7 @@ void plPythonSDLModifier::ISetCurrentStateFrom(const plStateDataRecord* srcState
     plStateDataRecord::SimpleVarsList vars;
     int num = srcState->GetUsedVars(&vars);
 
-    for (int i = 0; i < num; i++)
-    {
+    for (int i = 0; i < num; i++) {
         plSimpleStateVariable* var = vars[i];
 
         ST::string name = var->GetName();
@@ -309,7 +280,7 @@ void plPythonSDLModifier::ISetCurrentStateFrom(const plStateDataRecord* srcState
         PyObject* pyVar = ISDLVarToPython(var);
 
         SetItem(name, pyVar);
-        Py_XDECREF(pyVar);
+        Py_DECREF(pyVar);
     }
 
     // Notify the Python code that we updated the SDL record
@@ -318,18 +289,14 @@ void plPythonSDLModifier::ISetCurrentStateFrom(const plStateDataRecord* srcState
 
 void plPythonSDLModifier::IPutCurrentStateIn(plStateDataRecord* dstState)
 {
-    SDLMap::iterator it = fMap.begin();
-    for (; it != fMap.end(); it++)
-    {
-        IPythonVarToSDL(dstState, it->first);
-    }
+    for (auto it : fMap)
+        IPythonVarToSDL(dstState, it.first);
 }
 
 void plPythonSDLModifier::IDirtySynchState(const ST::string& name, bool sendImmediate)
 {
-    SDLMap::iterator it = fMap.find(name);
-    if (it != fMap.end())
-    {
+    auto it = fMap.find(name);
+    if (it != fMap.end()) {
         uint32_t flags = 0;
         if (it->second.sendToClients)
             flags |= kBCastToClients;
@@ -347,31 +314,24 @@ void plPythonSDLModifier::IDirtySynchState(const ST::string& name, bool sendImme
 bool plPythonSDLModifier::IPythonVarIdxToSDL(plSimpleStateVariable* var, int varIdx, int type, PyObject* pyVar, 
                                              const ST::string& hintstring)
 {
-    switch (type)
-    {
+    switch (type) {
     case plVarDescriptor::kShort:
     case plVarDescriptor::kByte:
     case plVarDescriptor::kBool:
     case plVarDescriptor::kInt:
-        if (PyInt_Check(pyVar))
-        {
+        if (PyInt_Check(pyVar)) {
             int v = PyInt_AsLong(pyVar);
             var->Set(v, varIdx);
             if (!hintstring.empty())
                 var->GetNotificationInfo().SetHintString(hintstring);
             return true;
-        }
-        else if (PyLong_Check(pyVar))
-        {
+        } else if (PyLong_Check(pyVar)) {
             int v = (int)PyLong_AsLong(pyVar);
             var->Set(v, varIdx);
             if (!hintstring.empty())
                 var->GetNotificationInfo().SetHintString(hintstring);
             return true;
-        }
-
-        else if (PyFloat_Check(pyVar))
-        {
+        } else if (PyFloat_Check(pyVar)) {
             int v = (int)PyFloat_AsDouble(pyVar);
             var->Set(v, varIdx);
             if (!hintstring.empty())
@@ -381,17 +341,13 @@ bool plPythonSDLModifier::IPythonVarIdxToSDL(plSimpleStateVariable* var, int var
         break;
 
     case plVarDescriptor::kFloat:
-        if (PyFloat_Check(pyVar))
-        {
+        if (PyFloat_Check(pyVar)) {
             float v = (float)PyFloat_AsDouble(pyVar);
             var->Set(v, varIdx);
             if (!hintstring.empty())
                 var->GetNotificationInfo().SetHintString(hintstring);
             return true;
-        }
-        // does python think that its an integer? too bad, we'll make it a float anyhow!
-        else if (PyInt_Check(pyVar))
-        {
+        } else if (PyInt_Check(pyVar)) {
             float v = (float)PyInt_AsLong(pyVar);
             var->Set(v, varIdx);
             if (!hintstring.empty())
@@ -401,8 +357,7 @@ bool plPythonSDLModifier::IPythonVarIdxToSDL(plSimpleStateVariable* var, int var
         break;
 
     case plVarDescriptor::kString32:
-        if (PyString_Check(pyVar))
-        {
+        if (PyString_Check(pyVar)) {
             char* v = PyString_AsString(pyVar);
             var->Set(v, varIdx);
             if (!hintstring.empty())
@@ -413,24 +368,22 @@ bool plPythonSDLModifier::IPythonVarIdxToSDL(plSimpleStateVariable* var, int var
     case plVarDescriptor::kKey:
         {
             pyKey* key = PythonInterface::GetpyKeyFromPython(pyVar);
-            if ( key )
-                var->Set(key->getKey(),varIdx);
+            if (key) {
+                var->Set(key->getKey(), varIdx);
                 if (!hintstring.empty())
                     var->GetNotificationInfo().SetHintString(hintstring);
+            }
         }
         break;
 
     case plVarDescriptor::kDouble:
-        if (PyFloat_Check(pyVar))
-        {
+        if (PyFloat_Check(pyVar)) {
             double v = PyFloat_AsDouble(pyVar);
             var->Set(v, varIdx);
             if (!hintstring.empty())
                 var->GetNotificationInfo().SetHintString(hintstring);
             return true;
-        }
-        else if (PyInt_Check(pyVar))
-        {
+        } else if (PyInt_Check(pyVar)) {
             double v = (double)PyInt_AsLong(pyVar);
             var->Set(v, varIdx);
             if (!hintstring.empty())
@@ -452,21 +405,19 @@ bool plPythonSDLModifier::IPythonVarIdxToSDL(plSimpleStateVariable* var, int var
 void plPythonSDLModifier::IPythonVarToSDL(plStateDataRecord* state, const ST::string& name)
 {
     plSimpleStateVariable* var = state->FindVar(name);
-    PyObject* pyVar = nil;
-    SDLMap::iterator it = fMap.find(name);
+    PyObject* pyVar = nullptr;
+    auto it = fMap.find(name);
     if (it != fMap.end())
         pyVar = it->second.obj;
 
     if (!var || !pyVar)
         return;
 
-    if (PyTuple_Check(pyVar))
-    {
-        int count = PyTuple_Size(pyVar);
+    if (PyTuple_Check(pyVar)) {
+        Py_ssize_t count = PyTuple_Size(pyVar);
         plSimpleVarDescriptor::Type type = var->GetSimpleVarDescriptor()->GetType();
 
-        for (int i = 0; i < count; i++)
-        {
+        for (Py_ssize_t i = 0; i < count; i++) {
             PyObject* pyVarItem = PyTuple_GetItem(pyVar, i);
             if (pyVarItem)
                 IPythonVarIdxToSDL(var, i, type, pyVarItem,it->second.hintString);
@@ -476,8 +427,7 @@ void plPythonSDLModifier::IPythonVarToSDL(plStateDataRecord* state, const ST::st
 
 PyObject* plPythonSDLModifier::ISDLVarIdxToPython(plSimpleStateVariable* var, int type, int idx)
 {
-    switch (type)
-    {
+    switch (type) {
     case plVarDescriptor::kShort:
     case plVarDescriptor::kByte:
     case plVarDescriptor::kInt:
@@ -499,7 +449,7 @@ PyObject* plPythonSDLModifier::ISDLVarIdxToPython(plSimpleStateVariable* var, in
         {
             bool v;
             var->Get(&v, idx);
-            return PyLong_FromLong(v);
+            return PyBool_FromLong(v ? 1: 0);
         }
 
     case plVarDescriptor::kString32:
@@ -544,11 +494,9 @@ PyObject* plPythonSDLModifier::ISDLVarToPython(plSimpleStateVariable* var)
     int count = var->GetCount();
 
     PyObject* pyTuple = PyTuple_New(count);
-
-    for (int i = 0; i < count; i++)
-    {
+    for (int i = 0; i < count; i++) {
         PyObject* varVal = ISDLVarIdxToPython(var, type, i);
-        PyTuple_SetItem(pyTuple, i, varVal);
+        PyTuple_SET_ITEM(pyTuple, i, varVal);
     }
 
     return pyTuple;
@@ -559,7 +507,7 @@ bool plPythonSDLModifier::HasSDL(const ST::string& pythonFile)
     return (plSDLMgr::GetInstance()->FindDescriptor(pythonFile, plSDL::kLatestVersion) != nil);
 }
 
-const plSDLModifier *ExternFindAgeSDL()
+const plSDLModifier* ExternFindAgeSDL()
 {
     return plPythonSDLModifier::FindAgeSDL();
 }
@@ -577,47 +525,39 @@ plPythonSDLModifier* plPythonSDLModifier::FindAgeSDL()
         return nullptr; // don't have an age, probably because we're running in max?
 
     // find the Age Global object
-    plLocation loc = plKeyFinder::Instance().FindLocation(ageName,plAgeDescription::GetCommonPage(plAgeDescription::kGlobal));
-    if ( loc.IsValid() )
-    {
+    plLocation loc = plKeyFinder::Instance().FindLocation(ageName, plAgeDescription::GetCommonPage(plAgeDescription::kGlobal));
+    if (loc.IsValid()) {
         plUoid oid(loc,plPythonFileMod::Index(), plPythonFileMod::kGlobalNameKonstant);
-        if ( oid.IsValid() )
-        {
+        if (oid.IsValid()) {
             plKey key = hsgResMgr::ResMgr()->FindKey(oid);
 
-            plPythonFileMod *pfmod = plPythonFileMod::ConvertNoRef(key ? key->ObjectIsLoaded() : nil);
-            if ( pfmod )
-            {
+            plPythonFileMod *pfmod = plPythonFileMod::ConvertNoRef(key ? key->ObjectIsLoaded() : nullptr);
+            if (pfmod) {
                 plPythonSDLModifier * sdlMod = pfmod->GetSDLMod();
-                if(sdlMod)
-                    // we found it!
+                if (sdlMod)
                     return sdlMod;
-                
+
                 plNetClientApp::StaticErrorMsg("pfmod {} has a nil python SDL modifier for age sdl {}",
                     pfmod->GetKeyName().c_str("?"), ageName);
-            }
-            else
-            {
+            } else {
                 if (!key)
                     plNetClientApp::StaticErrorMsg("nil key {} for age sdl {}", ageName, oid.StringIze());
-                else
-                if (!key->ObjectIsLoaded())
+                else if (!key->ObjectIsLoaded())
                     plNetClientApp::StaticErrorMsg("key {} not loaded for age sdl {}",
-                        key->GetName().c_str("?"), ageName);
-                else
-                if (!plPythonFileMod::ConvertNoRef(key->ObjectIsLoaded()))
+                                                   key->GetName().c_str("?"), ageName);
+                else if (!plPythonFileMod::ConvertNoRef(key->ObjectIsLoaded()))
                     plNetClientApp::StaticErrorMsg("key {} is not a python file mod for age sdl {}",
-                        key->GetName().c_str("?"), ageName);
+                                                   key->GetName().c_str("?"), ageName);
             }
-        }
-        else
+        } else {
             plNetClientApp::StaticErrorMsg("Invalid plUoid for age sdl {}", ageName);
-    }
-    else
+        }
+    } else {
         plNetClientApp::StaticErrorMsg("Invalid plLocation for age sdl {}", ageName);
+    }
 
     // couldn't find one (maybe because we didn't look)
-    return nil;
+    return nullptr;
 }
 
 plKey ExternFindAgeSDLTarget()
@@ -627,19 +567,15 @@ plKey ExternFindAgeSDLTarget()
 
 plKey plPythonSDLModifier::FindAgeSDLTarget()
 {
-
     // find the Age Global object
     plLocation loc = plKeyFinder::Instance().FindLocation(cyMisc::GetAgeName(),plAgeDescription::GetCommonPage(plAgeDescription::kGlobal));
-    if ( loc.IsValid() )
-    {
+    if (loc.IsValid()) {
         plUoid oid(loc,plPythonFileMod::Index(), plPythonFileMod::kGlobalNameKonstant);
-        if ( oid.IsValid() )
-        {
+        if (oid.IsValid()) {
             plKey key = hsgResMgr::ResMgr()->FindKey(oid);
 
-            plPythonFileMod *pfmod = plPythonFileMod::ConvertNoRef(key ? key->GetObjectPtr() : nil);
-            if ( pfmod )
-            {
+            plPythonFileMod* pfmod = plPythonFileMod::ConvertNoRef(key ? key->GetObjectPtr() : nullptr);
+            if (pfmod) {
                 if (pfmod->GetTarget(0))
                     return pfmod->GetTarget(0)->GetKey();
             }
@@ -647,7 +583,7 @@ plKey plPythonSDLModifier::FindAgeSDLTarget()
     }
 
     // couldn't find one (maybe because we didn't look)
-    return nil;
+    return nullptr;
 }
 
 
@@ -666,10 +602,8 @@ PyObject* pySDLModifier::GetAgeSDL()
         PYTHON_RETURN_NONE; // just return none if the age is blank (running in max?)
 
     const plPythonSDLModifier* ageSDL = plPythonSDLModifier::FindAgeSDL();
-    if ( ageSDL )
-    {
+    if (ageSDL)
         return pySDLModifier::New((plPythonSDLModifier*)ageSDL);
-    }
 
     // didn't find one, throw an exception for the python programmer to chew on
     ST::string err = ST::format("Age Global SDL for {} does not exist!", ageName);
@@ -703,7 +637,6 @@ void pySDLModifier::SetItem(pySDLModifier& self, const ST::string& key, PyObject
 {
     self.fRecord->SetItem(key, value);
 }
-
 
 void pySDLModifier::SetItemIdx(pySDLModifier& self, const ST::string& key, int idx, PyObject* value)
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyObjectRef.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyObjectRef.h
@@ -83,6 +83,13 @@ public:
         return fPyObject;
     }
 
+    PyObject* Release()
+    {
+        PyObject* temp = fPyObject;
+        fPyObject = nullptr;
+        return temp;
+    }
+
     void SetPyNone()
     {
         Py_INCREF(Py_None);

--- a/Sources/Plasma/FeatureLib/pfPython/pyObjectRef.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyObjectRef.h
@@ -1,0 +1,122 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef _pyObjectRef_h_
+#define _pyObjectRef_h_
+
+#include <Python.h>
+
+/** RAII reference count helper for Python objects. */
+class pyObjectRef
+{
+    PyObject* fPyObject;
+
+public:
+    pyObjectRef() : fPyObject() { }
+
+    /** Steals ownership of this object reference. */
+    pyObjectRef(PyObject* object) : fPyObject(object) { }
+
+    pyObjectRef(const pyObjectRef& copy)
+        : fPyObject(copy.fPyObject)
+    {
+        Py_XINCREF(fPyObject);
+    }
+
+    pyObjectRef(pyObjectRef&& move) HS_NOEXCEPT
+        : fPyObject(move.fPyObject)
+    {
+        move.fPyObject = nullptr;
+    }
+
+    ~pyObjectRef()
+    {
+        Py_XDECREF(fPyObject);
+    }
+
+    /**
+     * \brief Returns the managed PyObject pointer.
+     * \remarks This is an explicit operation to prevent a temporary implicit PyObject pointer from
+     *          being used to construct a new pyObjectRef.
+     */
+    PyObject* Get() const
+    {
+        return fPyObject;
+    }
+
+    void SetPyNone()
+    {
+        Py_INCREF(Py_None);
+        Py_XDECREF(fPyObject);
+        fPyObject = Py_None;
+    }
+
+    pyObjectRef& operator =(const pyObjectRef& copy)
+    {
+        Py_XINCREF(copy.fPyObject);
+        Py_XDECREF(fPyObject);
+        fPyObject = copy.fPyObject;
+        return *this;
+    }
+
+    /** Steals ownership of the provided object reference. */
+    pyObjectRef& operator =(PyObject* rhs)
+    {
+        Py_XDECREF(fPyObject);
+        fPyObject = rhs;
+        return *this;
+    }
+
+    pyObjectRef& operator =(pyObjectRef&& rhs) HS_NOEXCEPT
+    {
+        Py_XDECREF(fPyObject);
+        fPyObject = rhs.fPyObject;
+        rhs.fPyObject = nullptr;
+        return *this;
+    }
+
+    bool operator ==(const pyObjectRef& rhs) const { return (fPyObject == rhs.fPyObject); }
+    bool operator ==(const PyObject* rhs) const { return (fPyObject == rhs); }
+    operator bool() const { return (fPyObject != nullptr); }
+};
+
+#endif

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.h
@@ -120,7 +120,7 @@ public:
 
     uint32_t  GetNumClones();
     plKey   GetCloneByIdx(uint32_t idx);
-    plKey   GetCloneOwner() { return fCloneOwner; }
+    plKey   GetCloneOwner() const { return fCloneOwner; }
 
     void NotifyCreated();
     void ISetupNotify(plRefMsg* msg, plRefFlags::Type flags); // Setup notifcations for reference, don't send anything.


### PR DESCRIPTION
This was originally intended to be a set of changes to rewrite the glue.py file in C++. However, things got a little out of hand in the associated cleanups, so here they are instead. They include:
- A huge sweep of code style cleanups in plPythonFileMod and plPythonSDLModifier
- Rewriting the instance method calling code in plPythonFileMod to use variadic templates for ease of use
- Cleaning up some of the PyObject* reference management
- A handful of string cleanups

This depends on H-uru/moul-scripts#110