### PR TITLE
Fix plCorrectionMsg ctor compilation in clang.

### DIFF
--- a/Sources/Plasma/NucleusLib/pnMessage/plCorrectionMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCorrectionMsg.h
@@ -51,7 +51,7 @@ class plCorrectionMsg : public plMessage
 public:
     plCorrectionMsg() : plMessage(nullptr, nullptr, nullptr) { }
 
-    plCorrectionMsg(plKey& r, const hsMatrix44& l2w, const hsMatrix44& w2l,
+    plCorrectionMsg(const plKey& r, const hsMatrix44& l2w, const hsMatrix44& w2l,
                     bool dirtySynch = false)
         : plMessage(nullptr, r, nullptr),
           fLocalToWorld(l2w),


### PR DESCRIPTION
Fixes a compilation error in clang when initializing a `plCorrectionMsg` from an rvalue.

@dpogue Can you check this with #690?