### PR TITLE
Return uname info for DisplaySystemVersion on *nix

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -52,6 +52,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #if defined(HS_BUILD_FOR_UNIX)
 #   include <cstring>
 #   include <sys/stat.h>
+#   include <sys/utsname.h>
 #   include <fcntl.h>
 #   include <unistd.h>
 #   include <signal.h>
@@ -564,6 +565,10 @@ std::vector<ST::string> DisplaySystemVersion()
         }
         break;
     }
+#elif HS_BUILD_FOR_UNIX
+    struct utsname sysinfo;
+    uname(&sysinfo);
+    versionStrs.push_back(ST::format("{} {} ({})\n", sysinfo.sysname, sysinfo.release, sysinfo.machine));
 #endif
     return versionStrs;
 }


### PR DESCRIPTION
This gives us the kernel version and machine architecture.
ex: `Linux 5.7.6-arch1-1 (x86_64)`

Note that on macOS, this will return "Darwin" and the Darwin kernel version, rather than the (more useful) macOS product version. I looked into getting that info as a second item in the returned vector, but the easy way to do it involves private Apple APIs and the less-easy way to do it involves using CoreFoundation to parse plist files and extract values from a dictionary. Not impossible, but not exactly fun either.