### PR TITLE
Fix some issues with VLD Usage.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/Pch.h
+++ b/Sources/Plasma/FeatureLib/pfPython/Pch.h
@@ -52,6 +52,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <algorithm>
 #include <array>
 #include <exception>
+#include <functional>
 #include <locale>
 #include <string>
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.h
@@ -58,7 +58,7 @@ namespace ST { class string; }
 class cyAccountManagement
 {
 public:
-    static void         AddPlasmaMethods(std::vector<PyMethodDef> &methods);
+    static void         AddPlasmaMethods(PyObject* m);
     static void         AddPlasmaConstantsClasses(PyObject *m);
 
     static PyObject*    GetPlayerList();

--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagementGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagementGlue.cpp
@@ -118,15 +118,17 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtChangePassword, args, "Params: password\nChang
     PYTHON_RETURN_NONE;
 }
 
-void cyAccountManagement::AddPlasmaMethods(std::vector<PyMethodDef> &methods)
+void cyAccountManagement::AddPlasmaMethods(PyObject* m)
 {
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetAccountPlayerList);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetAccountName);
-    PYTHON_GLOBAL_METHOD(methods, PtCreatePlayer);
-    PYTHON_GLOBAL_METHOD(methods, PtDeletePlayer);
-    PYTHON_GLOBAL_METHOD(methods, PtSetActivePlayer);
-    PYTHON_GLOBAL_METHOD(methods, PtIsActivePlayerSet);
-    PYTHON_GLOBAL_METHOD(methods, PtChangePassword);
+    PYTHON_START_GLOBAL_METHOD_TABLE(ptAccountManagement)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetAccountPlayerList)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetAccountName)
+        PYTHON_GLOBAL_METHOD(PtCreatePlayer)
+        PYTHON_GLOBAL_METHOD(PtDeletePlayer)
+        PYTHON_GLOBAL_METHOD(PtSetActivePlayer)
+        PYTHON_GLOBAL_METHOD(PtIsActivePlayerSet)
+        PYTHON_GLOBAL_METHOD(PtChangePassword)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, ptAccountManagement)
 }
 
 void cyAccountManagement::AddPlasmaConstantsClasses(PyObject *m)

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatar.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatar.h
@@ -91,7 +91,7 @@ public:
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(cyAvatar); // converts a PyObject to a cyAvatar (throws error if not correct type)
 
     static void AddPlasmaClasses(PyObject *m);
-    static void AddPlasmaMethods(std::vector<PyMethodDef> &methods);
+    static void AddPlasmaMethods(PyObject* m);
     static void AddPlasmaConstantsClasses(PyObject *m);
 
     // setters

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatarGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatarGlue.cpp
@@ -888,37 +888,39 @@ void cyAvatar::AddPlasmaClasses(PyObject *m)
 //
 // AddPlasmaMethods - the python method definitions
 //
-void cyAvatar::AddPlasmaMethods(std::vector<PyMethodDef> &methods)
+void cyAvatar::AddPlasmaMethods(PyObject* m)
 {
-    // static/global functions (to the local avatar)
-    PYTHON_GLOBAL_METHOD(methods, PtSetBehaviorLoopCount);
-    PYTHON_GLOBAL_METHOD(methods, PtChangeAvatar);
-    PYTHON_GLOBAL_METHOD(methods, PtChangePlayerName);
-    PYTHON_GLOBAL_METHOD(methods, PtEmoteAvatar);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtAvatarSitOnGround);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtAvatarEnterLookingAtKI);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtAvatarExitLookingAtKI);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtAvatarEnterUsePersBook);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtAvatarExitUsePersBook);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtAvatarEnterAFK);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtAvatarExitAFK);
-    PYTHON_GLOBAL_METHOD(methods, PtAvatarEnterAnimMode);
+    PYTHON_START_GLOBAL_METHOD_TABLE(ptAvatar)
+        // static/global functions (to the local avatar)
+        PYTHON_GLOBAL_METHOD(PtSetBehaviorLoopCount)
+        PYTHON_GLOBAL_METHOD(PtChangeAvatar)
+        PYTHON_GLOBAL_METHOD(PtChangePlayerName)
+        PYTHON_GLOBAL_METHOD(PtEmoteAvatar)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtAvatarSitOnGround)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtAvatarEnterLookingAtKI)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtAvatarExitLookingAtKI)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtAvatarEnterUsePersBook)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtAvatarExitUsePersBook)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtAvatarEnterAFK)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtAvatarExitAFK)
+        PYTHON_GLOBAL_METHOD(PtAvatarEnterAnimMode)
 
-    // Suspend avatar input
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtDisableMovementKeys);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtEnableMovementKeys);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtDisableMouseMovement);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtEnableMouseMovement);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtDisableAvatarJump);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtEnableAvatarJump);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtDisableForwardMovement);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtEnableForwardMovement);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtLocalAvatarRunKeyDown);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtLocalAvatarIsMoving);
-    PYTHON_GLOBAL_METHOD(methods, PtSetMouseTurnSensitivity);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetMouseTurnSensitivity);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtIsCurrentBrainHuman);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtAvatarSpawnNext);
+        // Suspend avatar input
+        PYTHON_BASIC_GLOBAL_METHOD(PtDisableMovementKeys)
+        PYTHON_BASIC_GLOBAL_METHOD(PtEnableMovementKeys)
+        PYTHON_BASIC_GLOBAL_METHOD(PtDisableMouseMovement)
+        PYTHON_BASIC_GLOBAL_METHOD(PtEnableMouseMovement)
+        PYTHON_BASIC_GLOBAL_METHOD(PtDisableAvatarJump)
+        PYTHON_BASIC_GLOBAL_METHOD(PtEnableAvatarJump)
+        PYTHON_BASIC_GLOBAL_METHOD(PtDisableForwardMovement)
+        PYTHON_BASIC_GLOBAL_METHOD(PtEnableForwardMovement)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtLocalAvatarRunKeyDown)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtLocalAvatarIsMoving)
+        PYTHON_GLOBAL_METHOD(PtSetMouseTurnSensitivity)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetMouseTurnSensitivity)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtIsCurrentBrainHuman)
+        PYTHON_BASIC_GLOBAL_METHOD(PtAvatarSpawnNext)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, ptAvatar)
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -87,10 +87,10 @@ public:
     static void Update( double secs );
 
     // the python definitions
