### PR TITLE
Clean up uses of the recently deprecated ST::null and ST::null_t

### DIFF
--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -656,7 +656,7 @@ static void SaveUserPass(LoginDialogParam* pLoginParam, wchar_t* password)
         if (pLoginParam->remember)
             store->SetPassword(pLoginParam->username, thePass);
         else
-            store->SetPassword(pLoginParam->username, ST::null);
+            store->SetPassword(pLoginParam->username, ST::string());
     }
 
     NetCommSetAccountUsernamePassword(theUser, pLoginParam->namePassHash);

--- a/Sources/Plasma/Apps/plPythonPack/main.cpp
+++ b/Sources/Plasma/Apps/plPythonPack/main.cpp
@@ -233,7 +233,7 @@ void FindSubDirs(std::vector<plFileName> &dirnames, const plFileName &path)
     }
 }
 
-void FindPackages(std::vector<plFileName>& fileNames, std::vector<plFileName>& pathNames, const plFileName& path, const ST::string& parent_package=ST::null)
+void FindPackages(std::vector<plFileName>& fileNames, std::vector<plFileName>& pathNames, const plFileName& path, const ST::string& parent_package={})
 {
     std::vector<plFileName> packages;
     FindSubDirs(packages, path);

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
@@ -219,7 +219,7 @@ ST::string plClientLauncher::GetAppArgs() const
 {
     // If -Repair was specified, there are no args for the next call...
     if (hsCheckBits(fFlags, kRepairGame)) {
-        return ST::null;
+        return ST::string();
     }
 
     ST::string_stream ss;
@@ -477,7 +477,7 @@ void plClientLauncher::ParseArguments()
 
     // last chance setup
     if (hsCheckBits(fFlags, kPatchOnly))
-        fClientExecutable = ST::null;
+        fClientExecutable = plFileName();
     else if (hsCheckBits(fFlags, kRepairGame))
         fClientExecutable = plManifest::PatcherExecutable();
 

--- a/Sources/Plasma/CoreLib/plCmdParser.cpp
+++ b/Sources/Plasma/CoreLib/plCmdParser.cpp
@@ -133,7 +133,7 @@ plCmdParserImpl::plCmdParserImpl(const plCmdArgDef* defs, size_t defCount)
         // Store the argument data
         plCmdArgData& arg = fArgArray[loop];
         arg.def           = def;
-        arg.buffer        = ST::null;
+        arg.buffer        = ST::string();
         arg.nameChars     = def.name.size();
         arg.isSpecified   = false;
 
@@ -348,7 +348,7 @@ bool plCmdParserImpl::TokenizeFlags(plCmdTokenState* state, const ST::string& st
 
         // Process values for boolean arguments
         if (isBool) {
-            result = ProcessValue(state, lastIndex, ST::null);
+            result = ProcessValue(state, lastIndex, ST::string());
             continue;
         }
 

--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -91,7 +91,7 @@ ST::string plFileName::GetFileExt() const
     if (dot > end)
         return fName.substr(dot + 1);
 
-    return ST::null;
+    return ST::string();
 }
 
 ST::string plFileName::GetFileNameNoExt() const

--- a/Sources/Plasma/CoreLib/plFileSystem.h
+++ b/Sources/Plasma/CoreLib/plFileSystem.h
@@ -65,9 +65,6 @@ public:
     /** Construct an empty filename. */
     plFileName() { }
 
-    /** Construct an empty filename. */
-    plFileName(const ST::null_t &) { }
-
     /** Construct a filename from the UTF-8 character data in \a cstr. */
     plFileName(const char *cstr) : fName(cstr) { }
 
@@ -77,17 +74,13 @@ public:
     /** Copy constructor. */
     plFileName(const plFileName &copy) : fName(copy.fName) { }
 
+    /** Move constructor. */
+    plFileName(plFileName &&move) : fName(std::move(move.fName)) { }
+
     /** Assignment operator.  Same as plFileName(const char *). */
     plFileName &operator=(const char *cstr)
     {
         fName.operator=(cstr);
-        return *this;
-    }
-
-    /** Assignment operator.  Same as plFileName(const ST::null_t &). */
-    plFileName &operator=(const ST::null_t &)
-    {
-        fName.operator=(ST::null);
         return *this;
     }
 
@@ -102,6 +95,13 @@ public:
     plFileName &operator=(const plFileName &copy)
     {
         fName.operator=(copy.fName);
+        return *this;
+    }
+
+    /** Assignment operator.  Same as plFileName(plFileName &&). */
+    plFileName &operator=(plFileName &&move)
+    {
+        fName.operator=(std::move(move.fName));
         return *this;
     }
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -290,7 +290,7 @@ plKey FindObjectByName(const ST::string& name, int type, const ST::string& ageNa
         ST::string thisAge = plAgeLoader::GetInstance()->GetCurrAgeDesc().GetAgeName();
         if (!thisAge.empty())
         {
-            key = plKeyFinder::Instance().StupidSearch(thisAge, ST::null, type, name, subString);
+            key = plKeyFinder::Instance().StupidSearch(thisAge, ST::string(), type, name, subString);
             if (key != nil)
             {
                 if (statusStr)
@@ -300,7 +300,7 @@ plKey FindObjectByName(const ST::string& name, int type, const ST::string& ageNa
         }
     }
     // Fallback
-    key = plKeyFinder::Instance().StupidSearch(ageName, ST::null, type, name, subString);
+    key = plKeyFinder::Instance().StupidSearch(ageName, ST::string(), type, name, subString);
 
     if (!key)
     {
@@ -5719,7 +5719,7 @@ PF_CONSOLE_CMD( Animation,                          // Group name
 {
     plAnimCmdMsg *msg = new plAnimCmdMsg();
     msg->SetCmd(plAnimCmdMsg::kContinue);
-    msg->SetAnimName(ST::null);
+    msg->SetAnimName(ST::string());
     msg->SetBCastFlag(plMessage::kPropagateToModifiers);
     SendAnimCmdMsg(ST::string::from_utf8(params[0]), msg);
 }
@@ -5731,7 +5731,7 @@ PF_CONSOLE_CMD( Animation,                          // Group name
 {
     plAnimCmdMsg *msg = new plAnimCmdMsg();
     msg->SetCmd(plAnimCmdMsg::kStop);
-    msg->SetAnimName(ST::null);
+    msg->SetAnimName(ST::string());
     msg->SetBCastFlag(plMessage::kPropagateToModifiers);
     SendAnimCmdMsg(ST::string::from_utf8(params[0]), msg);
 }

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -213,7 +213,7 @@ public:
         kTurnBackPage
     };
     
-    pfBookData(const ST::string &guiName = ST::null);
+    pfBookData(const ST::string &guiName = {});
     virtual ~pfBookData();
 
     void LoadGUI(); // need this seperate because the plKey isn't setup until the constructor is done
@@ -364,8 +364,8 @@ class pfJournalBook : public hsKeyedObject
         // The constructor takes in the esHTML source for the journal, along with
         // the name of the mipmap to use as the cover of the book. The callback
         // key is the keyed object to send event messages to (see <img> tag).
-        pfJournalBook( const char *esHTMLSource, plKey coverImageKey = nil, plKey callbackKey = nil, const plLocation &hintLoc = plLocation::kGlobalFixedLoc, const ST::string &guiName = ST::null );
-        pfJournalBook( const wchar_t *esHTMLSource, plKey coverImageKey = nil, plKey callbackKey = nil, const plLocation &hintLoc = plLocation::kGlobalFixedLoc, const ST::string &guiName = ST::null );
+        pfJournalBook(const char *esHTMLSource, plKey coverImageKey = nil, plKey callbackKey = nil, const plLocation &hintLoc = plLocation::kGlobalFixedLoc, const ST::string &guiName = {});
+        pfJournalBook(const wchar_t *esHTMLSource, plKey coverImageKey = nil, plKey callbackKey = nil, const plLocation &hintLoc = plLocation::kGlobalFixedLoc, const ST::string &guiName = {});
 
         virtual ~pfJournalBook();
 

--- a/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
@@ -77,8 +77,8 @@ class pfKIMsg : public plMessage
         void IInit()
         {
             fCommand = kNoCommand;
-            fString = ST::null;
-            fUser = ST::null;
+            fString = ST::string();
+            fUser = ST::string();
             fPlayerID = 0;
             fFlags = 0;
             fDelay = 0.0;

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
@@ -85,7 +85,7 @@ pfFilePasswordStore::pfFilePasswordStore()
 ST::string pfFilePasswordStore::GetPassword(const ST::string& username)
 {
     plFileName loginDat = plFileName::Join(plFileSystem::GetInitPath(), "login.dat");
-    ST::string password = ST::null;
+    ST::string password;
 
 #ifndef PLASMA_EXTERNAL_RELEASE
     // internal builds can use the local init directory

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
@@ -67,7 +67,7 @@ ST::string pfApplePasswordStore::GetPassword(const ST::string& username)
                                        &passwd,
                                        nullptr) != errSecSuccess)
     {
-        return ST::null;
+        return ST::string();
     }
 
     ST::string ret(reinterpret_cast<const char*>(passwd), size_t(passwd_len));

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Win.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Win.cpp
@@ -56,7 +56,7 @@ ST::string pfWin32PasswordStore::GetPassword(const ST::string& username)
 {
     PCREDENTIALW credential;
     ST::string target = ST::format("{}__{}", GetServerDisplayName(), username);
-    ST::string password = ST::null;
+    ST::string password;
 
     if (!CredReadW(target.to_wchar().data(), CRED_TYPE_GENERIC, 0, &credential)) {
         return password;

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -148,7 +148,7 @@ struct pfPatcherWorker : public hsThread
 
     void OnQuit() override;
 
-    void EndPatch(ENetError result, const ST::string& msg=ST::null);
+    void EndPatch(ENetError result, const ST::string& msg={});
     bool IssueRequest();
     void Run() override;
     void ProcessFile();
@@ -317,8 +317,8 @@ static void IPreloaderManifestDownloadCB(ENetError result, void* param, const wc
         // so, we need to ask the AuthSrv about our game code
         {
             hsLockGuard(patcher->fRequestMut);
-            patcher->fRequests.emplace_back(ST::null, pfPatcherWorker::Request::kPythonList);
-            patcher->fRequests.emplace_back(ST::null, pfPatcherWorker::Request::kSdlList);
+            patcher->fRequests.emplace_back(ST::string(), pfPatcherWorker::Request::kPythonList);
+            patcher->fRequests.emplace_back(ST::string(), pfPatcherWorker::Request::kSdlList);
         }
 
         // continue pumping requests

--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagement.cpp
@@ -96,7 +96,7 @@ ST::string cyAccountManagement::GetAccountName()
     if (acct)
         return acct->accountName;
     else
-        return ST::null;
+        return ST::string();
 }
 
 void cyAccountManagement::CreatePlayer(const ST::string& playerName, const ST::string& avatar, const ST::string& invitationCode)

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -641,7 +641,7 @@ ST::string cyMisc::GetPrevAgeName()
         if (als)
             return als->GetAgeInfo()->GetAgeFilename();
     }
-    return ST::null;
+    return ST::string();
 }
 
 PyObject* cyMisc::GetPrevAgeInfo()

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -1356,7 +1356,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
     auto pRLNMsg = IScriptWantsMsg<plRoomLoadNotifyMsg>(kfunc_PageLoad, msg);
     if (pRLNMsg) {
         ICallScriptMethod(kfunc_PageLoad, pRLNMsg->GetWhatHappen(),
-                          pRLNMsg->GetRoom() ? pRLNMsg->GetRoom()->GetName() : ST::null);
+                          pRLNMsg->GetRoom() ? pRLNMsg->GetRoom()->GetName() : ST::string());
         return true;
     }
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonParameter.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonParameter.h
@@ -383,7 +383,7 @@ public:
                     fString = str;
                 }
                 else
-                    fString = ST::null;
+                    fString = ST::string();
                 break;
 
             case kSceneObject:

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrain.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrain.cpp
@@ -113,7 +113,7 @@ std::string pyCritterBrain::BehaviorName(int behavior) const
 ST::string pyCritterBrain::AnimationName(int behavior) const
 {
     if (!fBrain)
-        return ST::null;
+        return ST::string();
     return fBrain->AnimationName(behavior);
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyDniInfoSource.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDniInfoSource.cpp
@@ -81,7 +81,7 @@ ST::string pyDniInfoSource::GetAgeName() const
 {
     hsRef<RelVaultNode> node = VaultGetAgeInfoNode();
     if (!node)
-        return ST::null;
+        return ST::string();
 
     VaultAgeInfoNode ageInfo(node);
     return ageInfo.GetAgeInstanceName();

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
@@ -81,12 +81,12 @@ class pfColorListElement : public pfGUIListText
             if ( string1 )
             {
                 fString1 = hsStringToWString(string1);
-                fText = ST::null;
+                fText = ST::string();
             }
             else
             {
                 fString1 = nil;
-                fText = ST::null;
+                fText = ST::string();
             }
             fTextColor1 = color1;
             if (string2)
@@ -105,12 +105,12 @@ class pfColorListElement : public pfGUIListText
             {
                 fString1 = new wchar_t[wcslen(string1)+1];
                 wcscpy(fString1,string1);
-                fText = ST::null;
+                fText = ST::string();
             }
             else
             {
                 fString1 = nil;
-                fText = ST::null;
+                fText = ST::string();
             }
             fTextColor1 = color1;
             if (string2)
@@ -132,7 +132,7 @@ class pfColorListElement : public pfGUIListText
             {
                 delete [] fString1;
                 fString1 = nil;
-                fText = ST::null;
+                fText = ST::string();
             }
             if ( fString2 )
                 delete [] fString2;

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameScore.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameScore.cpp
@@ -87,7 +87,7 @@ ST::string pyGameScore::GetGameName() const
 {
     if (fScore)
         return fScore->GetGameName();
-    return ST::null;
+    return ST::string();
 }
 
 void pyGameScore::AddPoints(int32_t numPoints, pyKey& rcvr)

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameScoreMsg.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameScoreMsg.cpp
@@ -73,7 +73,7 @@ ST::string pyGameScoreListMsg::GetName() const
 {
     if (pfGameScoreListMsg* pList = pfGameScoreListMsg::ConvertNoRef(fMsg))
         return pList->GetName();
-    return ST::null;
+    return ST::string();
 }
 
 uint32_t pyGameScoreListMsg::GetOwnerID() const

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.cpp
@@ -56,7 +56,7 @@ ST::string PyUnicode_AsSTString(PyObject* obj)
             return ST::string::from_utf8(str, size, ST::assume_valid);
     }
 
-    return ST::null;
+    return ST::string();
 }
 
 int PyUnicode_STStringConverter(PyObject* obj, void* str)

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
@@ -85,8 +85,8 @@ public:
 
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptBook);
-    static PyObject *New(std::string htmlSource, plKey coverImageKey = nil, plKey callbackKey = nil, const ST::string &guiName = ST::null);
-    static PyObject *New(std::wstring htmlSource, plKey coverImageKey = nil, plKey callbackKey = nil, const ST::string &guiName = ST::null);
+    static PyObject *New(std::string htmlSource, plKey coverImageKey = nil, plKey callbackKey = nil, const ST::string &guiName = {});
+    static PyObject *New(std::wstring htmlSource, plKey coverImageKey = nil, plKey callbackKey = nil, const ST::string &guiName = {});
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyJournalBook object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyJournalBook); // converts a PyObject to a pyJournalBook (throws error if not correct type)
 
@@ -95,8 +95,8 @@ public:
     static void AddPlasmaConstantsClasses(PyObject *m);
 
     // Deletes the existing book and re-creates it, for use by the python glue
-    void MakeBook(std::string esHTMLSource, plKey coverImageKey = nil, plKey callbackKey = nil, const ST::string &guiName = ST::null);
-    void MakeBook(std::wstring esHTMLSource, plKey coverImageKey = nil, plKey callbackKey = nil, const ST::string &guiName = ST::null);
+    void MakeBook(std::string esHTMLSource, plKey coverImageKey = nil, plKey callbackKey = nil, const ST::string &guiName = {});
+    void MakeBook(std::wstring esHTMLSource, plKey coverImageKey = nil, plKey callbackKey = nil, const ST::string &guiName = {});
 
     // Interface functions per book
     virtual void    Show( bool startOpened );

--- a/Sources/Plasma/FeatureLib/pfPython/pyPlayer.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyPlayer.cpp
@@ -48,7 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 pyPlayer::pyPlayer() // only used by python glue, do NOT call
 {
     fAvatarKey = nil;
-    fPlayerName = ST::null;
+    fPlayerName = ST::string();
     fPlayerID = 0;
     fDistSq = -1;
     fIsCCR = false;

--- a/Sources/Plasma/FeatureLib/pfPython/pySDL.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySDL.cpp
@@ -82,7 +82,7 @@ PyObject * pySDLStateDataRecord::FindVar( const ST::string & name ) const
 ST::string pySDLStateDataRecord::GetName() const
 {
     if (!fRec)
-        return ST::null;
+        return ST::string();
     const plStateDescriptor *stateDesc = fRec->GetDescriptor();
     return stateDesc->GetName();
 }
@@ -255,7 +255,7 @@ int pySimpleStateVariable::GetType() const
 ST::string pySimpleStateVariable::GetDisplayOptions() const
 {
     if (!fVar)
-        return ST::null;
+        return ST::string();
     plVarDescriptor *varDesc = fVar->GetVarDescriptor();
     return varDesc->GetDisplayOptions();
 }
@@ -263,7 +263,7 @@ ST::string pySimpleStateVariable::GetDisplayOptions() const
 ST::string pySimpleStateVariable::GetDefault() const
 {
     if (!fVar)
-        return ST::null;
+        return ST::string();
     plVarDescriptor *varDesc = fVar->GetVarDescriptor();
     return varDesc->GetDefault();
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pySceneObject.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySceneObject.cpp
@@ -223,7 +223,7 @@ ST::string pySceneObject::GetName()
 {
     if ( fSceneObjects.Count() > 0 )
         return fSceneObjects[0]->GetName();
-    return ST::null;
+    return ST::string();
 }
 
 PyObject* pySceneObject::findObj(const ST::string& name)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
@@ -184,7 +184,7 @@ ST::string pyVaultAgeInfoNode::GetAgeFilename() const
         VaultAgeInfoNode access(fNode);
         return access.GetAgeFilename();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultAgeInfoNode::SetAgeFilename(const ST::string& v)
@@ -197,7 +197,7 @@ ST::string pyVaultAgeInfoNode::GetAgeInstanceName() const
         VaultAgeInfoNode access(fNode);
         return access.GetAgeInstanceName();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultAgeInfoNode::SetAgeInstanceName(const ST::string& v)
@@ -210,7 +210,7 @@ ST::string pyVaultAgeInfoNode::GetAgeUserDefinedName() const
         VaultAgeInfoNode access(fNode);
         return access.GetAgeUserDefinedName();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultAgeInfoNode::SetAgeUserDefinedName(const ST::string& v)
@@ -237,7 +237,7 @@ ST::string pyVaultAgeInfoNode::GetAgeDescription() const
         VaultAgeInfoNode access(fNode);
         return access.GetAgeDescription();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultAgeInfoNode::SetAgeDescription(const ST::string& v)
@@ -315,7 +315,7 @@ ST::string pyVaultAgeInfoNode::GetDisplayName() const
         }
         return ss.to_string();
     }
-    return ST::null;
+    return ST::string();
 }
 
 PyObject * pyVaultAgeInfoNode::AsAgeInfoStruct() const

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.cpp
@@ -85,7 +85,7 @@ ST::string pyVaultChronicleNode::Chronicle_GetName() const
         VaultChronicleNode chron(fNode);
         return chron.GetEntryName();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultChronicleNode::Chronicle_SetValue( const char * text )
@@ -102,7 +102,7 @@ ST::string pyVaultChronicleNode::Chronicle_GetValue() const
         VaultChronicleNode chron(fNode);
         return chron.GetEntryValue();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultChronicleNode::Chronicle_SetType( uint32_t type )

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.cpp
@@ -109,5 +109,5 @@ ST::string pyVaultFolderNode::Folder_GetName() const
         VaultFolderNode folder(fNode);
         return folder.GetFolderName();
     }
