### PR TITLE
Fix #718.

### DIFF
--- a/Scripts/Python/xSimpleImager.py
+++ b/Scripts/Python/xSimpleImager.py
@@ -321,14 +321,28 @@ class xSimpleImager(ptModifier):
                             self.IShowCurrentContent()
                         if newID == CurrentDisplayedElementID:
                             self.IShowCurrentContent()
+                    elif event[1][:9] == "Uploaded=":
+                        newID = int(event[1][9:])
+                        if newID == CurrentDisplayedElementID:
+                            self.IShowCurrentContent()
                     elif event[1][:7] == "Upload=":
                         deviceName = event[1][7:]
                         nodeId = int(event[3])
                         if deviceName == ImagerName.value:
                             ageVault = ptAgeVault()
                             folder = ageVault.getDeviceInbox(ImagerName.value)
-                            if folder:
+                            if folder and PtWasLocallyNotified(self.key):
                                 folder.linkToNode(nodeId)
+
+                                selfnotify = ptNotify(self.key)
+                                selfnotify.clearReceivers()
+                                selfnotify.addReceiver(self.key)
+                                selfnotify.netPropagate(True)
+                                selfnotify.netForce(True)
+                                selfnotify.setActivate(1.0)
+                                sname = f"Uploaded={nodeId}"
+                                selfnotify.addVarNumber(sname, 1.0)
+                                selfnotify.send()
 
 
     def IRefreshImagerFolder(self):


### PR DESCRIPTION
This fixes a crash introduced by aa8aa38. That commit was designed to ensure that text notes uploaded to the imager would display the sender of the note in the "From:" field instead of the owner of the imager scene object. Unfortunately, the fix was flawed in that it did not consider that MOULa clients will still send out the upload request to everyone in the Age. The crash resulted from a getting a null node into the callback if the item the remote player was attempting to upload did not already exist in our own vault.

A side effect of this is that if the imager becomes owned by a client containing this fix and a MOULa standard client user attempts to upload something, the upload will not be accepted. If it were accepted, that would just bring back the old "From: <wrong player>" bug. A complete fix for this situation will be to submit a change to the ownership test to the OU repository and have it deployed to MOULa.