-    static void AddPlasmaMethods(std::vector<PyMethodDef> &methods);
-    static void AddPlasmaMethods2(std::vector<PyMethodDef> &methods);
-    static void AddPlasmaMethods3(std::vector<PyMethodDef> &methods);
-    static void AddPlasmaMethods4(std::vector<PyMethodDef> &methods);
+    static void AddPlasmaMethods(PyObject* m);
+    static void AddPlasmaMethods2(PyObject* m);
+    static void AddPlasmaMethods3(PyObject* m);
+    static void AddPlasmaMethods4(PyObject* m);
 
     static void AddPlasmaConstantsClasses(PyObject *m);
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
@@ -448,51 +448,49 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtFindClones, args, "Params: key\nFinds all clon
 // AddPlasmaMethods - the python method definitions
 //
 
-void cyMisc::AddPlasmaMethods(std::vector<PyMethodDef> &methods)
+void cyMisc::AddPlasmaMethods(PyObject* m)
 {
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtFlashWindow);
+    PYTHON_START_GLOBAL_METHOD_TABLE(cyMisc)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtFlashWindow)
 
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetAgeName);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetAgeInfo);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetAgeTime);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetPrevAgeName); 
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetPrevAgeInfo);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetDniTime);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetServerTime);
-    PYTHON_GLOBAL_METHOD(methods, PtGMTtoDniTime);
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetAgeName)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetAgeInfo)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetAgeTime)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetPrevAgeName) 
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetPrevAgeInfo)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetDniTime)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetServerTime)
+        PYTHON_GLOBAL_METHOD(PtGMTtoDniTime)
+
+        PYTHON_GLOBAL_METHOD(PtGetClientName)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetLocalAvatar)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetLocalPlayer)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetPlayerList)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetPlayerListDistanceSorted)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtMaxListenListSize)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtMaxListenDistSq)
+        PYTHON_GLOBAL_METHOD(PtGetAvatarKeyFromClientID)
+        PYTHON_GLOBAL_METHOD(PtGetClientIDFromAvatarKey)
+        PYTHON_GLOBAL_METHOD(PtGetNPCByID)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetNPCCount)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetNumRemotePlayers)
+
+        PYTHON_GLOBAL_METHOD(PtValidateKey)
+
+        PYTHON_GLOBAL_METHOD(PtSendRTChat)
+        PYTHON_GLOBAL_METHOD(PtSendKIMessage)
+        PYTHON_GLOBAL_METHOD(PtSendKIMessageInt)
     
-    PYTHON_GLOBAL_METHOD(methods, PtGetClientName);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetLocalAvatar);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetLocalPlayer);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetPlayerList);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetPlayerListDistanceSorted);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtMaxListenListSize);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtMaxListenDistSq);
-    PYTHON_GLOBAL_METHOD(methods, PtGetAvatarKeyFromClientID);
-    PYTHON_GLOBAL_METHOD(methods, PtGetClientIDFromAvatarKey);
-    PYTHON_GLOBAL_METHOD(methods, PtGetNPCByID);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetNPCCount);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetNumRemotePlayers);
+        PYTHON_GLOBAL_METHOD(PtLoadAvatarModel)
+        PYTHON_GLOBAL_METHOD(PtUnLoadAvatarModel)
 
-    PYTHON_GLOBAL_METHOD(methods, PtValidateKey);
+        PYTHON_BASIC_GLOBAL_METHOD(PtForceCursorHidden)
+        PYTHON_BASIC_GLOBAL_METHOD(PtForceCursorShown)
 
-    PYTHON_GLOBAL_METHOD(methods, PtSendRTChat);
-    PYTHON_GLOBAL_METHOD(methods, PtSendKIMessage);
-    PYTHON_GLOBAL_METHOD(methods, PtSendKIMessageInt);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtLoadAvatarModel);
-    PYTHON_GLOBAL_METHOD(methods, PtUnLoadAvatarModel);
+        PYTHON_GLOBAL_METHOD(PtGetLocalizedString)
 
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtForceCursorHidden);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtForceCursorShown);
-
-    PYTHON_GLOBAL_METHOD(methods, PtGetLocalizedString);
-
-    PYTHON_GLOBAL_METHOD(methods, PtDumpLogs);
-    PYTHON_GLOBAL_METHOD(methods, PtCloneKey);
-    PYTHON_GLOBAL_METHOD(methods, PtFindClones);
-
-    AddPlasmaMethods2(methods);
-    AddPlasmaMethods3(methods);
-    AddPlasmaMethods4(methods);
+        PYTHON_GLOBAL_METHOD(PtDumpLogs)
+        PYTHON_GLOBAL_METHOD(PtCloneKey)
+        PYTHON_GLOBAL_METHOD(PtFindClones)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, cyMisc)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
@@ -439,41 +439,43 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtClearPrivateChatList, args, "Params: memberKey
 // AddPlasmaMethods - the python method definitions
 //
 