-    return ST::null;
+    return ST::string();
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.cpp
@@ -135,7 +135,7 @@ ST::string pyVaultImageNode::Image_GetTitle() const
         VaultImageNode image(fNode);
         return image.GetImageTitle();
     }
-    return ST::null;
+    return ST::string();
 }
 
 PyObject* pyVaultImageNode::Image_GetImage()

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNode.cpp
@@ -72,7 +72,7 @@ ST::string pyVaultMarkerGameNode::GetGameName () const
         VaultMarkerGameNode access(fNode);
         return access.GetGameName();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultMarkerGameNode::SetGameName (const ST::string& name)
@@ -89,7 +89,7 @@ ST::string pyVaultMarkerGameNode::GetReward() const
         VaultMarkerGameNode access(fNode);
         return access.GetReward();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultMarkerGameNode::SetReward(const ST::string& value)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -281,7 +281,7 @@ ST::string pyVaultNode::GetCreateAgeName() const
 {
     if (fNode)
         return fNode->GetCreateAgeName();
-    return ST::null;
+    return ST::string();
 }
 
 plUUID pyVaultNode::GetCreateAgeGuid() const

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.cpp
@@ -103,7 +103,7 @@ ST::string pyVaultPlayerInfoNode::Player_GetPlayerName() const
         VaultPlayerInfoNode playerInfo(fNode);
         return playerInfo.GetPlayerName();
     }
