### PR TITLE
VC++2013 does not support constexpr scalars.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAudio/plVoiceCodec.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plVoiceCodec.cpp
@@ -46,10 +46,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plVoiceCodec.h"
 #include "plVoiceChat.h"
 
-static constexpr int kSpeexSampleRate = 8000;
+static const int kSpeexSampleRate = 8000;
 
-static constexpr int kOpusEncoderSampleRate = 16000;
-static constexpr int kOpusDecoderSampleRate = 48000;
+static const int kOpusEncoderSampleRate = 16000;
+static const int kOpusDecoderSampleRate = 48000;
 
 /*****************************************************************************
 *


### PR DESCRIPTION
Sad. We can always change it back if/when we upgrade to VC++2015...