### PR TITLE
Move some hsLargeArray helpers to fix compiling

### DIFF
--- a/Sources/Plasma/CoreLib/hsTemplates.h
+++ b/Sources/Plasma/CoreLib/hsTemplates.h
@@ -871,6 +871,18 @@ public:
 };
 
 
+template <class T> void hsLargeArray_CopyForward(const T src[], T dst[], int count)
+{
+    for (int i = 0; i < count; i++)
+        dst[i] = src[i];
+}
+
+template <class T> void hsLargeArray_CopyBackward(const T src[], T dst[], int count)
+{
+    for (int i = count - 1; i >= 0; --i)
+        dst[i] = src[i];
+}
+
 template <class T> class hsLargeArray : public hsLargeArrayBase 
 {
     T*      fArray;
@@ -1146,18 +1158,6 @@ template <class T> bool hsLargeArray<T>::RemoveItem(const T& item)
 }
 
 //////////  These are the private methods for hsLargeArray
-
-template <class T> void hsLargeArray_CopyForward(const T src[], T dst[], int count)
-{
-    for (int i = 0; i < count; i++)
-        dst[i] = src[i];
-}
-
-template <class T> void hsLargeArray_CopyBackward(const T src[], T dst[], int count)
-{
-    for (int i = count - 1; i >= 0; --i)
-        dst[i] = src[i];
-}
 
 template <class T> void hsLargeArray<T>::IncCount(int index, int count)
 {


### PR DESCRIPTION
Apparently these are in the wrong spot in the header file, and clang complains.

<pre>In file included from <font color="#FFFFFF"><b>/home/dpogue/Coding/Plasma/Sources/Plasma/PubUtilLib/plPipeline/GL/plGLPipeline.cpp:52</b></font>:
/home/dpogue/Coding/Plasma/Sources/Plasma/PubUtilLib/plPipeline/../../CoreLib/hsTemplates.h: In instantiation of ‘<font color="#FFFFFF"><b>hsLargeArray&lt;T&gt;&amp; hsLargeArray&lt;T&gt;::operator=(const hsLargeArray&lt;T&gt;&amp;) [with T = short int]</b></font>’:
<font color="#FFFFFF"><b>/home/dpogue/Coding/Plasma/Sources/Plasma/PubUtilLib/plPipeline/../../PubUtilLib/plPipeline/plCullTree.h:64:7:</b></font>   required from here
<font color="#FFFFFF"><b>/home/dpogue/Coding/Plasma/Sources/Plasma/PubUtilLib/plPipeline/../../CoreLib/hsTemplates.h:1025:29:</b></font> <font color="#EF2929"><b>error: </b></font>‘<font color="#FFFFFF"><b>hsLargeArray_CopyForward</b></font>’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [<font color="#EF2929"><b>-fpermissive</b></font>]
 1025 |     <font color="#EF2929"><b>hsLargeArray_CopyForward(src.fArray, fArray, src.Count())</b></font>;
      |     <font color="#EF2929"><b>~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>/home/dpogue/Coding/Plasma/Sources/Plasma/PubUtilLib/plPipeline/../../CoreLib/hsTemplates.h:1150:25:</b></font> <font color="#34E2E2"><b>note: </b></font>‘<font color="#FFFFFF"><b>template&lt;class T&gt; void hsLargeArray_CopyForward(const T*, T*, int)</b></font>’ declared here, later in the translation unit
 1150 | template &lt;class T&gt; void <font color="#34E2E2"><b>hsLargeArray_CopyForward</b></font>(const T src[], T dst[], int count)
      |                         <font color="#34E2E2"><b>^~~~~~~~~~~~~~~~~~~~~~~~</b></font>
</pre>