### PR TITLE
Python Error Handling Improvements

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -658,8 +658,15 @@ PYTHON_METHOD_DEFINITION(ptOutputRedirector, write, args)
     PYTHON_RETURN_ERROR;
 }
 
+PYTHON_METHOD_DEFINITION_NOARGS(ptOutputRedirector, flush)
+{
+    // no-op
+    PYTHON_RETURN_NONE;
+}
+
 PYTHON_START_METHODS_TABLE(ptOutputRedirector)
     PYTHON_METHOD(ptOutputRedirector, write, "Adds text to the output object"),
+    PYTHON_METHOD_NOARGS(ptOutputRedirector, flush, "no-op"),
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition
@@ -789,9 +796,16 @@ PYTHON_METHOD_DEFINITION(ptErrorRedirector, excepthook, args)
     PYTHON_RETURN_NONE;
 }
 
+PYTHON_METHOD_DEFINITION_NOARGS(ptErrorRedirector, flush)
+{
+    // no-op
+    PYTHON_RETURN_NONE;
+}
+
 PYTHON_START_METHODS_TABLE(ptErrorRedirector)
     PYTHON_METHOD(ptErrorRedirector, write, "Adds text to the output object"),
     PYTHON_METHOD(ptErrorRedirector, excepthook, "Handles exceptions"),
+    PYTHON_METHOD_NOARGS(ptErrorRedirector, flush, "no-op"),
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.cpp
@@ -83,3 +83,12 @@ int PyUnicode_PlFileNameDecoder(PyObject* obj, void* fn)
     }
     return 0;
 }
+
+#ifdef HS_DEBUGGING
+PyObject* PyUnicode_FromSTString(const ST::string& x)
+{
+    auto nulpos = x.find('\0');
+    hsAssert(nulpos != -1, "null byte at index %u in PyUnicode_FromSTString", nulpos);
+    return PyUnicode_FromStringAndSize(x.c_str(), x.size());
+}
+#endif

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -53,8 +53,11 @@ ST::string PyUnicode_AsSTString(PyObject* obj);
 int PyUnicode_STStringConverter(PyObject* obj, void* str);
 int PyUnicode_PlFileNameDecoder(PyObject* obj, void* str);
 
-PyObject* PyUnicode_FromSTString(const ST::string& str);
+#ifdef HS_DEBUGGING
+PyObject* PyUnicode_FromSTString(const ST::string& x);
+#else
 #define PyUnicode_FromSTString(x) PyUnicode_FromStringAndSize((x).c_str(), (x).size())
+#endif
 #define PyUnicode_FromStdString(x) PyUnicode_FromStringAndSize((x).c_str(), (x).size())
 
 // Python 2.7 uses non-const "char *" in many places where a string literal


### PR DESCRIPTION
This fixes some issues observed with the Python Interface's error handling that were exacerbated by the move to Python 3. It adds the ability to log [unraisable exceptions](https://vstinner.github.io/sys-unraisablehook-python38.html) and detects null bytes being sent to Python as UTF-8 in debug mode.