-void cyMisc::AddPlasmaMethods2(std::vector<PyMethodDef> &methods)
+void cyMisc::AddPlasmaMethods2(PyObject* m)
 {
-    PYTHON_GLOBAL_METHOD(methods, PtYesNoDialog);
-    PYTHON_GLOBAL_METHOD(methods, PtRateIt);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtExcludeRegionSet);
-    PYTHON_GLOBAL_METHOD(methods, PtExcludeRegionSetNow);
+    PYTHON_START_GLOBAL_METHOD_TABLE(cyMisc2)
+        PYTHON_GLOBAL_METHOD(PtYesNoDialog)
+        PYTHON_GLOBAL_METHOD(PtRateIt)
 
-    PYTHON_GLOBAL_METHOD(methods, PtAcceptInviteInGame);
+        PYTHON_GLOBAL_METHOD(PtExcludeRegionSet)
+        PYTHON_GLOBAL_METHOD(PtExcludeRegionSetNow)
 
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetTime);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetGameTime);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetFrameDeltaTime);
+        PYTHON_GLOBAL_METHOD(PtAcceptInviteInGame)
 
-    PYTHON_GLOBAL_METHOD(methods, PtPageInNode);
-    PYTHON_GLOBAL_METHOD(methods, PtPageOutNode);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtLimitAvatarLOD);
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetTime)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetGameTime)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetFrameDeltaTime)
 
-    PYTHON_GLOBAL_METHOD(methods, PtFogSetDefColor);
-    PYTHON_GLOBAL_METHOD(methods, PtFogSetDefLinear);
-    PYTHON_GLOBAL_METHOD(methods, PtFogSetDefExp);
-    PYTHON_GLOBAL_METHOD(methods, PtFogSetDefExp2);
+        PYTHON_GLOBAL_METHOD(PtPageInNode)
+        PYTHON_GLOBAL_METHOD(PtPageOutNode)
 
-    PYTHON_GLOBAL_METHOD(methods, PtLoadDialog);
-    PYTHON_GLOBAL_METHOD(methods, PtUnloadDialog);
-    PYTHON_GLOBAL_METHOD(methods, PtIsDialogLoaded);
-    PYTHON_GLOBAL_METHOD(methods, PtShowDialog);
-    PYTHON_GLOBAL_METHOD(methods, PtHideDialog);
-    PYTHON_GLOBAL_METHOD(methods, PtGetDialogFromTagID);
-    PYTHON_GLOBAL_METHOD(methods, PtGetDialogFromString);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtIsGUIModal);
+        PYTHON_GLOBAL_METHOD(PtLimitAvatarLOD)
 
-    PYTHON_GLOBAL_METHOD(methods, PtSendPrivateChatList);
-    PYTHON_GLOBAL_METHOD(methods, PtClearPrivateChatList);
+        PYTHON_GLOBAL_METHOD(PtFogSetDefColor)
+        PYTHON_GLOBAL_METHOD(PtFogSetDefLinear)
+        PYTHON_GLOBAL_METHOD(PtFogSetDefExp)
+        PYTHON_GLOBAL_METHOD(PtFogSetDefExp2)
+
+        PYTHON_GLOBAL_METHOD(PtLoadDialog)
+        PYTHON_GLOBAL_METHOD(PtUnloadDialog)
+        PYTHON_GLOBAL_METHOD(PtIsDialogLoaded)
+        PYTHON_GLOBAL_METHOD(PtShowDialog)
+        PYTHON_GLOBAL_METHOD(PtHideDialog)
+        PYTHON_GLOBAL_METHOD(PtGetDialogFromTagID)
+        PYTHON_GLOBAL_METHOD(PtGetDialogFromString)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtIsGUIModal)
+
+        PYTHON_GLOBAL_METHOD(PtSendPrivateChatList)
+        PYTHON_GLOBAL_METHOD(PtClearPrivateChatList)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, cyMisc2)
 }
 
 void cyMisc::AddPlasmaConstantsClasses(PyObject *m)

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
@@ -675,76 +675,78 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetInitPath, "Returns the unicode path 
 // AddPlasmaMethods - the python method definitions
 //
 
-void cyMisc::AddPlasmaMethods3(std::vector<PyMethodDef> &methods)
+void cyMisc::AddPlasmaMethods3(PyObject* m)
 {
-    PYTHON_GLOBAL_METHOD(methods, PtSendPetitionToCCR);
-    PYTHON_GLOBAL_METHOD(methods, PtSendChatToCCR);
+    PYTHON_START_GLOBAL_METHOD_TABLE(cyMisc3)
+        PYTHON_GLOBAL_METHOD(PtSendPetitionToCCR)
+        PYTHON_GLOBAL_METHOD(PtSendChatToCCR)
 
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetPythonLoggingLevel);
-    PYTHON_GLOBAL_METHOD(methods, PtSetPythonLoggingLevel);
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetPythonLoggingLevel)
+        PYTHON_GLOBAL_METHOD(PtSetPythonLoggingLevel)
 
-    PYTHON_GLOBAL_METHOD(methods, PtConsole);
-    PYTHON_GLOBAL_METHOD(methods, PtConsoleNet);
+        PYTHON_GLOBAL_METHOD(PtConsole)
+        PYTHON_GLOBAL_METHOD(PtConsoleNet)
 
 #if 1
-    // TEMP
-    PYTHON_GLOBAL_METHOD(methods, PtPrintToScreen);
+        // TEMP
+        PYTHON_GLOBAL_METHOD(PtPrintToScreen)
 #endif
 
