### PR TITLE
Fix some stats displays.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
@@ -379,7 +379,7 @@ void    plGBufferGroup::Read( hsStream *s )
 
             vData = new uint8_t[size];
             fVertBuffStorage.push_back( vData );
-            plProfile_NewMem(MemBufGrpVertex, temp);
+            plProfile_NewMem(MemBufGrpVertex, size);
 
             coder.Read(s, vData, fFormat, fStride, numVerts);
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXDeviceRefs.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXDeviceRefs.cpp
@@ -206,14 +206,7 @@ plDXTextureRef& plDXTextureRef::Set( D3DFORMAT ft, uint32_t ml, uint32_t mw, uin
     return *this;
 }
 
-//// Constructor & Destructor /////////////////////////////////////////////////
-
-plDXTextureRef::plDXTextureRef( D3DFORMAT ft, uint32_t ml, uint32_t mw, uint32_t mh, uint32_t np, 
-                                uint32_t sz, uint32_t manSize, uint32_t* lSz, void* pd, bool ed, bool renderTarget )
-                                : fD3DTexture(nullptr), fLevelSizes(nullptr), fOwner(nullptr)
-{
-    Set( ft, ml, mw, mh, np, sz, manSize, lSz, pd, ed, renderTarget );
-}
+//// Destructor /////////////////////////////////////////////////
 
 plDXTextureRef::~plDXTextureRef() 
 {

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXTextureRef.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXTextureRef.h
@@ -100,7 +100,17 @@ class plDXTextureRef : public plDXDeviceRef
 
         plDXTextureRef& Set( D3DFORMAT tp, uint32_t ml, uint32_t mw, uint32_t mh, uint32_t np, uint32_t sz, uint32_t manSize, uint32_t* lSz, void* pd, bool ed=false, bool renderTarget = false );
 
-        plDXTextureRef( D3DFORMAT tp, uint32_t ml, uint32_t mw, uint32_t mh, uint32_t np, uint32_t sz, uint32_t manSize, uint32_t* lSz, void* pd, bool ed=false, bool renderTarget = false );
+        plDXTextureRef()
+            : fD3DTexture(), fFormatType(), fMMLvs(), fMaxWidth(), fMaxHeight(), fNumPix(),
+              fDataSize(), fLevelSizes(), fOwner(), fData()
+        { }
+        plDXTextureRef( D3DFORMAT tp, uint32_t ml, uint32_t mw, uint32_t mh, uint32_t np, uint32_t sz, uint32_t manSize, uint32_t* lSz, void* pd, bool ed=false, bool renderTarget = false )
+            : fD3DTexture(), fFormatType(), fMMLvs(), fMaxWidth(), fMaxHeight(), fNumPix(),
+              fDataSize(), fLevelSizes(), fOwner(), fData()
+        {
+            Set(tp, ml, mw, mh, np, sz, manSize, lSz, pd, ed, renderTarget);
+        }
+
         virtual ~plDXTextureRef();
 
         void            Link( plDXTextureRef **back ) { plDXDeviceRef::Link( (plDXDeviceRef **)back ); }


### PR DESCRIPTION
This fixes issues with the texture and vertex buffer memory display. Previously, they displayed values that indicated underflow.