### PR TITLE
Fix missing include for pfPasswordStore on macOS

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Mac.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Mac.cpp
@@ -45,6 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnNetBase/pnNbSrvs.h"
 
+#include <string_theory/string>
 #include <Security/Security.h>
 
 /*****************************************************************************


### PR DESCRIPTION
The other platforms all include `<string_theory/format>` but we don't actually need to do any formatting here