### PR TITLE
Update packages in vcpkg cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,7 @@ install:
         git pull 2> $null
         bootstrap-vcpkg.bat
         vcpkg integrate install
+        vcpkg upgrade --no-dry-run
         vcpkg install curl[sspi] expat freetype libjpeg-turbo libogg libpng libtheora libvorbis libvpx openal-soft opus pcre speex string-theory zlib --triplet x86-windows-static-dyncrt 2> $null
         Write-Host "OK" -foregroundColor Green
 


### PR DESCRIPTION
The vcpkg cache contains old, stale versions of several packages, which do not get updated automatically by vcpkg install.  This ensures they get updated before installing new packages.