### PR TITLE
Minor code style cleanup

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -1319,7 +1319,7 @@ void    plClient::IStartProgress( const char *title, float len )
 
 
 //============================================================================
-void    plClient::IStopProgress( void )
+void    plClient::IStopProgress()
 {
     if (fProgressBar)
     {
@@ -1486,7 +1486,7 @@ bool plClient::BeginGame()
 }
 
 //============================================================================
-void    plClient::IPatchGlobalAgeFiles( void )
+void    plClient::IPatchGlobalAgeFiles()
 {
     plgDispatch::Dispatch()->RegisterForExactType(plResPatcherMsg::Index(), GetKey());
 

--- a/Sources/Plasma/Apps/plClient/plClient.h
+++ b/Sources/Plasma/Apps/plClient/plClient.h
@@ -85,7 +85,7 @@ class plNetCommAuthMsg;
 class plAgeLoaded2Msg;
 class plResPatcherMsg;
 
-typedef void (*plMessagePumpProc)( void );
+typedef void (*plMessagePumpProc)();
 
 class plClient : public hsKeyedObject
 {
@@ -192,13 +192,13 @@ protected:
 
     void    IStartProgress( const char *title, float len );
     void    IIncProgress( float byHowMuch, const char *text );
-    void    IStopProgress( void );
+    void    IStopProgress();
 
     static void IDispatchMsgReceiveCallback();
     static void IReadKeyedObjCallback(plKey key);
     static void IProgressMgrCallbackProc( plOperationProgress *progress );
 
-    void    IPatchGlobalAgeFiles( void );
+    void    IPatchGlobalAgeFiles();
 
     int IFindRoomByLoc(const plLocation& loc);
     bool IIsRoomLoading(const plLocation& loc);

--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -362,7 +362,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     return DefWindowProc(hWnd, message, wParam, lParam);
 }
  
-void    PumpMessageQueueProc( void )
+void    PumpMessageQueueProc()
 {
     MSG msg;
 

--- a/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
+++ b/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
@@ -70,7 +70,7 @@ void PrintVersion()
 
 //// PrintHelp ///////////////////////////////////////////////////////////////
 
-int PrintHelp( void )
+int PrintHelp()
 {
     puts("");
     PrintVersion();

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
@@ -311,7 +311,7 @@ void plClientLauncher::PatchClient()
     patcher->Start();
 }
 
-bool plClientLauncher::CompleteSelfPatch(std::function<void(void)> waitProc) const
+bool plClientLauncher::CompleteSelfPatch(std::function<void()> waitProc) const
 {
     if (hsCheckBits(fFlags, kHaveSelfPatched))
         return false;

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
@@ -52,7 +52,7 @@ Mead, WA   99021
 class plClientLauncher
 {
 public:
-    typedef std::function<class pfPatcher*(void)> CreatePatcherFunc;
+    typedef std::function<class pfPatcher*()> CreatePatcherFunc;
     typedef std::function<void(ENetError, const ST::string&)> ErrorFunc;
     typedef std::function<bool(const plFileName&)> InstallRedistFunc;
     typedef std::function<void(const plFileName&, const ST::string&)> LaunchClientFunc;
@@ -115,7 +115,7 @@ public:
      *  here, then we need to relaunch ourselves so that the game client will look like what the server expects.
      *  \returns True if a self-patch was completed. False if not.
      */
-    bool CompleteSelfPatch(std::function<void(void)> waitProc) const;
+    bool CompleteSelfPatch(std::function<void()> waitProc) const;
 
     /** Start eap's weird network subsystem and the shard status pinger.
      *  \remarks Please note that this will also enqueue the first patch.

--- a/Sources/Plasma/CoreLib/hsMatrix44.cpp
+++ b/Sources/Plasma/CoreLib/hsMatrix44.cpp
@@ -819,7 +819,7 @@ hsPoint3*  hsMatrix44::MapPoints(long count, hsPoint3 points[]) const
     return points;
 }
 
-bool hsMatrix44::IsIdentity(void)
+bool hsMatrix44::IsIdentity()
 {
     bool retVal = true;
     int i, j;

--- a/Sources/Plasma/CoreLib/hsMatrix44.h
+++ b/Sources/Plasma/CoreLib/hsMatrix44.h
@@ -140,7 +140,7 @@ struct hsMatrix44 {
     
     hsPoint3*           MapPoints(long count, hsPoint3 points[]) const;
     
-    bool  IsIdentity(void);
+    bool  IsIdentity();
     void  NotIdentity() { fFlags &= ~kIsIdent; }
 
     bool operator==(const hsMatrix44& ss) const;

--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -763,7 +763,7 @@ void    plReadOnlySubStream::Open( hsStream *base, uint32_t offset, uint32_t len
     IFixPosition();
 }
 
-void    plReadOnlySubStream::IFixPosition( void )
+void    plReadOnlySubStream::IFixPosition()
 {
     fPosition = fBase->GetPosition() - fOffset;
 }

--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -317,7 +317,7 @@ class plReadOnlySubStream: public hsStream
     hsStream    *fBase;
     uint32_t      fOffset, fLength;
 
-    void    IFixPosition( void );
+    void    IFixPosition();
 
 public:
     plReadOnlySubStream(): fBase( nil ), fOffset( 0 ), fLength( 0 ) {}

--- a/Sources/Plasma/CoreLib/hsStringTokenizer.cpp
+++ b/Sources/Plasma/CoreLib/hsStringTokenizer.cpp
@@ -122,7 +122,7 @@ bool  hsStringTokenizer::Next( char *token, uint32_t maxTokLen )
 }
 
 // Restores the last character replaced to generate a terminator
-void    hsStringTokenizer::RestoreLastTerminator( void )
+void    hsStringTokenizer::RestoreLastTerminator()
 {
     if( fLastTerminator != nil )
     {
@@ -247,7 +247,7 @@ bool  hsWStringTokenizer::Next( wchar_t *token, uint32_t maxTokLen )
 }
 
 // Restores the last character replaced to generate a terminator
-void    hsWStringTokenizer::RestoreLastTerminator( void )
+void    hsWStringTokenizer::RestoreLastTerminator()
 {
     if( fLastTerminator != nil )
     {

--- a/Sources/Plasma/CoreLib/hsStringTokenizer.h
+++ b/Sources/Plasma/CoreLib/hsStringTokenizer.h
@@ -71,11 +71,11 @@ public:
     void Reset(const char *string, const char *seps);
     void ParseQuotes(bool qAsTok);
 
-    char    *GetRestOfString( void ) const { return fTok; }
+    char    *GetRestOfString() const { return fTok; }
 
     char *fString;
 
-    void    RestoreLastTerminator( void );
+    void    RestoreLastTerminator();
 
 private:
     bool IsSep(char c);
@@ -102,11 +102,11 @@ public:
     void Reset(const wchar_t *string, const wchar_t *seps);
     void ParseQuotes(bool qAsTok);
 
-    wchar_t   *GetRestOfString( void ) const { return fTok; }
+    wchar_t   *GetRestOfString() const { return fTok; }
 
     wchar_t *fString;
 
-    void    RestoreLastTerminator( void );
+    void    RestoreLastTerminator();
 
 private:
     bool IsSep(wchar_t c);

--- a/Sources/Plasma/CoreLib/hsTemplates.cpp
+++ b/Sources/Plasma/CoreLib/hsTemplates.cpp
@@ -224,7 +224,7 @@ void LargeArrayStats()
 
 char * hsTArrayBase::GetTypeName() { return ""; }
 
-int   hsTArrayBase::GetSizeOf(void) { return 0; }
+int   hsTArrayBase::GetSizeOf() { return 0; }
 
 hsTArrayBase::hsTArrayBase():fUseCount(0), fTotalCount(0)
 {
@@ -243,7 +243,7 @@ hsTArrayBase::~hsTArrayBase()
 
 char * hsLargeArrayBase::GetTypeName() { return ""; }
 
-int   hsLargeArrayBase::GetSizeOf(void) { return 0; }
+int   hsLargeArrayBase::GetSizeOf() { return 0; }
 
 hsLargeArrayBase::hsLargeArrayBase():fUseCount(0), fTotalCount(0)
 {

--- a/Sources/Plasma/CoreLib/pcSmallRect.h
+++ b/Sources/Plasma/CoreLib/pcSmallRect.h
@@ -65,10 +65,10 @@ class pcSmallRect
         pcSmallRect( int16_t x, int16_t y, int16_t w, int16_t h ) { Set( x, y, w, h ); }
         
         void    Set( int16_t x, int16_t y, int16_t w, int16_t h ) { fX = x; fY = y; fWidth = w; fHeight = h; }
-        void    Empty( void ) { fX = fY = fWidth = fHeight = 0; }
+        void    Empty() { fX = fY = fWidth = fHeight = 0; }
 
-        int16_t   GetRight( void ) const { return fX + fWidth; }
-        int16_t   GetBottom( void ) const { return fY + fHeight; }
+        int16_t   GetRight() const { return fX + fWidth; }
+        int16_t   GetBottom() const { return fY + fHeight; }
 
         void    Read( hsStream *s );
         void    Write( hsStream *s );

--- a/Sources/Plasma/FeatureLib/pfAnimation/pfObjectFlocker.h
+++ b/Sources/Plasma/FeatureLib/pfAnimation/pfObjectFlocker.h
@@ -121,7 +121,7 @@ private:
 
 public:
     // constructor
-    pfBasicProximityDatabase(void) {}
+    pfBasicProximityDatabase() {}
 
     // destructor
     virtual ~pfBasicProximityDatabase() {}
@@ -130,7 +130,7 @@ public:
     tokenType *MakeToken(T parentObject) {return new tokenType(parentObject, fGroup);}
 
     // return the number of tokens currently in the database
-    int Size(void) {return fGroup.size();}
+    int Size() {return fGroup.size();}
 };
 
 // A basic vehicle class that handles accelleration, braking, and turning

--- a/Sources/Plasma/FeatureLib/pfAudio/plListener.cpp
+++ b/Sources/Plasma/FeatureLib/pfAudio/plListener.cpp
@@ -216,7 +216,7 @@ void    plListener::ISetRef( const plKey &ref, bool binding, int type )
         GetKey()->Release( ref );
 }
 
-void    plListener::IEnsureVCamValid( void )
+void    plListener::IEnsureVCamValid()
 {
     if( fPosRatio == 1.f && fFacingRatio == 1.f && fVelRatio == 1.f )
     {
@@ -241,7 +241,7 @@ void    plListener::IEnsureVCamValid( void )
     }
 }
 
-void    plListener::ICheckAudio( void ) const
+void    plListener::ICheckAudio() const
 {
     if( ( fPosRatio < 1.f || fFacingRatio < 1.f || fVelRatio < 1.f ) && fVCam == nil )
         plgAudioSys::SetMuted( true );

--- a/Sources/Plasma/FeatureLib/pfAudio/plListener.h
+++ b/Sources/Plasma/FeatureLib/pfAudio/plListener.h
@@ -52,8 +52,8 @@ class plListener : public plSingleModifier
 {
 public:
 
-    plListener() :  fVCam(nil), fInitMe(true){;}
-    ~plListener(){;}
+    plListener() :  fVCam(nil), fInitMe(true) { }
+    ~plListener() { }
 
     CLASSNAME_REGISTER( plListener );
     GETINTERFACE_ANY( plListener, plSingleModifier );

--- a/Sources/Plasma/FeatureLib/pfAudio/plListener.h
+++ b/Sources/Plasma/FeatureLib/pfAudio/plListener.h
@@ -90,9 +90,9 @@ protected:
 
     virtual bool    IEval(double secs, float del, uint32_t dirty);
     void            ISetRef( const plKey &ref, bool binding, int type );
-    void            ICheckAudio( void ) const;
+    void            ICheckAudio() const;
 
-    void            IEnsureVCamValid( void );
+    void            IEnsureVCamValid();
 };
 
 #endif //plWin32Sound_h

--- a/Sources/Plasma/FeatureLib/pfCamera/plInterestingModifier.h
+++ b/Sources/Plasma/FeatureLib/pfCamera/plInterestingModifier.h
@@ -71,7 +71,7 @@ protected:
     
 public:
     plInterestingModifier(){ fType = kTypeInteresting;}
-    virtual ~plInterestingModifier(){;}
+    virtual ~plInterestingModifier() { }
     
     virtual bool MsgReceive(plMessage* msg) {return false;}
 

--- a/Sources/Plasma/FeatureLib/pfConditional/plActivatorConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plActivatorConditionalObject.h
@@ -57,14 +57,14 @@ protected:
 public:
     
     plActivatorConditionalObject();
-    ~plActivatorConditionalObject(){;}
+    ~plActivatorConditionalObject() { }
     
     CLASSNAME_REGISTER( plActivatorConditionalObject );
     GETINTERFACE_ANY( plActivatorConditionalObject, plConditionalObject );
     
     virtual bool MsgReceive(plMessage* msg);
     
-    void Evaluate(){;}
+    void Evaluate() { }
     void SetActivatorKey(plKey k);
     void Reset() { SetSatisfied(false); }
 
@@ -77,8 +77,8 @@ class plActivatorActivatorConditionalObject : public plActivatorConditionalObjec
 {
 public:
     
-    plActivatorActivatorConditionalObject(){;}
-    ~plActivatorActivatorConditionalObject(){;}
+    plActivatorActivatorConditionalObject() { }
+    ~plActivatorActivatorConditionalObject() { }
     
     CLASSNAME_REGISTER( plActivatorActivatorConditionalObject );
     GETINTERFACE_ANY( plActivatorActivatorConditionalObject, plActivatorConditionalObject );
@@ -92,8 +92,8 @@ class plVolActivatorConditionalObject : public plActivatorConditionalObject
 {
 public:
     
-    plVolActivatorConditionalObject(){;}
-    ~plVolActivatorConditionalObject(){;}
+    plVolActivatorConditionalObject() { }
+    ~plVolActivatorConditionalObject() { }
     
     CLASSNAME_REGISTER( plVolActivatorConditionalObject );
     GETINTERFACE_ANY( plVolActivatorConditionalObject, plActivatorConditionalObject );

--- a/Sources/Plasma/FeatureLib/pfConditional/plAnimationEventConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plAnimationEventConditionalObject.h
@@ -56,9 +56,9 @@ protected:
 public:
     
     
-    plAnimationEventConditionalObject(){;}
+    plAnimationEventConditionalObject() { }
     plAnimationEventConditionalObject(plKey pTargetModifier);
-    ~plAnimationEventConditionalObject(){;}
+    ~plAnimationEventConditionalObject() { }
     
     CLASSNAME_REGISTER( plAnimationEventConditionalObject );
     GETINTERFACE_ANY( plAnimationEventConditionalObject, plConditionalObject );
@@ -68,7 +68,7 @@ public:
 
     bool MsgReceive(plMessage* msg);
     
-    void Evaluate(){;}
+    void Evaluate() { }
     void Reset() { SetSatisfied(false); }
 
     void SetEvent(const CallbackEvent b, float time = 0.0f);

--- a/Sources/Plasma/FeatureLib/pfConditional/plControlEventConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plControlEventConditionalObject.h
@@ -55,7 +55,7 @@ protected:
 public:
     
     plControlEventConditionalObject();
-    ~plControlEventConditionalObject(){;}
+    ~plControlEventConditionalObject() { }
     
     CLASSNAME_REGISTER( plControlEventConditionalObject );
     GETINTERFACE_ANY( plControlEventConditionalObject, plConditionalObject );
@@ -66,7 +66,7 @@ public:
 
     bool MsgReceive(plMessage* msg);
     
-    void Evaluate(){;}
+    void Evaluate() { }
     void Reset() { SetSatisfied(false); }
 
     ControlEventCode fControlEvent;

--- a/Sources/Plasma/FeatureLib/pfConditional/plFacingConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plFacingConditionalObject.h
@@ -56,7 +56,7 @@ protected:
 public:
     
     plFacingConditionalObject();
-    ~plFacingConditionalObject(){;}
+    ~plFacingConditionalObject() { }
     
     CLASSNAME_REGISTER( plFacingConditionalObject );
     GETINTERFACE_ANY( plFacingConditionalObject, plConditionalObject );
@@ -68,7 +68,7 @@ public:
 
     virtual bool Verify(plMessage* msg);
 
-    void Evaluate(){;}
+    void Evaluate() { }
     void Reset() { SetSatisfied(true); }
 
     virtual void Read(hsStream* stream, hsResMgr* mgr);

--- a/Sources/Plasma/FeatureLib/pfConditional/plKeyPressConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plKeyPressConditionalObject.h
@@ -56,7 +56,7 @@ protected:
 public:
     
     plKeyPressConditionalObject();
-    ~plKeyPressConditionalObject(){;}
+    ~plKeyPressConditionalObject() { }
     
     CLASSNAME_REGISTER( plKeyPressConditionalObject );
     GETINTERFACE_ANY( plKeyPressConditionalObject, plConditionalObject );
@@ -66,7 +66,7 @@ public:
 
     bool MsgReceive(plMessage* msg);
     
-    void Evaluate(){;}
+    void Evaluate() { }
     void Reset() { SetSatisfied(false); }
     void SetKeyEvent(const plKeyDef k ) { fKeyEvent = k; }
 

--- a/Sources/Plasma/FeatureLib/pfConditional/plLocalPlayerInBoxConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plLocalPlayerInBoxConditionalObject.h
@@ -56,7 +56,7 @@ protected:
 public:
     
     plLocalPlayerInBoxConditionalObject();
-    ~plLocalPlayerInBoxConditionalObject(){;}
+    ~plLocalPlayerInBoxConditionalObject() { }
     
     CLASSNAME_REGISTER( plLocalPlayerInBoxConditionalObject );
     GETINTERFACE_ANY( plLocalPlayerInBoxConditionalObject, plConditionalObject );
@@ -65,7 +65,7 @@ public:
 
     void SetBox(plKey pKey) { fBox = pKey; }
     
-    void Evaluate(){;}
+    void Evaluate() { }
     void Reset() { SetSatisfied(false); }
 
 };

--- a/Sources/Plasma/FeatureLib/pfConditional/plLocalPlayerIntersectPlaneConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plLocalPlayerIntersectPlaneConditionalObject.h
@@ -56,7 +56,7 @@ protected:
 public:
     
     plLocalPlayerIntersectPlaneConditionalObject();
-    ~plLocalPlayerIntersectPlaneConditionalObject(){;}
+    ~plLocalPlayerIntersectPlaneConditionalObject() { }
     
     CLASSNAME_REGISTER( plLocalPlayerIntersectPlaneConditionalObject );
     GETINTERFACE_ANY( plLocalPlayerIntersectPlaneConditionalObject, plConditionalObject );
@@ -66,7 +66,7 @@ public:
     void SetTarget(plKey pKey) { fTarget = pKey; }
     void SetPlane(plKey pKey) { fPlane = pKey; }
     
-    void Evaluate(){;}
+    void Evaluate() { }
     void Reset() { SetSatisfied(false); }
 
 };

--- a/Sources/Plasma/FeatureLib/pfConditional/plORConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plORConditionalObject.h
@@ -65,7 +65,7 @@ public:
     virtual bool Satisfied(); 
 
     virtual bool MsgReceive(plMessage* msg);
-    void Evaluate(){;}
+    void Evaluate() { }
     void Reset();
 
     virtual void SetLogicMod(plLogicModBase* pMod);

--- a/Sources/Plasma/FeatureLib/pfConditional/plObjectInBoxConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plObjectInBoxConditionalObject.h
@@ -59,14 +59,14 @@ protected:
 public:
     
     plObjectInBoxConditionalObject();
-    ~plObjectInBoxConditionalObject(){;}
+    ~plObjectInBoxConditionalObject() { }
     
     CLASSNAME_REGISTER( plObjectInBoxConditionalObject );
     GETINTERFACE_ANY( plObjectInBoxConditionalObject, plConditionalObject );
     
     bool MsgReceive(plMessage* msg);
 
-    void Evaluate(){;}
+    void Evaluate() { }
     void Reset() { SetSatisfied(false); }
     virtual bool Satisfied() { return true; }
     virtual bool Verify(plMessage* msg);
@@ -103,7 +103,7 @@ public:
     };
 
     plVolumeSensorConditionalObject();
-    ~plVolumeSensorConditionalObject(){;}
+    ~plVolumeSensorConditionalObject() { }
 
     CLASSNAME_REGISTER(plVolumeSensorConditionalObject);
     GETINTERFACE_ANY(plVolumeSensorConditionalObject, plConditionalObject);

--- a/Sources/Plasma/FeatureLib/pfConditional/plObjectIntersectPlaneConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plObjectIntersectPlaneConditionalObject.h
@@ -56,7 +56,7 @@ protected:
 public:
     
     plObjectIntersectPlaneConditionalObject();
-    ~plObjectIntersectPlaneConditionalObject(){;}
+    ~plObjectIntersectPlaneConditionalObject() { }
     
     CLASSNAME_REGISTER( plObjectIntersectPlaneConditionalObject );
     GETINTERFACE_ANY( plObjectIntersectPlaneConditionalObject, plConditionalObject );
@@ -66,7 +66,7 @@ public:
     void SetTarget(plKey pKey) { fTarget = pKey; }
     void SetPlane(plKey pKey) { fPlane = pKey; }
     
-    void Evaluate(){;}
+    void Evaluate() { }
     void Reset() { SetSatisfied(false); }
 
 };

--- a/Sources/Plasma/FeatureLib/pfConditional/plPickedConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plPickedConditionalObject.h
@@ -55,14 +55,14 @@ protected:
 public:
     
     plPickedConditionalObject();
-    ~plPickedConditionalObject(){;}
+    ~plPickedConditionalObject() { }
     
     CLASSNAME_REGISTER( plPickedConditionalObject );
     GETINTERFACE_ANY( plPickedConditionalObject, plConditionalObject );
     
     bool MsgReceive(plMessage* msg);
     
-    void Evaluate(){;}
+    void Evaluate() { }
     void Reset() { SetSatisfied(false); }
 
 };

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -137,9 +137,9 @@ class pfConsoleInputInterface : public plInputInterface
             // RestoreDefaultKeyMappings()!!!!
         }
 
-        virtual uint32_t  GetPriorityLevel( void ) const          { return kConsolePriority; }
-        virtual uint32_t  GetCurrentCursorID( void ) const        { return kCursorHidden; }
-        virtual bool    HasInterestingCursorID( void ) const    { return false; }
+        virtual uint32_t  GetPriorityLevel() const          { return kConsolePriority; }
+        virtual uint32_t  GetCurrentCursorID() const        { return kCursorHidden; }
+        virtual bool    HasInterestingCursorID() const    { return false; }
 
         virtual bool    InterpretInputEvent( plInputEventMsg *pMsg )
         {
@@ -156,11 +156,11 @@ class pfConsoleInputInterface : public plInputInterface
             return false;
         }
 
-        virtual void    RefreshKeyMap( void )
+        virtual void    RefreshKeyMap()
         {
         }
 
-        virtual void    RestoreDefaultKeyMappings( void )
+        virtual void    RestoreDefaultKeyMappings()
         {
             if( fControlMap != nil )
             {
@@ -791,7 +791,7 @@ void    pfConsole::IAddParagraph( const char *s, short margin )
 
 //// IClear //////////////////////////////////////////////////////////////////
 
-void    pfConsole::IClear( void )
+void    pfConsole::IClear()
 {
     memset( fDisplayBuffer, 0, kMaxCharsWide * fNumDisplayLines );
 }
@@ -979,7 +979,7 @@ void    pfConsole::Draw( plPipeline *p )
 
 //// IUpdateTooltip //////////////////////////////////////////////////////////
 
-void    pfConsole::IUpdateTooltip( void )
+void    pfConsole::IUpdateTooltip()
 {
     char    tmpStr[ kWorkingLineSize ];
     char    *c;
@@ -997,7 +997,7 @@ void    pfConsole::IUpdateTooltip( void )
 
 //// IPrintSomeHelp //////////////////////////////////////////////////////////
 
-void    pfConsole::IPrintSomeHelp( void )
+void    pfConsole::IPrintSomeHelp()
 {
     char    msg1[] = "The console contains commands arranged under groups and subgroups. \
 To use a command, you type the group name plus the command, such as 'Console.Clear' or \

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.h
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.h
@@ -123,14 +123,14 @@ class pfConsole : public hsKeyedObject
 
         void    IAddLine( const char *string, short leftMargin = 0 );
         void    IAddParagraph( const char *string, short margin = 0 );
-        void    IClear( void );
+        void    IClear();
 
         void    ISetMode( uint8_t mode );
         void    IEnableFX( bool e ) { fFXEnabled = e; }
-        bool    IFXEnabled( void ) { return fFXEnabled; }
+        bool    IFXEnabled() { return fFXEnabled; }
 
-        void    IPrintSomeHelp( void );
-        void    IUpdateTooltip( void );
+        void    IPrintSomeHelp();
+        void    IUpdateTooltip();
 
     public:
 
@@ -149,16 +149,16 @@ class pfConsole : public hsKeyedObject
 
         static void AddLine( const char *string ) { fTheConsole->IAddParagraph( string ); }
         static void AddLineF(const char * fmt, ...);
-        static void Clear( void ) { fTheConsole->IClear(); }
-        static void Hide( void ) { fTheConsole->ISetMode(kModeHidden); }
+        static void Clear() { fTheConsole->IClear(); }
+        static void Hide() { fTheConsole->ISetMode(kModeHidden); }
 
         static void EnableEffects( bool enable ) { fTheConsole->IEnableFX( enable ); }
-        static bool AreEffectsEnabled( void ) { return fTheConsole->IFXEnabled(); }
+        static bool AreEffectsEnabled() { return fTheConsole->IFXEnabled(); }
         static void SetTextColor( uint32_t color ) { fConsoleTextColor = color; }
         static uint32_t GetTextColor() { return fConsoleTextColor; }
 
         static void         SetPipeline( plPipeline *pipe ) { fPipeline = pipe; }
-        static plPipeline   *GetPipeline( void ) { return fPipeline; }
+        static plPipeline   *GetPipeline() { return fPipeline; }
         
         static void RunCommandAsync (const char cmd[]);
 };

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.cpp
@@ -101,7 +101,7 @@ pfConsoleCmdGroup::~pfConsoleCmdGroup()
 
 //// GetBaseGroup ////////////////////////////////////////////////////////////
 
-pfConsoleCmdGroup   *pfConsoleCmdGroup::GetBaseGroup( void )
+pfConsoleCmdGroup   *pfConsoleCmdGroup::GetBaseGroup()
 {
     if( fBaseCmdGroup == nil )
     {
@@ -114,7 +114,7 @@ pfConsoleCmdGroup   *pfConsoleCmdGroup::GetBaseGroup( void )
 
 //// DecBaseCmdGroupRef //////////////////////////////////////////////////////
 
-void    pfConsoleCmdGroup::DecBaseCmdGroupRef( void )
+void    pfConsoleCmdGroup::DecBaseCmdGroupRef()
 {
     fBaseCmdGroupRef--;
     if( fBaseCmdGroupRef == 0 )
@@ -330,7 +330,7 @@ void    pfConsoleCmdGroup::Link( pfConsoleCmdGroup **prevPtr )
     *fPrevPtr = this;
 }
 
-void    pfConsoleCmdGroup::Unlink( void )
+void    pfConsoleCmdGroup::Unlink()
 {
     hsAssert( fNext != nil || fPrevPtr != nil, "Trying to unlink console group that isn't linked!" );
 
@@ -499,7 +499,7 @@ void    pfConsoleCmd::Register(const char *group, const char *name )
 
 //// Unregister //////////////////////////////////////////////////////////////
 
-void    pfConsoleCmd::Unregister( void )
+void    pfConsoleCmd::Unregister()
 {
     Unlink();
     pfConsoleCmdGroup::DecBaseCmdGroupRef();
@@ -526,7 +526,7 @@ void    pfConsoleCmd::Link( pfConsoleCmd **prevPtr )
     *fPrevPtr = this;
 }
 
-void    pfConsoleCmd::Unlink( void )
+void    pfConsoleCmd::Unlink()
 {
     hsAssert( fNext != nil || fPrevPtr != nil, "Trying to unlink console command that isn't linked!" );
 
@@ -562,7 +562,7 @@ uint8_t   pfConsoleCmd::GetSigEntry( uint8_t i )
 //  WARNING: uses a static buffer, so don't rely on the contents if you call
 //  it more than once! (You shouldn't need to, though)
 
-const char  *pfConsoleCmd::GetSignature( void )
+const char  *pfConsoleCmd::GetSignature()
 {
     static char string[256];
     
@@ -594,7 +594,7 @@ const char  *pfConsoleCmd::GetSignature( void )
 
 //// Conversion Functions ////////////////////////////////////////////////////
 
-const int & pfConsoleCmdParam::IToInt( void ) const
+const int & pfConsoleCmdParam::IToInt() const
 {
     hsAssert( fType == kInt || fType == kAny, "Trying to use a non-int parameter as an int!" );
 
@@ -609,7 +609,7 @@ const int & pfConsoleCmdParam::IToInt( void ) const
     return fValue.i;
 }
 
-const float &   pfConsoleCmdParam::IToFloat( void ) const
+const float &   pfConsoleCmdParam::IToFloat() const
 {
     hsAssert( fType == kFloat || fType == kAny, "Trying to use a non-float parameter as a float!" );
 
@@ -624,7 +624,7 @@ const float &   pfConsoleCmdParam::IToFloat( void ) const
     return fValue.f;
 }
 
-const bool &    pfConsoleCmdParam::IToBool( void ) const
+const bool &    pfConsoleCmdParam::IToBool() const
 {
     hsAssert( fType == kBool || fType == kAny, "Trying to use a non-bool parameter as a bool!" );
 
@@ -643,14 +643,14 @@ const bool &    pfConsoleCmdParam::IToBool( void ) const
     return fValue.b;
 }
 
-const pfConsoleCmdParam::CharPtr &  pfConsoleCmdParam::IToString( void ) const
+const pfConsoleCmdParam::CharPtr &  pfConsoleCmdParam::IToString() const
 {
     hsAssert( fType == kString || fType == kAny, "Trying to use a non-string parameter as a string!" );
 
     return fValue.s;
 }
 
-const char &    pfConsoleCmdParam::IToChar( void ) const
+const char &    pfConsoleCmdParam::IToChar() const
 {
     hsAssert( fType == kChar || fType == kAny, "Trying to use a non-char parameter as a char!" );
 

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.h
@@ -90,13 +90,13 @@ class pfConsoleCmdGroup
         void    AddSubGroup( pfConsoleCmdGroup *group );
 
         void    Link( pfConsoleCmdGroup **prevPtr );
-        void    Unlink( void );
+        void    Unlink();
 
-        pfConsoleCmdGroup   *GetNext( void ) { return fNext; }
-        char                *GetName( void ) { return fName; }
-        pfConsoleCmdGroup   *GetParent( void ) { return fParentGroup; }
+        pfConsoleCmdGroup   *GetNext() { return fNext; }
+        char                *GetName() { return fName; }
+        pfConsoleCmdGroup   *GetParent() { return fParentGroup; }
 
-        static pfConsoleCmdGroup    *GetBaseGroup( void );
+        static pfConsoleCmdGroup    *GetBaseGroup();
 
         pfConsoleCmd        *FindCommand( const char *name );
         pfConsoleCmd        *FindCommandNoCase( const char *name, uint8_t flags = 0, pfConsoleCmd *start = nil );
@@ -105,13 +105,13 @@ class pfConsoleCmdGroup
         pfConsoleCmdGroup   *FindSubGroup( const char *name );
         pfConsoleCmdGroup   *FindSubGroupNoCase( const char *name, uint8_t flags = 0, pfConsoleCmdGroup *start = nil );
 
-        pfConsoleCmd        *GetFirstCommand( void ) { return fCommands; }
-        pfConsoleCmdGroup   *GetFirstSubGroup( void ) { return fSubGroups; }
+        pfConsoleCmd        *GetFirstCommand() { return fCommands; }
+        pfConsoleCmdGroup   *GetFirstSubGroup() { return fSubGroups; }
 
         int                 IterateCommands(pfConsoleCmdIterator*, int depth=0);
 
         static pfConsoleCmdGroup    *FindSubGroupRecurse( const char *name );
-        static void                 DecBaseCmdGroupRef( void );
+        static void                 DecBaseCmdGroupRef();
 };
 
 //// pfConsoleCmdParam Class Definition //////////////////////////////////////
@@ -133,11 +133,11 @@ class pfConsoleCmdParam
             char    c;
         } fValue;
 
-        const int       &IToInt( void ) const;
-        const float     &IToFloat( void ) const;
-        const bool      &IToBool( void ) const;
-        const CharPtr   &IToString( void ) const;
-        const char      &IToChar( void ) const;
+        const int       &IToInt() const;
+        const float     &IToFloat() const;
+        const bool      &IToBool() const;
+        const CharPtr   &IToString() const;
+        const char      &IToChar() const;
 
     public:
 
@@ -158,7 +158,7 @@ class pfConsoleCmdParam
         operator CharPtr() const { return IToString(); }
         operator char() const { return IToChar(); }
 
-        uint8_t   GetType( void ) { return fType; }
+        uint8_t   GetType() { return fType; }
 
         void    SetInt( int i )         { fValue.i = i; fType = kInt; }
         void    SetFloat( float f )     { fValue.f = f; fType = kFloat; }
@@ -166,7 +166,7 @@ class pfConsoleCmdParam
         void    SetString( CharPtr s )  { fValue.s = s; fType = kString; }
         void    SetChar( char c )       { fValue.c = c; fType = kChar; }
         void    SetAny( CharPtr s )     { fValue.s = s; fType = kAny; }
-        void    SetNone( void )         { fType = kNone; }
+        void    SetNone()         { fType = kNone; }
 };
 
 //// pfConsoleCmd Class Definition ///////////////////////////////////////////
@@ -218,14 +218,14 @@ class pfConsoleCmd
         void    Execute( int32_t numParams, pfConsoleCmdParam *params, void (*PrintFn)( const char * ) = nil );
 
         void    Link( pfConsoleCmd **prevPtr );
-        void    Unlink( void );
+        void    Unlink();
 
-        pfConsoleCmd    *GetNext( void ) { return fNext; }
-        char            *GetName( void ) { return fName; }
-        const char      *GetHelp( void ) { return fHelpString; }
-        const char      *GetSignature( void );
+        pfConsoleCmd    *GetNext() { return fNext; }
+        char            *GetName() { return fName; }
+        const char      *GetHelp() { return fHelpString; }
+        const char      *GetSignature();
 
-        pfConsoleCmdGroup   *GetParent( void ) { return fParentGroup; }
+        pfConsoleCmdGroup   *GetParent() { return fParentGroup; }
 
         uint8_t           GetSigEntry( uint8_t i );
 };

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleContext.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleContext.cpp
@@ -53,7 +53,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 pfConsoleContext    pfConsoleContext::fRootContext( "global" );
 
-pfConsoleContext    &pfConsoleContext::GetRootContext( void )
+pfConsoleContext    &pfConsoleContext::GetRootContext()
 {
     return fRootContext;
 }
@@ -74,7 +74,7 @@ pfConsoleContext::~pfConsoleContext()
 
 //// Clear ///////////////////////////////////////////////////////////////////
 
-void    pfConsoleContext::Clear( void )
+void    pfConsoleContext::Clear()
 {
     int32_t       idx;
 
@@ -85,7 +85,7 @@ void    pfConsoleContext::Clear( void )
 
 //// Getters /////////////////////////////////////////////////////////////////
 
-uint32_t  pfConsoleContext::GetNumVars( void ) const
+uint32_t  pfConsoleContext::GetNumVars() const
 {
     hsAssert( fVarValues.GetCount() == fVarNames.GetCount(), "Mismatch in console var context arrays" );
     return fVarValues.GetCount();

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleContext.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleContext.h
@@ -74,9 +74,9 @@ class pfConsoleContext
         pfConsoleContext( const char *name );
         virtual ~pfConsoleContext();
 
-        void    Clear( void );
+        void    Clear();
 
-        uint32_t              GetNumVars( void ) const;
+        uint32_t              GetNumVars() const;
         const char          *GetVarName( uint32_t idx ) const;
         pfConsoleCmdParam   &GetVarValue( uint32_t idx ) const;
 
@@ -101,9 +101,9 @@ class pfConsoleContext
 
         // Decide whether Sets() on nonexistant variables will fail or add a new variable
         void    SetAddWhenNotFound( bool f ) { fAddWhenNotFound = f; }
-        bool    GetAddWhenNotFound( void ) const { return fAddWhenNotFound; }
+        bool    GetAddWhenNotFound() const { return fAddWhenNotFound; }
 
-        static pfConsoleContext &GetRootContext( void );
+        static pfConsoleContext &GetRootContext();
 };
 
 

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
@@ -98,10 +98,10 @@ class pfConsoleEngine
         bool    ExecuteFile( const plFileName &fileName );
 
         // Get the last reported error
-        const char  *GetErrorMsg( void ) { return fErrorMsg; }
+        const char  *GetErrorMsg() { return fErrorMsg; }
 
         // Get the line for which the last reported error was for
-        const char  *GetLastErrorLine( void ) { return fLastErrorLine; }
+        const char  *GetLastErrorLine() { return fLastErrorLine; }
 
         // Does command completion on a partially-complete console line
         bool        FindPartialCmd( char *line, bool findAgain = false, bool perserveParams = false );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIButtonMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIButtonMod.cpp
@@ -135,7 +135,7 @@ void    pfGUIButtonMod::StopDragging( bool cancel )
     fDialog->SetControlOfInterest( this );
 }
 
-void    pfGUIButtonMod::StartDragging( void )
+void    pfGUIButtonMod::StartDragging()
 {
     fOrigReportedDrag = fDraggable->HasFlag( pfGUIDraggableMod::kReportDragging );
     fDraggable->SetFlag( pfGUIDraggableMod::kReportDragging );
@@ -373,7 +373,7 @@ void    pfGUIButtonMod::SetMouseOverAnimKeys( hsTArray<plKey> &keys, const ST::s
 
 //// IGetDesiredCursor ///////////////////////////////////////////////////////
 
-uint32_t      pfGUIButtonMod::IGetDesiredCursor( void ) const
+uint32_t      pfGUIButtonMod::IGetDesiredCursor() const
 {
     if( fHandler == nil )
         return 0;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIButtonMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIButtonMod.h
@@ -78,7 +78,7 @@ class pfGUIButtonMod : public pfGUIControlMod
 
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        virtual uint32_t      IGetDesiredCursor( void ) const;    // As specified in plInputInterface.h
+        virtual uint32_t      IGetDesiredCursor() const;    // As specified in plInputInterface.h
 
     public:
 
@@ -125,7 +125,7 @@ class pfGUIButtonMod : public pfGUIControlMod
             kNotifyOnUpAndDown
         };
 
-        void    StartDragging( void );
+        void    StartDragging();
         void    StopDragging( bool cancel );
 
         // Export only

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICheckBoxCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICheckBoxCtrl.cpp
@@ -199,7 +199,7 @@ void    pfGUICheckBoxCtrl::SetAnimationKeys( hsTArray<plKey> &keys, const ST::st
 
 //// IGetDesiredCursor ///////////////////////////////////////////////////////
 
-uint32_t      pfGUICheckBoxCtrl::IGetDesiredCursor( void ) const
+uint32_t      pfGUICheckBoxCtrl::IGetDesiredCursor() const
 {
     if( fClicking )
         return plInputInterface::kCursorClicked;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICheckBoxCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICheckBoxCtrl.h
@@ -67,7 +67,7 @@ class pfGUICheckBoxCtrl : public pfGUIControlMod
 
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        virtual uint32_t      IGetDesiredCursor( void ) const;    // As specified in plInputInterface.h
+        virtual uint32_t      IGetDesiredCursor() const;    // As specified in plInputInterface.h
 
     public:
 
@@ -88,12 +88,12 @@ class pfGUICheckBoxCtrl : public pfGUIControlMod
         virtual void    UpdateBounds( hsMatrix44 *invXformMatrix = nil, bool force = false );
 
         void        SetChecked( bool checked, bool immediate = false );
-        bool        IsChecked( void ) { return fChecked; }
+        bool        IsChecked() { return fChecked; }
 
         void DontPlaySounds() { fPlaySound = false; } // should the checkbox play sounds?
         
-        const hsTArray<plKey>   &GetAnimationKeys( void ) const { return fAnimationKeys; }
-        ST::string              GetAnimationName( void ) const { return fAnimName; }
+        const hsTArray<plKey>   &GetAnimationKeys() const { return fAnimationKeys; }
+        ST::string              GetAnimationName() const { return fAnimName; }
 
         enum SoundEvents
         {

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIClickMapCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIClickMapCtrl.cpp
@@ -136,7 +136,7 @@ void    pfGUIClickMapCtrl::HandleMouseHover( hsPoint3 &mousePt, uint8_t modifier
 
 //// IGetDesiredCursor ///////////////////////////////////////////////////////
 
-uint32_t      pfGUIClickMapCtrl::IGetDesiredCursor( void ) const
+uint32_t      pfGUIClickMapCtrl::IGetDesiredCursor() const
 {
     if( fCustomCursor != -1 )
         return (uint32_t)fCustomCursor;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIClickMapCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIClickMapCtrl.h
@@ -62,7 +62,7 @@ class pfGUIClickMapCtrl : public pfGUIControlMod
 
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        virtual uint32_t      IGetDesiredCursor( void ) const;    // As specified in plInputInterface.h
+        virtual uint32_t      IGetDesiredCursor() const;    // As specified in plInputInterface.h
 
     public:
 
@@ -95,9 +95,9 @@ class pfGUIClickMapCtrl : public pfGUIControlMod
         virtual void Read( hsStream* s, hsResMgr* mgr );
         virtual void Write( hsStream* s, hsResMgr* mgr );
 
-        const hsPoint3  &GetLastMousePt( void ) const { return fLastMousePt; }
-        const hsPoint3  &GetLastMouseUpPt( void ) const { return fLastMouseUpPt; }
-        const hsPoint3  &GetLastMouseDragPt( void ) const { return fLastMouseDragPt; }
+        const hsPoint3  &GetLastMousePt() const { return fLastMousePt; }
+        const hsPoint3  &GetLastMouseUpPt() const { return fLastMouseUpPt; }
+        const hsPoint3  &GetLastMouseDragPt() const { return fLastMouseDragPt; }
 
         void    SetCustomCursor( int32_t cursor = -1 ) { fCustomCursor = cursor; }
 };

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlHandlers.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlHandlers.h
@@ -95,8 +95,8 @@ class pfGUICtrlProcObject
         virtual void    UserCallback( uint32_t userValue ) { ; }
 
         // ONLY THE GUI SYSTEM SHOULD CALL THESE
-        void    IncRef( void ) { fRefCnt++; }
-        bool    DecRef( void ) { fRefCnt--; return ( fRefCnt > 0 ) ? false : true; }
+        void    IncRef() { fRefCnt++; }
+        bool    DecRef() { fRefCnt--; return ( fRefCnt > 0 ) ? false : true; }
 };
 
 //// pfGUICtrlProcWriteableObject ////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlHandlers.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlHandlers.h
@@ -86,13 +86,13 @@ class pfGUICtrlProcObject
     public:
 
         pfGUICtrlProcObject() { fRefCnt = 0; }
-        virtual ~pfGUICtrlProcObject() { ; }
+        virtual ~pfGUICtrlProcObject() { }
 
         virtual void    DoSomething( pfGUIControlMod *ctrl ) = 0;
 
-        virtual void    HandleExtendedEvent( pfGUIControlMod *ctrl, uint32_t event ) { ; }
+        virtual void    HandleExtendedEvent( pfGUIControlMod *ctrl, uint32_t event ) { }
 
-        virtual void    UserCallback( uint32_t userValue ) { ; }
+        virtual void    UserCallback( uint32_t userValue ) { }
 
         // ONLY THE GUI SYSTEM SHOULD CALL THESE
         void    IncRef() { fRefCnt++; }
@@ -126,8 +126,8 @@ class pfGUICtrlProcWriteableObject : public pfGUICtrlProcObject
         };
 
         pfGUICtrlProcWriteableObject() { fType = kNull; }
-        pfGUICtrlProcWriteableObject( uint32_t type ) : fType( type ) { ; }
-        virtual ~pfGUICtrlProcWriteableObject() { ; }
+        pfGUICtrlProcWriteableObject( uint32_t type ) : fType( type ) { }
+        virtual ~pfGUICtrlProcWriteableObject() { }
 
         virtual void    DoSomething( pfGUIControlMod *ctrl ) = 0;
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
@@ -79,7 +79,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 //// pfGUIColorScheme Functions //////////////////////////////////////////////
 
-void    pfGUIColorScheme::IReset( void )
+void    pfGUIColorScheme::IReset()
 {
     fForeColor.Set( 1, 1, 1, 1 );
     fBackColor.Set( 0, 0, 0, 1 );
@@ -177,7 +177,7 @@ bool    pfGUIControlMod::IEval( double secs, float del, uint32_t dirty )
 
 //// GetBounds ///////////////////////////////////////////////////////////////
 
-const hsBounds3 &pfGUIControlMod::GetBounds( void )
+const hsBounds3 &pfGUIControlMod::GetBounds()
 {
     UpdateBounds();
     return fBounds; 
@@ -405,7 +405,7 @@ bool    pfGUIControlMod::PointInBounds( const hsPoint3 &point )
 //  any dynmaic text maps, since we want to use the initial bounds to do so
 //  instead of any currently animated state of the bounds.
 
-void    pfGUIControlMod::CalcInitialBounds( void )
+void    pfGUIControlMod::CalcInitialBounds()
 {
     UpdateBounds( nil, true );
     fInitialBounds = fBounds;
@@ -707,7 +707,7 @@ bool    pfGUIControlMod::ISetUpDynTextMap( plPipeline *pipe )
 
 //// Get/SetColorScheme //////////////////////////////////////////////////////
 
-pfGUIColorScheme    *pfGUIControlMod::GetColorScheme( void ) const
+pfGUIColorScheme    *pfGUIControlMod::GetColorScheme() const
 {
     if( fColorScheme == nil )
         return fDialog->GetColorScheme();
@@ -795,7 +795,7 @@ void    pfGUIControlMod::SetVisible( bool vis )
         fDialog->SetFocus( nil );
 }
 
-void    pfGUIControlMod::Refresh( void )
+void    pfGUIControlMod::Refresh()
 {
     IUpdate();
 }
@@ -930,7 +930,7 @@ void    pfGUIControlMod::ISetHandler( pfGUICtrlProcObject *h, bool clearInheritF
 
 //// DoSomething /////////////////////////////////////////////////////////////
 
-void    pfGUIControlMod::DoSomething( void )
+void    pfGUIControlMod::DoSomething()
 {
     if( fEnabled && fHandler != nil )
         fHandler->DoSomething( this );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.h
@@ -100,7 +100,7 @@ class pfGUIColorScheme : public hsRefCnt
 
     protected:
 
-        void    IReset( void );
+        void    IReset();
 };
 
 //// Class Def ///////////////////////////////////////////////////////////////
@@ -140,7 +140,7 @@ class pfGUIControlMod : public plSingleModifier
 
 
         bool            ISetUpDynTextMap( plPipeline *pipe );
-        virtual void    IPostSetUpDynTextMap( void ) {}
+        virtual void    IPostSetUpDynTextMap() {}
         virtual void    IGrowDTMDimsToDesiredSize( uint16_t &width, uint16_t &height ) { }
 
         virtual bool    IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
@@ -148,13 +148,13 @@ class pfGUIControlMod : public plSingleModifier
         void            ISetDialog( pfGUIDialogMod *mod ) { fDialog = mod; }
         void            IScreenToLocalPt( hsPoint3 &pt );
 
-        virtual void    IUpdate( void ) {;}
+        virtual void    IUpdate() {;}
         void            ISetHandler( pfGUICtrlProcObject *h, bool clearInheritFlag = false );
 
         void            IPlaySound( uint8_t guiCtrlEvent, bool loop = false );
         void            IStopSound( uint8_t guiCtrlEvent );
 
-        virtual uint32_t      IGetDesiredCursor( void ) const { return 0; }   // As specified in plInputInterface.h
+        virtual uint32_t      IGetDesiredCursor() const { return 0; }   // As specified in plInputInterface.h
 
     public:
 
@@ -170,31 +170,31 @@ class pfGUIControlMod : public plSingleModifier
         virtual void Read( hsStream* s, hsResMgr* mgr );
         virtual void Write( hsStream* s, hsResMgr* mgr );
 
-        uint32_t      GetTagID( void ) { return fTagID; }
+        uint32_t      GetTagID() { return fTagID; }
 
         virtual void    SetEnabled( bool e );
-        virtual bool    IsEnabled( void ) { return fEnabled; }
+        virtual bool    IsEnabled() { return fEnabled; }
         virtual void    SetFocused( bool e );
-        virtual bool    IsFocused( void ) { return fFocused; }
+        virtual bool    IsFocused() { return fFocused; }
         virtual void    SetVisible( bool vis );
-        virtual bool    IsVisible( void ) { return fVisible; }
+        virtual bool    IsVisible() { return fVisible; }
 
         virtual void    SetInteresting( bool i );
-        bool            IsInteresting( void ) { return fInteresting; }
+        bool            IsInteresting() { return fInteresting; }
 
         virtual void    SetNotifyOnInteresting( bool state ) { fNotifyOnInteresting = state; }
 
-        pfGUIDialogMod  *GetOwnerDlg( void ) { return fDialog; }
+        pfGUIDialogMod  *GetOwnerDlg() { return fDialog; }
         
-        virtual void    Refresh( void );
+        virtual void    Refresh();
 
         virtual void    UpdateBounds( hsMatrix44 *invXformMatrix = nil, bool force = false );
         void            SetObjectCenter( float x, float y );
         virtual hsPoint3 GetObjectCenter() { return fScreenCenter; }
-        float        GetScreenMinZ( void ) { return fScreenMinZ; }
-        void            CalcInitialBounds( void );
+        float        GetScreenMinZ() { return fScreenMinZ; }
+        void            CalcInitialBounds();
 
-        const hsBounds3 &GetBounds( void );
+        const hsBounds3 &GetBounds();
         bool            PointInBounds( const hsPoint3 &point );
 
         virtual void    SetTarget( plSceneObject *object );
@@ -212,13 +212,13 @@ class pfGUIControlMod : public plSingleModifier
         virtual bool    HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef key, uint8_t modifiers );
 
         void            SetHandler( pfGUICtrlProcObject *h ) { ISetHandler( h, true ); }
-        void            DoSomething( void );                        // Will call the handler
+        void            DoSomething();                        // Will call the handler
         void            HandleExtendedEvent( uint32_t event );        // Will call the handler
 
-        pfGUICtrlProcObject *GetHandler( void ) const { return fHandler; }
+        pfGUICtrlProcObject *GetHandler() const { return fHandler; }
 
         void                    SetDropTargetHdlr( pfGUIDropTargetProc *drop );
-        pfGUIDropTargetProc     *GetDropTargetHdlr( void ) { return fDropTargetHdlr; }
+        pfGUIDropTargetProc     *GetDropTargetHdlr() { return fDropTargetHdlr; }
 
         enum
         {
@@ -244,7 +244,7 @@ class pfGUIControlMod : public plSingleModifier
         };
 
         virtual void        SetColorScheme( pfGUIColorScheme *newScheme );
-        pfGUIColorScheme    *GetColorScheme( void ) const;
+        pfGUIColorScheme    *GetColorScheme() const;
 
         virtual void    UpdateColorScheme() { IPostSetUpDynTextMap(); IUpdate(); }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.h
@@ -148,7 +148,7 @@ class pfGUIControlMod : public plSingleModifier
         void            ISetDialog( pfGUIDialogMod *mod ) { fDialog = mod; }
         void            IScreenToLocalPt( hsPoint3 &pt );
 
-        virtual void    IUpdate() {;}
+        virtual void    IUpdate() { }
         void            ISetHandler( pfGUICtrlProcObject *h, bool clearInheritFlag = false );
 
         void            IPlaySound( uint8_t guiCtrlEvent, bool loop = false );
@@ -202,11 +202,11 @@ class pfGUIControlMod : public plSingleModifier
         // Return false if you actually DON'T want the mouse clicked at this point (should only be used for non-rectangular region rejection)
         virtual bool    FilterMousePosition( hsPoint3 &mousePt ) { return true; }
 
-        virtual void    HandleMouseDown( hsPoint3 &mousePt, uint8_t modifiers ) {;}
-        virtual void    HandleMouseUp( hsPoint3 &mousePt, uint8_t modifiers ) {;}
-        virtual void    HandleMouseDrag( hsPoint3 &mousePt, uint8_t modifiers ) {;}
-        virtual void    HandleMouseHover( hsPoint3 &mousePt, uint8_t modifiers ) {;}
-        virtual void    HandleMouseDblClick( hsPoint3 &mousePt, uint8_t modifiers ) {;}
+        virtual void    HandleMouseDown( hsPoint3 &mousePt, uint8_t modifiers ) { }
+        virtual void    HandleMouseUp( hsPoint3 &mousePt, uint8_t modifiers ) { }
+        virtual void    HandleMouseDrag( hsPoint3 &mousePt, uint8_t modifiers ) { }
+        virtual void    HandleMouseHover( hsPoint3 &mousePt, uint8_t modifiers ) { }
+        virtual void    HandleMouseDblClick( hsPoint3 &mousePt, uint8_t modifiers ) { }
 
         virtual bool    HandleKeyPress( wchar_t key, uint8_t modifiers );
         virtual bool    HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef key, uint8_t modifiers );
@@ -249,7 +249,7 @@ class pfGUIControlMod : public plSingleModifier
         virtual void    UpdateColorScheme() { IPostSetUpDynTextMap(); IUpdate(); }
 
         // should be override by specific GUIcontrol
-        virtual void        PurgeDynaTextMapImage() {;}
+        virtual void        PurgeDynaTextMapImage() { }
 
         // Override from plModifier so we can update our bounds
         virtual void SetTransform(const hsMatrix44& l2w, const hsMatrix44& w2l);

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.cpp
@@ -91,7 +91,7 @@ pfGUICtrlGenerator::~pfGUICtrlGenerator()
     Shutdown();
 }
 
-void    pfGUICtrlGenerator::Shutdown( void )
+void    pfGUICtrlGenerator::Shutdown()
 {
     int i;
     
@@ -113,7 +113,7 @@ void    pfGUICtrlGenerator::Shutdown( void )
 
 //// Instance ////////////////////////////////////////////////////////////////
 
-pfGUICtrlGenerator  &pfGUICtrlGenerator::Instance( void )
+pfGUICtrlGenerator  &pfGUICtrlGenerator::Instance()
 {
     static pfGUICtrlGenerator       myInstance;
 
@@ -435,7 +435,7 @@ pfGUIDragBarCtrl *pfGUICtrlGenerator::GenerateDragBar( float x, float y, float w
 
 //// IGetDialog //////////////////////////////////////////////////////////////
 
-pfGUIDialogMod  *pfGUICtrlGenerator::IGetDialog( void )
+pfGUIDialogMod  *pfGUICtrlGenerator::IGetDialog()
 {
     if( fDynDialogs.GetCount() == 0 )
         IGenerateDialog( "GUIBaseDynamicDlg", 20.f );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.h
@@ -92,7 +92,7 @@ class pfGUICtrlGenerator
         hsGMaterial *ICreateTextMaterial( const char *text, hsColorRGBA &bgColor, 
                                                  hsColorRGBA &textColor, float objWidth, float objHeight );
 
-        pfGUIDialogMod  *IGetDialog( void );
+        pfGUIDialogMod  *IGetDialog();
         pfGUIDialogMod  *IGenerateDialog( const char *name, float scrnWidth, bool show = true );
 
         plSceneObject   *IGenSceneObject( pfGUIDialogMod *dlg, plDrawable *myDraw, plSceneObject *parent = nil, hsMatrix44 *l2w = nil, hsMatrix44 *w2l = nil );
@@ -102,7 +102,7 @@ class pfGUICtrlGenerator
         pfGUICtrlGenerator();
         ~pfGUICtrlGenerator();
 
-        void    Shutdown( void );
+        void    Shutdown();
 
         void            SetFont( const char *face, uint16_t size );
 
@@ -123,7 +123,7 @@ class pfGUICtrlGenerator
         pfGUIButtonMod  *CreateRectButton( pfGUIDialogMod *parent, const wchar_t *title, float x, float y,
                                                 float width, float height, hsGMaterial *material, bool asMenuItem = false );
 
-        static pfGUICtrlGenerator   &Instance( void );
+        static pfGUICtrlGenerator   &Instance();
 };
 
 #endif // _pfGUICtrlGenerator_h

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogHandlers.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogHandlers.h
@@ -89,16 +89,16 @@ class pfGUIDialogProc : public pfGUICtrlProcObject
         virtual void    DoSomething( pfGUIControlMod *ctrl ) {;}
 
         // Called on dialog init (i.e. first showing, before OnShow() is called), only ever called once
-        virtual void    OnInit( void ) { ; }
+        virtual void    OnInit() { ; }
 
         // Called before the dialog is shown, always after OnInit()
-        virtual void    OnShow( void ) { ; }
+        virtual void    OnShow() { ; }
 
         // Called before the dialog is hidden
-        virtual void    OnHide( void ) { ; }
+        virtual void    OnHide() { ; }
 
         // Called on the dialog's destructor, before it's unregistered with the game GUI manager
-        virtual void    OnDestroy( void ) { ; }
+        virtual void    OnDestroy() { ; }
 
         // Called when the dialog's focused control changes
         virtual void    OnCtrlFocusChange( pfGUIControlMod *oldCtrl, pfGUIControlMod *newCtrl ) { ; }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogHandlers.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogHandlers.h
@@ -71,7 +71,7 @@ class pfGUIDialogProc : public pfGUICtrlProcObject
     public:
 
         pfGUIDialogProc() { }
-        virtual ~pfGUIDialogProc() { ; }
+        virtual ~pfGUIDialogProc() { }
 
         // Called by the mgr--don't call yourself!
         void    SetDialog( pfGUIDialogMod *dlg ) { fDialog = dlg; }
@@ -86,28 +86,28 @@ class pfGUIDialogProc : public pfGUICtrlProcObject
 
         // Overloaded here so you don't have to unless you want to. Overload
         // it if you want to use this for a control handler as well.
-        virtual void    DoSomething( pfGUIControlMod *ctrl ) {;}
+        virtual void    DoSomething( pfGUIControlMod *ctrl ) { }
 
         // Called on dialog init (i.e. first showing, before OnShow() is called), only ever called once
-        virtual void    OnInit() { ; }
+        virtual void    OnInit() { }
 
         // Called before the dialog is shown, always after OnInit()
-        virtual void    OnShow() { ; }
+        virtual void    OnShow() { }
 
         // Called before the dialog is hidden
-        virtual void    OnHide() { ; }
+        virtual void    OnHide() { }
 
         // Called on the dialog's destructor, before it's unregistered with the game GUI manager
-        virtual void    OnDestroy() { ; }
+        virtual void    OnDestroy() { }
 
         // Called when the dialog's focused control changes
-        virtual void    OnCtrlFocusChange( pfGUIControlMod *oldCtrl, pfGUIControlMod *newCtrl ) { ; }
+        virtual void    OnCtrlFocusChange( pfGUIControlMod *oldCtrl, pfGUIControlMod *newCtrl ) { }
 
         // Called when the key bound to a GUI event is pressed. Only called on the top modal dialog
-        virtual void    OnControlEvent( ControlEvt event ) { ; }
+        virtual void    OnControlEvent( ControlEvt event ) { }
 
         // Called when the GUI changes interesting state
-        virtual void    OnInterestingEvent( pfGUIControlMod *ctrl ) { ; }
+        virtual void    OnInterestingEvent( pfGUIControlMod *ctrl ) { }
 };
 
 #endif // _pfGUIDialogHandlers_h

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
@@ -348,7 +348,7 @@ void    pfGUIDialogMod::Write( hsStream *s, hsResMgr *mgr )
     mgr->WriteKey( s, fSceneNodeKey );
 }
 
-plKey   pfGUIDialogMod::GetSceneNodeKey( void )
+plKey   pfGUIDialogMod::GetSceneNodeKey()
 {
     if( fSceneNodeKey != nil )
         return fSceneNodeKey;
@@ -612,17 +612,17 @@ void    pfGUIDialogMod::SetFocus( pfGUIControlMod *ctrl )
 
 //// Show/Hide ///////////////////////////////////////////////////////////////
 
-void    pfGUIDialogMod::Show( void )
+void    pfGUIDialogMod::Show()
 {
     pfGameGUIMgr::GetInstance()->ShowDialog( this );
 }
 
-void    pfGUIDialogMod::ShowNoReset( void )
+void    pfGUIDialogMod::ShowNoReset()
 {
     pfGameGUIMgr::GetInstance()->ShowDialog( this, false );
 }
 
-void    pfGUIDialogMod::Hide( void )
+void    pfGUIDialogMod::Hide()
 {
     pfGameGUIMgr::GetInstance()->HideDialog( this );
 }
@@ -712,7 +712,7 @@ void    pfGUIDialogMod::SetControlHandler( uint32_t tagID, pfGUIDialogProc *hdlr
 
 //// UpdateAspectRatio ///////////////////////////////////////////////////////
 
-void    pfGUIDialogMod::UpdateAspectRatio( void )
+void    pfGUIDialogMod::UpdateAspectRatio()
 {
     if (fRenderMod)
     {
@@ -725,7 +725,7 @@ void    pfGUIDialogMod::UpdateAspectRatio( void )
 
 //// UpdateAllBounds /////////////////////////////////////////////////////////
 
-void    pfGUIDialogMod::UpdateAllBounds( void )
+void    pfGUIDialogMod::UpdateAllBounds()
 {
     int i;
     for( i = 0; i < fControls.GetCount(); i++ )
@@ -737,7 +737,7 @@ void    pfGUIDialogMod::UpdateAllBounds( void )
 
 //// RefreshAllControls //////////////////////////////////////////////////////
 
-void    pfGUIDialogMod::RefreshAllControls( void )
+void    pfGUIDialogMod::RefreshAllControls()
 {
     int i;
     for( i = 0; i < fControls.GetCount(); i++ )
@@ -750,7 +750,7 @@ void    pfGUIDialogMod::RefreshAllControls( void )
 
 //// ClearDragList ///////////////////////////////////////////////////////////
 
-void    pfGUIDialogMod::ClearDragList( void )
+void    pfGUIDialogMod::ClearDragList()
 {
     fDragElements.Reset();
 }
@@ -838,7 +838,7 @@ void    pfGUIDialogMod::IHandleDrag( hsPoint3 &mousePoint, pfGameGUIMgr::EventTy
 
 //// GetDesiredCursor ////////////////////////////////////////////////////////
 
-uint32_t      pfGUIDialogMod::GetDesiredCursor( void ) const
+uint32_t      pfGUIDialogMod::GetDesiredCursor() const
 {
     if( fMousedCtrl != nil ) 
         return fMousedCtrl->IGetDesiredCursor();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.h
@@ -123,12 +123,12 @@ class pfGUIDialogMod : public plSingleModifier
         virtual void Write( hsStream* s, hsResMgr* mgr );
 
         void        SetSceneNodeKey( plKey &key ) { fSceneNodeKey = key; }
-        plKey       GetSceneNodeKey( void );
+        plKey       GetSceneNodeKey();
 
         virtual void    SetEnabled( bool e );
-        bool            IsEnabled( void ) { return fEnabled; }
+        bool            IsEnabled() { return fEnabled; }
 
-        const char  *GetName( void ) { return fName; }
+        const char  *GetName() { return fName; }
 
         void        ScreenToWorldPoint( float x, float y, float z, hsPoint3 &outPt );
         hsPoint3    WorldToScreenPoint( const hsPoint3 &inPt );
@@ -139,18 +139,18 @@ class pfGUIDialogMod : public plSingleModifier
         void            UpdateInterestingThings( float mouseX, float mouseY, uint8_t modifiers, bool modalPreset );
 
         void            SetControlOfInterest( pfGUIControlMod *c );
-        pfGUIControlMod *GetControlOfInterest( void ) const { return fControlOfInterest; }
-        uint32_t          GetDesiredCursor( void ) const;
+        pfGUIControlMod *GetControlOfInterest() const { return fControlOfInterest; }
+        uint32_t          GetDesiredCursor() const;
 
-        void        UpdateAspectRatio( void );
-        void        UpdateAllBounds( void );
-        void        RefreshAllControls( void );
+        void        UpdateAspectRatio();
+        void        UpdateAllBounds();
+        void        RefreshAllControls();
 
         void            AddControl( pfGUIControlMod *ctrl );
-        uint32_t          GetNumControls( void ) { return fControls.GetCount(); }
+        uint32_t          GetNumControls() { return fControls.GetCount(); }
         pfGUIControlMod *GetControl( uint32_t idx ) { return fControls[ idx ]; }
 
-        pfGUIColorScheme    *GetColorScheme( void ) const { return fColorScheme; }
+        pfGUIColorScheme    *GetColorScheme() const { return fColorScheme; }
 
         void    LinkToList( pfGUIDialogMod **prevPtr )
         {
@@ -161,7 +161,7 @@ class pfGUIDialogMod : public plSingleModifier
             *prevPtr = this;
         }
 
-        void    Unlink( void )
+        void    Unlink()
         {
             if( fNext )
                 fNext->fPrevPtr = fPrevPtr;
@@ -172,21 +172,21 @@ class pfGUIDialogMod : public plSingleModifier
         }
 
         void            SetFocus( pfGUIControlMod *ctrl );
-        void            Show( void );
-        void            ShowNoReset( void );
-        void            Hide( void );
-        bool            IsVisible( void ) { return IsEnabled(); }
+        void            Show();
+        void            ShowNoReset();
+        void            Hide();
+        bool            IsVisible() { return IsEnabled(); }
 
-        pfGUIControlMod *GetFocus( void ) { return fFocusCtrl; }
+        pfGUIControlMod *GetFocus() { return fFocusCtrl; }
 
-        pfGUIDialogMod  *GetNext( void ) { return fNext; }
-        uint32_t          GetTagID( void ) { return fTagID; }
+        pfGUIDialogMod  *GetNext() { return fNext; }
+        uint32_t          GetTagID() { return fTagID; }
         pfGUIControlMod *GetControlFromTag( uint32_t tagID );
 
         void            SetHandler( pfGUIDialogProc *hdlr );
-        pfGUIDialogProc *GetHandler( void ) const { return fHandler; }
+        pfGUIDialogProc *GetHandler() const { return fHandler; }
 
-        plPostEffectMod *GetRenderMod( void ) const { return fRenderMod; }
+        plPostEffectMod *GetRenderMod() const { return fRenderMod; }
 
         // This sets the handler for the dialog and ALL of its controls
         void            SetHandlerForAll( pfGUIDialogProc *hdlr );
@@ -196,11 +196,11 @@ class pfGUIDialogMod : public plSingleModifier
 
         /// Methods for doing drag & drop of listElements
 
-        void    ClearDragList( void );
+        void    ClearDragList();
         void    AddToDragList( pfGUIListElement *e );
         void    EnterDragMode( pfGUIControlMod *source );
 
-        uint32_t  GetVersion( void ) const { return fVersion; }
+        uint32_t  GetVersion() const { return fVersion; }
 
         // Export only
         void        SetRenderMod( plPostEffectMod *mod ) { fRenderMod = mod; }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogNotifyProc.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogNotifyProc.cpp
@@ -115,7 +115,7 @@ void pfGUIDialogNotifyProc::HandleExtendedEvent( pfGUIControlMod *ctrl, uint32_t
     }
 }
 
-void pfGUIDialogNotifyProc::OnInit( void )
+void pfGUIDialogNotifyProc::OnInit()
 {
     if ( fDialog )
         ISendNotify( fDialog->GetKey(), pfGUINotifyMsg::kDialogLoaded );
@@ -123,7 +123,7 @@ void pfGUIDialogNotifyProc::OnInit( void )
         ISendNotify( nil, pfGUINotifyMsg::kDialogLoaded );
 }
 
-void pfGUIDialogNotifyProc::OnShow( void )
+void pfGUIDialogNotifyProc::OnShow()
 {
     if ( fDialog )
         ISendNotify( fDialog->GetKey(), pfGUINotifyMsg::kShowHide );
@@ -131,7 +131,7 @@ void pfGUIDialogNotifyProc::OnShow( void )
         ISendNotify( nil, pfGUINotifyMsg::kShowHide );
 }
 
-void pfGUIDialogNotifyProc::OnHide( void )
+void pfGUIDialogNotifyProc::OnHide()
 {
     if ( fDialog )
         ISendNotify( fDialog->GetKey(), pfGUINotifyMsg::kShowHide );
@@ -139,7 +139,7 @@ void pfGUIDialogNotifyProc::OnHide( void )
         ISendNotify( nil, pfGUINotifyMsg::kShowHide );
 }
 
-void pfGUIDialogNotifyProc::OnDestroy( void )
+void pfGUIDialogNotifyProc::OnDestroy()
 {
 }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogNotifyProc.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogNotifyProc.h
@@ -71,10 +71,10 @@ class pfGUIDialogNotifyProc : public pfGUIDialogProc
 
         virtual void    DoSomething( pfGUIControlMod *ctrl );
         virtual void    HandleExtendedEvent( pfGUIControlMod *ctrl, uint32_t event );
-        virtual void    OnInit( void );
-        virtual void    OnShow( void );
-        virtual void    OnHide( void );
-        virtual void    OnDestroy( void );
+        virtual void    OnInit();
+        virtual void    OnShow();
+        virtual void    OnHide();
+        virtual void    OnDestroy();
         virtual void    OnCtrlFocusChange( pfGUIControlMod *oldCtrl, pfGUIControlMod *newCtrl );
         virtual void    OnControlEvent( ControlEvt event );
         virtual void    OnInterestingEvent( pfGUIControlMod *ctrl );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDragBarCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDragBarCtrl.cpp
@@ -151,7 +151,7 @@ void    pfGUIDragBarCtrl::HandleMouseDrag( hsPoint3 &mousePt, uint8_t modifiers 
 
 //// IGetDesiredCursor ///////////////////////////////////////////////////////
 
-uint32_t      pfGUIDragBarCtrl::IGetDesiredCursor( void ) const
+uint32_t      pfGUIDragBarCtrl::IGetDesiredCursor() const
 {
     // if we are anchored, then no cursors that say we can move
     if ( fAnchored )

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDragBarCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDragBarCtrl.h
@@ -62,7 +62,7 @@ class pfGUIDragBarCtrl : public pfGUIControlMod
 
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        virtual uint32_t      IGetDesiredCursor( void ) const;    // As specified in plInputInterface.h
+        virtual uint32_t      IGetDesiredCursor() const;    // As specified in plInputInterface.h
 
     public:
 
@@ -83,7 +83,7 @@ class pfGUIDragBarCtrl : public pfGUIControlMod
         virtual void    HandleMouseDrag( hsPoint3 &mousePt, uint8_t modifiers );
 
         virtual void    SetAnchored( bool anchored ) { fAnchored = anchored; }
-        virtual bool    IsAnchored(void) { return fAnchored; }
+        virtual bool    IsAnchored() { return fAnchored; }
 
         virtual void    UpdateBounds( hsMatrix44 *invXformMatrix = nil, bool force = false );
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDraggableMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDraggableMod.cpp
@@ -152,7 +152,7 @@ void    pfGUIDraggableMod::HandleMouseDrag( hsPoint3 &mousePt, uint8_t modifiers
 
 //// IGetDesiredCursor ///////////////////////////////////////////////////////
 
-uint32_t      pfGUIDraggableMod::IGetDesiredCursor( void ) const
+uint32_t      pfGUIDraggableMod::IGetDesiredCursor() const
 {
     // if we are anchored, then no cursors that say we can move
     if( fDragging )

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDraggableMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDraggableMod.h
@@ -63,7 +63,7 @@ class pfGUIDraggableMod : public pfGUIControlMod
         
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        virtual uint32_t      IGetDesiredCursor( void ) const;    // As specified in plInputInterface.h
+        virtual uint32_t      IGetDesiredCursor() const;    // As specified in plInputInterface.h
 
     public:
 
@@ -100,7 +100,7 @@ class pfGUIDraggableMod : public pfGUIControlMod
         virtual void    UpdateBounds( hsMatrix44 *invXformMatrix = nil, bool force = false );
 
         void            StopDragging( bool cancel );
-        const hsPoint3  &GetLastMousePt( void ) const { return fLastMousePt; }
+        const hsPoint3  &GetLastMousePt() const { return fLastMousePt; }
 };
 
 #endif // _pfGUIDraggableMod_h

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDynDisplayCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDynDisplayCtrl.h
@@ -95,13 +95,13 @@ class pfGUIDynDisplayCtrl : public pfGUIControlMod
         virtual void Read( hsStream* s, hsResMgr* mgr );
         virtual void Write( hsStream* s, hsResMgr* mgr );
 
-        uint32_t              GetNumMaps( void ) const { return fTextMaps.GetCount(); }
+        uint32_t              GetNumMaps() const { return fTextMaps.GetCount(); }
         plDynamicTextMap    *GetMap( uint32_t i ) const { return fTextMaps[ i ]; }
 
-        uint32_t              GetNumLayers( void ) const { return fLayers.GetCount(); }
+        uint32_t              GetNumLayers() const { return fLayers.GetCount(); }
         plLayerInterface    *GetLayer( uint32_t i ) const { return fLayers[ i ]; }
 
-        uint32_t              GetNumMaterials( void ) const { return fMaterials.GetCount(); }
+        uint32_t              GetNumMaterials() const { return fMaterials.GetCount(); }
         hsGMaterial         *GetMaterial( uint32_t i ) const { return fMaterials[ i ]; }
 
         // Export only

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -100,7 +100,7 @@ bool    pfGUIEditBoxMod::MsgReceive( plMessage *msg )
 
 //// IPostSetUpDynTextMap ////////////////////////////////////////////////////
 
-void    pfGUIEditBoxMod::IPostSetUpDynTextMap( void )
+void    pfGUIEditBoxMod::IPostSetUpDynTextMap()
 {
     pfGUIColorScheme *scheme = GetColorScheme();
     fDynTextMap->SetFont( scheme->fFontFace, scheme->fFontSize, scheme->fFontFlags, 
@@ -109,7 +109,7 @@ void    pfGUIEditBoxMod::IPostSetUpDynTextMap( void )
 
 //// IUpdate /////////////////////////////////////////////////////////////////
 
-void    pfGUIEditBoxMod::IUpdate( void )
+void    pfGUIEditBoxMod::IUpdate()
 {
     hsColorRGBA c;
 
@@ -458,7 +458,7 @@ bool    pfGUIEditBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
     }
 }
 
-std::string pfGUIEditBoxMod::GetBuffer( void )
+std::string pfGUIEditBoxMod::GetBuffer()
 {
     char* temp = hsWStringToString(fBuffer);
     std::string retVal = temp;
@@ -466,7 +466,7 @@ std::string pfGUIEditBoxMod::GetBuffer( void )
     return retVal;
 }
 
-void    pfGUIEditBoxMod::ClearBuffer( void )
+void    pfGUIEditBoxMod::ClearBuffer()
 {
     if( fBuffer != nil )
     {
@@ -513,12 +513,12 @@ void    pfGUIEditBoxMod::SetBufferSize( uint32_t size )
 }
 
 
-void    pfGUIEditBoxMod::SetCursorToHome( void )
+void    pfGUIEditBoxMod::SetCursorToHome()
 {
     fCursorPos = 0;
 }
 
-void    pfGUIEditBoxMod::SetCursorToEnd( void )
+void    pfGUIEditBoxMod::SetCursorToEnd()
 {
     if( fBuffer != nil )
         fCursorPos = wcslen( fBuffer );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
@@ -75,8 +75,8 @@ class pfGUIEditBoxMod : public pfGUIControlMod
 
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        virtual void    IPostSetUpDynTextMap( void );
-        virtual void    IUpdate( void );
+        virtual void    IPostSetUpDynTextMap();
+        virtual void    IUpdate();
 
     public:
         enum
@@ -107,16 +107,16 @@ class pfGUIEditBoxMod : public pfGUIControlMod
 
         void    SetBufferSize( uint32_t size );
 
-        std::string GetBuffer( void );
-        std::wstring    GetBufferW( void ) { return fBuffer; }
-        void        ClearBuffer( void );
+        std::string GetBuffer();
+        std::wstring    GetBufferW() { return fBuffer; }
+        void        ClearBuffer();
         void        SetText( const char *str );
         void        SetText( const wchar_t *str );
 
-        void        SetCursorToHome( void );
-        void        SetCursorToEnd( void );
+        void        SetCursorToHome();
+        void        SetCursorToEnd();
 
-        bool        WasEscaped( void ) { bool e = fEscapedFlag; fEscapedFlag = false; return e; }
+        bool        WasEscaped() { bool e = fEscapedFlag; fEscapedFlag = false; return e; }
 
         void        SetSpecialCaptureKeyMode(bool state) { fSpecialCaptureKeyEventMode = state; }
         uint32_t      GetLastKeyCaptured() { return (uint32_t)fSavedKey; }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIKnobCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIKnobCtrl.cpp
@@ -266,7 +266,7 @@ void    pfGUIKnobCtrl::SetAnimationKeys( hsTArray<plKey> &keys, const ST::string
 //  Loops through and computes the max begin and end for our animations. If
 //  none of them are loaded and we're not already calced, returns false.
 
-bool    pfGUIKnobCtrl::ICalcAnimTimes( void )
+bool    pfGUIKnobCtrl::ICalcAnimTimes()
 {
     if( fAnimTimesCalced )
         return true;
@@ -351,7 +351,7 @@ void    pfGUIKnobCtrl::SetCurrValue( float v )
 
 //// IGetDesiredCursor ///////////////////////////////////////////////////////
 
-uint32_t      pfGUIKnobCtrl::IGetDesiredCursor( void ) const
+uint32_t      pfGUIKnobCtrl::IGetDesiredCursor() const
 {
     if( HasFlag( kLeftRightOrientation ) )
     {

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIKnobCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIKnobCtrl.h
@@ -73,9 +73,9 @@ class pfGUIKnobCtrl : public pfGUIValueCtrl
 
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        virtual uint32_t      IGetDesiredCursor( void ) const;    // As specified in plInputInterface.h
+        virtual uint32_t      IGetDesiredCursor() const;    // As specified in plInputInterface.h
 
-        bool            ICalcAnimTimes( void );
+        bool            ICalcAnimTimes();
 
     public:
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.cpp
@@ -178,7 +178,7 @@ bool    pfGUIListBoxMod::MsgReceive( plMessage *msg )
 
 //// IPostSetUpDynTextMap ////////////////////////////////////////////////////
 
-void    pfGUIListBoxMod::IPostSetUpDynTextMap( void )
+void    pfGUIListBoxMod::IPostSetUpDynTextMap()
 {
     pfGUIColorScheme *scheme = GetColorScheme();
     fDynTextMap->SetFont( scheme->fFontFace, scheme->fFontSize, scheme->fFontFlags, 
@@ -191,7 +191,7 @@ void    pfGUIListBoxMod::IPostSetUpDynTextMap( void )
 
 //// IUpdate /////////////////////////////////////////////////////////////////
 
-void    pfGUIListBoxMod::IUpdate( void )
+void    pfGUIListBoxMod::IUpdate()
 {
     int         i, j;
     uint16_t      x, y, width, height, maxHeight;
@@ -363,7 +363,7 @@ void    pfGUIListBoxMod::IUpdate( void )
 //  Calculates the starting indexes for each row of items. Call whenever you
 //  update the element list.
 
-void    pfGUIListBoxMod::ICalcWrapStarts( void )
+void    pfGUIListBoxMod::ICalcWrapStarts()
 {
     uint16_t      i, x, y, maxHeight, width, height;
 
@@ -421,7 +421,7 @@ void    pfGUIListBoxMod::ICalcWrapStarts( void )
 //// ICalcScrollRange ////////////////////////////////////////////////////////
 //  Call whenever you update the element list
 
-void    pfGUIListBoxMod::ICalcScrollRange( void )
+void    pfGUIListBoxMod::ICalcScrollRange()
 {
     uint16_t      ctrlHt, ctrlWd, height, width, maxHeight;
     int         i, j, end;
@@ -1009,7 +1009,7 @@ bool    pfGUIListBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
 
 //// ScrollToEnd /////////////////////////////////////////////////////////////
 
-void    pfGUIListBoxMod::ScrollToEnd( void )
+void    pfGUIListBoxMod::ScrollToEnd()
 {
     if( fScrollControl != nil )
     {
@@ -1021,7 +1021,7 @@ void    pfGUIListBoxMod::ScrollToEnd( void )
 
 //// ScrollToBegin ///////////////////////////////////////////////////////////
 
-void    pfGUIListBoxMod::ScrollToBegin( void )
+void    pfGUIListBoxMod::ScrollToBegin()
 {
     if( fScrollControl != nil )
     {
@@ -1054,12 +1054,12 @@ void pfGUIListBoxMod::SetScrollPos( int32_t pos )
     IUpdate();
 }
 
-int32_t pfGUIListBoxMod::GetScrollPos( void )
+int32_t pfGUIListBoxMod::GetScrollPos()
 {
     return (int)fScrollControl->GetCurrValue();
 }
 
-int32_t pfGUIListBoxMod::GetScrollRange( void )
+int32_t pfGUIListBoxMod::GetScrollRange()
 {
     return (int)fScrollControl->GetMax() - (int)fScrollControl->GetMin();
 }
@@ -1136,7 +1136,7 @@ int16_t   pfGUIListBoxMod::FindElement( pfGUIListElement *toCompareTo )
     return (int16_t)-1;
 }
 
-void    pfGUIListBoxMod::ClearAllElements( void )
+void    pfGUIListBoxMod::ClearAllElements()
 {
     int     i;
 
@@ -1167,7 +1167,7 @@ int16_t   pfGUIListBoxMod::FindString( const ST::string &toCompareTo )
     return FindElement( &text );
 }
 
-uint16_t  pfGUIListBoxMod::GetNumElements( void )
+uint16_t  pfGUIListBoxMod::GetNumElements()
 {
     return fElements.GetCount();
 }
@@ -1177,12 +1177,12 @@ pfGUIListElement    *pfGUIListBoxMod::GetElement( uint16_t idx )
     return fElements[ idx ];
 }
 
-void    pfGUIListBoxMod::LockList( void )
+void    pfGUIListBoxMod::LockList()
 {
     fLocked = true;
 }
 
-void    pfGUIListBoxMod::UnlockList( void )
+void    pfGUIListBoxMod::UnlockList()
 {
     fLocked = false;
     ICalcWrapStarts();
@@ -1192,7 +1192,7 @@ void    pfGUIListBoxMod::UnlockList( void )
 
 //// IGetDesiredCursor ///////////////////////////////////////////////////////
 
-uint32_t      pfGUIListBoxMod::IGetDesiredCursor( void ) const
+uint32_t      pfGUIListBoxMod::IGetDesiredCursor() const
 {
     if( fCurrHover == -1 )
         return plInputInterface::kNullCursor;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.h
@@ -91,12 +91,12 @@ class pfGUIListBoxMod : public pfGUIControlMod
 
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        void    ICalcScrollRange( void );
-        void    ICalcWrapStarts( void );
+        void    ICalcScrollRange();
+        void    ICalcWrapStarts();
 
-        virtual void    IUpdate( void );
-        virtual void    IPostSetUpDynTextMap( void );
-        virtual uint32_t  IGetDesiredCursor( void ) const;
+        virtual void    IUpdate();
+        virtual void    IPostSetUpDynTextMap();
+        virtual uint32_t  IGetDesiredCursor() const;
 
         int32_t   IGetItemFromPoint( hsPoint3 &mousePt );
         void    IFindSelectionRange( int32_t *min, int32_t *max );
@@ -157,19 +157,19 @@ class pfGUIListBoxMod : public pfGUIControlMod
         virtual void PurgeDynaTextMapImage();
 
         // Returns selected element. Only valid for kSingleSelect list boxes
-        int32_t   GetSelection( void ) { return fSingleSelElement; }
+        int32_t   GetSelection() { return fSingleSelElement; }
         void    SetSelection( int32_t item );
         void    RemoveSelection( int32_t item );
         void    AddSelection( int32_t item );
         
-        virtual void    ScrollToBegin( void );
-        virtual void    ScrollToEnd( void );
+        virtual void    ScrollToBegin();
+        virtual void    ScrollToEnd();
         virtual void    SetScrollPos( int32_t pos );
-        virtual int32_t   GetScrollPos( void );
-        virtual int32_t   GetScrollRange( void );
+        virtual int32_t   GetScrollPos();
+        virtual int32_t   GetScrollRange();
 
 
-        void    Refresh( void ) { IUpdate(); }
+        void    Refresh() { IUpdate(); }
 
         virtual void        SetColorScheme( pfGUIColorScheme *newScheme );
 
@@ -178,12 +178,12 @@ class pfGUIListBoxMod : public pfGUIControlMod
         uint16_t  AddElement( pfGUIListElement *el );
         void    RemoveElement( uint16_t index );
         int16_t   FindElement( pfGUIListElement *toCompareTo );
-        void    ClearAllElements( void );
+        void    ClearAllElements();
 
-        void    LockList( void );
-        void    UnlockList( void );
+        void    LockList();
+        void    UnlockList();
 
-        uint16_t              GetNumElements( void );
+        uint16_t              GetNumElements();
         pfGUIListElement    *GetElement( uint16_t idx );
 
         uint16_t  AddString( const ST::string &string );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListElement.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListElement.h
@@ -86,22 +86,22 @@ class pfGUIListElement
         virtual int     CompareTo( pfGUIListElement *rightSide ) = 0;
 
         virtual void    SetSelected( bool sel ) { fSelected = sel; }
-        virtual bool    IsSelected( void ) { return fSelected; }
+        virtual bool    IsSelected() { return fSelected; }
 
-        virtual bool    CanBeDragged( void ) { return false; }
+        virtual bool    CanBeDragged() { return false; }
 
         // Return true here if you need the list refreshed
         virtual bool    MouseClicked( uint16_t localX, uint16_t localY ) { return false; }
 
-        uint8_t   GetType( void ) { return fType; }
+        uint8_t   GetType() { return fType; }
 
         void    SetColorScheme( pfGUIColorScheme *scheme ) { fColors = scheme; }
         void    SetSkin( pfGUISkin *skin ) { fSkin = skin; }
 
-        bool            IsCollapsed( void ) const { return fCollapsed; }
+        bool            IsCollapsed() const { return fCollapsed; }
         virtual void    SetCollapsed( bool c ) { fCollapsed = c; }
 
-        uint8_t   GetIndentLevel( void ) const { return fIndentLevel; }
+        uint8_t   GetIndentLevel() const { return fIndentLevel; }
         void    SetIndentLevel( uint8_t i ) { fIndentLevel = i; }
 };
 
@@ -133,7 +133,7 @@ class pfGUIListText : public pfGUIListElement
         virtual void    GetSize( plDynamicTextMap *textGen, uint16_t *width, uint16_t *height );
         virtual int     CompareTo( pfGUIListElement *rightSide );
 
-        virtual bool    CanBeDragged( void ) { return true; }
+        virtual bool    CanBeDragged() { return true; }
         virtual void    SetJustify( JustifyTypes justify );
 
         // These two are virtual so we can derive and override them
@@ -162,7 +162,7 @@ class pfGUIListPicture : public pfGUIListElement
         virtual void    GetSize( plDynamicTextMap *textGen, uint16_t *width, uint16_t *height );
         virtual int     CompareTo( pfGUIListElement *rightSide );
 
-        virtual bool    CanBeDragged( void ) { return false; }
+        virtual bool    CanBeDragged() { return false; }
 
         void    SetBorderSize( uint32_t size ) { fBorderSize = (uint8_t)size; }
         void    SetRespectAlpha( bool r ) { fRespectAlpha = r; }
@@ -204,7 +204,7 @@ class pfGUIListTreeRoot : public pfGUIListElement
         virtual void    SetCollapsed( bool c );
 
         void        ShowChildren( bool s );
-        bool        IsShowingChildren( void ) const { return fShowChildren; }
+        bool        IsShowingChildren() const { return fShowChildren; }
 };
 
 //// pfGUIDropTargetProc /////////////////////////////////////////////////////
@@ -232,8 +232,8 @@ class pfGUIDropTargetProc
         virtual void    Eat( pfGUIListElement *element, pfGUIControlMod *source, pfGUIControlMod *parent ) = 0;
 
         // ONLY THE GUI SYSTEM SHOULD CALL THESE
-        void    IncRef( void ) { fRefCnt++; }
-        bool    DecRef( void ) { fRefCnt--; return ( fRefCnt > 0 ) ? false : true; }
+        void    IncRef() { fRefCnt++; }
+        bool    DecRef() { fRefCnt--; return ( fRefCnt > 0 ) ? false : true; }
 };
 
 #endif // _pfGUIListElement_h

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.cpp
@@ -117,7 +117,7 @@ void    pfGUIMenuItem::SetSkin( pfGUISkin *skin, HowToSkin s )
 //// IPostSetUpDynTextMap ////////////////////////////////////////////////////
 //  Draw our initial image on the dynTextMap
 
-void    pfGUIMenuItem::IPostSetUpDynTextMap( void )
+void    pfGUIMenuItem::IPostSetUpDynTextMap()
 {
 }
 
@@ -136,7 +136,7 @@ void    pfGUIMenuItem::IGrowDTMDimsToDesiredSize( uint16_t &width, uint16_t &hei
 //  DTMap, so we don't have to re-composite them every time we draw the
 //  control.
 
-void    pfGUIMenuItem::IUpdateSkinBuffers( void )
+void    pfGUIMenuItem::IUpdateSkinBuffers()
 {
     if( fSkinBuffersUpdated )
         return;
@@ -272,7 +272,7 @@ void    pfGUIMenuItem::IUpdateSingleSkinBuffer( uint16_t y, bool sel )
 
 //// IUpdate /////////////////////////////////////////////////////////////////
 
-void    pfGUIMenuItem::IUpdate( void )
+void    pfGUIMenuItem::IUpdate()
 {
     if( fDynTextMap == nil )
         return;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.h
@@ -74,10 +74,10 @@ class pfGUIMenuItem : public pfGUIButtonMod
         bool            fSkinBuffersUpdated;
 
         virtual void    IGrowDTMDimsToDesiredSize( uint16_t &width, uint16_t &height );
-        virtual void    IPostSetUpDynTextMap( void );
-        virtual void    IUpdate( void );
+        virtual void    IPostSetUpDynTextMap();
+        virtual void    IUpdate();
 
-        void            IUpdateSkinBuffers( void );
+        void            IUpdateSkinBuffers();
         void            IUpdateSingleSkinBuffer( uint16_t y, bool sel );
 
     public:
@@ -118,7 +118,7 @@ class pfGUIMenuItem : public pfGUIButtonMod
 
         void        SetName( const char *name );
         void        SetName( const wchar_t *name );
-        const wchar_t   *GetName( void ) const { return fName; }
+        const wchar_t   *GetName() const { return fName; }
     
         void    GetTextExtents( uint16_t &width, uint16_t &height );
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -266,7 +266,7 @@ void    pfGUIMultiLineEditCtrl::MoveCursor( Direction dir )
 
 //// IUpdateScrollRange //////////////////////////////////////////////////////
 
-void    pfGUIMultiLineEditCtrl::IUpdateScrollRange( void )
+void    pfGUIMultiLineEditCtrl::IUpdateScrollRange()
 {
     if( fScrollControl == nil )
         return;
@@ -323,7 +323,7 @@ void pfGUIMultiLineEditCtrl::SetScrollEnable( bool state )
 
 //// IPostSetUpDynTextMap ////////////////////////////////////////////////////
 
-void    pfGUIMultiLineEditCtrl::IPostSetUpDynTextMap( void )
+void    pfGUIMultiLineEditCtrl::IPostSetUpDynTextMap()
 {
     pfGUIColorScheme *scheme = GetColorScheme();
 
@@ -362,7 +362,7 @@ void    pfGUIMultiLineEditCtrl::IPostSetUpDynTextMap( void )
 
 //// ICalcNumVisibleLines ////////////////////////////////////////////////////
 
-int32_t   pfGUIMultiLineEditCtrl::ICalcNumVisibleLines( void ) const
+int32_t   pfGUIMultiLineEditCtrl::ICalcNumVisibleLines() const
 {
     if (fDynTextMap == nil || fLineHeight == 0)
         return 0;
@@ -642,7 +642,7 @@ void pfGUIMultiLineEditCtrl::PurgeDynaTextMapImage()
 
 //// IUpdate /////////////////////////////////////////////////////////////////
 
-void    pfGUIMultiLineEditCtrl::IUpdate( void )
+void    pfGUIMultiLineEditCtrl::IUpdate()
 {
     // Just call the ranged one with a full range
     IUpdate( 0, fLineStarts.GetCount() - 1 );
@@ -1438,7 +1438,7 @@ void    pfGUIMultiLineEditCtrl::IActuallyInsertStyle( int32_t pos, uint8_t style
 //  is in front of. Otherwise, deletes the current selection and places the
 //  cursor where the selection used to be.
 
-void    pfGUIMultiLineEditCtrl::DeleteChar( void )
+void    pfGUIMultiLineEditCtrl::DeleteChar()
 {
     if( fCursorPos < fBuffer.GetCount() - 1 )
     {
@@ -1488,7 +1488,7 @@ wchar_t *pfGUIMultiLineEditCtrl::ICopyRange( int32_t start, int32_t end ) const
 //// ClearBuffer /////////////////////////////////////////////////////////////
 //  Clears everything, including the undo list.
 
-void    pfGUIMultiLineEditCtrl::ClearBuffer( void )
+void    pfGUIMultiLineEditCtrl::ClearBuffer()
 {
     fBuffer.Reset();
     fBuffer.Append( 0 );
@@ -1553,7 +1553,7 @@ void    pfGUIMultiLineEditCtrl::SetBuffer( const uint16_t *codedText, uint32_t l
 //  and returns it. The caller is responsible for freeing it.
 //  To avoid code duplication, we'll just cheat and use CopySelection()...
 
-char    *pfGUIMultiLineEditCtrl::GetNonCodedBuffer( void ) const
+char    *pfGUIMultiLineEditCtrl::GetNonCodedBuffer() const
 {
     // recursively search back to the first control in the linked list and grab its buffer
     if (fPrevCtrl)
@@ -1569,7 +1569,7 @@ char    *pfGUIMultiLineEditCtrl::GetNonCodedBuffer( void ) const
     }
 }
 
-wchar_t *pfGUIMultiLineEditCtrl::GetNonCodedBufferW( void ) const
+wchar_t *pfGUIMultiLineEditCtrl::GetNonCodedBufferW() const
 {
     // recursively search back to the first control in the linked list and grab its buffer
     if (fPrevCtrl)
@@ -1650,13 +1650,13 @@ int32_t   pfGUIMultiLineEditCtrl::ICharPosToBufferPos( int32_t charPos ) const
 
 //// Locking /////////////////////////////////////////////////////////////////
 
-void    pfGUIMultiLineEditCtrl::Lock( void )
+void    pfGUIMultiLineEditCtrl::Lock()
 {
     fLockCount++;
     IUpdate();  
 }
 
-void    pfGUIMultiLineEditCtrl::Unlock( void )
+void    pfGUIMultiLineEditCtrl::Unlock()
 {
     fLockCount--;
     //hsAssert( fLockCount >= 0, "Too many unlocks for pfGUIMultiLineEditCtrl" );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -113,8 +113,8 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
 
         virtual bool    IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        virtual void    IPostSetUpDynTextMap( void );
-        virtual void    IUpdate( void );
+        virtual void    IPostSetUpDynTextMap();
+        virtual void    IUpdate();
         void            IUpdate( int32_t startLine, int32_t endLine );
 
         friend class pfMLScrollProc;
@@ -155,7 +155,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         bool    IStoreLineStart( uint32_t line, int32_t start );
         void    IOffsetLineStarts( uint32_t position, int32_t offset, bool offsetSelectionEnd = false );
         int32_t   IPointToPosition( int16_t x, int16_t y, bool searchOutsideBounds = false );
-        int32_t   ICalcNumVisibleLines( void ) const;
+        int32_t   ICalcNumVisibleLines() const;
 
         void    IReadColorCode( int32_t &pos, hsColorRGBA &color ) const;
         void    IReadStyleCode( int32_t &pos, uint8_t &fontStyle ) const;
@@ -171,7 +171,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         void    IActuallyInsertColor( int32_t pos, hsColorRGBA &color );
         void    IActuallyInsertStyle( int32_t pos, uint8_t style );
 
-        void    IUpdateScrollRange( void );
+        void    IUpdateScrollRange();
 
         wchar_t *ICopyRange( int32_t start, int32_t end ) const;
 
@@ -232,14 +232,14 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         void    InsertString( const wchar_t *string );
         void    InsertColor( hsColorRGBA &color );
         void    InsertStyle( uint8_t fontStyle );
-        void    DeleteChar( void );
-        void    ClearBuffer( void );
+        void    DeleteChar();
+        void    ClearBuffer();
         void    SetBuffer( const char *asciiText );
         void    SetBuffer( const wchar_t *asciiText );
         void    SetBuffer( const uint8_t *codedText, uint32_t length );
         void    SetBuffer( const uint16_t *codedText, uint32_t length );
-        char    *GetNonCodedBuffer( void ) const;
-        wchar_t *GetNonCodedBufferW( void ) const;
+        char    *GetNonCodedBuffer() const;
+        wchar_t *GetNonCodedBufferW() const;
         uint8_t   *GetCodedBuffer( uint32_t &length ) const;
         uint16_t  *GetCodedBufferW( uint32_t &length ) const;
         uint32_t  GetBufferSize();
@@ -249,9 +249,9 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
 
         void    GetThisKeyPressed( char &key, uint8_t &modifiers ) const { key = (char)fLastKeyPressed; modifiers = fLastKeyModifiers; }
 
-        void    Lock( void );
-        void    Unlock( void );
-        bool    IsLocked( void ) const { return ( fLockCount > 0 ) ? true : false; }
+        void    Lock();
+        void    Unlock();
+        bool    IsLocked() const { return ( fLockCount > 0 ) ? true : false; }
         
         void    SetScrollEnable( bool state );
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
@@ -343,7 +343,7 @@ void    pfGUIPopUpMenu::Show( float x, float y )
     ISeekToOrigin();
 }
 
-void    pfGUIPopUpMenu::ISeekToOrigin( void )
+void    pfGUIPopUpMenu::ISeekToOrigin()
 {
 #if 0
     uint32_t i;
@@ -429,7 +429,7 @@ void    pfGUIPopUpMenu::IHandleMenuSomething( uint32_t idx, pfGUIControlMod *ctr
 //// IBuildMenu //////////////////////////////////////////////////////////////
 //  Given the list of menu items, builds our set of dynamic buttons
 
-bool    pfGUIPopUpMenu::IBuildMenu( void )
+bool    pfGUIPopUpMenu::IBuildMenu()
 {
     int     i;
 
@@ -597,7 +597,7 @@ bool    pfGUIPopUpMenu::IBuildMenu( void )
 //// ITearDownMenu ///////////////////////////////////////////////////////////
 //  Destroys all of our dynamic controls representing the menu
 
-void    pfGUIPopUpMenu::ITearDownMenu( void )
+void    pfGUIPopUpMenu::ITearDownMenu()
 {
     int     i;
 
@@ -646,7 +646,7 @@ bool        pfGUIPopUpMenu::HandleMouseEvent( pfGameGUIMgr::EventType event, flo
 //// ClearItems //////////////////////////////////////////////////////////////
 //  Clears the list of template items
 
-void    pfGUIPopUpMenu::ClearItems( void )
+void    pfGUIPopUpMenu::ClearItems()
 {
     int     i;
 
@@ -697,7 +697,7 @@ void    pfGUIPopUpMenu::AddItem( const wchar_t *name, pfGUICtrlProcObject *handl
 //// ICreateDynMaterial //////////////////////////////////////////////////////
 //  Creates the hsGMaterial tree for a single layer with a plDynamicTextMap.
 
-hsGMaterial *pfGUIPopUpMenu::ICreateDynMaterial( void )
+hsGMaterial *pfGUIPopUpMenu::ICreateDynMaterial()
 {
     hsColorRGBA     black, white;
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.h
@@ -113,14 +113,14 @@ class pfGUIPopUpMenu : public pfGUIDialogMod
         Alignment               fAlignment;
 
 
-        bool        IBuildMenu( void );
-        void        ITearDownMenu( void );
+        bool        IBuildMenu();
+        void        ITearDownMenu();
 
-        hsGMaterial *ICreateDynMaterial( void );
+        hsGMaterial *ICreateDynMaterial();
 
         void        IHandleMenuSomething( uint32_t idx, pfGUIControlMod *ctrl, int32_t extended = -1 );
 
-        void        ISeekToOrigin( void );
+        void        ISeekToOrigin();
 
     public:
 
@@ -159,7 +159,7 @@ class pfGUIPopUpMenu : public pfGUIDialogMod
 
         void    SetOriginAnchor( plSceneObject *anchor, pfGUIDialogMod *context );
         void    SetAlignment( Alignment a ) { fAlignment = a; }
-        void    ClearItems( void );
+        void    ClearItems();
         void    AddItem( const char *name, pfGUICtrlProcObject *handler, pfGUIPopUpMenu *subMenu = nil );
         void    AddItem( const wchar_t *name, pfGUICtrlProcObject *handler, pfGUIPopUpMenu *subMenu = nil );
         void    SetSkin( pfGUISkin *skin );
@@ -197,7 +197,7 @@ class pfGUISkin : public hsKeyedObject
             public:
                 uint16_t  fX, fY, fWidth, fHeight;
 
-                void    Empty( void ) { fX = fY = fWidth = fHeight = 0; }
+                void    Empty() { fX = fY = fWidth = fHeight = 0; }
                 void    Read( hsStream *s );
                 void    Write( hsStream *s );
         };
@@ -226,7 +226,7 @@ class pfGUISkin : public hsKeyedObject
         virtual void    Write( hsStream *s, hsResMgr *mgr );
         virtual bool    MsgReceive( plMessage *msg );
 
-        plMipmap        *GetTexture( void ) const { return fTexture; }
+        plMipmap        *GetTexture() const { return fTexture; }
         void            SetTexture( plMipmap *tex );
 
         const pfSRect   &GetElement( uint32_t idx ) const { return fElements[ idx ]; }
@@ -234,8 +234,8 @@ class pfGUISkin : public hsKeyedObject
         void            SetElement( uint32_t idx, uint16_t x, uint16_t y, uint16_t w, uint16_t h );
 
         void            SetMargins( uint16_t item, uint16_t border ) { fItemMargin = item; fBorderMargin = border; }
-        uint16_t          GetItemMargin( void ) const { return fItemMargin; }
-        uint16_t          GetBorderMargin( void ) const { return fBorderMargin; }
+        uint16_t          GetItemMargin() const { return fItemMargin; }
+        uint16_t          GetBorderMargin() const { return fBorderMargin; }
 };
 
 #endif // _pfGUIPopUpMenu_h

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIProgressCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIProgressCtrl.cpp
@@ -145,7 +145,7 @@ void    pfGUIProgressCtrl::SetAnimationKeys( hsTArray<plKey> &keys, const ST::st
 //  Loops through and computes the max begin and end for our animations. If
 //  none of them are loaded and we're not already calced, returns false.
 
-bool    pfGUIProgressCtrl::ICalcAnimTimes( void )
+bool    pfGUIProgressCtrl::ICalcAnimTimes()
 {
     if( fAnimTimesCalced )
         return true;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIProgressCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIProgressCtrl.h
@@ -67,7 +67,7 @@ class pfGUIProgressCtrl : public pfGUIValueCtrl
 
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        bool            ICalcAnimTimes( void );
+        bool            ICalcAnimTimes();
 
         const uint32_t  fStopSoundTimer;
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIRadioGroupCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIRadioGroupCtrl.cpp
@@ -260,7 +260,7 @@ void    pfGUIRadioGroupCtrl::ClearControlsFlag( int flag )
 
 //// Export Functions ////////////////////////////////////////////////////////
 
-void    pfGUIRadioGroupCtrl::ClearControlList( void )
+void    pfGUIRadioGroupCtrl::ClearControlList()
 {
     fControls.Reset();
     fValue = -1;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIRadioGroupCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIRadioGroupCtrl.h
@@ -92,7 +92,7 @@ class pfGUIRadioGroupCtrl : public pfGUIControlMod
         virtual void Read( hsStream* s, hsResMgr* mgr );
         virtual void Write( hsStream* s, hsResMgr* mgr );
 
-        int32_t   GetValue( void ) { return fValue; }
+        int32_t   GetValue() { return fValue; }
         void    SetValue( int32_t value );
 
         virtual void    SetEnabled( bool e );
@@ -102,7 +102,7 @@ class pfGUIRadioGroupCtrl : public pfGUIControlMod
         virtual void    ClearControlsFlag( int flag );
 
         /// Export ONLY
-        void    ClearControlList( void );
+        void    ClearControlList();
         void    AddControl( pfGUICheckBoxCtrl *ctrl );
         void    SetDefaultValue( int32_t value ) { fDefaultValue = value; }
 };

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.cpp
@@ -93,7 +93,7 @@ bool    pfGUITextBoxMod::MsgReceive( plMessage *msg )
 
 //// IPostSetUpDynTextMap ////////////////////////////////////////////////////
 
-void    pfGUITextBoxMod::IPostSetUpDynTextMap( void )
+void    pfGUITextBoxMod::IPostSetUpDynTextMap()
 {
     pfGUIColorScheme *scheme = GetColorScheme();
 
@@ -105,7 +105,7 @@ void    pfGUITextBoxMod::IPostSetUpDynTextMap( void )
 
 //// IUpdate /////////////////////////////////////////////////////////////////
 
-void    pfGUITextBoxMod::IUpdate( void )
+void    pfGUITextBoxMod::IUpdate()
 {
     if( fDynTextMap == nil || !fDynTextMap->IsValid() )
         return;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.h
@@ -65,8 +65,8 @@ class pfGUITextBoxMod : public pfGUIControlMod
 
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 
-        virtual void    IUpdate( void );
-        virtual void    IPostSetUpDynTextMap( void );
+        virtual void    IUpdate();
+        virtual void    IPostSetUpDynTextMap();
 
     public:
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIUpDownPairMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIUpDownPairMod.cpp
@@ -124,7 +124,7 @@ bool    pfGUIUpDownPairMod::IEval( double secs, float del, uint32_t dirty )
     return pfGUIValueCtrl::IEval( secs, del, dirty );
 }
 
-void    pfGUIUpDownPairMod::IUpdate( void )
+void    pfGUIUpDownPairMod::IUpdate()
 {
     if (fEnabled)
     {
@@ -150,7 +150,7 @@ void    pfGUIUpDownPairMod::IUpdate( void )
     }
 }
 
-void    pfGUIUpDownPairMod::Update( void )
+void    pfGUIUpDownPairMod::Update()
 {
     IUpdate();
 }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIUpDownPairMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIUpDownPairMod.h
@@ -71,7 +71,7 @@ class pfGUIUpDownPairMod : public pfGUIValueCtrl
 
 
         virtual bool IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
-        virtual void    IUpdate( void );
+        virtual void    IUpdate();
 
     public:
 
@@ -84,7 +84,7 @@ class pfGUIUpDownPairMod : public pfGUIValueCtrl
 
         virtual bool    MsgReceive( plMessage* pMsg );
 
-        virtual void    Update( void );
+        virtual void    Update();
 
         virtual void Read( hsStream* s, hsResMgr* mgr );
         virtual void Write( hsStream* s, hsResMgr* mgr );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIValueCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIValueCtrl.h
@@ -69,12 +69,12 @@ class pfGUIValueCtrl : public pfGUIControlMod
         virtual void Read( hsStream* s, hsResMgr* mgr );
         virtual void Write( hsStream* s, hsResMgr* mgr );
 
-        virtual float    GetCurrValue( void ) { return fValue; }
+        virtual float    GetCurrValue() { return fValue; }
         virtual void        SetCurrValue( float v );
 
-        virtual float    GetMin( void ) { return fMin; }
-        virtual float    GetMax( void ) { return fMax; }
-        virtual float    GetStep( void ) { return fStep; }
+        virtual float    GetMin() { return fMin; }
+        virtual float    GetMax() { return fMax; }
+        virtual float    GetStep() { return fStep; }
 
         virtual void    SetRange( float min, float max );
         virtual void    SetStep( float step ) { fStep = step; }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
@@ -98,14 +98,14 @@ class pfGameUIInputInterface : public plInputInterface
 
         pfGameUIInputInterface( pfGameGUIMgr * const mgr );
 
-        virtual uint32_t  GetPriorityLevel( void ) const { return kGUISystemPriority; }
+        virtual uint32_t  GetPriorityLevel() const { return kGUISystemPriority; }
         virtual bool    InterpretInputEvent( plInputEventMsg *pMsg );
-        virtual uint32_t  GetCurrentCursorID( void ) const;
-        virtual float GetCurrentCursorOpacity( void ) const;
-        virtual bool    HasInterestingCursorID( void ) const { return fHaveInterestingCursor; }
-        virtual bool    SwitchInterpretOrder( void ) const { return true; }
+        virtual uint32_t  GetCurrentCursorID() const;
+        virtual float GetCurrentCursorOpacity() const;
+        virtual bool    HasInterestingCursorID() const { return fHaveInterestingCursor; }
+        virtual bool    SwitchInterpretOrder() const { return true; }
 
-        virtual void    RestoreDefaultKeyMappings( void )
+        virtual void    RestoreDefaultKeyMappings()
         {
             if( fControlMap != nil )
             {
@@ -162,7 +162,7 @@ pfGameGUIMgr::~pfGameGUIMgr()
 
 //// Init ////////////////////////////////////////////////////////////////////
 
-bool    pfGameGUIMgr::Init( void )
+bool    pfGameGUIMgr::Init()
 {
     return true;
 }
@@ -489,7 +489,7 @@ pfGUIPopUpMenu  *pfGameGUIMgr::FindPopUpMenu( const char *name )
     return nil;
 }
 
-std::vector<plPostEffectMod*> pfGameGUIMgr::GetDlgRenderMods( void ) const
+std::vector<plPostEffectMod*> pfGameGUIMgr::GetDlgRenderMods() const
 {
     std::vector<plPostEffectMod*> retVal;
     pfGUIDialogMod* curDialog = fActiveDialogs;
@@ -630,7 +630,7 @@ bool    pfGameGUIMgr::IHandleKeyPress( wchar_t key, uint8_t modifiers )
 //  Looks at the chain of active dialogs and determines if there's any modals
 //  blocking input. Returns true if so.
 
-bool    pfGameGUIMgr::IModalBlocking( void )
+bool    pfGameGUIMgr::IModalBlocking()
 {
     return ( IGetTopModal() != nil ) ? true : false;
 }
@@ -638,7 +638,7 @@ bool    pfGameGUIMgr::IModalBlocking( void )
 //// IGetTopModal ////////////////////////////////////////////////////////////
 //  Returns the topmost (visible) modal dialog, nil if none.
 
-pfGUIDialogMod  *pfGameGUIMgr::IGetTopModal( void ) const
+pfGUIDialogMod  *pfGameGUIMgr::IGetTopModal() const
 {
     pfGUIDialogMod  *dlg;
 
@@ -836,7 +836,7 @@ bool    pfGameUIInputInterface::InterpretInputEvent( plInputEventMsg *pMsg )
     return false;
 }   
 
-uint32_t  pfGameUIInputInterface::GetCurrentCursorID( void ) const
+uint32_t  pfGameUIInputInterface::GetCurrentCursorID() const
 {
     if( fCurrentCursor == 0 )
     {
@@ -849,7 +849,7 @@ uint32_t  pfGameUIInputInterface::GetCurrentCursorID( void ) const
     return fCurrentCursor;
 }
 
-float pfGameUIInputInterface::GetCurrentCursorOpacity( void ) const
+float pfGameUIInputInterface::GetCurrentCursorOpacity() const
 {
     if ( pfGameGUIMgr::GetInstance() )
         return pfGameGUIMgr::GetInstance()->GetCursorOpacity();
@@ -904,7 +904,7 @@ pfGUIControlMod *pfGameGUIMgr::GetControlFromTag( pfGUIDialogMod *dlg, uint32_t 
 
 //// GetNumTags //////////////////////////////////////////////////////////////
 
-uint32_t          pfGameGUIMgr::GetNumTags( void )
+uint32_t          pfGameGUIMgr::GetNumTags()
 {
     uint32_t      count;
 
@@ -926,7 +926,7 @@ pfGUITag        *pfGameGUIMgr::GetTag( uint32_t tagIndex )
     return &gGUITags[ tagIndex ];
 }
 
-uint32_t      pfGameGUIMgr::GetHighestTag( void )
+uint32_t      pfGameGUIMgr::GetHighestTag()
 {
     uint32_t  i, id = 1;
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.h
@@ -171,9 +171,9 @@ class pfGameGUIMgr : public hsKeyedObject
         bool    IHandleKeyEvt( EventType event, plKeyDef key, uint8_t modifiers );
         bool    IHandleKeyPress( wchar_t key, uint8_t modifiers );
 
-        bool    IModalBlocking( void );
+        bool    IModalBlocking();
 
-        pfGUIDialogMod  *IGetTopModal( void ) const;
+        pfGUIDialogMod  *IGetTopModal() const;
 
     public:
 
@@ -191,7 +191,7 @@ class pfGameGUIMgr : public hsKeyedObject
 
         void        Draw( plPipeline *p );
 
-        bool        Init( void );
+        bool        Init();
 
         virtual bool    MsgReceive( plMessage* pMsg );
 
@@ -217,20 +217,20 @@ class pfGameGUIMgr : public hsKeyedObject
 
         pfGUIPopUpMenu  *FindPopUpMenu( const char *name );
 
-        std::vector<plPostEffectMod*> GetDlgRenderMods( void ) const;
-        bool    IsModalBlocking( void ) {return IModalBlocking();}
+        std::vector<plPostEffectMod*> GetDlgRenderMods() const;
+        bool    IsModalBlocking() {return IModalBlocking();}
 
         // Tag ID stuff
         pfGUIDialogMod  *GetDialogFromTag( uint32_t tagID );
         pfGUIControlMod *GetControlFromTag( pfGUIDialogMod *dlg, uint32_t tagID );
 
-        static uint32_t       GetNumTags( void );
+        static uint32_t       GetNumTags();
         static pfGUITag     *GetTag( uint32_t tagIndex );
-        static uint32_t       GetHighestTag( void );
+        static uint32_t       GetHighestTag();
         void SetAspectRatio(float aspectratio);
         float GetAspectRatio() { return fAspectRatio; }
  
-        static pfGameGUIMgr *GetInstance( void ) { return fInstance; }
+        static pfGameGUIMgr *GetInstance() { return fInstance; }
 };
 
 #endif //_pfGameGUIMgr_h

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -346,22 +346,22 @@ class pfJournalDlgProc : public pfGUIDialogProc
         }
 
         // Called on dialog init (i.e. first showing, before OnShow() is called), only ever called once
-        virtual void    OnInit( void )
+        virtual void    OnInit()
         {
         }
 
         // Called before the dialog is shown, always after OnInit()
-        virtual void    OnShow( void )
+        virtual void    OnShow()
         {
         }
 
         // Called before the dialog is hidden
-        virtual void    OnHide( void )
+        virtual void    OnHide()
         {
         }
 
         // Called on the dialog's destructor, before it's unregistered with the game GUI manager
-        virtual void    OnDestroy( void )
+        virtual void    OnDestroy()
         {
         }
 
@@ -1137,14 +1137,14 @@ void pfBookData::EnableEditGUI(bool enable/* =true */)
 //pfJournalBook *pfJournalBook::fInstance = nil;
 std::map<ST::string,pfBookData*> pfJournalBook::fBookGUIs;
 
-void    pfJournalBook::SingletonInit( void )
+void    pfJournalBook::SingletonInit()
 {
     fBookGUIs["BkBook"] = new pfBookData(); // load the default book data object
     hsgResMgr::ResMgr()->NewKey("BkBook",fBookGUIs["BkBook"],pfGameGUIMgr::GetInstance()->GetKey()->GetUoid().GetLocation());
     fBookGUIs["BkBook"]->LoadGUI();
 }
 
-void    pfJournalBook::SingletonShutdown( void )
+void    pfJournalBook::SingletonShutdown()
 {
     std::map<ST::string,pfBookData*>::iterator i = fBookGUIs.begin();
     while (i != fBookGUIs.end())
@@ -1379,7 +1379,7 @@ void    pfJournalBook::IFinishShow( bool startOpened )
 
 //// Hide ////////////////////////////////////////////////////////////////////
 
-void    pfJournalBook::Hide( void )
+void    pfJournalBook::Hide()
 {
     if (fBookGUIs[fCurBookGUI])
     {
@@ -1429,7 +1429,7 @@ void    pfJournalBook::Open( uint32_t startingPage /*= 0 */)
 //// Close ///////////////////////////////////////////////////////////////////
 // Closes the book.
 
-void    pfJournalBook::Close( void )
+void    pfJournalBook::Close()
 {
     // don't allow them to close the book if the book started open
     if( !fBookGUIs[fCurBookGUI]->StartedOpen() && fBookGUIs[fCurBookGUI]->CurrentlyOpen() )
@@ -1442,7 +1442,7 @@ void    pfJournalBook::Close( void )
 //// CloseAndHide ////////////////////////////////////////////////////////////
 // Closes the book, then calls Hide() once it's done closing
 
-void    pfJournalBook::CloseAndHide( void )
+void    pfJournalBook::CloseAndHide()
 {
     // if they start with the book open, then don't allow them to close it
     if( !fBookGUIs[fCurBookGUI]->StartedOpen() && fBookGUIs[fCurBookGUI]->CurrentlyOpen() )
@@ -1508,7 +1508,7 @@ void    pfJournalBook::ITriggerCloseWithNotify( bool closeNotOpen, bool immediat
 //// NextPage ////////////////////////////////////////////////////////////////
 // Advances forward one page
 
-void    pfJournalBook::NextPage( void )
+void    pfJournalBook::NextPage()
 {
     if( (fBookGUIs[fCurBookGUI]->CurrentlyTurning()) || (!fAllowTurning) || (!fAreWeShowing) )
         return;
@@ -1565,7 +1565,7 @@ void    pfJournalBook::NextPage( void )
 //// PreviousPage ////////////////////////////////////////////////////////////
 // Same, only back
 
-void    pfJournalBook::PreviousPage( void )
+void    pfJournalBook::PreviousPage()
 {
     if(( fBookGUIs[fCurBookGUI]->CurrentlyTurning() )||( !fAllowTurning ))
         return;
@@ -1670,7 +1670,7 @@ int32_t   pfJournalBook::IFindCurrVisibleLink( bool rightNotLeft, bool hoverNotU
 
 //// IHandleLeftSideClick ////////////////////////////////////////////////////
 
-void    pfJournalBook::IHandleLeftSideClick( void )
+void    pfJournalBook::IHandleLeftSideClick()
 {
     if( fBookGUIs[fCurBookGUI]->CurrentlyTurning() )
         return;
@@ -1689,7 +1689,7 @@ void    pfJournalBook::IHandleLeftSideClick( void )
     PreviousPage();
 }
 
-void    pfJournalBook::IHandleRightSideClick( void )
+void    pfJournalBook::IHandleRightSideClick()
 {
     if( fBookGUIs[fCurBookGUI]->CurrentlyTurning() )
         return;
@@ -1768,7 +1768,7 @@ void    pfJournalBook::SetEditable(bool editable)
 //// ForceCacheCalculations //////////////////////////////////////////////////
 // Just forces a full calc of the cached info
 
-void    pfJournalBook::ForceCacheCalculations( void )
+void    pfJournalBook::ForceCacheCalculations()
 {
     // Make sure our page starts are up-to-snuff, at least to this point
     IRecalcPageStarts( -1 );
@@ -2327,7 +2327,7 @@ bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wc
     return true;
 }
 
-void    pfJournalBook::IFreeSource( void )
+void    pfJournalBook::IFreeSource()
 {
     uint32_t i;
     
@@ -3281,7 +3281,7 @@ void    pfJournalBook::IFindFontProps( uint32_t chunkIdx, ST::string &face, uint
 //// IFindLastAlignment //////////////////////////////////////////////////////
 // Find the last paragraph chunk and thus the last par alignment settings
 
-uint8_t   pfJournalBook::IFindLastAlignment( void ) const
+uint8_t   pfJournalBook::IFindLastAlignment() const
 {
     int32_t idx;
 

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -376,10 +376,10 @@ class pfJournalBook : public hsKeyedObject
         virtual bool    MsgReceive( plMessage *pMsg );
 
         // Init the singleton, for client startup
-        static void SingletonInit( void );
+        static void SingletonInit();
         
         // Shutdown the singleton
-        static void SingletonShutdown( void );
+        static void SingletonShutdown();
         
         // loads a gui
         static void LoadGUI( const ST::string &guiName );
@@ -402,34 +402,34 @@ class pfJournalBook : public hsKeyedObject
 
 
         // Book handles hiding itself once someone clicks away. 
-        void    Hide( void );
+        void    Hide();
 
         // Opens the book, optionally to the given page
         void    Open( uint32_t startingPage = 0 );
 
         // Closes the book.
-        void    Close( void );
+        void    Close();
 
         // Advances forward one page
-        void    NextPage( void );
+        void    NextPage();
 
         // Same, only back
-        void    PreviousPage( void );
+        void    PreviousPage();
 
         // For completeness...
         void    GoToPage( uint32_t pageNumber );
 
         // See below. Just forces a full calc of the cached info
-        void    ForceCacheCalculations( void );
+        void    ForceCacheCalculations();
 
         // Closes the book, then calls Hide() once it's done closing
-        void    CloseAndHide( void );
+        void    CloseAndHide();
 
         // Sets the book size scaling. 1,1 would be full size, 0,0 is the smallest size possible
         void    SetBookSize( float width, float height );
 
         // What page are we on?
-        uint32_t  GetCurrentPage( void ) const { return fCurrentPage; }
+        uint32_t  GetCurrentPage() const { return fCurrentPage; }
 
         // Set the margin (defaults to 16 pixels)
         void    SetPageMargin( uint32_t margin ) { fPageTMargin = fPageLMargin = fPageBMargin = fPageRMargin = margin; }
@@ -519,7 +519,7 @@ class pfJournalBook : public hsKeyedObject
         bool    ICompileSource( const wchar_t *source, const plLocation &hintLoc );
 
         // Frees our source array
-        void    IFreeSource( void );
+        void    IFreeSource();
 
         // Compile helpers
         uint8_t   IGetTagType( const wchar_t *string );
@@ -538,11 +538,11 @@ class pfJournalBook : public hsKeyedObject
         void    IFindFontProps( uint32_t chunkIdx, ST::string &face, uint8_t &size, uint8_t &flags, hsColorRGBA &color, int16_t &spacing );
 
         // Find the last paragraph chunk and thus the last par alignment settings
-        uint8_t   IFindLastAlignment( void ) const;
+        uint8_t   IFindLastAlignment() const;
 
         // Handle clicks on either side of the book
-        void    IHandleLeftSideClick( void );
-        void    IHandleRightSideClick( void );
+        void    IHandleLeftSideClick();
+        void    IHandleRightSideClick();
 
         // Just sends out a notify to our currently set receiver key
         void    ISendNotify( uint32_t type, uint32_t linkID = 0 );

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.h
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.h
@@ -122,8 +122,8 @@ public:
 
     static void Initialize(const plFileName & path);
     static void Shutdown();
-    static pfLocalizationDataMgr &Instance(void) {return *fInstance;}
-    static bool InstanceValid(void) {return fInstance != nil;}
+    static pfLocalizationDataMgr &Instance() {return *fInstance;}
+    static bool InstanceValid() {return fInstance != nil;}
     static plStatusLog* GetLog() { return fLog; }
 
     void SetupData();

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationMgr.h
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationMgr.h
@@ -65,8 +65,8 @@ public:
 
     static void Initialize(const plFileName & dataPath);
     static void Shutdown();
-    static pfLocalizationMgr &Instance(void) {return *fInstance;}
-    static bool InstanceValid(void) {return fInstance != nil;}
+    static pfLocalizationMgr &Instance() {return *fInstance;}
+    static bool InstanceValid() {return fInstance != nil;}
 
     // Returns the final localized string, designated by path, and with the arguments properly substituted
     // if you want to use the default argument order, just use %s like you would with printf, BUT, if you

--- a/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
@@ -208,23 +208,23 @@ class pfKIMsg : public plMessage
             s->WriteLE32( fValue );
         }
 
-        uint8_t     GetCommand( void ) const { return fCommand; }
+        uint8_t     GetCommand() const { return fCommand; }
 
         void        SetString( const ST::string &str ) { fString = str; }
-        ST::string  GetString( void ) { return fString; }
+        ST::string  GetString() { return fString; }
 
         void        SetUser(const ST::string &str, uint32_t pid=0) { fUser = str; fPlayerID = pid; }
         ST::string  GetUser() const { return fUser; }
         uint32_t    GetPlayerID() const { return fPlayerID; }
 
         void        SetFlags( uint32_t flags ) { fFlags = flags; }
-        uint32_t    GetFlags( void ) const { return fFlags; }
+        uint32_t    GetFlags() const { return fFlags; }
 
         void        SetDelay( float delay ) { fDelay = delay; }
-        float       GetDelay( void ) { return fDelay; }
+        float       GetDelay() { return fDelay; }
 
         void        SetIntValue( int32_t value ) { fValue = value; }
-        int32_t     GetIntValue( void ) { return fValue; }
+        int32_t     GetIntValue() { return fValue; }
 
 #endif // def KI_CONSTANTS_ONLY
 };

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -657,14 +657,14 @@ PyObject* cyMisc::GetPrevAgeInfo()
 }
 
 // current time in current age
-uint32_t cyMisc::GetAgeTime( void )
+uint32_t cyMisc::GetAgeTime()
 {
     return VaultAgeGetAgeTime();
 }
 
 
 
-time_t cyMisc::GetDniTime(void)
+time_t cyMisc::GetDniTime()
 {
     const plUnifiedTime utime = plNetClientMgr::GetInstance()->GetServerTime();
     if ( utime.GetSecs() != 0)
@@ -673,13 +673,13 @@ time_t cyMisc::GetDniTime(void)
         return 0;
 }
 
-time_t cyMisc::GetServerTime(void)
+time_t cyMisc::GetServerTime()
 {
     const plUnifiedTime utime = plNetClientMgr::GetInstance()->GetServerTime();
     return utime.GetSecs();
 }
 
-float cyMisc::GetAgeTimeOfDayPercent(void)
+float cyMisc::GetAgeTimeOfDayPercent()
 {
     return plNetClientMgr::GetInstance()->GetCurrentAgeTimeOfDayPercent();
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -96,7 +96,7 @@ public:
 
 
     static void         SetPipeline( plPipeline *pipe ) { fPipeline = pipe; }
-    static plPipeline   *GetPipeline( void ) { return fPipeline; }
+    static plPipeline   *GetPipeline() { return fPipeline; }
 
 
 #if 1
@@ -304,11 +304,11 @@ public:
     static ST::string GetPrevAgeName();
     static PyObject* GetPrevAgeInfo();
     // current time in current age
-    static uint32_t GetAgeTime( void );
-    static time_t GetDniTime(void);
+    static uint32_t GetAgeTime();
+    static time_t GetDniTime();
     static time_t ConvertGMTtoDni(time_t time);
-    static time_t GetServerTime( void ); // returns the current server time in GMT
-    static float GetAgeTimeOfDayPercent(void);
+    static time_t GetServerTime(); // returns the current server time in GMT
+    static float GetAgeTimeOfDayPercent();
 
     /////////////////////////////////////////////////////////////////////////////
     //

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.cpp
@@ -89,7 +89,7 @@ PyObject* pyAgeVault::GetAgeInfo()
     PYTHON_RETURN_NONE;
 }
 
-PyObject* pyAgeVault::GetAgeDevicesFolder( void )
+PyObject* pyAgeVault::GetAgeDevicesFolder()
 {
     hsRef<RelVaultNode> rvn = VaultGetAgeDevicesFolder();
     if (rvn)
@@ -99,7 +99,7 @@ PyObject* pyAgeVault::GetAgeDevicesFolder( void )
     PYTHON_RETURN_NONE;
 }
 
-PyObject* pyAgeVault::GetSubAgesFolder( void )
+PyObject* pyAgeVault::GetSubAgesFolder()
 {
     hsRef<RelVaultNode> rvn = VaultGetAgeSubAgesFolder();
     if (rvn)
@@ -109,7 +109,7 @@ PyObject* pyAgeVault::GetSubAgesFolder( void )
     PYTHON_RETURN_NONE;
 }
 
-PyObject* pyAgeVault::GetChronicleFolder( void )
+PyObject* pyAgeVault::GetChronicleFolder()
 {
     hsRef<RelVaultNode> rvn = VaultGetAgeChronicleFolder();
     if (rvn)
@@ -119,7 +119,7 @@ PyObject* pyAgeVault::GetChronicleFolder( void )
     PYTHON_RETURN_NONE;
 }
 
-PyObject* pyAgeVault::GetBookshelfFolder ( void )
+PyObject* pyAgeVault::GetBookshelfFolder ()
 {
     hsRef<RelVaultNode> rvn = VaultAgeGetBookshelfFolder();
     if (rvn)
@@ -129,7 +129,7 @@ PyObject* pyAgeVault::GetBookshelfFolder ( void )
     PYTHON_RETURN_NONE;
 }
 
-PyObject* pyAgeVault::GetPeopleIKnowAboutFolder( void )
+PyObject* pyAgeVault::GetPeopleIKnowAboutFolder()
 {
     hsRef<RelVaultNode> rvn = VaultGetAgePeopleIKnowAboutFolder();
     if (rvn)
@@ -140,7 +140,7 @@ PyObject* pyAgeVault::GetPeopleIKnowAboutFolder( void )
 }
 
 
-PyObject* pyAgeVault::GetPublicAgesFolder(void)
+PyObject* pyAgeVault::GetPublicAgesFolder()
 {
     hsRef<RelVaultNode> rvn = VaultGetAgePublicAgesFolder();
     if (rvn)
@@ -160,7 +160,7 @@ PyObject* pyAgeVault::GetSubAgeLink( const pyAgeInfoStruct & info )
     PYTHON_RETURN_NONE;
 }
 
-plUUID pyAgeVault::GetAgeGuid( void )
+plUUID pyAgeVault::GetAgeGuid()
 {
     hsRef<RelVaultNode> rvn = VaultGetAgeInfoNode();
     if (rvn) {

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.h
@@ -82,24 +82,24 @@ public:
 
     static void AddPlasmaClasses(PyObject *m);
 
-    plUUID          GetAgeGuid(void);
+    plUUID          GetAgeGuid();
 
     PyObject *      GetAgeSDL() const; // returns pySDLStateDataRecord
     void            UpdateAgeSDL( pySDLStateDataRecord & pyrec );
 
     PyObject*       GetAgeInfo(); // returns pyVaultAgeInfoNode
-    PyObject*       GetAgeDevicesFolder( void ); // returns pyVaultFolderNode
-    PyObject*       GetSubAgesFolder( void ); // returns pyVaultFolderNode
-    PyObject*       GetChronicleFolder( void ); // returns pyVaultFolderNode
+    PyObject*       GetAgeDevicesFolder(); // returns pyVaultFolderNode
+    PyObject*       GetSubAgesFolder(); // returns pyVaultFolderNode
+    PyObject*       GetChronicleFolder(); // returns pyVaultFolderNode
     // Age chronicle (not the player chronicle!)
     PyObject*       FindChronicleEntry( const ST::string& entryName ); // returns pyVaultChronicleNode
     void AddChronicleEntry( const ST::string& name, uint32_t type, const ST::string& value );
     // Players who have published to devices in this age
-    PyObject*       GetPeopleIKnowAboutFolder( void ); // returns pyVaultPlayerInfoListNode
+    PyObject*       GetPeopleIKnowAboutFolder(); // returns pyVaultPlayerInfoListNode
     // PERSONAL AGE SPECIFIC
-    PyObject*       GetBookshelfFolder ( void ); // returns pyVaultFolderNode
+    PyObject*       GetBookshelfFolder (); // returns pyVaultFolderNode
     // NEXUS SPECIFIC
-    PyObject*       GetPublicAgesFolder( void ); // returns pyVaultFolderNode
+    PyObject*       GetPublicAgesFolder(); // returns pyVaultFolderNode
     PyObject*       GetSubAgeLink( const pyAgeInfoStruct & info ); // returns pyVaultAgeLinkNode
     // AGE DEVICES. AKA IMAGERS, WHATEVER.
     // Add a new device.

--- a/Sources/Plasma/FeatureLib/pfPython/pyAudioControl.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAudioControl.cpp
@@ -367,7 +367,7 @@ void pyAudioControl::RecordSampleRate( int32_t sample_rate )
 {
 }
 
-uint8_t pyAudioControl::GetPriorityCutoff( void )
+uint8_t pyAudioControl::GetPriorityCutoff()
 {
     return plgAudioSys::GetPriorityCutoff();
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyAudioControl.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAudioControl.h
@@ -157,7 +157,7 @@ public:
     // Set the sample rate for recording
     virtual void RecordSampleRate( int32_t sample_rate );
 
-    virtual uint8_t GetPriorityCutoff( void );
+    virtual uint8_t GetPriorityCutoff();
     virtual void  SetPriorityCutoff( uint8_t cut );
 
     // does the device specified support EAX

--- a/Sources/Plasma/FeatureLib/pfPython/pyDniInfoSource.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDniInfoSource.cpp
@@ -50,7 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plVault/plVault.h"
 #include "pyDniCoordinates.h"
 
-PyObject* pyDniInfoSource::GetAgeCoords( void )
+PyObject* pyDniInfoSource::GetAgeCoords()
 {
 #if 0 // this may get retooled for another purpose someday...
     const plDniCoordinateInfo * coords = plNetPlayerVNodeMgr::GetInstance()->GetAgeInfo()->GetAgeCoords();
@@ -61,7 +61,7 @@ PyObject* pyDniInfoSource::GetAgeCoords( void )
     PYTHON_RETURN_NONE;
 }
 
-uint32_t pyDniInfoSource::GetAgeTime( void ) const
+uint32_t pyDniInfoSource::GetAgeTime() const
 {
     hsRef<RelVaultNode> node = VaultGetAgeInfoNode();
     if (!node)
@@ -87,7 +87,7 @@ ST::string pyDniInfoSource::GetAgeName() const
     return ageInfo.GetAgeInstanceName();
 }
 
-plUUID pyDniInfoSource::GetAgeGuid( void ) const
+plUUID pyDniInfoSource::GetAgeGuid() const
 {
     if (hsRef<RelVaultNode> node = VaultGetAgeInfoNode())
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyDniInfoSource.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDniInfoSource.h
@@ -65,13 +65,13 @@ public:
     static void AddPlasmaClasses(PyObject *m);
 
     // current coords of the player in current age as a pyDniCoordinates
-    PyObject* GetAgeCoords( void ); // returns pyDniCoordinates
+    PyObject* GetAgeCoords(); // returns pyDniCoordinates
     // current time in current age (tbd)
-    uint32_t          GetAgeTime( void ) const;
+    uint32_t          GetAgeTime() const;
     // name of current age
     ST::string    GetAgeName() const;
     // unique identifier for this age instance
-    plUUID          GetAgeGuid(void) const;
+    plUUID          GetAgeGuid() const;
 };
 
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyDynamicText.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDynamicText.cpp
@@ -163,7 +163,7 @@ void pyDynamicText::ClearToColor( pyColor& color )
     }
 }
 
-void pyDynamicText::Flush( void )
+void pyDynamicText::Flush()
 {
     // create message
     plDynamicTextMsg* pMsg = ICreateDTMsg();
@@ -174,7 +174,7 @@ void pyDynamicText::Flush( void )
     }
 }
 
-void pyDynamicText::PurgeImage( void )
+void pyDynamicText::PurgeImage()
 {
     // create message
     plDynamicTextMsg* pMsg = ICreateDTMsg();
@@ -319,7 +319,7 @@ void pyDynamicText::DrawImageClipped( uint16_t x, uint16_t y, pyImage& image, ui
 }
 
 
-uint16_t  pyDynamicText::GetWidth( void )
+uint16_t  pyDynamicText::GetWidth()
 {
     // We better just pick our first key. Note that the ONLY time we should be getting multiple receivers
     // is if the export process ends up creating multiple copies of the material. Now, WHY you'd be wanting
@@ -334,7 +334,7 @@ uint16_t  pyDynamicText::GetWidth( void )
     return (uint16_t)dtMap->GetWidth();
 }
 
-uint16_t  pyDynamicText::GetHeight( void )
+uint16_t  pyDynamicText::GetHeight()
 {
     // We better just pick our first key. Note that the ONLY time we should be getting multiple receivers
     // is if the export process ends up creating multiple copies of the material. Now, WHY you'd be wanting

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControl.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControl.cpp
@@ -139,7 +139,7 @@ void pyGUIControl::SetEnabled( bool e )
     }
 }
 
-bool pyGUIControl::IsEnabled( void )
+bool pyGUIControl::IsEnabled()
 {
     if ( fGCkey )
     {
@@ -162,7 +162,7 @@ void pyGUIControl::SetFocused( bool e )
     }
 }
 
-bool pyGUIControl::IsFocused( void )
+bool pyGUIControl::IsFocused()
 {
     if ( fGCkey )
     {
@@ -185,7 +185,7 @@ void pyGUIControl::SetVisible( bool vis )
     }
 }
 
-bool pyGUIControl::IsVisible( void )
+bool pyGUIControl::IsVisible()
 {
     if ( fGCkey )
     {
@@ -197,7 +197,7 @@ bool pyGUIControl::IsVisible( void )
     return false;
 }
 
-bool pyGUIControl::IsInteresting( void )
+bool pyGUIControl::IsInteresting()
 {
     if ( fGCkey )
     {
@@ -220,7 +220,7 @@ void pyGUIControl::SetNotifyOnInteresting( bool state )
     }
 }
 
-void pyGUIControl::Refresh( void )
+void pyGUIControl::Refresh()
 {
     if ( fGCkey )
     {
@@ -257,7 +257,7 @@ PyObject* pyGUIControl::GetObjectCenter()
 
 
 
-PyObject* pyGUIControl::GetOwnerDlg( void )
+PyObject* pyGUIControl::GetOwnerDlg()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControl.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControl.h
@@ -99,21 +99,21 @@ public:
     virtual void    SetEnabled( bool e );
     virtual void    Enable() { SetEnabled(true); }
     virtual void    Disable() { SetEnabled(false); }
-    virtual bool    IsEnabled( void );
+    virtual bool    IsEnabled();
     virtual void    SetFocused( bool e );
     virtual void    Focus() { SetFocused(true); }
     virtual void    UnFocus() { SetFocused(false); }
-    virtual bool    IsFocused( void );
+    virtual bool    IsFocused();
     virtual void    SetVisible( bool vis );
     virtual void    Show() { SetVisible(true); }
     virtual void    Hide() { SetVisible(false); }
-    virtual bool    IsVisible( void );
-    virtual bool    IsInteresting( void );
+    virtual bool    IsVisible();
+    virtual bool    IsInteresting();
     virtual void    SetNotifyOnInteresting( bool state );
-    virtual void    Refresh( void );
+    virtual void    Refresh();
     virtual void    SetObjectCenter( pyPoint3& pt);
     virtual PyObject* GetObjectCenter(); // returns pyPoint3
-    virtual PyObject* GetOwnerDlg( void ); // returns pyGUIDialog
+    virtual PyObject* GetOwnerDlg(); // returns pyGUIDialog
 
     // get color schemes
     virtual PyObject*   GetForeColor() const; // returns pyColor

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlCheckBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlCheckBox.cpp
@@ -78,7 +78,7 @@ void pyGUIControlCheckBox::SetChecked( bool checked )
 }
 
 
-bool pyGUIControlCheckBox::IsChecked( void )
+bool pyGUIControlCheckBox::IsChecked()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlCheckBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlCheckBox.h
@@ -75,7 +75,7 @@ public:
     static bool IsGUIControlCheckBox(pyKey& gckey);
 
     virtual void    SetChecked( bool checked );
-    virtual bool    IsChecked( void );
+    virtual bool    IsChecked();
 
 };
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlClickMap.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlClickMap.cpp
@@ -68,7 +68,7 @@ bool pyGUIControlClickMap::IsGUIControlClickMap(pyKey& gckey)
 }
 
 
-PyObject* pyGUIControlClickMap::GetLastMousePt( void )
+PyObject* pyGUIControlClickMap::GetLastMousePt()
 {
     if ( fGCkey )
     {
@@ -80,7 +80,7 @@ PyObject* pyGUIControlClickMap::GetLastMousePt( void )
     PYTHON_RETURN_NONE;
 }
 
-PyObject* pyGUIControlClickMap::GetLastMouseUpPt( void )
+PyObject* pyGUIControlClickMap::GetLastMouseUpPt()
 {
     if ( fGCkey )
     {
@@ -92,7 +92,7 @@ PyObject* pyGUIControlClickMap::GetLastMouseUpPt( void )
     PYTHON_RETURN_NONE;
 }
 
-PyObject* pyGUIControlClickMap::GetLastMouseDragPt( void )
+PyObject* pyGUIControlClickMap::GetLastMouseDragPt()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlClickMap.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlClickMap.h
@@ -73,9 +73,9 @@ public:
 
     static bool IsGUIControlClickMap(pyKey& gckey);
 
-    PyObject* GetLastMousePt( void ); // returns pyPoint3
-    PyObject* GetLastMouseUpPt( void ); // returns pyPoint3
-    PyObject* GetLastMouseDragPt( void ); // returns pyPoint3
+    PyObject* GetLastMousePt(); // returns pyPoint3
+    PyObject* GetLastMouseUpPt(); // returns pyPoint3
+    PyObject* GetLastMouseDragPt(); // returns pyPoint3
 
 };
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDragBar.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDragBar.cpp
@@ -71,7 +71,7 @@ bool pyGUIControlDragBar::IsGUIControlDragBar(pyKey& gckey)
 }
 
 
-void pyGUIControlDragBar::Anchor( void )
+void pyGUIControlDragBar::Anchor()
 {
     if ( fGCkey )
     {
@@ -82,7 +82,7 @@ void pyGUIControlDragBar::Anchor( void )
     }
 }
 
-void pyGUIControlDragBar::Unanchor( void )
+void pyGUIControlDragBar::Unanchor()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDragBar.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDragBar.h
@@ -77,8 +77,8 @@ public:
 
     static bool IsGUIControlDragBar(pyKey& gckey);
 
-    virtual void    Anchor( void );
-    virtual void    Unanchor( void );
+    virtual void    Anchor();
+    virtual void    Unanchor();
     virtual bool    IsAnchored();
 
 };

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDraggable.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDraggable.cpp
@@ -78,7 +78,7 @@ void pyGUIControlDraggable::StopDragging( bool cancel )
     }
 }
 
-PyObject* pyGUIControlDraggable::GetLastMousePt( void )
+PyObject* pyGUIControlDraggable::GetLastMousePt()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDraggable.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDraggable.h
@@ -79,7 +79,7 @@ public:
     static bool IsGUIControlDraggable(pyKey& gckey);
 
     void StopDragging( bool cancel );
-    PyObject* GetLastMousePt( void ); // returns pyPoint3
+    PyObject* GetLastMousePt(); // returns pyPoint3
 
 };
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
@@ -77,7 +77,7 @@ void pyGUIControlEditBox::SetBufferSize( uint32_t size )
 }
 
 
-std::string pyGUIControlEditBox::GetBuffer( void )
+std::string pyGUIControlEditBox::GetBuffer()
 {
     if ( fGCkey )
     {
@@ -89,7 +89,7 @@ std::string pyGUIControlEditBox::GetBuffer( void )
     return "";
 }
 
-std::wstring pyGUIControlEditBox::GetBufferW( void )
+std::wstring pyGUIControlEditBox::GetBufferW()
 {
     if ( fGCkey )
     {
@@ -101,7 +101,7 @@ std::wstring pyGUIControlEditBox::GetBufferW( void )
     return L"";
 }
 
-void pyGUIControlEditBox::ClearBuffer( void )
+void pyGUIControlEditBox::ClearBuffer()
 {
     if ( fGCkey )
     {
@@ -134,7 +134,7 @@ void pyGUIControlEditBox::SetTextW( const wchar_t *str )
     }
 }
 
-void pyGUIControlEditBox::SetCursorToHome(void)
+void pyGUIControlEditBox::SetCursorToHome()
 {
     if ( fGCkey )
     {
@@ -145,7 +145,7 @@ void pyGUIControlEditBox::SetCursorToHome(void)
     }
 }
 
-void pyGUIControlEditBox::SetCursorToEnd(void)
+void pyGUIControlEditBox::SetCursorToEnd()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.h
@@ -75,13 +75,13 @@ public:
     static bool IsGUIControlEditBox(pyKey& gckey);
 
     virtual void    SetBufferSize( uint32_t size );
-    virtual std::string GetBuffer( void );
-    virtual std::wstring GetBufferW( void );
-    virtual void    ClearBuffer( void );
+    virtual std::string GetBuffer();
+    virtual std::wstring GetBufferW();
+    virtual void    ClearBuffer();
     virtual void    SetText( const char *str );
     virtual void    SetTextW( const wchar_t *str );
-    virtual void    SetCursorToHome(void);
-    virtual void    SetCursorToEnd(void);
+    virtual void    SetCursorToHome();
+    virtual void    SetCursorToEnd();
     virtual void    SetColor(pyColor& forecolor, pyColor& backcolor);
     virtual void    SetSelColor(pyColor& forecolor, pyColor& backcolor);
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
@@ -435,7 +435,7 @@ bool pyGUIControlListBox::IsGUIControlListBox(pyKey& gckey)
     return false;
 }
 
-int32_t pyGUIControlListBox::GetSelection( void )
+int32_t pyGUIControlListBox::GetSelection()
 {
     if ( fGCkey )
     {
@@ -458,7 +458,7 @@ void pyGUIControlListBox::SetSelection( int32_t item )
     }
 }
 
-void pyGUIControlListBox::Refresh( void )
+void pyGUIControlListBox::Refresh()
 {
     if ( fGCkey )
     {
@@ -480,7 +480,7 @@ void pyGUIControlListBox::RemoveElement( uint16_t index )
     }
 }
 
-void pyGUIControlListBox::ClearAllElements( void )
+void pyGUIControlListBox::ClearAllElements()
 {
     if ( fGCkey )
     {
@@ -491,7 +491,7 @@ void pyGUIControlListBox::ClearAllElements( void )
     }
 }
 
-uint16_t pyGUIControlListBox::GetNumElements( void )
+uint16_t pyGUIControlListBox::GetNumElements()
 {
     if ( fGCkey )
     {
@@ -764,7 +764,7 @@ void    pyGUIControlListBox::SetSwatchEdgeOffset( uint32_t set )
 
 
 
-void pyGUIControlListBox::ScrollToBegin( void )
+void pyGUIControlListBox::ScrollToBegin()
 {
     if ( fGCkey )
     {
@@ -776,7 +776,7 @@ void pyGUIControlListBox::ScrollToBegin( void )
 }
 
 
-void pyGUIControlListBox::ScrollToEnd( void )
+void pyGUIControlListBox::ScrollToEnd()
 {
     if ( fGCkey )
     {
@@ -800,7 +800,7 @@ void pyGUIControlListBox::SetScrollPos( int32_t pos )
 }
 
 
-int32_t pyGUIControlListBox::GetScrollPos( void )
+int32_t pyGUIControlListBox::GetScrollPos()
 {
     if ( fGCkey )
     {
@@ -813,7 +813,7 @@ int32_t pyGUIControlListBox::GetScrollPos( void )
 }
 
 
-int32_t pyGUIControlListBox::GetScrollRange( void )
+int32_t pyGUIControlListBox::GetScrollRange()
 {
     if ( fGCkey )
     {
@@ -826,7 +826,7 @@ int32_t pyGUIControlListBox::GetScrollRange( void )
 }
 
 
-void pyGUIControlListBox::LockList( void )
+void pyGUIControlListBox::LockList()
 {
     if ( fGCkey )
     {
@@ -838,7 +838,7 @@ void pyGUIControlListBox::LockList( void )
 }
 
 
-void pyGUIControlListBox::UnlockList( void )
+void pyGUIControlListBox::UnlockList()
 {
     if ( fGCkey )
     {
@@ -849,7 +849,7 @@ void pyGUIControlListBox::UnlockList( void )
     }
 }
 
-void pyGUIControlListBox::Clickable( void )
+void pyGUIControlListBox::Clickable()
 {
     if ( fGCkey )
     {
@@ -860,7 +860,7 @@ void pyGUIControlListBox::Clickable( void )
     }
 }
 
-void pyGUIControlListBox::Unclickable( void )
+void pyGUIControlListBox::Unclickable()
 {
     if ( fGCkey )
     {
@@ -891,7 +891,7 @@ void    pyGUIControlListBox::AddBranch( const ST::string &name, bool initiallyOp
     }
 }
 
-void    pyGUIControlListBox::CloseBranch( void )
+void    pyGUIControlListBox::CloseBranch()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
@@ -83,15 +83,15 @@ public:
 
     // special case control for the listbox
     // ...this allows the listbox to be used without being selectable
-    virtual void    Clickable( void );
-    virtual void    Unclickable( void );
-    virtual int32_t   GetSelection( void );
+    virtual void    Clickable();
+    virtual void    Unclickable();
+    virtual int32_t   GetSelection();
     virtual void    SetSelection( int32_t item );
-    virtual void    Refresh( void );
+    virtual void    Refresh();
     virtual void    SetElement( uint16_t idx, const ST::string& text );
     virtual void    RemoveElement( uint16_t index );
-    virtual void    ClearAllElements( void );
-    virtual uint16_t  GetNumElements( void );
+    virtual void    ClearAllElements();
+    virtual uint16_t  GetNumElements();
     virtual ST::string  GetElement( uint16_t idx );
     virtual int16_t   AddString( const ST::string &string );
     virtual int16_t   AddImage( pyImage& image, bool respectAlpha );
@@ -109,19 +109,19 @@ public:
     virtual void    Add2TextWColor( const char *str1, pyColor& textcolor1,const char *str2, pyColor& textcolor2, uint32_t inheritalpha);
     virtual void    Add2TextWColorW( std::wstring str1, pyColor& textcolor1, std::wstring str2, pyColor& textcolor2, uint32_t inheritalpha);
     virtual int16_t   AddStringInBox( const ST::string &string, uint32_t min_width, uint32_t min_height );
-    virtual void    ScrollToBegin( void );
-    virtual void    ScrollToEnd( void );
+    virtual void    ScrollToBegin();
+    virtual void    ScrollToEnd();
     virtual void    SetScrollPos( int32_t pos );
-    virtual int32_t   GetScrollPos( void );
-    virtual int32_t   GetScrollRange( void );
+    virtual int32_t   GetScrollPos();
+    virtual int32_t   GetScrollRange();
 
-    virtual void    LockList( void );
-    virtual void    UnlockList( void );
+    virtual void    LockList();
+    virtual void    UnlockList();
 
     // To create tree branches, call AddBranch() with a name, then add elements as usual, including new sub-branches
     // via additional AddBranch() calls. Call CloseBranch() to stop writing elements to that branch.
     void            AddBranch( const ST::string &name, bool initiallyOpen );
-    void            CloseBranch( void );
+    void            CloseBranch();
 
     void            RemoveSelection( int32_t item );
     void            AddSelection( int32_t item );

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
@@ -116,7 +116,7 @@ void pyGUIControlMultiLineEdit::MoveCursor( int32_t dir)
 }
 
 
-void pyGUIControlMultiLineEdit::ClearBuffer( void )
+void pyGUIControlMultiLineEdit::ClearBuffer()
 {
     if ( fGCkey )
     {
@@ -155,7 +155,7 @@ void pyGUIControlMultiLineEdit::SetTextW( const wchar_t *asciiText )
     }
 }
 
-const char* pyGUIControlMultiLineEdit::GetText( void )
+const char* pyGUIControlMultiLineEdit::GetText()
 {
     // up to the caller to free the string... but when?
     if ( fGCkey )
@@ -173,7 +173,7 @@ const char* pyGUIControlMultiLineEdit::GetText( void )
     return nil;
 }
 
-const wchar_t* pyGUIControlMultiLineEdit::GetTextW( void )
+const wchar_t* pyGUIControlMultiLineEdit::GetTextW()
 {
     // up to the caller to free the string... but when?
     if ( fGCkey )
@@ -433,7 +433,7 @@ void pyGUIControlMultiLineEdit::InsertStyle( uint8_t fontStyle )
     }
 }
 
-void pyGUIControlMultiLineEdit::DeleteChar( void )
+void pyGUIControlMultiLineEdit::DeleteChar()
 {
     if ( fGCkey )
     {
@@ -446,7 +446,7 @@ void pyGUIControlMultiLineEdit::DeleteChar( void )
     }
 }
 
-void pyGUIControlMultiLineEdit::Lock( void )
+void pyGUIControlMultiLineEdit::Lock()
 {
     if ( fGCkey )
     {
@@ -457,7 +457,7 @@ void pyGUIControlMultiLineEdit::Lock( void )
     }
 }
 
-void pyGUIControlMultiLineEdit::Unlock( void )
+void pyGUIControlMultiLineEdit::Unlock()
 {
     if ( fGCkey )
     {
@@ -468,7 +468,7 @@ void pyGUIControlMultiLineEdit::Unlock( void )
     }
 }
 
-bool pyGUIControlMultiLineEdit::IsLocked( void )
+bool pyGUIControlMultiLineEdit::IsLocked()
 {
     if ( fGCkey )
     {
@@ -481,7 +481,7 @@ bool pyGUIControlMultiLineEdit::IsLocked( void )
     return false;
 }
 
-void pyGUIControlMultiLineEdit::Clickable( void )
+void pyGUIControlMultiLineEdit::Clickable()
 {
     if ( fGCkey )
     {
@@ -492,7 +492,7 @@ void pyGUIControlMultiLineEdit::Clickable( void )
     }
 }
 
-void pyGUIControlMultiLineEdit::Unclickable( void )
+void pyGUIControlMultiLineEdit::Unclickable()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
@@ -74,17 +74,17 @@ public:
 
     static bool IsGUIControlMultiLineEdit(pyKey& gckey);
 
-    virtual void    Clickable( void );
-    virtual void    Unclickable( void );
+    virtual void    Clickable();
+    virtual void    Unclickable();
     virtual void    SetScrollPosition( int32_t topLine );
     virtual int32_t GetScrollPosition();
     virtual bool    IsAtEnd();
     virtual void    MoveCursor( int32_t dir );
-    virtual void    ClearBuffer( void );
+    virtual void    ClearBuffer();
     virtual void    SetText( const char *asciiText );
     virtual void    SetTextW( const wchar_t *asciiText );
-    virtual const char* GetText( void );        // returns a python string object
-    virtual const wchar_t* GetTextW( void );
+    virtual const char* GetText();        // returns a python string object
+    virtual const wchar_t* GetTextW();
     virtual void    SetEncodedBuffer( PyObject* buffer_object );
     virtual void    SetEncodedBufferW( PyObject* buffer_object );
     virtual const char* GetEncodedBuffer();
@@ -100,11 +100,11 @@ public:
     virtual void    InsertStringW( const wchar_t *string );
     virtual void    InsertColor( pyColor& color );
     virtual void    InsertStyle( uint8_t fontStyle );
-    virtual void    DeleteChar( void );
+    virtual void    DeleteChar();
 
-    virtual void    Lock( void );
-    virtual void    Unlock( void );
-    virtual bool    IsLocked( void );
+    virtual void    Lock();
+    virtual void    Unlock();
+    virtual bool    IsLocked();
 
     virtual void    EnableScrollControl();
     virtual void    DisableScrollControl();

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlRadioGroup.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlRadioGroup.cpp
@@ -63,7 +63,7 @@ bool pyGUIControlRadioGroup::IsGUIControlRadioGroup(pyKey& gckey)
     return false;
 }
 
-int32_t pyGUIControlRadioGroup::GetValue( void )
+int32_t pyGUIControlRadioGroup::GetValue()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlRadioGroup.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlRadioGroup.h
@@ -74,7 +74,7 @@ public:
 
     static bool IsGUIControlRadioGroup(pyKey& gckey);
 
-    virtual int32_t   GetValue( void );
+    virtual int32_t   GetValue();
     virtual void    SetValue( int32_t value );
 
 };

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlValue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlValue.cpp
@@ -89,7 +89,7 @@ void pyGUIControlValue::SetValue( float v )
     }
 }
 
-float pyGUIControlValue::GetMin( void )
+float pyGUIControlValue::GetMin()
 {
     if ( fGCkey )
     {
@@ -101,7 +101,7 @@ float pyGUIControlValue::GetMin( void )
     return 0.0;
 }
 
-float pyGUIControlValue::GetMax( void )
+float pyGUIControlValue::GetMax()
 {
     if ( fGCkey )
     {
@@ -113,7 +113,7 @@ float pyGUIControlValue::GetMax( void )
     return 0.0;
 }
 
-float pyGUIControlValue::GetStep( void )
+float pyGUIControlValue::GetStep()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlValue.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlValue.h
@@ -74,9 +74,9 @@ public:
 
     virtual float    GetValue();
     virtual void        SetValue( float v );
-    virtual float    GetMin( void );
-    virtual float    GetMax( void );
-    virtual float    GetStep( void );
+    virtual float    GetMin();
+    virtual float    GetMax();
+    virtual float    GetStep();
     virtual void        SetRange( float min, float max );
     virtual void        SetStep( float step );
 };

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.cpp
@@ -184,7 +184,7 @@ void pyGUIDialog::SetEnabled( bool e )
     }
 }
 
-bool pyGUIDialog::IsEnabled( void )
+bool pyGUIDialog::IsEnabled()
 {
     if ( fGCkey )
     {
@@ -195,7 +195,7 @@ bool pyGUIDialog::IsEnabled( void )
     return false;
 }
 
-const char* pyGUIDialog::GetName( void )
+const char* pyGUIDialog::GetName()
 {
     if ( fGCkey )
     {
@@ -207,7 +207,7 @@ const char* pyGUIDialog::GetName( void )
 }
 
 
-uint32_t pyGUIDialog::GetVersion(void)
+uint32_t pyGUIDialog::GetVersion()
 {
     if ( fGCkey )
     {
@@ -219,7 +219,7 @@ uint32_t pyGUIDialog::GetVersion(void)
 }
 
 
-uint32_t pyGUIDialog::GetNumControls( void )
+uint32_t pyGUIDialog::GetNumControls()
 {
     if ( fGCkey )
     {
@@ -264,7 +264,7 @@ void pyGUIDialog::SetFocus( pyKey& gcKey )
     }
 }
 
-void pyGUIDialog::Show( void )
+void pyGUIDialog::Show()
 {
     if ( fGCkey )
     {
@@ -277,7 +277,7 @@ void pyGUIDialog::Show( void )
     }
 }
 
-void pyGUIDialog::ShowNoReset( void )
+void pyGUIDialog::ShowNoReset()
 {
     if ( fGCkey )
     {
@@ -287,7 +287,7 @@ void pyGUIDialog::ShowNoReset( void )
     }
 }
 
-void pyGUIDialog::Hide( void )
+void pyGUIDialog::Hide()
 {
     if ( fGCkey )
     {
@@ -485,7 +485,7 @@ void pyGUIDialog::SetFontSize(uint32_t fontsize)
     }
 }
 
-void pyGUIDialog::UpdateAllBounds( void )
+void pyGUIDialog::UpdateAllBounds()
 {
     if ( fGCkey )
     {
@@ -495,7 +495,7 @@ void pyGUIDialog::UpdateAllBounds( void )
     }
 }
 
-void pyGUIDialog::RefreshAllControls( void )
+void pyGUIDialog::RefreshAllControls()
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.h
@@ -119,17 +119,17 @@ public:
     virtual void    SetEnabled( bool e );
     virtual void    Enable() { SetEnabled(true); }
     virtual void    Disable() { SetEnabled(false); }
-    virtual bool        IsEnabled( void );
-    virtual const char  *GetName( void );
-    virtual uint32_t      GetVersion(void);
+    virtual bool        IsEnabled();
+    virtual const char  *GetName();
+    virtual uint32_t      GetVersion();
 
-    virtual uint32_t      GetNumControls( void );
+    virtual uint32_t      GetNumControls();
     virtual PyObject*   GetControl( uint32_t idx ); // returns pyKey
     virtual void        SetFocus( pyKey& gcKey );
     virtual void        NoFocus( );
-    virtual void        Show( void );
-    virtual void        ShowNoReset( void );
-    virtual void        Hide( void );
+    virtual void        Show();
+    virtual void        ShowNoReset();
+    virtual void        Hide();
     virtual PyObject*   GetControlFromTag( uint32_t tagID );  // returns pyKey
 
     // get color schemes
@@ -145,8 +145,8 @@ public:
     virtual void        SetBackSelColor( float r, float g, float b, float a );
     virtual void        SetFontSize(uint32_t fontsize);
 
-    virtual void        UpdateAllBounds( void );
-    virtual void        RefreshAllControls( void );
+    virtual void        UpdateAllBounds();
+    virtual void        RefreshAllControls();
 };
 
 #endif // _pyGUIDialog_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.cpp
@@ -232,33 +232,33 @@ void pyGUIPopUpMenu::SetEnabled( bool e )
     menu->SetEnabled(e);
 }
 
-bool pyGUIPopUpMenu::IsEnabled( void )
+bool pyGUIPopUpMenu::IsEnabled()
 {
     kGetMenuPtr( false );
     return menu->IsEnabled();
 }
 
-const char* pyGUIPopUpMenu::GetName( void )
+const char* pyGUIPopUpMenu::GetName()
 {
     kGetMenuPtr( "" );
     return menu->GetName();
 }
 
 
-uint32_t pyGUIPopUpMenu::GetVersion(void)
+uint32_t pyGUIPopUpMenu::GetVersion()
 {
     kGetMenuPtr( 0 );
     return menu->GetVersion();
 }
 
 
-void pyGUIPopUpMenu::Show( void )
+void pyGUIPopUpMenu::Show()
 {
     kGetMenuPtr( ; );
     ( (pfGUIDialogMod *)menu )->Show();
 }
 
-void pyGUIPopUpMenu::Hide( void )
+void pyGUIPopUpMenu::Hide()
 {
     kGetMenuPtr( ; );
     menu->Hide();

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.h
@@ -108,12 +108,12 @@ public:
     virtual void    SetEnabled( bool e );
     virtual void    Enable() { SetEnabled(true); }
     virtual void    Disable() { SetEnabled(false); }
-    virtual bool    IsEnabled( void );
-    virtual const char  *GetName( void );
-    virtual uint32_t     GetVersion(void);
+    virtual bool    IsEnabled();
+    virtual const char  *GetName();
+    virtual uint32_t     GetVersion();
 
-    virtual void        Show( void );
-    virtual void        Hide( void );
+    virtual void        Show();
+    virtual void        Hide();
 
     // get color schemes
     virtual PyObject*   GetForeColor(); // returns pyColor

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
@@ -60,7 +60,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 uint32_t  pyJournalBook::fNextKeyID = 0;
 
-void    pyJournalBook::IMakeNewKey( void )
+void    pyJournalBook::IMakeNewKey()
 {
     ST::string name = ST::format("pyJournalBook-{}", fNextKeyID++);
     hsgResMgr::ResMgr()->NewKey( name, fBook, plLocation::kGlobalFixedLoc );
@@ -170,7 +170,7 @@ void    pyJournalBook::Show( bool startOpened )
         fBook->Show( startOpened );
 }
 
-void    pyJournalBook::Hide( void )
+void    pyJournalBook::Hide()
 {
     if( fBook != nil )
         fBook->Hide();
@@ -182,25 +182,25 @@ void    pyJournalBook::Open( uint32_t startingPage )
         fBook->Open( startingPage );
 }
 
-void    pyJournalBook::Close( void )
+void    pyJournalBook::Close()
 {
     if( fBook != nil )
         fBook->Close();
 }
 
-void    pyJournalBook::CloseAndHide( void )
+void    pyJournalBook::CloseAndHide()
 {
     if( fBook != nil )
         fBook->CloseAndHide();
 }
 
-void    pyJournalBook::NextPage( void )
+void    pyJournalBook::NextPage()
 {
     if( fBook != nil )
         fBook->NextPage();
 }
 
-void    pyJournalBook::PreviousPage( void )
+void    pyJournalBook::PreviousPage()
 {
     if( fBook != nil )
         fBook->PreviousPage();
@@ -218,7 +218,7 @@ void    pyJournalBook::SetSize( float width, float height )
         fBook->SetBookSize( width, height );
 }
 
-uint32_t  pyJournalBook::GetCurrentPage( void ) const
+uint32_t  pyJournalBook::GetCurrentPage() const
 {
     if( fBook != nil )
         return fBook->GetCurrentPage();
@@ -282,7 +282,7 @@ void    pyJournalBook::SetEditable( bool editable )
         fBook->SetEditable(editable);
 }
 
-std::string pyJournalBook::GetEditableText( void ) const
+std::string pyJournalBook::GetEditableText() const
 {
     if (fBook != nil)
         return fBook->GetEditableText();

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
@@ -66,7 +66,7 @@ protected:
 
     static uint32_t   fNextKeyID;
 
-    void    IMakeNewKey( void );
+    void    IMakeNewKey();
 
     pyJournalBook(); // used by python glue only, do NOT call
     pyJournalBook( const char *esHTMLSource );
@@ -100,15 +100,15 @@ public:
 
     // Interface functions per book
     virtual void    Show( bool startOpened );
-    virtual void    Hide( void );
+    virtual void    Hide();
     virtual void    Open( uint32_t startingPage );
-    virtual void    Close( void );
-    virtual void    CloseAndHide( void );
+    virtual void    Close();
+    virtual void    CloseAndHide();
 
-    virtual void    NextPage( void );
-    virtual void    PreviousPage( void );
+    virtual void    NextPage();
+    virtual void    PreviousPage();
     virtual void    GoToPage( uint32_t page );
-    virtual uint32_t  GetCurrentPage( void ) const;
+    virtual uint32_t  GetCurrentPage() const;
     virtual void    SetPageMargin( uint32_t margin );
     virtual void    AllowPageTurning( bool allow );
 
@@ -123,7 +123,7 @@ public:
     virtual PyObject *GetMovie( uint8_t index ); // returns cyAnimation
     
     virtual void    SetEditable( bool editable );
-    virtual std::string GetEditableText( void ) const;
+    virtual std::string GetEditableText() const;
     virtual void    SetEditableText( std::string text );
 };
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyNetLinkingMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyNetLinkingMgr.cpp
@@ -55,7 +55,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyAgeInfoStruct.h"
 #include "pyAgeLinkStruct.h"
 
-bool pyNetLinkingMgr::IsEnabled( void ) const
+bool pyNetLinkingMgr::IsEnabled() const
 {
     return plNetLinkingMgr::GetInstance()->IsEnabled();
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyNetLinkingMgr.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyNetLinkingMgr.h
@@ -76,7 +76,7 @@ public:
 
 #ifndef BUILDING_PYPLASMA
     // enable/disable linking
-    bool IsEnabled( void ) const;
+    bool IsEnabled() const;
     void SetEnabled( bool b ) const;
 
     // Link to a public instance. PLS will load balance.

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
@@ -189,7 +189,7 @@ PyObject* pyVault::GetAgeJournalsFolder()
 
 // finds the stats for the players vault
 // ...such as how many pictures, notes and markers they have
-PyObject* pyVault::GetKIUsage(void)
+PyObject* pyVault::GetKIUsage()
 {
     uint32_t pictures = 0;
     uint32_t notes = 0;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.h
@@ -177,7 +177,7 @@ public:
     // set an age's public status, also works for non-owners
     bool SetAgePublic( const pyVaultAgeInfoNode * ageInfoNode, bool makePublic );
 
-    PyObject* GetGlobalInbox( void ); // returns pyVaultFolderNode
+    PyObject* GetGlobalInbox(); // returns pyVaultFolderNode
 
     // find matching node
     PyObject* FindNode( pyVaultNode* templateNode ) const; // returns pyVaultNode

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
@@ -131,7 +131,7 @@ PyObject * pyVaultAgeInfoNode::GetCanVisitFolder() const
     PYTHON_RETURN_NONE;
 }
 
-PyObject* pyVaultAgeInfoNode::GetChildAgesFolder( void )
+PyObject* pyVaultAgeInfoNode::GetChildAgesFolder()
 {
     if (!fNode)
         PYTHON_RETURN_NONE;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.h
@@ -83,7 +83,7 @@ public:
 //
     PyObject *  GetCanVisitFolder() const; // returns pyVaultPlayerInfoListNode
     PyObject * GetAgeOwnersFolder() const; // returns pyVaultPlayerInfoListNode
-    PyObject* GetChildAgesFolder( void ); // returns pyVaultFolderNode
+    PyObject* GetChildAgesFolder(); // returns pyVaultFolderNode
     PyObject *  GetAgeSDL() const; // returns pyVaultSDLNode
     PyObject * GetCzar() const; // returns pyVaultPlayerInfoNode
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.cpp
@@ -114,7 +114,7 @@ void pyVaultChronicleNode::Chronicle_SetType( uint32_t type )
     chron.SetEntryType(type);
 }
 
-uint32_t pyVaultChronicleNode::Chronicle_GetType( void )
+uint32_t pyVaultChronicleNode::Chronicle_GetType()
 {
     if (!fNode)
         return 0;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.h
@@ -83,7 +83,7 @@ public:
     void Chronicle_SetValue( const char * text );
     ST::string Chronicle_GetValue() const;
     void Chronicle_SetType( uint32_t type );
-    uint32_t Chronicle_GetType( void );
+    uint32_t Chronicle_GetType();
 };
 
 #endif // _pyVaultChronicleNode_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.cpp
@@ -78,7 +78,7 @@ void pyVaultFolderNode::Folder_SetType( int type )
     folder.SetFolderType(type);
 }
 
-int pyVaultFolderNode::Folder_GetType( void )
+int pyVaultFolderNode::Folder_GetType()
 {
     if (!fNode)
         return 0;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.h
@@ -77,7 +77,7 @@ public:
     static void AddPlasmaClasses(PyObject *m);
 
     virtual void    Folder_SetType( int type );
-    virtual int     Folder_GetType( void );
+    virtual int     Folder_GetType();
     void    Folder_SetName(const char* name);
     void    Folder_SetNameW(const wchar_t* name);
     ST::string Folder_GetName() const;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.cpp
@@ -138,7 +138,7 @@ ST::string pyVaultImageNode::Image_GetTitle() const
     return ST::null;
 }
 
-PyObject* pyVaultImageNode::Image_GetImage( void )
+PyObject* pyVaultImageNode::Image_GetImage()
 {
     if (!fNode)
         PYTHON_RETURN_NONE;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.h
@@ -89,7 +89,7 @@ public:
     void Image_SetTitleW( const wchar_t * text );
     ST::string Image_GetTitle() const;
 
-    PyObject* Image_GetImage( void ); // returns pyImage
+    PyObject* Image_GetImage(); // returns pyImage
     void Image_SetImage(pyImage& image);
 
     void SetImageFromBuf( PyObject * buf );

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -190,21 +190,21 @@ bool pyVaultNode::operator==(const pyVaultNode &vaultNode) const
 }
 
 // public getters
-uint32_t  pyVaultNode::GetID( void )
+uint32_t  pyVaultNode::GetID()
 {
     if (fNode)
         return fNode->GetNodeId();
     return 0;
 }
 
-uint32_t  pyVaultNode::GetType( void )
+uint32_t  pyVaultNode::GetType()
 {
     if (fNode)
         return fNode->GetNodeType();
     return 0;
 }
 
-uint32_t  pyVaultNode::GetOwnerNodeID( void )
+uint32_t  pyVaultNode::GetOwnerNodeID()
 {
     hsAssert(false, "eric, port?");
 //  if (fNode)
@@ -212,7 +212,7 @@ uint32_t  pyVaultNode::GetOwnerNodeID( void )
     return 0;
 }
 
-PyObject* pyVaultNode::GetOwnerNode( void )
+PyObject* pyVaultNode::GetOwnerNode()
 {
     hsAssert(false, "eric, port?");
 /*
@@ -227,21 +227,21 @@ PyObject* pyVaultNode::GetOwnerNode( void )
     PYTHON_RETURN_NONE;
 }
 
-uint32_t pyVaultNode::GetModifyTime( void )
+uint32_t pyVaultNode::GetModifyTime()
 {
     if (fNode)
         return fNode->GetModifyTime();
     return 0;
 }
 
-uint32_t pyVaultNode::GetCreatorNodeID( void )
+uint32_t pyVaultNode::GetCreatorNodeID()
 {
     if (fNode)
         return fNode->GetCreatorId();
     return 0;
 }
 
-PyObject* pyVaultNode::GetCreatorNode( void )
+PyObject* pyVaultNode::GetCreatorNode()
 {
     PyObject * result = nil;
     if (fNode)
@@ -262,14 +262,14 @@ PyObject* pyVaultNode::GetCreatorNode( void )
     PYTHON_RETURN_NONE;
 }
 
-uint32_t pyVaultNode::GetCreateTime( void )
+uint32_t pyVaultNode::GetCreateTime()
 {
     if (fNode)
         return fNode->GetCreateTime();
     return 0;
 }
 
-uint32_t pyVaultNode::GetCreateAgeTime( void )
+uint32_t pyVaultNode::GetCreateAgeTime()
 {
     hsAssert(false, "eric, port?");
 
@@ -284,7 +284,7 @@ ST::string pyVaultNode::GetCreateAgeName() const
     return ST::null;
 }
 
-plUUID pyVaultNode::GetCreateAgeGuid(void) const
+plUUID pyVaultNode::GetCreateAgeGuid() const
 {
     if (fNode) {
         return fNode->GetCreateAgeUuid();
@@ -469,7 +469,7 @@ bool pyVaultNode::RemoveNode( pyVaultNode& pynode, PyObject* cbObject, uint32_t 
 }
 
 // Remove all child nodes
-void pyVaultNode::RemoveAllNodes( void )
+void pyVaultNode::RemoveAllNodes()
 {
     if (!fNode)
         return;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
@@ -125,20 +125,20 @@ public:
     bool operator!=(const pyVaultNode &vaultNode) const { return !(vaultNode == *this); }
 
     // public getters
-    uint32_t  GetID( void );
-    virtual uint32_t  GetType( void );
-    uint32_t  GetPermissions( void );
-    uint32_t  GetOwnerNodeID( void );
-    PyObject* GetOwnerNode( void ); // returns pyVaultPlayerInfoNode
-    uint32_t  GetGroupNodeID( void );
-    PyObject* GetGroupNode( void ); // returns pyVaultNode
-    uint32_t GetModifyTime( void );
-    uint32_t GetCreatorNodeID( void );
-    PyObject* GetCreatorNode( void ); // returns pyVaultPlayerInfoNode
-    uint32_t GetCreateTime( void );
-    uint32_t GetCreateAgeTime( void );
+    uint32_t  GetID();
+    virtual uint32_t  GetType();
+    uint32_t  GetPermissions();
+    uint32_t  GetOwnerNodeID();
+    PyObject* GetOwnerNode(); // returns pyVaultPlayerInfoNode
+    uint32_t  GetGroupNodeID();
+    PyObject* GetGroupNode(); // returns pyVaultNode
+    uint32_t GetModifyTime();
+    uint32_t GetCreatorNodeID();
+    PyObject* GetCreatorNode(); // returns pyVaultPlayerInfoNode
+    uint32_t GetCreateTime();
+    uint32_t GetCreateAgeTime();
     ST::string GetCreateAgeName() const;
-    plUUID    GetCreateAgeGuid(void) const;
+    plUUID    GetCreateAgeGuid() const;
     PyObject* GetCreateAgeCoords ();
 
     // public setters
@@ -160,7 +160,7 @@ public:
     // Remove child node
     bool RemoveNode( pyVaultNode& pynode, PyObject* cbObject=nil, uint32_t cbContext=0 );
     // Remove all child nodes
-    void RemoveAllNodes( void );
+    void RemoveAllNodes();
     // Add/Save this node to vault
     void Save( PyObject* cbObject=nil, uint32_t cbContext=0 );
     // Save this node and all child nodes that need saving.
@@ -184,7 +184,7 @@ public:
     virtual int GetChildNodeCount();
 
     // Get the client ID from my Vault client.
-    uint32_t  GetClientID( void );
+    uint32_t  GetClientID();
 
     // all the upcasting stuff...
     PyObject* UpcastToFolderNode(); // returns pyVaultFolderNode

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.cpp
@@ -84,12 +84,12 @@ hsRef<RelVaultNode> pyVaultNodeRef::GetChildNode() const
 
 ///////////////////////////////////////////////////////////////////////////
 
-PyObject* pyVaultNodeRef::GetParent ( void )
+PyObject* pyVaultNodeRef::GetParent ()
 {
     return pyVaultNode::New(fParent);
 }
 
-PyObject* pyVaultNodeRef::GetChild( void )
+PyObject* pyVaultNodeRef::GetChild()
 {
     return pyVaultNode::New(fChild);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.cpp
@@ -80,7 +80,7 @@ void pyVaultPlayerInfoNode::Player_SetPlayerID( uint32_t plyrid )
     playerInfo.SetPlayerId(plyrid);
 }
 
-uint32_t pyVaultPlayerInfoNode::Player_GetPlayerID( void )
+uint32_t pyVaultPlayerInfoNode::Player_GetPlayerID()
 {
     if (!fNode)
         return 0;
@@ -134,7 +134,7 @@ void pyVaultPlayerInfoNode::Player_SetAgeGuid( const char * guidtext)
     playerInfo.SetAgeInstUuid(ageInstId);
 }
 
-plUUID pyVaultPlayerInfoNode::Player_GetAgeGuid(void) const
+plUUID pyVaultPlayerInfoNode::Player_GetAgeGuid() const
 {
     if (fNode) {
         VaultPlayerInfoNode playerInfo(fNode);
@@ -153,7 +153,7 @@ void pyVaultPlayerInfoNode::Player_SetOnline( bool b )
     playerInfo.SetOnline(b);
 }
 
-bool pyVaultPlayerInfoNode::Player_IsOnline( void )
+bool pyVaultPlayerInfoNode::Player_IsOnline()
 {
     if (!fNode)
         return false;
@@ -162,7 +162,7 @@ bool pyVaultPlayerInfoNode::Player_IsOnline( void )
     return playerInfo.GetOnline();
 }
 
-int pyVaultPlayerInfoNode::Player_GetCCRLevel( void )
+int pyVaultPlayerInfoNode::Player_GetCCRLevel()
 {
     if (!fNode)
         return 0;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.h
@@ -78,7 +78,7 @@ public:
 // class plVaultPlayerInfoNode : public plVaultNode
 //
     void    Player_SetPlayerID( uint32_t plyrid );
-    uint32_t  Player_GetPlayerID( void );
+    uint32_t  Player_GetPlayerID();
     void    Player_SetPlayerName(const ST::string& name);
     ST::string Player_GetPlayerName() const;
 
@@ -86,12 +86,12 @@ public:
     void    Player_SetAgeInstanceName(const ST::string& name);
     ST::string Player_GetAgeInstanceName() const;
     void    Player_SetAgeGuid( const char * guidtext);
-    plUUID  Player_GetAgeGuid(void) const;
+    plUUID  Player_GetAgeGuid() const;
     // online status
     void    Player_SetOnline( bool b );
-    bool  Player_IsOnline( void );
+    bool  Player_IsOnline();
 
-    int     Player_GetCCRLevel( void );
+    int     Player_GetCCRLevel();
 };
 
 #endif // _pyVaultPlayerInfoNode_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
@@ -134,7 +134,7 @@ void pyVaultTextNoteNode::Note_SetType( int32_t type )
     textNote.SetNoteType(type);
 }
 
-int32_t pyVaultTextNoteNode::Note_GetType( void )
+int32_t pyVaultTextNoteNode::Note_GetType()
 {
     if (!fNode)
         return 0;
@@ -152,7 +152,7 @@ void pyVaultTextNoteNode::Note_SetSubType( int32_t type )
     textNote.SetNoteSubType(type);
 }
 
-int32_t pyVaultTextNoteNode::Note_GetSubType( void )
+int32_t pyVaultTextNoteNode::Note_GetSubType()
 {
     if (!fNode)
         return 0;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.h
@@ -85,10 +85,10 @@ public:
     void Note_SetTextW( const wchar_t * text );
     ST::string Note_GetText() const;
     void Note_SetType( int32_t type );
-    int32_t Note_GetType( void );
+    int32_t Note_GetType();
 
     void Note_SetSubType( int32_t type );
-    int32_t Note_GetSubType( void );
+    int32_t Note_GetSubType();
 
     PyObject * GetDeviceInbox() const; // returns pyVaultFolderNode
     void SetDeviceInbox( const char * devName, PyObject * cb=nil, uint32_t cbContext=0 );

--- a/Sources/Plasma/NucleusLib/inc/plAudible.h
+++ b/Sources/Plasma/NucleusLib/inc/plAudible.h
@@ -101,7 +101,7 @@ public:
     virtual int         GetNumSounds() const = 0;   
     virtual plSound*    GetSound(int i) const = 0;
     virtual int         GetSoundIndex(const char *keyname) const = 0;
-    virtual void        Init(bool isLocal){;}
+    virtual void        Init(bool isLocal) { }
     virtual void        SetVolume(const float volume,int index = -1) = 0;
     virtual void        SetMuted( bool muted, int index = -1 ) = 0;
     virtual void        ToggleMuted( int index = -1 ) = 0;

--- a/Sources/Plasma/NucleusLib/inc/plDrawable.h
+++ b/Sources/Plasma/NucleusLib/inc/plDrawable.h
@@ -158,7 +158,7 @@ public:
     virtual plDrawable& SetSubType( uint32_t index, plSubDrawableType t, bool on ) = 0;
     virtual uint32_t GetSubType( uint32_t index ) const = 0; // returns or of all spans with this index (index==-1 is all spans).
 
-    virtual uint32_t  GetType( void ) const = 0;
+    virtual uint32_t  GetType() const = 0;
     virtual void    SetType( uint32_t type ) = 0;
 
     virtual void SetRenderLevel(const plRenderLevel& l) = 0;
@@ -196,7 +196,7 @@ public:
     virtual bool    DoIMatch( const plDrawableCriteria& crit ) = 0;
 
     // Take the list of triMeshes and convert them to buffers, building a list of spans for each
-    virtual void    Optimize( void ) = 0;
+    virtual void    Optimize() = 0;
 };
 
 #endif // plDrawable_inc

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -183,7 +183,7 @@ public:
 
     // Default fog settings
     virtual void                        SetDefaultFogEnviron( plFogEnvironment *fog ) = 0;
-    virtual const plFogEnvironment      &GetDefaultFogEnviron( void ) const = 0;
+    virtual const plFogEnvironment      &GetDefaultFogEnviron() const = 0;
 
     virtual void                        RegisterLight(plLightInfo* light) = 0;
     virtual void                        UnRegisterLight(plLightInfo* light) = 0;
@@ -222,11 +222,11 @@ public:
     virtual float                       GetClearDepth() const = 0;
     virtual hsGDeviceRef                *MakeRenderTargetRef( plRenderTarget *owner ) = 0;
     virtual void                        PushRenderTarget( plRenderTarget *target ) = 0;
-    virtual plRenderTarget              *PopRenderTarget( void ) = 0;
+    virtual plRenderTarget              *PopRenderTarget() = 0;
 
     virtual bool                        BeginRender() = 0;
     virtual bool                        EndRender() = 0;
-    virtual void                        RenderScreenElements( void ) = 0;
+    virtual void                        RenderScreenElements() = 0;
 
     virtual void                        BeginVisMgr(plVisMgr* visMgr) = 0;
     virtual void                        EndVisMgr(plVisMgr* visMgr) = 0;
@@ -264,9 +264,9 @@ public:
 
     // Drawable type mask
     virtual void                        SetDrawableTypeMask( uint32_t mask ) = 0;
-    virtual uint32_t                    GetDrawableTypeMask( void ) const = 0;
+    virtual uint32_t                    GetDrawableTypeMask() const = 0;
     virtual void                        SetSubDrawableTypeMask( uint32_t mask ) = 0;
-    virtual uint32_t                    GetSubDrawableTypeMask( void ) const = 0;
+    virtual uint32_t                    GetSubDrawableTypeMask() const = 0;
 
     // View state
     virtual hsPoint3                    GetViewPositionWorld() const = 0;
@@ -285,7 +285,7 @@ public:
     virtual void                        SetDepth(float hither, float yon) = 0;
 
     virtual void                        SetZBiasScale( float scale ) = 0;
-    virtual float                       GetZBiasScale( void ) const = 0;
+    virtual float                       GetZBiasScale() const = 0;
 
     virtual const hsMatrix44&           GetWorldToCamera() const = 0;
     virtual const hsMatrix44&           GetCameraToWorld() const = 0;
@@ -299,8 +299,8 @@ public:
     virtual void                        ScreenToWorldPoint( int n, uint32_t stride, int32_t *scrX, int32_t *scrY, 
                                                     float dist, uint32_t strideOut, hsPoint3 *worldOut ) = 0;
 
-    virtual void                        RefreshMatrices( void ) = 0;
-    virtual void                        RefreshScreenMatrices( void ) = 0;
+    virtual void                        RefreshMatrices() = 0;
+    virtual void                        RefreshScreenMatrices() = 0;
 
     // Overrides, always push returns whatever is necessary to restore on pop.
     virtual hsGMaterial*                PushOverrideMaterial(hsGMaterial* mat) = 0;
@@ -334,7 +334,7 @@ public:
     virtual plMipmap*                   ExtractMipMap(plRenderTarget* targ) = 0;
 
     /// Error handling
-    virtual const char                  *GetErrorString( void ) = 0;
+    virtual const char                  *GetErrorString() = 0;
 
     // info about current rendering device
     virtual void GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth = 32 ) = 0;

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
@@ -159,7 +159,7 @@ void    plKeyBinding::SetKey2( const plKeyCombo &newCombo )
     fKey2 = newCombo;
 }
 
-void    plKeyBinding::ClearKeys( void )
+void    plKeyBinding::ClearKeys()
 {
     fKey1 = fKey2 = plKeyCombo::kUnmapped;
 }
@@ -182,7 +182,7 @@ plKeyMap::~plKeyMap()
     ClearAll();
 }
 
-void    plKeyMap::ClearAll( void )
+void    plKeyMap::ClearAll()
 {
     uint32_t  i;
 
@@ -488,7 +488,7 @@ void    plKeyMap::UnmapBinding( ControlEventCode code )
 //// UnmapAllBindings ////////////////////////////////////////////////////////
 //  Unmaps all the bindings, but leaves the code records themselves
 
-void    plKeyMap::UnmapAllBindings( void )
+void    plKeyMap::UnmapAllBindings()
 {
     uint32_t  i;
 

--- a/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
@@ -125,16 +125,16 @@ class plKeyBinding
         plKeyBinding( ControlEventCode code, uint32_t codeFlags, const plKeyCombo &key1, const plKeyCombo &key2, const char *string = nil );
         virtual ~plKeyBinding();
 
-        ControlEventCode    GetCode( void ) const { return fCode; }
-        uint32_t              GetCodeFlags( void ) const { return fCodeFlags; }
-        const plKeyCombo    &GetKey1( void ) const { return fKey1; }
-        const plKeyCombo    &GetKey2( void ) const { return fKey2; }
-        const char          *GetExtendedString( void ) const { return fString; }
+        ControlEventCode    GetCode() const { return fCode; }
+        uint32_t              GetCodeFlags() const { return fCodeFlags; }
+        const plKeyCombo    &GetKey1() const { return fKey1; }
+        const plKeyCombo    &GetKey2() const { return fKey2; }
+        const char          *GetExtendedString() const { return fString; }
         const plKeyCombo    &GetMatchingKey( plKeyDef keyDef ) const;
 
         void    SetKey1( const plKeyCombo &newCombo );
         void    SetKey2( const plKeyCombo &newCombo );
-        void    ClearKeys( void );
+        void    ClearKeys();
         bool    HasUnmappedKey() const;
 };
 
@@ -207,20 +207,20 @@ class plKeyMap : public plInputMap
         void    UnmapBinding( ControlEventCode code );
 
         // Unmaps all the bindings, but leaves the code records themselves
-        void    UnmapAllBindings( void );
+        void    UnmapAllBindings();
 
         // Erases the given code binding. Note: should never really be used, but provided here for completeness
         void    EraseBinding( ControlEventCode code );
 
         // Clears ALL bindings
-        void    ClearAll( void );
+        void    ClearAll();
 
         static const char* GetStringCtrl();
         static const char* GetStringShift();
         static const char* GetStringUnmapped();
 
 
-        uint32_t              GetNumBindings( void ) const { return fBindings.GetCount(); }
+        uint32_t              GetNumBindings() const { return fBindings.GetCount(); }
         const plKeyBinding  &GetBinding( uint32_t i ) const { return *fBindings[ i ]; }
         void                HandleAutoDualBinding( plKeyDef key1, plKeyDef key2 );
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plAudioSysMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plAudioSysMsg.h
@@ -78,7 +78,7 @@ public:
     plAudioSysMsg(const plKey &s, 
                     const plKey &r, 
                     const double* t) : pObj(nil){SetBCastFlag(plMessage::kBCastByExactType);}
-    ~plAudioSysMsg(){;}
+    ~plAudioSysMsg() { }
 
     CLASSNAME_REGISTER(plAudioSysMsg);
     GETINTERFACE_ANY(plAudioSysMsg, plMessage);

--- a/Sources/Plasma/NucleusLib/pnMessage/plCameraMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCameraMsg.h
@@ -112,10 +112,10 @@ public:
     void SetFadeOut(bool b) { fFadeOut = b; }
 
     
-    plCameraTargetFadeMsg(){;}
+    plCameraTargetFadeMsg() { }
     plCameraTargetFadeMsg(const plKey &s, 
                     const plKey &r, 
-                    const double* t){;}
+                    const double* t) { }
     
     CLASSNAME_REGISTER(plCameraTargetFadeMsg);
     GETINTERFACE_ANY(plCameraTargetFadeMsg, plMessage);
@@ -245,10 +245,10 @@ public:
     bool GetEnable() const { return fEnable; }
     bool GetDisable() const { return fDisable; }
 
-    plIfaceFadeAvatarMsg() : fEnable(false),fDisable(false){;}
+    plIfaceFadeAvatarMsg() : fEnable(false),fDisable(false) { }
     plIfaceFadeAvatarMsg(const plKey &s, 
                     const plKey &r, 
-                    const double* t): fEnable(false),fDisable(false){;}
+                    const double* t): fEnable(false),fDisable(false) { }
     
     CLASSNAME_REGISTER(plIfaceFadeAvatarMsg);
     GETINTERFACE_ANY(plIfaceFadeAvatarMsg, plMessage);

--- a/Sources/Plasma/NucleusLib/pnMessage/plCmdIfaceModMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCmdIfaceModMsg.h
@@ -59,7 +59,7 @@ public:
     plCmdIfaceModMsg() : fInterface(nil), fIndex(0), fControlCode(0){SetBCastFlag(plMessage::kBCastByExactType);}
     plCmdIfaceModMsg(const plKey* s, 
                     const plKey* r, 
-                    const double* t) : fInterface(nil){;}
+                    const double* t) : fInterface(nil) { }
     
     CLASSNAME_REGISTER(plCmdIfaceModMsg);
     GETINTERFACE_ANY(plCmdIfaceModMsg, plMessage);

--- a/Sources/Plasma/NucleusLib/pnMessage/plCursorChangeMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCursorChangeMsg.h
@@ -54,11 +54,11 @@ class plCursorChangeMsg : public plMessage
 protected:
 
 public:
-    plCursorChangeMsg() : fType(0),fPriority(0){;}
+    plCursorChangeMsg() : fType(0),fPriority(0) { }
     plCursorChangeMsg(int i, int p) { fType = i;fPriority =p; }
     plCursorChangeMsg(const plKey &s, 
                     const plKey &r, 
-                    const double* t) : fType(0),fPriority(0){;}
+                    const double* t) : fType(0),fPriority(0) { }
 
     CLASSNAME_REGISTER(plCursorChangeMsg);
     GETINTERFACE_ANY(plCursorChangeMsg, plMessage);

--- a/Sources/Plasma/NucleusLib/pnMessage/plEventCallbackMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plEventCallbackMsg.h
@@ -72,17 +72,17 @@ public:
     int16_t         fRepeats;   // -1 for infinite repeats, 0 for one call, no repeats
     int16_t         fUser;      // User defined data, useful for keeping track of multiple callbacks
 
-    plEventCallbackMsg() : fEventTime(0.0f), fEvent((CallbackEvent)0), fRepeats(-1), fUser(0), fIndex(0) {;}
+    plEventCallbackMsg() : fEventTime(0.0f), fEvent((CallbackEvent)0), fRepeats(-1), fUser(0), fIndex(0) { }
     plEventCallbackMsg (const plKey &s, 
                     const plKey &r, 
                     const double* t) : 
                         plMessage(s, r, t),
-                        fEventTime(0.0f), fEvent((CallbackEvent)0), fRepeats(-1), fUser(0), fIndex(0) {;}
+                        fEventTime(0.0f), fEvent((CallbackEvent)0), fRepeats(-1), fUser(0), fIndex(0) { }
 
     plEventCallbackMsg(const plKey &receiver, CallbackEvent e, int idx=0, float t=0, int16_t repeats=-1, uint16_t user=0) :
                         plMessage(nil, receiver, nil), fEvent(e), fIndex(idx), fEventTime(t), fRepeats(repeats), fUser(user) {}
 
-    ~plEventCallbackMsg(){;}
+    ~plEventCallbackMsg() { }
 
     CLASSNAME_REGISTER(plEventCallbackMsg);
     GETINTERFACE_ANY(plEventCallbackMsg, plMessage);

--- a/Sources/Plasma/NucleusLib/pnMessage/plPlayerPageMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plPlayerPageMsg.h
@@ -54,10 +54,10 @@ class plPlayerPageMsg : public plMessage
 protected:
 
 public:
-    plPlayerPageMsg() : fPlayer(nil),fLocallyOriginated(false),fUnload(false),fLastOut(false),fClientID(-1){;}
+    plPlayerPageMsg() : fPlayer(nil),fLocallyOriginated(false),fUnload(false),fLastOut(false),fClientID(-1) { }
     plPlayerPageMsg(const plKey &s, 
                     const plKey &r, 
-                    const double* t) : fPlayer(nil),fLocallyOriginated(false),fUnload(false),fLastOut(false),fClientID(-1){;}
+                    const double* t) : fPlayer(nil),fLocallyOriginated(false),fUnload(false),fLastOut(false),fClientID(-1) { }
     
     CLASSNAME_REGISTER(plPlayerPageMsg);
     GETINTERFACE_ANY(plPlayerPageMsg, plMessage);

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.cpp
@@ -67,7 +67,7 @@ void plGenericType::CopyFrom(const plGenericType& c)
 
 //// Conversion Functions ////////////////////////////////////////////////////
 
-int32_t plGenericType::IToInt( void ) const
+int32_t plGenericType::IToInt() const
 {
     hsAssert( fType == kInt || fType == kAny, "Trying to use a non-int parameter as an int!" );
 
@@ -79,7 +79,7 @@ int32_t plGenericType::IToInt( void ) const
     return fI;
 }
 
-uint32_t plGenericType::IToUInt( void ) const
+uint32_t plGenericType::IToUInt() const
 {
     hsAssert( fType == kUInt || fType == kAny, "Trying to use a non-int parameter as an int!" );
 
@@ -91,7 +91,7 @@ uint32_t plGenericType::IToUInt( void ) const
     return fU;
 }
 
-double plGenericType::IToDouble( void ) const
+double plGenericType::IToDouble() const
 {
     hsAssert( fType == kDouble || fType == kAny, "Trying to use a non-float parameter as a Double!" );
 
@@ -103,7 +103,7 @@ double plGenericType::IToDouble( void ) const
     return fD;
 }
 
-float plGenericType::IToFloat( void ) const
+float plGenericType::IToFloat() const
 {
     hsAssert( fType == kFloat || fType == kAny, "Trying to use a non-float parameter as a float!" );
 
@@ -115,7 +115,7 @@ float plGenericType::IToFloat( void ) const
     return fF;
 }
 
-bool plGenericType::IToBool( void ) const
+bool plGenericType::IToBool() const
 {
     hsAssert( fType == kBool || fType == kAny, "Trying to use a non-bool parameter as a bool!" );
 
@@ -127,14 +127,14 @@ bool plGenericType::IToBool( void ) const
     return fB;
 }
 
-ST::string plGenericType::IToString( void ) const
+ST::string plGenericType::IToString() const
 {
     hsAssert( fType == kString || fType == kAny, "Trying to use a non-string parameter as a string!" );
 
     return fS;
 }
 
-char plGenericType::IToChar( void ) const
+char plGenericType::IToChar() const
 {
     hsAssert( fType == kChar || fType == kAny, "Trying to use a non-char parameter as a char!" );
 

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.h
@@ -83,13 +83,13 @@ public:
 protected:
     uint8_t   fType;
     
-    int32_t   IToInt( void ) const;
-    uint32_t  IToUInt( void ) const;
-    float     IToFloat( void ) const;
-    double    IToDouble( void ) const;
-    bool      IToBool( void ) const;
-    ST::string  IToString( void ) const;
-    char      IToChar( void ) const;
+    int32_t   IToInt() const;
+    uint32_t  IToUInt() const;
+    float     IToFloat() const;
+    double    IToDouble() const;
+    bool      IToBool() const;
+    ST::string  IToString() const;
+    char      IToChar() const;
 
 public:
 
@@ -110,7 +110,7 @@ public:
     operator char() const { return IToChar(); }
 
     void    SetType(Types t)        { fType=t; }
-    uint8_t GetType( void ) const   { return fType; }
+    uint8_t GetType() const   { return fType; }
 
     ST::string GetAsString() const;
 
@@ -132,7 +132,7 @@ public:
     void    SetString( const ST::string& s )  { fS = s; fType = kString; }
     void    SetChar( char c )       { fC = c; fType = kChar; }
     void    SetAny( const ST::string& s )     { fS = s; fType = kAny; }
-    void    SetNone( void )         { fType = kNone; }
+    void    SetNone()         { fType = kNone; }
 
     virtual void    Read(hsStream* s);
     virtual void    Write(hsStream* s);

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedValue.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedValue.h
@@ -204,7 +204,7 @@ public:
 #pragma warning( disable : 4284 )   // disable annoying warnings in release build for non pointer types
 #endif
     // for pointer types, which are allowed to change the object pointed to
-    T operator->(void) { return fValue; }
+    T operator->() { return fValue; }
 #if HS_BUILD_FOR_WIN32
 #pragma warning( pop ) 
 #endif    

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
@@ -98,7 +98,7 @@ public:
     void Read(hsStream* stream, hsResMgr* mgr=nullptr) HS_OVERRIDE;
     void Write(hsStream* stream, hsResMgr* mgr=nullptr) HS_OVERRIDE;
 
-    hsStream* GetStream(void) { return &fStream;}
+    hsStream* GetStream() { return &fStream;}
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plAudioInterface.h
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plAudioInterface.h
@@ -101,7 +101,7 @@ public:
     // Transform settable only, if you want it get it from the coordinate interface.
     void        SetTransform(const hsMatrix44& l2w, const hsMatrix44& w2l);
 
-    virtual void    ReleaseData( void );
+    virtual void    ReleaseData();
     void SetSoundFilename(int index, const char *filename, bool isCompressed);
     int GetSoundIndex(const char *keyname);
 };

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plDrawInterface.cpp
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plDrawInterface.cpp
@@ -191,7 +191,7 @@ void plDrawInterface::Write(hsStream* s, hsResMgr* mgr)
 //  Called by SceneViewer to release the data for this given object (when
 //  its parent sceneObject is deleted).
 
-void    plDrawInterface::ReleaseData( void )
+void    plDrawInterface::ReleaseData()
 {
     int i;
     for( i = 0; i < fDrawables.GetCount(); i++ )
@@ -372,7 +372,7 @@ void    plDrawInterface::SetUpForParticleSystem( uint32_t maxNumEmitters, uint32
     ISetVisRegions(0);
 }
 
-void    plDrawInterface::ResetParticleSystem( void )
+void    plDrawInterface::ResetParticleSystem()
 {
     hsAssert( fDrawables[0] != nil, "No drawable to use for particle system!" );
     fDrawables[0]->ResetParticleSystem( fDrawableIndices[0] );

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plDrawInterface.h
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plDrawInterface.h
@@ -104,11 +104,11 @@ public:
 
     virtual bool MsgReceive(plMessage* msg);
 
-    virtual void    ReleaseData( void );
+    virtual void    ReleaseData();
 
     /// Funky particle system functions
     void    SetUpForParticleSystem( uint32_t maxNumEmitters, uint32_t maxNumParticles, hsGMaterial *material, hsTArray<plKey>& lights );
-    void    ResetParticleSystem( void );
+    void    ResetParticleSystem();
     void    AssignEmitterToParticleSystem( plParticleEmitter *emitter );
 
     /// EXPORT-ONLY

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plObjInterface.h
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plObjInterface.h
@@ -112,7 +112,7 @@ public:
     virtual void Read(hsStream* stream, hsResMgr* mgr);
     virtual void Write(hsStream* stream, hsResMgr* mgr);
 
-    virtual void    ReleaseData( void ) { }
+    virtual void    ReleaseData() { }
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plSceneObject.cpp
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plSceneObject.cpp
@@ -178,7 +178,7 @@ void plSceneObject::Write(hsStream* stream, hsResMgr* mgr)
 //  Called by SceneViewer to release the data for this sceneObject (really
 //  just a switchboard).
 
-void    plSceneObject::ReleaseData( void )
+void    plSceneObject::ReleaseData()
 {
     if( fDrawInterface )
         fDrawInterface->ReleaseData();

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plSceneObject.h
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plSceneObject.h
@@ -155,7 +155,7 @@ public:
     // Network only strange function. Do not emulate or generalize this functionality.
     virtual void SetNetGroup(plNetGroupId netGroup);
 
-    virtual void    ReleaseData( void );
+    virtual void    ReleaseData();
 
     // Force an immediate re-sync of the transforms in the hierarchy this object belongs to,
     // as opposed to waiting for the plTransformMsg to resync.

--- a/Sources/Plasma/NucleusLib/pnUUID/pnUUID.h
+++ b/Sources/Plasma/NucleusLib/pnUUID/pnUUID.h
@@ -93,7 +93,7 @@ public:
     bool operator<(const plUUID& other) const {
         return CompareTo(&other) == -1;
     }
-    operator ST::string (void) const { return AsString(); }
+    operator ST::string () const { return AsString(); }
 
     static plUUID Generate();
 };

--- a/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.cpp
@@ -117,7 +117,7 @@ bool plAgePage::SetFromString( const ST::string &stringIn )
     return true;
 }
 
-ST::string plAgePage::GetAsString( void ) const
+ST::string plAgePage::GetAsString() const
 {
     if (fFlags)
         return ST::format("{},{},{}", fName, fSeqSuffix, fFlags);
@@ -188,7 +188,7 @@ void plAgeDescription::SetAgeNameFromPath( const plFileName &path )
     fName = path.GetFileNameNoExt();
 }
 
-void plAgeDescription::IInit( void )
+void plAgeDescription::IInit()
 {
     fName = "";
     fDayLength = 24.0f;
@@ -211,12 +211,12 @@ void    plAgeDescription::AppendPage( const ST::string &name, int seqSuffix, uin
     fPages.Append( plAgePage( name, ( seqSuffix == -1 ) ? fPages.GetCount() : (uint32_t)seqSuffix, flags ) );
 }
 
-void    plAgeDescription::SeekFirstPage( void )
+void    plAgeDescription::SeekFirstPage()
 {
     fPageIterator = 0;
 }
 
-plAgePage   *plAgeDescription::GetNextPage( void )
+plAgePage   *plAgeDescription::GetNextPage()
 {
     plAgePage   *ret = nil;
 
@@ -336,7 +336,7 @@ void plAgeDescription::Write(hsStream* stream) const
 // we only have one section, we can safely use ourselves as the section reader.
 // Later I might just add section readers with function pointers to avoid this need entirely
 
-const char  *plAgeDescription::GetSectionName( void ) const
+const char  *plAgeDescription::GetSectionName() const
 {
     return "AgeInfo";
 }
@@ -468,7 +468,7 @@ const char *plAgeDescription::GetCommonPage( int pageType )
     return fCommonPages[ pageType ];
 }
 
-void    plAgeDescription::AppendCommonPages( void )
+void    plAgeDescription::AppendCommonPages()
 {
     uint32_t startSuffix = 0xffff, i;
 

--- a/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.h
+++ b/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.h
@@ -78,15 +78,15 @@ class plAgePage
         plAgePage( const plAgePage &src );
         plAgePage();
 
-        ST::string  GetName( void ) const { return fName; }
-        uint32_t    GetSeqSuffix( void ) const { return fSeqSuffix; }
-        uint8_t     GetFlags( void ) const { return fFlags; }
+        ST::string  GetName() const { return fName; }
+        uint32_t    GetSeqSuffix() const { return fSeqSuffix; }
+        uint8_t     GetFlags() const { return fFlags; }
 
         void        SetSeqSuffix( uint32_t s ) { fSeqSuffix = s; }
         void        SetFlags(uint8_t f, bool on=true);
 
         bool        SetFromString( const ST::string &string );
-        ST::string  GetAsString( void ) const;
+        ST::string  GetAsString() const;
 
         plAgePage &operator=( const plAgePage &src );
 };
@@ -113,8 +113,8 @@ private:
     
     static const char* fCommonPages[];
 
-    void    IInit( void );
-    void    IDeInit( void );
+    void    IInit();
+    void    IDeInit();
 
     // Overload for plInitSectionTokenReader
     virtual bool        IParseToken( const char *token, hsStringTokenizer *tokenizer, uint32_t userData );
@@ -136,9 +136,9 @@ public:
     void Write(hsStream* stream) const;
 
     // Overload for plInitSectionTokenReader
-    virtual const char  *GetSectionName( void ) const;
+    virtual const char  *GetSectionName() const;
 
-    ST::string  GetAgeName( void ) const { return fName; }
+    ST::string  GetAgeName() const { return fName; }
     void        SetAgeNameFromPath( const plFileName &path );
     void        SetAgeName(const ST::string& ageName) { fName = ageName; }
 
@@ -147,8 +147,8 @@ public:
     void    RemovePage( const ST::string &page );
     void    AppendPage( const ST::string &name, int seqSuffix = -1, uint8_t flags = 0 );
 
-    void        SeekFirstPage( void );
-    plAgePage   *GetNextPage( void );
+    void        SeekFirstPage();
+    plAgePage   *GetNextPage();
     int         GetNumPages() const { return fPages.GetCount(); }
     plAgePage   *FindPage( const ST::string &name ) const;
     bool FindLocation(const plLocation& loc) const;
@@ -166,9 +166,9 @@ public:
 
     float   GetDayLength() const { return fDayLength; }
 
-    int32_t   GetSequencePrefix( void ) const { return fSeqPrefix; }
-    uint32_t  GetReleaseVersion( void ) const { return fReleaseVersion; }
-    bool    IsGlobalAge( void ) const { return ( fSeqPrefix < 0 ) ? true : false; }
+    int32_t   GetSequencePrefix() const { return fSeqPrefix; }
+    uint32_t  GetReleaseVersion() const { return fReleaseVersion; }
+    bool    IsGlobalAge() const { return ( fSeqPrefix < 0 ) ? true : false; }
 
     // Setters
     bool SetStart(short year, short month, short day, short hour, short minute, short second)
@@ -196,7 +196,7 @@ public:
 
     static const char *GetCommonPage( int pageType );
 
-    void    AppendCommonPages( void );
+    void    AppendCommonPages();
     void    CopyFrom(const plAgeDescription& other);
 
     plAgeDescription &operator=( const plAgeDescription &src )

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.h
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.h
@@ -125,11 +125,11 @@ public:
     void ExecPendingAgeCsvFiles();
 
     // Fun debugging exclude commands (to prevent certain pages from loading)
-    void    ClearPageExcludeList( void );
+    void    ClearPageExcludeList();
     void    AddExcludedPage( const ST::string& pageName, const ST::string& ageName = ST::null );
     bool    IsPageExcluded( const plAgePage *page, const ST::string& ageName = ST::null );
 
-    const plAgeDescription  &GetCurrAgeDesc( void ) const { return fCurAgeDescription; }
+    const plAgeDescription  &GetCurrAgeDesc() const { return fCurAgeDescription; }
 
     // paging
     void FinishedPagingInRoom(plKey* rmKey, int numRms);    // call when finished paging in/out a room      

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoaderPaging.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoaderPaging.cpp
@@ -270,7 +270,7 @@ class plExcludePage
 
 static hsTArray<plExcludePage>  sExcludeList;
 
-void    plAgeLoader::ClearPageExcludeList( void )
+void    plAgeLoader::ClearPageExcludeList()
 {
     sExcludeList.Reset();
 }

--- a/Sources/Plasma/PubUtilLib/plAudible/plAudibleNull.h
+++ b/Sources/Plasma/PubUtilLib/plAudible/plAudibleNull.h
@@ -52,7 +52,7 @@ class plAudibleNull : public plAudible
 {
 public:
 
-    plAudibleNull() : fSceneNode(nil),fSceneObj(nil) {;}
+    plAudibleNull() : fSceneNode(nil),fSceneObj(nil) { }
 
     CLASSNAME_REGISTER( plAudibleNull );
     GETINTERFACE_ANY( plAudibleNull, plAudible );
@@ -66,38 +66,38 @@ public:
     virtual plAudible& SetProperty(int prop, bool on) { return *this; }
     virtual bool GetProperty(int prop) { return false; }
 
-    void        Play(int index = -1){;}
-    void        SynchedPlay(int index = -1) {;}
-    void        Stop(int index = -1){;}
-    void        FastForwardPlay(int index = -1){;}
-    void        FastForwardToggle(int index = -1){;}
-    void        SetMin(const float m,int index = -1){;} // sets minimum falloff distance
-    void        SetMax(const float m,int index = -1){;} // sets maximum falloff distance
+    void        Play(int index = -1) { }
+    void        SynchedPlay(int index = -1) { }
+    void        Stop(int index = -1) { }
+    void        FastForwardPlay(int index = -1) { }
+    void        FastForwardToggle(int index = -1) { }
+    void        SetMin(const float m,int index = -1) { } // sets minimum falloff distance
+    void        SetMax(const float m,int index = -1) { } // sets maximum falloff distance
     virtual plAudible& SetTransform(const hsMatrix44& l2w, const hsMatrix44& w2l, int index = -1){return *this;}
     float    GetMin(int index = -1) const{return 0;}
     float    GetMax(int index = -1) const{return 0;}
-    void        SetVelocity(const hsVector3 vel,int index = -1){;}
+    void        SetVelocity(const hsVector3 vel,int index = -1) { }
     hsVector3   GetVelocity(int index = -1) const;
     hsPoint3    GetPosition(int index = -1);
-    void        SetLooping(bool loop,int index = -1){;} // sets continuous loop or stops looping
+    void        SetLooping(bool loop,int index = -1) { } // sets continuous loop or stops looping
     bool        IsPlaying(int index = -1){return false;}
     virtual void        SetTime(double t, int index = -1) {}
     virtual void        Activate(){}
     virtual void        DeActivate(){}
-    virtual void        GetStatus(plSoundMsg* pMsg) {;}
+    virtual void        GetStatus(plSoundMsg* pMsg) { }
     virtual int         GetNumSounds() const {return 0;}
     virtual plSound*    GetSound(int i) const { return nil; }
     virtual int         GetSoundIndex(const char *keyname) const { return -1; }
-    virtual void        SetVolume(const float volume,int index = -1) {;}
+    virtual void        SetVolume(const float volume,int index = -1) { }
     virtual void        SetFilename(int index, const char *filename, bool isCompressed){}
 
     virtual void    RemoveCallbacks(plSoundMsg* pMsg) {}
     virtual void    AddCallbacks(plSoundMsg* pMsg) {}
 
-    virtual void    SetMuted( bool muted, int index = -1 ) {;}
-    virtual void    ToggleMuted( int index = -1 ) {;}
-    virtual void    SetTalkIcon(int index, uint32_t str){;}
-    virtual void    ClearTalkIcon(){;}
+    virtual void    SetMuted( bool muted, int index = -1 ) { }
+    virtual void    ToggleMuted( int index = -1 ) { }
+    virtual void    SetTalkIcon(int index, uint32_t str) { }
+    virtual void    ClearTalkIcon() { }
 
     virtual void        SetFadeIn( const int type, const float length, int index = -1 ) {}
     virtual void        SetFadeOut( const int type, const float length, int index = -1 ) {}

--- a/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.h
+++ b/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.h
@@ -106,8 +106,8 @@ public:
     virtual void        SetVolume(const float volume,int index = -1);
     virtual void        SetMuted( bool muted, int index = -1 );
     virtual void        ToggleMuted( int index = -1 );
-    virtual void        SetTalkIcon(int index, uint32_t str){;}
-    virtual void        ClearTalkIcon(){;}
+    virtual void        SetTalkIcon(int index, uint32_t str) { }
+    virtual void        ClearTalkIcon() { }
     void                SetFilename(int index, const char *filename, bool isCompressed);
 
     virtual void        SetFadeIn( const int type, const float length, int index = -1 );

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioCaps.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioCaps.h
@@ -60,7 +60,7 @@ public:
 
     plAudioCaps() { Clear(); }
 
-    void    Clear( void )
+    void    Clear()
     {
         fIsAvailable = false;
         fEAXAvailable = false;
@@ -68,9 +68,9 @@ public:
         fMaxNumSources = 0;
     }
 
-    bool    IsAvailable( void ) const { return fIsAvailable; }
-    bool    IsEAXAvailable( void ) const { return fEAXAvailable; }
-    bool    UsingEAXUnified( void ) const { return fEAXUnified; }
+    bool    IsAvailable() const { return fIsAvailable; }
+    bool    IsEAXAvailable() const { return fEAXAvailable; }
+    bool    UsingEAXUnified() const { return fEAXUnified; }
     unsigned GetMaxNumVoices() { return fMaxNumSources; }
 
 protected:

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
@@ -108,7 +108,7 @@ class plSoftSoundNode
             *prev = this;
         }
 
-        void    Unlink( void )
+        void    Unlink()
         {
             if( fPrev != nil )
             {
@@ -150,7 +150,7 @@ class plSoftSoundNode
             }
         }
 
-        void    BootSourceOff( void )
+        void    BootSourceOff()
         {
             plSound *sound = plSound::ConvertNoRef( fSoundKey->ObjectIsLoaded() );
             if( sound != nil )
@@ -834,7 +834,7 @@ void    plAudioSystem::IUpdateSoftSounds( const hsPoint3 &newPosition )
     plProfile_EndTiming(SoundSoftUpdate);
 }
 
-void    plAudioSystem::NextDebugSound( void )
+void    plAudioSystem::NextDebugSound()
 {
     plSoftSoundNode     *node;
 
@@ -1169,7 +1169,7 @@ int plgAudioSys::GetAudioMode()
     }
 }
 
-void plgAudioSys::Restart( void )
+void plgAudioSys::Restart()
 {
     if( fSys )
     {
@@ -1256,7 +1256,7 @@ float    plgAudioSys::GetChannelVolume( ASChannel chan )
     return fChannelVolumes[ chan ];
 }
 
-void    plgAudioSys::NextDebugSound( void )
+void    plgAudioSys::NextDebugSound()
 {
     fSys->NextDebugSound();
 }

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.h
@@ -105,8 +105,8 @@ public:
     virtual bool MsgReceive(plMessage* msg);
     double GetTime();
     
-    void        NextDebugSound( void );
-    hsPoint3    GetCurrListenerPos( void ) const { return fCurrListenerPos; }
+    void        NextDebugSound();
+    hsPoint3    GetCurrListenerPos() const { return fCurrListenerPos; }
 
     int         GetNumAudioDevices();
     const char *GetAudioDeviceName(int index);
@@ -206,12 +206,12 @@ public:
     static bool Active() { return fInit; }
     static void Shutdown();
     static void Activate(bool b);
-    static bool     IsMuted( void ) { return fMuted; }
+    static bool     IsMuted() { return fMuted; }
     static plAudioSystem* Sys() { return fSys; }
-    static void Restart( void );
-    static bool     UsingEAX( void ) { return fSys->fUsingEAX; }
+    static void Restart();
+    static bool     UsingEAX() { return fSys->fUsingEAX; }
 
-    static void NextDebugSound( void );
+    static void NextDebugSound();
 
     static void     SetChannelVolume( ASChannel chan, float vol );
     static float GetChannelVolume( ASChannel chan );
@@ -220,22 +220,22 @@ public:
     static float Get2D3Dbias();
 
     static void     SetGlobalFadeVolume( float vol );
-    static float GetGlobalFadeVolume( void ) { return fGlobalFadeVolume; }
+    static float GetGlobalFadeVolume() { return fGlobalFadeVolume; }
 
     static void     SetDebugFlag( uint32_t flag, bool set = true ) { if( set ) fDebugFlags |= flag; else fDebugFlags &= ~flag; }
     static bool     IsDebugFlagSet( uint32_t flag ) { return fDebugFlags & flag; }
-    static void     ClearDebugFlags( void ) { fDebugFlags = 0; }
+    static void     ClearDebugFlags() { fDebugFlags = 0; }
 
-    static float GetStreamingBufferSize( void ) { return fStreamingBufferSize; }
+    static float GetStreamingBufferSize() { return fStreamingBufferSize; }
     static void     SetStreamingBufferSize( float size ) { fStreamingBufferSize = size; }
 
-    static uint8_t    GetPriorityCutoff( void ) { return fPriorityCutoff; }
+    static uint8_t    GetPriorityCutoff() { return fPriorityCutoff; }
     static void     SetPriorityCutoff( uint8_t cut ) { fPriorityCutoff = cut;  if(fSys) fSys->SetMaxNumberOfActiveSounds(); }
 
-    static bool     AreExtendedLogsEnabled( void ) { return fEnableExtendedLogs; }
+    static bool     AreExtendedLogsEnabled() { return fEnableExtendedLogs; }
     static void     EnableExtendedLogs( bool e ) { fEnableExtendedLogs = e; }
 
-    static float GetStreamFromRAMCutoff( void ) { return fStreamFromRAMCutoff; }
+    static float GetStreamFromRAMCutoff() { return fStreamFromRAMCutoff; }
     static void     SetStreamFromRAMCutoff( float c ) { fStreamFromRAMCutoff = c; }
 
     static void SetListenerPos(const hsPoint3 pos);

--- a/Sources/Plasma/PubUtilLib/plAudio/plDSoundBuffer.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plDSoundBuffer.cpp
@@ -118,7 +118,7 @@ void    plDSoundBuffer::IAllocate( uint32_t size, plWAVHeader &bufferDesc, bool 
 
 //// IRelease ////////////////////////////////////////////////////////////////
 
-void    plDSoundBuffer::IRelease( void )
+void    plDSoundBuffer::IRelease()
 {
     if( IsPlaying() )
         Stop();
@@ -596,7 +596,7 @@ void plDSoundBuffer::SetMaxDistance( int dist )
 
 //// Play ////////////////////////////////////////////////////////////////////
 
-void    plDSoundBuffer::Play( void )
+void    plDSoundBuffer::Play()
 {
     if(!source)
         return;
@@ -630,7 +630,7 @@ void plDSoundBuffer::Pause()
 
 //// Stop ////////////////////////////////////////////////////////////////////
 
-void    plDSoundBuffer::Stop( void )
+void    plDSoundBuffer::Stop()
 {
     if(!source)
         return;
@@ -693,7 +693,7 @@ void plDSoundBuffer::Rewind()
 
 //// IsPlaying ///////////////////////////////////////////////////////////////
 
-bool    plDSoundBuffer::IsPlaying( void )
+bool    plDSoundBuffer::IsPlaying()
 {
     ALint state = AL_STOPPED;
     alGetSourcei(source, AL_SOURCE_STATE, &state);
@@ -703,7 +703,7 @@ bool    plDSoundBuffer::IsPlaying( void )
 
 //// IsEAXAccelerated ////////////////////////////////////////////////////////
 
-bool    plDSoundBuffer::IsEAXAccelerated( void ) const
+bool    plDSoundBuffer::IsEAXAccelerated() const
 {
     return fEAXSource.IsValid();
 }
@@ -729,7 +729,7 @@ uint32_t  plDSoundBuffer::GetBufferBytePos( float timeInSecs ) const
 
 //// GetLengthInBytes ////////////////////////////////////////////////////////
 
-uint32_t  plDSoundBuffer::GetLengthInBytes( void ) const
+uint32_t  plDSoundBuffer::GetLengthInBytes() const
 {
     return fBufferSize;
 }
@@ -743,7 +743,7 @@ void    plDSoundBuffer::SetEAXSettings(  plEAXSourceSettings *settings, bool for
 
 //// GetBlockAlign ///////////////////////////////////////////////////////////
 
-uint8_t   plDSoundBuffer::GetBlockAlign( void ) const
+uint8_t   plDSoundBuffer::GetBlockAlign() const
 {
     return ( fBufferDesc != nil ) ? fBufferDesc->fBlockAlign : 0;
 }

--- a/Sources/Plasma/PubUtilLib/plAudio/plDSoundBuffer.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plDSoundBuffer.h
@@ -71,12 +71,12 @@ public:
     plDSoundBuffer( uint32_t size, plWAVHeader &bufferDesc, bool enable3D, bool looping, bool tryStatic = false, bool streaming = false );
     ~plDSoundBuffer();
 
-    void        Play( void );
-    void        Stop( void );
+    void        Play();
+    void        Stop();
     void        Rewind();
     void        Pause();
 
-    uint32_t      GetLengthInBytes( void ) const;
+    uint32_t      GetLengthInBytes() const;
     void        SetScalarVolume( float volume ); // Sets the volume, but on a range from 0 to 1
 
     unsigned    GetSource() { return source; }
@@ -91,10 +91,10 @@ public:
     void        SetMinDistance( int dist);
     void        SetMaxDistance( int dist );
 
-    bool        IsValid( void ) const { return fValid; }
-    bool        IsPlaying( void );
-    bool        IsLooping( void ) const { return fLooping; }
-    bool        IsEAXAccelerated( void ) const;
+    bool        IsValid() const { return fValid; }
+    bool        IsPlaying();
+    bool        IsLooping() const { return fLooping; }
+    bool        IsEAXAccelerated() const;
 
     bool        FillBuffer(void *data, unsigned bytes, plWAVHeader *header);
 
@@ -115,7 +115,7 @@ public:
 
     void            SetEAXSettings(  plEAXSourceSettings *settings, bool force = false );
     void            SetTimeOffsetBytes(unsigned bytes);
-    uint8_t           GetBlockAlign( void ) const;
+    uint8_t           GetBlockAlign() const;
     static uint32_t   GetNumBuffers() { return fNumBuffers; }
     float           GetDefaultMinDistance() { return fDefaultMinDistance; }
     bool            GetAvailableBufferId(unsigned *bufferId);
@@ -160,7 +160,7 @@ protected:
     float            fPrevVolume;
 
     void    IAllocate( uint32_t size, plWAVHeader &bufferDesc, bool enable3D, bool tryStatic );
-    void    IRelease( void );
+    void    IRelease();
     int     IGetALFormat(unsigned bitsPerSample, unsigned int numChannels);
 };
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plEAXEffects.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plEAXEffects.cpp
@@ -88,7 +88,7 @@ static EAXSet           s_EAXSet;
 
 //// GetInstance /////////////////////////////////////////////////////////////
 
-plEAXListener   &plEAXListener::GetInstance( void )
+plEAXListener   &plEAXListener::GetInstance()
 {
     static plEAXListener    instance;
     return instance;
@@ -109,7 +109,7 @@ plEAXListener::~plEAXListener()
 
 //// Init ////////////////////////////////////////////////////////////////////
 
-bool    plEAXListener::Init( void )
+bool    plEAXListener::Init()
 {
 #ifdef EAX_SDK_AVAILABLE
     if( fInited )
@@ -175,7 +175,7 @@ bool    plEAXListener::Init( void )
 
 //// Shutdown ////////////////////////////////////////////////////////////////
 
-void    plEAXListener::Shutdown( void )
+void    plEAXListener::Shutdown()
 {
     if( !fInited )
         return;
@@ -231,7 +231,7 @@ bool plEAXSource::GetSourceEAXProperty(unsigned source, GUID guid, unsigned long
 
 //// IRelease ////////////////////////////////////////////////////////////////
 
-void    plEAXListener::IRelease( void )
+void    plEAXListener::IRelease()
 {
     fInited = false;
 }
@@ -283,7 +283,7 @@ void    plEAXListener::IMuteProperties( EAXREVERBPROPERTIES *props, float percen
 //  Clears the cache settings used to speed up ProcessMods(). Call whenever
 //  the list of mods changed.
 
-void    plEAXListener::ClearProcessCache( void )
+void    plEAXListener::ClearProcessCache()
 {
     fLastBigRegion = nil;
     fLastModCount = -1;
@@ -608,7 +608,7 @@ void    plEAXSourceSettings::IRecalcSofts( uint8_t whichOnes )
 //// Source Soft Settings ////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-void    plEAXSourceSoftSettings::Reset( void )
+void    plEAXSourceSoftSettings::Reset()
 {
     fOcclusion = 0;
     fOcclusionLFRatio = 0.25f;
@@ -663,12 +663,12 @@ void    plEAXSource::Init( plDSoundBuffer *parent )
     SetFrom( &defaultParams, parent->GetSource() );
 }
 
-void    plEAXSource::Release( void )
+void    plEAXSource::Release()
 {
     fInit = false;
 }
 
-bool    plEAXSource::IsValid( void ) const
+bool    plEAXSource::IsValid() const
 {
     return true;
 }

--- a/Sources/Plasma/PubUtilLib/plAudio/plEAXEffects.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plEAXEffects.h
@@ -75,22 +75,22 @@ class plEAXListener
 {   
 public:
     ~plEAXListener();
-    static plEAXListener    &GetInstance( void );
+    static plEAXListener    &GetInstance();
 
-    bool    Init( void );
-    void    Shutdown( void );
+    bool    Init();
+    void    Shutdown();
 
     bool SetGlobalEAXProperty(GUID guid, unsigned long ulProperty, void *pData, unsigned long ulDataSize );
     bool GetGlobalEAXProperty(GUID guid, unsigned long ulProperty, void *pData, unsigned long ulDataSize );
     
     void    ProcessMods( hsTArray<plEAXListenerMod *> &modArray );
-    void    ClearProcessCache( void );
+    void    ClearProcessCache();
 
 protected:
     plEAXListener();
     void    IFail( bool major );
     void    IFail( const char *msg, bool major );
-    void    IRelease( void );
+    void    IRelease();
 
     void    IMuteProperties( EAXREVERBPROPERTIES *props, float percent );
 
@@ -119,12 +119,12 @@ public:
         void        Write( hsStream *s );
 
         void        SetOcclusion( int16_t occ, float lfRatio, float roomRatio, float directRatio );
-        int16_t       GetOcclusion( void ) const { return fOcclusion; }
-        float    GetOcclusionLFRatio( void ) const { return fOcclusionLFRatio; }
-        float    GetOcclusionRoomRatio( void ) const { return fOcclusionRoomRatio; }
-        float    GetOcclusionDirectRatio( void ) const { return fOcclusionDirectRatio; }
+        int16_t       GetOcclusion() const { return fOcclusion; }
+        float    GetOcclusionLFRatio() const { return fOcclusionLFRatio; }
+        float    GetOcclusionRoomRatio() const { return fOcclusionRoomRatio; }
+        float    GetOcclusionDirectRatio() const { return fOcclusionDirectRatio; }
 
-        void        Reset( void );
+        void        Reset();
 };
 
 //// Buffer Settings Class Definition /////////////////////////////////////////
@@ -141,32 +141,32 @@ class plEAXSourceSettings
         void    Write( hsStream *s );
 
         void    Enable( bool e );
-        bool    IsEnabled( void ) const { return fEnabled; }
+        bool    IsEnabled() const { return fEnabled; }
 
         void    SetRoomParams( int16_t room, int16_t roomHF, bool roomAuto, bool roomHFAuto );
-        int16_t   GetRoom( void ) const   { return fRoom; }
-        int16_t   GetRoomHF( void )  const  { return fRoomHF; }
-        bool    GetRoomAuto( void ) const   { return fRoomAuto; }
-        bool    GetRoomHFAuto( void ) const  { return fRoomHFAuto; }
+        int16_t   GetRoom() const   { return fRoom; }
+        int16_t   GetRoomHF()  const  { return fRoomHF; }
+        bool    GetRoomAuto() const   { return fRoomAuto; }
+        bool    GetRoomHFAuto() const  { return fRoomHFAuto; }
 
         void    SetOutsideVolHF( int16_t vol );
-        int16_t   GetOutsideVolHF( void ) const { return fOutsideVolHF; }
+        int16_t   GetOutsideVolHF() const { return fOutsideVolHF; }
 
         void        SetFactors( float airAbsorption, float roomRolloff, float doppler, float rolloff );
-        float    GetAirAbsorptionFactor( void ) const { return fAirAbsorptionFactor; }
-        float    GetRoomRolloffFactor( void ) const { return fRoomRolloffFactor; }
-        float    GetDopplerFactor( void ) const { return fDopplerFactor; }
-        float    GetRolloffFactor( void ) const { return fRolloffFactor; }
+        float    GetAirAbsorptionFactor() const { return fAirAbsorptionFactor; }
+        float    GetRoomRolloffFactor() const { return fRoomRolloffFactor; }
+        float    GetDopplerFactor() const { return fDopplerFactor; }
+        float    GetRolloffFactor() const { return fRolloffFactor; }
 
-        plEAXSourceSoftSettings &GetSoftStarts( void ) { return fSoftStarts; }
-        plEAXSourceSoftSettings &GetSoftEnds( void ) { return fSoftEnds; }
+        plEAXSourceSoftSettings &GetSoftStarts() { return fSoftStarts; }
+        plEAXSourceSoftSettings &GetSoftEnds() { return fSoftEnds; }
         
-        plEAXSourceSoftSettings &GetCurrSofts( void )  { return fCurrSoftValues; }
+        plEAXSourceSoftSettings &GetCurrSofts()  { return fCurrSoftValues; }
 
         void        SetOcclusionSoftValue( float value );
-        float    GetOcclusionSoftValue( void ) const { return fOcclusionSoftValue; }
+        float    GetOcclusionSoftValue() const { return fOcclusionSoftValue; }
 
-        void        ClearDirtyParams( void ) const { fDirtyParams = 0; }
+        void        ClearDirtyParams() const { fDirtyParams = 0; }
 
     protected:
         friend class plEAXSource;
@@ -205,8 +205,8 @@ public:
     virtual ~plEAXSource();
 
     void    Init( plDSoundBuffer *parent );
-    void    Release( void );
-    bool    IsValid( void ) const;
+    void    Release();
+    bool    IsValid() const;
     bool SetSourceEAXProperty(unsigned source, GUID guid, unsigned long ulProperty, void *pData, unsigned long ulDataSize);
     bool GetSourceEAXProperty(unsigned source, GUID guid, unsigned long ulProperty, void *pData, unsigned long ulDataSize);
     void    SetFrom(  plEAXSourceSettings *settings, unsigned source, bool force = false );

--- a/Sources/Plasma/PubUtilLib/plAudio/plEAXListenerMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plEAXListenerMod.cpp
@@ -88,7 +88,7 @@ plEAXListenerMod::~plEAXListenerMod()
     delete fListenerProps;
 }
 
-void    plEAXListenerMod::IRegister( void )
+void    plEAXListenerMod::IRegister()
 {
     if( !fGetsMessages )
     {
@@ -108,7 +108,7 @@ void    plEAXListenerMod::IRegister( void )
     }
 }
 
-void    plEAXListenerMod::IUnRegister( void )
+void    plEAXListenerMod::IUnRegister()
 {
     if( !fRegistered || GetKey() == nil )
         return;
@@ -244,7 +244,7 @@ void    plEAXListenerMod::SetFromPreset( uint32_t preset )
 #endif
 }
 
-float   plEAXListenerMod::GetStrength( void )
+float   plEAXListenerMod::GetStrength()
 {
     if( fSoftRegion == nil )
         return 0.f;

--- a/Sources/Plasma/PubUtilLib/plAudio/plEAXListenerMod.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plEAXListenerMod.h
@@ -75,9 +75,9 @@ public:
     virtual bool    MsgReceive( plMessage* pMsg );
     virtual void    Read( hsStream* s, hsResMgr* mgr );
     virtual void    Write( hsStream* s, hsResMgr* mgr );
-    float           GetStrength( void );
+    float           GetStrength();
 
-    EAXREVERBPROPERTIES *   GetListenerProps( void ) { return fListenerProps; }
+    EAXREVERBPROPERTIES *   GetListenerProps() { return fListenerProps; }
     void                    SetFromPreset( uint32_t preset );
 
 protected:
@@ -85,8 +85,8 @@ protected:
     EAXREVERBPROPERTIES *fListenerProps;
     bool        fRegistered, fGetsMessages;
 
-    void            IRegister( void );
-    void            IUnRegister( void );
+    void            IRegister();
+    void            IUnRegister();
     virtual bool    IEval( double secs, float del, uint32_t dirty ); // called only by owner object's Eval()
 };
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
@@ -142,7 +142,7 @@ void plSound::IPrintDbgMessage( const char *msg, bool isError )
 //  sound. Should be called every time any of the values change, which means
 //  the best place is inside ISetActualVolume(). Since that's a pure virtual,
 //  it makes the placement of the call a bit annoying, but oh well.
-void plSound::IUpdateDebugPlate( void )
+void plSound::IUpdateDebugPlate()
 {
     if( this == fCurrDebugPlateSound )
     {
@@ -335,7 +335,7 @@ void plSound::ISynchedPlay( double virtualStartTime )
 ///////////////////////////////////////////////////////////
 //  Takes the virtual start time and sets us to the real time we should be at,
 //  then starts us playing via ITryPlay().
-void plSound::ISynchToStartTime( void )
+void plSound::ISynchToStartTime()
 {
     if( !plgAudioSys::Active() )
         return;
@@ -392,12 +392,12 @@ void plSound::SetVelocity(const hsVector3 vel)
     f3DVelocity = vel;
 }
 
-hsPoint3 plSound::GetPosition( void ) const
+hsPoint3 plSound::GetPosition() const
 {
     return f3DPosition;
 }
 
-hsVector3 plSound::GetVelocity( void ) const
+hsVector3 plSound::GetVelocity() const
 {
     return f3DVelocity;
 }
@@ -448,7 +448,7 @@ void plSound::SetVolume(const float v)
     RefreshVolume();
 }
 
-void plSound::RefreshVolume( void )
+void plSound::RefreshVolume()
 {
     this->ISetActualVolume( fCurrVolume );
 }
@@ -467,7 +467,7 @@ void plSound::SetMuted( bool muted )
     }
 }
 
-void plSound::IRefreshParams( void )
+void plSound::IRefreshParams()
 {
     SetMax( fMaxFalloff );
     SetMin( fMinFalloff );
@@ -481,7 +481,7 @@ void plSound::IRefreshParams( void )
 ////////////////////////////////////////////////////////////////////////
 //  The public interface to stopping, which also synchs the state with the
 //  server.
-void plSound::Stop( void )
+void plSound::Stop()
 {
     fPlaying = false;
 
@@ -509,7 +509,7 @@ void plSound::Stop( void )
     }
 }
 
-void plSound::IActuallyStop( void )
+void plSound::IActuallyStop()
 {
     if( fLoadOnDemandFlag && !IsPropertySet( kPropDisableLOD ) && !IsPropertySet( kPropLoadOnlyOnCall ) )
     {
@@ -546,7 +546,7 @@ void plSound::Update()
     }
 }
 
-float plSound::IGetChannelVolume( void ) const
+float plSound::IGetChannelVolume() const
 {
     float channelVol = plgAudioSys::GetChannelVolume( (plgAudioSys::ASChannel)fType );
 
@@ -777,7 +777,7 @@ void plSound::ForceLoad()
     LoadSound( IsPropertySet( kPropIs3DSound ) );
 }
 
-void plSound::ForceUnload( void )
+void plSound::ForceUnload()
 {
     if( !IsPropertySet( kPropLoadOnlyOnCall ) )
         return;
@@ -786,7 +786,7 @@ void plSound::ForceUnload( void )
     IFreeBuffers();
 }
 
-bool plSound::ILoadDataBuffer( void )
+bool plSound::ILoadDataBuffer()
 {
     if(!fDataBufferLoaded)
     {
@@ -813,7 +813,7 @@ void plSound::FreeSoundData()
     }
 }
 
-void plSound::IUnloadDataBuffer( void )
+void plSound::IUnloadDataBuffer()
 {
     if(fDataBufferLoaded)
     {
@@ -853,7 +853,7 @@ plSoundBuffer::ELoadReturnVal plSound::IPreLoadBuffer( bool playWhenLoaded, bool
     }
 }
 
-plFileName plSound::GetFileName( void ) const
+plFileName plSound::GetFileName() const
 {
     if (fDataBufferKey->ObjectIsLoaded())
     {
@@ -871,7 +871,7 @@ plFileName plSound::GetFileName( void ) const
 //  Note that if we already set the length (like at export time), we never need
 //  to load the sound, so the optimization at export time is all ready to plug-
 //  and-play...
-double plSound::GetLength( void )
+double plSound::GetLength()
 {
     if( ( (double)fLength == 0.f ) )
         ILoadDataBuffer();
@@ -984,7 +984,7 @@ float plSound::CalcSoftVolume( bool enable, float distToListenerSquared )
 //  Wee function for the audio system. This basically returns the effective
 //  current volume of this sound. Useful for doing things like ranking all
 //  sounds based on volume.
-float plSound::GetVolumeRank( void )
+float plSound::GetVolumeRank()
 {
     if( !IsPlaying() && !this->IActuallyPlaying() )
         return 0.f;
@@ -1010,7 +1010,7 @@ float plSound::GetVolumeRank( void )
 //  Tests to see whether, if we try to play this sound now, it'll actually
 //  be able to play. Takes into account whether the sound is within range
 //  of the listener and the current soft region value.
-bool plSound::IWillBeAbleToPlay( void )
+bool plSound::IWillBeAbleToPlay()
 {
     if( fSoftVolume == 0.f )
         return false;
@@ -1110,7 +1110,7 @@ void plSound::UpdateSoftVolume( bool enable, bool firstTime )
 
 /////////////////////////////////////////////////////////////////////////
 // Returns the current volume, attenuated
-float plSound::QueryCurrVolume( void ) const
+float plSound::QueryCurrVolume() const
 {
     return IAttenuateActualVolume( fCurrVolume ) * IGetChannelVolume();
 }
@@ -1147,7 +1147,7 @@ void plSound::Activate(bool forcePlay)
     SetMuted(plgAudioSys::IsMuted());
 }
 
-void plSound::DeActivate( void )
+void plSound::DeActivate()
 {
     UnregisterOnAudioSys();
 
@@ -1167,7 +1167,7 @@ void plSound::DeActivate( void )
 
 /////////////////////////////////////////////////////////////////////////
 //  Tell the audio system about ourselves.
-void plSound::RegisterOnAudioSys( void )
+void plSound::RegisterOnAudioSys()
 {
     if( !fRegistered )
     {
@@ -1178,7 +1178,7 @@ void plSound::RegisterOnAudioSys( void )
 
 /////////////////////////////////////////////////////////////////////////
 //  Tell the audio system to stop caring about us
-void plSound::UnregisterOnAudioSys( void )
+void plSound::UnregisterOnAudioSys()
 {
     if( fRegistered )
     {
@@ -1192,7 +1192,7 @@ void plSound::UnregisterOnAudioSys( void )
 //  shutting down). Normally, we should already be shut down, but in case
 //  we're not, this function makes sure everything is cleaned up before
 //  the audio system itself shuts down.
-void plSound::ForceUnregisterFromAudioSys( void )
+void plSound::ForceUnregisterFromAudioSys()
 {
     DeActivate();
     fRegistered = false;
@@ -1352,7 +1352,7 @@ void plSound::plFadeParams::Write( hsStream *s )
     s->WriteBOOL( fFadeSoftVol );
 }
 
-float plSound::plFadeParams::InterpValue( void )
+float plSound::plFadeParams::InterpValue()
 {
     float    val;
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.h
@@ -168,14 +168,14 @@ public:
             void    Read( hsStream *s );
             void    Write( hsStream *s );
 
-            float    InterpValue( void );
+            float    InterpValue();
 
         protected:
             float    fCurrTime;          // -1 if we aren't active, else it's how far we're into the animation
     };
 
     virtual bool        LoadSound( bool is3D ) = 0;
-    float            GetVirtualStartTime( void ) const { return (float)fVirtualStartTime; }
+    float            GetVirtualStartTime() const { return (float)fVirtualStartTime; }
 
     virtual void        Play();
     void                SynchedPlay( unsigned bytes );
@@ -188,16 +188,16 @@ public:
     virtual int         GetMin() const;
     virtual int         GetMax() const;
     virtual void        SetVolume(const float volume);
-    virtual float       GetVolume(void) const { return fCurrVolume; }
+    virtual float       GetVolume() const { return fCurrVolume; }
     float            GetMaxVolume() { return fMaxVolume; }
     virtual bool        IsPlaying() { return fPlaying; }
     void                SetTime(double t);
-    virtual double      GetTime( void ) { return 0.f; }
+    virtual double      GetTime() { return 0.f; }
     virtual void        Activate(bool forcePlay = false);
     virtual void        DeActivate();
     virtual void        SetLength(double l) { fLength = l; }
     virtual void        SetMuted( bool muted );
-    virtual bool        IsMuted( void ) { return fMuted; }
+    virtual bool        IsMuted() { return fMuted; }
     void                Disable() { fDistAttenuation = 0; }
     virtual plSoundMsg* GetStatus(plSoundMsg* pMsg){return NULL;}
     virtual void        SetConeOrientation(float x, float y, float z);
@@ -210,16 +210,16 @@ public:
 
     virtual void        Update();
     
-    plSoundBuffer *     GetDataBuffer( void ) const { return (plSoundBuffer *)fDataBufferKey->ObjectIsLoaded(); }
-    float               QueryCurrVolume( void ) const;  // Returns the current volume, attenuated
+    plSoundBuffer *     GetDataBuffer() const { return (plSoundBuffer *)fDataBufferKey->ObjectIsLoaded(); }
+    float               QueryCurrVolume() const;  // Returns the current volume, attenuated
 
-    plFileName          GetFileName( void ) const;
+    plFileName          GetFileName() const;
     virtual double      GetLength();
 
     void                SetProperty( Property prop, bool on ) { if( on ) fProperties |= prop; else fProperties &= ~prop; }
     bool                IsPropertySet( Property prop ) const { return ( fProperties & prop ) ? true : false; }
 
-    virtual void        RefreshVolume( void );
+    virtual void        RefreshVolume();
 
     virtual void        SetStartPos(unsigned bytes) = 0;
     virtual unsigned    GetByteOffset(){return 0;}
@@ -228,7 +228,7 @@ public:
     virtual void        AddCallbacks(plSoundMsg* pMsg) = 0;
     virtual void        RemoveCallbacks(plSoundMsg* pMsg) = 0;
 
-    virtual uint8_t       GetChannelSelect( void ) const { return 0; }    // Only defined on Win32Sound right now, should be here tho
+    virtual uint8_t       GetChannelSelect() const { return 0; }    // Only defined on Win32Sound right now, should be here tho
 
     virtual void        Read(hsStream* s, hsResMgr* mgr);
     virtual void        Write(hsStream* s, hsResMgr* mgr);
@@ -246,34 +246,34 @@ public:
 
     // Type setting and getting, from the Types enum
     void                SetType( uint8_t type ) { fType = type; }
-    uint8_t               GetType( void ) const { return fType; }
+    uint8_t               GetType() const { return fType; }
 
     // Priority stuff
     void                SetPriority( uint8_t pri ) { fPriority = pri; }
-    uint8_t               GetPriority( void ) const { return fPriority; }
+    uint8_t               GetPriority() const { return fPriority; }
 
     // Visualization
     virtual plDrawableSpans*    CreateProxy(const hsMatrix44& l2w, hsGMaterial* mat, hsTArray<uint32_t>& idx, plDrawableSpans* addTo);
 
     // Forced loading/unloading (for when the audio system's LOD just doesn't cut it)
     virtual void        ForceLoad(  );
-    virtual void        ForceUnload( void );
+    virtual void        ForceUnload();
 
     // Note: ONLY THE AUDIOSYS SHOULD CALL THIS. If you're not the audioSys, get lost.
     static void         SetCurrDebugPlate( const plKey& soundKey );
 
-    void                RegisterOnAudioSys( void );
-    void                UnregisterOnAudioSys( void );
+    void                RegisterOnAudioSys();
+    void                UnregisterOnAudioSys();
 
     // Also only for the audio system
-    float            GetVolumeRank( void );
-    void                ForceUnregisterFromAudioSys( void );
+    float            GetVolumeRank();
+    void                ForceUnregisterFromAudioSys();
 
     static void         SetLoadOnDemand( bool activate ) { fLoadOnDemandFlag = activate; }
     static void         SetLoadFromDiskOnDemand( bool activate ) { fLoadFromDiskOnDemand = activate; }
 
-    const plEAXSourceSettings   &GetEAXSettings( void ) const { return fEAXSettings; }
-    plEAXSourceSettings         &GetEAXSettings( void ) { return fEAXSettings; }
+    const plEAXSourceSettings   &GetEAXSettings() const { return fEAXSettings; }
+    plEAXSourceSettings         &GetEAXSettings() { return fEAXSettings; }
     virtual StreamType          GetStreamType() const { return kNoStream; }
     virtual void    FreeSoundData();
 
@@ -340,40 +340,40 @@ protected:
     static bool         fLoadOnDemandFlag, fLoadFromDiskOnDemand;
     bool                fLoading;
 
-    void            IUpdateDebugPlate( void );
+    void            IUpdateDebugPlate();
     void            IPrintDbgMessage( const char *msg, bool isErr = false );
 
     virtual void    ISetActualVolume(float v) = 0;
-    virtual void    IActuallyStop( void );
-    virtual bool    IActuallyPlaying( void ) = 0;
-    virtual void    IActuallyPlay( void ) = 0;
-    virtual void    IFreeBuffers( void ) = 0;
+    virtual void    IActuallyStop();
+    virtual bool    IActuallyPlaying() = 0;
+    virtual void    IActuallyPlay() = 0;
+    virtual void    IFreeBuffers() = 0;
 
     //NOTE: if isIncidental is true the entire sound will be loaded. 
     virtual plSoundBuffer::ELoadReturnVal   IPreLoadBuffer( bool playWhenLoaded, bool isIncidental = false );   
     virtual void        ISetActualTime( double t ) = 0;
     
-    virtual bool        IActuallyLoaded( void ) = 0;
+    virtual bool        IActuallyLoaded() = 0;
     virtual void        IRefreshEAXSettings( bool force = false ) = 0;
 
-    virtual float    IGetChannelVolume( void ) const;
+    virtual float    IGetChannelVolume() const;
 
-    void    ISynchToStartTime( void );
+    void    ISynchToStartTime();
     void    ISynchedPlay( double virtualStartTime );
     void    IStartFade( plFadeParams *params, float offsetIntoFade = 0.f );
     void    IStopFade( bool shuttingDown = false, bool SetVolEnd = true);
     
-    bool    IWillBeAbleToPlay( void );
+    bool    IWillBeAbleToPlay();
 
     void        ISetSoftRegion( plSoftVolume *region );
     float    IAttenuateActualVolume( float volume ) const;
     void        ISetSoftOcclusionRegion( plSoftVolume *region );
 
     // Override to make sure the buffer is available before the base class is called
-    virtual void    IRefreshParams( void );
+    virtual void    IRefreshParams();
 
-    virtual bool    ILoadDataBuffer( void );
-    virtual void    IUnloadDataBuffer( void );
+    virtual bool    ILoadDataBuffer();
+    virtual void    IUnloadDataBuffer();
 
     //virtual void  ISetMinDistance( const int m ) = 0;
     //virtual void  ISetMaxDistance( const int m ) = 0;

--- a/Sources/Plasma/PubUtilLib/plAudio/plSoundEvent.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSoundEvent.cpp
@@ -114,7 +114,7 @@ bool    plSoundEvent::RemoveCallback( plEventCallbackMsg *msg )
     return false;
 }
 
-void    plSoundEvent::SendCallbacks( void )
+void    plSoundEvent::SendCallbacks()
 {
     int         j;
     plSoundMsg  *sMsg;
@@ -165,12 +165,12 @@ void    plSoundEvent::SendCallbacks( void )
     }
 }
 
-uint32_t  plSoundEvent::GetNumCallbacks( void ) const
+uint32_t  plSoundEvent::GetNumCallbacks() const
 {
     return fCallbacks.GetCount();
 }
 
-int plSoundEvent::GetType( void ) const
+int plSoundEvent::GetType() const
 {
     return (int)fType;
 }
@@ -180,7 +180,7 @@ void    plSoundEvent::SetType( Types type )
     fType = type;
 }
 
-uint32_t  plSoundEvent::GetTime( void ) const
+uint32_t  plSoundEvent::GetTime() const
 {
     return fBytePosTime;
 }

--- a/Sources/Plasma/PubUtilLib/plAudio/plSoundEvent.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSoundEvent.h
@@ -76,12 +76,12 @@ public:
     void    AddCallback( plEventCallbackMsg *msg );
     bool    RemoveCallback( plEventCallbackMsg *msg );
 
-    uint32_t  GetNumCallbacks( void ) const;
-    int     GetType( void ) const;
+    uint32_t  GetNumCallbacks() const;
+    int     GetType() const;
     void    SetType( Types type );
-    uint32_t  GetTime( void ) const;
+    uint32_t  GetTime() const;
 
-    void    SendCallbacks( void );
+    void    SendCallbacks();
 
     static Types    GetTypeFromCallbackMsg( plEventCallbackMsg *msg );
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.cpp
@@ -470,7 +470,7 @@ void plVoiceSound::SetSampleRate(uint32_t rate)
     }
 }
 
-void plVoiceSound::IDerivedActuallyPlay( void )
+void plVoiceSound::IDerivedActuallyPlay()
 {
     if(!fReallyPlaying) {
         fDSoundBuffer->Play();

--- a/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.h
@@ -84,13 +84,13 @@ public:
     void SetSampleRate(uint32_t rate);
 
 private:
-    virtual bool    ILoadDataBuffer( void ){ return true; }
-    virtual void    IUnloadDataBuffer( void ){}
+    virtual bool    ILoadDataBuffer(){ return true; }
+    virtual void    IUnloadDataBuffer(){}
 
-    virtual void    IDerivedActuallyPlay( void );
+    virtual void    IDerivedActuallyPlay();
     virtual void    ISetActualTime( double t ){}
     virtual float   GetActualTimeSec() { return 0.0f; }
-    virtual void    IRefreshParams( void );
+    virtual void    IRefreshParams();
 
     static unsigned fCount;
     double   fLastUpdate;

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32GroupedSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32GroupedSound.cpp
@@ -285,12 +285,12 @@ uint32_t      plWin32GroupedSound::IGetSoundbyteLength( int16_t soundIndex )
 //// IGetDataPointer/Length //////////////////////////////////////////////////
 // Abstracting a few things here for the incidentalMgr
 
-void    *plWin32GroupedSound::IGetDataPointer( void ) const
+void    *plWin32GroupedSound::IGetDataPointer() const
 {
     return ( fDataBufferKey->ObjectIsLoaded() ) ? (void *)( (uint8_t *)((plSoundBuffer *)fDataBufferKey->ObjectIsLoaded())->GetData() + fStartPositions[ fCurrentSound ] ) : nil;
 }
 
-uint32_t  plWin32GroupedSound::IGetDataLength( void ) const
+uint32_t  plWin32GroupedSound::IGetDataLength() const
 {
     return ( fDataBufferKey->ObjectIsLoaded() ) ? fCurrentSoundLength : 0;
 }
@@ -374,7 +374,7 @@ void    plWin32GroupedSound::IFillCurrentSound( int16_t newCurrent /*= -1*/ )
     plProfile_EndTiming( StaticSndShoveTime );
 }
 
-void plWin32GroupedSound::IDerivedActuallyPlay( void )
+void plWin32GroupedSound::IDerivedActuallyPlay()
 {
     // Ensure there's a stop notify for us
     if( !fReallyPlaying )

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32GroupedSound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32GroupedSound.h
@@ -83,7 +83,7 @@ protected:
     // Some extra handy info for us
     uint8_t               fNumDestChannels, fNumDestBytesPerSample;
 
-    virtual void    IDerivedActuallyPlay( void );
+    virtual void    IDerivedActuallyPlay();
 
     virtual void    IRead( hsStream *s, hsResMgr *mgr );
     virtual void    IWrite( hsStream *s, hsResMgr *mgr );
@@ -92,8 +92,8 @@ protected:
     void            IFillCurrentSound( int16_t newCurrent = -1 );
     
     // Abstracting a few things here for the incidentalMgr
-    virtual void *  IGetDataPointer( void ) const; 
-    virtual uint32_t  IGetDataLength( void ) const;
+    virtual void *  IGetDataPointer() const;
+    virtual uint32_t  IGetDataLength() const;
 };
 
 #endif //plWin32GroupedSound_h

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
@@ -97,7 +97,7 @@ void plWin32Sound::DeActivate()
     IFreeBuffers();
 }
 
-void plWin32Sound::IFreeBuffers( void )
+void plWin32Sound::IFreeBuffers()
 {
     if( fDSoundBuffer != nil )
     {
@@ -116,7 +116,7 @@ void plWin32Sound::Update()
     plSound::Update();
 }
 
-void plWin32Sound::IActuallyPlay( void )
+void plWin32Sound::IActuallyPlay()
 {
     //plSound::Play();
     if (!fDSoundBuffer && plgAudioSys::Active())
@@ -297,7 +297,7 @@ void plWin32Sound::ISetActualVolume(float volume)
 //  The base class will make sure all our params are correct and up-to-date,
 //  but before it does its work, we have to make sure our buffer is ready to
 //  be updated.
-void plWin32Sound::IRefreshParams( void )
+void plWin32Sound::IRefreshParams()
 {
     if (!fDSoundBuffer && plgAudioSys::Active())
         LoadSound( IsPropertySet( kPropIs3DSound ) );

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.h
@@ -94,7 +94,7 @@ public:
 
     // Selects a channel source from a multi-channel (stereo) file. Ignored if source is mono
     void            SetChannelSelect( ChannelSelect source ) { fChannelSelect = (uint8_t)source; }
-    virtual uint8_t   GetChannelSelect( void ) const { return fChannelSelect; }
+    virtual uint8_t   GetChannelSelect() const { return fChannelSelect; }
     
 protected:
 
@@ -112,16 +112,16 @@ protected:
     hsTArray<plSoundEvent *>    fSoundEvents;
 
     virtual void    ISetActualVolume(float v);
-    virtual void    IActuallyStop( void );
-    virtual bool    IActuallyPlaying( void ) { return fReallyPlaying; }
-    virtual void    IActuallyPlay( void );
-    virtual void    IFreeBuffers( void );
-    virtual bool    IActuallyLoaded( void ) { return ( fDSoundBuffer != nil ) ? true : false; }
+    virtual void    IActuallyStop();
+    virtual bool    IActuallyPlaying() { return fReallyPlaying; }
+    virtual void    IActuallyPlay();
+    virtual void    IFreeBuffers();
+    virtual bool    IActuallyLoaded() { return ( fDSoundBuffer != nil ) ? true : false; }
 
     // Override to make sure the buffer is available before the base class is called
-    virtual void    IRefreshParams( void );
+    virtual void    IRefreshParams();
 
-    virtual void    IDerivedActuallyPlay( void ) = 0;
+    virtual void    IDerivedActuallyPlay() = 0;
 
     virtual void    IAddCallback( plEventCallbackMsg *pMsg );
     virtual void    IRemoveCallback( plEventCallbackMsg *pMsg );

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StaticSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StaticSound.cpp
@@ -208,7 +208,7 @@ void plWin32StaticSound::Update()
     }
 }
 
-void plWin32StaticSound::IDerivedActuallyPlay( void )
+void plWin32StaticSound::IDerivedActuallyPlay()
 {
     // Ensure there's a stop notify for us
     if( !fReallyPlaying )

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StaticSound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StaticSound.h
@@ -69,7 +69,7 @@ public:
 protected:
     bool            fRegisteredOnThread;
 
-    virtual void    IDerivedActuallyPlay( void );
+    virtual void    IDerivedActuallyPlay();
     virtual void    ISetActualTime( double t );
     virtual float   GetActualTimeSec();
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.cpp
@@ -204,7 +204,7 @@ plSoundBuffer::ELoadReturnVal plWin32StreamingSound::IPreLoadBuffer( bool playWh
     return plSoundBuffer::kError;
 }
 
-void plWin32StreamingSound::IFreeBuffers( void )
+void plWin32StreamingSound::IFreeBuffers()
 {
     plWin32Sound::IFreeBuffers();
     if( fLoadFromDiskOnDemand && !IsPropertySet( kPropLoadOnlyOnCall ) )
@@ -403,7 +403,7 @@ void plWin32StreamingSound::Update()
     IStreamUpdate();
 }
 
-void plWin32StreamingSound::IDerivedActuallyPlay( void )
+void plWin32StreamingSound::IDerivedActuallyPlay()
 {
     fStopping = false;
     if( !fReallyPlaying )

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.h
@@ -86,17 +86,17 @@ protected:
     bool                fPlayWhenStopped;
     unsigned            fStartPos;
 
-    float               IGetTimeAtBufferStart( void ) { return fTimeAtBufferStart; }
+    float               IGetTimeAtBufferStart() { return fTimeAtBufferStart; }
     virtual void        SetStartPos(unsigned bytes);
 
-    virtual void        IDerivedActuallyPlay( void );
+    virtual void        IDerivedActuallyPlay();
     void                IActuallyStop();
     virtual void        ISetActualTime( double t );
     
     virtual void        IAddCallback( plEventCallbackMsg *pMsg );
     virtual void        IRemoveCallback( plEventCallbackMsg *pMsg );
 
-    virtual void        IFreeBuffers( void );
+    virtual void        IFreeBuffers();
     void                IStreamUpdate();
     virtual plSoundBuffer::ELoadReturnVal IPreLoadBuffer( bool playWhenLoaded, bool isIncidental = false  );
 };

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32VideoSound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32VideoSound.h
@@ -56,7 +56,7 @@ public:
     void FillSoundBuffer(void* buffer, size_t size);
 
 protected:
-    void IDerivedActuallyPlay(void);
+    void IDerivedActuallyPlay();
     bool LoadSound(bool is3D);
     void SetStartPos(unsigned bytes);
     float GetActualTimeSec();

--- a/Sources/Plasma/PubUtilLib/plAudio/plWinMicLevel.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWinMicLevel.cpp
@@ -73,8 +73,8 @@ DWORD       sVolControlID = 0;
 
 //// Local Static Helpers ////////////////////////////////////////////////////
 
-bool    IGetMuxMicVolumeControl( void );
-bool    IGetBaseMicVolumeControl( void );
+bool    IGetMuxMicVolumeControl();
+bool    IGetBaseMicVolumeControl();
 
 bool    IGetControlValue( DWORD &value );
 bool    ISetControlValue( DWORD value );
@@ -87,7 +87,7 @@ MIXERLINE       *IGetMixerSubLineByType( MIXERCONTROL *mux, DWORD type );
 
 //// The Publics /////////////////////////////////////////////////////////////
 
-float    plWinMicLevel::GetLevel( void )
+float    plWinMicLevel::GetLevel()
 {
     if( !CanSetLevel() )
         return -1;
@@ -115,7 +115,7 @@ void    plWinMicLevel::SetLevel( float level )
 #endif
 }
 
-bool    plWinMicLevel::CanSetLevel( void )
+bool    plWinMicLevel::CanSetLevel()
 {
     // Just to init
     plWinMicLevel   &instance = IGetInstance();
@@ -130,7 +130,7 @@ bool    plWinMicLevel::CanSetLevel( void )
 
 //// Protected Init Stuff ////////////////////////////////////////////////////
 
-plWinMicLevel   &plWinMicLevel::IGetInstance( void )
+plWinMicLevel   &plWinMicLevel::IGetInstance()
 {
     static plWinMicLevel    sInstance;
     return sInstance;
@@ -180,7 +180,7 @@ plWinMicLevel::~plWinMicLevel()
     IShutdown();
 }
 
-void    plWinMicLevel::IShutdown( void )
+void    plWinMicLevel::IShutdown()
 {
 #if HS_BUILD_FOR_WIN32
     if( sMixerHandle != nil )
@@ -197,7 +197,7 @@ void    plWinMicLevel::IShutdown( void )
 //  Note: testing indcates that this works but the direct SRC_MICROPHONE
 //  doesn't, hence we try this one first.
 
-bool    IGetMuxMicVolumeControl( void )
+bool    IGetMuxMicVolumeControl()
 {
     if( sMixerHandle == nil )
         return false;
@@ -239,7 +239,7 @@ bool    IGetMuxMicVolumeControl( void )
 //  Tries to get the volume control of the mic-in line. See 
 //  IGetMuxMicVolumeControl for why we don't do this one first.
 
-bool    IGetBaseMicVolumeControl( void )
+bool    IGetBaseMicVolumeControl()
 {
     if( sMixerHandle == nil )
         return false;

--- a/Sources/Plasma/PubUtilLib/plAudio/plWinMicLevel.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWinMicLevel.h
@@ -63,18 +63,18 @@ public:
 
     ~plWinMicLevel();
     // Gets the microphone volume, range 0-1, -1 if error
-    static float GetLevel( void );
+    static float GetLevel();
 
     // Sets the microphone volume, range 0-1
     static void     SetLevel( float level );
 
     // Returns whether we can set the level
-    static bool     CanSetLevel( void );
+    static bool     CanSetLevel();
 
 protected:
     plWinMicLevel();    // Protected constructor for IGetInstance. Just to init some stuff
-    static plWinMicLevel    &IGetInstance( void );
-    void    IShutdown( void );
+    static plWinMicLevel    &IGetInstance();
+    void    IShutdown();
 };
 
 #endif // _plWinMicLevel_h

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plAudioFileReader.h
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plAudioFileReader.h
@@ -62,7 +62,7 @@ class plAudioFileReader
 {
 public:
     virtual ~plAudioFileReader() {}
-    virtual plWAVHeader &GetHeader( void ) = 0;
+    virtual plWAVHeader &GetHeader() = 0;
 
     enum StreamType
     {
@@ -72,19 +72,19 @@ public:
     };
 
     virtual void    Open(){}
-    virtual void    Close( void ) = 0;
+    virtual void    Close() = 0;
 
-    virtual uint32_t  GetDataSize( void ) = 0;
-    virtual float   GetLengthInSecs( void ) = 0;
+    virtual uint32_t  GetDataSize() = 0;
+    virtual float   GetLengthInSecs() = 0;
 
     virtual bool    SetPosition( uint32_t numBytes ) = 0;
     virtual bool    Read( uint32_t numBytes, void *buffer ) = 0;
-    virtual uint32_t  NumBytesLeft( void ) = 0;
+    virtual uint32_t  NumBytesLeft() = 0;
 
     virtual bool    OpenForWriting( const plFileName& path, plWAVHeader &header ) { return false; }
     virtual uint32_t  Write( uint32_t bytes, void *buffer ) { return 0; }
 
-    virtual bool    IsValid( void ) = 0;
+    virtual bool    IsValid() = 0;
 
     static plAudioFileReader* CreateReader(const plFileName& path, plAudioCore::ChannelSelect whichChan = plAudioCore::kAll, StreamType type = kStreamWAV);
     static plAudioFileReader* CreateWriter(const plFileName& path, plWAVHeader& header);

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plBufferedFileReader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plBufferedFileReader.cpp
@@ -109,7 +109,7 @@ plBufferedFileReader::~plBufferedFileReader()
     Close();
 }
 
-void    plBufferedFileReader::Close( void )
+void    plBufferedFileReader::Close()
 {
     //plProfile_DelMem( SndBufferedMem, fBufferSize );
 
@@ -125,14 +125,14 @@ void    plBufferedFileReader::IError( const char *msg )
     Close();
 }
 
-plWAVHeader &plBufferedFileReader::GetHeader( void )
+plWAVHeader &plBufferedFileReader::GetHeader()
 {
     hsAssert( IsValid(), "GetHeader() called on an invalid RAM buffer" );
 
     return fHeader;
 }
 
-float   plBufferedFileReader::GetLengthInSecs( void )
+float   plBufferedFileReader::GetLengthInSecs()
 {
     hsAssert( IsValid(), "GetLengthInSecs() called on an invalid RAM buffer" );
 
@@ -172,7 +172,7 @@ bool    plBufferedFileReader::Read( uint32_t numBytes, void *buffer )
     return valid;
 }
 
-uint32_t  plBufferedFileReader::NumBytesLeft( void )
+uint32_t  plBufferedFileReader::NumBytesLeft()
 {
     hsAssert( IsValid(), "NumBytesLeft() called on an invalid RAM buffer" );
 

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plBufferedFileReader.h
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plBufferedFileReader.h
@@ -62,14 +62,14 @@ public:
     plBufferedFileReader( const plFileName &path, plAudioCore::ChannelSelect whichChan = plAudioCore::kAll );
     virtual ~plBufferedFileReader();
 
-    virtual plWAVHeader &GetHeader( void );
-    virtual void    Close( void );
-    virtual uint32_t  GetDataSize( void ) { return fBufferSize; }
-    virtual float   GetLengthInSecs( void );
+    virtual plWAVHeader &GetHeader();
+    virtual void    Close();
+    virtual uint32_t  GetDataSize() { return fBufferSize; }
+    virtual float   GetLengthInSecs();
     virtual bool    SetPosition( uint32_t numBytes );
     virtual bool    Read( uint32_t numBytes, void *buffer );
-    virtual uint32_t  NumBytesLeft( void );
-    virtual bool    IsValid( void ) { return ( fBuffer != nil ) ? true : false; }
+    virtual uint32_t  NumBytesLeft();
+    virtual bool    IsValid() { return ( fBuffer != nil ) ? true : false; }
 
 protected:
     uint32_t        fBufferSize;

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plFastWavReader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plFastWavReader.cpp
@@ -96,7 +96,7 @@ class plRIFFHeader
             }
         }
 
-        bool    IsValid( void )
+        bool    IsValid()
         {
             return fValid;
         }
@@ -233,7 +233,7 @@ void plFastWAV::Open()
     fseek( fFileHandle, fDataStartPos, SEEK_SET );
 }
 
-void    plFastWAV::Close( void )
+void    plFastWAV::Close()
 {
     if( fFileHandle != nil )
     {
@@ -248,14 +248,14 @@ void    plFastWAV::IError( const char *msg )
     Close();
 }
 
-plWAVHeader &plFastWAV::GetHeader( void )
+plWAVHeader &plFastWAV::GetHeader()
 {
     hsAssert( IsValid(), "GetHeader() called on an invalid WAV file" );
 
     return fFakeHeader;
 }
 
-float   plFastWAV::GetLengthInSecs( void )
+float   plFastWAV::GetLengthInSecs()
 {
     hsAssert( IsValid(), "GetLengthInSecs() called on an invalid WAV file" );
 
@@ -338,7 +338,7 @@ bool    plFastWAV::Read( uint32_t numBytes, void *buffer )
     return true;
 }
 
-uint32_t  plFastWAV::NumBytesLeft( void )
+uint32_t  plFastWAV::NumBytesLeft()
 {
     hsAssert( IsValid(), "GetHeader() called on an invalid WAV file" );
     hsAssert( fCurrDataPos <= fDataSize, "Invalid current position while reading WAV file" );

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plFastWavReader.h
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plFastWavReader.h
@@ -64,19 +64,19 @@ public:
     plFastWAV( const plFileName &path, plAudioCore::ChannelSelect whichChan = plAudioCore::kAll );
     virtual ~plFastWAV();
 
-    virtual plWAVHeader &GetHeader( void );
+    virtual plWAVHeader &GetHeader();
 
     virtual void    Open();
-    virtual void    Close( void );
+    virtual void    Close();
 
-    virtual uint32_t  GetDataSize( void ) { return fDataSize / fChannelAdjust; }
-    virtual float   GetLengthInSecs( void );
+    virtual uint32_t  GetDataSize() { return fDataSize / fChannelAdjust; }
+    virtual float   GetLengthInSecs();
 
     virtual bool    SetPosition( uint32_t numBytes );
     virtual bool    Read( uint32_t numBytes, void *buffer );
-    virtual uint32_t  NumBytesLeft( void );
+    virtual uint32_t  NumBytesLeft();
 
-    virtual bool    IsValid( void ) { return ( fFileHandle != nil ) ? true : false; }
+    virtual bool    IsValid() { return ( fFileHandle != nil ) ? true : false; }
 
 protected:
     enum

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plOGGCodec.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plOGGCodec.cpp
@@ -186,7 +186,7 @@ plOGGCodec::~plOGGCodec()
     Close();
 }
 
-void    plOGGCodec::Close( void )
+void    plOGGCodec::Close()
 {
     // plNetClientApp::StaticDebugMsg("Ogg Close, t={f}, start", hsTimer::GetSeconds());
     free(fHeadBuf);
@@ -212,14 +212,14 @@ void    plOGGCodec::IError( const char *msg )
     Close();
 }
 
-plWAVHeader &plOGGCodec::GetHeader( void )
+plWAVHeader &plOGGCodec::GetHeader()
 {
     hsAssert( IsValid(), "GetHeader() called on an invalid OGG file" );
 
     return fFakeHeader;
 }
 
-float   plOGGCodec::GetLengthInSecs( void )
+float   plOGGCodec::GetLengthInSecs()
 {
     hsAssert( IsValid(), "GetLengthInSecs() called on an invalid OGG file" );
 
@@ -343,7 +343,7 @@ bool    plOGGCodec::Read( uint32_t numBytes, void *buffer )
     return true;
 }
 
-uint32_t  plOGGCodec::NumBytesLeft( void )
+uint32_t  plOGGCodec::NumBytesLeft()
 {
     if(!IsValid())
     {

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plOGGCodec.h
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plOGGCodec.h
@@ -74,22 +74,22 @@ public:
         kFastSeeking = 0x01
     };
     
-    virtual plWAVHeader &GetHeader( void );
+    virtual plWAVHeader &GetHeader();
 
-    virtual void    Close( void );
+    virtual void    Close();
 
-    virtual uint32_t  GetDataSize( void ) { return fDataSize / fChannelAdjust; }
-    virtual float   GetLengthInSecs( void );
+    virtual uint32_t  GetDataSize() { return fDataSize / fChannelAdjust; }
+    virtual float   GetLengthInSecs();
 
     virtual bool    SetPosition( uint32_t numBytes );
     virtual bool    Read( uint32_t numBytes, void *buffer );
-    virtual uint32_t  NumBytesLeft( void );
+    virtual uint32_t  NumBytesLeft();
 
-    virtual bool    IsValid( void ) { return ( fOggFile != nil ) ? true : false; }
+    virtual bool    IsValid() { return ( fOggFile != nil ) ? true : false; }
 
     static void     SetDecodeFormat( DecodeFormat f ) { fDecodeFormat = f; }
     static void     SetDecodeFlag( uint8_t flag, bool on ) { if( on ) fDecodeFlags |= flag; else fDecodeFlags &= ~flag; }
-    static uint8_t  GetDecodeFlags( void ) { return fDecodeFlags; }
+    static uint8_t  GetDecodeFlags() { return fDecodeFlags; }
     void            ResetWaveHeaderRef() { fCurHeaderPos = 0; }
     void            BuildActualWaveHeader();
     bool            ReadFromHeader(int numBytes, void *data); // read from Actual wave header

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plSoundBuffer.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plSoundBuffer.cpp
@@ -209,7 +209,7 @@ void plSoundBuffer::IInitBuffer()
 
 //// GetDataLengthInSecs /////////////////////////////////////////////////////
 
-float    plSoundBuffer::GetDataLengthInSecs( void ) const
+float    plSoundBuffer::GetDataLengthInSecs() const
 {
     return (float)fDataLength / (float)fHeader.fAvgBytesPerSec;
 }
@@ -299,7 +299,7 @@ void    plSoundBuffer::SetFileName( const plFileName &name )
 //// GetReaderSelect /////////////////////////////////////////////////////////
 //  Translates our flags into the ChannelSelect enum for plAudioFileReader
 
-plAudioCore::ChannelSelect  plSoundBuffer::GetReaderSelect( void ) const
+plAudioCore::ChannelSelect  plSoundBuffer::GetReaderSelect() const
 {
     if( fFlags & kOnlyLeftChannel )
         return plAudioCore::kLeft;
@@ -378,7 +378,7 @@ plSoundBuffer::ELoadReturnVal plSoundBuffer::AsyncLoad(plAudioFileReader::Stream
 
 //// ForceNonInternal ////////////////////////////////////////////////////////
 // destroys loaded, and frees data
-void    plSoundBuffer::UnLoad( void )
+void    plSoundBuffer::UnLoad()
 {
     if(fLoaded)
         int i = 0;
@@ -490,7 +490,7 @@ plSoundBuffer::ELoadReturnVal plSoundBuffer::EnsureInternal()
 }
 
 //// IGrabHeaderInfo /////////////////////////////////////////////////////////
-bool    plSoundBuffer::IGrabHeaderInfo( void )
+bool    plSoundBuffer::IGrabHeaderInfo()
 {
     if (fFileName.IsValid())
     {

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plSoundBuffer.h
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plSoundBuffer.h
@@ -94,13 +94,13 @@ public:
     virtual void    Read( hsStream *s, hsResMgr *mgr );
     virtual void    Write( hsStream *s, hsResMgr *mgr );
 
-    plWAVHeader &GetHeader( void )              { return fHeader; }
-    uint32_t    GetDataLength( void ) const     { return fDataLength; }
+    plWAVHeader &GetHeader()              { return fHeader; }
+    uint32_t    GetDataLength() const     { return fDataLength; }
     void        SetDataLength(unsigned length)  { fDataLength = length; } 
-    void       *GetData( void ) const           { return fData; }
-    plFileName  GetFileName( void ) const       { return fFileName; }
-    bool        IsValid( void ) const           { return fValid; }
-    float       GetDataLengthInSecs( void ) const;
+    void       *GetData() const           { return fData; }
+    plFileName  GetFileName() const       { return fFileName; }
+    bool        IsValid() const           { return fValid; }
+    float       GetDataLengthInSecs() const;
 
     void                SetFileName( const plFileName &name );
     bool                HasFlag( uint32_t flag ) { return ( fFlags & flag ) ? true : false; }
@@ -110,7 +110,7 @@ public:
     ELoadReturnVal      AsyncLoad( plAudioFileReader::StreamType type, unsigned length = 0 );   
     void                UnLoad( );
 
-    plAudioCore::ChannelSelect  GetReaderSelect( void ) const;
+    plAudioCore::ChannelSelect  GetReaderSelect() const;
 
     
     static void         Init();
@@ -135,7 +135,7 @@ protected:
     
     void            IInitBuffer();
 
-    bool            IGrabHeaderInfo( void );
+    bool            IGrabHeaderInfo();
     void            IAddBuffers( void *base, void *toAdd, uint32_t lengthInBytes, uint8_t bitsPerSample );
     plFileName      IGetFullPath();
 

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plSoundDeswizzler.h
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plSoundDeswizzler.h
@@ -61,7 +61,7 @@ public:
     plSoundDeswizzler( uint32_t srcLength, uint8_t numChannels, uint32_t sampleSize );
     ~plSoundDeswizzler();
 
-    void    *GetSourceBuffer( void ) const { return fData; }
+    void    *GetSourceBuffer() const { return fData; }
     void    Extract( uint8_t channelSelect, void *destPtr, uint32_t numBytesToProcess = 0 );
 
 protected:

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plWavFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plWavFile.cpp
@@ -965,23 +965,23 @@ bool    CWaveFile::OpenForWriting( const char *path, plWAVHeader &header )
     return false;
 }
 
-plWAVHeader &CWaveFile::GetHeader( void )
+plWAVHeader &CWaveFile::GetHeader()
 {
     return fHeader;
 }
 
-void    CWaveFile::Close( void )
+void    CWaveFile::Close()
 {
     IClose();
 }
 
-uint32_t  CWaveFile::GetDataSize( void )
+uint32_t  CWaveFile::GetDataSize()
 {
     hsAssert( false, "Unsupported" );
     return 0;
 }
 
-float   CWaveFile::GetLengthInSecs( void )
+float   CWaveFile::GetLengthInSecs()
 {
     hsAssert( false, "Unsupported" );
     return 0.f;
@@ -999,7 +999,7 @@ bool    CWaveFile::Read( uint32_t numBytes, void *buffer )
     return false;
 }
 
-uint32_t  CWaveFile::NumBytesLeft( void )
+uint32_t  CWaveFile::NumBytesLeft()
 {
     hsAssert( false, "Unsupported" );
     return 0;
@@ -1012,7 +1012,7 @@ uint32_t  CWaveFile::Write( uint32_t bytes, void *buffer )
     return (uint32_t)written;
 }
 
-bool    CWaveFile::IsValid( void )
+bool    CWaveFile::IsValid()
 {
     return true;
 }

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plWavFile.h
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plWavFile.h
@@ -95,17 +95,17 @@ public:
     // Overloads for plAudioFileReader
     CWaveFile( const char *path, plAudioCore::ChannelSelect whichChan );
     virtual bool    OpenForWriting( const char *path, plWAVHeader &header );
-    virtual plWAVHeader &GetHeader( void );
-    virtual void    Close( void );
-    virtual uint32_t  GetDataSize( void );
-    virtual float   GetLengthInSecs( void );
+    virtual plWAVHeader &GetHeader();
+    virtual void    Close();
+    virtual uint32_t  GetDataSize();
+    virtual float   GetLengthInSecs();
 
     virtual bool    SetPosition( uint32_t numBytes );
     virtual bool    Read( uint32_t numBytes, void *buffer );
-    virtual uint32_t  NumBytesLeft( void );
+    virtual uint32_t  NumBytesLeft();
     virtual uint32_t  Write( uint32_t bytes, void *buffer );
 
-    virtual bool    IsValid( void );
+    virtual bool    IsValid();
     WAVEFORMATEX* m_pwfx;        // Pointer to WAVEFORMATEX structure
     HMMIO         m_hmmio;       // MM I/O handle for the WAVE
     MMCKINFO      m_ck;          // Multimedia RIFF chunk

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
@@ -386,7 +386,7 @@ protected:
     void    IFireBehaviorNotify(uint32_t type, bool behaviorStart = true);
     void    IHandleInputStateMsg(plAvatarInputStateMsg *msg);
     void    ILinkToPersonalAge();
-    int     IFindSpawnOverride(void);
+    int     IFindSpawnOverride();
     void    ISetTransparentDrawOrder(bool val);
     plLayerLinkAnimation *IFindLayerLinkAnim();
 

--- a/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.cpp
@@ -54,7 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 //// Singleton Instance ///////////////////////////////////////////////////////
 
-plClientResMgr& plClientResMgr::Instance(void)
+plClientResMgr& plClientResMgr::Instance()
 {
     static plClientResMgr theInstance;
     return theInstance;

--- a/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.h
+++ b/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.h
@@ -62,7 +62,7 @@ public:
 
     std::vector<ST::string> getResourceNames();
 
-    static plClientResMgr& Instance(void);
+    static plClientResMgr& Instance();
 };
 
 #endif // _plClientResMgr_

--- a/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.h
+++ b/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.h
@@ -58,7 +58,7 @@ class plClipboard
         bool IsTextInClipboard();
         ST::string GetClipboardText();
         void SetClipboardText(const ST::string& text);
-        static plClipboard& GetInstance( void );
+        static plClipboard& GetInstance();
 };
 
 #endif // _Clipboard_h

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
@@ -1441,7 +1441,7 @@ void    plDrawableSpans::SetCriteria( const plDrawableCriteria& crit )
 //  optimized version may be plugged into the Optimize function at a later
 //  date if this one doesn't perform enough (it does so far).
 
-void    plDrawableSpans::IQuickSpaceTree( void ) const
+void    plDrawableSpans::IQuickSpaceTree() const
 {
     int     i;
 
@@ -2830,7 +2830,7 @@ void    plDrawableSpans::RemoveDISpans( uint32_t index )
 
 //// IRebuildSpanArray ///////////////////////////////////////////////////////
 
-void    plDrawableSpans::IRebuildSpanArray( void )
+void    plDrawableSpans::IRebuildSpanArray()
 {
     uint32_t      j, i;
     plIcicle    *icicle = nil;
@@ -2920,7 +2920,7 @@ void    plDrawableSpans::ICleanupMatrices()
 //// IRemoveGarbage //////////////////////////////////////////////////////////
 //  Cleans out all the unused spans. Oh, joy.
 
-void    plDrawableSpans::IRemoveGarbage( void )
+void    plDrawableSpans::IRemoveGarbage()
 {
     int     groupIdx, ibIdx, i, j, k, count, offset;
 
@@ -3358,7 +3358,7 @@ uint8_t   plDrawableSpans::IFindBufferGroup(uint8_t vtxFormat, uint32_t numVerts
 //// GetParticleSpanVector ///////////////////////////////////////////////////
 //  Get a bitVector of the spans that are particle spans
 
-hsBitVector const   &plDrawableSpans::GetParticleSpanVector( void ) const
+hsBitVector const   &plDrawableSpans::GetParticleSpanVector() const
 {
     return fParticleSpanVector;
 }
@@ -3366,7 +3366,7 @@ hsBitVector const   &plDrawableSpans::GetParticleSpanVector( void ) const
 //// GetBlendingSpanVector ///////////////////////////////////////////////////
 //  Get a bitVector of the spans that are blending (i.e. numMatrices > 0)
 
-hsBitVector const   &plDrawableSpans::GetBlendingSpanVector( void ) const
+hsBitVector const   &plDrawableSpans::GetBlendingSpanVector() const
 {
     /// See the plRenderMsg handler for why we do this
     return fFakeBlendingSpanVector;
@@ -3383,7 +3383,7 @@ void    plDrawableSpans::SetBlendingSpanVectorBit( uint32_t bitNumber, bool on )
 
 //// IBuildVectors ///////////////////////////////////////////////////////////
 
-void    plDrawableSpans::IBuildVectors( void )
+void    plDrawableSpans::IBuildVectors()
 {
     int     i;
     bool    needRenderMsg = false;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.h
@@ -178,13 +178,13 @@ class plDrawableSpans : public plDrawable
         hsTArray<plGeometrySpan *>  fSourceSpans;
         bool                        fOptimized;
 
-        virtual void    IQuickSpaceTree( void ) const;
+        virtual void    IQuickSpaceTree() const;
 
         // Temp placeholder function. See code for comments.
         void    IUpdateMatrixPaletteBoundsHack( );
 
         void    ICleanupMatrices();
-        void    IRemoveGarbage( void );
+        void    IRemoveGarbage();
         void    IAdjustSortData( plGBufferTriangle *triList, uint32_t count, uint32_t threshhold, int32_t delta );
 
         // The following two functions return true if they create a new span, false if it's just an instance
@@ -210,15 +210,15 @@ class plDrawableSpans : public plDrawable
         void            IMakeSpanSortable( uint32_t index );
 
         /// Bit vector build thingies
-        virtual void            IBuildVectors( void );
+        virtual void            IBuildVectors();
 
         bool                    IBoundsInvalid(const hsBounds3Ext& bnd) const;
 
         /// EXPORT-ONLY FUNCTIONS
         // Packs the span indices
-        void    IPackSourceSpans( void );
+        void    IPackSourceSpans();
         // Sort the spans
-        void    ISortSourceSpans( void );
+        void    ISortSourceSpans();
         // Compare two spans for sorting
         short   ICompareSpans( plGeometrySpan *span1, plGeometrySpan *span2 );
         // Find a buffer group of the given format (returns its index into fGroups)
@@ -229,7 +229,7 @@ class plDrawableSpans : public plDrawable
 
         /// DYNAMIC FUNCTIONS
         plDISpanIndex   *IFindDIIndices( uint32_t &index );
-        void            IRebuildSpanArray( void );
+        void            IRebuildSpanArray();
         plParticleSpan  *ICreateParticleIcicle( hsGMaterial *material, plParticleSet *set );
 
         virtual void    SetKey(plKey k);
@@ -261,7 +261,7 @@ class plDrawableSpans : public plDrawable
         virtual plDrawable& SetSubType( uint32_t index, plSubDrawableType t, bool on );
         virtual uint32_t GetSubType( uint32_t index ) const; // returns or of all spans with this index (index==-1 is all spans).
 
-        virtual uint32_t  GetType( void ) const { return fType; }
+        virtual uint32_t  GetType() const { return fType; }
         virtual void    SetType( uint32_t type ) { fType = type; }
 
         virtual void SetRenderLevel(const plRenderLevel& l);
@@ -281,8 +281,8 @@ class plDrawableSpans : public plDrawable
 
         virtual const plSpan                *GetSpan( uint32_t index ) const { return fSpans[ index ]; }
         virtual const plSpan                *GetSpan( uint32_t diIndex, uint32_t index ) const { return fSpans[ (*fDIIndices[ diIndex ])[ index ] ]; }
-        virtual uint32_t                     GetNumSpans( void ) const { return fSpans.GetCount(); }
-        virtual const hsTArray<plSpan *>    &GetSpanArray( void ) const { return fSpans; }
+        virtual uint32_t                     GetNumSpans() const { return fSpans.GetCount(); }
+        virtual const hsTArray<plSpan *>    &GetSpanArray() const { return fSpans; }
 
         hsMatrix44* GetMatrixPalette(int baseMatrix) const { return const_cast<hsMatrix44*>(&fLocalToWorlds[baseMatrix]); }
         const hsMatrix44& GetPaletteMatrix(int i) const { return fLocalToWorlds[i]; }
@@ -313,20 +313,20 @@ class plDrawableSpans : public plDrawable
 
         // Lookup a material in the material array
         hsGMaterial     *GetMaterial( uint32_t index ) const { return ( ( index == (uint32_t)-1 ) ? nil : fMaterials[ index ] ); }
-        uint32_t          GetNumMaterials( void ) const { return fMaterials.GetCount(); }
+        uint32_t          GetNumMaterials() const { return fMaterials.GetCount(); }
 
         // Convert intermediate data into export/run-time-ready data
-        virtual void    Optimize( void );
+        virtual void    Optimize();
         // Called by the sceneNode to determine if we match the criteria
         virtual bool    DoIMatch( const plDrawableCriteria& crit );
         // To set the criteria that this ice fits
         void            SetCriteria( const plDrawableCriteria& crit );
 
         // Get a bitVector of the spans that are particle spans
-        virtual hsBitVector const   &GetParticleSpanVector( void ) const;
+        virtual hsBitVector const   &GetParticleSpanVector() const;
 
         // Get a bitVector of the spans that are blending (i.e. numMatrices > 0)
-        virtual hsBitVector const   &GetBlendingSpanVector( void ) const;
+        virtual hsBitVector const   &GetBlendingSpanVector() const;
 
         // Set a single bit in the bitVector of spans that are blending
         virtual void    SetBlendingSpanVectorBit( uint32_t bitNumber, bool on );
@@ -375,7 +375,7 @@ class plDrawableSpans : public plDrawable
         void            SortSpan( uint32_t index, plPipeline *pipe );
         void            SortVisibleSpans(const hsTArray<int16_t>& visList, plPipeline* pipe);
         void            SortVisibleSpansPartial(const hsTArray<int16_t>& visList, plPipeline* pipe);
-        void            CleanUpGarbage( void ) { IRemoveGarbage(); }
+        void            CleanUpGarbage() { IRemoveGarbage(); }
 
         /// Funky particle system functions
         virtual uint32_t  CreateParticleSystem( uint32_t maxNumEmitters, uint32_t maxNumParticles, hsGMaterial *material );

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpansExport.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpansExport.cpp
@@ -301,7 +301,7 @@ uint32_t  plDrawableSpans::AddDISpans( hsTArray<plGeometrySpan *> &spans, uint32
 
 //// Optimize ////////////////////////////////////////////////////////////////
 
-void    plDrawableSpans::Optimize( void )
+void    plDrawableSpans::Optimize()
 {
     int     i;
 
@@ -452,7 +452,7 @@ static void ILogSpan(plStatusLog* statusLog, plGeometrySpan* geo, plVertexSpan* 
 //  Takes the array of source spans and converts them to our internal icicle
 //  spans, vertex buffers and index buffers.
 
-void    plDrawableSpans::IPackSourceSpans( void )
+void    plDrawableSpans::IPackSourceSpans()
 {
     int             i, j;
     hsBounds3Ext    bounds;
@@ -607,7 +607,7 @@ void    plDrawableSpans::IPackSourceSpans( void )
 //  most efficient order possible. Also has to re-order the span lookup
 //  table.
 
-void    plDrawableSpans::ISortSourceSpans( void )
+void    plDrawableSpans::ISortSourceSpans()
 {
     hsTArray<uint32_t>    spanReorderTable, spanInverseTable;
     int                 i, j, idx;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
@@ -145,7 +145,7 @@ void plGBufferGroup::DirtyIndexBuffer(size_t i)
 
 //// TidyUp ///////////////////////////////////////////////////////////////////
 
-void    plGBufferGroup::TidyUp( void )
+void    plGBufferGroup::TidyUp()
 {
 /*  if( fVertBuffStorage.GetCount() == 0 && fNumVerts > 0 )
         return;     // Already tidy'd!
@@ -186,7 +186,7 @@ void plGBufferGroup::PurgeIndexBuffer(uint32_t idx)
 
 //// CleanUp //////////////////////////////////////////////////////////////////
 
-void    plGBufferGroup::CleanUp( void )
+void    plGBufferGroup::CleanUp()
 {
     // Clean up the storage
     for (size_t i = 0; i < fVertBuffSizes.size(); ++i)
@@ -638,7 +638,7 @@ void    plGBufferGroup::DeleteIndicesFromStorage( uint32_t which, uint32_t start
 //// GetNumPrimaryVertsLeft ///////////////////////////////////////////////////
 //  Base on the cells, so we can take instanced cells into account
 
-uint32_t  plGBufferGroup::GetNumPrimaryVertsLeft( void ) const
+uint32_t  plGBufferGroup::GetNumPrimaryVertsLeft() const
 {
     return GetNumVertsLeft( 0 );
 }

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.h
@@ -182,7 +182,7 @@ class plGBufferGroup
         plGBufferGroup(uint8_t format, bool vertsVolatile, bool idxVolatile, int LOD = 0);
         virtual ~plGBufferGroup();
 
-        uint8_t   GetNumUVs( void ) const { return ( fFormat & kUVCountMask ); }
+        uint8_t   GetNumUVs() const { return ( fFormat & kUVCountMask ); }
         uint8_t   GetNumWeights() const { return (fFormat & kSkinWeightMask) >> 4; }
 
         static uint8_t    CalcNumUVs( uint8_t format ) { return ( format & kUVCountMask ); }
@@ -192,13 +192,13 @@ class plGBufferGroup
         void    DirtyIndexBuffer(size_t i);
         bool    VertexReady(size_t i) const { return (i < fVertexBufferRefs.size()) && fVertexBufferRefs[i]; }
         bool    IndexReady(size_t i) const { return  (i < fIndexBufferRefs.size()) && fIndexBufferRefs[i]; }
-        uint8_t   GetVertexSize( void ) const { return fStride; }
-        uint8_t   GetVertexLiteStride( void ) const { return fLiteStride; }
-        uint8_t   GetVertexFormat( void ) const { return fFormat; }
-        uint32_t  GetMemUsage( void ) const { return ( fNumVerts * GetVertexSize() ) + ( fNumIndices * sizeof( uint16_t ) ); }
-        uint32_t  GetNumVerts( void ) const { return fNumVerts; }
-        uint32_t  GetNumIndices( void ) const { return fNumIndices; }
-        uint32_t  GetNumPrimaryVertsLeft( void ) const;
+        uint8_t   GetVertexSize() const { return fStride; }
+        uint8_t   GetVertexLiteStride() const { return fLiteStride; }
+        uint8_t   GetVertexFormat() const { return fFormat; }
+        uint32_t  GetMemUsage() const { return ( fNumVerts * GetVertexSize() ) + ( fNumIndices * sizeof( uint16_t ) ); }
+        uint32_t  GetNumVerts() const { return fNumVerts; }
+        uint32_t  GetNumIndices() const { return fNumIndices; }
+        uint32_t  GetNumPrimaryVertsLeft() const;
         uint32_t  GetNumVertsLeft( uint32_t idx ) const;
 
         uint32_t  GetVertBufferSize(uint32_t idx) const { return fVertBuffSizes[idx]; }
@@ -231,8 +231,8 @@ class plGBufferGroup
         void    SetIndexBufferEnd(uint32_t idx, uint32_t e) { fIdxBuffEnds[idx] = e; }
         ///////////////////////////////////////////////////////////////////////////////
 
-        uint32_t  GetNumVertexBuffers( void ) const { return fVertBuffStorage.size(); }
-        uint32_t  GetNumIndexBuffers( void ) const { return fIdxBuffStorage.size(); }
+        uint32_t  GetNumVertexBuffers() const { return fVertBuffStorage.size(); }
+        uint32_t  GetNumIndexBuffers() const { return fIdxBuffStorage.size(); }
 
         uint8_t           *GetVertBufferData( uint32_t idx ) { return fVertBuffStorage[ idx ]; }
         uint16_t          *GetIndexBufferData( uint32_t idx ) { return fIdxBuffStorage[ idx ]; }
@@ -259,10 +259,10 @@ class plGBufferGroup
         uint32_t      Format() const { return fFormat; }
 
         // Take temp accumulators and actually build buffer data from them
-        void    TidyUp( void );
+        void    TidyUp();
 
         // Delete the buffer data storage
-        void    CleanUp( void );
+        void    CleanUp();
 
         // Take buffer data and convert it to device-specific buffers
         void    PrepForRendering( plPipeline *pipe, bool adjustForNvidiaLighting );

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGeometrySpan.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGeometrySpan.cpp
@@ -83,7 +83,7 @@ plGeometrySpan::~plGeometrySpan()
     ClearBuffers();
 }
 
-void    plGeometrySpan::IClearMembers( void )
+void    plGeometrySpan::IClearMembers()
 {
     fVertexData = nil; 
     fIndexData = nil; 
@@ -120,7 +120,7 @@ void    plGeometrySpan::IClearMembers( void )
 
 //// ClearBuffers ////////////////////////////////////////////////////////////
 
-void    plGeometrySpan::ClearBuffers( void )
+void    plGeometrySpan::ClearBuffers()
 {
     // If UserOwned, the actual buffer data belongs to someone else (like a BufferGroup).
     // Just erase our knowledge of it and move on.
@@ -303,7 +303,7 @@ void plGeometrySpan::UnInstance()
 //  Static function that allocates a new groupID by finding an empty slot in
 //  the bitVector, then marking it as used and returning that bit #
 
-uint32_t  plGeometrySpan::IAllocateNewGroupID( void )
+uint32_t  plGeometrySpan::IAllocateNewGroupID()
 {
     uint32_t          id;
 
@@ -882,7 +882,7 @@ void    plGeometrySpan::AddIndexArray( uint32_t count, uint16_t *indices )
 
 //// EndCreate ////////////////////////////////////////////////////////////////
 
-void    plGeometrySpan::EndCreate( void )
+void    plGeometrySpan::EndCreate()
 {
     hsBounds3Ext    bounds;
     uint32_t          i, size;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGeometrySpan.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGeometrySpan.h
@@ -191,7 +191,7 @@ class plGeometrySpan
         ~plGeometrySpan();
 
         /// UV stuff
-        uint8_t   GetNumUVs( void ) const { return ( fFormat & kUVCountMask ); }
+        uint8_t   GetNumUVs() const { return ( fFormat & kUVCountMask ); }
         void    SetNumUVs( uint8_t numUVs ) 
         {
             hsAssert( numUVs < kMaxNumUVChannels, "Invalid UV count to plGeometrySpan" );
@@ -220,7 +220,7 @@ class plGeometrySpan
         void    AddVertexArray( uint32_t count, hsPoint3 *positions, hsVector3 *normals, uint32_t *colors, hsPoint3 *uvws=nil, int uvwsPerVtx=0 );
         void    AddIndexArray( uint32_t count, uint16_t *indices );
 
-        void    EndCreate( void );
+        void    EndCreate();
 
 
         /// Manipulation--currently only used for applying static lighting, which of course needs individual vertices
@@ -235,7 +235,7 @@ class plGeometrySpan
         void    StuffVertex( uint32_t index, hsColorRGBA *color, hsColorRGBA *specColor = nil );
 
         // Clear out the buffers
-        void            ClearBuffers( void );
+        void            ClearBuffers();
 
         // Duplicate this span from a given span
         void            CopyFrom( const plGeometrySpan *source );
@@ -276,7 +276,7 @@ class plGeometrySpan
 
         void        IUnShareData();
         void        IDuplicateUniqueData( const plGeometrySpan *source );
-        void        IClearMembers( void );
+        void        IClearMembers();
 
         // Please don't yell at me. We can't write out the instanceRef pointers, and we can't write
         // out keys because we're not keyed objects, and we can't be keyed objects because we need
@@ -302,7 +302,7 @@ class plGeometrySpan
         // the notes on IGetInstanceGroup().
         static uint32_t   fHighestReadInstanceGroup;
 
-        static uint32_t   IAllocateNewGroupID( void );
+        static uint32_t   IAllocateNewGroupID();
         static void     IClearGroupID( uint32_t groupID );
 
         static hsTArray<plGeometrySpan *>   *IGetInstanceGroup( uint32_t groupID, uint32_t expectedCount );

--- a/Sources/Plasma/PubUtilLib/plDrawable/plSpanTypes.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plSpanTypes.cpp
@@ -461,7 +461,7 @@ void    plIcicle::Write( hsStream *stream )
 
 //// Destroy /////////////////////////////////////////////////////////////////
 
-void    plIcicle::Destroy( void )
+void    plIcicle::Destroy()
 {
     plSpan::Destroy();
     delete [] fSortData;
@@ -544,7 +544,7 @@ void    plParticleSpan::MergeInto( plSpan *other )
 
 //// Destroy /////////////////////////////////////////////////////////////////
 
-void    plParticleSpan::Destroy( void )
+void    plParticleSpan::Destroy()
 {
     plIcicle::Destroy();
     fSource = nil;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plSpanTypes.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plSpanTypes.h
@@ -204,7 +204,7 @@ class plSpan
 
         virtual bool    CanMergeInto( plSpan* other );
         virtual void    MergeInto( plSpan* other );
-        virtual void    Destroy( void );
+        virtual void    Destroy();
 
         void            SetMinDist(float minDist) { fMinDist = minDist; }
         void            SetMaxDist(float maxDist) { fMaxDist = maxDist; }
@@ -262,7 +262,7 @@ class plIcicle : public plVertexSpan
 
         virtual bool    CanMergeInto( plSpan* other );
         virtual void    MergeInto( plSpan* other );
-        virtual void    Destroy( void );
+        virtual void    Destroy();
 };
 
 //// plParticleSpan Class Definition /////////////////////////////////////////
@@ -290,7 +290,7 @@ class plParticleSpan : public plIcicle
 
         virtual bool    CanMergeInto( plSpan* other );
         virtual void    MergeInto( plSpan* other );
-        virtual void    Destroy( void );
+        virtual void    Destroy();
 };
 
 //// plParticleSet Class Definition //////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plFile/plInitFileReader.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plInitFileReader.cpp
@@ -198,7 +198,7 @@ bool    plInitFileReader::Parse( uint32_t userData )
     return true;
 }
 
-void    plInitFileReader::Close( void )
+void    plInitFileReader::Close()
 {
     if( fStream == nil )
         return;

--- a/Sources/Plasma/PubUtilLib/plFile/plInitFileReader.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plInitFileReader.h
@@ -74,7 +74,7 @@ class plInitSectionReader
     public:
 
         // Override this to define what [string] your section starts with
-        virtual const char  *GetSectionName( void ) const = 0;
+        virtual const char  *GetSectionName() const = 0;
 
         // Override this to parse each line in your section. Return false to abort parsing
         virtual bool        ParseLine( const char *line, uint32_t userData ) = 0;
@@ -142,9 +142,9 @@ class plInitFileReader
         bool    Open( const char *fileName );
         bool    Open( hsStream *stream );
         bool    Parse( uint32_t userData = 0 );
-        void    Close( void );
+        void    Close();
 
-        bool    IsOpen( void ) const { return fStream != nil; }
+        bool    IsOpen() const { return fStream != nil; }
 };
 
 #endif //_plInitFileReader_h

--- a/Sources/Plasma/PubUtilLib/plGImage/plBitmap.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plBitmap.h
@@ -158,21 +158,21 @@ class plBitmap : public hsKeyedObject
         GETINTERFACE_ANY( plBitmap, hsKeyedObject );
 
         // Get the total size in bytes
-        virtual uint32_t  GetTotalSize( void ) const = 0;
+        virtual uint32_t  GetTotalSize() const = 0;
 
         // Read and write
         virtual void    Read( hsStream *s, hsResMgr *mgr ) { hsKeyedObject::Read( s, mgr ); this->Read( s ); }
         virtual void    Write( hsStream *s, hsResMgr *mgr ) { hsKeyedObject::Write( s, mgr ); this->Write( s ); }
 
-        uint16_t          GetFlags( void ) const { return fFlags; }
+        uint16_t          GetFlags() const { return fFlags; }
         void            SetFlags( uint16_t flags ) { fFlags = flags; }
 
-        uint8_t           GetPixelSize( void ) const { return fPixelSize; }
+        uint8_t           GetPixelSize() const { return fPixelSize; }
 
-        bool            IsCompressed( void ) const { return ( fCompressionType == kDirectXCompression ); }
+        bool            IsCompressed() const { return ( fCompressionType == kDirectXCompression ); }
 
         virtual void            MakeDirty();
-        virtual hsGDeviceRef    *GetDeviceRef( void ) const { return fDeviceRef; }
+        virtual hsGDeviceRef    *GetDeviceRef() const { return fDeviceRef; }
         virtual void            SetDeviceRef( hsGDeviceRef *const devRef );
 
         static void     SetGlobalLevelChopCount( uint8_t count ) { fGlobalNumLevelsToChop = count; }

--- a/Sources/Plasma/PubUtilLib/plGImage/plCubicEnvironmap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plCubicEnvironmap.cpp
@@ -80,7 +80,7 @@ plCubicEnvironmap::~plCubicEnvironmap()
 //// GetTotalSize /////////////////////////////////////////////////////////////
 //  Get the total size in bytes
 
-uint32_t  plCubicEnvironmap::GetTotalSize( void ) const
+uint32_t  plCubicEnvironmap::GetTotalSize() const
 {
     uint32_t  size, i;
 

--- a/Sources/Plasma/PubUtilLib/plGImage/plCubicEnvironmap.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plCubicEnvironmap.h
@@ -88,7 +88,7 @@ class plCubicEnvironmap : public plBitmap
 
 
         // Get the total size in bytes
-        virtual uint32_t  GetTotalSize( void ) const;
+        virtual uint32_t  GetTotalSize() const;
 
         virtual void    Read( hsStream *s, hsResMgr *mgr ) { hsKeyedObject::Read( s, mgr ); this->Read( s ); }
         virtual void    Write( hsStream *s, hsResMgr *mgr ) { hsKeyedObject::Write( s, mgr ); this->Write( s ); }

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
@@ -152,7 +152,7 @@ void    plDynamicTextMap::Create( uint32_t width, uint32_t height, bool hasAlpha
 
 //// Reset ////////////////////////////////////////////////////////////////////
 
-void    plDynamicTextMap::Reset( void )
+void    plDynamicTextMap::Reset()
 {
     IDestroyOSSurface();
 
@@ -174,7 +174,7 @@ void    plDynamicTextMap::Reset( void )
 //// OS-Specific Functions ////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 
-bool        plDynamicTextMap::IIsValid( void )
+bool        plDynamicTextMap::IIsValid()
 {
     if( GetImage() == nil && fHasCreateBeenCalled )
     {
@@ -235,7 +235,7 @@ uint32_t* plDynamicTextMap::IAllocateOSSurface( uint16_t width, uint16_t height 
 //// IDestroyOSSurface ////////////////////////////////////////////////////////
 //  Opposite of allocate. DUH!
 
-void    plDynamicTextMap::IDestroyOSSurface( void )
+void    plDynamicTextMap::IDestroyOSSurface()
 {
 #ifdef MEMORY_LEAK_TRACER
     if( fImage != nil )
@@ -772,7 +772,7 @@ void    plDynamicTextMap::DrawClippedImage( uint16_t x, uint16_t y, plMipmap *im
 
 //// FlushToHost //////////////////////////////////////////////////////////////
 
-void    plDynamicTextMap::FlushToHost( void )
+void    plDynamicTextMap::FlushToHost()
 {
     if( !IIsValid() )
         return;
@@ -787,7 +787,7 @@ void    plDynamicTextMap::FlushToHost( void )
 //  you want to be able to apply a layer texture transform that will compensate. This
 //  function will give you that transform. Just feed it into plLayer->SetTransform().
 
-hsMatrix44  plDynamicTextMap::GetLayerTransform( void )
+hsMatrix44  plDynamicTextMap::GetLayerTransform()
 {
     hsMatrix44  xform;
     hsVector3   scale;

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.h
@@ -123,12 +123,12 @@ class plDynamicTextMap : public plMipmap
         void            Create( uint32_t width, uint32_t height, bool hasAlpha, uint32_t extraWidth = 0, uint32_t extraHeight = 0, bool premultipliedAlpha = false );
         void            SetNoCreate( uint32_t width, uint32_t height, bool hasAlpha );
 
-        virtual void    Reset( void );
+        virtual void    Reset();
 
         virtual void    Read( hsStream *s, hsResMgr *mgr ) { hsKeyedObject::Read( s, mgr ); this->Read( s ); }
         virtual void    Write( hsStream *s, hsResMgr *mgr ) { hsKeyedObject::Write( s, mgr ); this->Write( s ); }
 
-        virtual uint8_t   GetNumLevels( void ) const { return 1; }
+        virtual uint8_t   GetNumLevels() const { return 1; }
 
         void        Colorize() HS_OVERRIDE { }
         plMipmap    *Clone() const HS_OVERRIDE;
@@ -183,31 +183,31 @@ class plDynamicTextMap : public plMipmap
         void    DrawClippedImage( uint16_t x, uint16_t y, plMipmap *image, uint16_t srcClipX, uint16_t srcClipY, 
                                 uint16_t srcClipWidth, uint16_t srcClipHeight, DrawMethods method = kImgNoAlpha );
 
-        void    FlushToHost( void );
+        void    FlushToHost();
 
         bool    MsgReceive( plMessage *msg );
 
-        uint16_t  GetVisibleWidth( void ) { return fVisWidth; }
-        uint16_t  GetVisibleHeight( void ) { return fVisHeight; }
+        uint16_t  GetVisibleWidth() { return fVisWidth; }
+        uint16_t  GetVisibleHeight() { return fVisHeight; }
 
         // Since the dynamic text can actually create a texture bigger than you were expecting,
         // you want to be able to apply a layer texture transform that will compensate. This
         // function will give you that transform. Just feed it into plLayer->SetTransform().
 
-        hsMatrix44  GetLayerTransform( void );
+        hsMatrix44  GetLayerTransform();
 
         void    SetInitBuffer( uint32_t *buffer );
 
         // Gets for font values
-        Justify     GetFontJustify( void ) const { return fJustify; }
-        ST::string  GetFontFace( void ) const { return fFontFace; }
-        uint16_t    GetFontSize( void ) const { return fFontSize; }
-        bool        GetFontAARGB( void ) const { return fFontAntiAliasRGB; }
-        hsColorRGBA GetFontColor( void ) const { return fFontColor; }
-        bool        GetFontBlockRGB( void ) const { return fFontBlockRGB; }
-        int16_t       GetLineSpacing( void ) const { return fLineSpacing; }
+        Justify     GetFontJustify() const { return fJustify; }
+        ST::string  GetFontFace() const { return fFontFace; }
+        uint16_t    GetFontSize() const { return fFontSize; }
+        bool        GetFontAARGB() const { return fFontAntiAliasRGB; }
+        hsColorRGBA GetFontColor() const { return fFontColor; }
+        bool        GetFontBlockRGB() const { return fFontBlockRGB; }
+        int16_t       GetLineSpacing() const { return fLineSpacing; }
 
-        plFont      *GetCurrFont( void ) const { return fCurrFont; }
+        plFont      *GetCurrFont() const { return fCurrFont; }
 
         virtual void    Swap( plDynamicTextMap *other );
 
@@ -215,11 +215,11 @@ class plDynamicTextMap : public plMipmap
 
         //// Protected Members ////
 
-        bool        IIsValid( void );
+        bool        IIsValid();
         void        IClearFromBuffer( uint32_t *clearBuffer );
 
         uint32_t      *IAllocateOSSurface( uint16_t width, uint16_t height );
-        void        IDestroyOSSurface( void );
+        void        IDestroyOSSurface();
 
         void        IPropagateFlags();
 

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -181,7 +181,7 @@ void    plFont::SetRenderWrapping( int16_t x, int16_t y, int16_t width, int16_t 
     SetRenderClipRect( x, y, width, height );
 }
 
-void    plFont::ICalcFontAscent( void )
+void    plFont::ICalcFontAscent()
 {
     uint32_t  i;
 
@@ -1582,28 +1582,28 @@ class plLineParser
 
         ~plLineParser() { }
 
-        const char  *GetKeyword( void )
+        const char  *GetKeyword()
         {
             return IGetNextToken();
         }
 
-        const char  *GetString( void )
+        const char  *GetString()
         {
             IAdvanceToNextToken();
             return IGetNextToken( sQuoteTester );
         }
 
-        const char  *GetKeywordNoDashes( void )
+        const char  *GetKeywordNoDashes()
         {
             return IGetNextToken( sDashTester );
         }
 
-        int32_t       GetInt( void )
+        int32_t       GetInt()
         {
             return atoi( IGetNextToken() );
         }
 
-        float    GetFloat( void )
+        float    GetFloat()
         {
             return (float)atof( IGetNextToken() );
         }
@@ -1678,7 +1678,7 @@ class plBDFCharsParser : public plBDFSectParser
         bool                fDoingData;
         uint32_t              fBytesWide, fBMapStride;
 
-        inline void IReset( void )
+        inline void IReset()
         {
             fBitmap = nil;
             fCharacter = nil;

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.h
@@ -75,7 +75,7 @@ class plBDFConvertCallback
 {
     public:
         virtual void    NumChars( uint16_t chars ) {}
-        virtual void    CharDone( void ) {}
+        virtual void    CharDone() {}
 };
 
 //// Class Definition /////////////////////////////////////////////////////////
@@ -220,7 +220,7 @@ class plFont : public hsKeyedObject
         plRenderInfo    fRenderInfo;
 
         void    IClear( bool onConstruct = false );
-        void    ICalcFontAscent( void );
+        void    ICalcFontAscent();
 
         uint8_t   *IGetFreeCharData( uint32_t &newOffset );
 
@@ -254,17 +254,17 @@ class plFont : public hsKeyedObject
         virtual void    Read( hsStream *s, hsResMgr *mgr );
         virtual void    Write( hsStream *s, hsResMgr *mgr );
 
-        ST::string  GetFace( void ) const { return fFace; }
-        uint8_t     GetSize( void ) const { return fSize; }
-        uint16_t    GetFirstChar( void ) const { return fFirstChar; }
-        uint16_t    GetNumChars( void ) const { return fCharacters.GetCount(); }
-        uint32_t    GetFlags( void ) const { return fFlags; }
-        float       GetDescent( void ) const { return (float)fFontDescent; }
-        float       GetAscent( void ) const { return (float)fFontAscent; }
+        ST::string  GetFace() const { return fFace; }
+        uint8_t     GetSize() const { return fSize; }
+        uint16_t    GetFirstChar() const { return fFirstChar; }
+        uint16_t    GetNumChars() const { return fCharacters.GetCount(); }
+        uint32_t    GetFlags() const { return fFlags; }
+        float       GetDescent() const { return (float)fFontDescent; }
+        float       GetAscent() const { return (float)fFontAscent; }
 
-        uint32_t      GetBitmapWidth( void ) const { return fWidth; }
-        uint32_t      GetBitmapHeight( void ) const { return fHeight; }
-        uint8_t       GetBitmapBPP( void ) const { return fBPP; }
+        uint32_t      GetBitmapWidth() const { return fWidth; }
+        uint32_t      GetBitmapHeight() const { return fHeight; }
+        uint8_t       GetBitmapBPP() const { return fBPP; }
 
         void    SetFace( const ST::string &face ) { fFace = face; }
         void    SetSize( uint8_t size ) { fSize = size; }

--- a/Sources/Plasma/PubUtilLib/plGImage/plFontCache.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFontCache.cpp
@@ -80,12 +80,12 @@ plFontCache::~plFontCache()
     fInstance = nil;
 }
 
-plFontCache &plFontCache::GetInstance( void )
+plFontCache &plFontCache::GetInstance()
 {
     return *fInstance;
 }
 
-void    plFontCache::Clear( void )
+void    plFontCache::Clear()
 {
 }
 
@@ -146,7 +146,7 @@ void plFontCache::LoadCustomFonts( const plFileName &dir )
     ILoadCustomFonts();
 }
 
-void plFontCache::ILoadCustomFonts( void )
+void plFontCache::ILoadCustomFonts()
 {
     if (!fCustFontDir.IsValid())
         return;

--- a/Sources/Plasma/PubUtilLib/plGImage/plFontCache.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFontCache.h
@@ -74,7 +74,7 @@ class plFontCache : public hsKeyedObject
 
         static plFontCache     *fInstance;
 
-        void    ILoadCustomFonts( void );
+        void    ILoadCustomFonts();
 
     public:
 
@@ -89,13 +89,13 @@ class plFontCache : public hsKeyedObject
 
         virtual bool    MsgReceive( plMessage* pMsg );
         
-        static plFontCache  &GetInstance( void );
+        static plFontCache  &GetInstance();
 
         plFont  *GetFont( const ST::string &face, uint8_t size, uint32_t fontFlags );
 
 //      HFONT   GetMeAFont( const char *face, int height, int weight, bool italic, uint32_t quality );
 //      void    FreeFont( HFONT font );
-        void    Clear( void );
+        void    Clear();
 
         void    LoadCustomFonts( const plFileName &dir );
 

--- a/Sources/Plasma/PubUtilLib/plGImage/plJPEG.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plJPEG.cpp
@@ -88,7 +88,7 @@ static void clear_jpegmsg()
 
 //// Instance /////////////////////////////////////////////////////////////////
 
-plJPEG  &plJPEG::Instance( void )
+plJPEG  &plJPEG::Instance()
 {
     clear_jpegmsg();
 
@@ -98,7 +98,7 @@ plJPEG  &plJPEG::Instance( void )
 
 //// GetLastError /////////////////////////////////////////////////////////////
 
-const char  *plJPEG::GetLastError( void )
+const char  *plJPEG::GetLastError()
 {
     return jpegmsg;
 }

--- a/Sources/Plasma/PubUtilLib/plGImage/plJPEG.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plJPEG.h
@@ -83,9 +83,9 @@ class plJPEG
         // Range is 0 (worst) to 100 (best)
         void    SetWriteQuality( uint8_t q ) { fWriteQuality = q; }
 
-        const char  *GetLastError( void );
+        const char  *GetLastError();
 
-        static plJPEG   &Instance( void );
+        static plJPEG   &Instance();
 };
 
 #endif // _plJPEG_h

--- a/Sources/Plasma/PubUtilLib/plGImage/plPNG.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plPNG.cpp
@@ -69,7 +69,7 @@ void pngWriteDelegate(png_structp png_ptr, png_bytep png_data, png_size_t length
 
 //// Singleton Instance ///////////////////////////////////////////////////////
 
-plPNG& plPNG::Instance(void)
+plPNG& plPNG::Instance()
 {
     static plPNG theInstance;
     return theInstance;

--- a/Sources/Plasma/PubUtilLib/plGImage/plPNG.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plPNG.h
@@ -65,7 +65,7 @@ public:
         const std::multimap<ST::string, ST::string>& textFields = std::multimap<ST::string, ST::string>()) { return IWrite(sourceData, outStream, textFields); }
     bool WriteToFile(const plFileName& fileName, plMipmap* sourceData, const std::multimap<ST::string, ST::string>& textFields = std::multimap<ST::string, ST::string>());
 
-    static plPNG& Instance(void);
+    static plPNG& Instance();
 };
 
 #endif // _plPNG_h

--- a/Sources/Plasma/PubUtilLib/plGImage/plTGAWriter.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plTGAWriter.h
@@ -70,7 +70,7 @@ class plTGAWriter
         
     public:
 
-        static plTGAWriter  &Instance( void ) { return fInstance; }
+        static plTGAWriter  &Instance() { return fInstance; }
 
         void    WriteMipmap( const char *fileName, plMipmap *mipmap );
 

--- a/Sources/Plasma/PubUtilLib/plGLight/plLightInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plLightInfo.cpp
@@ -553,7 +553,7 @@ plKey plLightInfo::GetSceneNode() const
 
 //// Link & Unlink ///////////////////////////////////////////////////////
 
-void    plLightInfo::Unlink( void )
+void    plLightInfo::Unlink()
 {
     hsAssert( fPrevDevPtr, "Light info not in list" );
     if( fNextDevPtr )

--- a/Sources/Plasma/PubUtilLib/plGLight/plLightInfo.h
+++ b/Sources/Plasma/PubUtilLib/plGLight/plLightInfo.h
@@ -221,10 +221,10 @@ public:
 
     virtual bool        MsgReceive(plMessage* msg);
 
-    virtual void        Unlink( void );
+    virtual void        Unlink();
     virtual void        Link( plLightInfo **back );
-    virtual plLightInfo *GetNext( void ) { return fNextDevPtr; }
-    virtual bool        IsLinked( void ) { return ( fNextDevPtr != nil || fPrevDevPtr != nil ) ? true : false; }
+    virtual plLightInfo *GetNext() { return fNextDevPtr; }
+    virtual bool        IsLinked() { return ( fNextDevPtr != nil || fPrevDevPtr != nil ) ? true : false; }
 
     // New shadow
     void                ClearSlaveBits() { fSlaveBits.Clear(); }

--- a/Sources/Plasma/PubUtilLib/plGLight/plLightKonstants.h
+++ b/Sources/Plasma/PubUtilLib/plGLight/plLightKonstants.h
@@ -46,7 +46,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plSillyLightKonstants
 {
 public:
-    static float  GetFarPowerKonst( void )
+    static float  GetFarPowerKonst()
     {
         // arbitrary const, make light drop to 1/kFarPower at attenEnd. 15 just looked good to me. mf
         // Done as a function so we don't have to worry about a separate .cpp file

--- a/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.cpp
@@ -185,7 +185,7 @@ void    plAvatarInputInterface::Init( plInputInterfaceMgr *manager )
     plInputInterface::Init( manager );
 }
 
-void    plAvatarInputInterface::Shutdown( void )
+void    plAvatarInputInterface::Shutdown()
 {
 }
 
@@ -302,7 +302,7 @@ void plAvatarInputInterface::ClearKeyMap()
 
 //// RestoreDefaultKeyMappings ///////////////////////////////////////////////
 
-void    plAvatarInputInterface::RestoreDefaultKeyMappings( void )
+void    plAvatarInputInterface::RestoreDefaultKeyMappings()
 {
     if( fControlMap == nil )
         return;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.h
@@ -227,10 +227,10 @@ class plAvatarInputInterface : public plInputInterface
         void CameraInThirdPerson(bool state);
     
         // Always return true, since the cursor should be representing how we control the avatar
-        virtual bool        HasInterestingCursorID( void ) const { return true; }
-        virtual uint32_t      GetPriorityLevel( void ) const { return kAvatarInputPriority; }
-        virtual uint32_t      GetCurrentCursorID( void ) const { return fCurrentCursor; }
-        virtual float    GetCurrentCursorOpacity( void ) const { return fCursorOpacity; }
+        virtual bool        HasInterestingCursorID() const { return true; }
+        virtual uint32_t      GetPriorityLevel() const { return kAvatarInputPriority; }
+        virtual uint32_t      GetCurrentCursorID() const { return fCurrentCursor; }
+        virtual float    GetCurrentCursorOpacity() const { return fCursorOpacity; }
         const char*         GetInputMapName() { return fInputMap ? fInputMap->GetName() : ""; }
 
         virtual bool        InterpretInputEvent( plInputEventMsg *pMsg );
@@ -239,9 +239,9 @@ class plAvatarInputInterface : public plInputInterface
         virtual bool        MsgReceive( plMessage *msg );
 
         virtual void        Init( plInputInterfaceMgr *manager );
-        virtual void        Shutdown( void );
+        virtual void        Shutdown();
 
-        virtual void        RestoreDefaultKeyMappings( void );
+        virtual void        RestoreDefaultKeyMappings();
         virtual void        ClearKeyMap(); 
         
         // [dis/en]able mouse commands for avatar movement
@@ -260,7 +260,7 @@ class plAvatarInputInterface : public plInputInterface
 
         bool    IsEnterChatModeBound();
 
-        static plAvatarInputInterface   *GetInstance( void ) { return fInstance; }
+        static plAvatarInputInterface   *GetInstance() { return fInstance; }
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plDebugInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plDebugInputInterface.cpp
@@ -106,13 +106,13 @@ void    plDebugInputInterface::Init( plInputInterfaceMgr *manager )
     plInputInterface::Init( manager );
 }
 
-void    plDebugInputInterface::Shutdown( void )
+void    plDebugInputInterface::Shutdown()
 {
 }
 
 //// RestoreDefaultKeyMappings ///////////////////////////////////////////////
 
-void    plDebugInputInterface::RestoreDefaultKeyMappings( void )
+void    plDebugInputInterface::RestoreDefaultKeyMappings()
 {
     if( fControlMap == nil )
         return;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plDebugInputInterface.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plDebugInputInterface.h
@@ -75,19 +75,19 @@ class plDebugInputInterface : public plInputInterface
         virtual ~plDebugInputInterface();
 
         // Always return false, 
-        virtual bool    HasInterestingCursorID( void ) const { return false; }
-        virtual uint32_t  GetPriorityLevel( void ) const { return kDebugCmdPrioity; }
-        virtual void    RestoreDefaultKeyMappings( void );
-        virtual uint32_t  GetCurrentCursorID( void ) const { return 0; }
+        virtual bool    HasInterestingCursorID() const { return false; }
+        virtual uint32_t  GetPriorityLevel() const { return kDebugCmdPrioity; }
+        virtual void    RestoreDefaultKeyMappings();
+        virtual uint32_t  GetCurrentCursorID() const { return 0; }
 
         virtual bool    InterpretInputEvent( plInputEventMsg *pMsg );
 
         virtual bool    MsgReceive( plMessage *msg );
 
         virtual void    Init( plInputInterfaceMgr *manager );
-        virtual void    Shutdown( void );
+        virtual void    Shutdown();
 
-        static plDebugInputInterface    *GetInstance( void ) { return fInstance; }
+        static plDebugInputInterface    *GetInstance() { return fInstance; }
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
@@ -69,18 +69,18 @@ protected:
     uint32_t fFlags;
 public:
     
-    plInputDevice() {;}
-    virtual ~plInputDevice() {;}
+    plInputDevice() { }
+    virtual ~plInputDevice() { }
 
     virtual const char* GetInputName() = 0;
 
     uint32_t GetFlags() { return fFlags; }
     void SetFlags(uint32_t f) { fFlags = f; }
-    virtual void HandleKeyEvent(plOSMsg message, plKeyDef key, bool bKeyDown, bool bKeyRepeat, wchar_t c = 0) {;}
-    virtual void HandleMouseEvent(plOSMsg message, plMouseState state)  {;}
-    virtual void HandleWindowActivate(bool bActive, hsWindowHndl hWnd) {;}
+    virtual void HandleKeyEvent(plOSMsg message, plKeyDef key, bool bKeyDown, bool bKeyRepeat, wchar_t c = 0) { }
+    virtual void HandleMouseEvent(plOSMsg message, plMouseState state)  { }
+    virtual void HandleWindowActivate(bool bActive, hsWindowHndl hWnd) { }
     virtual bool MsgReceive(plMessage* msg) {return false;}
-    virtual void Shutdown() {;}
+    virtual void Shutdown() { }
 
 
 };

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterface.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterface.h
@@ -109,7 +109,7 @@ class plInputInterface : public hsRefCnt
         bool            fEnabled;
 
         void        ISetMessageQueue( hsTArray<plCtrlCmd *> *queue ) { fMessageQueue = queue; }
-        plKeyMap    *IGetControlMap( void ) const { return fControlMap; }
+        plKeyMap    *IGetControlMap() const { return fControlMap; }
         bool        IOwnsControlCode( ControlEventCode code );
         bool        IVerifyShiftKey( plKeyDef key, int index );
 
@@ -175,32 +175,32 @@ class plInputInterface : public hsRefCnt
         virtual void    Write( hsStream* s, hsResMgr* mgr );
 
         // Returns the priority of this interface layer, based on the Priorities enum
-        virtual uint32_t      GetPriorityLevel( void ) const = 0;
+        virtual uint32_t      GetPriorityLevel() const = 0;
 
         // Returns true if the message was handled, false if not and we want to pass it on to others in the stack
         virtual bool        InterpretInputEvent( plInputEventMsg *pMsg ) = 0;
 
         // Returns the currently active mouse cursor for this layer, as defined in pnMessage/plCursorChangeMsg.h
-        virtual uint32_t      GetCurrentCursorID( void ) const = 0;
+        virtual uint32_t      GetCurrentCursorID() const = 0;
 
         // Returns the current opacity that this layer wants the cursor to be, from 0 (xparent) to 1 (opaque)
-        virtual float    GetCurrentCursorOpacity( void ) const { return 1.f; }
+        virtual float    GetCurrentCursorOpacity() const { return 1.f; }
 
         // Returns true if this layer is wanting to change the mouse, false if it isn't interested
-        virtual bool        HasInterestingCursorID( void ) const = 0;
+        virtual bool        HasInterestingCursorID() const = 0;
 
         // Gets called by the manager. If you want a message to come to you, set your manager as the destination
         virtual bool        MsgReceive( plMessage *msg ) { return false; }
 
         // Any initialization that requires a pointer to the manager needs to be done on Init()/Shutdown()
         virtual void        Init( plInputInterfaceMgr *manager ) { fManager = manager; RestoreDefaultKeyMappings(); }
-        virtual void        Shutdown( void ) {}
+        virtual void        Shutdown() {}
 
         // Gets called when any of the key mappings are changed, so that the interface layer can refresh the ones its interested in
-        virtual void        RefreshKeyMap( void ) {}
+        virtual void        RefreshKeyMap() {}
 
         // Called when the interface manager is setting all key mappings to default
-        virtual void        RestoreDefaultKeyMappings( void ) {}
+        virtual void        RestoreDefaultKeyMappings() {}
 
         // Called on each interface layer that gets missed when processing inputEvents in the manager (i.e. you either get this call or InterpretInputEvent)
         virtual void        MissedInputEvent( plInputEventMsg *pMsg ) {}
@@ -209,7 +209,7 @@ class plInputInterface : public hsRefCnt
         bool                ProcessKeyBindings( plInputEventMsg *keyMsg );
 
         void        SetEnabled( bool e ) { fEnabled = e; }
-        bool        IsEnabled( void ) const { return fEnabled; }
+        bool        IsEnabled() const { return fEnabled; }
         
         // clear all keys from map
         virtual void    ClearKeyMap(); 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterface.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterface.h
@@ -215,7 +215,7 @@ class plInputInterface : public hsRefCnt
         virtual void    ClearKeyMap(); 
         
         // reset clickable state
-        virtual void ResetClickableState() {;}
+        virtual void ResetClickableState() { }
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -145,7 +145,7 @@ plInputInterfaceMgr::~plInputInterfaceMgr()
 #include "plDebugInputInterface.h"
 #include "plTelescopeInputInterface.h"
 
-void    plInputInterfaceMgr::Init( void )
+void    plInputInterfaceMgr::Init()
 {
     RegisterAs( kInputInterfaceMgr_KEY );
 
@@ -174,7 +174,7 @@ void    plInputInterfaceMgr::Init( void )
 
 //// Shutdown ////////////////////////////////////////////////////////////////
 
-void    plInputInterfaceMgr::Shutdown( void )
+void    plInputInterfaceMgr::Shutdown()
 {
     int i;
 
@@ -737,7 +737,7 @@ const plKeyBinding* plInputInterfaceMgr::FindBindingByConsoleCmd( const char *cm
 
 //// InitDefaultKeyMap ///////////////////////////////////////////////////////
 
-void    plInputInterfaceMgr::InitDefaultKeyMap( void )
+void    plInputInterfaceMgr::InitDefaultKeyMap()
 {
     int     i;
 
@@ -749,7 +749,7 @@ void    plInputInterfaceMgr::InitDefaultKeyMap( void )
 
 //// RefreshInterfaceKeyMaps /////////////////////////////////////////////////
 
-void    plInputInterfaceMgr::RefreshInterfaceKeyMaps( void )
+void    plInputInterfaceMgr::RefreshInterfaceKeyMaps()
 {
     int     i;
 
@@ -760,7 +760,7 @@ void    plInputInterfaceMgr::RefreshInterfaceKeyMaps( void )
 
 //// WriteKeyMap /////////////////////////////////////////////////////////////
 
-void    plInputInterfaceMgr::WriteKeyMap( void )
+void    plInputInterfaceMgr::WriteKeyMap()
 {
 #ifdef PLASMA_EXTERNAL_RELEASE
     return;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
@@ -123,12 +123,12 @@ class plInputInterfaceMgr : public plSingleModifier
         virtual void    Read( hsStream* s, hsResMgr* mgr );
         virtual void    Write( hsStream* s, hsResMgr* mgr );
 
-        void    Init( void );
-        void    Shutdown( void );
+        void    Init();
+        void    Shutdown();
 
-        void        InitDefaultKeyMap( void );
-        void        WriteKeyMap( void );
-        void        RefreshInterfaceKeyMaps( void );
+        void        InitDefaultKeyMap();
+        void        WriteKeyMap();
+        void        RefreshInterfaceKeyMaps();
 
         void    SetCurrentFocus(plInputInterface *focus);
         void    ReleaseCurrentFocus(plInputInterface *focus);
@@ -148,7 +148,7 @@ class plInputInterfaceMgr : public plSingleModifier
 
         void    ClearAllKeyMaps();
         void    ResetClickableState();
-        static plInputInterfaceMgr  *GetInstance( void ) { return fInstance; }
+        static plInputInterfaceMgr  *GetInstance() { return fInstance; }
 };
 
 //// plCtrlCmd ///////////////////////////////////////////////////////////////
@@ -177,7 +177,7 @@ class plCtrlCmd
         void Read( hsStream* s, hsResMgr* mgr );
         void Write( hsStream* s, hsResMgr* mgr );
 
-        plInputInterface    *GetSource( void ) const { return fSource; }
+        plInputInterface    *GetSource() const { return fSource; }
 };
 
 //// Tiny Virtual Class For The Default Key Processor ////////////////////////

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
@@ -161,7 +161,7 @@ class plCtrlCmd
         plInputInterface    *fSource;
 
     public:
-        plCtrlCmd( plInputInterface *source ) : fCmd(nil),fPct(1.0f), fSource(source) {;}
+        plCtrlCmd( plInputInterface *source ) : fCmd(nil),fPct(1.0f), fSource(source) { }
         ~plCtrlCmd() { delete [] fCmd; }
 
         const char* GetCmdString()          { return fCmd; }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputManager.cpp
@@ -68,7 +68,7 @@ HWND    plInputManager::fhWnd = nil;
 
 struct plDIDevice
 {
-    plDIDevice() : fDevice(nil), fCaps(nil) {;}
+    plDIDevice() : fDevice(nil), fCaps(nil) { }
     plDIDevice(IDirectInputDevice8* _device) : fCaps(nil) { fDevice = _device;}
     IDirectInputDevice8*    fDevice;
     DIDEVCAPS*              fCaps;
@@ -79,7 +79,7 @@ struct plDInput
     plDInput() :
     fDInput(nil),
     fActionFormat(nil)
-    {;}
+    { }
     IDirectInput8*          fDInput; 
     hsTArray<plDIDevice*>   fSticks;
     DIACTIONFORMAT*         fActionFormat;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputManager.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputManager.h
@@ -85,7 +85,7 @@ public:
 
     void    Activate( bool activating );
 
-    float    GetMouseScale( void ) const { return fMouseScale; }
+    float    GetMouseScale() const { return fMouseScale; }
     void        SetMouseScale( float s );
     
     static plKeyDef UntranslateKey(plKeyDef key, bool extended);

--- a/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.cpp
@@ -156,7 +156,7 @@ void    plSceneInputInterface::Init( plInputInterfaceMgr *manager )
 
 }
 
-void    plSceneInputInterface::Shutdown( void )
+void    plSceneInputInterface::Shutdown()
 {
     if( fPipe == nil )
         plgDispatch::Dispatch()->UnRegisterForExactType( plRenderMsg::Index(), fManager->GetKey() );
@@ -1196,7 +1196,7 @@ void    plSceneInputInterface::IRequestLOSCheck( float xPos, float yPos, int ID 
         
 //// IWorldPosMovedSinceLastLOSCheck /////////////////////////////////////////
 
-bool    plSceneInputInterface::IWorldPosMovedSinceLastLOSCheck( void )
+bool    plSceneInputInterface::IWorldPosMovedSinceLastLOSCheck()
 {
     if( fPipe == nil )
         return false;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.h
@@ -113,7 +113,7 @@ class plSceneInputInterface : public plInputInterface
         void    ISetLastClicked( plKey obj, hsPoint3 hitPoint );
         void    IHalfFadeAvatar(bool out);
 
-        bool    IWorldPosMovedSinceLastLOSCheck( void );
+        bool    IWorldPosMovedSinceLastLOSCheck();
         void ClearClickableMap();
         void ISendOfferNotification(plKey& offeree, int ID, bool net);
         void IManageIgnoredAvatars(plKey& offeree, bool add);
@@ -127,9 +127,9 @@ class plSceneInputInterface : public plInputInterface
         static bool     fShowLOS;
 
         // Always return true, since the cursor should be representing how we control the avatar
-        virtual bool    HasInterestingCursorID( void ) const { return ( fCurrentCursor != kNullCursor ) ? true : false; }
-        virtual uint32_t  GetPriorityLevel( void ) const { return kSceneInteractionPriority; }
-        virtual uint32_t  GetCurrentCursorID( void ) const {return fCurrentCursor;}
+        virtual bool    HasInterestingCursorID() const { return ( fCurrentCursor != kNullCursor ) ? true : false; }
+        virtual uint32_t  GetPriorityLevel() const { return kSceneInteractionPriority; }
+        virtual uint32_t  GetCurrentCursorID() const {return fCurrentCursor;}
         uint32_t          SetCurrentCursorID(uint32_t id);
         virtual bool    InterpretInputEvent( plInputEventMsg *pMsg );
         void            RequestAvatarTurnToPointLOS();
@@ -137,12 +137,12 @@ class plSceneInputInterface : public plInputInterface
         virtual bool    MsgReceive( plMessage *msg );
 
         virtual void    Init( plInputInterfaceMgr *manager );
-        virtual void    Shutdown( void );
+        virtual void    Shutdown();
         
         virtual void ResetClickableState();
 
-        plKey           GetCurrMousedAvatar( void ) const { if( fCurrClickIsAvatar ) return fCurrentClickable; else return nil; }
-        static plSceneInputInterface *GetInstance( void ) { return fInstance; }     
+        plKey           GetCurrMousedAvatar() const { if( fCurrClickIsAvatar ) return fCurrentClickable; else return nil; }
+        static plSceneInputInterface *GetInstance() { return fInstance; }
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plTelescopeInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plTelescopeInputInterface.cpp
@@ -118,7 +118,7 @@ bool plTelescopeInputInterface::InterpretInputEvent( plInputEventMsg *pMsg )
 
 //// RestoreDefaultKeyMappings ///////////////////////////////////////////////
 
-void    plTelescopeInputInterface::RestoreDefaultKeyMappings( void )
+void    plTelescopeInputInterface::RestoreDefaultKeyMappings()
 {
     if( fControlMap == nil )
         return;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plTelescopeInputInterface.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plTelescopeInputInterface.h
@@ -71,7 +71,7 @@ class plTelescopeInputInterface : public plInputInterface
         virtual bool    MsgReceive( plMessage *msg );
 
         virtual void    Init( plInputInterfaceMgr *manager );
-        virtual void    Shutdown() {;}
+        virtual void    Shutdown() { }
 
         // Returns the priority of this interface layer, based on the Priorities enum
         virtual uint32_t  GetPriorityLevel() const { return kTelescopeInputPriority; }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plTelescopeInputInterface.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plTelescopeInputInterface.h
@@ -64,26 +64,26 @@ class plTelescopeInputInterface : public plInputInterface
         plTelescopeInputInterface();
         virtual ~plTelescopeInputInterface();
 
-        virtual void        RestoreDefaultKeyMappings( void );
+        virtual void        RestoreDefaultKeyMappings();
         
         virtual bool    InterpretInputEvent( plInputEventMsg *pMsg );
 
         virtual bool    MsgReceive( plMessage *msg );
 
         virtual void    Init( plInputInterfaceMgr *manager );
-        virtual void    Shutdown( void ) {;}
+        virtual void    Shutdown() {;}
 
         // Returns the priority of this interface layer, based on the Priorities enum
-        virtual uint32_t  GetPriorityLevel( void ) const { return kTelescopeInputPriority; }
+        virtual uint32_t  GetPriorityLevel() const { return kTelescopeInputPriority; }
 
         // Returns the currently active mouse cursor for this layer, as defined in pnMessage/plCursorChangeMsg.h
-        virtual uint32_t      GetCurrentCursorID( void ) const { return kCursorUp; }
+        virtual uint32_t      GetCurrentCursorID() const { return kCursorUp; }
 
         // Returns the current opacity that this layer wants the cursor to be, from 0 (xparent) to 1 (opaque)
-        virtual float    GetCurrentCursorOpacity( void ) const { return 1.f; }
+        virtual float    GetCurrentCursorOpacity() const { return 1.f; }
 
         // Returns true if this layer is wanting to change the mouse, false if it isn't interested
-        virtual bool        HasInterestingCursorID( void ) const { return false; }
+        virtual bool        HasInterestingCursorID() const { return false; }
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plClimbEventMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plClimbEventMsg.h
@@ -49,8 +49,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plClimbEventMsg : public plMessage
 {
 public:
-    plClimbEventMsg(){;}
-    virtual ~plClimbEventMsg(){;}
+    plClimbEventMsg() { }
+    virtual ~plClimbEventMsg() { }
     CLASSNAME_REGISTER(plClimbEventMsg);
     GETINTERFACE_ANY(plClimbEventMsg, plMessage);
     virtual void Read(hsStream* stream, hsResMgr* mgr){plMessage::IMsgRead(stream,mgr);}

--- a/Sources/Plasma/PubUtilLib/plMessage/plConsoleMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plConsoleMsg.h
@@ -75,8 +75,8 @@ public:
     CLASSNAME_REGISTER( plConsoleMsg );
     GETINTERFACE_ANY( plConsoleMsg, plMessage );
 
-    uint32_t      GetCmd( void ) const { return fCmd; }
-    const char  *GetString( void ) const { return fString; };
+    uint32_t      GetCmd() const { return fCmd; }
+    const char  *GetString() const { return fString; };
     
     void SetCmd (uint32_t cmd) { fCmd = cmd; }
     void SetString (const char str[]) { free(fString); fString = hsStrcpy(str); }

--- a/Sources/Plasma/PubUtilLib/plMessage/plDynamicTextMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plDynamicTextMsg.h
@@ -119,8 +119,8 @@ public:
 
     // Commands
     void    ClearToColor( hsColorRGBA &c ) { fCmd |= kClear; fClearColor = c; }
-    void    Flush( void ) { fCmd |= kFlush; }
-    void    PurgeImage( void ) { fCmd |= kPurgeImage; }
+    void    Flush() { fCmd |= kFlush; }
+    void    PurgeImage() { fCmd |= kPurgeImage; }
 
     // The following are mutually exclusive commands 'cause they share some parameters
     void    SetTextColor( hsColorRGBA &c, bool blockRGB = false );

--- a/Sources/Plasma/PubUtilLib/plMessage/plInterestingPing.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInterestingPing.h
@@ -55,7 +55,7 @@ public:
     plInterestingModMsg(const plKey &s, 
                     const plKey &r, 
                     const double* t){}
-    ~plInterestingModMsg(){;}
+    ~plInterestingModMsg() { }
 
     CLASSNAME_REGISTER( plInterestingModMsg );
     GETINTERFACE_ANY( plInterestingModMsg, plMessage );
@@ -98,7 +98,7 @@ public:
     plInterestingPing(const plKey &s, 
                     const plKey &r, 
                     const double* t){SetBCastFlag(plMessage::kBCastByExactType);}
-    ~plInterestingPing(){;}
+    ~plInterestingPing() { }
 
     CLASSNAME_REGISTER( plInterestingPing );
     GETINTERFACE_ANY( plInterestingPing, plMessage );

--- a/Sources/Plasma/PubUtilLib/plMessage/plLinkToAgeMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plLinkToAgeMsg.h
@@ -304,8 +304,8 @@ class plPseudoLinkAnimCallbackMsg : public plMessage
 {
 public:
 
-    plPseudoLinkAnimCallbackMsg() {;}
-    ~plPseudoLinkAnimCallbackMsg() {;}
+    plPseudoLinkAnimCallbackMsg() { }
+    ~plPseudoLinkAnimCallbackMsg() { }
 
     CLASSNAME_REGISTER(plPseudoLinkAnimCallbackMsg);
     GETINTERFACE_ANY(plPseudoLinkAnimCallbackMsg, plMessage);

--- a/Sources/Plasma/PubUtilLib/plMessage/plListenerMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plListenerMsg.h
@@ -113,9 +113,9 @@ public:
 
     void    Set( const plKey &key, uint8_t type, bool binding );
 
-    plKey       &GetSrcKey( void ) { return fSrcKey; }
-    uint8_t       GetType( void ) const { return fType; }
-    bool        IsBinding( void ) const { return fBinding; }
+    plKey       &GetSrcKey() { return fSrcKey; }
+    uint8_t       GetType() const { return fType; }
+    bool        IsBinding() const { return fBinding; }
 };
 
 #endif // plListenerMsg_inc

--- a/Sources/Plasma/PubUtilLib/plMessage/plMatrixUpdateMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMatrixUpdateMsg.h
@@ -54,7 +54,7 @@ public:
     plMatrixUpdateMsg(const plKey &s, 
                     const plKey &r, 
                     const double* t){SetBCastFlag(plMessage::kPropagateToModifiers);}
-    ~plMatrixUpdateMsg(){;}
+    ~plMatrixUpdateMsg() { }
 
     CLASSNAME_REGISTER( plMatrixUpdateMsg );
     GETINTERFACE_ANY( plMatrixUpdateMsg, plMessage );

--- a/Sources/Plasma/PubUtilLib/plMessage/plNetVoiceListMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plNetVoiceListMsg.h
@@ -67,7 +67,7 @@ public:
                 plMessage(nil, nil, nil), fCmd( cmd )
                 { SetBCastFlag( kBCastByExactType ); }
     
-    ~plNetVoiceListMsg() { ; }
+    ~plNetVoiceListMsg() { }
 
     CLASSNAME_REGISTER( plNetVoiceListMsg );
     GETINTERFACE_ANY( plNetVoiceListMsg, plMessage );

--- a/Sources/Plasma/PubUtilLib/plMessage/plNetVoiceListMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plNetVoiceListMsg.h
@@ -72,8 +72,8 @@ public:
     CLASSNAME_REGISTER( plNetVoiceListMsg );
     GETINTERFACE_ANY( plNetVoiceListMsg, plMessage );
 
-    uint32_t      GetCmd( void ) { return fCmd; }
-    hsTArray<uint32_t>* GetClientList( void ) { return &fClientIDs; };
+    uint32_t      GetCmd() { return fCmd; }
+    hsTArray<uint32_t>* GetClientList() { return &fClientIDs; };
     plKey GetRemovedKey() { return fRemoved; }
     void SetRemovedKey(plKey& k) { fRemoved = k; }
     virtual void Read(hsStream* s, hsResMgr* mgr); 

--- a/Sources/Plasma/PubUtilLib/plMessage/plPickedMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plPickedMsg.h
@@ -60,7 +60,7 @@ public:
     plPickedMsg(const plKey &s, 
                     const plKey &r, 
                     const double* t) : fPicked(true),fHitPoint(0,0,0) {SetBCastFlag(plMessage::kPropagateToModifiers);}
-    ~plPickedMsg(){;}
+    ~plPickedMsg() { }
 
     CLASSNAME_REGISTER( plPickedMsg );
     GETINTERFACE_ANY( plPickedMsg, plMessage );

--- a/Sources/Plasma/PubUtilLib/plMessage/plPlayerMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plPlayerMsg.h
@@ -62,7 +62,7 @@ public:
     plPlayerMsg(const plKey &s, 
                     const plKey &r, 
                     const double* t){ SetBCastFlag(plMessage::kBCastByExactType);    }
-    ~plPlayerMsg(){;}
+    ~plPlayerMsg() { }
 
     CLASSNAME_REGISTER( plPlayerMsg );
     GETINTERFACE_ANY( plPlayerMsg, plMessage ); 

--- a/Sources/Plasma/PubUtilLib/plMessage/plResMgrHelperMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plResMgrHelperMsg.h
@@ -85,7 +85,7 @@ public:
         hsAssert( false, "This should never get written" );
     }
 
-    uint8_t   GetCommand( void ) const { return fCommand; }
+    uint8_t   GetCommand() const { return fCommand; }
 };
 
 #endif // _plResMgrHelperMsg_h

--- a/Sources/Plasma/PubUtilLib/plMessage/plRoomLoadNotifyMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plRoomLoadNotifyMsg.h
@@ -74,7 +74,7 @@ public:
                 const plKey &r, 
                 const double* t)
         : plMessage(s, r, t) { IInit(); }
-    virtual ~plRoomLoadNotifyMsg() {;}
+    virtual ~plRoomLoadNotifyMsg() { }
 
     CLASSNAME_REGISTER( plRoomLoadNotifyMsg );
     GETINTERFACE_ANY( plRoomLoadNotifyMsg, plMessage );

--- a/Sources/Plasma/PubUtilLib/plMessage/plSpawnModMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plSpawnModMsg.h
@@ -55,11 +55,11 @@ class plSpawnModMsg : public plMessage
 {
 
 public:
-    plSpawnModMsg(){;}
+    plSpawnModMsg() { }
     plSpawnModMsg(const plKey &s, 
                     const plKey &r, 
-                    const double* t){;}
-    ~plSpawnModMsg(){;}
+                    const double* t) { }
+    ~plSpawnModMsg() { }
 
     CLASSNAME_REGISTER( plSpawnModMsg );
     GETINTERFACE_ANY( plSpawnModMsg, plMessage );

--- a/Sources/Plasma/PubUtilLib/plMessage/plSpawnRequestMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plSpawnRequestMsg.h
@@ -57,7 +57,7 @@ public:
     plSpawnRequestMsg(const plKey &s, 
                     const plKey &r, 
                     const double* t){SetBCastFlag(plMessage::kBCastByExactType);}
-    ~plSpawnRequestMsg(){;}
+    ~plSpawnRequestMsg() { }
 
     CLASSNAME_REGISTER( plSpawnRequestMsg );
     GETINTERFACE_ANY( plSpawnRequestMsg, plMessage );

--- a/Sources/Plasma/PubUtilLib/plMessage/plTimerCallbackMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plTimerCallbackMsg.h
@@ -50,10 +50,10 @@ class hsResMgr;
 class plTimerCallbackMsg : public plMessage
 {
 public:
-    plTimerCallbackMsg(){;}
-    plTimerCallbackMsg(const plKey &s, const plKey &r, const double* t){;}
+    plTimerCallbackMsg() { }
+    plTimerCallbackMsg(const plKey &s, const plKey &r, const double* t) { }
     plTimerCallbackMsg(const plKey &r, uint32_t id = 0) { AddReceiver(r); fID = id;}
-    ~plTimerCallbackMsg(){;}
+    ~plTimerCallbackMsg() { }
 
     CLASSNAME_REGISTER( plTimerCallbackMsg );
     GETINTERFACE_ANY( plTimerCallbackMsg, plMessage );

--- a/Sources/Plasma/PubUtilLib/plMessage/plTransitionMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plTransitionMsg.h
@@ -73,9 +73,9 @@ public:
     CLASSNAME_REGISTER( plTransitionMsg );
     GETINTERFACE_ANY( plTransitionMsg, plMessageWithCallbacks );
 
-    uint32_t GetEffect( void ) const { return fEffect; }
-    float    GetLengthInSecs( void ) const { return fLengthInSecs; }
-    bool     GetHoldState( void ) const { return fHoldUntilNext; }
+    uint32_t GetEffect() const { return fEffect; }
+    float    GetLengthInSecs() const { return fLengthInSecs; }
+    bool     GetHoldState() const { return fHoldUntilNext; }
 
     virtual void Read(hsStream* s, hsResMgr* mgr) 
     { 

--- a/Sources/Plasma/PubUtilLib/plMessage/plTriggerMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plTriggerMsg.h
@@ -56,7 +56,7 @@ public:
     plTriggerMsg(const plKey &s, 
                     const plKey &r, 
                     const double* t){SetBCastFlag(plMessage::kBCastByExactType | plMessage::kPropagateToModifiers);}
-    ~plTriggerMsg(){;}
+    ~plTriggerMsg() { }
 
     CLASSNAME_REGISTER( plTriggerMsg );
     GETINTERFACE_ANY( plTriggerMsg, plMessage );

--- a/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
@@ -69,7 +69,7 @@ class plAxisInputInterface : public plInputInterface
 
         plAxisAnimModifier  *fOwner;
 
-        virtual ControlEventCode    *IGetOwnedCodeList( void ) const
+        virtual ControlEventCode    *IGetOwnedCodeList() const
         {
             static ControlEventCode codes[] = { END_CONTROLS };
             return codes;
@@ -79,7 +79,7 @@ class plAxisInputInterface : public plInputInterface
 
         plAxisInputInterface( plAxisAnimModifier *owner ) { fOwner = owner; SetEnabled( true ); }
 
-        virtual uint32_t  GetPriorityLevel( void ) const { return kSceneInteractionPriority + 10; }
+        virtual uint32_t  GetPriorityLevel() const { return kSceneInteractionPriority + 10; }
         virtual bool    InterpretInputEvent( plInputEventMsg *pMsg )
         {
             plMouseEventMsg* pMMsg = plMouseEventMsg::ConvertNoRef( pMsg );
@@ -99,8 +99,8 @@ class plAxisInputInterface : public plInputInterface
             return false;
         }
 
-        virtual uint32_t  GetCurrentCursorID( void ) const { return kCursorGrab; }
-        virtual bool    HasInterestingCursorID( void ) const { return true; }
+        virtual uint32_t  GetCurrentCursorID() const { return kCursorGrab; }
+        virtual bool    HasInterestingCursorID() const { return true; }
 };
 
 plAxisAnimModifier::plAxisAnimModifier() : 

--- a/Sources/Plasma/PubUtilLib/plModifier/plImageLibMod.h
+++ b/Sources/Plasma/PubUtilLib/plModifier/plImageLibMod.h
@@ -73,7 +73,7 @@ public:
         kRefImage = 0
     };
 
-    uint32_t  GetNumImages( void ) const { return fImages.GetCount(); }
+    uint32_t  GetNumImages() const { return fImages.GetCount(); }
 };
 
 #endif // plImageLibMod_inc

--- a/Sources/Plasma/PubUtilLib/plModifier/plMaintainersMarkerModifier.h
+++ b/Sources/Plasma/PubUtilLib/plModifier/plMaintainersMarkerModifier.h
@@ -61,7 +61,7 @@ protected:
 
     int fCalibrated;
 public:
-    plMaintainersMarkerModifier() : fCalibrated(0){;}
+    plMaintainersMarkerModifier() : fCalibrated(0) { }
 
     CLASSNAME_REGISTER( plMaintainersMarkerModifier );
     GETINTERFACE_ANY( plMaintainersMarkerModifier, plMultiModifier );

--- a/Sources/Plasma/PubUtilLib/plModifier/plSpawnModifier.h
+++ b/Sources/Plasma/PubUtilLib/plModifier/plSpawnModifier.h
@@ -52,7 +52,7 @@ protected:
     virtual bool IEval(double secs, float del, uint32_t dirty) {return true;}
 
 public:
-    plSpawnModifier(){;}
+    plSpawnModifier() { }
 
     CLASSNAME_REGISTER( plSpawnModifier );
     GETINTERFACE_ANY( plSpawnModifier, plMultiModifier );

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
@@ -281,7 +281,7 @@ public:
     void SetPingServer(uint8_t serverType) { fPingServerType = serverType; }
     
     // getters
-    uint32_t            GetPlayerID( void ) const;
+    uint32_t            GetPlayerID() const;
     ST::string          GetPlayerName( const plKey avKey=nil ) const;
     ST::string          GetPlayerNameById (unsigned playerId) const;
     unsigned            GetPlayerIdByName(const ST::string & name) const;

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
@@ -762,7 +762,7 @@ void plNetLinkingMgr::OfferLinkToPlayer( const plAgeInfoStruct * inInfo, uint32_
 
 ////////////////////////////////////////////////////////////////////
 
-void plNetLinkingMgr::IPostProcessLink( void )
+void plNetLinkingMgr::IPostProcessLink()
 {
     // Grab some useful things...
     plAgeLinkStruct* link = GetAgeLink();
@@ -838,7 +838,7 @@ void plNetLinkingMgr::IPostProcessLink( void )
 
 ////////////////////////////////////////////////////////////////////
 
-uint8_t plNetLinkingMgr::IPreProcessLink(void)
+uint8_t plNetLinkingMgr::IPreProcessLink()
 {
     // Grab some stuff we're gonna use extensively
     plNetClientMgr* nc = plNetClientMgr::GetInstance();

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.h
@@ -103,8 +103,8 @@ class plNetLinkingMgr
         kLinkDeferred,
     };
 
-    uint8_t IPreProcessLink( void );
-    void IPostProcessLink( void );
+    uint8_t IPreProcessLink();
+    void IPostProcessLink();
     bool IProcessLinkingMgrMsg( plLinkingMgrMsg * msg );
     bool IProcessLinkToAgeMsg( plLinkToAgeMsg * msg );
     void IDoLink(plLinkToAgeMsg* link);
@@ -118,7 +118,7 @@ public:
     bool MsgReceive( plMessage *msg );    // TODO: Make this a hsKeyedObject so we can really handle messages.
     void Update();
 
-    bool IsEnabled( void ) const { return fLinkingEnabled;}
+    bool IsEnabled() const { return fLinkingEnabled;}
     void SetEnabled( bool b );
     
     bool LinkedIn () const { return  fLinkedIn &&  fLinkingEnabled; }
@@ -164,7 +164,7 @@ public:
     // lobby info
     void SetLobbyAddr( const char * ipaddr ) { fLobbyInfo.SetServerAddr( ipaddr );}
     void SetLobbyPort( int port ) { fLobbyInfo.SetServerPort( port );}
-    const plNetServerSessionInfo * GetLobbyServerInfo( void ) const { return &fLobbyInfo;}
+    const plNetServerSessionInfo * GetLobbyServerInfo() const { return &fLobbyInfo;}
 
     // helpers
     static ST::string GetProperAgeName( const ST::string & ageName );    // attempt to fix wrong case age name.

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plServerGuid.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plServerGuid.cpp
@@ -155,7 +155,7 @@ const char * plServerGuid::AsString() const
     return str;
 }
 
-std::string plServerGuid::AsStdString( void ) const
+std::string plServerGuid::AsStdString() const
 {
     std::string str;
     str.resize(kGuidBytes*2+1);

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plServerGuid.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plServerGuid.h
@@ -77,16 +77,16 @@ public:
     friend bool operator!=( const plServerGuid & X, const plServerGuid & Y );
     friend bool operator<( const plServerGuid & X, const plServerGuid & Y) ;
 
-    const char *    AsString( void ) const; // returns static buffer.
-    std::string     AsStdString( void ) const;
+    const char *    AsString() const; // returns static buffer.
+    std::string     AsStdString() const;
     bool            FromString( const char * s );
 
     hsWide          AsWide() const;
     void            FromWide( const hsWide & v );
 
-    bool            IsSet( void ) const;
+    bool            IsSet() const;
     bool            IsEqualTo( const plServerGuid * other ) const;
-    operator std::string ( void ) const { return AsString();}
+    operator std::string () const { return AsString();}
 
     void            Read( hsStream * s, hsResMgr* mgr=nil );
     void            Write( hsStream * s, hsResMgr* mgr=nil );
@@ -95,8 +95,8 @@ public:
     void            Clear();
 
     static void SetGuidSeed( uint32_t seed );
-    static bool GuidSeedIsSet( void ) { return fGuidSeed!=0;}
-    static plServerGuid GenerateGuid( void );
+    static bool GuidSeedIsSet() { return fGuidSeed!=0;}
+    static plServerGuid GenerateGuid();
 
     CLASSNAME_REGISTER( plServerGuid );
     GETINTERFACE_ANY( plServerGuid, plCreatable );

--- a/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.h
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.h
@@ -77,7 +77,7 @@ public:
 
     plCollisionDetector() : fType(0), fTriggered(false), fBumped(false){ }
     plCollisionDetector(int8_t type) : fType(type), fTriggered(false), fBumped(false) { }
-    virtual ~plCollisionDetector(){;}
+    virtual ~plCollisionDetector() { }
     
     virtual bool MsgReceive(plMessage* msg);
 
@@ -212,7 +212,7 @@ public:
     {
         kSubworld = 0,
     };
-    plSubworldRegionDetector() : fSub(nil), fOnExit(false){;}
+    plSubworldRegionDetector() : fSub(nil), fOnExit(false) { }
     ~plSubworldRegionDetector();
     
     virtual bool MsgReceive(plMessage* msg);

--- a/Sources/Plasma/PubUtilLib/plPhysical/plDetectorModifier.h
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plDetectorModifier.h
@@ -58,8 +58,8 @@ protected:
     plKey               fProxyKey;
 
 public:
-    plDetectorModifier() : fRemoteMod(nil),fProxyKey(nil){;}
-    virtual ~plDetectorModifier(){;}
+    plDetectorModifier() : fRemoteMod(nil),fProxyKey(nil) { }
+    virtual ~plDetectorModifier() { }
     
 //  virtual bool MsgReceive(plMessage* msg) = 0;
 
@@ -68,7 +68,7 @@ public:
     void AddLogicObj(plKey pKey) { fReceivers.Append(pKey); }
     void SetRemote(plModifier* p) { fRemoteMod = p; }
     plModifier* RemoteMod() { return fRemoteMod; }
-    virtual void SetType(int8_t i) {;}
+    virtual void SetType(int8_t i) { }
     int GetNumReceivers() const { return fReceivers.Count(); }
     plKey GetReceiver(int i) const { return fReceivers[i]; }
     void SetProxyKey(const plKey &k) { fProxyKey = k; }

--- a/Sources/Plasma/PubUtilLib/plPhysical/plPhysicalSndGroup.h
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plPhysicalSndGroup.h
@@ -92,7 +92,7 @@ public:
     bool HasSlideSound(uint32_t against);
     bool HasImpactSound(uint32_t against);
 
-    uint32_t GetGroup( void ) const { return fGroup; }
+    uint32_t GetGroup() const { return fGroup; }
 
     // Export only
     void    AddImpactSound( uint32_t against, plKey receiver );

--- a/Sources/Plasma/PubUtilLib/plPhysical/plPickingDetector.h
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plPickingDetector.h
@@ -52,8 +52,8 @@ class plPickingDetector : public plDetectorModifier
 protected:
     
 public:
-    plPickingDetector(){;}
-    virtual ~plPickingDetector(){;}
+    plPickingDetector() { }
+    virtual ~plPickingDetector() { }
     
     virtual bool MsgReceive(plMessage* msg);
 
@@ -67,8 +67,8 @@ class plClickDragDetector : public plDetectorModifier
 protected:
     
 public:
-    plPickingDetector(){;}
-    virtual ~plPickingDetector(){;}
+    plPickingDetector() { }
+    virtual ~plPickingDetector() { }
     
     virtual bool MsgReceive(plMessage* msg);
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXDeviceRefs.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXDeviceRefs.cpp
@@ -95,7 +95,7 @@ plDXDeviceRef::~plDXDeviceRef()
         Unlink();
 }
 
-void    plDXDeviceRef::Unlink( void )
+void    plDXDeviceRef::Unlink()
 {
     hsAssert( fBack, "plDXDeviceRef not in list" );
     if( fNext )
@@ -136,7 +136,7 @@ plDXIndexBufferRef::~plDXIndexBufferRef()
 
 //// Releases /////////////////////////////////////////////////////////////////
 
-void    plDXVertexBufferRef::Release( void )
+void    plDXVertexBufferRef::Release()
 {
     if( fD3DBuffer != nil )
     {
@@ -154,7 +154,7 @@ void    plDXVertexBufferRef::Release( void )
     SetDirty( true );
 }
 
-void    plDXIndexBufferRef::Release( void )
+void    plDXIndexBufferRef::Release()
 {
     if( fD3DBuffer != nil )
     {
@@ -217,7 +217,7 @@ plDXTextureRef::~plDXTextureRef()
 
 //// Release //////////////////////////////////////////////////////////////////
 
-void    plDXTextureRef::Release( void )
+void    plDXTextureRef::Release()
 {
     plProfile_DelMem(MemTexture, fDataSize + sizeof(plDXTextureRef));
     plProfile_Extern(ManagedMem);
@@ -326,7 +326,7 @@ plDXLightRef::~plDXLightRef()
 
 //// Release //////////////////////////////////////////////////////////////////
 
-void    plDXLightRef::Release( void )
+void    plDXLightRef::Release()
 {
     // Ensure that this light is disabled
     if( fD3DDevice )
@@ -469,7 +469,7 @@ plDXRenderTargetRef::~plDXRenderTargetRef()
 
 //// Release //////////////////////////////////////////////////////////////////
 
-void    plDXRenderTargetRef::Release( void )
+void    plDXRenderTargetRef::Release()
 {
     int                     i;
     plCubicRenderTarget     *cubic;

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXLightRef.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXLightRef.h
@@ -76,7 +76,7 @@ class plDXLightRef : public plDXDeviceRef
         IDirect3DDevice9    *fD3DDevice;
 
         void            Link( plDXLightRef **back ) { plDXDeviceRef::Link( (plDXDeviceRef **)back ); }
-        plDXLightRef    *GetNext( void ) { return (plDXLightRef *)fNext; }
+        plDXLightRef    *GetNext() { return (plDXLightRef *)fNext; }
 
         plDXLightRef()
         {
@@ -88,7 +88,7 @@ class plDXLightRef : public plDXDeviceRef
         }
 
         virtual ~plDXLightRef();
-        void    Release( void );
+        void    Release();
 
         void    UpdateD3DInfo( IDirect3DDevice9 *dev, plDXLightSettings *settings );
 };

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXRenderTargetRef.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXRenderTargetRef.h
@@ -71,7 +71,7 @@ class plDXRenderTargetRef: public plDXTextureRef
         bool                fReleaseDepth;
 
         void                    Link( plDXRenderTargetRef **back ) { plDXDeviceRef::Link( (plDXDeviceRef **)back ); }
-        plDXRenderTargetRef *GetNext( void ) { return (plDXRenderTargetRef *)fNext; }
+        plDXRenderTargetRef *GetNext() { return (plDXRenderTargetRef *)fNext; }
 
 
         plDXRenderTargetRef( D3DFORMAT tp, uint32_t ml, plRenderTarget *owner, bool releaseDepthOnDelete = true );
@@ -83,7 +83,7 @@ class plDXRenderTargetRef: public plDXTextureRef
         void    SetTexture( IDirect3DTexture9 *surface, IDirect3DSurface9 *depth );
         void    SetTexture( IDirect3DCubeTexture9 *surface, IDirect3DSurface9 *depth );
 
-        IDirect3DSurface9   *GetColorSurface( void ) const
+        IDirect3DSurface9   *GetColorSurface() const
         {
             if( fD3DTexture != nil )
             {
@@ -98,7 +98,7 @@ class plDXRenderTargetRef: public plDXTextureRef
         }
 
         virtual ~plDXRenderTargetRef();
-        void    Release( void );
+        void    Release();
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXSettings.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXSettings.h
@@ -105,7 +105,7 @@ class plDXGeneralSettings
         HRESULT                 fDXError;
         char                    fErrorStr[ 256 ];
 
-        void    Reset( void );
+        void    Reset();
 };
 
 //// Fog Settings /////////////////////////////////////////////////////////////
@@ -123,7 +123,7 @@ class plDXFogSettings
         float               fDensity;
         hsColorRGBA         fColor;
 
-        void    Reset( void )
+        void    Reset()
         {
             fEnvPtr = nil;
             fMode = D3DFOG_NONE;
@@ -164,9 +164,9 @@ class plDXLightSettings
         // Sets member variables to initial states. Does NOT release anything.
         void    Reset( plDXPipeline *pipe );
         // Releases/deletes anything associated with these settings
-        void    Release( void );
+        void    Release();
         // Reserve a D3D light index
-        uint32_t  ReserveD3DIndex( void );
+        uint32_t  ReserveD3DIndex();
         // Release a reserved D3D light index
         void    ReleaseD3DIndex( uint32_t idx );
 };
@@ -184,7 +184,7 @@ class plDXStencilSettings
         uint32_t  fMask;
         uint32_t  fWriteMask;
 
-        void    Reset( void )
+        void    Reset()
         {
             fEnabled = false;
             fCmpFunc = 0;

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXTextFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXTextFont.cpp
@@ -139,7 +139,7 @@ void plDXTextFont::ReleaseShared(IDirect3DDevice9* device)
 
 //// IInitStateBlocks /////////////////////////////////////////////////////////
 
-void    plDXTextFont::IInitStateBlocks( void )
+void    plDXTextFont::IInitStateBlocks()
 {
 
     for( int i = 0; i < 2; i++ )
@@ -264,7 +264,7 @@ void    plDXTextFont::IDrawLines( uint32_t count, plFontVertex *array )
 //// FlushDraws ///////////////////////////////////////////////////////////////
 //  Flushes out and finishes any drawing left to be done.
 
-void    plDXTextFont::FlushDraws( void )
+void    plDXTextFont::FlushDraws()
 {
     if( !fBuffer )
         return;
@@ -281,7 +281,7 @@ void    plDXTextFont::FlushDraws( void )
 
 //// SaveStates ///////////////////////////////////////////////////////////////
 
-void    plDXTextFont::SaveStates( void )
+void    plDXTextFont::SaveStates()
 {
     if( !fInitialized )
         IInitObjects();
@@ -308,7 +308,7 @@ void    plDXTextFont::SaveStates( void )
 
 //// RestoreStates ////////////////////////////////////////////////////////////
 
-void    plDXTextFont::RestoreStates( void )
+void    plDXTextFont::RestoreStates()
 {
     if (fOldStateBlock)
         fOldStateBlock->Apply();

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXTextFont.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXTextFont.h
@@ -66,7 +66,7 @@ protected:
     IDirect3DStateBlock9 *fTextStateBlock;
 
     virtual void    ICreateTexture( uint16_t *data );
-    virtual void    IInitStateBlocks( void );
+    virtual void    IInitStateBlocks();
     virtual void    IDrawPrimitive( uint32_t count, plFontVertex *array );
     virtual void    IDrawLines( uint32_t count, plFontVertex *array );
 
@@ -77,10 +77,10 @@ public:
     static  void CreateShared(IDirect3DDevice9* device);
     static  void ReleaseShared(IDirect3DDevice9* device);
 
-    virtual void    FlushDraws( void );
-    virtual void    SaveStates( void );
-    virtual void    RestoreStates( void );
-    virtual void    DestroyObjects( void );
+    virtual void    FlushDraws();
+    virtual void    SaveStates();
+    virtual void    RestoreStates();
+    virtual void    DestroyObjects();
 
     static const DWORD kFVF;
 };

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXTextureRef.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXTextureRef.h
@@ -114,9 +114,9 @@ class plDXTextureRef : public plDXDeviceRef
         virtual ~plDXTextureRef();
 
         void            Link( plDXTextureRef **back ) { plDXDeviceRef::Link( (plDXDeviceRef **)back ); }
-        plDXTextureRef  *GetNext( void ) { return (plDXTextureRef *)fNext; }
+        plDXTextureRef  *GetNext() { return (plDXTextureRef *)fNext; }
 
-        void    Release( void );
+        void    Release();
 };
 
 class plDXCubeTextureRef : public plDXTextureRef

--- a/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.h
@@ -104,20 +104,20 @@ public:
     uint32_t GetWidth() const { return fWidth; }
     uint32_t GetHeight() const { return fHeight; }
     uint32_t GetColorDepth() const { return fDepth; }
-    uint8_t  GetNumZStencilDepths( void ) const { return fZStencilDepths.GetCount(); }
+    uint8_t  GetNumZStencilDepths() const { return fZStencilDepths.GetCount(); }
     uint16_t GetZStencilDepth( uint8_t i ) const { return fZStencilDepths[ i ]; }
-    uint8_t  GetNumFSAATypes( void ) const { return fFSAATypes.GetCount(); }
+    uint8_t  GetNumFSAATypes() const { return fFSAATypes.GetCount(); }
     uint8_t  GetFSAAType( uint8_t i ) const { return fFSAATypes[ i ]; }
-    bool     GetCanRenderToCubics( void ) const { return fCanRenderToCubics; }
+    bool     GetCanRenderToCubics() const { return fCanRenderToCubics; }
 
     void SetDiscarded(bool on=true) { if(on) fFlags |= kDiscarded; else fFlags &= ~kDiscarded; }
     void SetWidth(uint32_t w) { fWidth = w; }
     void SetHeight(uint32_t h) { fHeight = h; }
     void SetColorDepth(uint32_t d) { fDepth = d; }
-    void ClearZStencilDepths( void ) { fZStencilDepths.Reset(); }
+    void ClearZStencilDepths() { fZStencilDepths.Reset(); }
     void AddZStencilDepth( uint16_t depth ) { fZStencilDepths.Append( depth ); }
 
-    void    ClearFSAATypes( void ) { fFSAATypes.Reset(); }
+    void    ClearFSAATypes() { fFSAATypes.Reset(); }
     void    AddFSAAType( uint8_t type ) { fFSAATypes.Append( type ); }
 
     void    SetCanRenderToCubics( bool can ) { fCanRenderToCubics = can; }
@@ -202,10 +202,10 @@ public:
     bool    GetCap(uint32_t cap) const { return fCaps.IsBitSet(cap); }
     void    SetCap(uint32_t cap, bool on=true) { fCaps.SetBit(cap, on); }
 
-    float   GetZBiasRating( void ) const { return fZBiasRating; }
+    float   GetZBiasRating() const { return fZBiasRating; }
     void    SetZBiasRating( float rating ) { fZBiasRating = rating; }
 
-    float   GetLODBiasRating( void ) const { return fLODBiasRating; }
+    float   GetLODBiasRating() const { return fLODBiasRating; }
     void    SetLODBiasRating( float rating ) { fLODBiasRating = rating; }
 
     void    GetFogApproxStarts( float &expApprox, float &exp2Approx ) const { expApprox = fFogExpApproxStart;
@@ -213,7 +213,7 @@ public:
     void    SetFogApproxStarts( float exp, float exp2 ) { fFogExpApproxStart = exp; 
                                                                 fFogExp2ApproxStart = exp2; }
 
-    float   GetFogEndBias( void ) const { return fFogEndBias; }
+    float   GetFogEndBias() const { return fFogEndBias; }
     void    SetFogEndBias( float rating ) { fFogEndBias = rating; }
 
     void    GetFogKneeParams( uint8_t type, float &knee, float &kneeVal ) const { knee = fFogKnees[ type ]; kneeVal = fFogKneeVals[ type ]; }
@@ -225,7 +225,7 @@ public:
     uint8_t   GetAASetting() const { return fAASetting; }
     void    SetAASetting( uint8_t s ) { fAASetting = s; }
 
-    uint8_t   GetMaxAnisotropicSamples( void ) const { return fMaxAnisotropicSamples; }
+    uint8_t   GetMaxAnisotropicSamples() const { return fMaxAnisotropicSamples; }
     void    SetMaxAnisotropicSamples( uint8_t num ) { fMaxAnisotropicSamples = num; }
 
     void SetDiscarded(bool on=true) { if(on)fFlags |= kDiscarded; else fFlags &= ~kDiscarded; }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plCubicRenderTarget.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plCubicRenderTarget.h
@@ -120,7 +120,7 @@ class plCubicRenderTarget : public plRenderTarget
         }
 
         // Get the total size in bytes
-        virtual uint32_t  GetTotalSize( void ) const;
+        virtual uint32_t  GetTotalSize() const;
 
         virtual void                SetCameraMatrix(const hsPoint3& pos);
         virtual const hsMatrix44&   GetWorldToCamera(uint8_t face) const { return fWorldToCameras[face]; }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plCubicRenderTargetModifier.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plCubicRenderTargetModifier.h
@@ -77,7 +77,7 @@ public:
     GETINTERFACE_ANY( plCubicRenderTargetModifier, plModifier);
 
     // Functions related to/required by plModifier
-    virtual int             GetNumTargets( void ) const { return fTarget ? 1 : 0; }
+    virtual int             GetNumTargets() const { return fTarget ? 1 : 0; }
     virtual plSceneObject   *GetTarget( int w ) const { hsAssert(w < GetNumTargets(), "Bad target"); return fTarget; }
     virtual void            AddTarget( plSceneObject* so );
     virtual void            RemoveTarget( plSceneObject* so );

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDTProgressMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDTProgressMgr.cpp
@@ -80,7 +80,7 @@ plDTProgressMgr::~plDTProgressMgr()
 {
 }
 
-void    plDTProgressMgr::DeclareThyself( void )
+void    plDTProgressMgr::DeclareThyself()
 {
     static plDTProgressMgr  thyself;
 }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDTProgressMgr.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDTProgressMgr.h
@@ -80,7 +80,7 @@ class plDTProgressMgr : public plProgressMgr
 
         virtual void    Draw( plPipeline *p );
 
-        static void     DeclareThyself( void );
+        static void     DeclareThyself();
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.h
@@ -93,7 +93,7 @@ class plDebugText
             kStyleBold = 0x02
         };
 
-        ~plDebugText() { ; }
+        ~plDebugText() { }
 
         static plDebugText  &Instance() { return fInstance; }
 
@@ -174,7 +174,7 @@ class   plDebugTextManager
             plDebugTextNode( const char *s, uint32_t c, uint16_t x, uint16_t y, uint8_t style ); 
             plDebugTextNode( uint16_t left, uint16_t top, uint16_t right, uint16_t bottom, uint32_t c ); 
             plDebugTextNode( uint16_t left, uint16_t top, uint16_t right, uint16_t bottom, uint32_t c1, uint32_t c2 );
-            ~plDebugTextNode() {;}
+            ~plDebugTextNode() { }
         };
 
         hsTArray<plDebugTextNode>   fList;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.h
@@ -95,7 +95,7 @@ class plDebugText
 
         ~plDebugText() { ; }
 
-        static plDebugText  &Instance( void ) { return fInstance; }
+        static plDebugText  &Instance() { return fInstance; }
 
         uint32_t CalcStringWidth(const char *string);
         uint32_t CalcStringWidth_TEMP(const ST::string &string) { return CalcStringWidth(string.c_str()); }
@@ -144,13 +144,13 @@ class plDebugText
         void    SetManager( plDebugTextManager *m ) { fManager = m; }
 
         void            SetFont(const char *face, uint16_t size ) { hsStrncpy( fFontFace, face, sizeof( fFontFace ) ); fFontSize = size; }
-        const char     *GetFontFace( void ) { return fFontFace; }
-        uint16_t        GetFontSize( void ) { return fFontSize; }
+        const char     *GetFontFace() { return fFontFace; }
+        uint16_t        GetFontSize() { return fFontSize; }
         uint16_t        GetFontHeight();
 
         void            SetEnable( bool on ) { fEnabled = on; }
-        void            DisablePermanently( void ) { fEnabled = false; fLockEnable = true; }
-        bool            IsEnabled( void ) { return fEnabled; }
+        void            DisablePermanently() { fEnabled = false; fLockEnable = true; }
+        bool            IsEnabled() { return fEnabled; }
 
         void            GetScreenSize( uint32_t *width, uint32_t *height );
 };

--- a/Sources/Plasma/PubUtilLib/plPipeline/plFogEnvironment.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plFogEnvironment.h
@@ -98,13 +98,13 @@ class plFogEnvironment : public hsKeyedObject
         void    SetColor( hsColorRGBA &color ) { fColor = color; }
 
         // Clear the environment to no fog
-        void    Clear( void ) { fType = kNoFog; }
+        void    Clear() { fType = kNoFog; }
 
         // Gets the type
-        uint8_t   GetType( void ) const { return fType; }
+        uint8_t   GetType() const { return fType; }
 
         // Gets the color
-        hsColorRGBA &GetColor( void ) { return fColor; }
+        hsColorRGBA &GetColor() { return fColor; }
 
         // Gets the parameters. Sets start to 0 if the type is not linear (can be nil)
         void    GetParameters( float *start, float *end, float *density, hsColorRGBA *color ) const;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plPlates.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plPlates.cpp
@@ -357,7 +357,7 @@ void    plGraphPlate::SetDataLabels( uint32_t min, uint32_t max )
 
 //// ClearData ///////////////////////////////////////////////////////////////
 
-void    plGraphPlate::ClearData( void )
+void    plGraphPlate::ClearData()
 {
     uint32_t  *bits = (uint32_t *)fMipmap->GetImage(), *ptr;
     int     i;
@@ -733,12 +733,12 @@ void    plPlateManager::DestroyPlate( plPlate *plate )
 
 //// GetPipeWidth/Height /////////////////////////////////////////////////////
 
-uint32_t  plPlateManager::GetPipeWidth( void )
+uint32_t  plPlateManager::GetPipeWidth()
 {
     return fOwner->Width();
 }
 
-uint32_t  plPlateManager::GetPipeHeight( void )
+uint32_t  plPlateManager::GetPipeHeight()
 {
     return fOwner->Height();
 }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plPlates.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plPlates.h
@@ -94,7 +94,7 @@ class plPlate
 
         void    ILink( plPlate **back );
 
-        void    IUnlink( void )
+        void    IUnlink()
         {
             hsAssert( fPrevPtr, "Plate not in list" );
             if( fNext )
@@ -123,18 +123,18 @@ class plPlate
         void    SetTexture(plBitmap *texture); // Creates a new single layer material to use the texture.
         void    SetTitle( const char *title ) { if( title != nil ) strncpy( fTitle, title, sizeof( fTitle ) ); else fTitle[ 0 ] = 0; }
 
-        hsGMaterial     *GetMaterial( void ) { return fMaterial; }
-        hsMatrix44      &GetTransform( void ) { return fXformMatrix; }
-        const char      *GetTitle( void ) { return fTitle; }
-        uint32_t          GetFlags( void ) { return fFlags; }
-        const plMipmap  *GetMipmap( void ) { return fMipmap; }
+        hsGMaterial     *GetMaterial() { return fMaterial; }
+        hsMatrix44      &GetTransform() { return fXformMatrix; }
+        const char      *GetTitle() { return fTitle; }
+        uint32_t          GetFlags() { return fFlags; }
+        const plMipmap  *GetMipmap() { return fMipmap; }
 
         void    SetVisible( bool vis ) { if( vis ) fFlags |= kFlagVisible; else fFlags &= ~kFlagVisible; }
-        bool    IsVisible( void );
+        bool    IsVisible();
 
         void    SetOpacity( float opacity = 1.f );
 
-        plPlate *GetNext( void ) { return fNext; }
+        plPlate *GetNext() { return fNext; }
 
 
         /// Helper functions
@@ -173,7 +173,7 @@ class plGraphPlate : public plPlate
         void    SetDataLabels( uint32_t min, uint32_t max );
         void    SetLabelText(const char *text1, const char *text2 = nil, const char *text3 = nil, const char *text4 = nil );
         void    SetLabelText( const std::vector<std::string> & text );
-        void    ClearData( void );
+        void    ClearData();
 
         void    AddData( int32_t value, int32_t value2 = -1, int32_t value3 = -1, int32_t value4 = -1 );
         void    AddData( std::vector<int32_t> values );
@@ -224,8 +224,8 @@ class plPlateManager
 
         virtual ~plPlateManager();
         
-        static plPlateManager   &Instance( void ) { return *fInstance; }
-        static bool InstanceValid( void ) { return fInstance != nil; }
+        static plPlateManager   &Instance() { return *fInstance; }
+        static bool InstanceValid() { return fInstance != nil; }
 
         void        CreatePlate( plPlate **handle );
         void        CreatePlate( plPlate **handle, float width, float height );
@@ -238,11 +238,11 @@ class plPlateManager
         void        SetPlateScreenPos( plPlate *plate, uint32_t x, uint32_t y );
         void        SetPlatePixelSize( plPlate *plate, uint32_t pWidth, uint32_t pHeight );
 
-        uint32_t      GetPipeWidth( void );
-        uint32_t      GetPipeHeight( void );
+        uint32_t      GetPipeWidth();
+        uint32_t      GetPipeHeight();
         void        DrawToDevice( plPipeline *pipe );
 
-        bool        IsValid( void ) { return fCreatedSucessfully; }
+        bool        IsValid() { return fCreatedSucessfully; }
 };
 
 // Sets the hInstance that we load our resources from.  A SceneViewer hack.

--- a/Sources/Plasma/PubUtilLib/plPipeline/plRenderTarget.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plRenderTarget.cpp
@@ -184,7 +184,7 @@ uint32_t  plCubicRenderTarget::Write( hsStream *s )
     return total;
 }
 
-uint32_t  plCubicRenderTarget::GetTotalSize( void ) const
+uint32_t  plCubicRenderTarget::GetTotalSize() const
 {
     uint32_t      size = 0, i;
     

--- a/Sources/Plasma/PubUtilLib/plPipeline/plRenderTarget.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plRenderTarget.h
@@ -169,26 +169,26 @@ class plRenderTarget : public plBitmap
             fViewport.fProportional.fBottom = bottom;
         }
 
-        uint16_t  GetWidth( void ) const { return fWidth; }
-        uint16_t  GetHeight( void ) const { return fHeight; }
-        uint8_t   GetZDepth( void ) { return fZDepth; }
-        uint8_t   GetStencilDepth( void ) { return fStencilDepth; }
+        uint16_t  GetWidth() const { return fWidth; }
+        uint16_t  GetHeight() const { return fHeight; }
+        uint8_t   GetZDepth() { return fZDepth; }
+        uint8_t   GetStencilDepth() { return fStencilDepth; }
 
-        uint16_t      GetVPLeft( void )   { ASSERT_ABSOLUTE; return fViewport.fAbsolute.fLeft; }
-        uint16_t      GetVPTop( void )    { ASSERT_ABSOLUTE; return fViewport.fAbsolute.fTop; }
-        uint16_t      GetVPRight( void )  { ASSERT_ABSOLUTE; return fViewport.fAbsolute.fRight; }
-        uint16_t      GetVPBottom( void ) { ASSERT_ABSOLUTE; return fViewport.fAbsolute.fBottom; }
+        uint16_t      GetVPLeft()   { ASSERT_ABSOLUTE; return fViewport.fAbsolute.fLeft; }
+        uint16_t      GetVPTop()    { ASSERT_ABSOLUTE; return fViewport.fAbsolute.fTop; }
+        uint16_t      GetVPRight()  { ASSERT_ABSOLUTE; return fViewport.fAbsolute.fRight; }
+        uint16_t      GetVPBottom() { ASSERT_ABSOLUTE; return fViewport.fAbsolute.fBottom; }
 
-        float    GetVPLeftProp( void )   { ASSERT_PROPORTIONAL; return fViewport.fProportional.fLeft; }
-        float    GetVPTopProp( void )    { ASSERT_PROPORTIONAL; return fViewport.fProportional.fTop; }
-        float    GetVPRightProp( void )  { ASSERT_PROPORTIONAL; return fViewport.fProportional.fRight; }
-        float    GetVPBottomProp( void ) { ASSERT_PROPORTIONAL; return fViewport.fProportional.fBottom; }
+        float    GetVPLeftProp()   { ASSERT_PROPORTIONAL; return fViewport.fProportional.fLeft; }
+        float    GetVPTopProp()    { ASSERT_PROPORTIONAL; return fViewport.fProportional.fTop; }
+        float    GetVPRightProp()  { ASSERT_PROPORTIONAL; return fViewport.fProportional.fRight; }
+        float    GetVPBottomProp() { ASSERT_PROPORTIONAL; return fViewport.fProportional.fBottom; }
 
-        bool        ViewIsProportional( void ) const { return fProportionalViewport; }
+        bool        ViewIsProportional() const { return fProportionalViewport; }
 
-        plCubicRenderTarget *GetParent( void ) const { return fParent; }
+        plCubicRenderTarget *GetParent() const { return fParent; }
 
-        virtual uint32_t  GetTotalSize( void ) const { return fWidth * fHeight * ( fPixelSize >> 3 ); }
+        virtual uint32_t  GetTotalSize() const { return fWidth * fHeight * ( fPixelSize >> 3 ); }
 
         virtual bool MsgReceive(plMessage* msg);
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.cpp
@@ -74,7 +74,7 @@ plTextFont::~plTextFont()
 
 //// IInitFontTexture /////////////////////////////////////////////////////////
 
-uint16_t  *plTextFont::IInitFontTexture( void )
+uint16_t  *plTextFont::IInitFontTexture()
 {
 #ifdef HS_BUILD_FOR_WIN32
     int     nHeight, x, y, c;
@@ -207,7 +207,7 @@ void    plTextFont::Create( char *face, uint16_t size )
 
 //// IInitObjects /////////////////////////////////////////////////////////////
 
-void    plTextFont::IInitObjects( void )
+void    plTextFont::IInitObjects()
 {
     uint16_t  *data;
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.h
@@ -103,15 +103,15 @@ class plTextFont
         plDXCharInfo    fCharInfo[ 128 ];
 
 
-        virtual void    IInitObjects( void );
+        virtual void    IInitObjects();
         virtual void    ICreateTexture( uint16_t *data ) = 0;
-        virtual void    IInitStateBlocks( void ) = 0;
+        virtual void    IInitStateBlocks() = 0;
         virtual void    IDrawPrimitive( uint32_t count, plFontVertex *array ) = 0;
         virtual void    IDrawLines( uint32_t count, plFontVertex *array ) = 0;
         
-        uint16_t  *IInitFontTexture( void );
+        uint16_t  *IInitFontTexture();
 
-        void    IUnlink( void )
+        void    IUnlink()
         {
             hsAssert( fPrevPtr, "Font not in list" );
             if( fNext )
@@ -132,14 +132,14 @@ class plTextFont
         void    DrawRect( int left, int top, int right, int bottom, uint32_t hexColor );
         void    Draw3DBorder( int left, int top, int right, int bottom, uint32_t hexColor1, uint32_t hexColor2 );
         uint32_t  CalcStringWidth( const char *string );
-        uint32_t  GetFontSize( void ) { return fSize; }
+        uint32_t  GetFontSize() { return fSize; }
 
         uint16_t  GetFontHeight() { return fFontHeight; }
 
-        virtual void    DestroyObjects( void ) = 0;
-        virtual void    SaveStates( void ) = 0;
-        virtual void    RestoreStates( void ) = 0;
-        virtual void    FlushDraws( void ) = 0;
+        virtual void    DestroyObjects() = 0;
+        virtual void    SaveStates() = 0;
+        virtual void    RestoreStates() = 0;
+        virtual void    FlushDraws() = 0;
 
         void    Link( plTextFont **back )
         {

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextGenerator.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextGenerator.cpp
@@ -211,7 +211,7 @@ uint32_t      *plTextGenerator::IAllocateOSSurface( uint16_t width, uint16_t hei
 //// Detach ///////////////////////////////////////////////////////////////////
 //  Release the mipmap unto itself.
 
-void    plTextGenerator::Detach( void )
+void    plTextGenerator::Detach()
 {
     if( fHost == nil )
         return;
@@ -241,7 +241,7 @@ void    plTextGenerator::Detach( void )
 //// IDestroyOSSurface ////////////////////////////////////////////////////////
 //  Opposite of allocate. DUH!
 
-void    plTextGenerator::IDestroyOSSurface( void )
+void    plTextGenerator::IDestroyOSSurface()
 {
 #if HS_BUILD_FOR_WIN32
 
@@ -529,7 +529,7 @@ void    plTextGenerator::FrameRect( uint16_t x, uint16_t y, uint16_t width, uint
 
 //// FlushToHost //////////////////////////////////////////////////////////////
 
-void    plTextGenerator::FlushToHost( void )
+void    plTextGenerator::FlushToHost()
 {
 #if HS_BUILD_FOR_WIN32
     // Flush the GDI first, to make sure it's done
@@ -564,12 +564,12 @@ void    plTextGenerator::FlushToHost( void )
 
 //// GetTextWidth/Height //////////////////////////////////////////////////////
 
-uint16_t  plTextGenerator::GetTextWidth( void )
+uint16_t  plTextGenerator::GetTextWidth()
 {
     return ( fHost != nil ) ? (uint16_t)(fHost->fWidth) : 0;
 }
 
-uint16_t  plTextGenerator::GetTextHeight( void )
+uint16_t  plTextGenerator::GetTextHeight()
 {
     return ( fHost != nil ) ? (uint16_t)(fHost->fHeight) : 0;
 }
@@ -579,7 +579,7 @@ uint16_t  plTextGenerator::GetTextHeight( void )
 //  you want to be able to apply a layer texture transform that will compensate. This
 //  function will give you that transform. Just feed it into plLayer->SetTransform().
 
-hsMatrix44  plTextGenerator::GetLayerTransform( void )
+hsMatrix44  plTextGenerator::GetLayerTransform()
 {
     hsMatrix44  xform;
     hsVector3   scale;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextGenerator.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextGenerator.h
@@ -84,7 +84,7 @@ class plTextGenerator : public hsKeyedObject
 #endif
 
         uint32_t      *IAllocateOSSurface( uint16_t width, uint16_t height );
-        void        IDestroyOSSurface( void );
+        void        IDestroyOSSurface();
 
     public:
 
@@ -93,7 +93,7 @@ class plTextGenerator : public hsKeyedObject
         virtual ~plTextGenerator();
 
         void    Attach( plMipmap *host, uint16_t width, uint16_t height );
-        void    Detach( void );
+        void    Detach();
 
         /// Operations to perform on the text block
         
@@ -117,19 +117,19 @@ class plTextGenerator : public hsKeyedObject
         void        FillRect( uint16_t x, uint16_t y, uint16_t width, uint16_t height, hsColorRGBA &color );
         void        FrameRect( uint16_t x, uint16_t y, uint16_t width, uint16_t height, hsColorRGBA &color );
 
-        void    FlushToHost( void );
+        void    FlushToHost();
 
-        uint16_t  GetTextWidth( void );
-        uint16_t  GetTextHeight( void );
+        uint16_t  GetTextWidth();
+        uint16_t  GetTextHeight();
 
-        uint16_t  GetWidth( void ) { return fWidth; }
-        uint16_t  GetHeight( void ) { return fHeight; }
+        uint16_t  GetWidth() { return fWidth; }
+        uint16_t  GetHeight() { return fHeight; }
 
         // Since the textGen can actually create a texture bigger than you were expecting,
         // you want to be able to apply a layer texture transform that will compensate. This
         // function will give you that transform. Just feed it into plLayer->SetTransform().
 
-        hsMatrix44  GetLayerTransform( void );
+        hsMatrix44  GetLayerTransform();
 
 
         virtual bool MsgReceive( plMessage *msg );

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTransitionMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTransitionMgr.cpp
@@ -87,7 +87,7 @@ plTransitionMgr::plTransitionMgr()
     fPlaying = false;
 }
 
-void    plTransitionMgr::Init( void )
+void    plTransitionMgr::Init()
 {
     ICreatePlate();
     plgDispatch::Dispatch()->RegisterForExactType( plTransitionMsg::Index(), GetKey() );
@@ -114,7 +114,7 @@ plTransitionMgr::~plTransitionMgr()
 
 //// ICreatePlate ////////////////////////////////////////////////////////////
 
-void    plTransitionMgr::ICreatePlate( void )
+void    plTransitionMgr::ICreatePlate()
 {
     int     x, y;
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTransitionMgr.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTransitionMgr.h
@@ -82,7 +82,7 @@ class plTransitionMgr : public hsKeyedObject
         void    IStartFadeIn( float lengthInSecs, uint8_t effect = kFadeIn );
         void    IStartFadeOut( float lengthInSecs, uint8_t effect = kFadeOut );
 
-        void    ICreatePlate( void );
+        void    ICreatePlate();
 
         void    IStop( bool aboutToStartAgain = false );
 
@@ -96,7 +96,7 @@ class plTransitionMgr : public hsKeyedObject
         CLASSNAME_REGISTER( plTransitionMgr );
         GETINTERFACE_ANY( plTransitionMgr, hsKeyedObject );
 
-        void    Init( void );
+        void    Init();
 
         virtual bool MsgReceive( plMessage* msg );
 };

--- a/Sources/Plasma/PubUtilLib/plProgressMgr/plProgressMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plProgressMgr/plProgressMgr.cpp
@@ -222,7 +222,7 @@ plProgressMgrCallbackProc plProgressMgr::SetCallbackProc( plProgressMgrCallbackP
 
 //// CancelAllOps ////////////////////////////////////////////////////////////
 
-void    plProgressMgr::CancelAllOps( void )
+void    plProgressMgr::CancelAllOps()
 {
     plOperationProgress *op;
 

--- a/Sources/Plasma/PubUtilLib/plProgressMgr/plProgressMgr.h
+++ b/Sources/Plasma/PubUtilLib/plProgressMgr/plProgressMgr.h
@@ -228,7 +228,7 @@ class plProgressMgr
         virtual void Activate() {}
         virtual void Deactivate() {}
 
-        static plProgressMgr    *IGetManager( void ) { return fManager; }
+        static plProgressMgr    *IGetManager() { return fManager; }
 
     public:
 
@@ -247,9 +247,9 @@ class plProgressMgr
 
         plProgressMgrCallbackProc SetCallbackProc( plProgressMgrCallbackProc proc );
 
-        bool        IsActive( void ) const { return ( fOperations != nil ) ? true : false; }
+        bool        IsActive() const { return ( fOperations != nil ) ? true : false; }
 
-        void    CancelAllOps( void );
+        void    CancelAllOps();
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
@@ -132,7 +132,7 @@ protected:
     ST::string  fAgeName;
 
 public:
-    plKey   GetFoundKey( void ) const { return fFoundKey; }
+    plKey   GetFoundKey() const { return fFoundKey; }
 
     plKeyFinderIter( uint16_t classType, const ST::string &obName, bool substr )
             : fFoundKey( nil ), fClassType( classType ), fObjName( obName ), fSubstr( substr ) { }

--- a/Sources/Plasma/PubUtilLib/plResMgr/plPageInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plPageInfo.cpp
@@ -192,7 +192,7 @@ void    plPageInfo::Write( hsStream *s )
 //// IsValid /////////////////////////////////////////////////////////////////
 //  Just a simple test for now.
 
-bool    plPageInfo::IsValid( void ) const
+bool    plPageInfo::IsValid() const
 {
     return fLocation.IsValid();
 }

--- a/Sources/Plasma/PubUtilLib/plResMgr/plPageInfo.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plPageInfo.h
@@ -69,7 +69,7 @@ protected:
     uint32_t    fChecksum;
     uint32_t    fDataStart, fIndexStart;
 
-    void        IInit( void );
+    void        IInit();
     void        ISetFrom( const plPageInfo &src );
 
 public:
@@ -97,17 +97,17 @@ public:
     void    SetMajorVersion(uint16_t major) { fMajorVersion = major; }
 
     void    SetChecksum( uint32_t c ) { fChecksum = c; }
-    uint32_t  GetChecksum( void ) const { return fChecksum; }
+    uint32_t  GetChecksum() const { return fChecksum; }
 
     void    Read( hsStream *s );
     void    Write( hsStream *s );
 
-    bool    IsValid( void ) const;
+    bool    IsValid() const;
 
-    uint32_t  GetDataStart( void ) const { return fDataStart; }
+    uint32_t  GetDataStart() const { return fDataStart; }
     void    SetDataStart( uint32_t s ) { fDataStart = s; }
 
-    uint32_t  GetIndexStart( void ) const { return fIndexStart; }
+    uint32_t  GetIndexStart() const { return fIndexStart; }
     void    SetIndexStart( uint32_t s ) { fIndexStart = s; }
 };
 #endif // _plPageInfo_h

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.cpp
@@ -108,7 +108,7 @@ plResManagerHelper::~plResManagerHelper()
 
 //// Shutdown ////////////////////////////////////////////////////////////////
 
-void    plResManagerHelper::Shutdown( void )
+void    plResManagerHelper::Shutdown()
 {
     EnableDebugScreen( false );
     UnRegisterAs( kResManagerHelper_KEY );
@@ -116,7 +116,7 @@ void    plResManagerHelper::Shutdown( void )
 
 //// Init ////////////////////////////////////////////////////////////////////
 
-void    plResManagerHelper::Init( void )
+void    plResManagerHelper::Init()
 {
     RegisterAs( kResManagerHelper_KEY );
 }
@@ -204,7 +204,7 @@ class plResMgrDebugInterface : public plInputInterface
     protected:
         plResManagerHelper  * const fParent;
 
-        virtual ControlEventCode    *IGetOwnedCodeList( void ) const
+        virtual ControlEventCode    *IGetOwnedCodeList() const
         {
             static ControlEventCode codes[] = { END_CONTROLS };
             return codes;
@@ -214,7 +214,7 @@ class plResMgrDebugInterface : public plInputInterface
 
         plResMgrDebugInterface( plResManagerHelper * const mgr ) : fParent( mgr ) { SetEnabled( true ); }
 
-        virtual uint32_t  GetPriorityLevel( void ) const { return kGUISystemPriority + 10; }
+        virtual uint32_t  GetPriorityLevel() const { return kGUISystemPriority + 10; }
         virtual bool    InterpretInputEvent( plInputEventMsg *pMsg )
         {
             plKeyEventMsg *pKeyMsg = plKeyEventMsg::ConvertNoRef( pMsg );
@@ -268,8 +268,8 @@ class plResMgrDebugInterface : public plInputInterface
             return false;
         }
 
-        virtual uint32_t  GetCurrentCursorID( void ) const { return 0; }
-        virtual bool    HasInterestingCursorID( void ) const { return false; }
+        virtual uint32_t  GetCurrentCursorID() const { return 0; }
+        virtual bool    HasInterestingCursorID() const { return false; }
 };
 
 #endif

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.h
@@ -115,8 +115,8 @@ class plResManagerHelper : public hsKeyedObject
         virtual void    Read( hsStream *s, hsResMgr *mgr );
         virtual void    Write( hsStream *s, hsResMgr *mgr );
 
-        void    Init( void );
-        void    Shutdown( void );
+        void    Init();
+        void    Shutdown();
 
         void    LoadAndHoldPageKeys( plRegistryPageNode *page );
 
@@ -126,7 +126,7 @@ class plResManagerHelper : public hsKeyedObject
         void    SetInShutdown(bool b) { fInShutdown = b; }
         bool    GetInShutdown() const { return fInShutdown; }
 
-        static plResManagerHelper   *GetInstance( void ) { return fInstance; }
+        static plResManagerHelper   *GetInstance() { return fInstance; }
 };
 
 //// Reffer Class ////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
@@ -557,7 +557,7 @@ public:
     static plSDLMgr* GetInstance();
     plStateDescriptor* FindDescriptor(const ST::string& name, int version, const plSDL::DescriptorList * dl=nil) const;   // version or kLatestVersion
     
-    const plSDL::DescriptorList * GetDescriptors( void ) const { return &fDescriptors;}
+    const plSDL::DescriptorList * GetDescriptors() const { return &fDescriptors;}
 
     void SetSDLDir(const plFileName& s) { fSDLDir=s; }
     plFileName GetSDLDir() const { return fSDLDir; }

--- a/Sources/Plasma/PubUtilLib/plScene/plPostEffectMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plPostEffectMod.cpp
@@ -115,7 +115,7 @@ void plPostEffectMod::ISetupRenderRequest()
 
     IUpdateRenderRequest();
 }
-void        plPostEffectMod::EnableLightsOnRenderRequest( void )
+void        plPostEffectMod::EnableLightsOnRenderRequest()
 {
     fRenderRequest->SetRenderState( fRenderRequest->GetRenderState() & ~plPipeline::kRenderNoLights );
 }

--- a/Sources/Plasma/PubUtilLib/plScene/plPostEffectMod.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plPostEffectMod.h
@@ -136,7 +136,7 @@ public:
     void        SetWorldToCamera( hsMatrix44 &w2c, hsMatrix44 &c2w );
 
     // Very bad
-    void        EnableLightsOnRenderRequest( void );
+    void        EnableLightsOnRenderRequest();
 };
 
 #endif // plPostEffectMod_inc

--- a/Sources/Plasma/PubUtilLib/plScene/plSceneNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plSceneNode.cpp
@@ -455,7 +455,7 @@ bool plSceneNode::MsgReceive(plMessage* msg)
 //// ICleanUp ////////////////////////////////////////////////////////////////
 //  Export only: Clean up the scene node (i.e. make sure drawables optimize)
 
-void    plSceneNode::ICleanUp( void )
+void    plSceneNode::ICleanUp()
 {
     /// Go find drawables to delete
     for (auto draw : fDrawPool)
@@ -497,7 +497,7 @@ plDrawable  *plSceneNode::GetMatchingDrawable( const plDrawableCriteria& crit )
 //  Loops through all the drawables and calls Optimize on each one. For the
 //  export side, to be called right before writing the drawables to disk.
 
-void    plSceneNode::OptimizeDrawables( void )
+void    plSceneNode::OptimizeDrawables()
 {
     for (auto draw : fDrawPool)
         draw->Optimize();

--- a/Sources/Plasma/PubUtilLib/plScene/plSceneNode.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plSceneNode.h
@@ -115,7 +115,7 @@ protected:
     bool IOnAdd(plNodeRefMsg* refMsg);
 
     // Export only: Clean up empty drawables
-    void    ICleanUp( void );
+    void    ICleanUp();
 
 public:
     plSceneNode();
@@ -138,7 +138,7 @@ public:
     int16_t IncDepth() { return ++fDepth; }
     int16_t DecDepth() { return --fDepth; }
 
-    void    Init( void );
+    void    Init();
 
     plSpaceTree*    GetSpaceTree();
 
@@ -146,7 +146,7 @@ public:
     virtual plDrawable  *GetMatchingDrawable( const plDrawableCriteria& crit );
 
     // Export only: Optimize all my stinkin' drawables
-    virtual void    OptimizeDrawables( void );
+    virtual void    OptimizeDrawables();
 
     void SetFilterGenericsOnly(bool b) { fFilterGenerics = b; }
 

--- a/Sources/Plasma/PubUtilLib/plSockets/plFdSet.cpp
+++ b/Sources/Plasma/PubUtilLib/plSockets/plFdSet.cpp
@@ -47,7 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <sys/time.h>
 #endif
 
-plFdSet::plFdSet(void)
+plFdSet::plFdSet()
 {
     ZeroFds();
 }
@@ -164,7 +164,7 @@ int plFdSet::WaitForError(bool shouldZeroFds, unsigned long timeoutMillis)
 }
 
 
-void plFdSet::ZeroFds(void)
+void plFdSet::ZeroFds()
 {
     fMaxFd = 0;
     FD_ZERO(&fFds);

--- a/Sources/Plasma/PubUtilLib/plSockets/plTcpSocket.cpp
+++ b/Sources/Plasma/PubUtilLib/plSockets/plTcpSocket.cpp
@@ -66,7 +66,7 @@ bool plTcpSocket::operator==(const plTcpSocket & rhs)
 }
 
 // Disable Nagle algorithm.
-int plTcpSocket::SetNoDelay(void)
+int plTcpSocket::SetNoDelay()
 {
     int  nodel = 1;
     int ret1;    

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
@@ -102,7 +102,7 @@ plStatusLogMgr::~plStatusLogMgr()
     }
 }
 
-plStatusLogMgr  &plStatusLogMgr::GetInstance( void )
+plStatusLogMgr  &plStatusLogMgr::GetInstance()
 {
     static plStatusLogMgr   theManager;
     return theManager;
@@ -110,7 +110,7 @@ plStatusLogMgr  &plStatusLogMgr::GetInstance( void )
 
 //// Draw ////////////////////////////////////////////////////////////////////
 
-void    plStatusLogMgr::Draw( void )
+void    plStatusLogMgr::Draw()
 {
     /// Just draw current plStatusLog
     if( fCurrDisplay != nil && fDrawer != nil )
@@ -168,7 +168,7 @@ void plStatusLogMgr::SetCurrStatusLog(const plFileName& logName)
 
 //// NextStatusLog ///////////////////////////////////////////////////////////
 
-void    plStatusLogMgr::NextStatusLog( void )
+void    plStatusLogMgr::NextStatusLog()
 {
     if( fCurrDisplay == nil )
         fCurrDisplay = fDisplays;
@@ -178,7 +178,7 @@ void    plStatusLogMgr::NextStatusLog( void )
     fLastLogChangeTime = hsTimer::GetSysSeconds();
 }
 
-void    plStatusLogMgr::PrevStatusLog( void )
+void    plStatusLogMgr::PrevStatusLog()
 {
     if( fCurrDisplay == nil )
     {
@@ -314,7 +314,7 @@ void    plStatusLog::IInit()
 
 }
 
-bool plStatusLog::IReOpen( void )
+bool plStatusLog::IReOpen()
 {
     if( fFileHandle != nil )
     {
@@ -361,7 +361,7 @@ bool plStatusLog::IReOpen( void )
     return fFileHandle != nil;
 }
 
-void    plStatusLog::IFini( void )
+void    plStatusLog::IFini()
 {
     int     i;
 
@@ -410,7 +410,7 @@ plStatusLog* plStatusLog::IFindLog(const plFileName& filename)
 
 //// IUnlink /////////////////////////////////////////////////////////////////
 
-void    plStatusLog::IUnlink( void )
+void    plStatusLog::IUnlink()
 {
     hsAssert( fBack, "plStatusLog not in list" );
     if( fNext )
@@ -526,7 +526,7 @@ bool plStatusLog::AddLine( const char *line, uint32_t color )
 
 //// Clear ///////////////////////////////////////////////////////////////////
 
-void    plStatusLog::Clear( void )
+void    plStatusLog::Clear()
 {
     int     i;
 

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.h
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.h
@@ -97,7 +97,7 @@ class plStatusLog : public plLog
 
         plStatusLog **fDisplayPointer;      // Inside pfConsole
         
-        void    IUnlink( void );
+        void    IUnlink();
         void    ILink( plStatusLog **back );
 
         bool    IAddLine( const char *line, int32_t count, uint32_t color );
@@ -105,9 +105,9 @@ class plStatusLog : public plLog
         void    IParseFileName(plFileName &fileNoExt, ST::string &ext) const;
         static plStatusLog* IFindLog(const plFileName& filename);
 
-        void    IInit( void );
-        void    IFini( void );
-        bool    IReOpen( void );
+        void    IInit();
+        void    IFini();
+        bool    IReOpen();
 
         plStatusLog( uint8_t numDisplayLines, const plFileName &filename, uint32_t flags );
 
@@ -210,7 +210,7 @@ class plStatusLog : public plLog
             return log->AddLine(color, format, std::forward<_Args>(args)...);
         }
 
-        void    Clear( void );
+        void    Clear();
 
         // Clear and open a new file.
         void    Bounce( uint32_t flags=0 );
@@ -252,14 +252,14 @@ class plStatusLogMgr
 
         ~plStatusLogMgr();
 
-        static plStatusLogMgr   &GetInstance( void );
+        static plStatusLogMgr   &GetInstance();
 
-        void        Draw( void );
+        void        Draw();
 
         plStatusLog *CreateStatusLog( uint8_t numDisplayLines, const plFileName &filename, uint32_t flags = plStatusLog::kFilledBackground );
         void        ToggleStatusLog( plStatusLog *logToDisplay );
-        void        NextStatusLog( void );
-        void        PrevStatusLog( void );
+        void        NextStatusLog();
+        void        PrevStatusLog();
         void        SetCurrStatusLog( const plFileName &logName );
         plStatusLog *FindLog( const plFileName &filename, bool createIfNotFound = true );
 

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.cpp
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.cpp
@@ -1001,7 +1001,7 @@ bool plUnifiedTime::FromString(const char * buf, const char * fmt)
 
 int32_t   plUnifiedTime::fLocalTimeZoneOffset = -1;
 
-int32_t   plUnifiedTime::IGetLocalTimeZoneOffset( void )
+int32_t   plUnifiedTime::IGetLocalTimeZoneOffset()
 {
     static bool     inited = false;
 

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.h
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.h
@@ -80,7 +80,7 @@ protected:
 
     struct tm * IGetTime(const time_t * timer) const;
 
-    static int32_t    IGetLocalTimeZoneOffset( void );
+    static int32_t    IGetLocalTimeZoneOffset();
 
 public:
     plUnifiedTime() : fSecs(0),fMicros(0), fMode(kGmt) { }      // set ToEpoch() at start

--- a/Sources/Plasma/PubUtilLib/plVault/plAgeInfoSource.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plAgeInfoSource.h
@@ -51,11 +51,11 @@ class plAgeInfoSource
 {
 public:
     // current time in current age
-    virtual const plUnifiedTime *       GetAgeTime( void ) const = 0;
+    virtual const plUnifiedTime *       GetAgeTime() const = 0;
     // name of current age
-    virtual const char *                GetAgeName( void ) const = 0;
+    virtual const char *                GetAgeName() const = 0;
     // unique identifier for this age instance
-    virtual const plUUID *      GetAgeGuid( void ) const = 0;
+    virtual const plUUID *      GetAgeGuid() const = 0;
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plVault/plDniCoordinateInfo.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plDniCoordinateInfo.h
@@ -67,11 +67,11 @@ public:
     CLASSNAME_REGISTER( plDniCoordinateInfo );
     GETINTERFACE_ANY( plDniCoordinateInfo, plCreatable );
 
-    int GetHSpans( void ) const { return fHSpans;}
+    int GetHSpans() const { return fHSpans;}
     void    SetHSpans( int v ) { fHSpans = v; }
-    int GetVSpans( void ) const { return fVSpans;}
+    int GetVSpans() const { return fVSpans;}
     void    SetVSpans( int v ) { fVSpans = v;}
-    int GetTorans( void ) const { return fTorans; }
+    int GetTorans() const { return fTorans; }
     void    SetTorans( int v ) { fTorans = v; }
 
     void    CopyFrom( const plDniCoordinateInfo * other );

--- a/Sources/Tools/MaxComponent/pfGUISkinComp.cpp
+++ b/Sources/Tools/MaxComponent/pfGUISkinComp.cpp
@@ -125,7 +125,7 @@ void    pfGUISkinEditProc::IJustDrawOneRect( int whichElement, IParamBlock2 *pb,
     SetROP2( hDC, rop2 );
 }
 
-void    pfGUISkinEditProc::IRefreshDblBuffer( void )
+void    pfGUISkinEditProc::IRefreshDblBuffer()
 {
     // Image buffer is where we keep our resized image. Dbl buffer is where we draw our bounds
     if( fDblDC == nil )
@@ -174,7 +174,7 @@ void    pfGUISkinEditProc::IRefreshDblBuffer( void )
     }
 }
 
-void    pfGUISkinEditProc::IRefreshImageBuffer( void )
+void    pfGUISkinEditProc::IRefreshImageBuffer()
 {
     IInitDblBuffer();
 
@@ -215,7 +215,7 @@ void    pfGUISkinEditProc::IRefreshImageBuffer( void )
     IRefreshDblBuffer();
 }
 
-void    pfGUISkinEditProc::IInitDblBuffer( void )
+void    pfGUISkinEditProc::IInitDblBuffer()
 {
     if( fDblDC == NULL )
     {
@@ -254,7 +254,7 @@ void    pfGUISkinEditProc::IInitDblBuffer( void )
     }
 }
 
-void    pfGUISkinEditProc::IKillDblBuffer( void )
+void    pfGUISkinEditProc::IKillDblBuffer()
 {
     if( fDblDC != NULL )
     {
@@ -274,7 +274,7 @@ void    pfGUISkinEditProc::IKillDblBuffer( void )
     fDblBitmap = fImageBitmap = nil;
 }
 
-void    pfGUISkinEditProc::ISetScrollRanges( void )
+void    pfGUISkinEditProc::ISetScrollRanges()
 {
     SCROLLINFO  info;
 

--- a/Sources/Tools/MaxComponent/pfGUISkinComp.h
+++ b/Sources/Tools/MaxComponent/pfGUISkinComp.h
@@ -63,9 +63,9 @@ public:
 
     bool DeInit(plMaxNode *node, plErrorMsg *pErrMsg);
 
-    plLayerTex  *GetSkinBitmap( void );
+    plLayerTex  *GetSkinBitmap();
 
-    virtual uint32_t  GetNumMtls( void ) const;
+    virtual uint32_t  GetNumMtls() const;
     virtual Texmap  *GetMtl( uint32_t idx );
 
     enum
@@ -89,8 +89,8 @@ public:
         kRefBorderMargin
     };
 
-    pfGUISkin   *GetConvertedSkin( void ) const { return fConvertedSkin; }
-    plKey       GetConvertedSkinKey( void ) const;
+    pfGUISkin   *GetConvertedSkin() const { return fConvertedSkin; }
+    plKey       GetConvertedSkinKey() const;
 
     // Given an INode, gives you a pointer to the GUI component if it actually is one, nil otherwise
     static plGUISkinComp        *GetGUIComp( INode *node );
@@ -127,12 +127,12 @@ class pfGUISkinEditProc
         pfGUISkin::pfSRect  fBackups[ pfGUISkin::kNumElements ];
 
 
-        void    IRefreshDblBuffer( void );
-        void    IRefreshImageBuffer( void );
-        void    IInitDblBuffer( void );
-        void    IKillDblBuffer( void );
+        void    IRefreshDblBuffer();
+        void    IRefreshImageBuffer();
+        void    IInitDblBuffer();
+        void    IKillDblBuffer();
 
-        void    ISetScrollRanges( void );
+        void    ISetScrollRanges();
 
         enum
         {

--- a/Sources/Tools/MaxComponent/plAnimComponent.h
+++ b/Sources/Tools/MaxComponent/plAnimComponent.h
@@ -131,7 +131,7 @@ public:
 
     // plAnimObjInterface functions
     virtual void    PickTargetNode( IParamBlock2 *destPB, ParamID destParamID, ParamID typeID );
-    virtual bool    IsNodeRestricted( void ) { return true; }
+    virtual bool    IsNodeRestricted() { return true; }
     virtual ST::string GetIfaceSegmentName( bool allowNil );
 
 protected:
@@ -161,7 +161,7 @@ public:
 
     plKey GetModKey(plMaxNode *node);
 
-    virtual bool    IsNodeRestricted( void ) { return false; }
+    virtual bool    IsNodeRestricted() { return false; }
     virtual bool    GetKeyList( INode *restrictedNode, hsTArray<plKey> &outKeys );
 };
 
@@ -189,7 +189,7 @@ protected:
 
 public:
 
-    int     GetHandledDlgItem( void ) const { return fDlgItem; }
+    int     GetHandledDlgItem() const { return fDlgItem; }
 
     // No node restriction version
     plPlasmaAnimSelectDlgProc( ParamID paramID, int dlgItem, TCHAR *promptTitle, ParamMap2UserDlgProc *chainedDlgProc = nil );

--- a/Sources/Tools/MaxComponent/plAnimObjInterface.h
+++ b/Sources/Tools/MaxComponent/plAnimObjInterface.h
@@ -61,7 +61,7 @@ class plAnimObjInterface
         // If the following function returns true, then it makes sense to restrict
         // the animation conversion to a specific node (i.e. PickTargetNode() makes
         // sense)
-        virtual bool    IsNodeRestricted( void ) = 0;
+        virtual bool    IsNodeRestricted() = 0;
 
         // Allows the user to pick an INode that this animation is applied to
         // (ex. as a material or as a component) and stores it in the given ID
@@ -84,7 +84,7 @@ class plAnimObjInterface
         virtual ST::string  GetIfaceSegmentName( bool allowNil ) = 0;
 
         // This animation would require (depending on the node restriction) a separate material (i.e. material anim)
-        virtual bool        MightRequireSeparateMaterial( void ) { return false; }
+        virtual bool        MightRequireSeparateMaterial() { return false; }
 };
 
 // Strings for above NodeTypes enums

--- a/Sources/Tools/MaxComponent/plAudioComponents.cpp
+++ b/Sources/Tools/MaxComponent/plAudioComponents.cpp
@@ -2551,7 +2551,7 @@ public:
     bool PreConvert(plMaxNode *node, plErrorMsg *pErrMsg);
     bool Convert(plMaxNode *node, plErrorMsg *pErrMsg);
 
-    virtual void    UpdateSoundFileSelection() { ; }
+    virtual void    UpdateSoundFileSelection() { }
 
 protected:
 

--- a/Sources/Tools/MaxComponent/plAudioComponents.cpp
+++ b/Sources/Tools/MaxComponent/plAudioComponents.cpp
@@ -269,7 +269,7 @@ RefTargetHandle plBaseSoundEmitterComponent::Clone( RemapDir &remap )
     return obj;
 }
 
-void    plBaseSoundEmitterComponent::IConvertOldVolume( void )
+void    plBaseSoundEmitterComponent::IConvertOldVolume()
 {
     int oldVol = fCompPB->GetInt( (ParamID)kOldSoundVolumeSlider, 0 );
     if( oldVol != 4999 )
@@ -292,7 +292,7 @@ void    plBaseSoundEmitterComponent::IConvertOldVolume( void )
     }
 }
 
-float   plBaseSoundEmitterComponent::IGetDigitalVolume( void ) const
+float   plBaseSoundEmitterComponent::IGetDigitalVolume() const
 {
     return (float)pow( 10.f, fCompPB->GetFloat( (ParamID)kSoundVolumeSlider, 0 ) / 20.f );
 }
@@ -390,7 +390,7 @@ jvUniqueId plBaseSoundEmitterComponent::GetSoundAssetID( plBaseSoundEmitterCompo
 }
 #endif
 
-void    plBaseSoundEmitterComponent::IUpdateAssets( void )
+void    plBaseSoundEmitterComponent::IUpdateAssets()
 {
 #ifdef MAXASS_AVAILABLE
     if( fAssetsUpdated )
@@ -569,7 +569,7 @@ void    plBaseSoundEmitterComponent::IGrabSoftRegion( plSound *sound, plErrorMsg
     }
 }
 
-uint32_t  plBaseSoundEmitterComponent::ICalcSourceBufferFlags( void ) const
+uint32_t  plBaseSoundEmitterComponent::ICalcSourceBufferFlags() const
 {
     uint32_t bufferFlags = 0;
 
@@ -736,7 +736,7 @@ plSoundBuffer   *plBaseSoundEmitterComponent::IProcessSourceBuffer( plMaxNode *m
     return srcBuffer;
 }
 
-void    plBaseSoundEmitterComponent::UpdateSoundFileSelection( void )
+void    plBaseSoundEmitterComponent::UpdateSoundFileSelection()
 {
     plSoundBuffer   *baseBuffer = nil;
 
@@ -779,7 +779,7 @@ void    plBaseSoundEmitterComponent::UpdateSoundFileSelection( void )
         delete baseBuffer;
 }
 
-float    plBaseSoundEmitterComponent::GetSoundVolume( void ) const
+float    plBaseSoundEmitterComponent::GetSoundVolume() const
 {
     return IGetDigitalVolume();
 }
@@ -1402,7 +1402,7 @@ class plEAXPropsDlgProc : public plSingleCompSelProc
 
 public:
 
-    void    FlushSwappedPBs( void )
+    void    FlushSwappedPBs()
     {
         if( fLastBlockSwapped != nil )
             ISwapOutOcclusion( fLastBlockSwapped );
@@ -1765,7 +1765,7 @@ public:
     bool PreConvert(plMaxNode *node, plErrorMsg *pErrMsg);
     bool Convert(plMaxNode *node, plErrorMsg *pErrMsg);
 
-    virtual bool    IsLocalOnly( void ) const { if( fCompPB->GetInt( (ParamID)kSndIsLocalOnly ) ) return true; else return false; }
+    virtual bool    IsLocalOnly() const { if( fCompPB->GetInt( (ParamID)kSndIsLocalOnly ) ) return true; else return false; }
 
 
     virtual bool    ConvertGrouped( plMaxNode *baseNode, hsTArray<plBaseSoundEmitterComponent *> &groupArray, plErrorMsg *pErrMsg );
@@ -1774,7 +1774,7 @@ protected:
 
     bool IValidate(plMaxNode *node, plErrorMsg *pErrMsg);
 
-    virtual bool    IAllowStereoFiles( void ) const { return false; }
+    virtual bool    IAllowStereoFiles() const { return false; }
 
     void    ISetParameters( plWin32Sound *destSound, plErrorMsg *pErrMsg );
 
@@ -2376,7 +2376,7 @@ public:
     bool PreConvert(plMaxNode *node, plErrorMsg *pErrMsg);
     bool Convert(plMaxNode *node, plErrorMsg *pErrMsg);
 
-    virtual bool    IsLocalOnly( void ) const { if( fCompPB->GetInt( (ParamID)kSndIsLocalOnly ) ) return true; else return false; }
+    virtual bool    IsLocalOnly() const { if( fCompPB->GetInt( (ParamID)kSndIsLocalOnly ) ) return true; else return false; }
 
 protected:
     virtual uint32_t ICalcSourceBufferFlags() const;
@@ -2551,7 +2551,7 @@ public:
     bool PreConvert(plMaxNode *node, plErrorMsg *pErrMsg);
     bool Convert(plMaxNode *node, plErrorMsg *pErrMsg);
 
-    virtual void    UpdateSoundFileSelection( void ) { ; }
+    virtual void    UpdateSoundFileSelection() { ; }
 
 protected:
 
@@ -2559,7 +2559,7 @@ protected:
 
     virtual bool    IGetCategoryList( char **&catList, int *&catKonstantList );
 
-    virtual bool    IHasWaveformProps( void ) const { return false; }
+    virtual bool    IHasWaveformProps() const { return false; }
 };
 
 //Max desc stuff necessary below.
@@ -2718,7 +2718,7 @@ public:
     bool PreConvert(plMaxNode *pNode, plErrorMsg *errMsg);
     bool Convert(plMaxNode *node, plErrorMsg *errMsg);
 
-    const char *GetCustFileName( void ) const;
+    const char *GetCustFileName() const;
     void        SetCustFile( const char *path );
 };
 
@@ -2993,7 +2993,7 @@ bool plEAXListenerComponent::SetupProperties(plMaxNode *pNode,  plErrorMsg *errM
     return true;
 }
 
-const char *plEAXListenerComponent::GetCustFileName( void ) const
+const char *plEAXListenerComponent::GetCustFileName() const
 {
     return (const char *)fCompPB->GetStr( (ParamID)kRefCustFile );
 }

--- a/Sources/Tools/MaxComponent/plAudioComponents.h
+++ b/Sources/Tools/MaxComponent/plAudioComponents.h
@@ -121,13 +121,13 @@ class plBaseSoundEmitterComponent : public plComponent
         static plSoundBuffer    *GetSourceBuffer( const plFileName &fileName, plMaxNode *node, uint32_t srcBufferFlags );
         static bool             LookupLatestAsset( const char *waveName, char *retPath, plErrorMsg *errMsg );
 
-        virtual void    UpdateSoundFileSelection( void );
+        virtual void    UpdateSoundFileSelection();
 
         // Loads the given combo box with category selections and sets the ParamID for the category parameter.
         // Returns false if there are no categories to choose for this component
         virtual bool    UpdateCategories( HWND dialogBox, int &categoryID, ParamID &paramID );
 
-        virtual bool    IsLocalOnly( void ) const { return true; }
+        virtual bool    IsLocalOnly() const { return true; }
 
         // Virtuals for handling animated volumes
         virtual bool    AddToAnim( plAGAnim *anim, plMaxNode *node );
@@ -137,7 +137,7 @@ class plBaseSoundEmitterComponent : public plComponent
         void            SetCreateGrouped( plMaxNode *baseNode, int commonSoundIdx );
 
         // Grabs the current sound volume
-        virtual float    GetSoundVolume( void ) const;
+        virtual float    GetSoundVolume() const;
 
     protected:
 #ifdef MAXASS_AVAILABLE
@@ -161,7 +161,7 @@ class plBaseSoundEmitterComponent : public plComponent
             kMergeSourceFormatMismatch
         };
 
-        void    IUpdateAssets( void );
+        void    IUpdateAssets();
 
         static void     IShowError( uint32_t type, const char *errMsg, const char *nodeName, plErrorMsg *pErrMsg );
 
@@ -170,8 +170,8 @@ class plBaseSoundEmitterComponent : public plComponent
 
         bool IValidate(plMaxNode *node, plErrorMsg *pErrMsg);
 
-        void    IConvertOldVolume( void );
-        float   IGetDigitalVolume( void ) const;        // In scale 0. to 1., not in db
+        void    IConvertOldVolume();
+        float   IGetDigitalVolume() const;        // In scale 0. to 1., not in db
         void    IGrabFadeValues( plSound *sound );
         void    IGrabSoftRegion( plSound *sound, plErrorMsg *pErrMsg );
         void    IGrabEAXParams( plSound *sound, plErrorMsg *pErrMsg );
@@ -182,9 +182,9 @@ class plBaseSoundEmitterComponent : public plComponent
 
         plSoundBuffer   *IProcessSourceBuffer( plMaxNode *maxNode, plErrorMsg *errMsg );
 
-        virtual bool    IAllowStereoFiles( void ) const { return true; }
-        virtual bool    IAllowMonoFiles( void ) const { return true; }
-        virtual bool    IHasWaveformProps( void ) const { return true; }
+        virtual bool    IAllowStereoFiles() const { return true; }
+        virtual bool    IAllowMonoFiles() const { return true; }
+        virtual bool    IHasWaveformProps() const { return true; }
 
         // Returns pointers to arrays defining the names and konstants for the supported categories
         // for this component. Name array should have an extra "" entry at the end. Returns false if none supported

--- a/Sources/Tools/MaxComponent/plCameraComponents.h
+++ b/Sources/Tools/MaxComponent/plCameraComponents.h
@@ -151,7 +151,7 @@ public:
 class plCameraBaseComponent : public plComponent
 {
 public:
-    plCameraBaseComponent(){;}
+    plCameraBaseComponent(){ }
 
     virtual bool SetupProperties(plMaxNode* pNode, plErrorMsg* pErrMsg);
     virtual bool PreConvert(plMaxNode* pNode, plErrorMsg* pErrMsg);

--- a/Sources/Tools/MaxComponent/plComponentBase.h
+++ b/Sources/Tools/MaxComponent/plComponentBase.h
@@ -111,7 +111,7 @@ public:
 
     plMaxNodeBase *GetINode();
 
-    virtual void AddReceiverKey(plKey key, plMaxNode* node=nil) {;}
+    virtual void AddReceiverKey(plKey key, plMaxNode* node=nil) { }
     virtual plKey GetLogicKey(plMaxNode* node) {return nil;}
 
     // Return true if you want to allow yourself to be unhidden.  This is for components

--- a/Sources/Tools/MaxComponent/plGUIComponents.cpp
+++ b/Sources/Tools/MaxComponent/plGUIComponents.cpp
@@ -242,7 +242,7 @@ protected:
 
 public:
 
-    int     GetHandledDlgItem( void ) const { return fDlgItem; }
+    int     GetHandledDlgItem() const { return fDlgItem; }
 
     static const Class_ID       kEndClassList; 
 
@@ -1177,7 +1177,7 @@ plGUIDialogComponent::plGUIDialogComponent( bool dontInit )
     fProcReceiver = nil;
 }
 
-pfGUIDialogMod  *plGUIDialogComponent::IMakeDialog( void )
+pfGUIDialogMod  *plGUIDialogComponent::IMakeDialog()
 {
     return new pfGUIDialogMod();
 }
@@ -1404,7 +1404,7 @@ void plGUIDialogComponent::IMakeEveryoneOpaqueRecur(plMaxNode* node)
     }
 }
 
-plKey   plGUIDialogComponent::GetModifierKey( void )
+plKey   plGUIDialogComponent::GetModifierKey()
 {
     if( fDialogMod != nil )
         return fDialogMod->GetKey();
@@ -1877,8 +1877,8 @@ class plGUIButtonComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIButtonMod; }
-    virtual bool            ICanHaveProxy( void ) { return true; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIButtonMod; }
+    virtual bool            ICanHaveProxy() { return true; }
 
 public:
     plGUIButtonComponent();
@@ -2219,8 +2219,8 @@ class plGUICheckBoxComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUICheckBoxCtrl; }
-    virtual bool            ICanHaveProxy( void ) { return true; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUICheckBoxCtrl; }
+    virtual bool            ICanHaveProxy() { return true; }
 
 public:
     plGUICheckBoxComponent();
@@ -2419,8 +2419,8 @@ class plGUIDraggableComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIDraggableMod; }
-    virtual bool            ICanHaveProxy( void ) { return true; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIDraggableMod; }
+    virtual bool            ICanHaveProxy() { return true; }
 
 public:
     plGUIDraggableComponent();
@@ -2528,8 +2528,8 @@ class plGUIKnobCtrlComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIKnobCtrl; }
-    virtual bool            ICanHaveProxy( void ) { return true; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIKnobCtrl; }
+    virtual bool            ICanHaveProxy() { return true; }
 
     bool    IGrabAnimationRange( plMaxNode *node, plErrorMsg *pErrMsg, hsMatrix44 &startL2W, hsMatrix44 &endL2W );
 
@@ -2777,8 +2777,8 @@ class plGUIListBoxComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIListBoxMod; }
-    virtual bool            INeedsDynamicText( void ) { return true; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIListBoxMod; }
+    virtual bool            INeedsDynamicText() { return true; }
 
 public:
     plGUIListBoxComponent();
@@ -3012,8 +3012,8 @@ class plGUITextBoxComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUITextBoxMod; }
-    virtual bool            INeedsDynamicText( void ) { return true; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUITextBoxMod; }
+    virtual bool            INeedsDynamicText() { return true; }
 
 public:
     plGUITextBoxComponent();
@@ -3309,8 +3309,8 @@ class plGUIEditBoxComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIEditBoxMod; }
-    virtual bool            INeedsDynamicText( void ) { return true; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIEditBoxMod; }
+    virtual bool            INeedsDynamicText() { return true; }
 
 public:
     plGUIEditBoxComponent();
@@ -3404,7 +3404,7 @@ class plGUIUpDownPairComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIUpDownPairMod; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIUpDownPairMod; }
 
 public:
     plGUIUpDownPairComponent();
@@ -3616,8 +3616,8 @@ class plGUIDragBarComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIDragBarCtrl; }
-    virtual bool            ICanHaveProxy( void ) { return true; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIDragBarCtrl; }
+    virtual bool            ICanHaveProxy() { return true; }
 
 public:
     plGUIDragBarComponent();
@@ -3698,7 +3698,7 @@ class plGUIRadioGroupComponent : public plGUIControlBase
 
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIRadioGroupCtrl; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIRadioGroupCtrl; }
 
 public:
     plGUIRadioGroupComponent();
@@ -3911,8 +3911,8 @@ class plGUIDynDisplayComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIDynDisplayCtrl; }
-    virtual bool            IHasProcRollout( void ) { return false; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIDynDisplayCtrl; }
+    virtual bool            IHasProcRollout() { return false; }
 
 public:
     plGUIDynDisplayComponent();
@@ -4087,8 +4087,8 @@ class plGUIMultiLineEditComp : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIMultiLineEditCtrl; }
-    virtual bool            INeedsDynamicText( void ) { return true; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIMultiLineEditCtrl; }
+    virtual bool            INeedsDynamicText() { return true; }
 
 public:
     plGUIMultiLineEditComp();
@@ -4209,8 +4209,8 @@ class plGUIProgressCtrlComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIProgressCtrl; }
-    virtual bool            ICanHaveProxy( void ) { return false; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIProgressCtrl; }
+    virtual bool            ICanHaveProxy() { return false; }
 
 public:
     plGUIProgressCtrlComponent();
@@ -4471,8 +4471,8 @@ class plGUIClickMapComponent : public plGUIControlBase
 {
 protected:
 
-    virtual pfGUIControlMod *IGetNewControl( void ) { return new pfGUIClickMapCtrl; }
-    virtual bool            ICanHaveProxy( void ) { return false; }
+    virtual pfGUIControlMod *IGetNewControl() { return new pfGUIClickMapCtrl; }
+    virtual bool            ICanHaveProxy() { return false; }
 
 public:
     plGUIClickMapComponent();
@@ -4682,7 +4682,7 @@ BOOL pfGUISkinProc::DlgProc( TimeValue t, IParamMap2 *pmap, HWND hWnd, UINT msg,
     return false;
 }
 
-plKey   plGUISkinComp::GetConvertedSkinKey( void ) const
+plKey   plGUISkinComp::GetConvertedSkinKey() const
 {
     if( fConvertedSkin != nil )
         return fConvertedSkin->GetKey();
@@ -4690,7 +4690,7 @@ plKey   plGUISkinComp::GetConvertedSkinKey( void ) const
     return nil;
 }
 
-uint32_t  plGUISkinComp::GetNumMtls( void ) const
+uint32_t  plGUISkinComp::GetNumMtls() const
 {
     return 1;
 }
@@ -4702,7 +4702,7 @@ Texmap  *plGUISkinComp::GetMtl( uint32_t idx )
 
 //// GetSkinBitmap ///////////////////////////////////////////////////////////
 
-plLayerTex  *plGUISkinComp::GetSkinBitmap( void )
+plLayerTex  *plGUISkinComp::GetSkinBitmap()
 {  
     // If we don't have one, create one
     plLayerTex  *layer = (plLayerTex *)fCompPB->GetTexmap( kRefBitmap, 0 );
@@ -4896,12 +4896,12 @@ plGUIMenuComponent::plGUIMenuComponent() : plGUIDialogComponent( true )
     fClassDesc->MakeAutoParamBlocks(this);
 }
 
-pfGUIDialogMod  *plGUIMenuComponent::IMakeDialog( void )
+pfGUIDialogMod  *plGUIMenuComponent::IMakeDialog()
 {
     return new pfGUIPopUpMenu();
 }
 
-plKey   plGUIMenuComponent::GetConvertedMenuKey( void ) const
+plKey   plGUIMenuComponent::GetConvertedMenuKey() const
 {
     if( fConvertedMenu == nil )
         return nil;

--- a/Sources/Tools/MaxComponent/plGUIComponents.h
+++ b/Sources/Tools/MaxComponent/plGUIComponents.h
@@ -71,7 +71,7 @@ class plGUIDialogComponent : public plComponent
         plKey           fProcReceiver;  // non-nil means to send out notifys as our proc
         bool            fSeqNumValidated;
 
-        virtual pfGUIDialogMod  *IMakeDialog( void );
+        virtual pfGUIDialogMod  *IMakeDialog();
 
     public:
         // I believe booleans should always default to false, hence why this is dontInit instead of init. uint8_t me.
@@ -83,11 +83,11 @@ class plGUIDialogComponent : public plComponent
         bool Convert( plMaxNode *node, plErrorMsg *pErrMsg );
         bool DeInit(plMaxNode *node, plErrorMsg *pErrMsg)     { fProcReceiver = nil; return true;}
 
-        pfGUIDialogMod  *GetModifier( void ) { return fDialogMod; }
+        pfGUIDialogMod  *GetModifier() { return fDialogMod; }
 
         // For those too lazy to get it from the modifier
         // ... or can't trust that just because you have a modifier doesn't mean that you have a key :-) :-)
-        plKey           GetModifierKey( void );
+        plKey           GetModifierKey();
 
         // Set this to have the dialog send out notify messages on events. Do it before Convert(). Returns false if it failed.
         bool            SetNotifyReceiver( plKey key );
@@ -125,10 +125,10 @@ class plGUIControlBase : public plComponent
 
         pfGUIDialogMod  *IGetDialogMod( plMaxNode *node );
 
-        virtual pfGUIControlMod *IGetNewControl( void ) = 0;
-        virtual bool            IHasProcRollout( void ) { return true; }
-        virtual bool            INeedsDynamicText( void ) { return false; }
-        virtual bool            ICanHaveProxy( void ) { return false; }
+        virtual pfGUIControlMod *IGetNewControl() = 0;
+        virtual bool            IHasProcRollout() { return true; }
+        virtual bool            INeedsDynamicText() { return false; }
+        virtual bool            ICanHaveProxy() { return false; }
 
         const char              *ISetSoundIndex( ParamID checkBoxID, ParamID sndCompID, uint8_t guiCtrlEvent, plMaxNode *node );
 
@@ -150,7 +150,7 @@ class plGUIControlBase : public plComponent
 
         virtual void    CollectNonDrawables( INodeTab &nonDrawables );
 
-        virtual uint32_t  GetNumMtls( void ) const { return 0; }
+        virtual uint32_t  GetNumMtls() const { return 0; }
         virtual Texmap  *GetMtl( uint32_t idx ) { return nil; }
 
         // Given a maxNode that is really a component, will return a pointer to the GUI control modifier
@@ -195,7 +195,7 @@ class plGUIMenuComponent : public plGUIDialogComponent
 {
     protected:
 
-        virtual pfGUIDialogMod  *IMakeDialog( void );
+        virtual pfGUIDialogMod  *IMakeDialog();
 
         pfGUIPopUpMenu      *fConvertedMenu;
         plKey               fConvertedNode;
@@ -209,7 +209,7 @@ class plGUIMenuComponent : public plGUIDialogComponent
         virtual bool Convert( plMaxNode *node, plErrorMsg *pErrMsg );
         virtual bool DeInit(plMaxNode *node, plErrorMsg *pErrMsg);
 
-        plKey   GetConvertedMenuKey( void ) const;
+        plKey   GetConvertedMenuKey() const;
 
         enum
         {

--- a/Sources/Tools/MaxComponent/plMiscComponents.cpp
+++ b/Sources/Tools/MaxComponent/plMiscComponents.cpp
@@ -2466,7 +2466,7 @@ void pfImageLibComponent::Validate()
         fCompPB->SetCount(kCompressImage, fCompPB->Count(kRefImageList));
 }
 
-int pfImageLibComponent::GetNumBitmaps( void ) const
+int pfImageLibComponent::GetNumBitmaps() const
 {
     return fCompPB->Count( (ParamID)kRefImageList );
 }

--- a/Sources/Tools/MaxComponent/plMiscComponents.h
+++ b/Sources/Tools/MaxComponent/plMiscComponents.h
@@ -123,7 +123,7 @@ public:
         kCompressImage,
     };
 
-    int         GetNumBitmaps( void ) const;
+    int         GetNumBitmaps() const;
     plLayerTex  *GetBitmap( int idx );
     int         AppendBitmap( plLayerTex *tex );
     void        RemoveBitmap( int idx );

--- a/Sources/Tools/MaxConvert/plBitmapCreator.cpp
+++ b/Sources/Tools/MaxConvert/plBitmapCreator.cpp
@@ -109,12 +109,12 @@ void    plBitmapCreator::Init( bool save, plErrorMsg *msg )
     fErrorMsg = msg;
 }
 
-void    plBitmapCreator::DeInit( void )
+void    plBitmapCreator::DeInit()
 {
     CleanUpMaps();
 }
 
-void    plBitmapCreator::CleanUpMaps( void )
+void    plBitmapCreator::CleanUpMaps()
 {
     sCommonBitmapLib.ClearObjectList();
 }

--- a/Sources/Tools/MaxConvert/plBitmapCreator.h
+++ b/Sources/Tools/MaxConvert/plBitmapCreator.h
@@ -103,8 +103,8 @@ class plBitmapCreator
         plMipmap    *CreateBlankMipmap( uint32_t width, uint32_t height, unsigned config, uint8_t numLevels, const ST::string &keyName, const plLocation &keyLocation );
 
         void    Init( bool save, plErrorMsg *msg );
-        void    DeInit( void );
-        void    CleanUpMaps( void );
+        void    DeInit();
+        void    CleanUpMaps();
 
         ~plBitmapCreator();
 

--- a/Sources/Tools/MaxConvert/plLayerConverter.cpp
+++ b/Sources/Tools/MaxConvert/plLayerConverter.cpp
@@ -149,7 +149,7 @@ plLayerConverter::~plLayerConverter()
 {
 }
 
-plLayerConverter    &plLayerConverter::Instance( void )
+plLayerConverter    &plLayerConverter::Instance()
 {
     hsGuardBegin( "plLayerConverter::Instance" );
 
@@ -168,7 +168,7 @@ void    plLayerConverter::Init( bool save, plErrorMsg *msg )
     fInterface = GetCOREInterface();
 }
 
-void    plLayerConverter::DeInit( void )
+void    plLayerConverter::DeInit()
 {
     int i;
     for( i = 0; i < fConvertedLayers.GetCount(); i++ )
@@ -181,13 +181,13 @@ void    plLayerConverter::DeInit( void )
 
 //// Mute/Unmute Warnings /////////////////////////////////////////////////////
 
-void    plLayerConverter::MuteWarnings( void )
+void    plLayerConverter::MuteWarnings()
 {
     fSavedWarned = fWarned; 
     fWarned |= kWarnedNoBaseTexture | kWarnedUpperTextureMissing; 
 }
 
-void    plLayerConverter::UnmuteWarnings( void )
+void    plLayerConverter::UnmuteWarnings()
 {
     fWarned = fSavedWarned; 
 }

--- a/Sources/Tools/MaxConvert/plLayerConverter.h
+++ b/Sources/Tools/MaxConvert/plLayerConverter.h
@@ -82,17 +82,17 @@ class plLayerConverter
     public:
 
         ~plLayerConverter();
-        static plLayerConverter &Instance( void );
+        static plLayerConverter &Instance();
 
         void    Init( bool save, plErrorMsg *msg );
-        void    DeInit( void );
+        void    DeInit();
 
         plLayerInterface    *ConvertTexmap( Texmap *texmap, plMaxNode *maxNode,
                                             uint32_t blendFlags, bool preserveUVOffset, bool upperLayer );
         plBitmap *CreateSimpleTexture(const char *fileName, const plLocation &loc, uint32_t clipID = 0, uint32_t texFlags = 0, bool usePNG = false);
         
-        void    MuteWarnings( void );
-        void    UnmuteWarnings( void );
+        void    MuteWarnings();
+        void    UnmuteWarnings();
 
     protected:
 

--- a/Sources/Tools/MaxConvert/plMaxLightContext.h
+++ b/Sources/Tools/MaxConvert/plMaxLightContext.h
@@ -115,7 +115,7 @@ public:
     virtual Point3 VectorFrom(const Point3& p, RefFrame ifrom) { return p; }
 };
 
-inline Point3 plMaxLightContext::PObjRelBox(void)
+inline Point3 plMaxLightContext::PObjRelBox()
 {
     Point3 q;
     Point3 p = PObj();

--- a/Sources/Tools/MaxConvert/plMeshConverter.cpp
+++ b/Sources/Tools/MaxConvert/plMeshConverter.cpp
@@ -163,7 +163,7 @@ class plMAXVertexAccumulator
         void        StuffMyData( plMaxNode* node, plGeometrySpan *span, Mesh* mesh, ISkinContextData* skinData );
 
         int         GetVertexCount();
-        uint32_t      GetIndexCount( void ) { return fIndices.GetCount(); }
+        uint32_t      GetIndexCount() { return fIndices.GetCount(); }
 };
 
 class plMAXVertNormal
@@ -178,7 +178,7 @@ class plMAXVertNormal
         plMAXVertNormal() { fSmGroup = 0; fNext = nil; fInited = false; fNormal = Point3( 0, 0, 0 ); }
         plMAXVertNormal( Point3 &n, DWORD s ) { fNext = nil; fInited = true; fNormal = n; fSmGroup = s; }
         ~plMAXVertNormal() { /*delete fNext; */}
-        void    DestroyChain( void ) { if( fNext != nil ) fNext->DestroyChain(); delete fNext; fNext = nil; }
+        void    DestroyChain() { if( fNext != nil ) fNext->DestroyChain(); delete fNext; fNext = nil; }
 
         // Adding normalization of input n. Input is usually just crossproduct of face edges. Non-normalized,
         // large faces will overwhelm small faces on summation, which is the opposite of what we want, since
@@ -217,7 +217,7 @@ class plMAXVertNormal
             return pt;
         }
 
-        void    Normalize( void )
+        void    Normalize()
         {
             plMAXVertNormal *ptr = fNext, *prev = this;
 

--- a/Sources/Tools/MaxMain/plAgeDescInterface.cpp
+++ b/Sources/Tools/MaxMain/plAgeDescInterface.cpp
@@ -534,7 +534,7 @@ void plAgeDescInterface::ICheckedPageFlag(int ctrlID)
     }
 }
 
-void    plAgeDescInterface::ICheckOutCurrentAge( void )
+void    plAgeDescInterface::ICheckOutCurrentAge()
 {
 #ifdef MAXASS_AVAILABLE
     hsAssert( !fCurrAgeCheckedOut, "Trying to re-check out an age!" );
@@ -566,7 +566,7 @@ void    plAgeDescInterface::ICheckOutCurrentAge( void )
     IEnableControls( true );
 }
 
-void    plAgeDescInterface::ICheckInCurrentAge( void )
+void    plAgeDescInterface::ICheckInCurrentAge()
 {
 #ifdef MAXASS_AVAILABLE
     hsAssert( fCurrAgeCheckedOut, "Trying to check in an age when none is checked out!" );
@@ -590,7 +590,7 @@ void    plAgeDescInterface::ICheckInCurrentAge( void )
     IEnableControls( true );
 }
 
-void    plAgeDescInterface::IUndoCheckOutCurrentAge( void )
+void    plAgeDescInterface::IUndoCheckOutCurrentAge()
 {
 #ifdef MAXASS_AVAILABLE
     hsAssert( fCurrAgeCheckedOut, "Trying to undo check out an age when none is checked out!" );
@@ -614,7 +614,7 @@ void    plAgeDescInterface::IUndoCheckOutCurrentAge( void )
     IEnableControls( true );
 }
 
-void    plAgeDescInterface::IInvalidateCheckOutIndicator( void )
+void    plAgeDescInterface::IInvalidateCheckOutIndicator()
 {
     RECT    r;
     HWND    dummy = GetDlgItem( fhDlg, IDC_AGEDESC );
@@ -624,7 +624,7 @@ void    plAgeDescInterface::IInvalidateCheckOutIndicator( void )
     RedrawWindow( fhDlg, &r, nil, RDW_INVALIDATE | RDW_ERASE );
 }
 
-bool    plAgeDescInterface::IMakeSureCheckedIn( void )
+bool    plAgeDescInterface::IMakeSureCheckedIn()
 {
 #ifdef MAXASS_AVAILABLE
     int result;
@@ -677,7 +677,7 @@ bool    plAgeDescInterface::IMakeSureCheckedIn( void )
     return true;
 }
 
-void    plAgeDescInterface::IUpdateCurAge( void )
+void    plAgeDescInterface::IUpdateCurAge()
 {
     // Get the current age selection
     plAgeFile   *currAge = IGetCurrentAge();
@@ -918,7 +918,7 @@ hsTArray<plFileName> plAgeDescInterface::BuildAgeFileList()
 //// IFillAgeTree /////////////////////////////////////////////////////////////
 //  Refreshes/inits the tree view of all ages we have to work with. If
 //  specified, will also get the latest version of the .age files from assetMan.
-void plAgeDescInterface::IFillAgeTree( void )
+void plAgeDescInterface::IFillAgeTree()
 {
     HWND ageTree = GetDlgItem( fhDlg, IDC_AGE_LIST );
 
@@ -1338,7 +1338,7 @@ uint32_t  plAgeDescInterface::IGetNextFreeSequencePrefix( bool getReservedPrefix
     return searchSeq;
 }
 
-plAgeFile* plAgeDescInterface::IGetCurrentAge( void )
+plAgeFile* plAgeDescInterface::IGetCurrentAge()
 {
     HWND    ageTree = GetDlgItem( fhDlg, IDC_AGE_LIST );
     fCurrAgeItem = TreeView_GetSelection( ageTree );

--- a/Sources/Tools/MaxMain/plAgeDescInterface.h
+++ b/Sources/Tools/MaxMain/plAgeDescInterface.h
@@ -107,7 +107,7 @@ protected:
     static plFileName IGetLocalAgePath();
 
     // Fill out the age tree view
-    void IFillAgeTree( void );
+    void IFillAgeTree();
 
     // Create a new age file and select it in the browser
     void INewAge();
@@ -117,13 +117,13 @@ protected:
     uint32_t  IGetNextFreeSequencePrefix( bool getReservedPrefix );
     uint32_t  IGetFreePageSeqSuffix( HWND pageCombo );
 
-    void    ICheckOutCurrentAge( void );
-    void    ICheckInCurrentAge( void );
-    void    IUndoCheckOutCurrentAge( void );
-    bool    IMakeSureCheckedIn( void );
+    void    ICheckOutCurrentAge();
+    void    ICheckInCurrentAge();
+    void    IUndoCheckOutCurrentAge();
+    bool    IMakeSureCheckedIn();
 
-    plAgeFile* IGetCurrentAge( void );
+    plAgeFile* IGetCurrentAge();
 
-    void    IInvalidateCheckOutIndicator( void );
+    void    IInvalidateCheckOutIndicator();
     void    ICheckSequenceNumber( plAgeDescription &aged );
 };

--- a/Sources/Tools/MaxMain/plCommonObjLib.cpp
+++ b/Sources/Tools/MaxMain/plCommonObjLib.cpp
@@ -94,7 +94,7 @@ class plCommonObjLibList
 
 plCommonObjLibList  *plCommonObjLib::fLibList = nil;
 
-uint32_t  plCommonObjLib::GetNumLibs( void )
+uint32_t  plCommonObjLib::GetNumLibs()
 {
     return ( fLibList != nil ) ? fLibList->fLibs.GetCount() : 0;
 }
@@ -145,7 +145,7 @@ plCommonObjLib::~plCommonObjLib()
 
 //// ClearObjectList /////////////////////////////////////////////////////////
 
-void    plCommonObjLib::ClearObjectList( void )
+void    plCommonObjLib::ClearObjectList()
 {
     int     i;
 

--- a/Sources/Tools/MaxMain/plCommonObjLib.h
+++ b/Sources/Tools/MaxMain/plCommonObjLib.h
@@ -88,14 +88,14 @@ class plCommonObjLib
         void            AddObject( hsKeyedObject *object );
         bool            RemoveObjectAndKey( plKey &key );
         hsKeyedObject   *FindObject( const ST::string &name, uint16_t classType = (uint16_t)-1 );
-        void            ClearObjectList( void );
+        void            ClearObjectList();
 
         /// THIS IS YOUR VIRTUAL HERE. Override this to define which objects you collect
         virtual bool    IsInteresting( const plKey &objectKey ) { return false; }
 
 
         /// Static functions for use only by the export resManager
-        static uint32_t           GetNumLibs( void );
+        static uint32_t           GetNumLibs();
         static plCommonObjLib   *GetLib( uint32_t idx );
 
 

--- a/Sources/Tools/MaxMain/plMaxNode.cpp
+++ b/Sources/Tools/MaxMain/plMaxNode.cpp
@@ -4004,7 +4004,7 @@ TriObject* plMaxNode::GetTriObject(bool& deleteIt)
 //  Starting at 0, returns an incrementing index for each maxNode. Useful for 
 //  assigning indices to sound objects attached to the node.
 
-uint32_t  plMaxNode::GetNextSoundIdx( void )
+uint32_t  plMaxNode::GetNextSoundIdx()
 {
     uint32_t  idx = GetSoundIdxCounter();
     SetSoundIdxCounter( idx + 1 );
@@ -4015,7 +4015,7 @@ uint32_t  plMaxNode::GetNextSoundIdx( void )
 //  Fun temp hack function to tell if a maxNode is physical. Useful after
 //  preConvert (checks for a physical on the simInterface)
 
-bool    plMaxNode::IsPhysical( void )
+bool    plMaxNode::IsPhysical()
 {
     if( GetSceneObject() && GetSceneObject()->GetSimulationInterface() && 
         GetSceneObject()->GetSimulationInterface()->GetPhysical() )

--- a/Sources/Tools/MaxMain/plMaxNode.h
+++ b/Sources/Tools/MaxMain/plMaxNode.h
@@ -164,9 +164,9 @@ public:
     plLightMapComponent* GetLightMapComponent();
     // Starting at 0, returns an incrementing index for each maxNode. Useful for assigning
     // indices to sound objects attached to the node
-    uint32_t  GetNextSoundIdx( void );
+    uint32_t  GetNextSoundIdx();
 
-    bool    IsPhysical( void );
+    bool    IsPhysical();
 
     bool    CanMakeMesh( Object *obj, plErrorMsg *pErrMsg, plConvertSettings *settings );
     plDrawInterface* GetDrawInterface(); // Returns nil if there isn't a sceneobject and a drawinterface.

--- a/Sources/Tools/MaxMain/plMaxNodeData.h
+++ b/Sources/Tools/MaxMain/plMaxNodeData.h
@@ -201,7 +201,7 @@ public:
         return *this; 
     }
     // Ditto
-    void            DeInit( void ) 
+    void            DeInit()
     { 
         fpKey = nil; 
         fpRoomKey = nil;
@@ -405,7 +405,7 @@ public:
 
     plPhysicalProps* GetPhysicalProps()                 { return &fPhysicalProps; }
 
-    hsTArray<int>   *GetAlphaHackLayersCache( void )                        { return fCachedAlphaHackLayerCounts; }
+    hsTArray<int>   *GetAlphaHackLayersCache()                        { return fCachedAlphaHackLayerCounts; }
     void            SetAlphaHackLayersCache( hsTArray<int> *cache )         { fCachedAlphaHackLayerCounts = cache; }
     bool            GetOverrideHighLevelSDL()           { return MaxDatBF.CanBF(MaxDatBF.kOverrideHighLevelSDL); }
     void            SetOverrideHighLevelSDL(bool b)   { MaxDatBF.SetBF(b, MaxDatBF.kOverrideHighLevelSDL); }

--- a/Sources/Tools/MaxMain/plTextureExportLog.cpp
+++ b/Sources/Tools/MaxMain/plTextureExportLog.cpp
@@ -117,7 +117,7 @@ void    plTextureExportLog::AddTexture( plBitmap *texture )
     IAddBMapNode( texture->GetTotalSize(), texture );
 }
 
-void    plTextureExportLog::Write( void )
+void    plTextureExportLog::Write()
 {
     plBMapNode      *node;
     hsUNIXStream    *stream = new hsUNIXStream;

--- a/Sources/Tools/MaxMain/plTextureExportLog.h
+++ b/Sources/Tools/MaxMain/plTextureExportLog.h
@@ -84,7 +84,7 @@ class plTextureExportLog
         ~plTextureExportLog();
 
         void    AddTexture( plBitmap *texture );
-        void    Write( void );
+        void    Write();
 };
 
 

--- a/Sources/Tools/MaxPlasmaLights/plRTProjDirLight.h
+++ b/Sources/Tools/MaxPlasmaLights/plRTProjDirLight.h
@@ -69,7 +69,7 @@ class plRTProjPBAccessor : public PBAccessor
         void Set( PB2Value& val, ReferenceMaker* owner, ParamID id, int tabIndex, TimeValue t );
         void Get( PB2Value& v, ReferenceMaker* owner, ParamID id, int tabIndex, TimeValue t, Interval &valid );
 
-        static plRTProjPBAccessor   *Instance( void ) { return &fAccessor; }
+        static plRTProjPBAccessor   *Instance() { return &fAccessor; }
 
     protected:
 
@@ -119,8 +119,8 @@ class plRTProjDirLight : public plRTLightBase
         plRTProjDirLight();
 
         /// Class ID stuff
-        Class_ID    ClassID( void ) { return RTPDIR_LIGHT_CLASSID; }        
-        SClass_ID   SuperClassID( void ) { return LIGHT_CLASS_ID; }
+        Class_ID    ClassID() { return RTPDIR_LIGHT_CLASSID; }
+        SClass_ID   SuperClassID() { return LIGHT_CLASS_ID; }
 
         ObjLightDesc    *CreateLightDesc( INode *n, BOOL forceShadowBuf = FALSE );
         GenLight        *NewLight( int type ) { return new plRTProjDirLight(); }
@@ -132,7 +132,7 @@ class plRTProjDirLight : public plRTLightBase
         virtual int     DrawConeAndLine( TimeValue t, INode* inode, GraphicsWindow *gw, int drawing );
         virtual void    DrawCone( TimeValue t, GraphicsWindow *gw, float dist );
 
-        virtual BOOL            IsDir( void )   { return TRUE; }
+        virtual BOOL            IsDir()   { return TRUE; }
         virtual RefTargetHandle GetReference( int i );
         virtual void            SetReference( int ref, RefTargetHandle rtarg );
         virtual int             NumRefs() { return kNumRefs; }
@@ -151,7 +151,7 @@ class plRTProjDirLight : public plRTLightBase
         virtual void            InitNodeName( TSTR &s ) { s = _T( "RTProjDirLight" ); }
 
         // To get using-light-as-camera-viewport to work
-        virtual int             GetSpotShape( void ) { return RECT_LIGHT; }
+        virtual int             GetSpotShape() { return RECT_LIGHT; }
         virtual float           GetAspect( TimeValue t, Interval &valid = Interval(0,0) );
         virtual float           GetFallsize( TimeValue t, Interval &valid = Interval(0,0) );
         virtual int             Type() { return DIR_LIGHT; }

--- a/Sources/Tools/MaxPlasmaLights/plRTProjDirLightClassDesc.h
+++ b/Sources/Tools/MaxPlasmaLights/plRTProjDirLightClassDesc.h
@@ -70,7 +70,7 @@ class plRTProjDirLightDesc : public ClassDesc2
 
         static plRTProjDirLightDesc fStaticDesc;
 
-        static ClassDesc2   *GetDesc( void )        { return &fStaticDesc; }
+        static ClassDesc2   *GetDesc()        { return &fStaticDesc; }
 };
 
 #endif  // _plRTProjDirLightClassDesc_h

--- a/Sources/Tools/MaxPlasmaLights/plRealTimeLightBase.cpp
+++ b/Sources/Tools/MaxPlasmaLights/plRealTimeLightBase.cpp
@@ -1665,7 +1665,7 @@ void plRTLightBase::SetConeDisplay(int s, int notify)
         NotifyDependents(FOREVER, PART_OBJ, REFMSG_CHANGE);
 }
 
-BOOL plRTLightBase::GetConeDisplay(void)
+BOOL plRTLightBase::GetConeDisplay()
 {
     if(!IsDir())
         return fLightPB->GetInt(kShowConeBool);

--- a/Sources/Tools/MaxPlasmaLights/plRealTimeLightBase.h
+++ b/Sources/Tools/MaxPlasmaLights/plRealTimeLightBase.h
@@ -112,7 +112,7 @@ class plLightTexPBAccessor : public PBAccessor
         void Set( PB2Value& val, ReferenceMaker* owner, ParamID id, int tabIndex, TimeValue t );
         void Get( PB2Value& v, ReferenceMaker* owner, ParamID id, int tabIndex, TimeValue t, Interval &valid );
 
-        static plLightTexPBAccessor *Instance( void ) { return &fAccessor; }
+        static plLightTexPBAccessor *Instance() { return &fAccessor; }
 
     protected:
 
@@ -134,7 +134,7 @@ protected:
     plLayerTex*  fTex;
 
 
-    virtual bool    IHasAttenuation( void ) { return false; }
+    virtual bool    IHasAttenuation() { return false; }
     virtual void    IBuildMeshes( BOOL isNew ) {}
 
     void    BuildStaticMeshes();
@@ -323,7 +323,7 @@ public:
     virtual ~plRTLightBase();
     void DeleteThis() { delete this; }
 
-    static ParamBlockDesc2  *GetAnimPBDesc( void );
+    static ParamBlockDesc2  *GetAnimPBDesc();
 
     TCHAR* GetObjectName()      { return (TCHAR*)fClassDesc->ClassName(); }
     void GetClassName(TSTR& s)  { s = fClassDesc->ClassName(); }
@@ -357,7 +357,7 @@ public:
     virtual int DrawConeAndLine(TimeValue t, INode* inode, GraphicsWindow *gw, int drawing );
     void GetConePoints(TimeValue t, float aspect, float angle, float dist, Point3 *q);
     virtual void DrawCone(TimeValue t, GraphicsWindow *gw, float dist);
-    int GetSpotShape(void){ return 0; }
+    int GetSpotShape(){ return 0; }
     void SetExtendedDisplay(int flags){ extDispFlags = flags; }
     void BoxCircle(TimeValue t, float r, float d, Box3& box, int extraPt, Matrix3 *tm);
     void BoxDirPoints(TimeValue t, float angle, float dist, Box3 &box, Matrix3 *tm);
@@ -411,13 +411,13 @@ public:
     //
     //
 
-    virtual BOOL IsSpot( void ) { return FALSE; }
-    virtual BOOL IsDir( void )  { return FALSE; }
+    virtual BOOL IsSpot() { return FALSE; }
+    virtual BOOL IsDir()  { return FALSE; }
 
     RefResult EvalLightState(TimeValue time, Interval& valid, LightState *ls);
     ObjLightDesc *CreateLightDesc(INode *n, BOOL forceShadowBuffer=FALSE);
     void SetUseLight(int onOff) { fLightPB->SetValue(kLightOn, 0, onOff); NotifyDependents(FOREVER, PART_OBJ, REFMSG_CHANGE); }
-    BOOL GetUseLight(void) { BOOL v; fLightPB->GetValue(kLightOn, 0, v, FOREVER); return v; }
+    BOOL GetUseLight() { BOOL v; fLightPB->GetValue(kLightOn, 0, v, FOREVER); return v; }
     void SetHotspot(TimeValue time, float f); 
     float GetHotspot(TimeValue t, Interval& valid = Interval(0,0));
     void SetFallsize(TimeValue time, float f); 
@@ -430,7 +430,7 @@ public:
     float GetTDist(TimeValue t, Interval& valid = Interval(0,0));
 
     void SetConeDisplay(int s, int notify=TRUE);
-    BOOL GetConeDisplay(void);
+    BOOL GetConeDisplay();
 
     void SetRGBColor(TimeValue t, Point3& rgb); //fLightPB->SetValue(kRGB, t, rgb); NotifyDependents(FOREVER, PART_ALL, REFMSG_CHANGE);}
     Point3 GetRGBColor(TimeValue t, Interval &valid = Interval(0,0)); //return fLightPB->GetPoint3(kRGB, t); }        
@@ -439,13 +439,13 @@ public:
     void SetAspect(TimeValue t, float f) {}
     float GetAspect(TimeValue t, Interval& valid = Interval(0,0)) { return 0.0; }    
     void SetUseAtten(int s){ fLightPB->SetValue(kUseAttenuationBool, 0, s); NotifyDependents(FOREVER, PART_OBJ, REFMSG_CHANGE); }
-    BOOL GetUseAtten(void) {return fLightPB->GetInt(kUseAttenuationBool, 0);}
+    BOOL GetUseAtten() {return fLightPB->GetInt(kUseAttenuationBool, 0);}
     void SetUseAttenNear(int s) {  }
-    BOOL GetUseAttenNear(void) {return false;}
+    BOOL GetUseAttenNear() {return false;}
     void SetAttenDisplay(int s){  }
-    BOOL GetAttenDisplay(void) {return fLightPB->GetInt(kUseAttenuationBool, 0);}      
+    BOOL GetAttenDisplay() {return fLightPB->GetInt(kUseAttenuationBool, 0);}
     void SetAttenDisplayNear(int s){ }
-    BOOL GetAttenDisplayNear(void){return false;}      
+    BOOL GetAttenDisplayNear(){return false;}
     void Enable(int enab) { fLightPB->SetValue(kLightOn, 0, enab); }
     void SetMapBias(TimeValue t, float f) {}
     float GetMapBias(TimeValue t, Interval& valid = Interval(0,0)){return 0.0f;}

--- a/Sources/Tools/MaxPlasmaLights/plRealTimeLights.h
+++ b/Sources/Tools/MaxPlasmaLights/plRealTimeLights.h
@@ -87,7 +87,7 @@ class plRTOmniLight : public plRTLightBase
 
     protected:
         virtual void    IBuildMeshes( BOOL isNew );
-        virtual bool    IHasAttenuation( void ) { return true; }
+        virtual bool    IHasAttenuation() { return true; }
 };
 
 class plRTOmniLightDesc : public ClassDesc2 
@@ -105,7 +105,7 @@ class plRTOmniLightDesc : public ClassDesc2
 
     static plRTOmniLightDesc    fStaticDesc;
 
-    static ClassDesc2   *GetDesc( void )        { return &fStaticDesc; }
+    static ClassDesc2   *GetDesc()        { return &fStaticDesc; }
 };
 
 
@@ -131,7 +131,7 @@ class plRTSpotLight : public plRTLightBase
         
         virtual Texmap  *GetProjMap();
 
-        virtual BOOL    IsSpot( void )  { return TRUE; }
+        virtual BOOL    IsSpot()  { return TRUE; }
         virtual int     GetProjector() { return fLightPB->GetInt( kUseProjectorBool, 0 ); }
 
         virtual void            InitNodeName( TSTR &s ) { s = _T( "RTSpotLight" ); }
@@ -142,7 +142,7 @@ class plRTSpotLight : public plRTLightBase
 
     protected:
         virtual void    IBuildMeshes( BOOL isNew );
-        virtual bool    IHasAttenuation( void ) { return true; }
+        virtual bool    IHasAttenuation() { return true; }
 };
 
 class plRTSpotLightDesc : public ClassDesc2 
@@ -159,7 +159,7 @@ class plRTSpotLightDesc : public ClassDesc2
 
     static plRTSpotLightDesc    fStaticDesc;
 
-    static ClassDesc2   *GetDesc( void )        { return &fStaticDesc; }
+    static ClassDesc2   *GetDesc()        { return &fStaticDesc; }
 
 };
 
@@ -186,7 +186,7 @@ class plRTDirLight : public plRTLightBase
         virtual void    DrawCone(TimeValue t, GraphicsWindow *gw, float dist);
         virtual void    GetLocalBoundBox( TimeValue t, INode *node, ViewExp *vpt, Box3 &box );
 
-        virtual BOOL IsDir( void )  { return TRUE; }
+        virtual BOOL IsDir()  { return TRUE; }
 
         virtual void            InitNodeName( TSTR &s ) { s = _T( "RTDirLight" ); }
 
@@ -210,7 +210,7 @@ class plRTDirLightDesc : public ClassDesc2
 
     static plRTDirLightDesc     fStaticDesc;
 
-    static ClassDesc2   *GetDesc( void )        { return &fStaticDesc; }
+    static ClassDesc2   *GetDesc()        { return &fStaticDesc; }
 
 };
 

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plAngleAttenLayer.h
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plAngleAttenLayer.h
@@ -168,7 +168,7 @@ public:
     // Pure virtual accessors for the various bitmap related elements
     virtual Bitmap *GetMaxBitmap(int index = 0) { hsAssert( false, "Function call not valid on this type of layer." ); return nil; }
     virtual PBBitmap *GetPBBitmap( int index = 0 ) { hsAssert( false, "Function call not valid on this type of layer." ); return nil; }
-    virtual int     GetNumBitmaps( void ) { return 0; }
+    virtual int     GetNumBitmaps() { return 0; }
 
     // Some specific to processing this layer type into runtime materials.
     virtual Box3 GetFade();

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plDynamicEnvLayer.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plDynamicEnvLayer.cpp
@@ -411,7 +411,7 @@ DWORD plDynamicEnvLayer::GetActiveTexHandle(TimeValue t, TexHandleMaker& thmaker
 //  must *ALSO* be unique. Hence why this function is called by
 //  hsMaterialConverter::IMustBeUniqueMaterial().
 
-bool    plDynamicEnvLayer::MustBeUnique( void )
+bool    plDynamicEnvLayer::MustBeUnique()
 {
     if( fBitmapPB->GetINode( kBmpAnchorNode ) == nil )
         return true;

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plDynamicEnvLayer.h
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plDynamicEnvLayer.h
@@ -119,7 +119,7 @@ public:
     BITMAPINFO  *GetVPDisplayDIB(TimeValue t, TexHandleMaker& thmaker, Interval &valid, BOOL mono=FALSE, int forceW=0, int forceH=0);
     DWORD       GetActiveTexHandle(TimeValue t, TexHandleMaker& thmaker);
 
-    virtual bool    MustBeUnique( void );
+    virtual bool    MustBeUnique();
 
 protected:
     void IDiscardTexHandle();
@@ -179,7 +179,7 @@ public:
         // Pure virtual accessors for the various bitmap related elements
         virtual Bitmap *GetMaxBitmap(int index = 0) { hsAssert( false, "Function call not valid on this type of layer." ); return nil; }
         virtual PBBitmap *GetPBBitmap( int index = 0 ) { hsAssert( false, "Function call not valid on this type of layer." ); return nil; }
-        virtual int     GetNumBitmaps( void ) { return 0; }
+        virtual int     GetNumBitmaps() { return 0; }
 
     protected:
         virtual void ISetMaxBitmap(Bitmap *bitmap, int index = 0) { hsAssert( false, "Function call not valid on this type of layer." ); }

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plDynamicTextLayer.h
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plDynamicTextLayer.h
@@ -213,7 +213,7 @@ public:
         // Pure virtual accessors for the various bitmap related elements
         virtual Bitmap *GetMaxBitmap(int index = 0) { return fInitBitmap; }
         virtual PBBitmap *GetPBBitmap( int index = 0 );
-        virtual int     GetNumBitmaps( void ) { return 1; }
+        virtual int     GetNumBitmaps() { return 1; }
 
         // Virtual function called by plBMSampler to get various things while sampling the layer's image
         virtual bool    GetSamplerInfo( plBMSamplerData *samplerData );

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plLayerTex.h
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plLayerTex.h
@@ -160,7 +160,7 @@ public:
     // Accessors needed by the base class for the various bitmap related elements
     virtual Bitmap *GetMaxBitmap(int index = 0) { return fBM; }
     virtual PBBitmap *GetPBBitmap( int index = 0 ); 
-    virtual int     GetNumBitmaps( void ) { return 1; }
+    virtual int     GetNumBitmaps() { return 1; }
 
     // Virtual function called by plBMSampler to get various things while sampling the layer's image
     virtual bool    GetSamplerInfo( plBMSamplerData *samplerData );

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plMAXCameraLayer.h
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plMAXCameraLayer.h
@@ -149,7 +149,7 @@ public:
     // Pure virtual accessors for the various bitmap related elements
     virtual Bitmap *GetMaxBitmap(int index = 0) { hsAssert(false, "Function call not valid on this type of layer."); return nil; }
     virtual PBBitmap *GetPBBitmap(int index = 0) { hsAssert(false, "Function call not valid on this type of layer."); return nil; }
-    virtual int     GetNumBitmaps(void) { return 0; }
+    virtual int     GetNumBitmaps() { return 0; }
 
 protected:
     virtual void ISetMaxBitmap(Bitmap *bitmap, int index = 0) { hsAssert(false, "Function call not valid on this type of layer."); }

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.cpp
@@ -181,7 +181,7 @@ void    plPlasmaMAXLayer::IAddConversionTarget( plLayerInterface *target )
                                         plRefFlags::kPassiveRef );
 }
 
-void    plPlasmaMAXLayer::IClearConversionTargets( void )
+void    plPlasmaMAXLayer::IClearConversionTargets()
 {
     if( fConversionTargets != nil )
     {
@@ -190,7 +190,7 @@ void    plPlasmaMAXLayer::IClearConversionTargets( void )
     }
 }
 
-int     plPlasmaMAXLayer::GetNumConversionTargets( void )
+int     plPlasmaMAXLayer::GetNumConversionTargets()
 {
     if( fConversionTargets == nil )
         return 0;

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.h
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.h
@@ -103,7 +103,7 @@ class plPlasmaMAXLayer : public Texmap
 
 
         void    IAddConversionTarget( plLayerInterface *target );
-        void    IClearConversionTargets( void );
+        void    IClearConversionTargets();
 
     public:
 
@@ -118,7 +118,7 @@ class plPlasmaMAXLayer : public Texmap
 
         // Some layers must be unique for each node they're applied to (i.e. can't be shared among nodes).
         // This returns true if the layer must be unique.
-        virtual bool MustBeUnique( void ) { return false; }
+        virtual bool MustBeUnique() { return false; }
 
         // These let the material make an informed decision on what to do with
         // the color and alpha values coming out of an EvalColor call. Something
@@ -130,7 +130,7 @@ class plPlasmaMAXLayer : public Texmap
 
 
         // Return the number of conversion targets (only valid after the MakeMesh pass)
-        int     GetNumConversionTargets( void );
+        int     GetNumConversionTargets();
 
         // Get an indexed conversion target
         plLayerInterface    *GetConversionTarget( int index );
@@ -145,7 +145,7 @@ class plPlasmaMAXLayer : public Texmap
         // Pure virtual accessors for the various bitmap related elements
         virtual Bitmap *GetMaxBitmap(int index = 0) = 0;
         virtual PBBitmap *GetPBBitmap( int index = 0 ) = 0;
-        virtual int     GetNumBitmaps( void ) = 0;
+        virtual int     GetNumBitmaps() = 0;
 
         // Makes sure the textures are the latest versions (including getting
         // the latest version from AssetMan)

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plStaticEnvLayer.h
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plStaticEnvLayer.h
@@ -239,7 +239,7 @@ public:
         // Pure virtual accessors for the various bitmap related elements
         virtual Bitmap *GetMaxBitmap(int index = 0) { return fBitmaps[ index ]; }
         virtual PBBitmap *GetPBBitmap( int index = 0 );
-        virtual int     GetNumBitmaps( void ) { return 6; }
+        virtual int     GetNumBitmaps() { return 6; }
 
     protected:
         virtual void ISetMaxBitmap(Bitmap *bitmap, int index = 0) { fBitmaps[ index ] = bitmap; }

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthConvert.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthConvert.cpp
@@ -124,7 +124,7 @@ static int GetMatAnimModKey(Mtl* mtl, plMaxNodeBase* node, const ST::string& seg
     return retVal;
 }
 
-SegmentSpec *plAnimStealthNode::IGetSegmentSpec( void ) const
+SegmentSpec *plAnimStealthNode::IGetSegmentSpec() const
 {
     if( fCachedSegMap != nil )
     {
@@ -143,7 +143,7 @@ SegmentSpec *plAnimStealthNode::IGetSegmentSpec( void ) const
 }
 
 
-float    plAnimStealthNode::GetSegStart( void ) const
+float    plAnimStealthNode::GetSegStart() const
 {
     SegmentSpec *spec = IGetSegmentSpec();
     if( spec != nil )
@@ -152,7 +152,7 @@ float    plAnimStealthNode::GetSegStart( void ) const
     return 0.f;
 }
 
-float    plAnimStealthNode::GetSegEnd( void ) const
+float    plAnimStealthNode::GetSegEnd() const
 {
     SegmentSpec *spec = IGetSegmentSpec();
     if( spec != nil )

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.cpp
@@ -255,7 +255,7 @@ plAnimStealthNode   *plAnimStealthNode::ConvertToStealth( INode *objNode )
 }
 
 
-ST::string plAnimStealthNode::GetSegmentName( void ) const
+ST::string plAnimStealthNode::GetSegmentName() const
 {
     const char *str = fParamBlock->GetStr( (ParamID)kPBName );
     if( str == nil || str[ 0 ] == 0 )
@@ -407,7 +407,7 @@ IOResult plAnimStealthNode::Load(ILoad* iload)
     return IO_OK;
 }
 
-plPassMtlBase   *plAnimStealthNode::GetParentMtl( void )
+plPassMtlBase   *plAnimStealthNode::GetParentMtl()
 {
     return fParentMtl;
 }
@@ -427,7 +427,7 @@ class plGetRefs : public DependentEnumProc
         }
 };
 
-bool        plAnimStealthNode::IsParentUsedInScene( void )
+bool        plAnimStealthNode::IsParentUsedInScene()
 {
     if( GetParentMtl() == nil )
         return false;
@@ -760,7 +760,7 @@ void plAnimStealthNode::EndEditParams(IObjParam *ip, ULONG flags, Animatable *ne
 
 //// ReleaseDlg //////////////////////////////////////////////////////////////
 
-void    plAnimStealthNode::ReleaseDlg( void )
+void    plAnimStealthNode::ReleaseDlg()
 {
     IParamMap2 *map = fParamBlock->GetMap();
     fParamBlock->SetMap( nil );
@@ -822,7 +822,7 @@ bool    plAnimStealthNode::CreateAndEmbedDlg( IParamMap2 *parentMap, IMtlParams 
 //// GetWinDlg ///////////////////////////////////////////////////////////////
 //  Get the actual window handle of the currently active dialog displaying us
 
-HWND    plAnimStealthNode::GetWinDlg( void ) const
+HWND    plAnimStealthNode::GetWinDlg() const
 {
     IParamMap2 *map = fParamBlock->GetMap();
     if( map != nil )
@@ -894,21 +894,21 @@ ST::string plAnimStealthNode::GetIfaceSegmentName( bool allowNil )
 
 #pragma warning( push ) 
 #pragma warning( disable:4800 ) // Forcing value to bool true or false (go figure, i'm even explicitly casting)
-bool    plAnimStealthNode::GetAutoStart( void ) const   { return (bool)fParamBlock->GetInt( (ParamID)kPBAutoStart ); }
+bool    plAnimStealthNode::GetAutoStart() const   { return (bool)fParamBlock->GetInt( (ParamID)kPBAutoStart ); }
 void    plAnimStealthNode::SetAutoStart( bool b )       { fParamBlock->SetValue( (ParamID)kPBAutoStart, 0, (int)b ); };
 
-bool        plAnimStealthNode::GetLoop( void ) const                    { return fParamBlock->GetInt( (ParamID)kPBLoop ); }
-ST::string  plAnimStealthNode::GetLoopName( void ) const                { return ST::string::from_utf8( fParamBlock->GetStr( (ParamID)kPBLoopName ) ); }
+bool        plAnimStealthNode::GetLoop() const                    { return fParamBlock->GetInt( (ParamID)kPBLoop ); }
+ST::string  plAnimStealthNode::GetLoopName() const                { return ST::string::from_utf8( fParamBlock->GetStr( (ParamID)kPBLoopName ) ); }
 void        plAnimStealthNode::SetLoop( bool b, const ST::string &name )
 {
     fParamBlock->SetValue( (ParamID)kPBLoop, 0, (int)b );
     fParamBlock->SetValue( (ParamID)kPBLoopName, 0, (char *)name.c_str() );
 }
 
-uint8_t       plAnimStealthNode::GetEaseInType( void ) const      { return (uint8_t)fParamBlock->GetInt( (ParamID)kPBEaseInType ); }
-float    plAnimStealthNode::GetEaseInLength( void ) const    { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseInLength ); }
-float    plAnimStealthNode::GetEaseInMin( void ) const       { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseInMin ); }
-float    plAnimStealthNode::GetEaseInMax( void ) const       { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseInMax ); }
+uint8_t       plAnimStealthNode::GetEaseInType() const      { return (uint8_t)fParamBlock->GetInt( (ParamID)kPBEaseInType ); }
+float    plAnimStealthNode::GetEaseInLength() const    { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseInLength ); }
+float    plAnimStealthNode::GetEaseInMin() const       { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseInMin ); }
+float    plAnimStealthNode::GetEaseInMax() const       { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseInMax ); }
 void        plAnimStealthNode::SetEaseIn( uint8_t type, float length, float min, float max )
 {
     fParamBlock->SetValue( (ParamID)kPBEaseInType, 0, (int)type );
@@ -917,10 +917,10 @@ void        plAnimStealthNode::SetEaseIn( uint8_t type, float length, float min,
     fParamBlock->SetValue( (ParamID)kPBEaseInMax, 0, (float)max );
 }
 
-uint8_t       plAnimStealthNode::GetEaseOutType( void ) const     { return (uint8_t)fParamBlock->GetInt( (ParamID)kPBEaseOutType ); }
-float    plAnimStealthNode::GetEaseOutLength( void ) const   { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseOutLength ); }
-float    plAnimStealthNode::GetEaseOutMin( void ) const      { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseOutMin ); }
-float    plAnimStealthNode::GetEaseOutMax( void ) const      { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseOutMax ); }
+uint8_t       plAnimStealthNode::GetEaseOutType() const     { return (uint8_t)fParamBlock->GetInt( (ParamID)kPBEaseOutType ); }
+float    plAnimStealthNode::GetEaseOutLength() const   { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseOutLength ); }
+float    plAnimStealthNode::GetEaseOutMin() const      { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseOutMin ); }
+float    plAnimStealthNode::GetEaseOutMax() const      { return (float)fParamBlock->GetFloat( (ParamID)kPBEaseOutMax ); }
 void        plAnimStealthNode::SetEaseOut( uint8_t type, float length, float min, float max )
 {
     fParamBlock->SetValue( (ParamID)kPBEaseOutType, 0, (int)type );
@@ -932,7 +932,7 @@ void        plAnimStealthNode::SetEaseOut( uint8_t type, float length, float min
 
 //// Parent Accessor Functions ///////////////////////////////////////////////
 
-plStealthNodeAccessor   &plStealthNodeAccessor::GetInstance( void )
+plStealthNodeAccessor   &plStealthNodeAccessor::GetInstance()
 {
     static plStealthNodeAccessor    instance;
     return instance;

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.h
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.h
@@ -84,7 +84,7 @@ protected:
     bool            fPreppedForConvert;
     SegmentMap      *fCachedSegMap;
 
-    SegmentSpec     *IGetSegmentSpec( void ) const;
+    SegmentSpec     *IGetSegmentSpec() const;
 
 public:
 
@@ -120,8 +120,8 @@ public:
     virtual ~plAnimStealthNode();
     void DeleteThis() { delete this; }
 
-    INode           *GetINode( void );
-    plPassMtlBase   *GetParentMtl( void );
+    INode           *GetINode();
+    plPassMtlBase   *GetParentMtl();
     void            SetParentMtl( plPassMtlBase *parent );
     void            SetNodeName( const char *parentName );
 
@@ -129,16 +129,16 @@ public:
     bool    CreateAndEmbedDlg( IParamMap2 *parentMap, IMtlParams *parentParams, HWND frameCtrl = nil );
 
     // Release said dialog
-    void    ReleaseDlg( void );
+    void    ReleaseDlg();
 
     // Switch underlying objects in the dialog (to avoid unnecessary deletion/recreations)
     void    SwitchDlg( plAnimStealthNode *toSwitchTo );
 
     // Get the actual window handle of the currently active dialog displaying us
-    HWND    GetWinDlg( void ) const;
+    HWND    GetWinDlg() const;
 
     // Interesting functions
-    ST::string  GetSegmentName( void ) const;
+    ST::string  GetSegmentName() const;
     void        SetSegment( const char *name ); // nil for "entire animation"
 
     // Conversion from stealth's INode to the actual object
@@ -195,45 +195,45 @@ public:
 
     /// Parameter access
 
-    bool    GetAutoStart( void ) const;
+    bool    GetAutoStart() const;
     void    SetAutoStart( bool b );
 
-    bool        GetLoop( void ) const;
-    ST::string  GetLoopName( void ) const;
+    bool        GetLoop() const;
+    ST::string  GetLoopName() const;
     void        SetLoop( bool b, const ST::string &name );
 
-    uint8_t     GetEaseInType( void ) const;
-    float       GetEaseInLength( void ) const;
-    float       GetEaseInMin( void ) const;
-    float       GetEaseInMax( void ) const;
+    uint8_t     GetEaseInType() const;
+    float       GetEaseInLength() const;
+    float       GetEaseInMin() const;
+    float       GetEaseInMax() const;
     void        SetEaseIn( uint8_t type, float length, float min, float max );
 
-    uint8_t     GetEaseOutType( void ) const;
-    float       GetEaseOutLength( void ) const;
-    float       GetEaseOutMin( void ) const;
-    float       GetEaseOutMax( void ) const;
+    uint8_t     GetEaseOutType() const;
+    float       GetEaseOutLength() const;
+    float       GetEaseOutMin() const;
+    float       GetEaseOutMax() const;
     void        SetEaseOut( uint8_t type, float length, float min, float max );
 
     // Conversion stuff
     void        GetAllStopPoints( hsTArray<float> &out );
-    float       GetSegStart( void ) const;
-    float       GetSegEnd( void ) const;
+    float       GetSegStart() const;
+    float       GetSegEnd() const;
     void        GetLoopPoints( float &start, float &end ) const;
     void        StuffToTimeConvert( plAnimTimeConvert &convert, float maxLength );
 
     // plAnimObjInterface functions
     virtual void    PickTargetNode( IParamBlock2 *destPB, ParamID destParamID, ParamID typeID );
-    virtual bool    IsNodeRestricted( void ) { return true; }
+    virtual bool    IsNodeRestricted() { return true; }
     virtual ST::string GetIfaceSegmentName( bool allowNil );
     virtual bool    GetKeyList( INode *restrictedNode, hsTArray<plKey> &outKeys );
-    virtual bool        MightRequireSeparateMaterial( void ) { return true; }
+    virtual bool        MightRequireSeparateMaterial() { return true; }
 
     // Convert time, called on the setupProps pass for each material applied to a node in the scene
     virtual bool    SetupProperties( plMaxNode *node, plErrorMsg *pErrMsg );
     virtual bool    ConvertDeInit( plMaxNode *node, plErrorMsg *pErrMsg );
 
     // Returns true if the parent material is applied to any node in the scene, false otherwise
-    bool            IsParentUsedInScene( void );
+    bool            IsParentUsedInScene();
 };
 
 //// Accessor for Parent's ParamBlock ////////////////////////////////////////
@@ -249,7 +249,7 @@ class plStealthNodeAccessor : public PBAccessor
     public:
 
         plStealthNodeAccessor() { }
-        static plStealthNodeAccessor    &GetInstance( void );
+        static plStealthNodeAccessor    &GetInstance();
         
         virtual void    Set( PB2Value &v, ReferenceMaker *owner, ParamID id, int tabIndex, TimeValue t );
         virtual void    TabChanged( tab_changes changeCode, Tab<PB2Value> *tab, ReferenceMaker *owner, 

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plPassAnimDlgProc.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plPassAnimDlgProc.cpp
@@ -85,7 +85,7 @@ plPassAnimDlgProc::~plPassAnimDlgProc()
     }
 }
 
-plPassAnimDlgProc   &plPassAnimDlgProc::Get( void )
+plPassAnimDlgProc   &plPassAnimDlgProc::Get()
 {
     static plPassAnimDlgProc    instance;
     return instance;
@@ -192,7 +192,7 @@ BOOL plPassAnimDlgProc::DlgProc(TimeValue t, IParamMap2 *pMap, HWND hWnd, UINT m
     return FALSE;
 }
 
-void    plPassAnimDlgProc::SegmentListChanged( void )
+void    plPassAnimDlgProc::SegmentListChanged()
 {
     if( fCurrParamMap != nil )
         ILoadNames( fCurrParamMap->GetParamBlock() );

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plPassAnimDlgProc.h
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plPassAnimDlgProc.h
@@ -81,9 +81,9 @@ class plPassAnimDlgProc : public ParamMap2UserDlgProc, public plMtlChangeCallbac
         virtual void SetThing(ReferenceTarget *m);
         virtual void Update(TimeValue t, Interval& valid, IParamMap2* pmap);
 
-        void    SegmentListChanged( void );
+        void    SegmentListChanged();
 
-        static plPassAnimDlgProc    &Get( void );
+        static plPassAnimDlgProc    &Get();
 
     protected:
         // Set all the controls to their stored value

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plPassMtlBase.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plPassMtlBase.cpp
@@ -151,14 +151,14 @@ plPassMtlBase::~plPassMtlBase()
     }
 }
 
-void    plPassMtlBase::Reset( void ) 
+void    plPassMtlBase::Reset()
 {
     fIValid.SetEmpty();
 }
 
 //// Stealth Accessors ///////////////////////////////////////////////////////
 
-int     plPassMtlBase::GetNumStealths( void )
+int     plPassMtlBase::GetNumStealths()
 {
     return IGetNumStealths( true );
 }
@@ -265,7 +265,7 @@ void    plPassMtlBase::UnregisterChangeCallback( plMtlChangeCallback *callback )
 //  Updates the list of stealth nodes in the anim paramBlock to match our
 //  list of anim segments.
 
-void    plPassMtlBase::IUpdateAnimNodes( void )
+void    plPassMtlBase::IUpdateAnimNodes()
 {
     // Our beautiful hack, to make sure we don't update until we actually are loaded
     if( fLoading )
@@ -327,7 +327,7 @@ void    plPassMtlBase::IUpdateAnimNodes( void )
 //// NameChanged /////////////////////////////////////////////////////////////
 //  Notify from NTWatcher so we can update the names of our stealth nodes
 
-void    plPassMtlBase::NameChanged( void )
+void    plPassMtlBase::NameChanged()
 {
     for( int idx = 0; idx < fAnimPB->Count( (ParamID)kPBAnimStealthNodes ); idx++ )
     {
@@ -340,7 +340,7 @@ void    plPassMtlBase::NameChanged( void )
 //// NoteTrackAdded/Removed //////////////////////////////////////////////////
 //  Notifies from NTWatcher so we can update our list of stealths
 
-void    plPassMtlBase::NoteTrackAdded( void )
+void    plPassMtlBase::NoteTrackAdded()
 {
     int     i;
 
@@ -362,7 +362,7 @@ void    plPassMtlBase::NoteTrackAdded( void )
     IUpdateAnimNodes();
 }
 
-void    plPassMtlBase::NoteTrackRemoved( void )
+void    plPassMtlBase::NoteTrackRemoved()
 {
     int         i;
     hsBitVector stillThere;
@@ -496,7 +496,7 @@ RefResult plPassMtlBase::NotifyRefChanged( Interval changeInt, RefTargetHandle h
 //        callbacks don't work because they're called right after our object
 //        is loaded but not necessarily before the notetracks are attached)
 
-void    plPassMtlBase::PostLoadAnimPBFixup( void )
+void    plPassMtlBase::PostLoadAnimPBFixup()
 {
     SetLoadingFlag( false );
 

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plPassMtlBase.h
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plPassMtlBase.h
@@ -293,8 +293,8 @@ public:
 class plMtlChangeCallback
 {
     public:
-        virtual void    NoteTrackListChanged() { ; }
-        virtual void    SegmentListChanged() { ; }
+        virtual void    NoteTrackListChanged() { }
+        virtual void    SegmentListChanged() { }
 };
 
 #endif // PL_PASSMTLBASE_H

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plPassMtlBase.h
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plPassMtlBase.h
@@ -79,7 +79,7 @@ protected:
     bool                            fStealthsChanged;
     hsTArray<plMtlChangeCallback *> fChangeCallbacks;
 
-    void                IUpdateAnimNodes( void );
+    void                IUpdateAnimNodes();
     plAnimStealthNode   *IFindStealth( const ST::string &animName );
     plAnimStealthNode   *IVerifyStealthPresent( const ST::string &animName );
 
@@ -110,21 +110,21 @@ public:
         kRefNotetracks  = 4 // MUST BE THE LAST REF ID SPECIFIED
     };
     void    SetLoadingFlag( bool f ) { fLoading = f; }
-    void    PostLoadAnimPBFixup( void );
+    void    PostLoadAnimPBFixup();
 
     void    RegisterChangeCallback( plMtlChangeCallback *callback );
     void    UnregisterChangeCallback( plMtlChangeCallback *callback );
 
     // Change notifys from our ntWatcher
-    virtual void    NoteTrackAdded( void );
-    virtual void    NoteTrackRemoved( void );
-    virtual void    NameChanged( void );
+    virtual void    NoteTrackAdded();
+    virtual void    NoteTrackRemoved();
+    virtual void    NameChanged();
 
     // Loading/Saving
     IOResult Load(ILoad *iload);
     IOResult Save(ISave *isave);
 
-    virtual void    Reset( void );
+    virtual void    Reset();
 
     int                     NumRefs();
     virtual RefTargetHandle GetReference( int i );
@@ -135,7 +135,7 @@ public:
     virtual bool    SetupProperties( plMaxNode *node, plErrorMsg *pErrMsg );
     virtual bool    ConvertDeInit( plMaxNode *node, plErrorMsg *pErrMsg );
 
-    int                 GetNumStealths( void );
+    int                 GetNumStealths();
     plAnimStealthNode   *GetStealth( int index );
 
     // Static convert to our plPassMtlBase type, if possible
@@ -293,8 +293,8 @@ public:
 class plMtlChangeCallback
 {
     public:
-        virtual void    NoteTrackListChanged( void ) { ; }
-        virtual void    SegmentListChanged( void ) { ; }
+        virtual void    NoteTrackListChanged() { ; }
+        virtual void    SegmentListChanged() { ; }
 };
 
 #endif // PL_PASSMTLBASE_H

--- a/Sources/Tools/MaxPlasmaMtls/plDetailCurveCtrl.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/plDetailCurveCtrl.cpp
@@ -122,7 +122,7 @@ void    plDetailCurveCtrl::IRegisterCtrl( HINSTANCE instance )
     fClassRefCnt++;
 }
 
-void    plDetailCurveCtrl::IUnregisterCtrl( void )
+void    plDetailCurveCtrl::IUnregisterCtrl()
 {
     fClassRefCnt--;
     if( fClassRefCnt == 0 )
@@ -192,7 +192,7 @@ plDetailCurveCtrl::~plDetailCurveCtrl()
 //  any good, 'cause it's black-and-white (right, THAT makes sense). Grabbing
 //  the desktop DC works, however.
 
-void    plDetailCurveCtrl::IInitDblBuffer( void )
+void    plDetailCurveCtrl::IInitDblBuffer()
 {
     if( fDblDC == NULL )
     {
@@ -220,7 +220,7 @@ void    plDetailCurveCtrl::IInitDblBuffer( void )
 
 //// IRefreshDblBuffer ////////////////////////////////////////////////////////
 
-void    plDetailCurveCtrl::IRefreshDblBuffer( void )
+void    plDetailCurveCtrl::IRefreshDblBuffer()
 {
     HDC         hBgndDC;
     RECT        clientRect, r;

--- a/Sources/Tools/MaxPlasmaMtls/plDetailCurveCtrl.h
+++ b/Sources/Tools/MaxPlasmaMtls/plDetailCurveCtrl.h
@@ -95,8 +95,8 @@ class plDetailCurveCtrl
         float   fStartPercent, fEndPercent;
         float   fStartOpac, fEndOpac;
 
-        void    IInitDblBuffer( void );
-        void    IRefreshDblBuffer( void );
+        void    IInitDblBuffer();
+        void    IRefreshDblBuffer();
         void    IDrawCurve( HDC hDC, bool clampToInts, int cornerX, int cornerY, SIZE *bgndSize );
 
         float   IXlateDistToValue( float dist, bool clampToInts );
@@ -118,7 +118,7 @@ class plDetailCurveCtrl
 #endif
 
         static void IRegisterCtrl( HINSTANCE instance );
-        static void IUnregisterCtrl( void );
+        static void IUnregisterCtrl();
 
         static LRESULT CALLBACK IWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam );
 

--- a/Sources/Tools/MaxPlasmaMtls/plMtlImport.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/plMtlImport.cpp
@@ -57,7 +57,7 @@ extern ClassDesc2* GetStealthClassDesc();
 extern ClassDesc2* GetBinkClassDesc();
 extern ClassDesc2* GetMAXCameraLayerDesc();
 
-int         plPlasmaMtlImport::GetNumMtlDescs( void )
+int         plPlasmaMtlImport::GetNumMtlDescs()
 {
     return 15;
 }

--- a/Sources/Tools/MaxPlasmaMtls/plMtlImport.h
+++ b/Sources/Tools/MaxPlasmaMtls/plMtlImport.h
@@ -46,7 +46,7 @@ class ClassDesc2;
 
 namespace plPlasmaMtlImport
 {
-    int         GetNumMtlDescs( void );
+    int         GetNumMtlDescs();
     ClassDesc2  *GetMtlDesc( int i );
 };
 


### PR DESCRIPTION
This applies a couple of tool-assisted minor code style cleanups to the source:
* Replace function parameters of the C-style `(void)` syntax with C++-style `()`
* Replace empty function bodies with a stray `;` with `{ }`

Note that none of the above cleanups modify the code in any way -- only the code style.