### PR TITLE
Fix memory leaks.

### DIFF
--- a/Sources/Plasma/CoreLib/hsRefCnt.h
+++ b/Sources/Plasma/CoreLib/hsRefCnt.h
@@ -132,6 +132,15 @@ public:
     _Ref *operator->() const { return fObj; }
     operator _Ref *() const { return fObj; }
 
+    /** Creates a new object of type _Ref. Use this instead of operator new. */
+    template<typename... _Args>
+    static hsRef<_Ref> New(_Args&&... args)
+    {
+        hsRef<_Ref> obj;
+        obj.fObj = new _Ref(std::forward<_Args>(args)...);
+        return obj;
+    }
+
 private:
     _Ref *fObj;
 };

--- a/Sources/Plasma/CoreLib/hsRefCnt.h
+++ b/Sources/Plasma/CoreLib/hsRefCnt.h
@@ -78,6 +78,8 @@ public:
             dst = src;                  \
         } while (0)
 
+struct hsStealRef_Type {};
+constexpr hsStealRef_Type hsStealRef;
 
 template <class _Ref>
 class hsRef
@@ -86,6 +88,7 @@ public:
     hsRef() : fObj(nullptr) { }
     hsRef(std::nullptr_t) : fObj(nullptr) { }
     hsRef(_Ref *obj) : fObj(obj) { if (fObj) fObj->Ref(); }
+    hsRef(_Ref *obj, hsStealRef_Type) : fObj(obj) { }
     hsRef(const hsRef<_Ref> &copy) : fObj(copy.fObj) { if (fObj) fObj->Ref(); }
     hsRef(hsRef<_Ref> &&move) : fObj(move.fObj) { move.fObj = nullptr; }
 
@@ -132,13 +135,11 @@ public:
     _Ref *operator->() const { return fObj; }
     operator _Ref *() const { return fObj; }
 
-    /** Creates a new object of type _Ref. Use this instead of operator new. */
-    template<typename... _Args>
-    static hsRef<_Ref> New(_Args&&... args)
+    void Steal(_Ref *obj)
     {
-        hsRef<_Ref> obj;
-        obj.fObj = new _Ref(std::forward<_Args>(args)...);
-        return obj;
+        if (fObj)
+            fObj->UnRef();
+        fObj = obj;
     }
 
 private:

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
@@ -49,21 +49,17 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 /* Get the pfPasswordStore instance */
 pfPasswordStore* pfPasswordStore::Instance()
 {
-    static pfPasswordStore* store = nullptr;
-
-    if (store == nullptr) {
 #if defined(HS_BUILD_FOR_WIN32)
-        store = new pfWin32PasswordStore();
+    static pfWin32PasswordStore store;
 #elif defined(HS_BUILD_FOR_APPLE)
-        store = new pfApplePasswordStore();
+    static pfApplePasswordStore store;
 #elif defined(HAVE_LIBSECRET)
-        store = new pfUnixPasswordStore();
+    static pfUnixPasswordStore store;
 #else
-        store = new pfFilePasswordStore();
+    static pfFilePasswordStore store;
 #endif
-    }
 
-    return store;
+    return &store;
 }
 
 

--- a/Sources/Plasma/FeatureLib/pfPython/Pch.h
+++ b/Sources/Plasma/FeatureLib/pfPython/Pch.h
@@ -54,6 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <exception>
 #include <functional>
 #include <locale>
+#include <memory>
 #include <string>
 
 // Platform Library Includes

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -80,6 +80,9 @@ struct pythonClassName \
 // This makes sure that our python new function can access our constructors
 #define PYTHON_CLASS_NEW_FRIEND(pythonClassName) friend PyObject *pythonClassName##_new(PyTypeObject *type, PyObject *args, PyObject *keywords)
 
+#define PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION \
+    static PyObject* New(hsRef<RelVaultNode> vaultNode=nullptr);
+
 // This defines the basic new function for a class
 #define PYTHON_CLASS_NEW_DEFINITION static PyObject *New()
 
@@ -87,6 +90,15 @@ struct pythonClassName \
 PyObject *glueClassName::New() \
 { \
     pythonClassName *newObj = (pythonClassName*)pythonClassName##_type.tp_new(&pythonClassName##_type, NULL, NULL); \
+    return (PyObject*)newObj; \
+}
+
+#define PYTHON_CLASS_VAULT_NODE_NEW_IMPL(pythonClassName, glueClassName) \
+PyObject* glueClassName::New(hsRef<RelVaultNode> nfsNode) \
+{ \
+    pythonClassName* newObj = (pythonClassName*)pythonClassName##_type.tp_new(&pythonClassName##_type, nullptr, nullptr); \
+    if (nfsNode) \
+        newObj->fThis->fNode = std::move(nfsNode); \
     return (PyObject*)newObj; \
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
@@ -114,11 +114,11 @@ PyObject* pyVault::GetPlayerInfo()
         if (hsRef<RelVaultNode> rvnPlrInfo = rvnPlr->GetChildNode(plVault::kNodeType_PlayerInfo, 1))
             result = pyVaultPlayerInfoNode::New(rvnPlrInfo);
     }
-    
+
     // just return an empty node
     if (!result)
-        result = pyVaultPlayerInfoNode::New(nil);
-        
+        result = pyVaultPlayerInfoNode::New();
+
     return result;
 }
 
@@ -177,8 +177,8 @@ PyObject* pyVault::GetAgeJournalsFolder()
     
     // just return an empty node
     if (!result)
-        result = pyVaultFolderNode::New(nil);
-        
+        result = pyVaultFolderNode::New();
+
     return result;
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
@@ -45,6 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 //////////////////////////////////////////////////////////////////////
 
+#include <memory>
 #include <Python.h>
 #pragma hdrstop
 
@@ -80,35 +81,29 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 //============================================================================
 static PyObject * GetFolder (unsigned folderType) {
-    PyObject * result = nil;
     if (hsRef<RelVaultNode> rvnPlr = VaultGetPlayerNode()) {
         if (hsRef<RelVaultNode> rvnFldr = rvnPlr->GetChildFolderNode(folderType, 1))
-            result = pyVaultFolderNode::New(rvnFldr);
+            return pyVaultFolderNode::New(rvnFldr);
     }
-    
-    return result;
+    return nullptr;
 }
 
 //============================================================================
 static PyObject * GetPlayerInfoList (unsigned folderType) {
-    PyObject * result = nil;
     if (hsRef<RelVaultNode> rvnPlr = VaultGetPlayerNode()) {
         if (hsRef<RelVaultNode> rvnFldr = rvnPlr->GetChildPlayerInfoListNode(folderType, 1))
-            result = pyVaultPlayerInfoListNode::New(rvnFldr);
+            return pyVaultPlayerInfoListNode::New(rvnFldr);
     }
-    
-    return result;
+    return nullptr;
 }
 
 //============================================================================
 static PyObject * GetAgeInfoList (unsigned folderType) {
-    PyObject * result = nil;
     if (hsRef<RelVaultNode> rvnPlr = VaultGetPlayerNode()) {
         if (hsRef<RelVaultNode> rvnFldr = rvnPlr->GetChildAgeInfoListNode(folderType, 1))
-            result = pyVaultAgeInfoListNode::New(rvnFldr);
+            return pyVaultAgeInfoListNode::New(rvnFldr);
     }
-    
-    return result;
+    return nullptr;
 }
 
 //////////////////////////////////////////////////
@@ -395,34 +390,25 @@ PyObject* pyVault::GetInviteFolder()
 
 PyObject* pyVault::GetPsnlAgeSDL() const
 {
-    PyObject * result = nil;
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-
     if (hsRef<RelVaultNode> rvnFldr = VaultGetAgesIOwnFolder()) {
-
-        templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-        VaultAgeInfoNode ageInfo(templateNode);
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
+        VaultAgeInfoNode ageInfo(&templateNode);
         ageInfo.SetAgeFilename(kPersonalAgeFilename);
 
-        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(templateNode, 2)) {
-            templateNode->Clear();
-            templateNode->SetNodeType(plVault::kNodeType_SDL);
+        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(&templateNode, 2)) {
+            templateNode.Clear();
+            templateNode.SetNodeType(plVault::kNodeType_SDL);
 
-            if (hsRef<RelVaultNode> rvnSdl = rvnInfo->GetChildNode(templateNode, 1)) {
+            if (hsRef<RelVaultNode> rvnSdl = rvnInfo->GetChildNode(&templateNode, 1)) {
                 VaultSDLNode sdl(rvnSdl);
-                plStateDataRecord * rec = new plStateDataRecord;
-                if (sdl.GetStateDataRecord(rec, plSDL::kKeepDirty))
-                    result = pySDLStateDataRecord::New(rec);
-                else
-                    delete rec;
+                auto rec = std::make_unique<plStateDataRecord>();
+                if (sdl.GetStateDataRecord(rec.get(), plSDL::kKeepDirty))
+                    return pySDLStateDataRecord::New(rec.release());
             }
         }
     }
-
-    if (!result)
-        PYTHON_RETURN_NONE;
-    
-    return result;
+    PYTHON_RETURN_NONE;
 }
 
 void pyVault::UpdatePsnlAgeSDL( pySDLStateDataRecord & pyrec )