-    return ST::null;
+    return ST::string();
 }
 
 // age the player is currently in, if any.
@@ -121,7 +121,7 @@ ST::string pyVaultPlayerInfoNode::Player_GetAgeInstanceName() const
         VaultPlayerInfoNode playerInfo(fNode);
         return playerInfo.GetAgeInstName();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultPlayerInfoNode::Player_SetAgeGuid( const char * guidtext)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.cpp
@@ -248,7 +248,7 @@ ST::string pyVaultPlayerNode::GetPlayerName() const
         VaultPlayerNode player(fNode);
         return player.GetPlayerName();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultPlayerNode::SetAvatarShapeName(const char *value)
@@ -262,7 +262,7 @@ ST::string pyVaultPlayerNode::GetAvatarShapeName() const
         VaultPlayerNode player(fNode);
         return player.GetAvatarShapeName();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultPlayerNode::SetDisabled(bool value)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
@@ -96,7 +96,7 @@ ST::string pyVaultTextNoteNode::Note_GetTitle() const
         VaultTextNoteNode note(fNode);
         return note.GetNoteTitle();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultTextNoteNode::Note_SetText(const char * text)
@@ -122,7 +122,7 @@ ST::string pyVaultTextNoteNode::Note_GetText() const
         VaultTextNoteNode note(fNode);
         return note.GetNoteText();
     }
