### PR TITLE
Improvements for prepare_env.ps1

### DIFF
--- a/prepare_env.ps1
+++ b/prepare_env.ps1
@@ -40,6 +40,10 @@ if (Get-ChildItem Env:PATH | Where-Object {$_.Value -match "CMake"}) {
           -DPython3_LIBRARY=$path/devlibs/lib/python38.lib -DPython3_INCLUDE_DIR=$path/devlibs/include `
           -DPLASMA_BUILD_TOOLS=OFF -DPLASMA_BUILD_RESOURCE_DAT=OFF `
           -A Win32 -G "Visual Studio 15 2017" $source_path
+    if ($lastExitCode -Ne 0) { throw "Failed to configure build system!" }
+    Write-Host "Copying Python 3 dist-packages..."
+    cmake --build . --target ScriptsSystem
+    if ($lastExitCode -Ne 0) { throw "Failed to copy Python dist-packages!" }
 } else {
     Write-Host "CMake not found in PATH."
     Write-Host "Please run the CMake installer and select the option to add CMake to your system PATH."


### PR DESCRIPTION
This fixes a crash bug in prepare_env.ps1, preventing project generation from CMake. Also, this makes it build the ScriptsSystem target so the Python 3 stdlib is available since the manual build of ScriptsSystem has led to gotchas. See commit log for sources.