### PR TITLE
Updates for C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(Plasma)
 
-# Require C++14 (Note: VC++ 2013 will ignore this)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/Sources/Plasma/CoreLib/hsAlignedAllocator.hpp
+++ b/Sources/Plasma/CoreLib/hsAlignedAllocator.hpp
@@ -47,12 +47,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <stdexcept>
 #include <new>
 
-template<class T, size_t ALIGNMENT=16>
-
 /**
  * An aligned allocator for storing SIMD ready values in STL containers
  * \remarks Based on https://gist.github.com/donny-dont/1471329
  */
+template<class T, size_t ALIGNMENT=16>
 class hsAlignedAllocator
 {
     hsAlignedAllocator& operator=(const hsAlignedAllocator&) { }
@@ -72,28 +71,28 @@ public:
     typedef size_t size_type;
     typedef ptrdiff_t difference_type;
 
-    hsAlignedAllocator() { }
-    hsAlignedAllocator(const hsAlignedAllocator&) { }
-    template <typename U> hsAlignedAllocator(const hsAlignedAllocator<U, ALIGNMENT>&) { }
+    typedef std::true_type propagate_on_container_move_assignment;
+    typedef std::true_type is_always_equal;
+
+    constexpr hsAlignedAllocator() noexcept { }
+    constexpr hsAlignedAllocator(const hsAlignedAllocator&) noexcept { }
+
+    template <typename U>
+    constexpr hsAlignedAllocator(const hsAlignedAllocator<U, ALIGNMENT>&) noexcept { }
+
     ~hsAlignedAllocator() { }
 
-    pointer address(reference r) const { return &r; }
-    const_pointer address(const_reference r) const { return &r; }
+    pointer address(reference r) const noexcept { return &r; }
+    const_pointer address(const_reference r) const noexcept { return &r; }
 
     pointer allocate(size_type size, const_pointer hint=nullptr)
     {
         if (size == 0)
             return nullptr;
         if (size > max_size())
-            throw std::length_error("integer overflow");
+            throw std::bad_array_new_length();
 
-#ifdef HS_BUILD_FOR_WIN32
-        void* ptr = _aligned_malloc(size * sizeof(value_type), ALIGNMENT);
-#else
-        void* ptr = nullptr;
-        posix_memalign(&ptr, ALIGNMENT, size * sizeof(value_type));
-#endif // HS_BUILD_FOR_WIN32
-
+        void* ptr = ::operator new(size * sizeof(value_type), std::align_val_t{ALIGNMENT});
         if (!ptr)
             throw std::bad_alloc();
         return static_cast<pointer>(ptr);
@@ -108,24 +107,21 @@ public:
 
     void deallocate(pointer ptr, size_type size)
     {
-#ifdef HS_BUILD_FOR_WIN32
-        _aligned_free(ptr);
-#else
-        free(ptr);
-#endif // HS_BUILD_FOR_WIN32
+        (void)size;
+        ::operator delete(reinterpret_cast<void *>(ptr), std::align_val_t{ALIGNMENT});
     }
 
-    void destroy(T* const p) const
+    void destroy(T* const p) const noexcept(noexcept(p->~T()))
     {
         p->~T();
     }
 
-    size_type max_size() const
+    constexpr size_type max_size() const noexcept
     {
-        return static_cast<size_t>(-1) / sizeof(value_type);
+        return std::numeric_limits<size_type>::max() / sizeof(value_type);
     }
 
-    bool operator==(const hsAlignedAllocator& other) const { return true; }
+    constexpr bool operator==(const hsAlignedAllocator& other) const noexcept { return true; }
 };
 
 #endif // _HS_ALIGNED_ALLOCATOR_H

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
@@ -1990,7 +1990,7 @@ void plDrawableSpans::SortVisibleSpans(const hsTArray<int16_t>& visList, plPipel
 #endif // MF_CHUNKSORT
 }
 
-struct buffTriCmpBackToFront : public std::binary_function<plGBufferTriangle, plGBufferTriangle, bool>
+struct buffTriCmpBackToFront
 {
     hsPoint3 fViewPos;
     buffTriCmpBackToFront(const hsPoint3& p) : fViewPos(p) {}
@@ -2001,7 +2001,7 @@ struct buffTriCmpBackToFront : public std::binary_function<plGBufferTriangle, pl
     }
 };
 
-struct buffTriCmpFrontToBack : public std::binary_function<plGBufferTriangle, plGBufferTriangle, bool>
+struct buffTriCmpFrontToBack
 {
     hsPoint3 fViewPos;
     buffTriCmpFrontToBack(const hsPoint3& p) : fViewPos(p) {}

--- a/Sources/Plasma/PubUtilLib/plDrawable/plVisLOSMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plVisLOSMgr.cpp
@@ -114,7 +114,7 @@ bool plVisLOSMgr::ICheckSpaceTreeRecur(plSpaceTree* space, int which, hsTArray<p
     return false;
 }
 
-struct plCompSpaceHit : public std::binary_function<plSpaceHit, plSpaceHit, bool>
+struct plCompSpaceHit
 {
     bool operator()( const plSpaceHit& lhs, const plSpaceHit& rhs) const
     {

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -2388,7 +2388,7 @@ struct plSortFace
     float    fDist;
 };
 
-struct plCompSortFace : public std::binary_function<plSortFace, plSortFace, bool>
+struct plCompSortFace
 {
     bool operator()( const plSortFace& lhs, const plSortFace& rhs) const
     {

--- a/Sources/Tools/MaxMain/plMaxNode.cpp
+++ b/Sources/Tools/MaxMain/plMaxNode.cpp
@@ -2075,8 +2075,6 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
     plLocation nodeLoc = GetLocation();
 
     bool moving = IsMovable();
-    if( moving )
-        moving++;
 
     Matrix3 tmp(true);
 


### PR DESCRIPTION
* Compatibility fixes with changed/removed features
* Use C++17's built-in aligned `operator new` instead of platform-specific memory allocation in `hsAlignedAllocator`

TODO: Python 2.7's headers now spit out a bunch of warnings due to the deprecation of the `register` keyword in C++17