-    return ST::null;
+    return ST::string();
 }
 
 void pyVaultTextNoteNode::Note_SetType( int32_t type )

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plUoid.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plUoid.cpp
@@ -220,7 +220,7 @@ void plUoid::Invalidate()
     fCloneID = 0;
     fClonePlayerID = 0;
     fClassType = 0;
-    fObjectName = ST::null;
+    fObjectName = ST::string();
     fLocation.Invalidate();
     fLoadMask = plLoadMask::kAlways;
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plNotifyMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plNotifyMsg.cpp
@@ -1315,12 +1315,12 @@ void proControlKeyEventData::IWriteVersion(hsStream* s, hsResMgr* mgr)
 
 void proVariableEventData::IInit()
 {
-    fName = ST::null;
+    fName = ST::string();
 }
 
 void proVariableEventData::IDestruct()
 {
-    fName = ST::null;
+    fName = ST::string();
 }
 
 void proVariableEventData::IReadNumber(hsStream * stream) {

--- a/Sources/Plasma/NucleusLib/pnMessage/plSDLModifierMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSDLModifierMsg.h
@@ -71,7 +71,7 @@ protected:
     uint32_t fFlags;
 
 public:
-    plSDLModifierMsg(const ST::string& sdlName=ST::null, Action a=kActionNone);
+    plSDLModifierMsg(const ST::string& sdlName={}, Action a=kActionNone);
     ~plSDLModifierMsg();
 
     CLASSNAME_REGISTER(plSDLModifierMsg);

--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbSrvs.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbSrvs.cpp
@@ -49,9 +49,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *
 ***/
 
-static ST::string s_authAddrs[] = { ST::null };
-static ST::string s_fileAddrs[] = { ST::null };
-static ST::string s_gateKeeperAddrs[] = { ST::null };
+static ST::string s_authAddrs[] = { ST::string() };
+static ST::string s_fileAddrs[] = { ST::string() };
+static ST::string s_gateKeeperAddrs[] = { ST::string() };
 
 static unsigned s_clientPort = 14617;
 

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.cpp
@@ -257,5 +257,5 @@ ST::string plGenericType::GetAsString() const
         hsAssert(false,"plGenericType::GetAsString unknown type");
     }
 
-    return ST::null;
+    return ST::string();
 }

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.h
@@ -148,7 +148,7 @@ protected:
     ST::string    fName;
 public:
     plGenericVar(const plGenericVar &c) { CopyFrom(c); }
-    plGenericVar(const ST::string& name=ST::null) : fName(name) { }
+    plGenericVar(const ST::string& name={}) : fName(name) { }
     virtual ~plGenericVar() { }
 
     virtual void Reset() { Value().Reset(); }   // reset runtime state, not inherent state

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedValue.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedValue.h
@@ -144,7 +144,7 @@ public:
         {
             MakeDirty();                        // dirty value
             if (GetSynchedObject())
-                GetSynchedObject()->DirtySynchState(ST::null, 0);    // dirty owner
+                GetSynchedObject()->DirtySynchState(ST::string(), 0);    // dirty owner
         }
     }
 

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.cpp
@@ -359,7 +359,7 @@ inline void IZero(T& dest)
 template<>
 inline void IZero<ST::string>(ST::string& dest)
 {
-    dest = ST::null;
+    dest = ST::string();
 }
 
 template<>

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.h
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.h
@@ -126,8 +126,8 @@ public:
 
     // Fun debugging exclude commands (to prevent certain pages from loading)
     void    ClearPageExcludeList();
-    void    AddExcludedPage( const ST::string& pageName, const ST::string& ageName = ST::null );
-    bool    IsPageExcluded( const plAgePage *page, const ST::string& ageName = ST::null );
+    void    AddExcludedPage(const ST::string& pageName, const ST::string& ageName = {});
+    bool    IsPageExcluded(const plAgePage *page, const ST::string& ageName = {});
 
     const plAgeDescription  &GetCurrAgeDesc() const { return fCurAgeDescription; }
 

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
@@ -76,7 +76,7 @@ void plResPatcher::Shutdown()
 
 void plResPatcher::OnCompletion(ENetError result, const ST::string& status)
 {
-    ST::string error = ST::null;
+    ST::string error;
     if (IS_NET_ERROR(result))
         error = ST::format("Update Failed: {}\n{}", NetErrorAsString(result), status);
     plgDispatch::Dispatch()->MsgQueue(new plResPatcherMsg(IS_NET_SUCCESS(result), error));

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnim.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnim.cpp
@@ -207,7 +207,7 @@ ST::string plAGAnim::GetChannelName(int index)
     {
         return fApps[index]->GetChannel()->GetName();
     } else {
-        return ST::null;
+        return ST::string();
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -175,7 +175,7 @@ plAGAnimInstance::plAGAnimInstance(plAGAnim * anim, plAGMasterMod * master,
     fFadeBlend = fFadeAmp = false;
 
 #ifdef TRACK_AG_ALLOCS
-    gGlobalAnimName = ST::null;
+    gGlobalAnimName = ST::string();
 #endif // TRACK_AG_ALLOCS
 }
 
@@ -398,7 +398,7 @@ ST::string plAGAnimInstance::GetName()
     if(fAnimation)
         return fAnimation->GetName();
     else
-        return ST::null;
+        return ST::string();
 }
 
 // SetLoop ----------------------------------

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
@@ -221,7 +221,7 @@ ST::string plAudioSystem::GetDefaultPlaybackDevice() const
         return ST::string::from_utf8(alcGetString(nullptr, ALC_DEVICE_SPECIFIER));
     } else {
         plStatusLog::AddLineS("audio.log", plStatusLog::kRed, "ASYS: Unable to fetch the default playback device name.");
-        return ST::null;
+        return ST::string();
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.h
@@ -239,7 +239,7 @@ public:
     virtual void        UpdateSoftVolume( bool enable, bool firstTime = false );
 
     virtual bool        MsgReceive( plMessage* pMsg );
-    virtual bool        DirtySynchState( const ST::string &sdlName = ST::null, uint32_t sendFlags = 0 ); // call when state has changed
+    virtual bool        DirtySynchState( const ST::string &sdlName = {}, uint32_t sendFlags = 0 ); // call when state has changed
 
     // Tests whether this sound is within range of the given position, not counting soft regions
     bool                IsWithinRange( const hsPoint3 &listenerPos, float *distSquared );

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -658,12 +658,12 @@ void plArmatureMod::IInitDefaults()
     fPhysHeight = 0.f;
     fPhysWidth = 0.f;
     fUpdateMsg = nil;
-    fRootName = ST::null;
+    fRootName = ST::string();
     fDontPanicLink = false;
     fBodyAgeName = "GlobalAvatars";
     fBodyFootstepSoundPage = "Audio";
     fAnimationPrefix = "Male";
-    fUserStr = ST::null;
+    fUserStr = ST::string();
 }
 
 plArmatureMod::plArmatureMod() : plArmatureModBase()