-    PYTHON_GLOBAL_METHOD(methods, PtAtTimeCallback);
-    PYTHON_GLOBAL_METHOD(methods, PtClearTimerCallbacks);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtFindSceneobject);
-    PYTHON_GLOBAL_METHOD(methods, PtFindSceneobjects);
-    PYTHON_GLOBAL_METHOD(methods, PtFindActivator);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtClearCameraStack);
-    PYTHON_GLOBAL_METHOD(methods, PtWasLocallyNotified);
+        PYTHON_GLOBAL_METHOD(PtAtTimeCallback)
+        PYTHON_GLOBAL_METHOD(PtClearTimerCallbacks)
 
-    PYTHON_GLOBAL_METHOD(methods, PtAttachObject);
-    PYTHON_GLOBAL_METHOD(methods, PtDetachObject);
-    
-    //PYTHON_GLOBAL_METHOD(methods, PtLinkToAge);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtDirtySynchState);
-    PYTHON_GLOBAL_METHOD(methods, PtDirtySynchClients);
+        PYTHON_GLOBAL_METHOD(PtFindSceneobject)
+        PYTHON_GLOBAL_METHOD(PtFindSceneobjects)
+        PYTHON_GLOBAL_METHOD(PtFindActivator)
+        PYTHON_BASIC_GLOBAL_METHOD(PtClearCameraStack)
+        PYTHON_GLOBAL_METHOD(PtWasLocallyNotified)
 
-    PYTHON_GLOBAL_METHOD(methods, PtEnableControlKeyEvents);
-    PYTHON_GLOBAL_METHOD(methods, PtDisableControlKeyEvents);
+        PYTHON_GLOBAL_METHOD(PtAttachObject)
+        PYTHON_GLOBAL_METHOD(PtDetachObject)
 
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtEnableAvatarCursorFade);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtDisableAvatarCursorFade);
-    PYTHON_GLOBAL_METHOD(methods, PtFadeLocalAvatar);
+        //PYTHON_GLOBAL_METHOD(PtLinkToAge)
 
-    PYTHON_GLOBAL_METHOD(methods, PtSetOfferBookMode);
-    PYTHON_GLOBAL_METHOD(methods, PtSetShareSpawnPoint);
-    PYTHON_GLOBAL_METHOD(methods, PtSetShareAgeInstanceGuid);
-    PYTHON_GLOBAL_METHOD(methods, PtNotifyOffererLinkAccepted);
-    PYTHON_GLOBAL_METHOD(methods, PtNotifyOffererLinkRejected);
-    PYTHON_GLOBAL_METHOD(methods, PtNotifyOffererLinkCompleted);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtClearOfferBookMode);
+        PYTHON_GLOBAL_METHOD(PtDirtySynchState)
+        PYTHON_GLOBAL_METHOD(PtDirtySynchClients)
 
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetLocalClientID);
-    
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtIsCCRAway);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtAmCCR);
+        PYTHON_GLOBAL_METHOD(PtEnableControlKeyEvents)
+        PYTHON_GLOBAL_METHOD(PtDisableControlKeyEvents)
 
-    PYTHON_GLOBAL_METHOD(methods, PtToggleAvatarClickability);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtTransferParticlesToObject);
-    PYTHON_GLOBAL_METHOD(methods, PtSetParticleDissentPoint);
+        PYTHON_BASIC_GLOBAL_METHOD(PtEnableAvatarCursorFade)
+        PYTHON_BASIC_GLOBAL_METHOD(PtDisableAvatarCursorFade)
+        PYTHON_GLOBAL_METHOD(PtFadeLocalAvatar)
 
-    PYTHON_GLOBAL_METHOD(methods, PtGetControlEvents);
-    
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetLanguage);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtUsingUnicode);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtFakeLinkAvatarToObject);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtWearDefaultClothingType);
+        PYTHON_GLOBAL_METHOD(PtSetOfferBookMode)
+        PYTHON_GLOBAL_METHOD(PtSetShareSpawnPoint)
+        PYTHON_GLOBAL_METHOD(PtSetShareAgeInstanceGuid)
+        PYTHON_GLOBAL_METHOD(PtNotifyOffererLinkAccepted)
+        PYTHON_GLOBAL_METHOD(PtNotifyOffererLinkRejected)
+        PYTHON_GLOBAL_METHOD(PtNotifyOffererLinkCompleted)
+        PYTHON_BASIC_GLOBAL_METHOD(PtClearOfferBookMode)
 
-    PYTHON_GLOBAL_METHOD(methods, PtFileExists);
-    PYTHON_GLOBAL_METHOD(methods, PtCreateDir);
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetLocalClientID)
 
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetUserPath);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetInitPath);
+        PYTHON_GLOBAL_METHOD_NOARGS(PtIsCCRAway)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtAmCCR)
+
+        PYTHON_GLOBAL_METHOD(PtToggleAvatarClickability)
+
+        PYTHON_GLOBAL_METHOD(PtTransferParticlesToObject)
+        PYTHON_GLOBAL_METHOD(PtSetParticleDissentPoint)
+
+        PYTHON_GLOBAL_METHOD(PtGetControlEvents)
+
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetLanguage)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtUsingUnicode)
+
+        PYTHON_GLOBAL_METHOD(PtFakeLinkAvatarToObject)
+
+        PYTHON_GLOBAL_METHOD(PtWearDefaultClothingType)
+
+        PYTHON_GLOBAL_METHOD(PtFileExists)
+        PYTHON_GLOBAL_METHOD(PtCreateDir)
+
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetUserPath)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetInitPath)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, cyMisc3)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue4.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue4.cpp
@@ -761,74 +761,76 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtVaultDownload, args, "Params: nodeId\nDownload
 // AddPlasmaMethods - the python method definitions
 //
 
