### PR TITLE
Fix ptVaultNode's richcompare function.

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
@@ -316,6 +316,7 @@ protected:
 
 public:
     bool IsDirty() const { return fDirtyFields != 0; }
+    bool IsUsed() const { return fUsedFields != 0; }
 
     plUUID GetRevision() const { return fRevision; }
     void GenerateRevision() { fRevision = plUUID::Generate(); }


### PR DESCRIPTION
The Cyan standard function did not properly handle comparing vault nodes with incompatible types, which is expected to return False. Instead, they tried to return an exception. Unfortunately, they did this incorrectly by returning a value of -1, which was interpreted to be a result of True.

This resulted in interesting things like `node == "Ahnonay"` evaluating to True. See also H-uru/moul-scripts#120