### PR TITLE
Fix `PyTypeObject` helpers for Python 3.9.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -177,9 +177,14 @@ int pythonClassName##___init__(pythonClassName *self, PyObject *args, PyObject *
 #define PYTHON_DEFAULT_METHODS_TABLE(pythonClassName) pythonClassName##_methods
 
 // tp_print moved to the end, and two new vectorcall fields inserted in Python 3.8...
-#if (PY_MAJOR_VERSION >= 4) || ((PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION >= 8))
+// tp_print gone in Python 3.9...
+#if PY_VERSION_HEX >= 0x03080000
 #   define PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET(tp_print) 0
-#   define PYTHON_TP_VECTORCALL_PRINT(tp_print) 0, tp_print,
+#   if PY_VERSION_HEX >= 0x03090000
+#       define PYTHON_TP_VECTORCALL_PRINT(tp_print) 0,
+#   else
+#       define PYTHON_TP_VECTORCALL_PRINT(tp_print) 0, tp_print,
+#   endif
 #else
 #   define PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET(tp_print) tp_print
 #   define PYTHON_TP_VECTORCALL_PRINT(tp_print)


### PR DESCRIPTION
Per [bpo-40170](https://bugs.python.org/issue40170), we need to eventually start thinking about `PyTypeObject` as an opaque structure. That means going through and using type specs to initialize types on the heap. This would actually be a good thing because the code is cleaner. But, for now, the quick fix.