### PR TITLE
Make hsTArray::SetCountAndZero safer.

### DIFF
--- a/Sources/Plasma/CoreLib/hsTemplates.h
+++ b/Sources/Plasma/CoreLib/hsTemplates.h
@@ -668,6 +668,9 @@ template <class T> void hsTArray<T>::Swap( hsTArray<T>& src )
 
 template <class T> void hsTArray<T>::SetCountAndZero(int count)
 {
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Cannot use SetCountAndZero on non-trivially copyable types");
+
     if( fTotalCount <= count )
     {
         int n = fTotalCount;
@@ -681,6 +684,9 @@ template <class T> void hsTArray<T>::SetCountAndZero(int count)
 
 template <class T> void hsTArray<T>::ExpandAndZero(int count)
 {
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Cannot use ExpandAndZero on non-trivially copyable types");
+
     if( fTotalCount <= count )
     {
         int n = fTotalCount;
@@ -1041,6 +1047,9 @@ template <class T> void hsLargeArray<T>::Swap( hsLargeArray<T>& src )
 
 template <class T> void hsLargeArray<T>::SetCountAndZero(int count)
 {
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Cannot use SetCountAndZero on non-trivially copyable types");
+
     if( fTotalCount <= count )
     {
         int n = fTotalCount;
@@ -1052,6 +1061,9 @@ template <class T> void hsLargeArray<T>::SetCountAndZero(int count)
 
 template <class T> void hsLargeArray<T>::ExpandAndZero(int count)
 {
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Cannot use ExpandAndZero on non-trivially copyable types");
+
     if( fTotalCount <= count )
     {
         int n = fTotalCount;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
@@ -242,7 +242,7 @@ void    pfGUIPopUpMenu::Read( hsStream *s, hsResMgr *mgr )
     fMargin = s->ReadLE16();
 
     uint32_t i, count = s->ReadLE32();
-    fMenuItems.SetCountAndZero( count );
+    fMenuItems.SetCount( count );
     for( i = 0; i < count; i++ )
     {
         char readTemp[ 256 ];

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.h
@@ -95,7 +95,7 @@ class pfGUIPopUpMenu : public pfGUIDialogMod
                 pfGUIPopUpMenu      *fSubMenu;
                 float               fYOffsetToNext;     // Filled in by IBuildMenu()
 
-                pfMenuItem& operator=(const int zero) { fName = L""; fHandler = nil; fSubMenu = nil; fYOffsetToNext = 0; return *this; }
+                pfMenuItem() : fHandler(), fSubMenu(), fYOffsetToNext() { }
         };
 
         // Array of info to rebuild our menu from. Note that this is ONLY used when rebuilding


### PR DESCRIPTION
Ensure hsTArray::SetCountAndZero/ExpandAndZero are only used on trivially copyable types where it is safe to do so.  Fixes one use case which was previously unsafe (memsetting a std::wstring)