-void cyMisc::AddPlasmaMethods4(std::vector<PyMethodDef> &methods)
+void cyMisc::AddPlasmaMethods4(PyObject* m)
 {
-    PYTHON_GLOBAL_METHOD(methods, PtRequestLOSScreen);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtKillParticles);
-    PYTHON_GLOBAL_METHOD(methods, PtGetNumParticles);
-    PYTHON_GLOBAL_METHOD(methods, PtSetParticleOffset);
+    PYTHON_START_GLOBAL_METHOD_TABLE(cyMisc4)
+        PYTHON_GLOBAL_METHOD(PtRequestLOSScreen)
 
-    PYTHON_GLOBAL_METHOD(methods, PtSetLightValue);
-    PYTHON_GLOBAL_METHOD(methods, PtSetLightAnimStart);
-    
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtIsSinglePlayerMode);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtIsDemoMode);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtIsInternalRelease);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtIsEnterChatModeKeyBound);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtShootBulletFromScreen);
-    PYTHON_GLOBAL_METHOD(methods, PtShootBulletFromObject);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtGetPublicAgeList);
-    PYTHON_GLOBAL_METHOD(methods, PtCreatePublicAge);
-    PYTHON_GLOBAL_METHOD(methods, PtRemovePublicAge);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtSetClearColor);
-    
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetLocalKILevel);
-    
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtClearCameraStack);
-    PYTHON_GLOBAL_METHOD(methods, PtGetCameraNumber);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetNumCameras);
-    PYTHON_GLOBAL_METHOD(methods, PtRebuildCameraStack);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtRecenterCamera);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtFirstPerson);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtFadeIn);
-    PYTHON_GLOBAL_METHOD(methods, PtFadeOut);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtSetGlobalClickability);
-    PYTHON_GLOBAL_METHOD(methods, PtDebugAssert);
-    PYTHON_GLOBAL_METHOD(methods, PtDebugPrint);
-    PYTHON_GLOBAL_METHOD(methods, PtSetAlarm);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtSaveScreenShot);
-    PYTHON_GLOBAL_METHOD(methods, PtStartScreenCapture);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtSendKIGZMarkerMsg);
-    PYTHON_GLOBAL_METHOD(methods, PtSendKIRegisterImagerMsg);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtWearMaintainerSuit);
-    PYTHON_GLOBAL_METHOD(methods, PtWearDefaultClothing);
-    
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetAgeTimeOfDayPercent);
-    
-    PYTHON_GLOBAL_METHOD(methods, PtCheckVisLOS);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtCheckVisLOSFromCursor);
+        PYTHON_GLOBAL_METHOD(PtKillParticles)
+        PYTHON_GLOBAL_METHOD(PtGetNumParticles)
+        PYTHON_GLOBAL_METHOD(PtSetParticleOffset)
 
-    PYTHON_GLOBAL_METHOD(methods, PtEnablePlanarReflections);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetSupportedDisplayModes);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetDesktopWidth);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetDesktopHeight);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetDesktopColorDepth);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetDefaultDisplayParams);
-    PYTHON_GLOBAL_METHOD(methods, PtSetGraphicsOptions);
+        PYTHON_GLOBAL_METHOD(PtSetLightValue)
+        PYTHON_GLOBAL_METHOD(PtSetLightAnimStart)
 
-    PYTHON_GLOBAL_METHOD(methods, PtSetBehaviorNetFlags);
-    PYTHON_GLOBAL_METHOD(methods, PtSendFriendInvite);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGuidGenerate);
-    PYTHON_GLOBAL_METHOD(methods, PtGetAIAvatarsByModelName);
-    PYTHON_GLOBAL_METHOD(methods, PtForceVaultNodeUpdate);
-    PYTHON_GLOBAL_METHOD(methods, PtVaultDownload);
+        PYTHON_GLOBAL_METHOD_NOARGS(PtIsSinglePlayerMode)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtIsDemoMode)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtIsInternalRelease)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtIsEnterChatModeKeyBound)
+
+        PYTHON_GLOBAL_METHOD(PtShootBulletFromScreen)
+        PYTHON_GLOBAL_METHOD(PtShootBulletFromObject)
+
+        PYTHON_GLOBAL_METHOD(PtGetPublicAgeList)
+        PYTHON_GLOBAL_METHOD(PtCreatePublicAge)
+        PYTHON_GLOBAL_METHOD(PtRemovePublicAge)
+
+        PYTHON_GLOBAL_METHOD(PtSetClearColor)
+
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetLocalKILevel)
+
+        PYTHON_BASIC_GLOBAL_METHOD(PtClearCameraStack)
+        PYTHON_GLOBAL_METHOD(PtGetCameraNumber)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetNumCameras)
+        PYTHON_GLOBAL_METHOD(PtRebuildCameraStack)
+        PYTHON_BASIC_GLOBAL_METHOD(PtRecenterCamera)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtFirstPerson)
+
+        PYTHON_GLOBAL_METHOD(PtFadeIn)
+        PYTHON_GLOBAL_METHOD(PtFadeOut)
+
+        PYTHON_GLOBAL_METHOD(PtSetGlobalClickability)
+        PYTHON_GLOBAL_METHOD(PtDebugAssert)
+        PYTHON_GLOBAL_METHOD(PtDebugPrint)
+        PYTHON_GLOBAL_METHOD(PtSetAlarm)
+
+        PYTHON_GLOBAL_METHOD(PtSaveScreenShot)
+        PYTHON_GLOBAL_METHOD(PtStartScreenCapture)
+
+        PYTHON_GLOBAL_METHOD(PtSendKIGZMarkerMsg)
+        PYTHON_GLOBAL_METHOD(PtSendKIRegisterImagerMsg)
+
+        PYTHON_GLOBAL_METHOD(PtWearMaintainerSuit)
+        PYTHON_GLOBAL_METHOD(PtWearDefaultClothing)
+
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetAgeTimeOfDayPercent)
+
+        PYTHON_GLOBAL_METHOD(PtCheckVisLOS)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtCheckVisLOSFromCursor)
+
+        PYTHON_GLOBAL_METHOD(PtEnablePlanarReflections)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetSupportedDisplayModes)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetDesktopWidth)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetDesktopHeight)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetDesktopColorDepth)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetDefaultDisplayParams)
+        PYTHON_GLOBAL_METHOD(PtSetGraphicsOptions)
+
+        PYTHON_GLOBAL_METHOD(PtSetBehaviorNetFlags)
+        PYTHON_GLOBAL_METHOD(PtSendFriendInvite)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGuidGenerate)
+        PYTHON_GLOBAL_METHOD(PtGetAIAvatarsByModelName)
+        PYTHON_GLOBAL_METHOD(PtForceVaultNodeUpdate)
+        PYTHON_GLOBAL_METHOD(PtVaultDownload)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, cyMisc4)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
@@ -68,11 +68,6 @@ private:
     static bool FirstTimeInit;
     static bool IsInShutdown; // whether we are _really_ in shutdown mode
 
