### PR TITLE
Fix compatibility with OpenAL Soft 1.20

### DIFF
--- a/Sources/Plasma/FeatureLib/pfCamera/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfCamera/CMakeLists.txt
@@ -4,6 +4,8 @@ include_directories(../../NucleusLib)
 include_directories(../../NucleusLib/inc)
 include_directories(../../PubUtilLib)
 
+include_directories(${OPENAL_INCLUDE_DIR})
+
 set(pfCamera_SOURCES
     pfCameraProxy.cpp
     plCameraBrain.cpp

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
@@ -41,7 +41,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 #include "HeadSpin.h"
 #include <al.h>
-#include <alc.h>
 #include <efx.h>
 #ifdef EAX_SDK_AVAILABLE
 #include <eax.h>

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.h
@@ -44,6 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include <string>
+#include <alc.h>
 
 #include "hsTemplates.h"
 #include "hsGeometry3.h"
@@ -58,10 +59,6 @@ class plSoftSoundNode;
 class plgAudioSys;
 class plStatusLog;
 class plEAXListenerMod;
-
-typedef struct ALCdevice_struct ALCdevice;
-typedef struct ALCcontext_struct ALCcontext;
-
 
 class DeviceDescriptor
 {

--- a/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.h
@@ -66,7 +66,6 @@ class  plWinAudible;
 class  plPlate;
 class  plStatusLog;
 class  plSpeex;
-typedef struct ALCdevice_struct ALCdevice;
 class plVoiceDecoder;
 class plVoiceEncoder;
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plPipeline/CMakeLists.txt
@@ -7,6 +7,7 @@ include_directories("../../PubUtilLib")
 if(PLASMA_PIPELINE STREQUAL "DirectX")
     include_directories(${DirectX_INCLUDE_DIR})
 endif(PLASMA_PIPELINE STREQUAL "DirectX")
+include_directories(${OPENAL_INCLUDE_DIR})
 
 set(plPipeline_SOURCES
     hsG3DDeviceSelector.cpp

--- a/Sources/Tests/FeatureTests/pfPythonTest/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/pfPythonTest/CMakeLists.txt
@@ -8,6 +8,8 @@ include_directories(../../../Plasma/PubUtilLib/inc)
 include_directories(../../../Plasma/FeatureLib)
 include_directories(../../../Plasma/FeatureLib/inc)
 
+include_directories(${OPENAL_INCLUDE_DIR})
+
 set(pfPythonTest_SOURCES
     test_cyMisc.cpp
     )


### PR DESCRIPTION
OpenAL Soft 1.20 changed the ALCdevice and ALCcontext typedefs.

Since the `<alc.h>` header is very small and does not include any other headers, we can just include it directly where necessary instead of trying to forward-declare the types.