@@ -1790,7 +1790,7 @@ void plArmatureMod::Read(hsStream * stream, hsResMgr *mgr)
             {
                 // So it exists... but FindKey won't properly create our clone. So we do.
                 SOUoid.SetClone(myUoid.GetClonePlayerID(), myUoid.GetCloneID());
-                fFootSoundSOKey = mgr->ReRegister(ST::null, SOUoid);
+                fFootSoundSOKey = mgr->ReRegister(ST::string(), SOUoid);
             }
 
             // Add the effect to our effects manager
@@ -1799,7 +1799,7 @@ void plArmatureMod::Read(hsStream * stream, hsResMgr *mgr)
             if (effectKey)
             {
                 effectUoid.SetClone(myUoid.GetClonePlayerID(), myUoid.GetCloneID());
-                effectKey = mgr->ReRegister(ST::null, effectUoid);
+                effectKey = mgr->ReRegister(ST::string(), effectUoid);
             }
             if (effectKey != nil)
                 mgr->AddViaNotify(effectKey, new plGenRefMsg(effectMgrKey, plRefMsg::kOnCreate, -1, -1), plRefFlags::kActiveRef);
@@ -1810,7 +1810,7 @@ void plArmatureMod::Read(hsStream * stream, hsResMgr *mgr)
             if (fLinkSoundSOKey)
             {
                 LinkUoid.SetClone(myUoid.GetClonePlayerID(), myUoid.GetCloneID());
-                fLinkSoundSOKey = mgr->ReRegister(ST::null, LinkUoid);
+                fLinkSoundSOKey = mgr->ReRegister(ST::string(), LinkUoid);
             }
         }
     }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
@@ -302,7 +302,7 @@ std::string plAvBrainCritter::BehaviorName(int behavior) const
 ST::string plAvBrainCritter::AnimationName(int behavior) const
 {
     if ((behavior >= fBehaviors.Count()) || (behavior < 0))
-        return ST::null;
+        return ST::string();
     return ((CritterBehavior*)fBehaviors[behavior])->AnimName();
 }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
@@ -181,7 +181,7 @@ void plClothingItem::Read(hsStream *s, hsResMgr *mgr)
         for (j = 0; j < layerCount; j++)
         {
             int layer = s->ReadByte();
-            mgr->ReadKeyNotifyMe(s, new plElementRefMsg(GetKey(), plRefMsg::kOnCreate, i, -1, ST::null, layer), plRefFlags::kActiveRef); // texture
+            mgr->ReadKeyNotifyMe(s, new plElementRefMsg(GetKey(), plRefMsg::kOnCreate, i, -1, ST::string(), layer), plRefFlags::kActiveRef); // texture
         }
     }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.h
@@ -304,7 +304,7 @@ public:
     plClothingItem *GetLRMatch(plClothingItem *item);
     bool IsLRMatch(plClothingItem *item1, plClothingItem *item2);
 
