### PR TITLE
Fixed b0rked hoods on MOULa.

### DIFF
--- a/Scripts/Python/nxusBookMachine.py
+++ b/Scripts/Python/nxusBookMachine.py
@@ -477,10 +477,7 @@ class nxusBookMachine(ptModifier):
         for age in ages:
             ageFilename = age[0].getAgeFilename()
             if ageFilename == "Neighborhood":
-                # if the current population and number of owners is zero then don't display it
-                #looks like it doesn't work (at least on Dirtsand)
-                if age[2] != 0 or age[1] != 0:
-                    hoods.append(AgeInstance(age))
+                hoods.append(AgeInstance(age))
             else:
                 PtDebugPrint("nxusBookMachine.gotPublicAgeList() - got the list of %s instances" % ageFilename)
                 try:


### PR DESCRIPTION
This issue seems to only affect Cyan's server (aka MOULa). Per Susa'n, the Cavern Events Hood [sic] on MOULa will only appear in the Nexus when the Age is occupied. Once the last player leaves the Age, it is removed from the list. Upon further investigation by @cwalther and myself, we determined that the server is incorrectly reporting the owner count of the "b0rked" Neighborhoods as zero. On a quick investigation, we found three affected Neighborhoods currently in the list on MOULa. However, more Neighborhoods are known to be affected.

Per discussion on discord, it makes more sense to NOT filter Neighborhoods in this way in the Nexus. Rather, we should simply allow natural selection to cull inactive Neighborhoods from the list.