### PR TITLE
Make TArray/TFArray use SFINAE to determine whether to use CopyBits or CopyObject semantics...

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
@@ -639,7 +639,7 @@ PyObject* pyVault::FindNode( pyVaultNode* templateNode ) const
         return pyVaultNode::New(rvn);
     
     // See if a matching node exists on the server
-    ARRAY(unsigned) nodeIds;
+    TArray<unsigned> nodeIds;
     VaultFindNodesAndWait(templateNode->GetNode(), &nodeIds);
     
     if (nodeIds.Count()) {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -485,7 +485,7 @@ void pyVaultNode::RemoveAllNodes( void )
     if (!fNode)
         return;
         
-    ARRAY(unsigned) nodeIds;
+    TArray<unsigned> nodeIds;
     fNode->GetChildNodeIds(&nodeIds, 1);
     for (unsigned i = 0; i < nodeIds.Count(); ++i)
         VaultRemoveChildNode(fNode->GetNodeId(), nodeIds[i], nil, nil);
@@ -583,7 +583,7 @@ int pyVaultNode::GetChildNodeCount()
     if (!fNode)
         return 0;
         
-    ARRAY(unsigned) nodeIds;
+    TArray<unsigned> nodeIds;
     fNode->GetChildNodeIds(&nodeIds, 1);
     
     return nodeIds.Count();

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.cpp
@@ -131,7 +131,7 @@ PyObject * pyVaultNodeRef::GetSaver () {
             saver = VaultGetNode(templateNode);
 
             if (!saver) {
-                ARRAY(unsigned) nodeIds;
+                TArray<unsigned> nodeIds;
                 VaultFindNodesAndWait(templateNode, &nodeIds);
                 if (nodeIds.Count() > 0) {
                     VaultFetchNodesAndWait(nodeIds.Ptr(), nodeIds.Count());

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
@@ -108,7 +108,7 @@ void pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
     VaultPlayerInfoNode access(templateNode);
     access.SetPlayerId(playerID);
 
-    ARRAY(uint32_t) nodeIds;
+    TArray<uint32_t> nodeIds;
     VaultLocalFindNodes(templateNode, &nodeIds);
 
     // So, if we know about this node, we can take it easy. If not, we lazy load it.

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Nt/pnAceNtSocket.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Nt/pnAceNtSocket.cpp
@@ -839,7 +839,7 @@ static void HardCloseSocket (SOCKET sock) {
 
 //===========================================================================
 static unsigned SocketCloseTimerCallback (void *) {
-    ARRAY(SOCKET) sockets;
+    TArray<SOCKET> sockets;
 
     unsigned sleepMs;
     unsigned currTimeMs = TimeGetMs();

--- a/Sources/Plasma/NucleusLib/pnNetCli/Intern.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/Intern.h
@@ -114,8 +114,8 @@ void NetMsgCryptServerConnect (
 ***/
 
 class CInputAccumulator {
-    ARRAY(uint8_t) buffer;
-    uint8_t *      curr;
+    TArray<uint8_t> buffer;
+    uint8_t *       curr;
 
 public:
     CInputAccumulator ();

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcChannel.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcChannel.cpp
@@ -90,8 +90,8 @@ struct NetMsgChannel : hsRefCnt {
 
     // Message definitions
     uint32_t                m_largestRecv;
-    ARRAY(NetMsgInitSend)   m_sendMsgs;
-    ARRAY(NetMsgInitRecv)   m_recvMsgs;
+    TArray<NetMsgInitSend>  m_sendMsgs;
+    TArray<NetMsgInitRecv>  m_recvMsgs;
 
     // Diffie-Hellman constants
     uint32_t                m_dh_g;

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -145,7 +145,7 @@ struct NetCli {
 
     // Message buffers
     uint8_t                    sendBuffer[kAsyncSocketBufferSize];
-    ARRAY(uint8_t)             recvBuffer;
+    TArray<uint8_t>            recvBuffer;
 
     NetCli()
         : sock(nil), protocol((ENetProtocol)0), channel(nil), server(false)

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.cpp
@@ -106,14 +106,14 @@ inline void IReadString (T ** buf, uint8_t ** buffer, unsigned * bufsz) {
 
 //============================================================================
 template <typename T>
-inline void IWriteValue (const T & value, ARRAY(uint8_t) * buffer) {
+inline void IWriteValue (const T & value, TArray<uint8_t> * buffer) {
     T * ptr = (T *) buffer->New(sizeof(T));
     *ptr = value;
 }
 
 //============================================================================
 template <typename T>
-inline void IWriteArray (const T buf[], unsigned elems, ARRAY(uint8_t) * buffer) {
+inline void IWriteArray (const T buf[], unsigned elems, TArray<uint8_t> * buffer) {
     unsigned bytes = elems * sizeof(T);
     IWriteValue(bytes, buffer);
     T * dst = (T *) buffer->New(bytes);
@@ -122,7 +122,7 @@ inline void IWriteArray (const T buf[], unsigned elems, ARRAY(uint8_t) * buffer)
 
 //============================================================================
 template <typename T>
-inline void IWriteString (const T str[], ARRAY(uint8_t) * buffer) {
+inline void IWriteString (const T str[], TArray<uint8_t> * buffer) {
     IWriteArray(str, StrLen(str) + 1, buffer);
 }
 
@@ -217,7 +217,7 @@ unsigned NetGameScore::Read(const uint8_t inbuffer[], unsigned bufsz, uint8_t** 
 }
 
 //============================================================================
-unsigned NetGameScore::Write(ARRAY(uint8_t) * buffer) const {
+unsigned NetGameScore::Write(TArray<uint8_t> * buffer) const {
 
     unsigned pos = buffer->Count();
 
@@ -269,7 +269,7 @@ unsigned NetGameRank::Read(const uint8_t inbuffer[], unsigned bufsz, uint8_t** e
 }
 
 //============================================================================
-unsigned NetGameRank::Write(ARRAY(uint8_t) * buffer) const {
+unsigned NetGameRank::Write(TArray<uint8_t> * buffer) const {
 
     unsigned pos = buffer->Count();
 
@@ -562,14 +562,14 @@ void NetVaultNode::Read(const uint8_t* buf, size_t size)
 
 //============================================================================
 template<typename T>
-inline void IWrite(ARRAY(uint8_t)* buffer, const T& value)
+inline void IWrite(TArray<uint8_t>* buffer, const T& value)
 {
     uint8_t* ptr = buffer->New(sizeof(T));
     memcpy(ptr, &value, sizeof(T));
 }
 
 template<>
-inline void IWrite<ST::string>(ARRAY(uint8_t)* buffer, const ST::string& value)
+inline void IWrite<ST::string>(TArray<uint8_t>* buffer, const ST::string& value)
 {
     ST::utf16_buffer utf16 = value.to_utf16();
     uint32_t strsz = (utf16.size() + 1) * sizeof(char16_t);
@@ -580,7 +580,7 @@ inline void IWrite<ST::string>(ARRAY(uint8_t)* buffer, const ST::string& value)
 }
 
 template<>
-inline void IWrite<NetVaultNode::Blob>(ARRAY(uint8_t)* buffer, const NetVaultNode::Blob& blob)
+inline void IWrite<NetVaultNode::Blob>(TArray<uint8_t>* buffer, const NetVaultNode::Blob& blob)
 {
     IWrite(buffer, static_cast<uint32_t>(blob.size));
 
@@ -590,7 +590,7 @@ inline void IWrite<NetVaultNode::Blob>(ARRAY(uint8_t)* buffer, const NetVaultNod
     }
 }
 
-void NetVaultNode::Write(ARRAY(uint8_t)* buf, uint32_t ioFlags)
+void NetVaultNode::Write(TArray<uint8_t>* buf, uint32_t ioFlags)
 {
     uint64_t flags = fUsedFields;
     if (ioFlags & kDirtyNodeType)

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
@@ -125,7 +125,7 @@ struct NetGameScore {
     int         value;
 
     unsigned Read (const uint8_t inbuffer[], unsigned bufsz, uint8_t** end = nil);    // returns number of bytes read
-    unsigned Write (ARRAY(uint8_t) * buffer) const;                                // returns number of bytes written
+    unsigned Write (TArray<uint8_t> * buffer) const;                                // returns number of bytes written
 
     void CopyFrom (const NetGameScore & score);
 };
@@ -142,7 +142,7 @@ struct NetGameRank {
     wchar_t       name[kMaxPlayerNameLength];
 
     unsigned Read (const uint8_t inbuffer[], unsigned bufsz, uint8_t** end = nil);    // returns number of bytes read
-    unsigned Write (ARRAY(uint8_t) * buffer) const;                                // returns number of bytes written
+    unsigned Write (TArray<uint8_t> * buffer) const;                                // returns number of bytes written
 
     void CopyFrom (const NetGameRank & fromRank);
 };
@@ -309,7 +309,7 @@ public:
     bool Matches(const NetVaultNode* rhs) const;
 
     void Read(const uint8_t* buf, size_t size);
-    void Write(ARRAY(uint8_t)* buf, uint32_t ioFlags=0);
+    void Write(TArray<uint8_t>* buf, uint32_t ioFlags=0);
 
 protected:
     uint64_t GetFieldFlags() const { return fUsedFields; }

--- a/Sources/Plasma/NucleusLib/pnUtils/pnUtArray.h
+++ b/Sources/Plasma/NucleusLib/pnUtils/pnUtArray.h
@@ -57,10 +57,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *
 ***/
 
-#define  ARRAY(type)      TArray< type, TArrayCopyBits< type > >
-#define  ARRAYOBJ(type)   TArray< type, TArrayCopyObject< type > >
-#define  FARRAY(type)     TFArray< type, TArrayCopyBits< type > >
-#define  FARRAYOBJ(type)  TFArray< type, TArrayCopyObject< type > >
+#define  ARRAY(type)      TArray<type>
+#define  ARRAYOBJ(type)   TArray<type>
+#define  FARRAY(type)     TFArray<type>
+#define  FARRAYOBJ(type)  TFArray<type>
 
 /****************************************************************************
 *
@@ -275,110 +275,95 @@ protected:
 
 /****************************************************************************
 *
-*   TArrayCopyBits
+*   TArrayCopy
 *
 ***/
 
-template<class T>
-class TArrayCopyBits {
+class TArrayCopy {
 public:
-    inline static void Assign (T * dest, const T source[], unsigned count);
-    inline static void Construct (T * dest) { }
-    inline static void Construct (T * dest, unsigned count) { }
-    inline static void CopyConstruct (T * dest, const T & source);
-    inline static void CopyConstruct (T * dest, const T source[], unsigned count);
-    inline static void Destruct (T * dest) { }
-    inline static void Destruct (T * dest, unsigned count) { }
-};
+    template <class T, typename std::enable_if_t<std::is_trivially_copyable<T>::value, int> = 0>
+    inline static void Assign(T* dest, const T source[], unsigned count)
+    {
+        memmove(dest, source, count * sizeof(T));
+    }
 
-//===========================================================================
-template<class T>
-void TArrayCopyBits<T>::Assign (T * dest, const T source[], unsigned count) {
-    memmove(dest, source, count * sizeof(T));
-}
+    template <class T, typename std::enable_if_t<!std::is_trivially_copyable<T>::value, int> = 0>
+    inline static void Assign(T* dest, const T source[], unsigned count)
+    {
+        if (dest > source) {
+            for (unsigned loop = count; loop--; )
+                dest[loop] = source[loop];
+        } else if (dest < source) {
+            for (unsigned loop = 0; loop < count; ++loop)
+                dest[loop] = source[loop];
+        }
+    }
 
-//===========================================================================
-template<class T>
-void TArrayCopyBits<T>::CopyConstruct (T * dest, const T & source) {
-    *dest = source;
-}
+    template <class T, typename std::enable_if_t<std::is_trivial<T>::value, int> = 0>
+    inline static void Construct(T* dest) { }
 
-//===========================================================================
-template<class T>
-void TArrayCopyBits<T>::CopyConstruct (T * dest, const T source[], unsigned count) {
-    ASSERT((dest + count <= source) || (source + count <= dest));
-    memcpy(dest, source, count * sizeof(T));
-}
+    template <class T, typename std::enable_if_t<!std::is_trivial<T>::value, int> = 0>
+    inline static void Construct(T* dest)
+    {
+        new(dest) T;
+    }
 
+    template <class T, typename std::enable_if_t<std::is_trivial<T>::value, int> = 0>
+    inline static void Construct(T* dest, unsigned count) { }
 
-/****************************************************************************
-*
-*   TArrayCopyObject
-*
-***/
-
-template<class T>
-class TArrayCopyObject {
-public:
-    inline static void Assign (T * dest, const T source[], unsigned count);
-    inline static void Construct (T * dest);
-    inline static void Construct (T * dest, unsigned count);
-    inline static void CopyConstruct (T * dest, const T & source);
-    inline static void CopyConstruct (T * dest, const T source[], unsigned count);
-    inline static void Destruct (T * dest);
-    inline static void Destruct (T * dest, unsigned count);
-};
-
-//===========================================================================
-template<class T>
-void TArrayCopyObject<T>::Assign (T * dest, const T source[], unsigned count) {
-    if (dest > source)
-        for (unsigned loop = count; loop--; )
-            dest[loop] = source[loop];
-    else if (dest < source)
+    template <class T, typename std::enable_if_t<!std::is_trivial<T>::value, int> = 0>
+    inline static void Construct(T* dest, unsigned count)
+    {
         for (unsigned loop = 0; loop < count; ++loop)
-            dest[loop] = source[loop];
-}
+            new(&dest[loop]) T;
+    }
 
-//===========================================================================
-template<class T>
-void TArrayCopyObject<T>::Construct (T * dest) {
-    new(dest) T;
-}
+    template <class T, typename std::enable_if_t<std::is_trivially_copyable<T>::value, int> = 0>
+    inline static void CopyConstruct(T* dest, const T& source)
+    {
+        *dest = source;
+    }
 
-//===========================================================================
-template<class T>
-void TArrayCopyObject<T>::Construct (T * dest, unsigned count) {
-    for (unsigned loop = 0; loop < count; ++loop)
-        new(&dest[loop]) T;
-}
+    template <class T, typename std::enable_if_t<!std::is_trivially_copyable<T>::value, int> = 0>
+    inline static void CopyConstruct(T* dest, const T& source)
+    {
+        new(dest) T(source);
+    }
 
-//===========================================================================
-template<class T>
-void TArrayCopyObject<T>::CopyConstruct (T * dest, const T & source) {
-    new(dest) T(source);
-}
+    template <class T, typename std::enable_if_t<std::is_trivially_copyable<T>::value, int> = 0>
+    inline static void CopyConstruct(T* dest, const T source[], unsigned count)
+    {
+        ASSERT((dest + count <= source) || (source + count <= dest));
+        memcpy(dest, source, count * sizeof(T));
+    }
 
-//===========================================================================
-template<class T>
-void TArrayCopyObject<T>::CopyConstruct (T * dest, const T source[], unsigned count) {
-    ASSERT((dest + count <= source) || (source + count <= dest));
-    for (unsigned loop = 0; loop < count; ++loop)
-        new(&dest[loop]) T(source[loop]);
-}
+    template <class T, typename std::enable_if_t<!std::is_trivially_copyable<T>::value, int> = 0>
+    inline static void CopyConstruct(T* dest, const T source[], unsigned count)
+    {
+        ASSERT((dest + count <= source) || (source + count <= dest));
+        for (unsigned loop = 0; loop < count; ++loop)
+            new(&dest[loop]) T(source[loop]);
+    }
 
-//===========================================================================
-template<class T>
-void TArrayCopyObject<T>::Destruct (T * dest) {
-    dest->~T();
-}
+    template <class T, typename std::enable_if_t<std::is_trivially_copyable<T>::value, int> = 0>
+    inline static void Destruct(T* dest) { }
 
-//===========================================================================
-template<class T>
-void TArrayCopyObject<T>::Destruct (T * dest, unsigned count) {
-    for (unsigned loop = count; loop--; )
-        dest[loop].~T();
-}
+    template <class T, typename std::enable_if_t<!std::is_trivially_copyable<T>::value, int> = 0>
+    inline static void Destruct(T* dest)
+    {
+        dest->~T();
+    }
+
+    template <class T, typename std::enable_if_t<std::is_trivially_copyable<T>::value, int> = 0>
+    inline static void Destruct(T* dest, unsigned count) { }
+
+    template <class T, typename std::enable_if_t<!std::is_trivially_copyable<T>::value, int> = 0>
+    inline static void Destruct(T* dest, unsigned count)
+    {
+        for (unsigned loop = count; loop--; )
+            dest[loop].~T();
+    }
+};
 
 
 /****************************************************************************
@@ -387,7 +372,7 @@ void TArrayCopyObject<T>::Destruct (T * dest, unsigned count) {
 *
 ***/
 
-template<class T, class C>
+template<class T>
 class TFArray : protected CBaseArray {
 protected:
     T *      m_data;
@@ -400,10 +385,10 @@ public:
     inline TFArray ();
     inline TFArray (unsigned count);
     inline TFArray (const T * source, unsigned count);
-    inline TFArray (const TFArray<T,C> & source);
+    inline TFArray (const TFArray<T> & source);
     inline ~TFArray ();
-    inline TFArray<T,C> & operator= (const TFArray<T,C> & source);
-    inline bool operator== (const TFArray<T,C> & source) const;
+    inline TFArray<T> & operator= (const TFArray<T> & source);
+    inline bool operator== (const TFArray<T> & source) const;
     inline T & operator[] (unsigned index);
     inline const T & operator[] (unsigned index) const;
     inline void Attach (T * source, unsigned count);
@@ -416,7 +401,7 @@ public:
     inline T * Ptr ();
     inline const T * Ptr () const;
     inline void Set (const T * source, unsigned count);
-    inline void SetArray (const TFArray<T,C> & source);
+    inline void SetArray (const TFArray<T> & source);
     inline void SetCount (unsigned count);
     inline T * Term ();
     inline const T * Term () const;
@@ -429,69 +414,69 @@ public:
 };
 
 //===========================================================================
-template<class T, class C>
-TFArray<T,C>::TFArray () {
+template<class T>
+TFArray<T>::TFArray () {
     m_alloc = 0;
     m_count = 0;
     m_data  = nil;
 }
 
 //===========================================================================
-template<class T, class C>
-TFArray<T,C>::TFArray (unsigned count) {
+template<class T>
+TFArray<T>::TFArray (unsigned count) {
     m_alloc = m_count = count;
     if (count) {
         m_data = (T *)malloc(count * sizeof(T));
-        C::Construct(m_data, count);
+        TArrayCopy::Construct(m_data, count);
     }
     else
         m_data = nil;
 }
 
 //===========================================================================
-template<class T, class C>
-TFArray<T,C>::TFArray (const T * source, unsigned count) {
+template<class T>
+TFArray<T>::TFArray (const T * source, unsigned count) {
     m_alloc = m_count = count;
     if (count) {
         m_data = (T *)malloc(count * sizeof(T));
-        C::CopyConstruct(m_data, source, count);
+        TArrayCopy::CopyConstruct(m_data, source, count);
     }
     else
         m_data = nil;
 }
 
 //===========================================================================
-template<class T, class C>
-TFArray<T,C>::TFArray (const TFArray<T,C> & source) {
+template<class T>
+TFArray<T>::TFArray (const TFArray<T> & source) {
     m_alloc = m_count = source.m_count;
     if (m_count) {
         m_data = (T *)malloc(m_count * sizeof(T));
-        C::CopyConstruct(m_data, source.m_data, m_count);
+        TArrayCopy::CopyConstruct(m_data, source.m_data, m_count);
     }
     else
         m_data = nil;
 }
 
 //===========================================================================
-template<class T, class C>
-TFArray<T,C>::~TFArray () {
+template<class T>
+TFArray<T>::~TFArray () {
     Clear();
 }
 
 //===========================================================================
-template<class T, class C>
-TFArray<T,C> & TFArray<T,C>::operator= (const TFArray<T,C> & source) {
+template<class T>
+TFArray<T> & TFArray<T>::operator= (const TFArray<T> & source) {
     if (&source == this)
         return *this;
     AdjustSize(source.m_count, 0);
-    C::CopyConstruct(m_data, source.m_data, source.m_count);
+    TArrayCopy::CopyConstruct(m_data, source.m_data, source.m_count);
     m_count = source.m_count;
     return *this;
 }
 
 //===========================================================================
-template<class T, class C>
-inline bool TFArray<T,C>::operator== (const TFArray<T,C> & source) const {
+template<class T>
+inline bool TFArray<T>::operator== (const TFArray<T> & source) const {
     if (m_count != source.m_count)
         return false;
     for (unsigned index = 0; index < m_count; ++index)
@@ -501,26 +486,26 @@ inline bool TFArray<T,C>::operator== (const TFArray<T,C> & source) const {
 }
 
 //===========================================================================
-template<class T, class C>
-T & TFArray<T,C>::operator[] (unsigned index) {
+template<class T>
+T & TFArray<T>::operator[] (unsigned index) {
     ASSERT(index < m_count);
     return m_data[index];
 }
 
 //===========================================================================
-template<class T, class C>
-const T & TFArray<T,C>::operator[] (unsigned index) const {
+template<class T>
+const T & TFArray<T>::operator[] (unsigned index) const {
     ASSERT(index < m_count);
     return m_data[index];
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::AdjustSize (unsigned newAlloc, unsigned newCount) {
+template<class T>
+void TFArray<T>::AdjustSize (unsigned newAlloc, unsigned newCount) {
 
     // Destruct elements if the array is shrinking
     if (m_count > newCount) {
-        C::Destruct(m_data + newCount, m_count - newCount);
+        TArrayCopy::Destruct(m_data + newCount, m_count - newCount);
         m_count = newCount;
     }
 
@@ -528,8 +513,8 @@ void TFArray<T,C>::AdjustSize (unsigned newAlloc, unsigned newCount) {
     if (m_alloc != newAlloc) {
         T * newData = (T *)ReallocPtr(m_data, newAlloc * sizeof(T));
         if (newData != m_data) {
-            C::CopyConstruct(newData, m_data, m_count);
-            C::Destruct(m_data, m_count);
+            TArrayCopy::CopyConstruct(newData, m_data, m_count);
+            TArrayCopy::Destruct(m_data, m_count);
             if (m_data)
                 free(m_data);
         }
@@ -539,16 +524,16 @@ void TFArray<T,C>::AdjustSize (unsigned newAlloc, unsigned newCount) {
 
     // Construct elements if the array is growing
     if (m_count < newCount) {
-        C::Construct(m_data + m_count, newCount - m_count);
+        TArrayCopy::Construct(m_data + m_count, newCount - m_count);
         m_count = newCount;
     }
 
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::Attach (T * source, unsigned count) {
-    C::Destruct(m_data, m_count);
+template<class T>
+void TFArray<T>::Attach (T * source, unsigned count) {
+    TArrayCopy::Destruct(m_data, m_count);
     if (m_data)
         free(m_data);
     m_data  = source;
@@ -558,9 +543,9 @@ void TFArray<T,C>::Attach (T * source, unsigned count) {
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::AttachTemp (T * source, unsigned count) {
-    C::Destruct(m_data, m_count);
+template<class T>
+void TFArray<T>::AttachTemp (T * source, unsigned count) {
+    TArrayCopy::Destruct(m_data, m_count);
     if (m_data)
         free(m_data);
     m_data  = source;
@@ -569,15 +554,15 @@ void TFArray<T,C>::AttachTemp (T * source, unsigned count) {
 }
 
 //===========================================================================
-template<class T, class C>
-unsigned TFArray<T,C>::Bytes () const {
+template<class T>
+unsigned TFArray<T>::Bytes () const {
     return m_count * sizeof(T);
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::Clear () {
-    C::Destruct(m_data, m_count);
+template<class T>
+void TFArray<T>::Clear () {
+    TArrayCopy::Destruct(m_data, m_count);
     if (m_data)
         free(m_data);
     m_data = nil;
@@ -585,14 +570,14 @@ void TFArray<T,C>::Clear () {
 }
 
 //===========================================================================
-template<class T, class C>
-unsigned TFArray<T,C>::Count () const {
+template<class T>
+unsigned TFArray<T>::Count () const {
     return m_count;
 }
 
 //===========================================================================
-template<class T, class C>
-T * TFArray<T,C>::Detach () {
+template<class T>
+T * TFArray<T>::Detach () {
     T * result = m_data;
     m_data  = nil;
     m_alloc = 0;
@@ -601,95 +586,95 @@ T * TFArray<T,C>::Detach () {
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::Fill (uint8_t value) {
-    C::Destruct(m_data, m_count);
+template<class T>
+void TFArray<T>::Fill (uint8_t value) {
+    TArrayCopy::Destruct(m_data, m_count);
     memset(m_data, value, m_count * sizeof(T));
-    C::Construct(m_data, m_count);
+    TArrayCopy::Construct(m_data, m_count);
 }
 
 //===========================================================================
-template<class T, class C>
-T * TFArray<T,C>::Ptr () {
+template<class T>
+T * TFArray<T>::Ptr () {
     return m_data;
 }
 
 //===========================================================================
-template<class T, class C>
-const T * TFArray<T,C>::Ptr () const {
+template<class T>
+const T * TFArray<T>::Ptr () const {
     return m_data;
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::Set (const T * source, unsigned count) {
+template<class T>
+void TFArray<T>::Set (const T * source, unsigned count) {
     AdjustSize(count, 0);
-    C::CopyConstruct(m_data, source, count);
+    TArrayCopy::CopyConstruct(m_data, source, count);
     m_count = count;
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::SetArray (const TFArray<T,C> & source) {
+template<class T>
+void TFArray<T>::SetArray (const TFArray<T> & source) {
     AdjustSize(source.m_count, 0);
-    C::CopyConstruct(m_data, source.m_data, source.m_count);
+    TArrayCopy::CopyConstruct(m_data, source.m_data, source.m_count);
     m_count = source.m_count;
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::SetCount (unsigned count) {
+template<class T>
+void TFArray<T>::SetCount (unsigned count) {
     AdjustSize(count, count);
 }
 
 //===========================================================================
-template<class T, class C>
-T * TFArray<T,C>::Term () {
+template<class T>
+T * TFArray<T>::Term () {
     return m_data + m_count;
 }
 
 //===========================================================================
-template<class T, class C>
-const T * TFArray<T,C>::Term () const {
+template<class T>
+const T * TFArray<T>::Term () const {
     return m_data + m_count;
 }
 
 //===========================================================================
-template<class T, class C>
-T * TFArray<T,C>::Top () {
+template<class T>
+T * TFArray<T>::Top () {
     ASSERT(m_count);
     return m_data + m_count - 1;
 }
 
 //===========================================================================
-template<class T, class C>
-const T * TFArray<T,C>::Top () const {
+template<class T>
+const T * TFArray<T>::Top () const {
     ASSERT(m_count);
     return m_data + m_count - 1;
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::Zero () {
-    C::Destruct(m_data, m_count);
+template<class T>
+void TFArray<T>::Zero () {
+    TArrayCopy::Destruct(m_data, m_count);
     memset(m_data, 0, m_count * sizeof(T));
-    C::Construct(m_data, m_count);
+    TArrayCopy::Construct(m_data, m_count);
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::ZeroCount () {
-    C::Destruct(m_data, m_count);
+template<class T>
+void TFArray<T>::ZeroCount () {
+    TArrayCopy::Destruct(m_data, m_count);
     m_count = 0;
 }
 
 //===========================================================================
-template<class T, class C>
-void TFArray<T,C>::ZeroRange (unsigned index, unsigned count) {
+template<class T>
+void TFArray<T>::ZeroRange (unsigned index, unsigned count) {
     ASSERT(index + count <= m_count);
-    C::Destruct(m_data + index, count);
+    TArrayCopy::Destruct(m_data + index, count);
     memset(m_data + index, 0, count * sizeof(T));
-    C::Construct(m_data + index, count);
+    TArrayCopy::Construct(m_data + index, count);
 }
 
 
@@ -699,8 +684,8 @@ void TFArray<T,C>::ZeroRange (unsigned index, unsigned count) {
 *
 ***/
 
-template<class T, class C>
-class TArray : public TFArray<T,C> {
+template<class T>
+class TArray : public TFArray<T> {
 
 private:
     unsigned m_chunkSize;
@@ -712,11 +697,11 @@ public:
     inline TArray (const char file[], int line);
     inline TArray (unsigned count);
     inline TArray (const T * source, unsigned count);
-    inline TArray (const TArray<T,C> & source);
-    inline TArray<T,C> & operator= (const TArray<T,C> & source);
+    inline TArray (const TArray<T> & source);
+    inline TArray<T> & operator= (const TArray<T> & source);
     inline unsigned Add (const T & source);
     inline unsigned Add (const T * source, unsigned count);
-    inline unsigned AddArray (const TArray<T,C> & source);
+    inline unsigned AddArray (const TArray<T> & source);
     inline void Copy (unsigned destIndex, unsigned sourceIndex, unsigned count);
     inline void DeleteOrdered (unsigned index);
     inline void DeleteUnordered (unsigned index);
@@ -738,78 +723,78 @@ public:
 };
 
 //===========================================================================
-template<class T, class C>
-TArray<T,C>::TArray () : TFArray<T,C>() {
+template<class T>
+TArray<T>::TArray () : TFArray<T>() {
     m_chunkSize = std::max(size_t(1), 256 / sizeof(T));
 }
 
 //===========================================================================
-template<class T, class C>
-TArray<T,C>::TArray (const char file[], int line) : TFArray<T,C>(file, line) {
+template<class T>
+TArray<T>::TArray (const char file[], int line) : TFArray<T>(file, line) {
     m_chunkSize = std::max(size_t(1), 256 / sizeof(T));
 }
 
 //===========================================================================
-template<class T, class C>
-TArray<T,C>::TArray (unsigned count) : TFArray<T,C>(count) {
+template<class T>
+TArray<T>::TArray (unsigned count) : TFArray<T>(count) {
     m_chunkSize = std::max(size_t(1), 256 / sizeof(T));
 }
 
 //===========================================================================
-template<class T, class C>
-TArray<T,C>::TArray (const T * source, unsigned count) : TFArray<T,C>(source, count) {
+template<class T>
+TArray<T>::TArray (const T * source, unsigned count) : TFArray<T>(source, count) {
     m_chunkSize = std::max(size_t(1), 256 / sizeof(T));
 }
 
 //===========================================================================
-template<class T, class C>
-TArray<T,C>::TArray (const TArray & source) : TFArray<T,C>(source) {
+template<class T>
+TArray<T>::TArray (const TArray & source) : TFArray<T>(source) {
     m_chunkSize = source.m_chunkSize;
 }
 
 //===========================================================================
-template<class T, class C>
-TArray<T,C> & TArray<T,C>::operator= (const TArray<T,C> & source) {
+template<class T>
+TArray<T> & TArray<T>::operator= (const TArray<T> & source) {
     if (&source == this)
         return *this;
     m_chunkSize = source.m_chunkSize;
     AdjustSize(max(this->m_alloc, source.m_count), 0);
-    C::CopyConstruct(this->m_data, source.m_data, source.m_count);
+    TArrayCopy::CopyConstruct(this->m_data, source.m_data, source.m_count);
     this->m_count = source.m_count;
     return *this;
 }
 
 //===========================================================================
-template<class T, class C>
-unsigned TArray<T,C>::Add (const T & source) {
+template<class T>
+unsigned TArray<T>::Add (const T & source) {
     unsigned index = this->m_count;
     Push(source);
     return index;
 }
 
 //===========================================================================
-template<class T, class C>
-unsigned TArray<T,C>::Add (const T * source, unsigned count) {
+template<class T>
+unsigned TArray<T>::Add (const T * source, unsigned count) {
     unsigned index = this->m_count;
     AdjustSizeChunked(this->m_count + count, this->m_count);
-    C::CopyConstruct(&this->m_data[this->m_count], source, count);
+    TArrayCopy::CopyConstruct(&this->m_data[this->m_count], source, count);
     this->m_count += count;
     return index;
 }
 
 //===========================================================================
-template<class T, class C>
-unsigned TArray<T,C>::AddArray (const TArray<T,C> & source) {
+template<class T>
+unsigned TArray<T>::AddArray (const TArray<T> & source) {
     unsigned index = this->m_count;
     AdjustSizeChunked(this->m_count + source.m_count, this->m_count);
-    C::CopyConstruct(&this->m_data[this->m_count], source.m_data, source.m_count);
+    TArrayCopy::CopyConstruct(&this->m_data[this->m_count], source.m_data, source.m_count);
     this->m_count += source.m_count;
     return index;
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::AdjustSizeChunked (unsigned newAlloc, unsigned newCount) {
+template<class T>
+void TArray<T>::AdjustSizeChunked (unsigned newAlloc, unsigned newCount) {
 
     // Disallow shrinking the allocation
     if (newAlloc <= this->m_alloc)
@@ -825,151 +810,151 @@ void TArray<T,C>::AdjustSizeChunked (unsigned newAlloc, unsigned newCount) {
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::Copy (unsigned destIndex, unsigned sourceIndex, unsigned count) {
+template<class T>
+void TArray<T>::Copy (unsigned destIndex, unsigned sourceIndex, unsigned count) {
 
     // Copy the data to the destination
     ASSERT(destIndex +   count <= this->m_count);
     ASSERT(sourceIndex + count <= this->m_count);
-    C::Assign(this->m_data + destIndex, this->m_data + sourceIndex, count);
+    TArrayCopy::Assign(this->m_data + destIndex, this->m_data + sourceIndex, count);
 
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::DeleteOrdered (unsigned index) {
+template<class T>
+void TArray<T>::DeleteOrdered (unsigned index) {
     ASSERT(index < this->m_count);
     if (index + 1 < this->m_count)
-        C::Assign(&this->m_data[index], &this->m_data[index + 1], this->m_count - index - 1);
-    C::Destruct(&this->m_data[--this->m_count]);
+        TArrayCopy::Assign(&this->m_data[index], &this->m_data[index + 1], this->m_count - index - 1);
+    TArrayCopy::Destruct(&this->m_data[--this->m_count]);
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::DeleteUnordered (unsigned index) {
+template<class T>
+void TArray<T>::DeleteUnordered (unsigned index) {
     ASSERT(index < this->m_count);
     if (index + 1 < this->m_count)
-        C::Assign(&this->m_data[index], &this->m_data[this->m_count - 1], 1);
-    C::Destruct(&this->m_data[--this->m_count]);
+        TArrayCopy::Assign(&this->m_data[index], &this->m_data[this->m_count - 1], 1);
+    TArrayCopy::Destruct(&this->m_data[--this->m_count]);
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::GrowToCount (unsigned count, bool zero) {
+template<class T>
+void TArray<T>::GrowToCount (unsigned count, bool zero) {
     if (count <= this->m_count)
         return;
     AdjustSizeChunked(count, this->m_count);
     if (zero)
         memset(this->m_data + this->m_count, 0, (count - this->m_count) * sizeof(T));
-    C::Construct(this->m_data + this->m_count, count - this->m_count);
+    TArrayCopy::Construct(this->m_data + this->m_count, count - this->m_count);
     this->m_count = count;
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::GrowToFit (unsigned index, bool zero) {
+template<class T>
+void TArray<T>::GrowToFit (unsigned index, bool zero) {
     GrowToCount(index + 1, zero);
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::ShrinkBy (unsigned count) {
+template<class T>
+void TArray<T>::ShrinkBy (unsigned count) {
     ASSERT(count <= this->m_count);
-    C::Destruct(this->m_data + this->m_count - count, count);
+    TArrayCopy::Destruct(this->m_data + this->m_count - count, count);
     this->m_count -= count;
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::Move (unsigned destIndex, unsigned sourceIndex, unsigned count) {
+template<class T>
+void TArray<T>::Move (unsigned destIndex, unsigned sourceIndex, unsigned count) {
 
     // Copy the data to the destination
     ASSERT(destIndex +   count <= this->m_count);
     ASSERT(sourceIndex + count <= this->m_count);
-    C::Assign(this->m_data + destIndex, this->m_data + sourceIndex, count);
+    TArrayCopy::Assign(this->m_data + destIndex, this->m_data + sourceIndex, count);
 
     // Remove it from the source
     if (destIndex >= sourceIndex) {
-        C::Destruct(this->m_data + sourceIndex, std::min(count, destIndex - sourceIndex));
-        C::Construct(this->m_data + sourceIndex, std::min(count, destIndex - sourceIndex));
+        TArrayCopy::Destruct(this->m_data + sourceIndex, std::min(count, destIndex - sourceIndex));
+        TArrayCopy::Construct(this->m_data + sourceIndex, std::min(count, destIndex - sourceIndex));
     }
     else {
         unsigned overlap = (destIndex + count > sourceIndex) ? (destIndex + count - sourceIndex) : 0;
         ASSERT(overlap <= count);
-        C::Destruct(this->m_data + sourceIndex + overlap, count - overlap);
-        C::Construct(this->m_data + sourceIndex + overlap, count - overlap);
+        TArrayCopy::Destruct(this->m_data + sourceIndex + overlap, count - overlap);
+        TArrayCopy::Construct(this->m_data + sourceIndex + overlap, count - overlap);
     }
 
 }
 
 //===========================================================================
-template<class T, class C>
-T * TArray<T,C>::New () {
+template<class T>
+T * TArray<T>::New () {
     AdjustSizeChunked(this->m_count + 1, this->m_count + 1);
     return &this->m_data[this->m_count - 1];
 }
 
 //===========================================================================
-template<class T, class C>
-T * TArray<T,C>::New (unsigned count) {
+template<class T>
+T * TArray<T>::New (unsigned count) {
     AdjustSizeChunked(this->m_count + count, this->m_count + count);
     return &this->m_data[this->m_count - count];
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::Push (const T & source) {
+template<class T>
+void TArray<T>::Push (const T & source) {
     AdjustSizeChunked(this->m_count + 1, this->m_count);
-    C::CopyConstruct(&this->m_data[this->m_count], source);
+    TArrayCopy::CopyConstruct(&this->m_data[this->m_count], source);
     ++this->m_count;
 }
 
 //===========================================================================
-template<class T, class C>
-T TArray<T,C>::Pop () {
+template<class T>
+T TArray<T>::Pop () {
     ASSERT(this->m_count);
     T result = this->m_data[--this->m_count];
-    C::Destruct(this->m_data + this->m_count);
+    TArrayCopy::Destruct(this->m_data + this->m_count);
     return result;
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::Reserve (unsigned additionalCount) {
+template<class T>
+void TArray<T>::Reserve (unsigned additionalCount) {
     AdjustSizeChunked(std::max(this->m_alloc, this->m_count + additionalCount), this->m_count);
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::Set (const T * source, unsigned count) {
+template<class T>
+void TArray<T>::Set (const T * source, unsigned count) {
     AdjustSizeChunked(count, 0);
-    C::CopyConstruct(this->m_data, source, count);
+    TArrayCopy::CopyConstruct(this->m_data, source, count);
     this->m_count = count;
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::SetChunkSize (unsigned chunkSize) {
+template<class T>
+void TArray<T>::SetChunkSize (unsigned chunkSize) {
     this->m_chunkSize = chunkSize;
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::SetCount (unsigned count) {
+template<class T>
+void TArray<T>::SetCount (unsigned count) {
     AdjustSizeChunked(std::max(this->m_alloc, count), count);
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::SetCountFewer (unsigned count) {
+template<class T>
+void TArray<T>::SetCountFewer (unsigned count) {
     ASSERT(count <= this->m_count);
-    C::Destruct(this->m_data + count, this->m_count - count);
+    TArrayCopy::Destruct(this->m_data + count, this->m_count - count);
     this->m_count = count;
 }
 
 //===========================================================================
-template<class T, class C>
-void TArray<T,C>::Trim () {
+template<class T>
+void TArray<T>::Trim () {
     this->AdjustSize(this->m_count, this->m_count);
 }
 #endif

--- a/Sources/Plasma/NucleusLib/pnUtils/pnUtArray.h
+++ b/Sources/Plasma/NucleusLib/pnUtils/pnUtArray.h
@@ -53,17 +53,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 /****************************************************************************
 *
-*   Macros
-*
-***/
-
-#define  ARRAY(type)      TArray<type>
-#define  ARRAYOBJ(type)   TArray<type>
-#define  FARRAY(type)     TFArray<type>
-#define  FARRAYOBJ(type)  TFArray<type>
-
-/****************************************************************************
-*
 *   CBuffer
 *
 ***/

--- a/Sources/Plasma/NucleusLib/pnUtils/pnUtHash.h
+++ b/Sources/Plasma/NucleusLib/pnUtils/pnUtHash.h
@@ -227,7 +227,7 @@ private:
 
     LIST(T)            m_fullList;
     int                m_linkOffset;
-    FARRAYOBJ(LIST(T)) m_slotListArray;
+    TFArray<LIST(T)>   m_slotListArray;
     unsigned           m_slotMask;  // always set to a power of two minus one
     unsigned           m_slotMaxCount;
 

--- a/Sources/Plasma/NucleusLib/pnUtils/pnUtPriQ.h
+++ b/Sources/Plasma/NucleusLib/pnUtils/pnUtPriQ.h
@@ -109,7 +109,7 @@ private:
     enum { LINK_OFFSET_UNINIT = 0xdddddddd };
 
     int m_linkOffset;
-    ARRAY(C *) m_array;
+    TArray<C *> m_array;
 
     friend class TBasePriority<C,P>;
 };

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
@@ -859,7 +859,7 @@ void plClothingOutfit::WriteToVault()
     if (!rvn)
         return;
 
-    ARRAY(plStateDataRecord*) SDRs;
+    TArray<plStateDataRecord*> SDRs;
     
     plStateDataRecord clothingSDR(kSDLClothing);
     fAvatar->GetClothingSDLMod()->PutCurrentStateIn(&clothingSDR);
@@ -874,7 +874,7 @@ void plClothingOutfit::WriteToVault()
     WriteToVault(SDRs);
 }
 
-void plClothingOutfit::WriteToVault(const ARRAY(plStateDataRecord*) & SDRs)
+void plClothingOutfit::WriteToVault(const TArray<plStateDataRecord*> & SDRs)
 {
     // We'll hit this case when the server asks us to save state for NPCs.
     if (fAvatar->GetTarget(0) != plNetClientApp::GetInstance()->GetLocalPlayer())
@@ -884,7 +884,7 @@ void plClothingOutfit::WriteToVault(const ARRAY(plStateDataRecord*) & SDRs)
     if (!rvn)
         return;
         
-    ARRAY(plStateDataRecord*)   morphs;
+    TArray<plStateDataRecord*>   morphs;
 
     // Gather morph SDRs    
     hsTArray<const plMorphSequence*> morphsSDRs;
@@ -910,12 +910,12 @@ void plClothingOutfit::WriteToVault(const ARRAY(plStateDataRecord*) & SDRs)
     // Get all existing clothing SDRs
     rvn->GetChildNodes(plVault::kNodeType_SDL, 1, &nodes);    // REF: Find
 
-    const ARRAY(plStateDataRecord*) * arrs[] = {
+    const TArray<plStateDataRecord*> * arrs[] = {
         &SDRs,
         &morphs,
     };
     for (unsigned arrIdx = 0; arrIdx < arrsize(arrs); ++arrIdx) {
-        const ARRAY(plStateDataRecord*) * arr = arrs[arrIdx];
+        const TArray<plStateDataRecord*> * arr = arrs[arrIdx];
         
         // Write all SDL to to the outfit folder, reusing existing nodes and creating new ones as necessary
         for (unsigned i = 0; i < arr->Count(); ++i) {

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.h
@@ -220,7 +220,7 @@ public:
     bool ReadClothing();
 
     void WriteToVault();
-    void WriteToVault(const ARRAY(plStateDataRecord*) & SDRs);
+    void WriteToVault(const TArray<plStateDataRecord*> & SDRs);
 
     /** Write the avatar clothing to a file */
     bool WriteToFile(const plFileName &filename);

--- a/Sources/Plasma/PubUtilLib/plMessage/plNetCommMsgs.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plNetCommMsgs.h
@@ -53,6 +53,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnNetBase/pnNbError.h"
 #include "pnNetProtocol/pnNetProtocol.h"
 #include "pnMessage/plMessage.h"
+#include "plNetGameLib/plNetGameLib.h"
 
 class plNetCommReplyMsg : public plMessage {
 public:
@@ -88,7 +89,6 @@ public:
     void Write (hsStream * s, hsResMgr * mgr) { plMessage::IMsgWrite(s, mgr); }
 };
 
-struct NetCliAuthFileInfo;
 class plNetCommFileListMsg : public plNetCommReplyMsg {
 public:
     FARRAY(NetCliAuthFileInfo)  fileInfoArr;
@@ -141,7 +141,7 @@ public:
     CLASSNAME_REGISTER(plNetCommPublicAgeListMsg);
     GETINTERFACE_ANY(plNetCommPublicAgeListMsg, plMessage);
     
-    ARRAY(struct NetAgeInfo)    ages;
+    ARRAY(NetAgeInfo)    ages;
 };
 
 class plNetCommPublicAgeMsg : public plNetCommReplyMsg {

--- a/Sources/Plasma/PubUtilLib/plMessage/plNetCommMsgs.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plNetCommMsgs.h
@@ -91,7 +91,7 @@ public:
 
 class plNetCommFileListMsg : public plNetCommReplyMsg {
 public:
-    FARRAY(NetCliAuthFileInfo)  fileInfoArr;
+    TFArray<NetCliAuthFileInfo>  fileInfoArr;
 
     CLASSNAME_REGISTER(plNetCommFileListMsg);
     GETINTERFACE_ANY(plNetCommFileListMsg, plMessage);
@@ -141,7 +141,7 @@ public:
     CLASSNAME_REGISTER(plNetCommPublicAgeListMsg);
     GETINTERFACE_ANY(plNetCommPublicAgeListMsg, plMessage);
     
-    ARRAY(NetAgeInfo)    ages;
+    TArray<NetAgeInfo>    ages;
 };
 
 class plNetCommPublicAgeMsg : public plNetCommReplyMsg {

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -526,7 +526,7 @@ static void INetCliAuthChangePasswordCallback (
 static void INetCliAuthGetPublicAgeListCallback (
     ENetError                   result,
     void *                      param,
-    const ARRAY(NetAgeInfo) &   ages
+    const TArray<NetAgeInfo> &  ages
 ) {
     NetCommParam * cp = (NetCommParam *) param;
     

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -110,7 +110,7 @@ struct PingRequestTrans : NetAuthTrans {
     void *                          m_param;
     unsigned                        m_pingAtMs;
     unsigned                        m_replyAtMs;
-    ARRAY(uint8_t)                     m_payload;
+    TArray<uint8_t>                 m_payload;
     
     PingRequestTrans (
         FNetCliAuthPingRequestCallback  callback,
@@ -432,7 +432,7 @@ struct GetPublicAgeListTrans : NetAuthTrans {
     ST::string                              m_ageName;
 
     // recv
-    ARRAY(NetAgeInfo)                       m_ages;
+    TArray<NetAgeInfo>                      m_ages;
     
     GetPublicAgeListTrans (
         const ST::string&                   ageName,
@@ -534,7 +534,7 @@ struct FileListRequestTrans : NetAuthTrans {
     wchar_t                               m_directory[MAX_PATH];
     wchar_t                               m_ext[MAX_EXT];
 
-    ARRAY(NetCliAuthFileInfo)           m_fileInfoArray;
+    TArray<NetCliAuthFileInfo>          m_fileInfoArray;
 
     FileListRequestTrans (
         FNetCliAuthFileListRequestCallback  callback,
@@ -663,7 +663,7 @@ struct VaultFetchNodeRefsTrans : NetAuthTrans {
     FNetCliAuthVaultNodeRefsFetched m_callback;
     void *                          m_param;
 
-    ARRAY(NetVaultNodeRef)          m_refs;
+    TArray<NetVaultNodeRef>         m_refs;
 
     VaultFetchNodeRefsTrans (
         unsigned                        nodeId,
@@ -750,7 +750,7 @@ struct VaultFetchNodeTrans : NetAuthTrans {
 //============================================================================
 struct VaultFindNodeTrans : NetAuthTrans {
 
-    ARRAY(unsigned)             m_nodeIds;
+    TArray<unsigned>            m_nodeIds;
     FNetCliAuthVaultNodeFind    m_callback;
     void *                      m_param;
     
@@ -803,7 +803,7 @@ struct VaultSaveNodeTrans : NetAuthTrans {
 
     unsigned                            m_nodeId;
     plUUID                              m_revisionId;
-    ARRAY(uint8_t)                      m_buffer;
+    TArray<uint8_t>                     m_buffer;
     FNetCliAuthVaultNodeSaveCallback    m_callback;
     void *                              m_param;
 
@@ -4013,7 +4013,7 @@ bool VaultFindNodeTrans::Send () {
     if (!AcquireConn())
         return false;
         
-    ARRAY(uint8_t) buffer;
+    TArray<uint8_t> buffer;
     m_node->Write(&buffer);
 
     const uintptr_t msg[] = {
@@ -4081,7 +4081,7 @@ bool VaultCreateNodeTrans::Send () {
     if (!AcquireConn())
         return false;
         
-    ARRAY(uint8_t) buffer;
+    TArray<uint8_t> buffer;
     m_templateNode->Write(&buffer, 0);
 
     const uintptr_t msg[] = {
@@ -5732,7 +5732,7 @@ unsigned NetCliAuthVaultNodeSave (
         ioFlags |= NetVaultNode::kDirtyString64_1;
     ioFlags |= NetVaultNode::kDirtyNodeType;
 
-    ARRAY(uint8_t) buffer;
+    TArray<uint8_t> buffer;
     node->Write(&buffer, ioFlags);
 
     VaultSaveNodeTrans * trans = new VaultSaveNodeTrans(

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
@@ -262,7 +262,7 @@ struct NetAgeInfo;
 typedef void (*FNetCliAuthGetPublicAgeListCallback)(
     ENetError                   result,
     void *                      param,
-    const ARRAY(NetAgeInfo) &   ages
+    const TArray<NetAgeInfo> &  ages
 );
 void NetCliAuthGetPublicAgeList (
     const ST::string&                   ageName,

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -67,7 +67,7 @@ struct CliFileConn : hsRefCnt {
     ST::string          name;
     plNetAddress        addr;
     unsigned            seq;
-    ARRAY(uint8_t)      recvBuffer;
+    TArray<uint8_t>     recvBuffer;
     AsyncCancelId       cancelId;
     bool                abandoned;
     unsigned            buildId;
@@ -148,7 +148,7 @@ struct ManifestRequestTrans : NetFileTrans {
     wchar_t                             m_group[MAX_PATH];
     unsigned                            m_buildId;
 
-    ARRAY(NetCliFileManifestEntry)      m_manifest;
+    TArray<NetCliFileManifestEntry>     m_manifest;
     unsigned                            m_numEntriesReceived;
 
     ManifestRequestTrans (

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -107,7 +107,7 @@ struct PingRequestTrans : NetGateKeeperTrans {
     void *                                  m_param;
     unsigned                                m_pingAtMs;
     unsigned                                m_replyAtMs;
-    ARRAY(uint8_t)                             m_payload;
+    TArray<uint8_t>                         m_payload;
     
     PingRequestTrans (
         FNetCliGateKeeperPingRequestCallback    callback,

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -350,8 +350,8 @@ static void CDECL LogDumpProc (
 static void BuildNodeTree (
     const NetVaultNodeRef   refs[],
     unsigned                refCount,
-    ARRAY(unsigned) *       newNodeIds,
-    ARRAY(unsigned) *       existingNodeIds,
+    TArray<unsigned> *      newNodeIds,
+    TArray<unsigned> *      existingNodeIds,
     bool                    notifyNow = true
 ) {
     for (unsigned i = 0; i < refCount; ++i) {
@@ -428,7 +428,7 @@ static void FetchRefOwners (
     NetVaultNodeRef *           refs,
     unsigned                    refCount
 ) {
-    ARRAY(unsigned) ownerIds;
+    TArray<unsigned> ownerIds;
     {   for (unsigned i = 0; i < refCount; ++i)
             if (unsigned ownerId = refs[i].ownerId)
                 ownerIds.Add(ownerId);
@@ -468,12 +468,12 @@ static void FetchNodesFromRefs (
 
     *fetchCount = 0;
     
-    ARRAY(unsigned) newNodeIds;
-    ARRAY(unsigned) existingNodeIds;
+    TArray<unsigned> newNodeIds;
+    TArray<unsigned> existingNodeIds;
     
     BuildNodeTree(refs, refCount, &newNodeIds, &existingNodeIds);
 
-    ARRAY(unsigned) nodeIds;
+    TArray<unsigned> nodeIds;
     nodeIds.Add(newNodeIds.Ptr(), newNodeIds.Count());
     nodeIds.Add(existingNodeIds.Ptr(), existingNodeIds.Count());
     QSORT(unsigned, nodeIds.Ptr(), nodeIds.Count(), elem1 < elem2);
@@ -611,12 +611,12 @@ static void VaultNodeAdded (
     NetVaultNodeRef refs[] = {
         { parentId, childId, ownerId }
     };
-    ARRAY(unsigned) newNodeIds;
-    ARRAY(unsigned) existingNodeIds;
+    TArray<unsigned> newNodeIds;
+    TArray<unsigned> existingNodeIds;
     
     BuildNodeTree(refs, arrsize(refs), &newNodeIds, &existingNodeIds, false);
 
-    ARRAY(unsigned) nodeIds;
+    TArray<unsigned> nodeIds;
     nodeIds.Add(newNodeIds.Ptr(), newNodeIds.Count());
     nodeIds.Add(existingNodeIds.Ptr(), existingNodeIds.Count());
     QSORT(unsigned, nodeIds.Ptr(), nodeIds.Count(), elem1 < elem2);
@@ -1125,7 +1125,7 @@ bool RelVaultNode::IsChildOf (unsigned parentId, unsigned maxDepth) {
 }
 
 //============================================================================
-void RelVaultNode::GetRootIds (ARRAY(unsigned) * nodeIds) {
+void RelVaultNode::GetRootIds (TArray<unsigned> * nodeIds) {
     RelVaultNodeLink * link = state->parents.Head();
     if (!link) {
         nodeIds->Add(GetNodeId());
@@ -1144,7 +1144,7 @@ unsigned RelVaultNode::RemoveChildNodes (unsigned maxDepth) {
 
 //============================================================================
 void RelVaultNode::GetChildNodeIds (
-    ARRAY(unsigned) *   nodeIds,
+    TArray<unsigned> *  nodeIds,
     unsigned            maxDepth
 ) {
     if (!maxDepth)
@@ -1158,7 +1158,7 @@ void RelVaultNode::GetChildNodeIds (
 
 //============================================================================
 void RelVaultNode::GetParentNodeIds (
-    ARRAY(unsigned) *   nodeIds,
+    TArray<unsigned> *  nodeIds,
     unsigned            maxDepth
 ) {
     if (!maxDepth)
@@ -1611,8 +1611,8 @@ void VaultAddChildNode (
                 { parentId, childId, ownerId }
             };
 
-            ARRAY(unsigned) newNodeIds;
-            ARRAY(unsigned) existingNodeIds;
+            TArray<unsigned> newNodeIds;
+            TArray<unsigned> existingNodeIds;
 
             BuildNodeTree(refs, arrsize(refs), &newNodeIds, &existingNodeIds);
         
@@ -1965,7 +1965,7 @@ void VaultFindNodes (
 //============================================================================
 namespace _VaultFindNodesAndWait {
     struct _FindNodeParam {
-        ARRAY(unsigned)     nodeIds;
+        TArray<unsigned>    nodeIds;
         ENetError           result;
         bool                complete;
 
@@ -1989,7 +1989,7 @@ namespace _VaultFindNodesAndWait {
 
 void VaultFindNodesAndWait (
     NetVaultNode *          templateNode,
-    ARRAY(unsigned) *       nodeIds
+    TArray<unsigned> *      nodeIds
 ) {
     using namespace _VaultFindNodesAndWait;
 
@@ -2013,7 +2013,7 @@ void VaultFindNodesAndWait (
 //============================================================================
 void VaultLocalFindNodes (
     NetVaultNode *          templateNode,
-    ARRAY(unsigned) *       nodeIds
+    TArray<unsigned> *      nodeIds
 ) {
     for (RelVaultNodeLink * link = s_nodes.Head(); link != nil; link = s_nodes.Next(link)) {
         if (link->node->Matches(templateNode))
@@ -2328,7 +2328,7 @@ bool VaultAddOwnedAgeSpawnPoint (const plUUID& ageInstId, const plSpawnPointInfo
         if (!fldr)
             break;
 
-        ARRAY(unsigned) nodeIds;
+        TArray<unsigned> nodeIds;
         fldr->GetChildNodeIds(&nodeIds, 1);
         
         hsRef<NetVaultNode> templateNode = new NetVaultNode;
@@ -4657,7 +4657,7 @@ void VaultCull (unsigned vaultId) {
         if (link->node->GetNodeType() > plVault::kNodeType_VNodeMgrLow && link->node->GetNodeType() < plVault::kNodeType_VNodeMgrHigh)
             continue;
 
-        ARRAY(unsigned) nodeIds;
+        TArray<unsigned> nodeIds;
         link->node->GetRootIds(&nodeIds);
         bool foundRoot = false;
         for (unsigned i = 0; i < nodeIds.Count(); ++i) {

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -105,27 +105,27 @@ struct RelVaultNode : NetVaultNode {
     bool IsParentOf (unsigned nodeId, unsigned maxDepth);
     bool IsChildOf (unsigned nodeId, unsigned maxDepth);
     
-    void GetRootIds (ARRAY(unsigned) * nodeIds);
+    void GetRootIds (TArray<unsigned> * nodeIds);
     
     unsigned RemoveChildNodes (unsigned maxDepth);  // returns # of nodes removed
 
     void GetChildNodeIds (
-        ARRAY(unsigned) *   nodeIds,
+        TArray<unsigned> *  nodeIds,
         unsigned            maxDepth
     );
     void GetParentNodeIds (
-        ARRAY(unsigned) *   nodeIds,
+        TArray<unsigned> *  nodeIds,
         unsigned            maxDepth
     );
     
     void GetMatchingChildNodeIds (
         NetVaultNode *      templateNode,
-        ARRAY(unsigned) *   nodeIds,
+        TArray<unsigned> *  nodeIds,
         unsigned            maxDepth
     );
     void GetMatchingParentNodeIds (
         NetVaultNode *      templateNode,
-        ARRAY(unsigned) *   nodeIds,
+        TArray<unsigned> *  nodeIds,
         unsigned            maxDepth
     );
 
@@ -297,11 +297,11 @@ void VaultFindNodes (
 );
 void VaultFindNodesAndWait (
     NetVaultNode *          templateNode,
-    ARRAY(unsigned) *       nodeIds
+    TArray<unsigned> *      nodeIds
 );
 void VaultLocalFindNodes (
     NetVaultNode *          templateNode,
-    ARRAY(unsigned) *       nodeIds
+    TArray<unsigned> *      nodeIds
 );
 void VaultFetchNodesAndWait (   // Use VaultGetNode to access the fetched nodes
     const unsigned          nodeIds[],


### PR DESCRIPTION
...and get rid of no-longer-needed `ARRAY()` macros.

I haven't evaluated the performance or functionality cost or benefit of eliminating these in favor of std::vector yet, but this change at least eliminates a potential source of errors (as discovered in #617)