### PR TITLE
Update packages in vcpkg cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,13 @@ set_package_properties(Python3 PROPERTIES
     TYPE REQUIRED
 )
 
+find_package(EXPAT REQUIRED)
+set_package_properties(EXPAT PROPERTIES
+    URL "http://expat.sourceforge.net/"
+    DESCRIPTION "Expat XML Parser for C"
+    TYPE REQUIRED
+)
+
 find_package(ZLIB REQUIRED)
 set_package_properties(ZLIB PROPERTIES
     URL "http://www.zlib.net"

--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -153,6 +153,7 @@ target_link_libraries(plClient pnUtils)
 target_link_libraries(plClient pnUUID)
 
 target_link_libraries(plClient ${OPENSSL_LIBRARIES})
+target_link_libraries(plClient ${EXPAT_LIBRARY})
 target_link_libraries(plClient ${JPEG_LIBRARY})
 target_link_libraries(plClient ${PNG_LIBRARY})
 target_link_libraries(plClient ${PHYSX_LIBRARIES})

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/CMakeLists.txt
@@ -2,24 +2,7 @@ include_directories(../../CoreLib)
 include_directories(../../NucleusLib/inc)
 include_directories(../../PubUtilLib)
 
-# Skip CMake's built in FindExpat module and use libexpat's CMake config, if possible,
-# due to library rename in libexpat 2.2.8 and higher.
-find_package(EXPAT CONFIG QUIET)
-if(NOT TARGET expat::libexpat)
-    message(DEBUG "libexpat CMake Config not found, using FindExpat module.")
-    find_package(EXPAT REQUIRED)
-    add_library(expat::libexpat STATIC IMPORTED)
-    set_target_properties(expat::libexpat PROPERTIES
-                          INTERFACE_INCLUDE_DIRECTORIES ${EXPAT_INCLUDE_DIR}
-                          IMPORTED_LOCATION ${EXPAT_LIBRARY}
-    )
-endif()
-
-set_package_properties(EXPAT PROPERTIES
-    URL "https://github.com/libexpat/libexpat"
-    DESCRIPTION "Expat XML Parser for C"
-    TYPE REQUIRED
-)
+include_directories(${EXPAT_INCLUDE_DIR})
 
 if(WIN32)
     add_definitions(-DWIN32)
@@ -42,7 +25,6 @@ set(pfLocalizationMgr_HEADERS
 )
 
 add_library(pfLocalizationMgr STATIC ${pfLocalizationMgr_SOURCES} ${pfLocalizationMgr_HEADERS})
-target_link_libraries(pfLocalizationMgr expat::libexpat)
 
 source_group("Source Files" FILES ${pfLocalizationMgr_SOURCES})
 source_group("Header Files" FILES ${pfLocalizationMgr_HEADERS})

--- a/Sources/Tests/FeatureTests/pfPythonTest/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/pfPythonTest/CMakeLists.txt
@@ -95,6 +95,7 @@ target_link_libraries(test_pfPython pnUtils)
 target_link_libraries(test_pfPython pnUUID)
 
 target_link_libraries(test_pfPython ${OPENSSL_LIBRARIES})
+target_link_libraries(test_pfPython ${EXPAT_LIBRARY})
 target_link_libraries(test_pfPython ${JPEG_LIBRARY})
 target_link_libraries(test_pfPython ${PNG_LIBRARY})
 target_link_libraries(test_pfPython ${PHYSX_LIBRARIES})

--- a/Sources/Tools/MaxMain/CMakeLists.txt
+++ b/Sources/Tools/MaxMain/CMakeLists.txt
@@ -93,6 +93,7 @@ target_link_libraries(MaxMain MaxExport)
 target_link_libraries(MaxMain MaxPlasmaMtls)
 target_link_libraries(MaxMain ${3dsm_LIBRARIES})
 
+target_link_libraries(MaxMain ${EXPAT_LIBRARY})
 target_link_libraries(MaxMain ${DirectX_LIBRARIES})
 target_link_libraries(MaxMain ${JPEG_LIBRARY})
 target_link_libraries(MaxMain ${PNG_LIBRARY})

--- a/Sources/Tools/plLocalizationEditor/CMakeLists.txt
+++ b/Sources/Tools/plLocalizationEditor/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(plLocalizationEditor pnUUID)
 target_link_libraries(plLocalizationEditor plResMgr)
 target_link_libraries(plLocalizationEditor pfLocalizationMgr)
 target_link_libraries(plLocalizationEditor plAgeDescription)
+target_link_libraries(plLocalizationEditor ${EXPAT_LIBRARY})
 target_link_libraries(plLocalizationEditor ${STRING_THEORY_LIBRARIES})
 target_link_libraries(plLocalizationEditor Qt5::Widgets)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ install:
         Write-Host "OK" -foregroundColor Green
 
         Write-Host "Installing library dependencies... "
-        Set-Location C:\tools\vcpkg
+        Set-Location C:\Tools\vcpkg
         git pull 2> $null
         bootstrap-vcpkg.bat
         vcpkg upgrade --no-dry-run
@@ -67,7 +67,7 @@ before_build:
 - ps: |
     Set-Location build
 
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x86-windows-static-md `
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x86-windows-static-md `
     -DCMAKE_INSTALL_PREFIX=devlibs -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=bin -DPHYSX_SDK_PATH=devlibs\PhysX -DQt5_DIR=C:\Qt\$Env:QT_VER\msvc2017\lib\cmake\Qt5 `
     -DPLASMA_EXTERNAL_RELEASE="$Env:PLASMA_EXTERNAL_RELEASE" -DPLASMA_BUILD_TESTS=ON -DPLASMA_BUILD_TOOLS=ON -DPLASMA_BUILD_RESOURCE_DAT=ON ..
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,17 +48,12 @@ install:
 
         Write-Host "Installing library dependencies... "
         Set-Location C:\tools\vcpkg
-        # Create our own custom triplet, for static-linking of libraries, but dynamic CRT linkage.
-        If ($Env:CONFIGURATION -eq "Release") {
-          Set-Content -Path "triplets/x86-windows-static-dyncrt.cmake" -Value "set(VCPKG_TARGET_ARCHITECTURE x86)`nset(VCPKG_CRT_LINKAGE dynamic)`nset(VCPKG_LIBRARY_LINKAGE static)`nset(VCPKG_BUILD_TYPE release)`n"
-        } Else {
-          Set-Content -Path "triplets/x86-windows-static-dyncrt.cmake" -Value "set(VCPKG_TARGET_ARCHITECTURE x86)`nset(VCPKG_CRT_LINKAGE dynamic)`nset(VCPKG_LIBRARY_LINKAGE static)`n"
-        }
         git pull 2> $null
         bootstrap-vcpkg.bat
