### PR TITLE
Remove some cross-folder includes from plLogicMod

### DIFF
--- a/Sources/Plasma/PubUtilLib/plModifier/plLogicModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plLogicModifier.cpp
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plModifier/plDetectorLog.h"
 #include "plInputCore/plSceneInputInterface.h"
-#include "pfConditional/plFacingConditionalObject.h"
 #include "pfConditional/plObjectInBoxConditionalObject.h"
 
 
@@ -179,12 +178,7 @@ bool plLogicModifier::MsgReceive(plMessage* msg)
                     {
                         if (!fConditionList[i]->Verify(msg))
                         {
-                            if ( plObjectInBoxConditionalObject::ConvertNoRef(fConditionList[i]) )
-                                plDetectorLog::Red("{}: LogicMod InRegion conditional not met", fConditionList[i]->GetKeyName());
-                            else if ( plFacingConditionalObject::ConvertNoRef(fConditionList[i]) )
-                                plDetectorLog::Red("{}: LogicMod Facing conditional not met", fConditionList[i]->GetKeyName());
-                            else
-                                plDetectorLog::Red("{}: LogicMod <unknown> conditional not met", fConditionList[i]->GetKeyName());
+                            plDetectorLog::Red("{}: LogicMod {} conditional not met", fConditionList[i]->GetKeyName(), fConditionList[i]->ClassName());
                         }
                     }
                 }


### PR DESCRIPTION
We have PubUtilLib code depending on FeatureLib code solely for the purpose of printing a slightly nicer debugging message based on what type of conditional is involved. We can avoid the dependency in this scenario if we just print the class name of the conditional instead.

(Note: There's another spot where plLogicModifier depends directly on pfConditional to implement 2 console commands at the bottom of the file. I'm thinking it might be best to add a new message type for propagating those to the conditionals?)