### PR TITLE
Updates for MSVC 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ be expected to change.
 
 PhysX and DirectX SDK will need to be acquired through the above links.
 All other required libraries are available as precompiled binaries and
-associated files in the [development libraries bundle](https://github.com/H-uru/PlasmaPrefix/releases/download/20200114/devlibs.zip)
+associated files in the [development libraries bundle](https://github.com/H-uru/PlasmaPrefix/releases/download/2020.05.01/devlibs.zip)
 or can be built using their individual build instructions.
 
 
@@ -61,7 +61,7 @@ Compiling Instructions
 ----------------------
 
 Currently, compilation only targets Windows systems and requires Visual Studio
-2015 (including Visual Studio 2015 Community).
+2017 (including Visual Studio 2017 Community).
 
 **Quick-start instructions:**
 
@@ -80,10 +80,10 @@ Currently, compilation only targets Windows systems and requires Visual Studio
 3. Set the *Where to build the binaries* option to a subfolder of the
    aforementioned location called *build*.
 4. Check the **Grouped** and **Advanced** options.
-5. Press **Configure**. Select *Visual Studio 14* as the generator.
+5. Press **Configure**. Select *Visual Studio 15 2017* as the generator.
 6. Set the *CMAKE_INSTALL_PREFIX* option under CMAKE to the *cwe-prefix* folder
    that you extracted from the [development libraries
-   bundle](https://github.com/H-uru/PlasmaPrefix/releases/download/20200114/devlibs.zip).
+   bundle](https://github.com/H-uru/PlasmaPrefix/releases/download/2020.05.01/devlibs.zip).
 7. Press **Configure** again.
 8. Press **Generate**. You will now have a Visual Studio solution file (.sln)
    in the folder that you specified to build the binaries in.

--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -194,6 +194,7 @@ if (WIN32)
     target_link_libraries(plClient winmm)
     target_link_libraries(plClient strmiids)
     target_link_libraries(plClient crypt32)
+    target_link_libraries(plClient wldap32)
 endif(WIN32)
 
 source_group("Source Files" FILES ${plClient_SOURCES})

--- a/Sources/Plasma/Apps/plUruLauncher/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plUruLauncher/CMakeLists.txt
@@ -68,6 +68,7 @@ if(WIN32)
     target_link_libraries(plUruLauncher rpcrt4)
     target_link_libraries(plUruLauncher comctl32)
     target_link_libraries(plUruLauncher crypt32)
+    target_link_libraries(plUruLauncher wldap32)
 endif()
 
 source_group("Source Files" FILES ${plUruLauncher_SOURCES})

--- a/prepare_env.ps1
+++ b/prepare_env.ps1
@@ -1,4 +1,4 @@
-$devlibs_url = "https://github.com/H-uru/PlasmaPrefix/releases/download/20200114/devlibs.zip"
+$devlibs_url = "https://github.com/H-uru/PlasmaPrefix/releases/download/2020.05.01/devlibs.zip"
 
 if (!(Test-Path -PathType Container build)) {
     Write-Host "Creating build folder... " -noNewLine
@@ -28,7 +28,7 @@ if (!(Test-Path -PathType Container devlibs)) {
 
 if (Get-ChildItem Env:PATH | Where-Object {$_.Value -match "CMake"}) {
     Write-Host "Running CMake to configure build system... "
-    cmake -DCMAKE_INSTALL_PREFIX=devlibs -DPLASMA_BUILD_TOOLS=OFF -DPLASMA_BUILD_RESOURCE_DAT=OFF -G "Visual Studio 14" ..
+    cmake -DCMAKE_INSTALL_PREFIX=devlibs -DPLASMA_BUILD_TOOLS=OFF -DPLASMA_BUILD_RESOURCE_DAT=OFF -G "Visual Studio 15 2017" ..
 } else {
     Write-Host "CMake not found in PATH."
     Write-Host "Please run the CMake installer and select the option to add CMake to your system PATH."


### PR DESCRIPTION
* Update documentation to refer to MSVC 2017 instead of 2015
* Update documentation and prepare_env.ps1 for new devlibs
* Fix apps that link against libcurl to now also link wldap32