-    static PyMethodDef* plasmaMethods;
-    static PyObject* plasmaMod; // python object that holds the Plasma module
-    static PyObject* plasmaConstantsMod; // python object that holds the PlasmaConstants module
-    static PyObject* plasmaNetConstantsMod; // python object that holds the PlasmaNetConstants module
-    static PyObject* plasmaVaultConstantsMod; // python object that holds the PlasmaVaultConstants module
     static PyObject* stdOut;    // python object of the stdout file
     static PyObject* stdErr;    // python object of the err file
 
@@ -88,10 +83,10 @@ private:
     static plCyDebServer debugServer;
 #endif
 
-    static PyObject* initPlasmaModule();
-    static PyObject* initPlasmaConstantsModule();
-    static PyObject* initPlasmaNetConstantsModule();
-    static PyObject* initPlasmaVaultConstantsModule();
+    static void initPlasmaModule();
+    static void initPlasmaConstantsModule();
+    static void initPlasmaNetConstantsModule();
+    static void initPlasmaVaultConstantsModule();
 
 public:
 
@@ -105,17 +100,17 @@ public:
     static void initPyPackHook();
 
     // Initialize the Plasma module
-    static void AddPlasmaMethods(std::vector<PyMethodDef> &methods);
-    static void AddPlasmaClasses();
+    static void AddPlasmaMethods(PyObject* m);
+    static void AddPlasmaClasses(PyObject* m);
 
     // Initialize the PlasmaConstants module
-    static void AddPlasmaConstantsClasses();
+    static void AddPlasmaConstantsClasses(PyObject* m);
 
     // Initialize the PlasmaNetConstants module;
-    static void AddPlasmaNetConstantsClasses();
+    static void AddPlasmaNetConstantsClasses(PyObject* m);
 
     // Initialize the PlasmaVaultConstants module;
-    static void AddPlasmaVaultConstantsClasses();
+    static void AddPlasmaVaultConstantsClasses(PyObject* m);
 
     // Initialize the Python to Plasma 
     static void initDebugInterface();
@@ -146,10 +141,6 @@ public:
 
     // create a new module with built-ins
     static PyObject* CreateModule(const char* module);
-
-    // checks to see if a specific function is defined in this module
-    // get an item (probably a function) from the Plasma module
-    static PyObject* GetPlasmaItem(const char* item);
 
     // Determine if the module name is unique
     static bool IsModuleNameUnique(const ST::string& module);

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.h
@@ -137,7 +137,7 @@ public:
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pySDLModifier); // converts a PyObject to a pySDLModifier (throws error if not correct type)
 
     static void AddPlasmaClasses(PyObject *m);
-    static void AddPlasmaMethods(std::vector<PyMethodDef> &methods);
+    static void AddPlasmaMethods(PyObject* m);
 
     // global function to get the GrandMaster Age SDL object
     static PyObject* GetAgeSDL();

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifierGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifierGlue.cpp
@@ -256,7 +256,9 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetAgeSDL, "Returns the global ptSDL fo
     return pySDLModifier::GetAgeSDL();
 }
 
-void pySDLModifier::AddPlasmaMethods(std::vector<PyMethodDef> &methods)
+void pySDLModifier::AddPlasmaMethods(PyObject* m)
 {
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetAgeSDL);
+    PYTHON_START_GLOBAL_METHOD_TABLE(ptSDL)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetAgeSDL)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, ptSDL)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyDrawControl.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDrawControl.h
@@ -58,7 +58,7 @@ protected:
     pyDrawControl() {};
 
 public:
-    static void AddPlasmaMethods(std::vector<PyMethodDef> &methods);
+    static void AddPlasmaMethods(PyObject* m);
     //static void AddPlasmaConstantsClasses(PyObject* m);
 
     // static python functions

--- a/Sources/Plasma/FeatureLib/pfPython/pyDrawControlGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDrawControlGlue.cpp
@@ -121,22 +121,24 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtIsClickToTurn, "Is click-to-turn on?")
 // AddPlasmaMethods - the python method definitions
 //
 
