### PR TITLE
Allow specifying build dir for prepare_env

### DIFF
--- a/prepare_env.ps1
+++ b/prepare_env.ps1
@@ -1,11 +1,13 @@
+param([string]$builddir='build')
+
 $devlibs_url = "https://github.com/H-uru/PlasmaPrefix/releases/download/2020.05.01/devlibs.zip"
 
-if (!(Test-Path -PathType Container build)) {
-    Write-Host "Creating build folder... " -noNewLine
-    New-Item -ItemType directory build | Out-Null
+if (!(Test-Path -PathType Container $builddir)) {
+    Write-Host "Creating build folder at .\$builddir... " -noNewLine
+    New-Item -ItemType directory $builddir | Out-Null
     Write-Host "OK" -foregroundColor Green
 }
-Set-Location build
+Set-Location $builddir
 $path = (Get-Location).Path
 
 if (!(Test-Path -PathType Container devlibs)) {


### PR DESCRIPTION
By default, this will use the existing folder name "build", but that can
be overridden by calling the script with a `-builddir` option.

Example:
```powershell
.\prepare_env.ps1 -builddir build_vs2019
```

I suppose to really feel like powershell it should be `-Build-Output-Folder`, but `-builddir` is so much nicer 😛 