### PR TITLE
Disable artifacts on AppVeyor build.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,6 +86,3 @@ before_package:
       ls
     }
 test: off
-artifacts:
-- path: build\bin
-  name: Plasma-$(APPVEYOR_BUILD_VERSION)-$(CLIENT_TYPE)-$(CONFIGURATION)


### PR DESCRIPTION
AppVeyor has a maximum total artifact storage limit, and apparently no way to manually clean out old builds (though they are pruned automatically after 6 months)...

This can be re-enabled when some older builds expire, or if we switch to GH actions