@@ -431,19 +417,17 @@ void pyVault::UpdatePsnlAgeSDL( pySDLStateDataRecord & pyrec )
     if ( !rec )
         return;
 
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-
+    NetVaultNode templateNode;
     if (hsRef<RelVaultNode> rvnFldr = VaultGetAgesIOwnFolder()) {
-
-        templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-        VaultAgeInfoNode ageInfo(templateNode);
+        templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
+        VaultAgeInfoNode ageInfo(&templateNode);
         ageInfo.SetAgeFilename(kPersonalAgeFilename);
 
-        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(templateNode, 2)) {
-            templateNode->Clear();
-            templateNode->SetNodeType(plVault::kNodeType_SDL);
+        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(&templateNode, 2)) {
+            templateNode.Clear();
+            templateNode.SetNodeType(plVault::kNodeType_SDL);
 
-            if (hsRef<RelVaultNode> rvnSdl = rvnInfo->GetChildNode(templateNode, 1)) {
+            if (hsRef<RelVaultNode> rvnSdl = rvnInfo->GetChildNode(&templateNode, 1)) {
                 VaultSDLNode sdl(rvnSdl);
                 sdl.SetStateDataRecord(rec, plSDL::kDirtyOnly | plSDL::kTimeStampOnRead);
             }
@@ -529,7 +513,7 @@ void _InvitePlayerToAge(ENetError result, void* state, void* param, RelVaultNode
 
 void pyVault::InvitePlayerToAge( const pyAgeLinkStruct & link, uint32_t playerID )
 {
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
+    auto templateNode = hsRef<NetVaultNode>::New();
     templateNode->SetNodeType(plVault::kNodeType_TextNote);
     VaultTextNoteNode visitAcc(templateNode);
     visitAcc.SetNoteType(plVault::kNoteType_Visit);
@@ -557,7 +541,7 @@ void pyVault::UnInvitePlayerToAge( const char * str, uint32_t playerID )
         }
     }
 
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
+    auto templateNode = hsRef<NetVaultNode>::New();
     templateNode->SetNodeType(plVault::kNodeType_TextNote);
     VaultTextNoteNode visitAcc(templateNode);
     visitAcc.SetNoteType(plVault::kNoteType_UnVisit);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
@@ -513,12 +513,12 @@ void _InvitePlayerToAge(ENetError result, void* state, void* param, RelVaultNode
 
 void pyVault::InvitePlayerToAge( const pyAgeLinkStruct & link, uint32_t playerID )
 {
-    auto templateNode = hsRef<NetVaultNode>::New();
-    templateNode->SetNodeType(plVault::kNodeType_TextNote);
-    VaultTextNoteNode visitAcc(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_TextNote);
+    VaultTextNoteNode visitAcc(&templateNode);
     visitAcc.SetNoteType(plVault::kNoteType_Visit);
     visitAcc.SetVisitInfo(*link.GetAgeLink()->GetAgeInfo());
-    VaultCreateNode(templateNode, (FVaultCreateNodeCallback)_InvitePlayerToAge, nil, (void*)(uintptr_t)playerID);
+    VaultCreateNode(&templateNode, (FVaultCreateNodeCallback)_InvitePlayerToAge, nullptr, (void*)(uintptr_t)playerID);
 }
 
 //============================================================================
@@ -541,12 +541,12 @@ void pyVault::UnInvitePlayerToAge( const char * str, uint32_t playerID )
         }
     }
 
-    auto templateNode = hsRef<NetVaultNode>::New();
-    templateNode->SetNodeType(plVault::kNodeType_TextNote);
-    VaultTextNoteNode visitAcc(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_TextNote);
+    VaultTextNoteNode visitAcc(&templateNode);
     visitAcc.SetNoteType(plVault::kNoteType_UnVisit);
     visitAcc.SetVisitInfo(info);
-    VaultCreateNode(templateNode, (FVaultCreateNodeCallback)_UninvitePlayerToAge, nil, (void*)(uintptr_t)playerID);
+    VaultCreateNode(&templateNode, (FVaultCreateNodeCallback)_UninvitePlayerToAge, nullptr, (void*)(uintptr_t)playerID);
 }
 
 //============================================================================

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoListNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoListNode.cpp
@@ -52,15 +52,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plVault/plVault.h"
 
-// should only be created from C++ side
-pyVaultAgeInfoListNode::pyVaultAgeInfoListNode(RelVaultNode* nfsNode)
-: pyVaultFolderNode(nfsNode)
-{
-}
-
 //create from the Python side
-pyVaultAgeInfoListNode::pyVaultAgeInfoListNode(int n)
-: pyVaultFolderNode(n)
+pyVaultAgeInfoListNode::pyVaultAgeInfoListNode()
+    : pyVaultFolderNode()
 {
     fNode->SetNodeType(plVault::kNodeType_AgeInfoList);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoListNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoListNode.h
@@ -54,21 +54,16 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 struct RelVaultNode;
 
-    
 class pyVaultAgeInfoListNode : public pyVaultFolderNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultAgeInfoListNode(RelVaultNode* nfsNode);
-
     // python-side ctor
-    pyVaultAgeInfoListNode(int n=0);
+    pyVaultAgeInfoListNode();
 public:
     
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultAgeInfoListNode);
-    static PyObject *New(RelVaultNode* nfsNode);
-    static PyObject *New(int n=0);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultAgeInfoListNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultAgeInfoListNode); // converts a PyObject to a pyVaultAgeInfoListNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoListNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoListNodeGlue.cpp
@@ -105,22 +105,10 @@ PYTHON_START_METHODS_TABLE(ptVaultAgeInfoListNode)
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition
-PLASMA_DEFAULT_TYPE_WBASE(ptVaultAgeInfoListNode, pyVaultFolderNode, "Params: n=0\nPlasma vault age info list node");
+PLASMA_DEFAULT_TYPE_WBASE(ptVaultAgeInfoListNode, pyVaultFolderNode, "Plasma vault age info list node");
 
 // required functions for PyObject interoperability
-PyObject *pyVaultAgeInfoListNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultAgeInfoListNode *newObj = (ptVaultAgeInfoListNode*)ptVaultAgeInfoListNode_type.tp_new(&ptVaultAgeInfoListNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
-
-PyObject *pyVaultAgeInfoListNode::New(int n /* =0 */)
-{
-    ptVaultAgeInfoListNode *newObj = (ptVaultAgeInfoListNode*)ptVaultAgeInfoListNode_type.tp_new(&ptVaultAgeInfoListNode_type, NULL, NULL);
-    // oddly enough, nothing to do here
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultAgeInfoListNode, pyVaultAgeInfoListNode);
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultAgeInfoListNode, pyVaultAgeInfoListNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultAgeInfoListNode, pyVaultAgeInfoListNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
@@ -62,15 +62,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnUUID/pnUUID.h"
 #include "plVault/plVault.h"
 
-// should only be created from C++ side
-pyVaultAgeInfoNode::pyVaultAgeInfoNode(RelVaultNode* nfsNode)
-: pyVaultNode(nfsNode)
-{
-}
-
-//create from the Python side
-pyVaultAgeInfoNode::pyVaultAgeInfoNode(int n)
-: pyVaultNode(new RelVaultNode)
+pyVaultAgeInfoNode::pyVaultAgeInfoNode()
+    : pyVaultNode()
 {
     fNode->SetNodeType(plVault::kNodeType_AgeInfo);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.h
@@ -62,17 +62,13 @@ class plUUID;
 class pyVaultAgeInfoNode : public pyVaultNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultAgeInfoNode(RelVaultNode* vaultNode);
-
     //create from the Python side
-    pyVaultAgeInfoNode(int n=0);
+    pyVaultAgeInfoNode();
 
 public:
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultAgeInfoNode);
-    static PyObject *New(RelVaultNode* vaultNode);
-    static PyObject *New(int n=0);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultAgeInfoNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultAgeInfoNode); // converts a PyObject to a pyVaultAgeInfoNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNodeGlue.cpp
@@ -281,22 +281,10 @@ PYTHON_START_METHODS_TABLE(ptVaultAgeInfoNode)
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition
-PLASMA_DEFAULT_TYPE_WBASE(ptVaultAgeInfoNode, pyVaultNode, "Params: n=0\nPlasma vault age info node");
+PLASMA_DEFAULT_TYPE_WBASE(ptVaultAgeInfoNode, pyVaultNode, "Plasma vault age info node");
 
 // required functions for PyObject interoperability
-PyObject *pyVaultAgeInfoNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultAgeInfoNode *newObj = (ptVaultAgeInfoNode*)ptVaultAgeInfoNode_type.tp_new(&ptVaultAgeInfoNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
-
-PyObject *pyVaultAgeInfoNode::New(int n /* =0 */)
-{
-    ptVaultAgeInfoNode *newObj = (ptVaultAgeInfoNode*)ptVaultAgeInfoNode_type.tp_new(&ptVaultAgeInfoNode_type, NULL, NULL);
-    // oddly enough, nothing to do here
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultAgeInfoNode, pyVaultAgeInfoNode);
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultAgeInfoNode, pyVaultAgeInfoNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultAgeInfoNode, pyVaultAgeInfoNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.cpp
@@ -58,15 +58,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plNetCommon/plSpawnPointInfo.h"
 
-// should only be created from C++ side
-pyVaultAgeLinkNode::pyVaultAgeLinkNode(RelVaultNode* nfsNode)
-: pyVaultNode(nfsNode)
-{
-}
-
 //create from the Python side
-pyVaultAgeLinkNode::pyVaultAgeLinkNode(int n)
-: pyVaultNode(new RelVaultNode)
+pyVaultAgeLinkNode::pyVaultAgeLinkNode()
+    : pyVaultNode()
 {
     fNode->SetNodeType(plVault::kNodeType_AgeLink);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.cpp
@@ -81,13 +81,8 @@ PyObject* pyVaultAgeLinkNode::GetAgeInfo() const
     if (!fNode)
         PYTHON_RETURN_NONE;
 
-    PyObject * result = nil;        
     if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(plVault::kNodeType_AgeInfo, 1))
-        result = pyVaultAgeInfoNode::New(rvn);
-    
-    if (result)
-        return result;
-        
+        return pyVaultAgeInfoNode::New(rvn);
     PYTHON_RETURN_NONE;
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.h
@@ -67,17 +67,13 @@ private:
     mutable plAgeLinkStruct     fAgeLinkStruct; // for use with AsAgeLinkStruct()
 
 protected:
-    // should only be created from C++ side
-    pyVaultAgeLinkNode(RelVaultNode* nfsNode);
-
     //create from the Python side
-    pyVaultAgeLinkNode(int n=0);
+    pyVaultAgeLinkNode();
 
 public:
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultAgeLinkNode);
-    static PyObject *New(RelVaultNode* nfsNode);
-    static PyObject *New(int n=0);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultAgeLinkNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultAgeLinkNode); // converts a PyObject to a pyVaultAgeLinkNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNodeGlue.cpp
@@ -193,22 +193,10 @@ PYTHON_START_METHODS_TABLE(ptVaultAgeLinkNode)
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition
-PLASMA_DEFAULT_TYPE_WBASE(ptVaultAgeLinkNode, pyVaultNode, "Params: n=0\nPlasma vault age link node");
+PLASMA_DEFAULT_TYPE_WBASE(ptVaultAgeLinkNode, pyVaultNode, "Plasma vault age link node");
 
 // required functions for PyObject interoperability