-        vcpkg integrate install
         vcpkg upgrade --no-dry-run
-        vcpkg install curl[sspi] expat freetype libjpeg-turbo libogg libpng libtheora libvorbis libvpx openal-soft opus pcre speex string-theory zlib --triplet x86-windows-static-dyncrt 2> $null
+        vcpkg install curl[sspi] expat freetype libjpeg-turbo libogg libpng libtheora libvorbis libvpx openal-soft `
+                      opus pcre speex string-theory zlib --triplet x86-windows-static-md
+        vcpkg integrate install
         Write-Host "OK" -foregroundColor Green
 
         Set-Location $path
@@ -72,7 +67,7 @@ before_build:
 - ps: |
     Set-Location build
 
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x86-windows-static-dyncrt `
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x86-windows-static-md `
     -DCMAKE_INSTALL_PREFIX=devlibs -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=bin -DPHYSX_SDK_PATH=devlibs\PhysX -DQt5_DIR=C:\Qt\$Env:QT_VER\msvc2017\lib\cmake\Qt5 `
     -DPLASMA_EXTERNAL_RELEASE="$Env:PLASMA_EXTERNAL_RELEASE" -DPLASMA_BUILD_TESTS=ON -DPLASMA_BUILD_TOOLS=ON -DPLASMA_BUILD_RESOURCE_DAT=ON ..
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,8 @@ before_build:
     Set-Location build
 
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x86-windows-static-md `
-    -DCMAKE_INSTALL_PREFIX=devlibs -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=bin -DPHYSX_SDK_PATH=devlibs\PhysX -DQt5_DIR=C:\Qt\$Env:QT_VER\msvc2017\lib\cmake\Qt5 `
+    -DCMAKE_BUILD_TYPE=$Env:CONFIGURATION -DCMAKE_INSTALL_PREFIX=devlibs -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=bin `
+    -DPHYSX_SDK_PATH=devlibs\PhysX -DQt5_DIR=C:\Qt\$Env:QT_VER\msvc2017\lib\cmake\Qt5 `
     -DPLASMA_EXTERNAL_RELEASE="$Env:PLASMA_EXTERNAL_RELEASE" -DPLASMA_BUILD_TESTS=ON -DPLASMA_BUILD_TOOLS=ON -DPLASMA_BUILD_RESOURCE_DAT=ON ..
 build:
   project: build/Plasma.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,7 @@ install:
         git pull 2> $null
         bootstrap-vcpkg.bat
         vcpkg integrate install
+        vcpkg upgrade --no-dry-run
         vcpkg install curl[sspi] expat freetype libjpeg-turbo libogg libpng libtheora libvorbis libvpx openal-soft opus pcre speex string-theory zlib --triplet x86-windows-static-dyncrt 2> $null
         Write-Host "OK" -foregroundColor Green
 


### PR DESCRIPTION
(Moved from #701 due to being in the wrong fork and thus duplicating builds)

The vcpkg cache contains old, stale versions of several packages, which do not get updated automatically by vcpkg install. This ensures they get updated before installing new packages.

This now also removes the old manually-created x86-windows-static-dyncrt triplet in favor of the upstream-supported x86-windows-static-md triplet.