-    static void ChangeAvatar(const ST::string& name, const plFileName &clothingFile = ST::null);
+    static void ChangeAvatar(const ST::string& name, const plFileName &clothingFile = {});
     
     static plClothingMgr *GetClothingMgr() { return fInstance; }    
     static void Init();

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarMgr.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarMgr.h
@@ -118,7 +118,7 @@ public:
     plKey LoadPlayer(const ST::string &name, const ST::string &account, const ST::string &linkName);
     plKey LoadPlayerFromFile(const ST::string &name, const ST::string &account, const plFileName &clothingFile);
     plKey LoadAvatar(ST::string name, const ST::string &accountName, bool isPlayer, plKey spawnPoint, plAvTask *initialTask,
-                     const ST::string &userStr = ST::null, const plFileName &clothingFile = ST::null);
+                     const ST::string &userStr = {}, const plFileName &clothingFile = {});
 
     /**
      * Unload an avatar clone

--- a/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
+++ b/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
@@ -64,11 +64,11 @@ bool plClipboard::IsTextInClipboard()
 ST::string plClipboard::GetClipboardText()
 {
     if (!IsTextInClipboard()) 
-        return ST::null;
+        return ST::string();
 
 #ifdef HS_BUILD_FOR_WIN32
     if (!::OpenClipboard(NULL))
-        return ST::null;
+        return ST::string();
 
     HANDLE clipboardData = ::GetClipboardData(CF_UNICODETEXT);
     size_t size = ::GlobalSize(clipboardData) / sizeof(wchar_t);
@@ -81,7 +81,7 @@ ST::string plClipboard::GetClipboardText()
 
     return result;
 #else
-    return ST::null;
+    return ST::string();
 #endif	
 }
 

--- a/Sources/Plasma/PubUtilLib/plContainer/plConfigInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plContainer/plConfigInfo.cpp
@@ -1089,7 +1089,7 @@ void plConfigAggregateValue::AddItem(plConfigValueBase * item)
 plWWWAuthenticateConfigSource::plWWWAuthenticateConfigSource(const ST::string& auth)
 :   fAuth(auth)
 {
-    fEffectiveSection = fCurrSection = ST::null;
+    fEffectiveSection = fCurrSection = ST::string();
 }
 
 bool plWWWAuthenticateConfigSource::ReadInto(plConfigInfo & configInfo, KAddValueMode mode)

--- a/Sources/Plasma/PubUtilLib/plContainer/plConfigInfo.h
+++ b/Sources/Plasma/PubUtilLib/plContainer/plConfigInfo.h
@@ -103,12 +103,12 @@ public:
     plKeysAndValues GetSection(const ST::string & section, bool & found);
     std::vector<ST::string> GetSectionNames();
     // get value for key from given section
-    ST::string GetValue(const ST::string & section, const ST::string & key, const ST::string & defval=ST::null, bool * outFound=nil) const;
+    ST::string GetValue(const ST::string & section, const ST::string & key, const ST::string & defval={}, bool * outFound=nil) const;
     int GetValue(const ST::string & section, const ST::string & key, int defval, bool * outFound=nil) const;
     double GetValue(const ST::string & section, const ST::string & key, double defval, bool * outFound=nil) const;
     std::vector<ST::string> GetAllValues(const ST::string & section, const ST::string & key) const;
     // get value for key from any section
-    ST::string GetValueAny(const ST::string & key, const ST::string & defval=ST::null, bool * outFound=nil) const;
+    ST::string GetValueAny(const ST::string & key, const ST::string & defval={}, bool * outFound=nil) const;
     int GetValueAny(const ST::string & key, int defval, bool * outFound=nil) const;
     double GetValueAny(const ST::string & key, double defval, bool * outFound=nil) const;
     std::vector<ST::string> GetAllValuesAny(const ST::string & key) const;

--- a/Sources/Plasma/PubUtilLib/plContainer/plKeysAndValues.h
+++ b/Sources/Plasma/PubUtilLib/plContainer/plKeysAndValues.h
@@ -96,7 +96,7 @@ public:
     bool SetValue(const ST::string & key, int value);
     bool SetValue(const ST::string & key, double value);
     // get single value
-    ST::string GetValue(const ST::string & key, const ST::string & defval=ST::null, bool * outFound=nil) const;
+    ST::string GetValue(const ST::string & key, const ST::string & defval={}, bool * outFound=nil) const;
     uint32_t GetValue(const ST::string & key, uint32_t defval, bool * outFound=nil) const;
     int GetValue(const ST::string & key, int defval, bool * outFound=nil) const;
     double GetValue(const ST::string & key, double defval, bool * outFound=nil) const;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGeometrySpan.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGeometrySpan.cpp
@@ -115,7 +115,7 @@ void    plGeometrySpan::IClearMembers()
 
     fDecalLevel = 0;
 
-    fMaxOwner = ST::null;
+    fMaxOwner = ST::string();
 }
 
 //// ClearBuffers ////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.h
@@ -48,6 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsTemplates.h"
 #include "pnEncryption/plRandom.h"
 #include "hsBounds.h"
+#include "plStatusLog/plStatusLog.h"
 
 #include "plFixedWaterState7.h"
 

--- a/Sources/Plasma/PubUtilLib/plFile/plBrowseFolder.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plBrowseFolder.cpp
@@ -60,7 +60,7 @@ plFileName plBrowseFolder::GetFolder(const plFileName &startPath, const ST::stri
     plFileName path;
     if (!iil) {
         // Browse failed, or cancel was selected
-        path = ST::null;
+        path = plFileName();
     } else {
         // Browse succeded.  Get the path.
         wchar_t buffer[MAX_PATH];

--- a/Sources/Plasma/PubUtilLib/plFile/plBrowseFolder.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plBrowseFolder.h
@@ -64,8 +64,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plBrowseFolder
 {
 public:
-    static plFileName GetFolder(const plFileName &startPath = ST::null,
-                                const ST::string &title = ST::null, HWND hwndOwner = NULL);
+    static plFileName GetFolder(const plFileName &startPath = {},
+                                const ST::string &title = {}, HWND hwndOwner = NULL);
 
 protected:
     static int CALLBACK BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData);

--- a/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
@@ -185,7 +185,7 @@ bool plEncryptedStream::Close()
         fRAMStream = nil;
     }
 
-    fWriteFileName = ST::null;
+    fWriteFileName = ST::string();
     fActualFileSize = 0;
     fBufferedStream = false;
     fOpenMode = kOpenFail;

--- a/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
@@ -294,7 +294,7 @@ bool plSecureStream::Close()
         fRAMStream = nil;
     }
 
-    fWriteFileName = ST::null;
+    fWriteFileName = ST::string();
     fActualFileSize = 0;
     fBufferedStream = false;
     fOpenMode = kOpenFail;

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
@@ -164,7 +164,7 @@ void    plDynamicTextMap::Reset()
     delete [] fInitBuffer;
     fInitBuffer = nil;
 
-    fFontFace = ST::null;
+    fFontFace = ST::string();
 
     // Destroy the old texture ref, since we're no longer using it
     SetDeviceRef( nil );

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -117,7 +117,7 @@ void    plFont::IClear( bool onConstruct )
     if( !onConstruct )
         delete [] fBMapData;
 
-    fFace = ST::null;
+    fFace = ST::string();
     fSize = 0;
     fFlags = 0;
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plAnimCmdMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAnimCmdMsg.h
@@ -55,7 +55,13 @@ protected:
     ST::string fLoopName;
 
 private:
-    void IInit() { fBegin=fEnd=fLoopBegin=fLoopEnd=fSpeed=fSpeedChangeRate=fTime=0; fAnimName=fLoopName=ST::null;}
+    void IInit()
+    {
+        fBegin = fEnd = fLoopBegin = fLoopEnd = fSpeed = fSpeedChangeRate = fTime = 0;
+        fAnimName = ST::string();
+        fLoopName = ST::string();
+    }
+
 public:
     plAnimCmdMsg()
         : plMessageWithCallbacks(nil, nil, nil) { IInit(); }
@@ -135,8 +141,12 @@ protected:
     ST::string fAnimName;
 
 private:
-    void IInit() { fBlend = fAmp = 0;
-                   fAnimName=ST::null;}
+    void IInit()
+    {
+        fBlend = fAmp = 0;
+        fAnimName = ST::string();
+    }
+
 public:
     plAGCmdMsg()
         : plMessage(nil, nil, nil) { IInit(); }

--- a/Sources/Plasma/PubUtilLib/plMessage/plAvatarMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAvatarMsg.h
@@ -190,7 +190,7 @@ public:
     // tors
     plAvSeekMsg();
     plAvSeekMsg(const plKey& sender, const plKey& receiver, const plKey &seekKey, float duration, bool smartSeek,
-                plAvAlignment align = kAlignHandle, const ST::string& animName = ST::null, bool noSeek = false,
+                plAvAlignment align = kAlignHandle, const ST::string& animName = {}, bool noSeek = false,
                 uint8_t flags = kSeekFlagForce3rdPersonOnStart, plKey finishKey = nil);
     
     // plasma protocol

--- a/Sources/Plasma/PubUtilLib/plMessage/plLoadAvatarMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plLoadAvatarMsg.h
@@ -84,7 +84,7 @@ public:
         */
     plLoadAvatarMsg(const plUoid &uoidToClone, const plKey &requestorKey, uint32_t userData,
                     bool isPlayer, const plKey &spawnPoint, plAvTask *initialTask,
-                    const ST::string &userStr = ST::null);
+                    const ST::string &userStr = {});
 
     /** Use this form if you're sending a message about an existing clone -- either
         to propagate it to other machines or to tell them to unload it.
@@ -98,7 +98,7 @@ public:
         \param userStr - a string that the user can set
         */
     plLoadAvatarMsg(const plKey &existing, const plKey &requestorKey, uint32_t userData,
-                    bool isPlayer, bool isLoading, const ST::string &userStr = ST::null);
+                    bool isPlayer, bool isLoading, const ST::string &userStr = {});
 
     void SetIsPlayer(bool is) { fIsPlayer = is; }
     bool GetIsPlayer() { return fIsPlayer; }

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -1098,7 +1098,7 @@ ST::string plNetClientMgr::GetPlayerName(const plKey avKey) const
         return NetCommGetPlayer()->playerName;
 
     plNetTransportMember* mbr=TransportMgr().GetMember(TransportMgr().FindMember(avKey));
