### PR TITLE
Let the Bahro Smoke in Peace.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIProgressCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIProgressCtrl.h
@@ -69,7 +69,7 @@ class pfGUIProgressCtrl : public pfGUIValueCtrl
 
         bool            ICalcAnimTimes();
 
-        const uint32_t  fStopSoundTimer;
+        const int32_t  fStopSoundTimer;
 
     public:
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -294,7 +294,7 @@ void cyMisc::PopUpConsole(const char* command)
 //
 //  PURPOSE    : Execute a console command from a python script
 //
-void cyMisc::TimerCallback(pyKey& selfkey, float time, uint32_t id)
+void cyMisc::TimerCallback(pyKey& selfkey, float time, int32_t id)
 {
     // setup the message to come back to whoever the pyKey is pointing to
     plTimerCallbackMsg* pTimerMsg = new plTimerCallbackMsg(selfkey.getKey(),id);

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -167,7 +167,7 @@ public:
     //
     //  PURPOSE    : Execute a console command from a python script
     //
-    static void TimerCallback(pyKey& selfkey, float time, uint32_t id);
+    static void TimerCallback(pyKey& selfkey, float time, int32_t id);
 
     /////////////////////////////////////////////////////////////////////////////
     //

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
@@ -142,15 +142,15 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtAtTimeCallback, args, "Params: selfkey,time,id
 {
     PyObject* keyObj = NULL;
     float time;
-    unsigned long id;
-    if (!PyArg_ParseTuple(args, "Ofl", &keyObj, &time, &id))
+    int id;
+    if (!PyArg_ParseTuple(args, "Ofi", &keyObj, &time, &id))
     {
-        PyErr_SetString(PyExc_TypeError, "PtAtTimeCallback expects a ptKey, a float, and an unsigned long");
+        PyErr_SetString(PyExc_TypeError, "PtAtTimeCallback expects a ptKey, a float, and an int");
         PYTHON_RETURN_ERROR;
     }
     if (!pyKey::Check(keyObj))
     {
-        PyErr_SetString(PyExc_TypeError, "PtAtTimeCallback expects a ptKey, a float, and an unsigned long");
+        PyErr_SetString(PyExc_TypeError, "PtAtTimeCallback expects a ptKey, a float, and an int");
         PYTHON_RETURN_ERROR;
     }
     pyKey* key = pyKey::ConvertFrom(keyObj);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plCoopCoordinator.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plCoopCoordinator.cpp
@@ -68,7 +68,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plTimerCallbackManager.h"
 #include "plMessage/plTimerCallbackMsg.h"
 
-const unsigned kAbortTimer = 1;
+const int kAbortTimer = 1;
 const float kAbortTimerDuration = 15; // 15 seconds
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plMessage/plTimerCallbackMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plTimerCallbackMsg.h
@@ -52,13 +52,13 @@ class plTimerCallbackMsg : public plMessage
 public:
     plTimerCallbackMsg() { }
     plTimerCallbackMsg(const plKey &s, const plKey &r, const double* t) { }
-    plTimerCallbackMsg(const plKey &r, uint32_t id = 0) { AddReceiver(r); fID = id;}
+    plTimerCallbackMsg(const plKey &r, int32_t id = 0) { AddReceiver(r); fID = id;}
     ~plTimerCallbackMsg() { }
 
     CLASSNAME_REGISTER( plTimerCallbackMsg );
     GETINTERFACE_ANY( plTimerCallbackMsg, plMessage );
-    
-    uint32_t fID;
+
+    int32_t fID;
     float fTime;
 
     virtual void Read(hsStream* stream, hsResMgr* mgr)

--- a/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
@@ -167,9 +167,9 @@ bool plResponderModifier::MsgReceive(plMessage* msg)
     plTimerCallbackMsg *timerMsg = plTimerCallbackMsg::ConvertNoRef(msg);
     if (pEventMsg || timerMsg)
     {
-        uint32_t waitID = pEventMsg ? pEventMsg->fUser : timerMsg->fID;
+        int32_t waitID = pEventMsg ? pEventMsg->fUser : timerMsg->fID;
 
-        if (waitID != -1)
+        if (waitID >= 0)
         {
             // Flag that this callback completed and try sending in case any commands were waiting on this
             fCompletedEvents.SetBit(waitID);

--- a/Sources/Tools/MaxComponent/plResponderLink.cpp
+++ b/Sources/Tools/MaxComponent/plResponderLink.cpp
@@ -1231,7 +1231,7 @@ plMessage *plResponderCmdDelay::CreateMsg(plMaxNode* node, plErrorMsg *pErrMsg, 
 
     plTimerCallbackMsg *msg = new plTimerCallbackMsg;
     msg->fTime = time;
-    msg->fID = uint32_t(-1);
+    msg->fID = -1;
 
     return msg;
 }
@@ -1241,7 +1241,7 @@ void plResponderCmdDelay::CreateWait(plMaxNode* node, plErrorMsg* pErrMsg, IPara
     plTimerCallbackMsg *timerMsg = plTimerCallbackMsg::ConvertNoRef(waitInfo.msg);
     hsAssert(timerMsg, "Somebody is crazy");
 
-    if (timerMsg->fID != uint32_t(-1))
+    if (timerMsg->fID >= 0)
     {
         pErrMsg->Set(true,
                     "Responder Delay",


### PR DESCRIPTION
This issue was exposed by #601. The Relto bahro pole smokers would intentionally use a negative value as the timer callback ID. While this is strictly speaking not kosher according to the `PtAtTimeCallback` docstring, the implementation gladly accepted signed integers. Additionally, throughout the code, -1 was used as a magic value. Therefore, we fix everyone to use signed integers for timer callback IDs. plPythonFileMod is now correctly passing signed values to the PFM's `OnTimer` method.

Fixes the observed Relto traceback:
(05/17 16:02:38) cPythBahroPoles - Traceback (most recent call last):
(05/17 16:02:38)   File ".\python\psnlBahroPoles.py", line 679, in OnTimer
(05/17 16:02:38)     self.RunState(self.PoleIDMap[ageID], state, 0)
(05/17 16:02:38) KeyError: 429496729