### PR TITLE
Client Resource build enhancements.

### DIFF
--- a/Sources/Plasma/Apps/plClient/external/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/external/CMakeLists.txt
@@ -24,7 +24,10 @@ add_custom_command(
     COMMAND ${Make_Resource_Command}
     DEPENDS ${external_SOURCES} ${external_SCRIPTS}
 )
-add_custom_target(externalResources DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/resource.dat)
+add_custom_target(externalResources 
+    SOURCES ${external_SOURCES} ${external_SCRIPTS} 
+    DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/resource.dat
+)
 
 source_group("Source Files" FILES ${external_SOURCES})
 source_group("Script Files" FILES ${external_SCRIPTS})

--- a/Sources/Plasma/Apps/plClient/external/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/external/CMakeLists.txt
@@ -20,11 +20,11 @@ else(PLASMA_EXTERNAL_RELEASE)
 endif(PLASMA_EXTERNAL_RELEASE)
 
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/resource.dat
+    OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/resource.dat
     COMMAND ${Make_Resource_Command}
     DEPENDS ${external_SOURCES} ${external_SCRIPTS}
 )
-add_custom_target(externalResources DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/resource.dat)
+add_custom_target(externalResources DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/resource.dat)
 
 source_group("Source Files" FILES ${external_SOURCES})
 source_group("Script Files" FILES ${external_SCRIPTS})


### PR DESCRIPTION
This fixes the current behavior where the `resource.dat` file would always be rebuilt even if it had already been created and the dependencies had not changed, due to use of the wrong output directory in the CMake configuration.

It also adds the existing source groups (containing the scripts and images) as Sources for the custom target so that they are displayed and editable in Visual Studio.