-void pyDrawControl::AddPlasmaMethods(std::vector<PyMethodDef> &methods)
+void pyDrawControl::AddPlasmaMethods(PyObject* m)
 {
-    PYTHON_GLOBAL_METHOD(methods, PtSetGamma2);
-    PYTHON_GLOBAL_METHOD(methods, PtSetShadowVisDistance);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetShadowVisDistance);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtEnableShadows);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtDisableShadows);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtIsShadowsEnabled);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtCanShadowCast);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtDisableRenderScene);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtEnableRenderScene);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtSetMouseInverted);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtSetMouseUninverted);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtIsMouseInverted);
-    PYTHON_GLOBAL_METHOD(methods, PtSetClickToTurn);
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtIsClickToTurn);
+    PYTHON_START_GLOBAL_METHOD_TABLE(ptDraw)
+        PYTHON_GLOBAL_METHOD(PtSetGamma2)
+        PYTHON_GLOBAL_METHOD(PtSetShadowVisDistance)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetShadowVisDistance)
+        PYTHON_BASIC_GLOBAL_METHOD(PtEnableShadows)
+        PYTHON_BASIC_GLOBAL_METHOD(PtDisableShadows)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtIsShadowsEnabled)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtCanShadowCast)
+        PYTHON_BASIC_GLOBAL_METHOD(PtDisableRenderScene)
+        PYTHON_BASIC_GLOBAL_METHOD(PtEnableRenderScene)
+        PYTHON_BASIC_GLOBAL_METHOD(PtSetMouseInverted)
+        PYTHON_BASIC_GLOBAL_METHOD(PtSetMouseUninverted)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtIsMouseInverted)
+        PYTHON_GLOBAL_METHOD(PtSetClickToTurn)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtIsClickToTurn)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, ptDraw)
 }
 
 /*void pyDrawControl::AddPlasmaConstantsClasses(PyObject *m)

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.h
@@ -76,7 +76,7 @@ public:
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyGUIDialog); // converts a PyObject to a pyGUIDialog (throws error if not correct type)
 
     static void AddPlasmaClasses(PyObject *m);
-    static void AddPlasmaMethods(std::vector<PyMethodDef> &methods);
+    static void AddPlasmaMethods(PyObject* m);
 
     static bool IsGUIDialog(pyKey& gckey);
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialogGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialogGlue.cpp
@@ -376,10 +376,12 @@ PYTHON_BASIC_GLOBAL_METHOD_DEFINITION(PtGUICursorOff, pyGUIDialog::GUICursorOff,
 PYTHON_BASIC_GLOBAL_METHOD_DEFINITION(PtGUICursorOn, pyGUIDialog::GUICursorOn, "Turns the GUI cursor on")
 PYTHON_BASIC_GLOBAL_METHOD_DEFINITION(PtGUICursorDimmed, pyGUIDialog::GUICursorDimmed, "Dimms the GUI cursor")
 
-void pyGUIDialog::AddPlasmaMethods(std::vector<PyMethodDef> &methods)
+void pyGUIDialog::AddPlasmaMethods(PyObject* m)
 {
-    PYTHON_GLOBAL_METHOD(methods, PtWhatGUIControlType);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtGUICursorOff);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtGUICursorOn);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtGUICursorDimmed);
+    PYTHON_START_GLOBAL_METHOD_TABLE(ptGUIDialog)
+        PYTHON_GLOBAL_METHOD(PtWhatGUIControlType)
+        PYTHON_BASIC_GLOBAL_METHOD(PtGUICursorOff)
+        PYTHON_BASIC_GLOBAL_METHOD(PtGUICursorOn)
+        PYTHON_BASIC_GLOBAL_METHOD(PtGUICursorDimmed)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, ptGUIDialog)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -566,17 +566,28 @@ static PyObject *methodName(PyObject *self) /* and now for the actual function *
     PYTHON_RETURN_NONE; \
 }
 
+#define PYTHON_START_GLOBAL_METHOD_TABLE(name) \
+    { \
+        static PyMethodDef name##_globalMethods[] = {
+
 // this goes in the definition function
-#define PYTHON_GLOBAL_METHOD(vectorVarName, methodName) vectorVarName.push_back(methodName##_method)
+#define PYTHON_GLOBAL_METHOD(methodName) methodName##_method,
 
 // not necessary, but for continuity with the NOARGS function definition above
-#define PYTHON_GLOBAL_METHOD_NOARGS(vectorVarName, methodName) vectorVarName.push_back(methodName##_method);
+#define PYTHON_GLOBAL_METHOD_NOARGS(methodName) methodName##_method,
 
 // not necessary, but for continuity with the WKEY function definition above
-#define PYTHON_GLOBAL_METHOD_WKEY(vectorVarName, methodName) vectorVarName.push_back(methodName##_method)
+#define PYTHON_GLOBAL_METHOD_WKEY(methodName) methodName##_method,
 
 // not necessary, but for continuity with the BASIC function definition above
-#define PYTHON_BASIC_GLOBAL_METHOD(vectorVarName, methodName) vectorVarName.push_back(methodName##_method)
+#define PYTHON_BASIC_GLOBAL_METHOD(methodName) methodName##_method,
+
+#define PYTHON_END_GLOBAL_METHOD_TABLE(moduleVarName, name) \
+            { nullptr, nullptr, 0, nullptr } \
+        }; \
+        if (PyModule_AddFunctions(moduleVarName, name##_globalMethods) < 0) \
+            return; \
+    }
 
 /////////////////////////////////////////////////////////////////////
 // Enum glue (these should all be inside a function)

--- a/Sources/Plasma/FeatureLib/pfPython/pyImage.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyImage.h
@@ -119,7 +119,7 @@ public:
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyImage); // converts a PyObject to a pyImage (throws error if not correct type)
 
     static void AddPlasmaClasses(PyObject *m);
-    static void AddPlasmaMethods(std::vector<PyMethodDef> &methods);
+    static void AddPlasmaMethods(PyObject* m);
 
     void setKey(pyKey& mipmapKey);
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyImageGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyImageGlue.cpp
@@ -275,10 +275,12 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtLoadPNGFromDisk, args, "Params: filename,width
 }
 #endif
 
-void pyImage::AddPlasmaMethods(std::vector<PyMethodDef> &methods)
+void pyImage::AddPlasmaMethods(PyObject* m)
 {
 #ifndef BUILDING_PYPLASMA
-    PYTHON_GLOBAL_METHOD(methods, PtLoadJPEGFromDisk);
-    PYTHON_GLOBAL_METHOD(methods, PtLoadPNGFromDisk);
+    PYTHON_START_GLOBAL_METHOD_TABLE(ptImage)
+        PYTHON_GLOBAL_METHOD(PtLoadJPEGFromDisk)
+        PYTHON_GLOBAL_METHOD(PtLoadPNGFromDisk)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, ptImage)
 #endif
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
@@ -91,7 +91,7 @@ public:
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyJournalBook); // converts a PyObject to a pyJournalBook (throws error if not correct type)
 
     static void AddPlasmaClasses(PyObject *m);
-    static void AddPlasmaMethods(std::vector<PyMethodDef> &methods);
+    static void AddPlasmaMethods(PyObject* m);
     static void AddPlasmaConstantsClasses(PyObject *m);
 
     // Deletes the existing book and re-creates it, for use by the python glue

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
@@ -344,11 +344,13 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtUnloadBookGUI, args, "Params: guiName\nUnloads
 
 PYTHON_BASIC_GLOBAL_METHOD_DEFINITION(PtUnloadAllBookGUIs, pyJournalBook::UnloadAllGUIs, "Unloads all loaded guis except for the default one")
 
-void pyJournalBook::AddPlasmaMethods(std::vector<PyMethodDef> &methods)
+void pyJournalBook::AddPlasmaMethods(PyObject* m)
 {
-    PYTHON_GLOBAL_METHOD(methods, PtLoadBookGUI);
-    PYTHON_GLOBAL_METHOD(methods, PtUnloadBookGUI);
-    PYTHON_BASIC_GLOBAL_METHOD(methods, PtUnloadAllBookGUIs);
+    PYTHON_START_GLOBAL_METHOD_TABLE(ptJournalBook)
+        PYTHON_GLOBAL_METHOD(PtLoadBookGUI)
+        PYTHON_GLOBAL_METHOD(PtUnloadBookGUI)
+        PYTHON_BASIC_GLOBAL_METHOD(PtUnloadAllBookGUIs)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, ptJournalBook)
 }
 
 void pyJournalBook::AddPlasmaConstantsClasses(PyObject *m)

--- a/Sources/Plasma/FeatureLib/pfPython/pySpawnPointInfo.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pySpawnPointInfo.h
@@ -70,7 +70,7 @@ public:
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pySpawnPointInfo); // converts a PyObject to a pySpawnPointInfo (throws error if not correct type)
 
     static void AddPlasmaClasses(PyObject *m);
-    static void AddPlasmaMethods(std::vector<PyMethodDef> &methods);
+    static void AddPlasmaMethods(PyObject* m);
 
     plSpawnPointInfo & SpawnPoint() { return fInfo; }
     void    SetTitle( const char * v ) { fInfo.SetTitle( v ); }

--- a/Sources/Plasma/FeatureLib/pfPython/pySpawnPointInfoGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySpawnPointInfoGlue.cpp
@@ -176,9 +176,11 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetDefaultSpawnPoint, "Returns the defa
     return pySpawnPointInfo::GetDefaultSpawnPoint();
 }
 
-void pySpawnPointInfo::AddPlasmaMethods(std::vector<PyMethodDef> &methods)
+void pySpawnPointInfo::AddPlasmaMethods(PyObject* m)
 {
-    PYTHON_GLOBAL_METHOD_NOARGS(methods, PtGetDefaultSpawnPoint);
+    PYTHON_START_GLOBAL_METHOD_TABLE(ptSpawnPointInfo)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtGetDefaultSpawnPoint)
+    PYTHON_END_GLOBAL_METHOD_TABLE(m, ptSpawnPointInfo)
 }
 
 // glue functions

--- a/Sources/Tools/plShaderAssembler/CMakeLists.txt
+++ b/Sources/Tools/plShaderAssembler/CMakeLists.txt
@@ -13,5 +13,8 @@ add_executable(plShaderAssembler ${plShaderAssembler_SOURCES})
 target_link_libraries(plShaderAssembler ${DirectX_LIBRARIES})
 target_link_libraries(plShaderAssembler CoreLib)
 target_link_libraries(plShaderAssembler ${STRING_THEORY_LIBRARIES})
+if(USE_VLD)
+    target_link_libraries(plShaderAssembler ${VLD_LIBRARIES})
+endif()
 
 source_group("Source Files" FILES ${plShaderAssembler_SOURCES})


### PR DESCRIPTION
This fixes two issues when trying to use VLD with the current code:
- Fixes missing target link library for plShaderAssembler, preventing linking.
- Fixes a crash on exit caused by the builtin Plasma python modules, triggering VLD to think all memory had been leaked. You get quite a bit of bonus code cleanup here.