### PR TITLE
Remove hard-coded framecount for linking progress animation.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.cpp
@@ -134,3 +134,15 @@ plMipmap* plClientResMgr::getResource(const ST::string& resname)
 
     return resmipmap;
 }
+
+
+std::vector<ST::string> plClientResMgr::getResourceNames()
+{
+    std::vector<ST::string> names;
+    names.reserve(ClientResources.size());
+
+    for (const auto& resource : ClientResources)
+        names.push_back(resource.first);
+
+    return names;
+}

--- a/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.h
+++ b/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.h
@@ -60,6 +60,8 @@ public:
 
     plMipmap* getResource(const ST::string& resname);
 
+    std::vector<ST::string> getResourceNames();
+
     static plClientResMgr& Instance(void);
 };
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDTProgressMgr.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDTProgressMgr.h
@@ -61,7 +61,7 @@ class plPipeline;
 class plDTProgressMgr : public plProgressMgr
 {
     protected:
-        int32_t     fCurrentImage;
+        uint32_t    fCurrentImage;
         float       fLastDraw;
         plPlate*    fActivePlate;
         plPlate*    fStaticTextPlate;

--- a/Sources/Plasma/PubUtilLib/plProgressMgr/plProgressMgr.h
+++ b/Sources/Plasma/PubUtilLib/plProgressMgr/plProgressMgr.h
@@ -202,7 +202,7 @@ class plProgressMgr
     private:
 
         static plProgressMgr*    fManager;
-        static ST::string        fImageRotation[];
+        static std::vector<ST::string> fImageRotation;
         static const ST::string  fStaticTextIDs[];
 
     protected:
@@ -235,7 +235,7 @@ class plProgressMgr
         virtual ~plProgressMgr();
 
         static plProgressMgr* GetInstance() { return fManager; }
-        static const ST::string GetLoadingFrameID(int index);
+        static const ST::string GetLoadingFrameID(uint32_t index);
         uint32_t NumLoadingFrames() const;
         static const ST::string GetStaticTextID(StaticText staticTextType);
 


### PR DESCRIPTION
This fixes a long-standing crash which could occur if using a different `resource.dat` than one the client was hard-coded to expect.  Previously, the number of frames was dictated at compile-time.  This change allows the plProgressMgr to query for the list of resources, find the ones matching the given pattern, and subsequently use that sorted list as the IDs from which it builds and cycles the animation. 