-PyObject *pyVaultAgeLinkNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultAgeLinkNode *newObj = (ptVaultAgeLinkNode*)ptVaultAgeLinkNode_type.tp_new(&ptVaultAgeLinkNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
-
-PyObject *pyVaultAgeLinkNode::New(int n /* =0 */)
-{
-    ptVaultAgeLinkNode *newObj = (ptVaultAgeLinkNode*)ptVaultAgeLinkNode_type.tp_new(&ptVaultAgeLinkNode_type, NULL, NULL);
-    // oddly enough, nothing to do here
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultAgeLinkNode, pyVaultAgeLinkNode)
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultAgeLinkNode, pyVaultAgeLinkNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultAgeLinkNode, pyVaultAgeLinkNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.cpp
@@ -53,15 +53,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   include "pyVault.h"
 #endif
 
-// should only be created from C++ side
-pyVaultChronicleNode::pyVaultChronicleNode(RelVaultNode* nfsNode)
-: pyVaultNode(nfsNode)
-{
-}
-
 //create from the Python side
-pyVaultChronicleNode::pyVaultChronicleNode(int n)
-: pyVaultNode(new RelVaultNode)
+pyVaultChronicleNode::pyVaultChronicleNode()
+    : pyVaultNode()
 {
     fNode->SetNodeType(plVault::kNodeType_Chronicle);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.h
@@ -57,19 +57,15 @@ struct RelVaultNode;
 class pyVaultChronicleNode : public pyVaultNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultChronicleNode(RelVaultNode* nfsNode);
-
     //create from the Python side
-    pyVaultChronicleNode(int n=0);
+    pyVaultChronicleNode();
 
 public:
     ~pyVaultChronicleNode() { }
 
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultChronicleNode);
-    static PyObject *New(RelVaultNode* nfsNode);
-    static PyObject *New(int n=0);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultChronicleNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultChronicleNode); // converts a PyObject to a pyVaultChronicleNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNodeGlue.cpp
@@ -184,22 +184,10 @@ PYTHON_START_METHODS_TABLE(ptVaultChronicleNode)
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition
-PLASMA_DEFAULT_TYPE_WBASE(ptVaultChronicleNode, pyVaultNode, "Params: n=0\nPlasma vault chronicle node");
+PLASMA_DEFAULT_TYPE_WBASE(ptVaultChronicleNode, pyVaultNode, "Plasma vault chronicle node");
 
 // required functions for PyObject interoperability
-PyObject *pyVaultChronicleNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultChronicleNode *newObj = (ptVaultChronicleNode*)ptVaultChronicleNode_type.tp_new(&ptVaultChronicleNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
-
-PyObject *pyVaultChronicleNode::New(int n /* =0 */)
-{
-    ptVaultChronicleNode *newObj = (ptVaultChronicleNode*)ptVaultChronicleNode_type.tp_new(&ptVaultChronicleNode_type, NULL, NULL);
-    // oddly enough, nothing to do here
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultChronicleNode, pyVaultChronicleNode)
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultChronicleNode, pyVaultChronicleNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultChronicleNode, pyVaultChronicleNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.cpp
@@ -50,20 +50,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyVaultFolderNode.h"
 #include "plVault/plVault.h"
 
-// should only be created from C++ side
-pyVaultFolderNode::pyVaultFolderNode( RelVaultNode* nfsNode )
-: pyVaultNode( nfsNode )
-{
-}
-
 //create from the Python side
-pyVaultFolderNode::pyVaultFolderNode(int n)
-: pyVaultNode(new RelVaultNode)
+pyVaultFolderNode::pyVaultFolderNode()
+    : pyVaultNode()
 {
     fNode->SetNodeType(plVault::kNodeType_Folder);
-}
-
-pyVaultFolderNode::~pyVaultFolderNode () {
 }
 
 //==================================================================

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.h
@@ -57,20 +57,14 @@ struct RelVaultNode;
 class pyVaultFolderNode : public pyVaultNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultFolderNode(RelVaultNode* nfsNode);
-
     //create from the Python side
-    pyVaultFolderNode(int n=0);
+    pyVaultFolderNode();
 
 public:
-    ~pyVaultFolderNode();
-
     // required functions for PyObject interoperability
     PYTHON_EXPOSE_TYPE; // so we can subclass
     PYTHON_CLASS_NEW_FRIEND(ptVaultFolderNode);
-    static PyObject *New(RelVaultNode* nfsNode);
-    static PyObject *New(int n=0);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultFolderNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultFolderNode); // converts a PyObject to a pyVaultFolderNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNodeGlue.cpp
@@ -177,19 +177,7 @@ PLASMA_DEFAULT_TYPE_WBASE(ptVaultFolderNode, pyVaultNode, "Params: n=0\nPlasma v
 PYTHON_EXPOSE_TYPE_DEFINITION(ptVaultFolderNode, pyVaultFolderNode);
 
 // required functions for PyObject interoperability
-PyObject *pyVaultFolderNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultFolderNode *newObj = (ptVaultFolderNode*)ptVaultFolderNode_type.tp_new(&ptVaultFolderNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
-
-PyObject *pyVaultFolderNode::New(int n /* =0 */)
-{
-    ptVaultFolderNode *newObj = (ptVaultFolderNode*)ptVaultFolderNode_type.tp_new(&ptVaultFolderNode_type, NULL, NULL);
-    // oddly enough, nothing to do here
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultFolderNode, pyVaultFolderNode);
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultFolderNode, pyVaultFolderNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultFolderNode, pyVaultFolderNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.cpp
@@ -85,19 +85,9 @@ static plKey CreateAndRefImageKey (unsigned nodeId, plMipmap * mipmap) {
     return key;
 }
 
-// should only be created from C++ side
-pyVaultImageNode::pyVaultImageNode(RelVaultNode* nfsNode)
-: pyVaultNode(nfsNode)
-, fMipmapKey(nil)
-, fMipmap(nil)
-{
-}
-
 //create from the Python side
-pyVaultImageNode::pyVaultImageNode(int n)
-: pyVaultNode(new RelVaultNode)
-, fMipmapKey(nil)
-, fMipmap(nil)
+pyVaultImageNode::pyVaultImageNode()
+    : fMipmap(), pyVaultNode()
 {
     fNode->SetNodeType(plVault::kNodeType_Image);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.h
@@ -63,20 +63,15 @@ class pyVaultImageNode : public pyVaultNode
     plMipmap *  fMipmap;
     
 protected:
-    // should only be created from C++ side
-    pyVaultImageNode(RelVaultNode* nfsNode);
-
     //create from the Python side
-    pyVaultImageNode(int n=0);
-    
+    pyVaultImageNode();
 
 public:
     ~pyVaultImageNode ();
 
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultImageNode);
-    static PyObject *New(RelVaultNode* nfsNode);
-    static PyObject *New(int n=0);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultImageNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultImageNode); // converts a PyObject to a pyVaultImageNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNodeGlue.cpp
@@ -206,19 +206,7 @@ PYTHON_END_METHODS_TABLE;
 PLASMA_DEFAULT_TYPE_WBASE(ptVaultImageNode, pyVaultNode, "Params: n=0\nPlasma vault image node");
 
 // required functions for PyObject interoperability
-PyObject *pyVaultImageNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultImageNode *newObj = (ptVaultImageNode*)ptVaultImageNode_type.tp_new(&ptVaultImageNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
-
-PyObject *pyVaultImageNode::New(int n /* =0 */)
-{
-    ptVaultImageNode *newObj = (ptVaultImageNode*)ptVaultImageNode_type.tp_new(&ptVaultImageNode_type, NULL, NULL);
-    // oddly enough, nothing to do here
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultImageNode, pyVaultImageNode)
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultImageNode, pyVaultImageNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultImageNode, pyVaultImageNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNode.cpp
@@ -53,15 +53,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plVault/plVault.h"
 #include "pnUUID/pnUUID.h"
 
-// should only be created from C++ side
-pyVaultMarkerGameNode::pyVaultMarkerGameNode(RelVaultNode* nfsNode)
-: pyVaultNode(nfsNode)
-{
-}
-
 //create from the Python side
-pyVaultMarkerGameNode::pyVaultMarkerGameNode(int n)
-: pyVaultNode(new RelVaultNode)
+pyVaultMarkerGameNode::pyVaultMarkerGameNode()
+    : pyVaultNode()
 {
     fNode->SetNodeType(plVault::kNodeType_MarkerGame);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNode.h
@@ -61,17 +61,13 @@ class plUUID;
 class pyVaultMarkerGameNode : public pyVaultNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultMarkerGameNode(RelVaultNode* vaultNode);
-
     //create from the Python side
-    pyVaultMarkerGameNode(int n=0);
+    pyVaultMarkerGameNode();
 
 public:
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultMarkerGameNode);
-    static PyObject *New(RelVaultNode* vaultNode);
-    static PyObject *New(int n=0);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultMarkerGameNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultMarkerGameNode); // converts a PyObject to a pyVaultMarkerGameNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNodeGlue.cpp
@@ -156,19 +156,7 @@ PYTHON_END_METHODS_TABLE;
 PLASMA_DEFAULT_TYPE_WBASE(ptVaultMarkerGameNode, pyVaultNode, "Params: n=0\nPlasma vault age info node");
 
 // required functions for PyObject interoperability
-PyObject *pyVaultMarkerGameNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultMarkerGameNode *newObj = (ptVaultMarkerGameNode*)ptVaultMarkerGameNode_type.tp_new(&ptVaultMarkerGameNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
-
-PyObject *pyVaultMarkerGameNode::New(int n /* =0 */)
-{
-    ptVaultMarkerGameNode *newObj = (ptVaultMarkerGameNode*)ptVaultMarkerGameNode_type.tp_new(&ptVaultMarkerGameNode_type, NULL, NULL);
-    // oddly enough, nothing to do here
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultMarkerGameNode, pyVaultMarkerGameNode)
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultMarkerGameNode, pyVaultMarkerGameNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultMarkerGameNode, pyVaultMarkerGameNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -157,23 +157,22 @@ hsRef<RelVaultNode> pyVaultNode::pyVaultNodeOperationCallback::GetNode() const {
 }
 
 pyVaultNode::pyVaultNode()
+    : fNode(decltype(fNode)::New())
 {
 }
 
-// should only be created from C++ side
-pyVaultNode::pyVaultNode( RelVaultNode* nfsNode )
-:   fNode(nfsNode)
+pyVaultNode::pyVaultNode(std::nullptr_t)
 {
 }
 
-pyVaultNode::~pyVaultNode() {}
-
+pyVaultNode::~pyVaultNode()
+{
+}
 
 hsRef<RelVaultNode> pyVaultNode::GetNode() const
 {
     return fNode;
 }
-
 
 // override the equals to operator
 bool pyVaultNode::operator==(const pyVaultNode &vaultNode) const

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -157,7 +157,7 @@ hsRef<RelVaultNode> pyVaultNode::pyVaultNodeOperationCallback::GetNode() const {
 }
 
 pyVaultNode::pyVaultNode()
-    : fNode(decltype(fNode)::New())
+    : fNode(new RelVaultNode, hsStealRef)
 {
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -243,21 +243,16 @@ uint32_t pyVaultNode::GetCreatorNodeID()
 
 PyObject* pyVaultNode::GetCreatorNode()
 {
-    PyObject * result = nil;
-    if (fNode)
-    {
-        hsRef<RelVaultNode> templateNode = new RelVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
-        VaultPlayerInfoNode plrInfo(templateNode);
+    if (fNode) {
+        RelVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_PlayerInfo);
+        VaultPlayerInfoNode plrInfo(&templateNode);
         plrInfo.SetPlayerId(fNode->GetCreatorId());
         
-        if (hsRef<RelVaultNode> rvn = VaultGetNode(templateNode))
-            result = pyVaultPlayerInfoNode::New(rvn);
+        if (hsRef<RelVaultNode> rvn = VaultGetNode(&templateNode))
+            return pyVaultPlayerInfoNode::New(rvn);
     }
-    
-    if (result)
-        return result;
-        
+
     // just return a None object
     PYTHON_RETURN_NONE;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
@@ -101,10 +101,9 @@ public:
     hsRef<RelVaultNode> fNode;
 
 protected:
-    // only for python glue, do NOT call
     pyVaultNode();
-    // should only be created from C++ side
-    pyVaultNode( RelVaultNode* node );
+
+    pyVaultNode(std::nullptr_t);
 
 public:
     virtual ~pyVaultNode();
@@ -112,7 +111,7 @@ public:
     // required functions for PyObject interoperability
     PYTHON_EXPOSE_TYPE; // so we can subclass
     PYTHON_CLASS_NEW_FRIEND(ptVaultNode);
-    static PyObject *New(RelVaultNode* node);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultNode); // converts a PyObject to a pyVaultNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeGlue.cpp
@@ -525,13 +525,7 @@ PLASMA_CUSTOM_TYPE(ptVaultNode, "Vault node class");
 PYTHON_EXPOSE_TYPE_DEFINITION(ptVaultNode, pyVaultNode);
 
 // required functions for PyObject interoperability
-PyObject *pyVaultNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultNode *newObj = (ptVaultNode*)ptVaultNode_type.tp_new(&ptVaultNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
-
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultNode, pyVaultNode);
 PYTHON_CLASS_CHECK_IMPL(ptVaultNode, pyVaultNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultNode, pyVaultNode)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.cpp
@@ -124,15 +124,15 @@ PyObject * pyVaultNodeRef::GetSaver () {
     if (hsRef<RelVaultNode> child = VaultGetNode(fChild->GetNodeId())) {
         if (unsigned saverId = child->GetRefOwnerId(fParent->GetNodeId())) {
             // Find the player info node representing the saver
-            hsRef<NetVaultNode> templateNode = new NetVaultNode;
-            templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
-            VaultPlayerInfoNode access(templateNode);
+            NetVaultNode templateNode;
+            templateNode.SetNodeType(plVault::kNodeType_PlayerInfo);
+            VaultPlayerInfoNode access(&templateNode);
             access.SetPlayerId(saverId);
-            saver = VaultGetNode(templateNode);
+            saver = VaultGetNode(&templateNode);
 
             if (!saver) {
                 TArray<unsigned> nodeIds;
-                VaultFindNodesAndWait(templateNode, &nodeIds);
+                VaultFindNodesAndWait(&templateNode, &nodeIds);
                 if (nodeIds.Count() > 0) {
                     VaultFetchNodesAndWait(nodeIds.Ptr(), nodeIds.Count());
                     saver = VaultGetNode(nodeIds[0]);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
@@ -96,19 +96,19 @@ void pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
     if (HasPlayer(playerID) || !fNode)
         return;
 
-    auto templateNode = hsRef<NetVaultNode>::New();
-    templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
-    VaultPlayerInfoNode access(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_PlayerInfo);
+    VaultPlayerInfoNode access(&templateNode);
     access.SetPlayerId(playerID);
 
     TArray<uint32_t> nodeIds;
-    VaultLocalFindNodes(templateNode, &nodeIds);
+    VaultLocalFindNodes(&templateNode, &nodeIds);
 
     // So, if we know about this node, we can take it easy. If not, we lazy load it.
     if (nodeIds.Count())
         VaultAddChildNode(fNode->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr, nullptr);
     else
-        VaultFindNodes(templateNode, IAddPlayer_NodesFound, (NetVaultNode *)fNode);
+        VaultFindNodes(&templateNode, IAddPlayer_NodesFound, (NetVaultNode *)fNode);
 }
 
 void pyVaultPlayerInfoListNode::RemovePlayer( uint32_t playerID )

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
@@ -58,15 +58,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   include "pyVault.h"
 #endif
 
-// should only be created from C++ side
-pyVaultPlayerInfoListNode::pyVaultPlayerInfoListNode(RelVaultNode* nfsNode)
-: pyVaultFolderNode(nfsNode)
-{
-}
-
 //create from the Python side
-pyVaultPlayerInfoListNode::pyVaultPlayerInfoListNode(int n)
-: pyVaultFolderNode(n)
+pyVaultPlayerInfoListNode::pyVaultPlayerInfoListNode()
+    : pyVaultFolderNode()
 {
     fNode->SetNodeType(plVault::kNodeType_PlayerInfoList);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
@@ -79,14 +79,13 @@ bool pyVaultPlayerInfoListNode::HasPlayer( uint32_t playerID )
     if (!fNode)
         return false;
 
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
-    VaultPlayerInfoNode access(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_PlayerInfo);
+    VaultPlayerInfoNode access(&templateNode);
     access.SetPlayerId(playerID);
-    
-    hsRef<RelVaultNode> rvn = fNode->GetChildNode(templateNode, 1);
-    
-    return (rvn != nil);
+
+    hsRef<RelVaultNode> rvn = fNode->GetChildNode(&templateNode, 1);
+    return rvn != nullptr;
 }
 
 //==================================================================
@@ -103,7 +102,7 @@ void pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
     if (HasPlayer(playerID) || !fNode)
         return;
 
-    hsRef<NetVaultNode> templateNode = new NetVaultNode();
+    auto templateNode = hsRef<NetVaultNode>::New();
     templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
     VaultPlayerInfoNode access(templateNode);
     access.SetPlayerId(playerID);
@@ -123,12 +122,12 @@ void pyVaultPlayerInfoListNode::RemovePlayer( uint32_t playerID )
     if (!fNode)
         return;
 
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
-    VaultPlayerInfoNode access(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_PlayerInfo);
+    VaultPlayerInfoNode access(&templateNode);
     access.SetPlayerId(playerID);
 
-    if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(templateNode, 1))
+    if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(&templateNode, 1))
         VaultRemoveChildNode(fNode->GetNodeId(), rvn->GetNodeId(), nil, nil);
 }
 
@@ -137,19 +136,14 @@ PyObject * pyVaultPlayerInfoListNode::GetPlayer( uint32_t playerID )
     if (!fNode)
         PYTHON_RETURN_NONE;
 
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
-    VaultPlayerInfoNode access(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_PlayerInfo);
+    VaultPlayerInfoNode access(&templateNode);
     access.SetPlayerId(playerID);
 
-    PyObject * result = nil;
-    if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(templateNode, 1))
-        result = pyVaultPlayerInfoNode::New(rvn);
-    
-    if (!result)
-        PYTHON_RETURN_NONE;
-        
-    return result;
+    if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(&templateNode, 1))
+        return pyVaultPlayerInfoNode::New(rvn);
+    PYTHON_RETURN_NONE;
 }
 
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.h
@@ -59,17 +59,13 @@ class pyVaultPlayerInfoNode;
 class pyVaultPlayerInfoListNode : public pyVaultFolderNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultPlayerInfoListNode(RelVaultNode* nfsNode);
-
     //create from the Python side
-    pyVaultPlayerInfoListNode(int n=0);
+    pyVaultPlayerInfoListNode();
 
 public:
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultPlayerInfoListNode);
-    static PyObject *New(RelVaultNode* nfsNode);
-    static PyObject *New(int n=0);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultPlayerInfoListNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultPlayerInfoListNode); // converts a PyObject to a pyVaultPlayerInfoListNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNodeGlue.cpp
@@ -173,22 +173,10 @@ PYTHON_START_METHODS_TABLE(ptVaultPlayerInfoListNode)
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition
-PLASMA_DEFAULT_TYPE_WBASE(ptVaultPlayerInfoListNode, pyVaultFolderNode, "Params: n=0\nPlasma vault player info list node");
+PLASMA_DEFAULT_TYPE_WBASE(ptVaultPlayerInfoListNode, pyVaultFolderNode, "Plasma vault player info list node");
 
 // required functions for PyObject interoperability
-PyObject *pyVaultPlayerInfoListNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultPlayerInfoListNode *newObj = (ptVaultPlayerInfoListNode*)ptVaultPlayerInfoListNode_type.tp_new(&ptVaultPlayerInfoListNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
-
-PyObject *pyVaultPlayerInfoListNode::New(int n /* =0 */)
-{
-    ptVaultPlayerInfoListNode *newObj = (ptVaultPlayerInfoListNode*)ptVaultPlayerInfoListNode_type.tp_new(&ptVaultPlayerInfoListNode_type, NULL, NULL);
-    // oddly enough, nothing to do here
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultPlayerInfoListNode, pyVaultPlayerInfoListNode)
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultPlayerInfoListNode, pyVaultPlayerInfoListNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultPlayerInfoListNode, pyVaultPlayerInfoListNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.cpp
@@ -54,15 +54,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   include "pyVault.h"
 #endif
 
-// should only be created from C++ side
-pyVaultPlayerInfoNode::pyVaultPlayerInfoNode(RelVaultNode* nfsNode)
-: pyVaultNode(nfsNode)
-{
-}
-
 //create from the Python side
 pyVaultPlayerInfoNode::pyVaultPlayerInfoNode()
-: pyVaultNode(new RelVaultNode)
+    : pyVaultNode()
 {
     fNode->SetNodeType(plVault::kNodeType_PlayerInfo);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.h
@@ -56,9 +56,6 @@ class plUUID;
 class pyVaultPlayerInfoNode : public pyVaultNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultPlayerInfoNode(RelVaultNode * node);
-
     //create from the Python side
     pyVaultPlayerInfoNode();
 
@@ -67,8 +64,7 @@ public:
 
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultPlayerInfoNode);
-    PYTHON_CLASS_NEW_DEFINITION;
-    static PyObject *New(RelVaultNode * node);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultPlayerInfoNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultPlayerInfoNode); // converts a PyObject to a pyVaultPlayerInfoNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNodeGlue.cpp
@@ -166,14 +166,7 @@ PYTHON_END_METHODS_TABLE;
 PLASMA_DEFAULT_TYPE_WBASE(ptVaultPlayerInfoNode, pyVaultNode, "Plasma vault folder node");
 
 // required functions for PyObject interoperability
