### PR TITLE
Fix non-synchonized link out animation.

### DIFF
--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -331,7 +331,7 @@ class xLinkingBookGUIPopup(ptModifier):
                                         #PtDebugPrint("agePanel = ",agePanel)
                                         if agePanel in xLinkingBookDefs.CityBookLinks:
                                             self.IDoCityLinksChron(agePanel)
-                                        respLinkResponder.run(self.key,avatar=PtGetLocalAvatar(),netPropagate=0)
+                                        respLinkResponder.run(self.key,avatar=PtGetLocalAvatar())
 
                                 else:  #Bookshelf Book
                                     if ptVault().amOwnerOfCurrentAge():


### PR DESCRIPTION
This fixes the issue by which the linking responder in a non-bookshelf book is not properly synchronized to remote players. Previously, On the local machine, the player sees him or herself placing his/her hand on the page and linking out. On the remote machine, an avatar walks up to the linking book and links away without touching the page.

This was especially obvious when Chiso Preniv was released on Gehn and during the big August event on MOULa. Both Cyan and Korman generated Ages are affected by this issue.