### PR TITLE
Kill `exec(code)`

### DIFF
--- a/Scripts/Python/kdshShadowPath.py
+++ b/Scripts/Python/kdshShadowPath.py
@@ -157,11 +157,8 @@ class kdshShadowPath(ptResponder):
             PtDebugPrint("\t ShadowPathLight0%s = %s " % (light, lightstate))
             
             if lightstate == 1:
-                
-                code = "respSwitch0" + str(light) + ".run(self.key,fastforward=1)"
-                exec(code)
-               
-                PtDebugPrint("\t\tTurning on light #", light)
+                globals()["respSwitch0{}".format(light)].run(self.key, fastforward=True)
+                PtDebugPrint("\t\tTurning on light #", light, level=kWarningLevel)
         
         solved = ageSDL["ShadowPathSolved"][0]
         if solved:
@@ -214,8 +211,7 @@ class kdshShadowPath(ptResponder):
                 return
 
             PtDebugPrint("Light ", id, " clicked.")
-            code = 'respBtnPush0' + str(id) + '.run(self.key,events=events)'
-            exec(code)
+            globals()["respBtnPush0{}".format(id)].run(self.key, events=events)
 
         elif id in [26,27,28,29,30]: 
             if lightClickedByAvatar != localAvatar:  #Make sure we don't have any rogue avatars reporting...
@@ -260,14 +256,11 @@ class kdshShadowPath(ptResponder):
             
             #turn off the lights
             for light in [1,2,3,4,5]:
-                lightstate = ageSDL["ShadowPathLight0" + str(light)][0]  
-                if lightstate == 1:
-                    code = 'ageSDL["ShadowPathLight0' + str(light) + '"] = (0,)'
-                    PtDebugPrint("resetcode = ", code)
-                    exec(code)
-                        
-                    PtDebugPrint("\tTurning off light #", light)
-                    
+                var = "ShadowPathLight0{}".format(light)
+                if ageSDL[var][0]:
+                    ageSDL[var] = (0,)
+                    PtDebugPrint("\tTurning off light #", light, level=kWarningLevel)
+
             #...and close the floor
             ageSDL["ShadowPathSolved"] = (0,)
             
@@ -290,20 +283,15 @@ class kdshShadowPath(ptResponder):
                 
             newstate = ageSDL["ShadowPathLight0" + str(light)][0] 
 
+            resp = globals()["respSwitch0{}".format(light)]
             if newstate == 0: # true if that switch is now off
-                PtDebugPrint("kdshShadowPath.OnSDLNotify: Light", light," was on. Turning it off.")
-                code = "respSwitch0" + str(light) + ".run(self.key, state='off')"
-                #~ PtDebugPrint("off code = ", code)
-                exec(code)
-                
+                PtDebugPrint("kdshShadowPath.OnSDLNotify: Light", light," was on. Turning it off.", level=kWarningLevel)
+                resp.run(self.key, state="off")
             elif newstate == 1: # true if that switch is now on
-                PtDebugPrint("kdshShadowPath.OnSDLNotify: Light", light," was off. Turning it on.")
-                code = "respSwitch0" + str(light) + ".run(self.key, state='on')"
-                #~ PtDebugPrint("On code = ", code)
-                exec(code)
-
+                PtDebugPrint("kdshShadowPath.OnSDLNotify: Light", light," was off. Turning it on.", level=kWarningLevel)
+                resp.run(self.key, state="on")
             else: 
