### PR TITLE
HS_BUILD_FOR_OSX -> HS_BUILD_FOR_MACOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,13 @@ if(UNIX)
     add_definitions(-DHS_BUILD_FOR_UNIX)
 endif(UNIX)
 
-if(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    add_definitions(-DHS_BUILD_FOR_OSX)
-endif(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(APPLE)
+    add_definitions(-DHS_BUILD_FOR_APPLE)
+
+    if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+        add_definitions(-DHS_BUILD_FOR_MACOS)
+    endif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+endif(APPLE)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     add_definitions(-DHS_BUILD_FOR_LINUX)

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/CMakeLists.txt
@@ -28,7 +28,7 @@ endif(HAVE_LIBSECRET)
 
 if(APPLE)
     set(pfPasswordStore_SOURCES ${pfPasswordStore_SOURCES}
-        pfPasswordStore_Mac.cpp
+        pfPasswordStore_Apple.cpp
     )
 endif(APPLE)
 

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
@@ -54,8 +54,8 @@ pfPasswordStore* pfPasswordStore::Instance()
     if (store == nullptr) {
 #if defined(HS_BUILD_FOR_WIN32)
         store = new pfWin32PasswordStore();
-#elif defined(HS_BUILD_FOR_OSX)
-        store = new pfMacPasswordStore();
+#elif defined(HS_BUILD_FOR_APPLE)
+        store = new pfApplePasswordStore();
 #elif defined(HAVE_LIBSECRET)
         store = new pfUnixPasswordStore();
 #else

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
@@ -49,9 +49,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <Security/Security.h>
 
 /*****************************************************************************
- ** pfMacPasswordStore                                                      **
+ ** pfApplePasswordStore                                                    **
  *****************************************************************************/
-ST::string pfMacPasswordStore::GetPassword(const ST::string& username)
+ST::string pfApplePasswordStore::GetPassword(const ST::string& username)
 {
     ST::string service = GetServerDisplayName();
 
@@ -77,7 +77,7 @@ ST::string pfMacPasswordStore::GetPassword(const ST::string& username)
     return ret;
 }
 
-bool pfMacPasswordStore::SetPassword(const ST::string& username, const ST::string& password)
+bool pfApplePasswordStore::SetPassword(const ST::string& username, const ST::string& password)
 {
     ST::string service = GetServerDisplayName();
 

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_impl.h
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_impl.h
@@ -89,18 +89,18 @@ public:
 };
 #endif // HAVE_LIBSECRET
 
-#ifdef HS_BUILD_FOR_OSX
+#ifdef HS_BUILD_FOR_APPLE
 /**
- * An OSX Keychain password storage mechanism.
+ * An Apple Keychain password storage mechanism.
  */
-class pfMacPasswordStore : public pfPasswordStore
+class pfApplePasswordStore : public pfPasswordStore
 {
 public:
-    pfMacPasswordStore() { }
+    pfApplePasswordStore() { }
 
     ST::string GetPassword(const ST::string& username) override;
     bool SetPassword(const ST::string& username, const ST::string& password) override;
 };
-#endif //HS_BUILD_FOR_OSX
+#endif //HS_BUILD_FOR_APPLE
 
 #endif //pfPasswordStore_impl_inc

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Pch.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Pch.h
@@ -62,7 +62,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <process.h>
 
-#ifdef HS_BUILD_FOR_OSX
+#ifdef HS_BUILD_FOR_MACOS
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>

--- a/Sources/Plasma/NucleusLib/pnNetCli/Pch.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/Pch.h
@@ -59,7 +59,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnNetCli.h"
 #include "Intern.h"
 
-#ifdef HS_BUILD_FOR_OSX
+#ifdef HS_BUILD_FOR_MACOS
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Pch.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Pch.h
@@ -64,7 +64,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "Private/pnNpAllIncludes.h"
 #include "Intern.h"
 
-#ifdef HS_BUILD_FOR_OSX
+#ifdef HS_BUILD_FOR_MACOS
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>

--- a/Sources/Plasma/NucleusLib/pnUtils/Pch.h
+++ b/Sources/Plasma/NucleusLib/pnUtils/Pch.h
@@ -51,7 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnUtCoreLib.h"    // must be first in list
 #include "pnUtPragma.h"
 
-#ifdef HS_BUILD_FOR_OSX
+#ifdef HS_BUILD_FOR_MACOS
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -66,7 +66,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsResMgr.h"
 
-#ifdef HS_BUILD_FOR_OSX
+#ifdef HS_BUILD_FOR_MACOS
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Pch.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Pch.h
@@ -70,7 +70,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "Private/plNglAllIncludes.h"
 #include "Intern.h"
 
-#ifdef HS_BUILD_FOR_OSX
+#ifdef HS_BUILD_FOR_MACOS
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>

--- a/Sources/Plasma/PubUtilLib/plVault/Pch.h
+++ b/Sources/Plasma/PubUtilLib/plVault/Pch.h
@@ -93,7 +93,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "Intern.h"
 
-#ifdef HS_BUILD_FOR_OSX
+#ifdef HS_BUILD_FOR_MACOS
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>


### PR DESCRIPTION
Reasons this is better:

1. Apple renamed their operating system.
2. It's the same character length as `WIN32` and `LINUX`.

`HS_BUILD_FOR_APPLE` covers Apple systems that are technically not macOS, but that's not an intended area of support.