-PYTHON_CLASS_NEW_IMPL(ptVaultPlayerInfoNode, pyVaultPlayerInfoNode)
-
-PyObject *pyVaultPlayerInfoNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultPlayerInfoNode *newObj = (ptVaultPlayerInfoNode*)ptVaultPlayerInfoNode_type.tp_new(&ptVaultPlayerInfoNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultPlayerInfoNode, pyVaultPlayerInfoNode)
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultPlayerInfoNode, pyVaultPlayerInfoNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultPlayerInfoNode, pyVaultPlayerInfoNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.cpp
@@ -64,23 +64,16 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 //============================================================================
 static PyObject * GetPlayerVaultFolder (unsigned folderType) {
-    PyObject * result = nil;
     if (hsRef<RelVaultNode> rvnPlr = VaultGetPlayerNode()) {
         if (hsRef<RelVaultNode> rvnFldr = rvnPlr->GetChildFolderNode(folderType, 1))
-            result = pyVaultFolderNode::New(rvnFldr);
+            return pyVaultFolderNode::New(rvnFldr);
     }
-    
-    return result;
-}
-
-pyVaultPlayerNode::pyVaultPlayerNode(RelVaultNode *nfsNode)
-: pyVaultNode(nfsNode)
-{
+    return nullptr;
 }
 
 //create from the Python side
 pyVaultPlayerNode::pyVaultPlayerNode()
-: pyVaultNode(nil)  // may not create player nodes from python
+    : pyVaultNode(nullptr)
 {
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.h
@@ -57,17 +57,13 @@ struct RelVaultNode;
 class pyVaultPlayerNode : public pyVaultNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultPlayerNode(RelVaultNode *nfsNode);
-
     //create from the Python side
     pyVaultPlayerNode();
 
 public:
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultPlayerNode);
-    PYTHON_CLASS_NEW_DEFINITION;
-    static PyObject *New(RelVaultNode *nfsNode);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultPlayerNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultPlayerNode); // converts a PyObject to a pyVaultPlayerNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNodeGlue.cpp
@@ -316,14 +316,7 @@ PYTHON_END_METHODS_TABLE;
 PLASMA_DEFAULT_TYPE_WBASE(ptVaultPlayerNode, pyVaultNode, "Plasma vault player node");
 
 // required functions for PyObject interoperability
-PYTHON_CLASS_NEW_IMPL(ptVaultPlayerNode, pyVaultPlayerNode)
-
-PyObject *pyVaultPlayerNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultPlayerNode *newObj = (ptVaultPlayerNode*)ptVaultPlayerNode_type.tp_new(&ptVaultPlayerNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultPlayerNode, pyVaultPlayerNode)
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultPlayerNode, pyVaultPlayerNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultPlayerNode, pyVaultPlayerNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.cpp
@@ -53,15 +53,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pySDL.h"
 #include "plVault/plVault.h"
 
-// should only be created from C++ side
-pyVaultSDLNode::pyVaultSDLNode(RelVaultNode* nfsNode)
-: pyVaultNode(nfsNode)
-{
-}
-
 //create from the Python side
 pyVaultSDLNode::pyVaultSDLNode()
-: pyVaultNode(new RelVaultNode)
+    : pyVaultNode()
 {
     fNode->SetNodeType(plVault::kNodeType_SDL);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.h
@@ -59,17 +59,13 @@ class pySDLStateDataRecord;
 class pyVaultSDLNode : public pyVaultNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultSDLNode(RelVaultNode* nfsNode);
-
     //create from the Python side
     pyVaultSDLNode();
 
 public:
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultSDLNode);
-    PYTHON_CLASS_NEW_DEFINITION;
-    static PyObject *New(RelVaultNode* nfsNode);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultSDLNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultSDLNode); // converts a PyObject to a pyVaultSDLNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNodeGlue.cpp
@@ -124,14 +124,7 @@ PYTHON_END_METHODS_TABLE;
 PLASMA_DEFAULT_TYPE_WBASE(ptVaultSDLNode, pyVaultNode, "Plasma vault SDL node");
 
 // required functions for PyObject interoperability
-PYTHON_CLASS_NEW_IMPL(ptVaultSDLNode, pyVaultSDLNode)
-
-PyObject *pyVaultSDLNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultSDLNode *newObj = (ptVaultSDLNode*)ptVaultSDLNode_type.tp_new(&ptVaultSDLNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultSDLNode, pyVaultSDLNode)
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultSDLNode, pyVaultSDLNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultSDLNode, pyVaultSDLNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSystemNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSystemNode.cpp
@@ -48,21 +48,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #pragma hdrstop
 
 #include "pyVaultSystemNode.h"
-#include "pyVaultAgeLinkNode.h"
-#include "pyVaultFolderNode.h"
 #include "plVault/plVault.h"
-#ifndef BUILDING_PYPLASMA
-#   include "pyVault.h"
-#endif
-
-// should only be created from C++ side
-pyVaultSystemNode::pyVaultSystemNode(RelVaultNode* nfsNode)
-: pyVaultNode(nfsNode)
-{
-}
 
 //create from the Python side
 pyVaultSystemNode::pyVaultSystemNode()
-: pyVaultNode(nil)  // may not create this node type from python
+    : pyVaultNode(nullptr)  // may not create this node type from python
 {
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSystemNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSystemNode.h
@@ -56,17 +56,13 @@ struct RelVaultNode;
 class pyVaultSystemNode : public pyVaultNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultSystemNode(RelVaultNode* nfsNode);
-
     //create from the Python side
     pyVaultSystemNode();
 
 public:
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultSystemNode);
-    PYTHON_CLASS_NEW_DEFINITION;
-    static PyObject *New(RelVaultNode* nfsNode);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultSystemNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultSystemNode); // converts a PyObject to a pyVaultSystemNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSystemNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSystemNodeGlue.cpp
@@ -65,14 +65,7 @@ PYTHON_END_METHODS_TABLE;
 PLASMA_DEFAULT_TYPE_WBASE(ptVaultSystemNode, pyVaultNode, "Plasma vault system node");
 
 // required functions for PyObject interoperability
-PYTHON_CLASS_NEW_IMPL(ptVaultSystemNode, pyVaultSystemNode)
-
-PyObject *pyVaultSystemNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultSystemNode *newObj = (ptVaultSystemNode*)ptVaultSystemNode_type.tp_new(&ptVaultSystemNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultSystemNode, pyVaultSystemNode)
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultSystemNode, pyVaultSystemNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultSystemNode, pyVaultSystemNode)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
@@ -56,15 +56,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   include "pyVault.h"
 #endif
 
-// should only be created from C++ side
-pyVaultTextNoteNode::pyVaultTextNoteNode(RelVaultNode* nfsNode)
-: pyVaultNode(nfsNode)
-{
-}
-
 //create from the Python side
 pyVaultTextNoteNode::pyVaultTextNoteNode()
-: pyVaultNode(new RelVaultNode)
+    : pyVaultNode()
 {
     fNode->SetNodeType(plVault::kNodeType_TextNote);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.h
@@ -58,17 +58,13 @@ class pyVaultAgeLinkNode;
 class pyVaultTextNoteNode : public pyVaultNode
 {
 protected:
-    // should only be created from C++ side
-    pyVaultTextNoteNode(RelVaultNode* nfsNode);
-
     //create from the Python side
     pyVaultTextNoteNode();
 
 public:
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptVaultTextNoteNode);
-    PYTHON_CLASS_NEW_DEFINITION;
-    static PyObject *New(RelVaultNode* nfsNode);
+    PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION;
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultTextNoteNode object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultTextNoteNode); // converts a PyObject to a pyVaultTextNoteNode (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNodeGlue.cpp
@@ -291,14 +291,7 @@ PYTHON_END_METHODS_TABLE;
 PLASMA_DEFAULT_TYPE_WBASE(ptVaultTextNoteNode, pyVaultNode, "Plasma vault text note node");
 
 // required functions for PyObject interoperability