-    return mbr ? mbr->GetPlayerName() : ST::null;
+    return mbr ? mbr->GetPlayerName() : ST::string();
 }
 
 ST::string plNetClientMgr::GetPlayerNameById (unsigned playerId) const {
@@ -1107,7 +1107,7 @@ ST::string plNetClientMgr::GetPlayerNameById (unsigned playerId) const {
         return NetCommGetPlayer()->playerName;
 
     plNetTransportMember * mbr = TransportMgr().GetMember(TransportMgr().FindMember(playerId));
-    return mbr ? mbr->GetPlayerName() : ST::null;
+    return mbr ? mbr->GetPlayerName() : ST::string();
 }
 
 unsigned plNetClientMgr::GetPlayerIdByName (const ST::string & name) const {

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.cpp
@@ -201,7 +201,8 @@ void plCreatableListHelper::AddDouble( uint16_t id, double value )
 ST::string plCreatableListHelper::GetString( uint16_t id )
 {
     plCreatableGenericValue * V = plCreatableGenericValue::ConvertNoRef( GetItem( id ) );
-    if ( !V ) return ST::null;
+    if (!V)
+        return ST::string();
     return (ST::string)V->Value();
 }
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.cpp
@@ -204,10 +204,10 @@ void hsG3DDeviceRecord::Clear()
 {
     fFlags = kNone;
 
-    fG3DDriverDesc = ST::null;
-    fG3DDriverName = ST::null;
-    fG3DDriverVersion = ST::null;
-    fG3DDeviceDesc = ST::null;
+    fG3DDriverDesc = ST::string();
+    fG3DDriverName = ST::string();
+    fG3DDriverVersion = ST::string();
+    fG3DDeviceDesc = ST::string();
 
     fCaps.Clear();
     fLayersAtOnce = 0;

--- a/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
@@ -263,12 +263,12 @@ void plKeyFinder::IGetNames(std::vector<ST::string>& names, const ST::string& se
 
 void plKeyFinder::GetResponderNames(std::vector<ST::string>& names)
 {
-    IGetNames(names, ST::null, CLASS_INDEX_SCOPED(plResponderModifier));
+    IGetNames(names, ST::string(), CLASS_INDEX_SCOPED(plResponderModifier));
 }
 
 void plKeyFinder::GetActivatorNames(std::vector<ST::string>& names)
 {
-    IGetNames(names, ST::null, CLASS_INDEX_SCOPED(plLogicModifier));
+    IGetNames(names, ST::string(), CLASS_INDEX_SCOPED(plLogicModifier));
 }
 
 class plKeyFinderIterator : public plRegistryKeyIterator, public plRegistryPageIterator

--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
@@ -109,7 +109,7 @@ plFileName plLocalization::IGetLocalized(const plFileName& name, Language lang)
             return name.AsString().replace(fLangTags[kEnglish], fLangTags[lang]);
     }
 
-    return ST::null;
+    return plFileName();
 }
 
 plFileName plLocalization::ExportGetLocalized(const plFileName& name, int lang)

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.h
@@ -156,7 +156,7 @@ public:
     // Single page version
     bool IterateKeys(plRegistryKeyIterator* iterator, const plLocation& pageToRestrictTo);
     // Iterate through loaded pages
-    bool IteratePages(plRegistryPageIterator* iterator, const ST::string& ageToRestrictTo = ST::null);
+    bool IteratePages(plRegistryPageIterator* iterator, const ST::string& ageToRestrictTo = {});
     // Iterate through ALL pages, loaded or not
     bool IterateAllPages(plRegistryPageIterator* iterator);
 

--- a/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
@@ -224,7 +224,7 @@ void plAutoProfileImp::INextProfile()
                 plJPEG::Instance().WriteToFile(fileName.c_str(), &mipmap);
             }
 
-            fLastSpawnPointName = ST::null;
+            fLastSpawnPointName = ST::string();
         }
 
         // Try to go to the next spawn point
@@ -302,7 +302,7 @@ bool plAutoProfileImp::INextSpawnPoint()
 
     if (!foundGood)
     {
-        fLastSpawnPointName = ST::null;
+        fLastSpawnPointName = ST::string();
         fStatusMessage = "No profile spawn point found";
         return false;
     }

--- a/Sources/Tools/MaxComponent/plAGComponents.cpp
+++ b/Sources/Tools/MaxComponent/plAGComponents.cpp
@@ -270,7 +270,7 @@ bool plAnimAvatarComponent::ConvertNodeSegmentBranch(plMaxNode *node, plAGAnim *
 {
     // Check for a suppression marker
     plNotetrackAnim noteAnim(node, pErrMsg);
-    plAnimInfo info = noteAnim.GetAnimInfo(ST::null);
+    plAnimInfo info = noteAnim.GetAnimInfo(ST::string());
     bool suppressed = info.IsSuppressed(mod->GetName());
 
     // Get the affine parts and the TM Controller

--- a/Sources/Tools/MaxComponent/plAnimComponent.cpp
+++ b/Sources/Tools/MaxComponent/plAnimComponent.cpp
@@ -616,7 +616,7 @@ ST::string plAnimComponentBase::GetAnimName()
 {
     const char *name = fCompPB->GetStr(kAnimName);
     if (!name || name[0] == '\0')
-        return ST::null;
+        return ST::string();
     return ST::string::from_utf8(name);
 }
 

--- a/Sources/Tools/MaxComponent/plAutoUIParams.cpp
+++ b/Sources/Tools/MaxComponent/plAutoUIParams.cpp
@@ -1616,7 +1616,7 @@ void plPickMaterialAnimationButtonParam::CreateKeyArray(IParamBlock2* pb)
 
     Mtl* mtl = (Mtl*)pb->GetReferenceTarget(fID);
 
-    int bob = GetMatAnimModKey(mtl, nil, ST::null, fKeys);
+    int bob = GetMatAnimModKey(mtl, nil, ST::string(), fKeys);
 }
 
 void plPickMaterialAnimationButtonParam::DestroyKeyArray()

--- a/Sources/Tools/MaxComponent/plNotetrackAnim.cpp
+++ b/Sources/Tools/MaxComponent/plNotetrackAnim.cpp
@@ -86,7 +86,7 @@ plNotetrackAnim::~plNotetrackAnim()
 ST::string plNotetrackAnim::GetNextAnimName()
 {
     if (!fSegMap)
-        return ST::null;
+        return ST::string();
 
     while (fAnimIt != fSegMap->end())
     {
@@ -98,7 +98,7 @@ ST::string plNotetrackAnim::GetNextAnimName()
     }
 
     fAnimIt = fSegMap->begin();
-    return ST::null;
+    return ST::string();
 }
 
 plAnimInfo plNotetrackAnim::GetAnimInfo(const ST::string &animName)
@@ -107,7 +107,7 @@ plAnimInfo plNotetrackAnim::GetAnimInfo(const ST::string &animName)
         return plAnimInfo();
 
     if (animName.empty() || fSegMap->find(animName) == fSegMap->end())
-        return plAnimInfo(fSegMap, ST::null);
+        return plAnimInfo(fSegMap, ST::string());
     else 
         return plAnimInfo(fSegMap, animName);
 }
