### PR TITLE
Fix an infinite loop in plDXPipeline.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -7684,10 +7684,9 @@ bool  plDXPipeline::IProcessMipmapLevels( plMipmap *mipmap, uint32_t &numLevels,
             if( mipmap->IsCompressed() || !( fSettings.fD3DCaps & kCapsDoesSmallTextures ) )
             {
                 mipmap->SetCurrLevel( maxLevel );
-                while( ( mipmap->GetCurrWidth() | mipmap->GetCurrHeight() ) & sizeMask )
+                while (maxLevel && (mipmap->GetCurrWidth() | mipmap->GetCurrHeight()) & sizeMask)
                 {
                     maxLevel--;
-                    hsAssert( maxLevel >= 0, "How was this ever compressed?" );
                     mipmap->SetCurrLevel( maxLevel );
                 }
             }


### PR DESCRIPTION
This was observed in a 2x2 DXT1 mipmap produced by Korman. While Korman should probably force such a thing to be uncompressed, the pipeline should also not be able to enter such an obviously invalid state.