-                PtDebugPrint("Error. Not sure what the light thought it was.")
+                PtDebugPrint("kdshShadowPath.OnSDLNotify: Error. Not sure what the light thought it was.")
 
 '''
     def BatonPassCheck(self,id,events,ageSDL):

--- a/Scripts/Python/kdshTreeRingsSolution.py
+++ b/Scripts/Python/kdshTreeRingsSolution.py
@@ -241,45 +241,15 @@ class kdshTreeRingsSolution(ptModifier):
         self.InitRings()
 
     def InitRings(self):
-        ageSDL = PtGetAgeSDL()        
-        
-        OuterRing01 = ageSDL["OuterRing01"][0]
-        MiddleRing01 = ageSDL["MiddleRing01"][0]
-        InnerRing01 = ageSDL["InnerRing01"][0]
-        OuterRing02 = ageSDL["OuterRing02"][0]
-        MiddleRing02 = ageSDL["MiddleRing02"][0]
-        InnerRing02 = ageSDL["InnerRing02"][0]
-        OuterRing03 = ageSDL["OuterRing03"][0]
-        MiddleRing03 = ageSDL["MiddleRing03"][0]
-        InnerRing03 = ageSDL["InnerRing03"][0]
+        PtDebugPrint("kdshTreeRingSolution: When I got here:", level=kWarningLevel)
 
-        PtDebugPrint("kdshTreeRingSolution: When I got here:")
-        #~ PtDebugPrint("\tOuterRing01=",OuterRing01)
-        #~ PtDebugPrint("\tMiddleRing01=",MiddleRing01)
-        #~ PtDebugPrint("\tInnerRing01=",InnerRing01)
-        #~ PtDebugPrint("\tOuterRing02=",OuterRing02)
-        #~ PtDebugPrint("\tMiddleRing02=",MiddleRing02)
-        #~ PtDebugPrint("\tInnerRing02=",InnerRing02)
-        #~ PtDebugPrint("\tOuterRing03=",OuterRing03)
-        #~ PtDebugPrint("\tMiddleRing03=",MiddleRing03)
-        #~ PtDebugPrint("\tInnerRing03=",InnerRing03)
-
-        for i in ["Outer", "Middle", "Inner"]:
-            for j in ["1","2","3"]:
-                
-                ffcode1 = "InitState = "+i + "Ring0" +j
-                #~ PtDebugPrint("ffcode1 = ", ffcode1)
-                
-                exec(ffcode1)
-                #~ PtDebugPrint("InitState = ", InitState)
-                
-                ffcode2 = i + "Ring0" + j + "_0" + str(InitState) + ".animation.skipToEnd()"
-                #~ PtDebugPrint("ffcode2 = ", ffcode2)
-                
-                exec(ffcode2)
-            
-                #~ PtDebugPrint("Fastforwarding: Set = ",j," Ring = ",i," Position = ",InitState)
-                PtDebugPrint("\t",i,"Ring0",j," = ", InitState)
+        ageSDL = PtGetAgeSDL()
+        for i in ("Outer", "Middle", "Inner"):
+            for j in ("1", "2", "3"):
+                ring = "{location}Ring0{idx}".format(location=i, idx=j)
+                ring_attrib = "{ring}_0{bearing}".format(ring=ring, bearing=ageSDL[ring][0])
+                globals()[ring_attrib].animation.skipToEnd()
+                PtDebugPrint("\t{} = {}".format(ring, ageSDL[ring][0]), level=kWarningLevel)
 
         
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
@@ -290,10 +260,7 @@ class kdshTreeRingsSolution(ptModifier):
         StillSolved = False
         newbearing = ageSDL[VARname][0]
         #~ PtDebugPrint("VARname = ", VARname, "newbear = ", newbearing)
-        
-        code = VARname + "_0" + str(newbearing) + ".animation.play()"
-        #~ PtDebugPrint("code = ", code)
-        exec(code) # this runs the animation on the actual ring in the garden
+        globals()["{id}_0{bearing}".format(id=VARname, bearing=newbearing)].animation.play()
         
         if "3" in VARname: 
             #~ PtDebugPrint("TRS: Nothing to ff. VARname = ", VARname)
@@ -357,27 +324,13 @@ class kdshTreeRingsSolution(ptModifier):
         if ageSDL == None:
             PtDebugPrint("kdshTreeRings.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value)
 
-        Outerbearing = ageSDL["OuterRing0" + str(ScopeNumber-1)][0]
-        Middlebearing = ageSDL["MiddleRing0" + str(ScopeNumber-1)][0]
-        Innerbearing = ageSDL["InnerRing0" + str(ScopeNumber-1)][0]
+        for bearing in ("Outer", "Middle", "Inner"):
+            sdl_var = "{location}Ring0{idx}".format(location=bearing, idx=ScopeNumber-1)
+            attrib_name = "GUI{location}0{idx}_0{newbearing}".format(location=bearing,
+                                                                     idx=ScopeNumber-1,
+                                                                     newbearing=ageSDL[sdl_var][0])
+            globals()[attrib_name].animation.skipToEnd()
 
-        #~ PtDebugPrint("Outerbearing = ", Outerbearing)
-        #~ PtDebugPrint("Middlebearing = ", Middlebearing)
-        #~ PtDebugPrint("Innerbearing = ", Innerbearing)
-        
-
-        GUIcode = "GUIOuter0" + str(ScopeNumber-1) + "_0" + str(Outerbearing) + ".animation.skipToEnd()"
-        #~ PtDebugPrint("FF Outer code = ", GUIcode)
-        exec(GUIcode) 
-
-        GUIcode = "GUIMiddle0" + str(ScopeNumber-1) + "_0" + str(Middlebearing) + ".animation.skipToEnd()"
-        #~ PtDebugPrint("FF Middle code = ", GUIcode)
-        exec(GUIcode) 
-
-        GUIcode = "GUIInner0" + str(ScopeNumber-1) + "_0" + str(Innerbearing) + ".animation.skipToEnd()"
-        #~ PtDebugPrint("FF Inner code = ", GUIcode)
-        exec(GUIcode) 
-        
         # this runs the animation on the "fake" ring in front of the GUI
         #~ animname= "GUI{id}_0{bearing}".format(id="".join(VARname.split("Ring")), bearing=newbearing)
         #~ globals()[animname].animation.play()

--- a/Scripts/Python/kdshVault.py
+++ b/Scripts/Python/kdshVault.py
@@ -357,15 +357,11 @@ class kdshVault(ptResponder):
             #~ PtDebugPrint("kdshVault.OnSDLNotify: lastbuttonpushed = ", lastbuttonpushed)
             
             #run the animation on the button itself
-            code = "respButton" + str(lastbuttonpushed) + ".run(self.key)"
-            #~ PtDebugPrint("code = ", code)
-            exec(code)
-        
+            globals()["respButton{}".format(lastbuttonpushed)].run(self.key)
+
             #disable the clickable for that button
-            code = "actButton" + str(lastbuttonpushed) + ".disable()"
-            #~ PtDebugPrint("code = ", code)
-            exec(code)
-        
+            globals()["actButton{}".format(lastbuttonpushed)].disable()
+
     def OnTimer(self,id):
         global VaultDoorMoving
 

--- a/Scripts/Python/minkDayClicks.py
+++ b/Scripts/Python/minkDayClicks.py
@@ -136,5 +136,4 @@ class minkDayClicks(ptResponder):
             if id != behRespCage.id:
                 num = ResponderId.index(id) + 1
                 PtDebugPrint("minkDayClicks.OnNotify(): Should show %d" % (num))
-                code = "ageSDL[\"minkSymbolShow0%d\"] = (1,)" % (num)
-                exec(code)
+                ageSDL["minkSymbolShow0%d" % num] = (1,)

--- a/Scripts/Python/minkSymbols.py
+++ b/Scripts/Python/minkSymbols.py
@@ -200,14 +200,10 @@ class minkSymbols(ptResponder):
 
         if id in RegionToResponder.viewkeys():
             PtDebugPrint("minkSymbols.OnNotify(): Region %d triggered" % (id))
-            code = "regCave0" + str(id) + ".disable()"
-            exec(code)
+            globals()["regCave0{}".format(id)].disable()
 
             ageSDL = PtGetAgeSDL()
-            code = "ageSDL[\"minkSymbolPart0" + str(id) + "\"] = (1,)"
-            exec(code)
-
-            code = "ageSDL[\"minkSymbolTouch0" + str(id) + "\"] = (1,)"
-            exec(code)
+            ageSDL["minkSymbolPart0{}".format(id)] = (1,)
+            ageSDL["minkSymbolTouch0{}".format(id)] = (1,)
 
             RegionToResponder[id].run(self.key)

--- a/Scripts/Python/tldnShroomieBrain.py
+++ b/Scripts/Python/tldnShroomieBrain.py
@@ -234,21 +234,9 @@ class tldnShroomieBrain(ptResponder):
 
         whichspawnpoint = random.randint(1,5)
 
-
-        if NearOrFar == "Near":
-            code = "target = SpawnNear0" + str(whichspawnpoint) + ".sceneobject.getKey()"        
-        elif NearOrFar == "Mid":
-            code = "target = SpawnMid0" + str(whichspawnpoint) + ".sceneobject.getKey()"            
-        elif NearOrFar == "Far":
-            code = "target = SpawnFar0" + str(whichspawnpoint) + ".sceneobject.getKey()"
-        PtDebugPrint("target code:", code)
-        exec(code)
-        ShroomieMaster.sceneobject.physics.warpObj(target)
-        
-        code = "respTrick0" + str(whichbehavior) + ".run(self.key)"
-        #~ PtDebugPrint("code = ", code)
-        exec(code)
-
+        target = globals()["Spawn{NearOrFar}0{SpawnPoint}".format(NearOrFar=NearOrFar, SpawnPoint=whichspawnpoint)]
+        ShroomieMaster.sceneobject.physics.warpObj(target.sceneobject.getKey())
+        globals()["respTrick0{}".format(whichbehavior)].run(self.key)
 
         CurrentTime = PtGetDniTime()
         ageSDL["ShroomieTimeLastSeen"] = (CurrentTime,)

--- a/Scripts/Python/xCheat.py
+++ b/Scripts/Python/xCheat.py
@@ -622,9 +622,8 @@ def ImportGames(args):
                     jfolder = agefolder
                     argresidual = argresidual[len(agefolder.folderGetName())+1:]
     if jfolder:
-        exec("import %s" % (filename))
-        exec("mgs = %s.mgs" % (filename))
-        for mg in mgs:
+        from importlib import import_module
+        for mg in import_module(filename).mgs:
             nMarkerFolder = Plasma.ptVaultMarkerListNode(PlasmaVaultConstants.PtVaultNodePermissionFlags.kDefaultPermissions)
             nMarkerFolder.folderSetName(mg[1])
             nMarkerFolder.setOwnerID(mg[0][0])
@@ -666,9 +665,8 @@ def ImportMarkers(args):
                     jfolder = agefolder
                     argresidual = argresidual[len(agefolder.folderGetName())+1:]
     if jfolder:
-        exec("import %s" % (filename))
-        exec("mgs = %s.mgs" % (filename))
-        for mg in mgs:
+        from importlib import import_module
+        for mg in import_module(filename).mgs:
             # need to try to find the game to stick these in
             jfolderRefs = jfolder.getChildNodeRefList()
             for jref in jfolderRefs:


### PR DESCRIPTION
This removes all uses of the `exec()` function from the Python scripts. This fixes an observed traceback in Python 3 related to exec statements with side effects. The code is also much cleaner as a result.

cPythScopeSolution - Traceback (most recent call last):
  File ".\python\kdshTreeRingsSolution.py", line 241, in OnServerInitComplete
    self.InitRings()
  File ".\python\kdshTreeRingsSolution.py", line 276, in InitRings
    ffcode2 = i + "Ring0" + j + "_0" + str(InitState) + ".animation.skipToEnd()"
NameError: name 'InitState' is not defined
