### PR TITLE
Restore sequence conflict verification.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.h
@@ -236,8 +236,9 @@ protected:
 
     typedef std::set<plRegistryPageNode*> PageSet;
     typedef std::map<plLocation, plRegistryPageNode*> PageMap;
-    PageMap fAllPages;      // All the pages, loaded or not
-    PageSet fLoadedPages;   // Just the loaded pages
+    PageMap fAllPages;         // All the pages, loaded or not
+    PageSet fLoadedPages;      // Just the loaded pages
+    PageSet fConflictingPages; // Pages whose sequence numbers conflict
 
     mutable plRegistryPageNode* fLastFoundPage;
 };


### PR DESCRIPTION
This was removed when the page list was converted to an `std::map`. However, not checking for conflicting sequences causes a deadlock on loading an age that had a PRP renamed without changing its sequence suffix.