@@ -129,7 +129,7 @@ plAnimInfo::plAnimInfo(SegmentMap *segMap, const ST::string &animName)
 
 ST::string plAnimInfo::GetAnimName()
 {
-    return fAnimSpec ? fAnimSpec->fName : ST::null;
+    return fAnimSpec ? fAnimSpec->fName : ST::string();
 }
 
 float plAnimInfo::GetAnimStart()
@@ -150,7 +150,7 @@ float plAnimInfo::GetAnimInitial()
 ST::string plAnimInfo::GetNextLoopName()
 {
     if (!fSegMap)
-        return ST::null;
+        return ST::string();
 
     while (fLoopIt != fSegMap->end())
     {
@@ -163,7 +163,7 @@ ST::string plAnimInfo::GetNextLoopName()
     }
 
     fLoopIt = fSegMap->begin();
-    return ST::null;
+    return ST::string();
 }
 
 float plAnimInfo::GetLoopStart(const ST::string &loopName)
@@ -203,7 +203,7 @@ float plAnimInfo::GetLoopEnd(const ST::string &loopName)
 ST::string plAnimInfo::GetNextMarkerName()
 {
     if (!fSegMap)
-        return ST::null;
+        return ST::string();
 
     while (fMarkerIt != fSegMap->end())
     {
@@ -216,7 +216,7 @@ ST::string plAnimInfo::GetNextMarkerName()
     }
 
     fMarkerIt = fSegMap->begin();
-    return ST::null;
+    return ST::string();
 }
 
 float plAnimInfo::GetMarkerTime(const ST::string &markerName)

--- a/Sources/Tools/MaxComponent/plObjectFlockerComponent.cpp
+++ b/Sources/Tools/MaxComponent/plObjectFlockerComponent.cpp
@@ -276,7 +276,7 @@ bool plObjectFlockerComponent::PreConvert(plMaxNode *node, plErrorMsg *pErrMsg)
 
 bool plObjectFlockerComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
 {
-    node->AddModifier(fFlocker, ST::null);
+    node->AddModifier(fFlocker, ST::string());
 
     return true;
 }

--- a/Sources/Tools/MaxComponent/plResponderComponent.cpp
+++ b/Sources/Tools/MaxComponent/plResponderComponent.cpp
@@ -503,7 +503,7 @@ void plResponderComponent::ISetupDefaultWait(plMaxNode* node, plErrorMsg* pErrMs
             waitInfo.receiver = responder->GetKey();
             waitInfo.callbackUser = numCallbacks++;
             waitInfo.msg = cmds[convertedIdx].fMsg;
-            waitInfo.point = ST::null;
+            waitInfo.point = ST::string();
 
             IParamBlock2 *pb = (IParamBlock2*)statePB->GetReferenceTarget(kStateCmdParams, 0, i);
             plResponderCmd *cmd = plResponderCmd::Find(pb);

--- a/Sources/Tools/MaxComponent/plResponderWait.cpp
+++ b/Sources/Tools/MaxComponent/plResponderWait.cpp
@@ -149,7 +149,7 @@ ST::string ResponderWait::GetWaitPoint(IParamBlock2* waitPB)
 {
     const char* point = waitPB->GetStr(kWaitPoint);
     if (point && *point == '\0')
-        return ST::null;
+        return ST::string();
     return ST::string::from_utf8(point);
 }
 

--- a/Sources/Tools/MaxMain/plMaxNode.cpp
+++ b/Sources/Tools/MaxMain/plMaxNode.cpp
@@ -168,7 +168,7 @@ static ST::string GetAnimCompAnimName(plComponentBase *comp)
 {
     if (comp->ClassID() == ANIM_COMP_CID || comp->ClassID() == ANIM_GROUP_COMP_CID)
         return ((plAnimComponentBase*)comp)->GetAnimName();
-    return ST::null;
+    return ST::string();
 }
 
 static plKey GetAnimCompModKey(plComponentBase *comp, plMaxNodeBase *node)

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthConvert.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthConvert.cpp
@@ -85,7 +85,7 @@ static void ISearchLayerRecur( plLayerInterface *layer, const ST::string &segNam
 
 static int ISearchLayerRecur(hsGMaterial* mat, const ST::string &segName, hsTArray<plKey>& keys)
 {
-    ST::string name = ( segName.compare( ENTIRE_ANIMATION_NAME ) == 0 ) ? ST::null : segName;
+    ST::string name = ( segName.compare( ENTIRE_ANIMATION_NAME ) == 0 ) ? ST::string() : segName;
     int i;
     for( i = 0; i < mat->GetNumLayers(); i++ )
         ISearchLayerRecur(mat->GetLayer(i), name, keys);

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.cpp
@@ -887,7 +887,7 @@ ST::string plAnimStealthNode::GetIfaceSegmentName( bool allowNil )
 {
     // When sending messages to material animations, they're already addressed for the right
     // layer, no need for a segment name
-    return ST::null;
+    return ST::string();
 }
 
 //// Parameter Access Functions //////////////////////////////////////////////

--- a/Sources/Tools/plLocalizationEditor/plEditDlg.cpp
+++ b/Sources/Tools/plLocalizationEditor/plEditDlg.cpp
@@ -312,7 +312,7 @@ void EditDialog::AddClicked()
             else
             {
                 ST::string path = ST::format("{}.{}", key, newLanguage);
-                fCurrentLocPath = ST::null;
+                fCurrentLocPath = ST::string();
                 fUI->fLocalizationTree->clear();
                 fUI->fLocalizationTree->LoadData(path);
                 LoadLocalization(path);
@@ -366,7 +366,7 @@ void EditDialog::DeleteClicked()
 void SplitLocalizationPath(const ST::string &path, ST::string &ageName,
         ST::string &setName, ST::string &locName, ST::string &locLanguage)
 {
-    ageName = setName = locName = locLanguage = ST::null;
+    ageName = setName = locName = locLanguage = ST::string();
 
     std::vector<ST::string> tokens = path.tokenize(".");
     if (tokens.size() >= 1)

--- a/Sources/Tools/plLocalizationEditor/plLocTreeView.cpp
+++ b/Sources/Tools/plLocalizationEditor/plLocTreeView.cpp
@@ -130,5 +130,5 @@ ST::string plLocTreeView::CurrentPath() const
 {
     return (currentItem() != nullptr)
         ? ST::string(currentItem()->data(0, kLocPathRole).toString().toUtf8().constData())
-        : ST::null;
+        : ST::string();
 }


### PR DESCRIPTION
NOTE: Intentionally not using `clear()` since that would require an increase of the minimum string_theory version to 3.4.