### PR TITLE
ASan-directed Destructor Fixes

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
@@ -84,6 +84,8 @@ struct NlmOp {
     NlmOp (const ENlmOp & op)
     : opcode(op)
     { }
+
+    virtual ~NlmOp() = default;
 };
 
 struct NlmNoOpOp : NlmOp {


### PR DESCRIPTION
Visual C++ ASan points out these destructors should be virtual. There is still an issue with an out of scope access around `pfGUITextBoxMod::IUpdate` and `plLocalization::StringToLocal` that I wasn't sure how to fix.