### PR TITLE
KI Easter Egg Updates/Age Constants

### DIFF
--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1266,6 +1266,30 @@ class CommandsProcessor:
                 self.chatMgr.AddChatLine(None, "You search... but find no other feathers.", 0)
             else:
                 self.chatMgr.AddChatLine(None, "You search... but then suddenly stop when you realize that you are missing the \"Duck\" feather.", 0)
+        elif currentAge == "GoMePubNew":
+            if self.chatMgr.gFeather == 13:
+                self.chatMgr.AddChatLine(None, "You search... and find a \"Yellow\" feather and put it in your pocket.", 0)
+                self.chatMgr.gFeather += 1
+            elif self.chatMgr.gFeather > 13:
+                self.chatMgr.AddChatLine(None, "You search... but find no other feathers.", 0)
+            else:
+                self.chatMgr.AddChatLine(None, "You search... but then suddenly stop when you realize that you are missing the \"Rukh\" feather.", 0)
+        elif currentAge == "ChisoPreniv":
+            if self.chatMgr.gFeather == 14:
+                self.chatMgr.AddChatLine(None, "You search... and find a \"Raven\" feather and put it in your pocket.", 0)
+                self.chatMgr.gFeather += 1
+            elif self.chatMgr.gFeather > 14:
+                self.chatMgr.AddChatLine(None, "You search... but find no other feathers.", 0)
+            else:
+                self.chatMgr.AddChatLine(None, "You search... but then suddenly stop when you realize that you are missing the \"Yellow\" feather.", 0)
+        elif currentAge == "VeeTsah":
+            if self.chatMgr.gFeather == 15:
+                self.chatMgr.AddChatLine(None, "You search... and find a \"Dove\" feather and put it in your pocket.", 0)
+                self.chatMgr.gFeather += 1
+            elif self.chatMgr.gFeather > 15:
+                self.chatMgr.AddChatLine(None, "You search... but find no other feathers.", 0)
+            else:
+                self.chatMgr.AddChatLine(None, "You search... but then suddenly stop when you realize that you are missing the \"Raven\" feather.", 0)
         else:
             self.chatMgr.AddChatLine(None, "There are no feathers here.", 0)
             return
@@ -1300,6 +1324,12 @@ class CommandsProcessor:
                     pOut += " and a \"Duck\" feather"
                 if self.chatMgr.gFeather > 12:
                     pOut += " and a large \"Rukh\" feather (sticking out of your pocket)"
+                if self.chatMgr.gFeather > 13:
+                    pOut += " and a \"Yellow\" feather"
+                if self.chatMgr.gFeather > 14:
+                    pOut += " and a \"Raven\" feather"
+                if self.chatMgr.gFeather > 15:
+                    pOut += " and a \"Dove\" feather"
                 pOut += "."
                 self.chatMgr.AddChatLine(None, pOut, 0)
         else:

--- a/Scripts/Python/ki/xKIConstants.py
+++ b/Scripts/Python/ki/xKIConstants.py
@@ -98,6 +98,11 @@ kEasterEggs = {
                "Cleft" : {"see" : "You see sand for as far as the eye can see. Gonna need a vehicle of some sort.",
                           "exits" : "... well, I don't know. Maybe you can ask the old man (if he ever stops listening to that music!).",
                           "people" : "an old man. Ok, maybe he's not standing. BTW, wasn't he on M*A*S*H?"},
+               "GoMePubNew" : {"see" : "You are in a festively yet dimly lit Pub. The echoes of Messenger work and play echo along the walls of the massive main chamber.",
+                               "exits" : "... wait, where ARE the exits? Who built this place anyway?",
+                               "people" : "You see many people...unless you are here by yourself...in which case, you don't."},
+               "ChisoPreniv" : {"see" : "All around you are bookshelves upon bookshelves but not a book to read. To the south is a large set of windows that reveal a vast landscape that you'll never be able to access.",
+                                "exits" : " ... I guess in this library, the only exit is through the window, but let's not do that"},
 }
 
 ## Constants for Age display names.
@@ -113,14 +118,14 @@ class kAges:
                "EderTsogal" : "Eder Tsogal",
                "Er'canaCitySilo" : "D'ni-Ashem'en",
                "ErcanaCitySilo" : "D'ni-Ashem'en",
-               "GreatTreePub" : "The Watcher's Pub",
+               "GreatTreePub" : "D'ni-Watcher's Pub",
                "Great Zero" : "D'ni-Rezeero",
                "GreatZero" : "D'ni-Rezeero",
-               "GuildPub-Cartographers" : "The Cartographers' Pub",
-               "GuildPub-Greeters" : "The Greeters' Pub",
-               "GuildPub-Maintainers" : "The Maintainers' Pub",
-               "GuildPub-Messengers" : "The Messengers' Pub",
-               "GuildPub-Writers" : "The Writers' Pub",
+               "GuildPub-Cartographers" : "D'ni-Cartographers' Pub",
+               "GuildPub-Greeters" : "D'ni-Greeters' Pub",
+               "GuildPub-Maintainers" : "D'ni-Maintainers' Pub",
+               "GuildPub-Messengers" : "D'ni-Messengers' Pub",
+               "GuildPub-Writers" : "D'ni-Writers' Pub",
                "Kirel" : "D'ni-Kirel",
                "K'veer" : "D'ni-K'veer",
                "Kveer" : "D'ni-K'veer",
@@ -130,9 +135,14 @@ class kAges:
                "Shaft" : "D'ni-Tiwah",
                "Spy Room" : "D'ni-Ae'gura",
                "spyroom" : "D'ni-Ae'gura",
+##             Fan Ages
                "Trebivdil" : "Tre'bivdil",
                "trebivdil" : "Tre'bivdil",
-               "vothol" : "Vothol Gallery"}
+               "vothol" : "D'ni-Vothol Gallery",
+               "FehnirHouse" : "D'ni-Fehnir's House",
+               "GoMePubNew" : "D'ni-Messengers' Pub - Ae'gura",
+               "ChisoPreniv" : "Chiso Preniv",
+               "VeeTsah" : "Veelay Tsahvahn"}
     Hide = {"BahroCave", "PelletBahroCave", "Pellet Cave", "LiveBahroCave", "LiveBahroCaves"}
     NoInvite = {"Personal", "Nexus", "Cleft", "AvatarCustomization", "city",
                 "BahroCave", "LiveBahroCave", "LiveBahroCaves", 


### PR DESCRIPTION
Adds new Easter Eggs (feathers) and Constants for Fan Ages.

- Adds yellow, raven and dove feathers for GoMePubNew, Chiso, and Veelay respectively.

- Adds proper name constants for Fehnir's House, GoMePubNew, Chiso and Veelay.

- Adds /look comments for GoMePubNew and Chiso.

- Adds GoMePubNew, Chiso and Veelay to "No Invite" list.

- (proposed) Takes out unneeded "The" from some of the Age Name constants to help them display better in areas of the KI. While it does appear to cut off the latter part of the text in lists, this should eliminate instances where the Age name only displays as "The...".