### PR TITLE
Fix fallout from upstream libexpat library rename.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,13 +70,6 @@ set_package_properties(Python3 PROPERTIES
     TYPE REQUIRED
 )
 
-find_package(EXPAT REQUIRED)
-set_package_properties(EXPAT PROPERTIES
-    URL "http://expat.sourceforge.net/"
-    DESCRIPTION "Expat XML Parser for C"
-    TYPE REQUIRED
-)
-
 find_package(ZLIB REQUIRED)
 set_package_properties(ZLIB PROPERTIES
     URL "http://www.zlib.net"

--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -153,7 +153,6 @@ target_link_libraries(plClient pnUtils)
 target_link_libraries(plClient pnUUID)
 
 target_link_libraries(plClient ${OPENSSL_LIBRARIES})
-target_link_libraries(plClient ${EXPAT_LIBRARY})
 target_link_libraries(plClient ${JPEG_LIBRARY})
 target_link_libraries(plClient ${PNG_LIBRARY})
 target_link_libraries(plClient ${PHYSX_LIBRARIES})

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/CMakeLists.txt
@@ -2,7 +2,24 @@ include_directories(../../CoreLib)
 include_directories(../../NucleusLib/inc)
 include_directories(../../PubUtilLib)
 
-include_directories(${EXPAT_INCLUDE_DIR})
+# Skip CMake's built in FindExpat module and use libexpat's CMake config, if possible,
+# due to library rename in libexpat 2.2.8 and higher.
+find_package(EXPAT CONFIG QUIET)
+if(NOT TARGET expat::libexpat)
+    message(DEBUG "libexpat CMake Config not found, using FindExpat module.")
+    find_package(EXPAT REQUIRED)
+    add_library(expat::libexpat STATIC IMPORTED)
+    set_target_properties(expat::libexpat PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES ${EXPAT_INCLUDE_DIR}
+                          IMPORTED_LOCATION ${EXPAT_LIBRARY}
+    )
+endif()
+
+set_package_properties(EXPAT PROPERTIES
+    URL "https://github.com/libexpat/libexpat"
+    DESCRIPTION "Expat XML Parser for C"
+    TYPE REQUIRED
+)
 
 if(WIN32)
     add_definitions(-DWIN32)
@@ -25,6 +42,7 @@ set(pfLocalizationMgr_HEADERS
 )
 
 add_library(pfLocalizationMgr STATIC ${pfLocalizationMgr_SOURCES} ${pfLocalizationMgr_HEADERS})
+target_link_libraries(pfLocalizationMgr expat::libexpat)
 
 source_group("Source Files" FILES ${pfLocalizationMgr_SOURCES})
 source_group("Header Files" FILES ${pfLocalizationMgr_HEADERS})

--- a/Sources/Tests/FeatureTests/pfPythonTest/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/pfPythonTest/CMakeLists.txt
@@ -95,7 +95,6 @@ target_link_libraries(test_pfPython pnUtils)
 target_link_libraries(test_pfPython pnUUID)
 
 target_link_libraries(test_pfPython ${OPENSSL_LIBRARIES})
-target_link_libraries(test_pfPython ${EXPAT_LIBRARY})
 target_link_libraries(test_pfPython ${JPEG_LIBRARY})
 target_link_libraries(test_pfPython ${PNG_LIBRARY})
 target_link_libraries(test_pfPython ${PHYSX_LIBRARIES})

--- a/Sources/Tools/MaxMain/CMakeLists.txt
+++ b/Sources/Tools/MaxMain/CMakeLists.txt
@@ -93,7 +93,6 @@ target_link_libraries(MaxMain MaxExport)
 target_link_libraries(MaxMain MaxPlasmaMtls)
 target_link_libraries(MaxMain ${3dsm_LIBRARIES})
 
-target_link_libraries(MaxMain ${EXPAT_LIBRARY})
 target_link_libraries(MaxMain ${DirectX_LIBRARIES})
 target_link_libraries(MaxMain ${JPEG_LIBRARY})
 target_link_libraries(MaxMain ${PNG_LIBRARY})

--- a/Sources/Tools/plLocalizationEditor/CMakeLists.txt
+++ b/Sources/Tools/plLocalizationEditor/CMakeLists.txt
@@ -53,7 +53,6 @@ target_link_libraries(plLocalizationEditor pnUUID)
 target_link_libraries(plLocalizationEditor plResMgr)
 target_link_libraries(plLocalizationEditor pfLocalizationMgr)
 target_link_libraries(plLocalizationEditor plAgeDescription)
-target_link_libraries(plLocalizationEditor ${EXPAT_LIBRARY})
 target_link_libraries(plLocalizationEditor ${STRING_THEORY_LIBRARIES})
 target_link_libraries(plLocalizationEditor Qt5::Widgets)
 


### PR DESCRIPTION
As of libexpat 2.2.8, the library was renamed from libexpat to expat. In 2.2.9, this was supposedly reverted back to libexpat; however, in practice, I find that vcpkg builds libexpatMD. Therefore, we now use libexpat's config. However, this is not present in the most recent devlibs bundle with expat 2.2.7, so we fall back on the out of date cmake find module in that case.

This should fix the latest CI failure in #702.