-PYTHON_CLASS_NEW_IMPL(ptVaultTextNoteNode, pyVaultTextNoteNode)
-
-PyObject *pyVaultTextNoteNode::New(RelVaultNode* nfsNode)
-{
-    ptVaultTextNoteNode *newObj = (ptVaultTextNoteNode*)ptVaultTextNoteNode_type.tp_new(&ptVaultTextNoteNode_type, NULL, NULL);
-    newObj->fThis->fNode = nfsNode;
-    return (PyObject*)newObj;
-}
+PYTHON_CLASS_VAULT_NODE_NEW_IMPL(ptVaultTextNoteNode, pyVaultTextNoteNode)
 
 PYTHON_CLASS_CHECK_IMPL(ptVaultTextNoteNode, pyVaultTextNoteNode)
 PYTHON_CLASS_CONVERT_FROM_IMPL(ptVaultTextNoteNode, pyVaultTextNoteNode)

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -3978,7 +3978,7 @@ bool VaultFetchNodeTrans::Recv (
     const Auth2Cli_VaultNodeFetched & reply = *(const Auth2Cli_VaultNodeFetched *) msg;
     
     if (IS_NET_SUCCESS(reply.result)) {
-        m_node = new NetVaultNode;
+        m_node = hsRef<NetVaultNode>::New();
         m_node->Read(reply.nodeBuffer, reply.nodeBytes);
     }
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -750,12 +750,11 @@ struct VaultFetchNodeTrans : NetAuthTrans {
 //============================================================================
 struct VaultFindNodeTrans : NetAuthTrans {
 
+    TArray<uint8_t>             m_buffer;
     TArray<unsigned>            m_nodeIds;
     FNetCliAuthVaultNodeFind    m_callback;
     void *                      m_param;
-    
-    hsRef<NetVaultNode>         m_node;
-    
+
     VaultFindNodeTrans (
         NetVaultNode *              templateNode,
         FNetCliAuthVaultNodeFind    callback,
@@ -776,12 +775,11 @@ struct VaultFindNodeTrans : NetAuthTrans {
 //============================================================================
 struct VaultCreateNodeTrans : NetAuthTrans {
 
-    hsRef<NetVaultNode>             m_templateNode;
+    TArray<uint8_t>                 m_buffer;
     FNetCliAuthVaultNodeCreated     m_callback;
     void *                          m_param;
-    
     unsigned                        m_nodeId;
-    
+
     VaultCreateNodeTrans (
         NetVaultNode *                  templateNode,
         FNetCliAuthVaultNodeCreated     callback,
@@ -4003,27 +4001,22 @@ VaultFindNodeTrans::VaultFindNodeTrans (
 ) : NetAuthTrans(kVaultFindNodeTrans)
 ,   m_callback(callback)
 ,   m_param(param)
-,   m_node(templateNode)
 {
+    templateNode->Write(&m_buffer, 0);
 }
 
 //============================================================================
 bool VaultFindNodeTrans::Send () {
     if (!AcquireConn())
         return false;
-        
-    TArray<uint8_t> buffer;
-    m_node->Write(&buffer);
 
     const uintptr_t msg[] = {
-        kCli2Auth_VaultNodeFind,
-                        m_transId,
-                        buffer.Count(),
-        (uintptr_t)  buffer.Ptr(),
+            kCli2Auth_VaultNodeFind,
+            m_transId,
+            m_buffer.Count(),
+            (uintptr_t)m_buffer.Ptr(),
     };
-            
     m_conn->Send(msg, std::size(msg));
-    
     return true;
 }
 
@@ -4068,30 +4061,25 @@ VaultCreateNodeTrans::VaultCreateNodeTrans (
     FNetCliAuthVaultNodeCreated     callback,
     void *                          param
 ) : NetAuthTrans(kVaultCreateNodeTrans)
-,   m_templateNode(templateNode)
 ,   m_callback(callback)
 ,   m_param(param)
 ,   m_nodeId(0)
 {
+    templateNode->Write(&m_buffer, 0);
 }
 
 //============================================================================
 bool VaultCreateNodeTrans::Send () {
     if (!AcquireConn())
         return false;
-        
-    TArray<uint8_t> buffer;
-    m_templateNode->Write(&buffer, 0);
 
     const uintptr_t msg[] = {
-        kCli2Auth_VaultNodeCreate,
-                        m_transId,
-                        buffer.Count(),
-        (uintptr_t)  buffer.Ptr()
+            kCli2Auth_VaultNodeCreate,
+            m_transId,
+            m_buffer.Count(),
+            (uintptr_t)m_buffer.Ptr()
     };
-            
     m_conn->Send(msg, std::size(msg));
-    
     return true;
 }
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -3976,7 +3976,7 @@ bool VaultFetchNodeTrans::Recv (
     const Auth2Cli_VaultNodeFetched & reply = *(const Auth2Cli_VaultNodeFetched *) msg;
     
     if (IS_NET_SUCCESS(reply.result)) {
-        m_node = hsRef<NetVaultNode>::New();
+        m_node.Steal(new NetVaultNode);
         m_node->Read(reply.nodeBuffer, reply.nodeBytes);
     }
 

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -83,7 +83,7 @@ struct RelVaultNodeLink : THashKeyVal<unsigned> {
     bool                        seen;
 
     RelVaultNodeLink(bool seen, unsigned ownerId, unsigned nodeId)
-        : THashKeyVal<unsigned>(nodeId), node(hsRef<RelVaultNode>::New()), ownerId(ownerId), seen(seen)
+        : THashKeyVal<unsigned>(nodeId), node(new RelVaultNode, hsStealRef), ownerId(ownerId), seen(seen)
     { }
 
     RelVaultNodeLink (bool seen, unsigned ownerId, unsigned nodeId, RelVaultNode * node)

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -422,18 +422,18 @@ static void FetchRefOwners (
                 ownerIds.Add(ownerId);
     }
     QSORT(unsigned, ownerIds.Ptr(), ownerIds.Count(), elem1 < elem2);
-    auto templateNode = hsRef<NetVaultNode>::New();
-    templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_PlayerInfo);
     {   unsigned prevId = 0;
         for (unsigned i = 0; i < ownerIds.Count(); ++i) {
             if (ownerIds[i] != prevId) {
                 prevId = ownerIds[i];
-                VaultPlayerInfoNode access(templateNode);
+                VaultPlayerInfoNode access(&templateNode);
                 access.SetPlayerId(refs[i].ownerId);
-                if (VaultGetNode(templateNode))
+                if (VaultGetNode(&templateNode))
                     continue;
                 NetCliAuthVaultNodeFind(
-                    templateNode,
+                    &templateNode,
                     VaultNodeFound,
                     nil
                 );
@@ -1828,11 +1828,11 @@ void VaultCreateNode (
     void *                      state,
     void *                      param
 ) {
-    auto templateNode = hsRef<NetVaultNode>::New();
-    templateNode->SetNodeType(nodeType);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(nodeType);
 
     VaultCreateNode(
-        templateNode,
+        &templateNode,
         callback,
         state,
         param
@@ -1892,10 +1892,10 @@ hsRef<RelVaultNode> VaultCreateNodeAndWait (
     plVault::NodeTypes          nodeType,
     ENetError *                 result
 ) {
-    auto templateNode = hsRef<NetVaultNode>::New();
-    templateNode->SetNodeType(nodeType);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(nodeType);
 
-    return VaultCreateNodeAndWait(templateNode, result);
+    return VaultCreateNodeAndWait(&templateNode, result);
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -1215,9 +1215,9 @@ hsRef<RelVaultNode> RelVaultNode::GetChildNode (
     unsigned            nodeType,
     unsigned            maxDepth
 ) {
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(nodeType);
-    return GetChildNode(templateNode, maxDepth);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(nodeType);
+    return GetChildNode(&templateNode, maxDepth);
 }
 
 //============================================================================
@@ -1225,11 +1225,11 @@ hsRef<RelVaultNode> RelVaultNode::GetChildFolderNode (
     unsigned            folderType,
     unsigned            maxDepth
 ) {
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_Folder);
-    VaultFolderNode folder(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_Folder);
+    VaultFolderNode folder(&templateNode);
     folder.SetFolderType(folderType);
-    return GetChildNode(templateNode, maxDepth);
+    return GetChildNode(&templateNode, maxDepth);
 }
 
 //============================================================================
@@ -1237,11 +1237,11 @@ hsRef<RelVaultNode> RelVaultNode::GetChildPlayerInfoListNode (
     unsigned            folderType,
     unsigned            maxDepth
 ) {
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_PlayerInfoList);
-    VaultPlayerInfoListNode access(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_PlayerInfoList);
+    VaultPlayerInfoListNode access(&templateNode);
     access.SetFolderType(folderType);
-    return GetChildNode(templateNode, maxDepth);
+    return GetChildNode(&templateNode, maxDepth);
 }
 
 //============================================================================
@@ -1249,11 +1249,11 @@ hsRef<RelVaultNode> RelVaultNode::GetChildAgeInfoListNode (
     unsigned            folderType,
     unsigned            maxDepth
 ) {
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_AgeInfoList);
-    VaultAgeInfoListNode access(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_AgeInfoList);
+    VaultAgeInfoListNode access(&templateNode);
     access.SetFolderType(folderType);
-    return GetChildNode(templateNode, maxDepth);
+    return GetChildNode(&templateNode, maxDepth);
 }
 
 //============================================================================
@@ -1301,10 +1301,10 @@ void RelVaultNode::GetChildNodes (
     unsigned                maxDepth,
     RelVaultNode::RefList * nodes
 ) {
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(nodeType);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(nodeType);
     GetChildNodes(
-        templateNode,
+        &templateNode,
         maxDepth,
         nodes
     );
@@ -1316,12 +1316,12 @@ void RelVaultNode::GetChildFolderNodes (
     unsigned                maxDepth,
     RelVaultNode::RefList * nodes
 ) {
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_Folder);
-    VaultFolderNode fldr(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_Folder);
+    VaultFolderNode fldr(&templateNode);
     fldr.SetFolderType(folderType);
     GetChildNodes(
-        templateNode,
+        &templateNode,
         maxDepth,
         nodes
     );
@@ -1443,14 +1443,13 @@ hsRef<RelVaultNode> RelVaultNode::GetParentAgeLink () {
     ASSERT(GetNodeType() == plVault::kNodeType_AgeInfo);
 
     hsRef<RelVaultNode> result;
-
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_AgeLink);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_AgeLink);
 
     // Get our parent AgeLink node  
-    if (hsRef<RelVaultNode> rvnLink = GetParentNode(templateNode, 1)) {
+    if (hsRef<RelVaultNode> rvnLink = GetParentNode(&templateNode, 1)) {
         // Get the next AgeLink node in our parent tree
-        result = rvnLink->GetParentNode(templateNode, 3);
+        result = rvnLink->GetParentNode(&templateNode, 3);
     }
 
     return result;
@@ -2090,11 +2089,11 @@ void VaultInitAge (
 
 //============================================================================
 static hsRef<RelVaultNode> GetPlayerNode () {
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_VNodeMgrPlayer);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_VNodeMgrPlayer);
     if (NetCommGetPlayer())
-        templateNode->SetNodeId(NetCommGetPlayer()->playerInt);
-    return VaultGetNode(templateNode);
+        templateNode.SetNodeId(NetCommGetPlayer()->playerInt);
+    return VaultGetNode(&templateNode);
 }
 
 //============================================================================
@@ -2117,13 +2116,13 @@ hsRef<RelVaultNode> VaultGetPlayerInfoNode () {
     if (!rvnPlr)
         return nullptr;
 
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
-    VaultPlayerInfoNode plrInfo(templateNode);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_PlayerInfo);
+    VaultPlayerInfoNode plrInfo(&templateNode);
     plrInfo.SetPlayerId(rvnPlr->GetNodeId());
 
     hsRef<RelVaultNode> result;
-    if (hsRef<RelVaultNode> rvnPlrInfo = rvnPlr->GetChildNode(templateNode, 1))
+    if (hsRef<RelVaultNode> rvnPlrInfo = rvnPlr->GetChildNode(&templateNode, 1))
         result = rvnPlrInfo;
 
     return result;
@@ -2177,14 +2176,14 @@ bool VaultGetLinkToMyNeighborhood (plAgeLinkStruct * link) {
     if (!rvnFldr)
         return false;
 
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    
-    templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-    VaultAgeInfoNode ageInfo(templateNode);
+    NetVaultNode templateNode;
+
+    templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
+    VaultAgeInfoNode ageInfo(&templateNode);
     ageInfo.SetAgeFilename(kNeighborhoodAgeFilename);
 
     hsRef<RelVaultNode> node;
-    if (node = rvnFldr->GetChildNode(templateNode, 2)) {
+    if (node = rvnFldr->GetChildNode(&templateNode, 2)) {
         VaultAgeInfoNode info(node);
         info.CopyTo(link->GetAgeInfo());
     }
@@ -2198,14 +2197,14 @@ bool VaultGetLinkToMyPersonalAge (plAgeLinkStruct * link) {
     if (!rvnFldr)
         return false;
 
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
+    NetVaultNode templateNode;
 
-    templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-    VaultAgeInfoNode ageInfo(templateNode);
+    templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
+    VaultAgeInfoNode ageInfo(&templateNode);
     ageInfo.SetAgeFilename(kPersonalAgeFilename);
 
     hsRef<RelVaultNode> node;
-    if (node = rvnFldr->GetChildNode(templateNode, 2)) {
+    if (node = rvnFldr->GetChildNode(&templateNode, 2)) {
         VaultAgeInfoNode info(node);
         info.CopyTo(link->GetAgeInfo());
     }
@@ -2219,14 +2218,14 @@ bool VaultGetLinkToCity (plAgeLinkStruct * link) {
     if (!rvnFldr)
         return false;
 
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
 
-    VaultAgeInfoNode ageInfo(templateNode);
+    VaultAgeInfoNode ageInfo(&templateNode);
     ageInfo.SetAgeFilename(kCityAgeFilename);
 
     hsRef<RelVaultNode> node;
-    if (node = rvnFldr->GetChildNode(templateNode, 2)) {
+    if (node = rvnFldr->GetChildNode(&templateNode, 2)) {
         VaultAgeInfoNode info(node);
         info.CopyTo(link->GetAgeInfo());
     }
@@ -2236,15 +2235,14 @@ bool VaultGetLinkToCity (plAgeLinkStruct * link) {
 
 //============================================================================
 hsRef<RelVaultNode> VaultGetOwnedAgeLink (const plAgeInfoStruct * info) {
-    
     hsRef<RelVaultNode> rvnLink;
-    
+
     if (hsRef<RelVaultNode> rvnFldr = VaultGetAgesIOwnFolder()) {
 
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
 
-        VaultAgeInfoNode ageInfo(templateNode);
+        VaultAgeInfoNode ageInfo(&templateNode);
         if (info->HasAgeFilename()) {
             ageInfo.SetAgeFilename(info->GetAgeFilename());
         }
@@ -2252,10 +2250,10 @@ hsRef<RelVaultNode> VaultGetOwnedAgeLink (const plAgeInfoStruct * info) {
             ageInfo.SetAgeInstanceGuid(*info->GetAgeInstanceGuid());
         }
 
-        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(templateNode, 2)) {
-            templateNode->Clear();
-            templateNode->SetNodeType(plVault::kNodeType_AgeLink);
-            rvnLink = rvnInfo->GetParentNode(templateNode, 1);
+        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(&templateNode, 2)) {
+            templateNode.Clear();
+            templateNode.SetNodeType(plVault::kNodeType_AgeLink);
+            rvnLink = rvnInfo->GetParentNode(&templateNode, 1);
         }
     }
     
@@ -2264,14 +2262,12 @@ hsRef<RelVaultNode> VaultGetOwnedAgeLink (const plAgeInfoStruct * info) {
 
 //============================================================================
 hsRef<RelVaultNode> VaultGetOwnedAgeInfo (const plAgeInfoStruct * info) {
-    
     hsRef<RelVaultNode> rvnInfo;
     if (hsRef<RelVaultNode> rvnFldr = VaultGetAgesIOwnFolder()) {
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
 
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-
-        VaultAgeInfoNode ageInfo(templateNode);
+        VaultAgeInfoNode ageInfo(&templateNode);
         if (info->HasAgeFilename()) {
             ageInfo.SetAgeFilename(info->GetAgeFilename());
         }
@@ -2279,7 +2275,7 @@ hsRef<RelVaultNode> VaultGetOwnedAgeInfo (const plAgeInfoStruct * info) {
             ageInfo.SetAgeInstanceGuid(*info->GetAgeInstanceGuid());
         }
 
-        rvnInfo = rvnFldr->GetChildNode(templateNode, 2);
+        rvnInfo = rvnFldr->GetChildNode(&templateNode, 2);
     }
     return rvnInfo;
 }
@@ -2321,17 +2317,17 @@ bool VaultAddOwnedAgeSpawnPoint (const plUUID& ageInstId, const plSpawnPointInfo
 
         TArray<unsigned> nodeIds;
         fldr->GetChildNodeIds(&nodeIds, 1);
-        
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-        VaultAgeInfoNode access(templateNode);
+
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
+        VaultAgeInfoNode access(&templateNode);
         access.SetAgeInstanceGuid(ageInstId);
         
         for (unsigned i = 0; i < nodeIds.Count(); ++i) {
             link = VaultGetNode(nodeIds[i]);
             if (!link)
                 continue;
-            if (link->GetChildNode(templateNode, 1)) {
+            if (link->GetChildNode(&templateNode, 1)) {
                 VaultAgeLinkNode access(link);
                 access.AddSpawnPoint(spawnPt);
                 link = nullptr;
@@ -2375,13 +2371,11 @@ bool VaultSetAgePublicAndWait (NetVaultNode * ageInfoNode, bool publicOrNot) {
 //============================================================================
 hsRef<RelVaultNode> VaultGetVisitAgeLink (const plAgeInfoStruct * info) {
     hsRef<RelVaultNode> rvnLink;
-    
     if (hsRef<RelVaultNode> rvnFldr = VaultGetAgesICanVisitFolder()) {
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
 
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-
-        VaultAgeInfoNode ageInfo(templateNode);
+        VaultAgeInfoNode ageInfo(&templateNode);
         if (info->HasAgeFilename()) {
             ageInfo.SetAgeFilename(info->GetAgeFilename());
         }
@@ -2389,10 +2383,10 @@ hsRef<RelVaultNode> VaultGetVisitAgeLink (const plAgeInfoStruct * info) {
             ageInfo.SetAgeInstanceGuid(*info->GetAgeInstanceGuid());
         }
 
-        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(templateNode, 2)) {
-            templateNode->Clear();
-            templateNode->SetNodeType(plVault::kNodeType_AgeLink);
-            rvnLink = rvnInfo->GetParentNode(templateNode, 1);
+        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(&templateNode, 2)) {
+            templateNode.Clear();
+            templateNode.SetNodeType(plVault::kNodeType_AgeLink);
+            rvnLink = rvnInfo->GetParentNode(&templateNode, 1);
         }
     }
     
@@ -3236,13 +3230,13 @@ hsRef<RelVaultNode> VaultFindChronicleEntry (const ST::string& entryName, int en
 
     hsRef<RelVaultNode> result;
     if (hsRef<RelVaultNode> rvnFldr = GetChildFolderNode(GetPlayerNode(), plVault::kChronicleFolder, 1)) {
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_Chronicle);
-        VaultChronicleNode chrn(templateNode);
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_Chronicle);
+        VaultChronicleNode chrn(&templateNode);
         chrn.SetEntryName(entryName);
         if (entryType >= 0)
             chrn.SetEntryType(entryType);
-        if (hsRef<RelVaultNode> rvnChrn = rvnFldr->GetChildNode(templateNode, 255))
+        if (hsRef<RelVaultNode> rvnChrn = rvnFldr->GetChildNode(&templateNode, 255))
             result = rvnChrn;
     }
     return result;
@@ -3266,14 +3260,14 @@ void VaultAddChronicleEntryAndWait (
         chrnNode.SetEntryValue(entryValue);
     }
     else if (hsRef<RelVaultNode> rvnFldr = GetChildFolderNode(GetPlayerNode(), plVault::kChronicleFolder, 1)) {
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_Chronicle);
-        VaultChronicleNode chrnNode(templateNode);
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_Chronicle);
+        VaultChronicleNode chrnNode(&templateNode);
         chrnNode.SetEntryName(entryName);
         chrnNode.SetEntryType(entryType);
         chrnNode.SetEntryValue(entryValue);
         ENetError result;
-        if (hsRef<RelVaultNode> rvnChrn = VaultCreateNodeAndWait(templateNode, &result))
+        if (hsRef<RelVaultNode> rvnChrn = VaultCreateNodeAndWait(&templateNode, &result))
             VaultAddChildNode(rvnFldr->GetNodeId(), rvnChrn->GetNodeId(), 0, nil, nil);
     }
 }
@@ -3282,12 +3276,12 @@ void VaultAddChronicleEntryAndWait (
 bool VaultAmIgnoringPlayer (unsigned playerId) {
     bool retval = false;
     if (hsRef<RelVaultNode> rvnFldr = GetChildPlayerInfoListNode(GetPlayerNode(), plVault::kIgnoreListFolder, 1)) {
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_PlayerInfo);
-        VaultPlayerInfoNode pinfoNode(templateNode);
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_PlayerInfo);
+        VaultPlayerInfoNode pinfoNode(&templateNode);
         pinfoNode.SetPlayerId(playerId);
 
-        if (rvnFldr->GetChildNode(templateNode, 1))
+        if (rvnFldr->GetChildNode(&templateNode, 1))
             retval = true;
     }
 
@@ -3470,11 +3464,11 @@ void VaultProcessPlayerInbox () {
     if (hsRef<RelVaultNode> rvnInbox = VaultGetPlayerInboxFolder()) {
         {   // Process new visit requests
             RelVaultNode::RefList visits;
-            hsRef<RelVaultNode> templateNode = new RelVaultNode;
-            templateNode->SetNodeType(plVault::kNodeType_TextNote);
-            VaultTextNoteNode tmpAcc(templateNode);
+            RelVaultNode templateNode;
+            templateNode.SetNodeType(plVault::kNodeType_TextNote);
+            VaultTextNoteNode tmpAcc(&templateNode);
             tmpAcc.SetNoteType(plVault::kNoteType_Visit);
-            rvnInbox->GetChildNodes(templateNode, 1, &visits);
+            rvnInbox->GetChildNodes(&templateNode, 1, &visits);
 
             for (const hsRef<RelVaultNode> &rvnVisit : visits) {
                 VaultTextNoteNode visitAcc(rvnVisit);
@@ -3518,23 +3512,20 @@ void VaultProcessPlayerInbox () {
 
 //============================================================================
 static hsRef<RelVaultNode> GetAgeNode () {
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_VNodeMgrAge);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_VNodeMgrAge);
     if (NetCommGetAge())
-        templateNode->SetNodeId(NetCommGetAge()->ageVaultId);
-    return VaultGetNode(templateNode);
+        templateNode.SetNodeId(NetCommGetAge()->ageVaultId);
+    return VaultGetNode(&templateNode);
 }
 
 //============================================================================
 hsRef<RelVaultNode> VaultGetAgeNode () {
-    hsRef<RelVaultNode> result;
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_VNodeMgrAge);
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_VNodeMgrAge);
     if (NetCommGetAge())
-        templateNode->SetNodeId(NetCommGetAge()->ageVaultId);
-    if (hsRef<RelVaultNode> rvnAge = VaultGetNode(templateNode))
-        result = rvnAge;
-    return result;
+        templateNode.SetNodeId(NetCommGetAge()->ageVaultId);
+    return VaultGetNode(&templateNode);
 }
 
 //============================================================================
@@ -3543,16 +3534,10 @@ static hsRef<RelVaultNode> GetAgeInfoNode () {
     if (!rvnAge)
         return nullptr;
 
-    hsRef<RelVaultNode> result;
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    
-    templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-    templateNode->SetCreatorId(rvnAge->GetNodeId());
-            
-    if (hsRef<RelVaultNode> rvnAgeInfo = rvnAge->GetChildNode(templateNode, 1))
-        result = rvnAgeInfo;
-    
-    return result;
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
+    templateNode.SetCreatorId(rvnAge->GetNodeId());
+    return rvnAge->GetChildNode(&templateNode, 1);
 }
 
 //============================================================================
@@ -3561,15 +3546,10 @@ hsRef<RelVaultNode> VaultGetAgeInfoNode () {
     if (!rvnAge)
         return nullptr;
 
-    hsRef<RelVaultNode> result;
-    hsRef<NetVaultNode> templateNode = new NetVaultNode;
-    templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-    templateNode->SetCreatorId(rvnAge->GetNodeId());
-            
-    if (hsRef<RelVaultNode> rvnAgeInfo = rvnAge->GetChildNode(templateNode, 1))
-        result = rvnAgeInfo;
-
-    return result;
+    NetVaultNode templateNode;
+    templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
+    templateNode.SetCreatorId(rvnAge->GetNodeId());
+    return rvnAge->GetChildNode(&templateNode, 1);
 }
 
 //============================================================================
@@ -3630,19 +3610,17 @@ hsRef<RelVaultNode> VaultAgeGetBookshelfFolder () {
 //============================================================================
 hsRef<RelVaultNode> VaultFindAgeSubAgeLink (const plAgeInfoStruct * info) {
     hsRef<RelVaultNode> rvnLink;
-    
     if (hsRef<RelVaultNode> rvnFldr = VaultGetAgeSubAgesFolder()) {
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
 
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-
-        VaultAgeInfoNode ageInfo(templateNode);
+        VaultAgeInfoNode ageInfo(&templateNode);
         ageInfo.SetAgeFilename(info->GetAgeFilename());
 
-        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(templateNode, 2)) {
-            templateNode->Clear();
-            templateNode->SetNodeType(plVault::kNodeType_AgeLink);
-            rvnLink = rvnInfo->GetParentNode(templateNode, 1);
+        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(&templateNode, 2)) {
+            templateNode.Clear();
+            templateNode.SetNodeType(plVault::kNodeType_AgeLink);
+            rvnLink = rvnInfo->GetParentNode(&templateNode, 1);
         }
     }
     
@@ -3695,11 +3673,11 @@ hsRef<RelVaultNode> VaultAgeAddDeviceAndWait (const ST::string& deviceName) {
 //============================================================================
 void VaultAgeRemoveDevice (const ST::string& deviceName) {
     if (hsRef<RelVaultNode> folder = VaultGetAgeDevicesFolder()) {
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_TextNote);
-        VaultTextNoteNode access(templateNode);
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_TextNote);
+        VaultTextNoteNode access(&templateNode);
         access.SetNoteTitle(deviceName);
-        if (hsRef<RelVaultNode> device = folder->GetChildNode(templateNode, 1)) {
+        if (hsRef<RelVaultNode> device = folder->GetChildNode(&templateNode, 1)) {
             VaultRemoveChildNode(folder->GetNodeId(), device->GetNodeId(), nil, nil);
 
             auto it = s_ageDeviceInboxes.find(deviceName);
@@ -3711,27 +3689,26 @@ void VaultAgeRemoveDevice (const ST::string& deviceName) {
 
 //============================================================================
 bool VaultAgeHasDevice (const ST::string& deviceName) {
-    bool found = false;
     if (hsRef<RelVaultNode> folder = VaultGetAgeDevicesFolder()) {
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_TextNote);
-        VaultTextNoteNode access(templateNode);
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_TextNote);
+        VaultTextNoteNode access(&templateNode);
         access.SetNoteTitle(deviceName);
-        if (folder->GetChildNode(templateNode, 1))
-            found = true;
+        if (folder->GetChildNode(&templateNode, 1))
+            return true;
     }
-    return found;
+    return false;
 }
 
 //============================================================================
 hsRef<RelVaultNode> VaultAgeGetDevice (const ST::string& deviceName) {
     hsRef<RelVaultNode> result;
     if (hsRef<RelVaultNode> folder = VaultGetAgeDevicesFolder()) {
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_TextNote);
-        VaultTextNoteNode access(templateNode);
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_TextNote);
+        VaultTextNoteNode access(&templateNode);
         access.SetNoteTitle(deviceName);
-        if (hsRef<RelVaultNode> device = folder->GetChildNode(templateNode, 1))
+        if (hsRef<RelVaultNode> device = folder->GetChildNode(&templateNode, 1))
             result = device;
     }
     return result;
@@ -3786,12 +3763,12 @@ hsRef<RelVaultNode> VaultAgeGetDeviceInbox (const ST::string& deviceName) {
             parentNode = VaultGetGlobalInbox();
 
         if (parentNode) {
-            hsRef<NetVaultNode> templateNode = new NetVaultNode;
-            templateNode->SetNodeType(plVault::kNodeType_Folder);
-            VaultFolderNode access(templateNode);
+            NetVaultNode templateNode;
+            templateNode.SetNodeType(plVault::kNodeType_Folder);
+            VaultFolderNode access(&templateNode);
             access.SetFolderType(plVault::kDeviceInboxFolder);
             access.SetFolderName(it->second);
-            result = parentNode->GetChildNode(templateNode, 1);
+            result = parentNode->GetChildNode(&templateNode, 1);
         }
     }
     return result;
@@ -3836,21 +3813,18 @@ unsigned VaultAgeGetAgeTime () {
 
 //============================================================================
 hsRef<RelVaultNode> VaultGetSubAgeLink (const plAgeInfoStruct * info) {
-    
     hsRef<RelVaultNode> rvnLink;
-    
     if (hsRef<RelVaultNode> rvnFldr = VaultGetAgeSubAgesFolder()) {
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
 
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
-
-        VaultAgeInfoNode ageInfo(templateNode);
+        VaultAgeInfoNode ageInfo(&templateNode);
         ageInfo.SetAgeFilename(info->GetAgeFilename());
 
-        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(templateNode, 2)) {
-            templateNode->Clear();
-            templateNode->SetNodeType(plVault::kNodeType_AgeLink);
-            rvnLink = rvnInfo->GetParentNode(templateNode, 1);
+        if (hsRef<RelVaultNode> rvnInfo = rvnFldr->GetChildNode(&templateNode, 2)) {
+            templateNode.Clear();
+            templateNode.SetNodeType(plVault::kNodeType_AgeLink);
+            rvnLink = rvnInfo->GetParentNode(&templateNode, 1);
         }
     }
     
@@ -4276,16 +4250,16 @@ bool VaultAgeFindOrCreateChildAgeLinkAndWait (
         
         // Check for existing child age in folder
         hsRef<RelVaultNode> rvnLink;
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_AgeInfo);
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_AgeInfo);
 
-        VaultAgeInfoNode ageInfo(templateNode);
+        VaultAgeInfoNode ageInfo(&templateNode);
         ageInfo.SetAgeFilename(info->GetAgeFilename());
 
-        if (hsRef<RelVaultNode> rvnInfo = rvnChildAges->GetChildNode(templateNode, 2)) {
-            templateNode->Clear();
-            templateNode->SetNodeType(plVault::kNodeType_AgeLink);
-            rvnLink = rvnInfo->GetParentNode(templateNode, 1);
+        if (hsRef<RelVaultNode> rvnInfo = rvnChildAges->GetChildNode(&templateNode, 2)) {
+            templateNode.Clear();
+            templateNode.SetNodeType(plVault::kNodeType_AgeLink);
+            rvnLink = rvnInfo->GetParentNode(&templateNode, 1);
         }
 
         if (rvnLink) {
@@ -4523,12 +4497,12 @@ uint8_t VaultAgeFindOrCreateChildAgeLink(
     uint8_t retval = hsFail;
     if (hsRef<RelVaultNode> rvnChildAges = rvnParentInfo->GetChildAgeInfoListNode(plVault::kChildAgesFolder, 1)) {
         // Search for our age
-        hsRef<NetVaultNode> temp = new NetVaultNode;
-        temp->SetNodeType(plVault::kNodeType_AgeInfo);
-        VaultAgeInfoNode theAge(temp);
+        NetVaultNode temp;
+        temp.SetNodeType(plVault::kNodeType_AgeInfo);
+        VaultAgeInfoNode theAge(&temp);
         theAge.SetAgeFilename(info->GetAgeFilename());
 
-        if (hsRef<RelVaultNode> rvnAgeInfo = rvnChildAges->GetChildNode(temp, 2)) {
+        if (hsRef<RelVaultNode> rvnAgeInfo = rvnChildAges->GetChildNode(&temp, 2)) {
             hsRef<RelVaultNode> rvnAgeLink = rvnAgeInfo->GetParentAgeLink();
 
             VaultAgeLinkNode accAgeLink(rvnAgeLink);
@@ -4676,9 +4650,9 @@ void VaultCull (unsigned vaultId) {
 hsRef<RelVaultNode> VaultGetSystemNode () {
     hsRef<RelVaultNode> result;
     if (hsRef<RelVaultNode> player = VaultGetPlayerNode()) {
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_System);
-        if (hsRef<RelVaultNode> systemNode = player->GetChildNode(templateNode, 1))
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_System);
+        if (hsRef<RelVaultNode> systemNode = player->GetChildNode(&templateNode, 1))
             result = systemNode;
     }
     return result;
@@ -4688,11 +4662,11 @@ hsRef<RelVaultNode> VaultGetSystemNode () {
 hsRef<RelVaultNode> VaultGetGlobalInbox () {
     hsRef<RelVaultNode> result;
     if (hsRef<RelVaultNode> system = VaultGetSystemNode()) {
-        hsRef<NetVaultNode> templateNode = new NetVaultNode;
-        templateNode->SetNodeType(plVault::kNodeType_Folder);
-        VaultFolderNode folder(templateNode);
+        NetVaultNode templateNode;
+        templateNode.SetNodeType(plVault::kNodeType_Folder);
+        VaultFolderNode folder(&templateNode);
         folder.SetFolderType(plVault::kGlobalInboxFolder);
-        if (hsRef<RelVaultNode> inbox = system->GetChildNode(templateNode, 1))
+        if (hsRef<RelVaultNode> inbox = system->GetChildNode(&templateNode, 1))
             result = inbox;
     }
     return result;


### PR DESCRIPTION
This changeset fixes a major source of memory leaks in the vault client API. Any time `hsRef<NetVaultNode> foo = new NetVaultNode;` was called resulted in a leak due to a change in behavior when the old AtomicRef was merged with hsRefCnt.