### PR TITLE
Fix Ahnoying Cathedral Seams

### DIFF
--- a/Scripts/dat/AhnonayCathedral.fni
+++ b/Scripts/dat/AhnonayCathedral.fni
@@ -1,4 +1,4 @@
 Graphics.Renderer.Setyon 10000 
 Graphics.Renderer.Fog.SetDefLinear 0 1500 0
 Graphics.Renderer.Fog.SetDefColor 0 0 0
-Graphics.Renderer.SetClearColor 1 1 1
+Graphics.Renderer.SetClearColor 0 0 0


### PR DESCRIPTION
This fixes white seams visible in the Ahnonay Cathedral by setting the render clear color to black.

## Comparison Screenshots
Enlarge to see the difference better!

### Before
![ahny_before](https://user-images.githubusercontent.com/714455/82775261-3772e580-9e15-11ea-925a-96328cc432bb.png)

### After
![ahny_after](https://user-images.githubusercontent.com/714455/82775293-4d80a600-9e15-11ea-8fdd-d1aeff52dda9.png)
