### PR TITLE
Fix potential whitespace prepend to age descriptions

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/Pch.h
+++ b/Sources/Plasma/FeatureLib/pfPython/Pch.h
@@ -61,6 +61,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <sys/stat.h>
 
 #include <string_theory/string>
+#include <string_theory/string_stream>
 
 // Python Library Includes
 #include <Python.h>

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
@@ -46,6 +46,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //////////////////////////////////////////////////////////////////////
 
 #include <Python.h>
+#include <string_theory/string_stream>
 #pragma hdrstop
 
 #include "pyVaultAgeInfoNode.h"
@@ -298,10 +299,21 @@ ST::string pyVaultAgeInfoNode::GetDisplayName() const
 {
     if (fNode) {
         VaultAgeInfoNode access(fNode);
-        if (access.GetAgeSequenceNumber() > 0)
-            return ST::format("{}({}) {}", access.GetAgeUserDefinedName(), access.GetAgeSequenceNumber(), access.GetAgeInstanceName());
-        else
-            return ST::format("{} {}", access.GetAgeUserDefinedName(), access.GetAgeInstanceName());
+        ST::string_stream ss;
+
+        if (access.GetAgeUserDefinedName().empty()) {
+            // Ae'gura(1)
+            ss << access.GetAgeInstanceName();
+            if (access.GetAgeSequenceNumber() > 0)
+                ss << '(' << access.GetAgeSequenceNumber() << ')';
+        } else {
+            // Troll's(1) Neighborhood
+            ss << access.GetAgeUserDefinedName();
+            if (access.GetAgeSequenceNumber() > 0)
+                ss << '(' << access.GetAgeSequenceNumber() << ") ";
+            ss << access.GetAgeInstanceName();
+        }
+        return ss.to_string();
     }
     return ST::null;
 }


### PR DESCRIPTION
This fixes an observed issue in the Nexus where the entry for the GreatTreePub was listed as " Watcher's Pub". It also corrects a potential ugly description generation issue when instances are generated by the server with no user name. Previously this would be " (1) Ae'gura" -- this has been changed to "Ae'gura(1)". This issue should never be triggered.