### PR TITLE
Update resource-building scripts for future compatibility.

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -12,6 +12,7 @@ jobs:
         sudo apt install cmake libcurl4-openssl-dev libopenal-dev libssl-dev \
           libogg-dev libopus-dev libspeex-dev uuid-dev libvpx-dev \
           libvorbis-dev qtbase5-dev
+        sudo pip install -r ${GITHUB_WORKSPACE}/requirements.txt
     - name: Build string_theory
       run: |
         mkdir -p build_deps && cd build_deps

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Plasma currently requires the following third-party libraries:
 
 The following libraries are optional:
 
-- (for building resource.dat) PyGTK - http://www.pygtk.org/downloads.html
+- (for building resource.dat) CairoSVG - https://cairosvg.org/
 - (for building resource.dat) Pillow - https://python-pillow.org/
 - (for plFontConverter) Freetype - http://freetype.org/
 - (for the GUI tools) Qt5 - http://www.qt.io/download-open-source/

--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -28,12 +28,14 @@ set_package_properties(PythonInterp PROPERTIES
 
 if(PYTHONINTERP_FOUND)
     include(FindPythonModule)
+
     # Test for Python modules needed to build resource.dat
-    find_python_module(rsvg)
+    find_python_module(cairosvg)
     find_python_module(PIL)
-    if((DEFINED PY_RSVG) AND (DEFINED PY_PIL))
+
+    if((DEFINED PY_CAIROSVG) AND (DEFINED PY_PIL))
         set(CAN_BUILD_RESOURCE_DAT ON)
-    endif((DEFINED PY_RSVG) AND (DEFINED PY_PIL))
+    endif((DEFINED PY_CAIROSVG) AND (DEFINED PY_PIL))
 endif(PYTHONINTERP_FOUND)
 
 set(plClient_HEADERS

--- a/Sources/Plasma/Apps/plClient/external/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/external/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(external_SCRIPTS
+    create_resource_dat.py
     makeres.py
-	render_svg.py
-	create_resource_dat.py
+    render_svg.py
+    scalergba.py
 )
 
 set(external_SOURCES

--- a/Sources/Plasma/Apps/plClient/external/Linking_Book.svg
+++ b/Sources/Plasma/Apps/plClient/external/Linking_Book.svg
@@ -103,8 +103,7 @@
      inkscape:groupmode="layer"
      id="circles"
      inkscape:label="Circles"
-     style="display:inline"
-     transform="translate(0,125.47572)">
+     style="display:inline">
     <path
        sodipodi:type="arc"
        style="fill:none;stroke:none"
@@ -116,8 +115,8 @@
        d="m 1175.8176,463.44324 c 0,325.25095 -263.21571,588.91896 -587.90879,588.91896 C 263.21574,1052.3622 0,788.69419 0,463.44324 0,138.19228 263.21574,-125.47571 587.90881,-125.47571 c 324.69308,0 587.90879,263.66799 587.90879,588.91895 z"
        transform="matrix(0.8793304,0,0,0.8793304,70.94272,55.923509)" />
     <g
-       id="g3224"
-       transform="translate(-0.03253824,-0.03474644)"
+       id="circlesGroup"
+       transform="translate(0,125.47572)"
        inkscape:export-xdpi="19.561266"
        inkscape:export-ydpi="19.561266"
        style="fill:#352f42;fill-opacity:1">

--- a/Sources/Plasma/Apps/plClient/external/create_resource_dat.py
+++ b/Sources/Plasma/Apps/plClient/external/create_resource_dat.py
@@ -75,7 +75,7 @@ def create_resource_dat(resfilepath, inrespath):
 		datFile.write(struct.pack("<I",len(resourceList)))
 		for res in resourceList:
 			with open(res, "rb") as resFile:
-				name = os.path.basename(res)
+				name = os.path.basename(res).encode("utf-8")
 				datFile.write(struct.pack("<I", len(name)))
 				datFile.write(name)
 				datFile.write(struct.pack("<I", os.path.getsize(res)))

--- a/Sources/Plasma/Apps/plClient/external/requirements.txt
+++ b/Sources/Plasma/Apps/plClient/external/requirements.txt
@@ -1,0 +1,4 @@
+https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/cp27/pycairo-1.18.2-cp27-cp27m-win32.whl; sys_platform == "win32" and python_version ~= "2.7"
+cairosvg==1.0.22 ; python_version ~= "2.7"
+cairosvg; python_version >= "3.7"
+pillow

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,9 +43,7 @@ install:
         Write-Host "OK" -foregroundColor Green
 
         Write-Host "Installing Python modules... " -noNewLine
-        Invoke-WebRequest "http://ftp.gnome.org/pub/GNOME/binaries/win32/pygtk/2.24/pygtk-all-in-one-2.24.2.win32-py2.7.msi" -OutFile pygtk-all-in-one-2.24.2.win32-py2.7.msi
-        Start-Process msiexec -ArgumentList "/i pygtk-all-in-one-2.24.2.win32-py2.7.msi TRANSFORMS=devlibs\EnableRSVG.mst TARGETDIR=C:\Python27 /qn /norestart" -wait
-        C:\Python27\python.exe -m pip install -q Pillow 2> $null
+        C:\Python27\python.exe -m pip install -q Pillow CairoSVG==1.0.22 2> $null
         Write-Host "OK" -foregroundColor Green
 
         Write-Host "Installing library dependencies... "

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
         Write-Host "OK" -foregroundColor Green
 
         Write-Host "Installing Python modules... " -noNewLine
-        C:\Python27\python.exe -m pip install -q Pillow CairoSVG==1.0.22 2> $null
+        C:\Python27\python.exe -m pip install -r ../requirements.txt 2> $null
         Write-Host "OK" -foregroundColor Green
 
         Write-Host "Installing library dependencies... "

--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -14,7 +14,7 @@ function(find_python_module module)
 		# A module's location is usually a directory, but for binary modules
 		# it's a .so file.
 		execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-			"import re, ${module}; print re.compile('/__init__.py.*').sub('',${module}.__file__)"
+			"import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
 			RESULT_VARIABLE _${module}_status
 			OUTPUT_VARIABLE _${module}_location
 			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# - Python Module Requirements
+
+# Required for building plClient's resource.dat assets
+-r ./Sources/Plasma/Apps/plClient/external/requirements.txt


### PR DESCRIPTION
This updates the resource.dat creation to render the SVG assets using a newer, maintained Python module "CairoSVG" instead of relying on the Pycairo/rsvg pair which is no longer actively maintained for Python on Windows.  Also included are a few Python 3.x+ fixes which should allow the scripts and build system to function with the newer interpreter.

This is a foundation for fixes coming in #650.