### PR TITLE
Fix issues with resource.dat generation on Windows.

### DIFF
--- a/Sources/Plasma/Apps/plClient/external/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/external/CMakeLists.txt
@@ -12,22 +12,39 @@ set(external_SOURCES
     Voice_Chat.svg
 )
 
-if(PLASMA_EXTERNAL_RELEASE)
-    set(Make_Resource_Command
-		${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/makeres.py --optimize --render --package -i ${CMAKE_CURRENT_SOURCE_DIR} -w ${CMAKE_CURRENT_BINARY_DIR} -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-else(PLASMA_EXTERNAL_RELEASE)
-	set(Make_Resource_Command
-		${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/makeres.py --render --package -i ${CMAKE_CURRENT_SOURCE_DIR} -w ${CMAKE_CURRENT_BINARY_DIR} -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-endif(PLASMA_EXTERNAL_RELEASE)
+find_program(
+    PNGCRUSH_EXECUTABLE pngcrush
+    DOC "Path to pngcrush"
+)
+
+include(CMakeDependentOption)
+cmake_dependent_option(RESOURCE_OPTIMIZE "Optimize the images in resource.dat" ON PNGCRUSH_EXECUTABLE OFF)
+cmake_dependent_option(RESOURCE_BRUTE "Allow pngcrush brute-force optimization" OFF PNGCRUSH_EXECUTABLE OFF)
+
+if(RESOURCE_OPTIMIZE)
+    string(APPEND OPTIMIZE_ARGUMENT "--pngcrush \"${PNGCRUSH_EXECUTABLE}\" ")
+endif()
+if(RESOURCE_BRUTE)
+    string(APPEND OPTIMIZE_ARGUMENT "--brute ")
+endif()
+
+set(Make_Resource_Command
+    ${Python3_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/makeres.py"
+    ${OPTIMIZE_ARGUMENT}
+    --render --package
+    -i "${CMAKE_CURRENT_SOURCE_DIR}"
+    -w "${CMAKE_CURRENT_BINARY_DIR}"
+    -o "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
+)
 
 add_custom_command(
-    OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/resource.dat
+    OUTPUT resource.dat
     COMMAND ${Make_Resource_Command}
     DEPENDS ${external_SOURCES} ${external_SCRIPTS}
 )
 add_custom_target(externalResources 
     SOURCES ${external_SOURCES} ${external_SCRIPTS} 
-    DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/resource.dat
+    DEPENDS resource.dat
 )
 
 source_group("Source Files" FILES ${external_SOURCES})

--- a/Sources/Plasma/Apps/plClient/external/makeres.py
+++ b/Sources/Plasma/Apps/plClient/external/makeres.py
@@ -53,7 +53,8 @@ if __name__ == '__main__':
 	parser.add_option("-q", "--quiet", dest="verbose", default=True, action="store_false", help="Don't print status messages")
 	parser.add_option("-r", "--render", dest="render", default=False, action="store_true", help="Perform SVG Render to images")
 	parser.add_option("-p", "--package", dest="package", default=False, action="store_true", help="Perform packaging into resource container")
-	parser.add_option("-z", "--optimize", dest="optimize", default=False, action="store_true", help="Perform PNGCrush optimization on PNG resources")
+	parser.add_option("-z", "--pngcrush", dest="pngcrush", type="string", help="Perform PNGCrush optimization on PNG resources")
+	parser.add_option("-b", "--brute", dest="brute", default=False, action="store_true", help="Allow brute-force optimization")
 	parser.add_option("-w", "--workpath", dest="workpath", default=".", help="Sets working output path for image renders")
 	parser.add_option("-o", "--outpath", dest="outpath", default=".", help="Sets output path for resource container")
 	parser.add_option("-i", "--inpath", dest="inpath", default=".", help="Sets input path for files to add to resource file")
@@ -72,16 +73,18 @@ if __name__ == '__main__':
 
 	## Do the work!
 	if options.render:
-		ret = subprocess.call(["python", os.path.join(inpath, "render_svg.py"), "-i", inpath, "-o", os.path.join(workpath, "render")], stdout=sys.stdout, stderr=sys.stderr)
+		ret = subprocess.call([sys.executable, os.path.join(inpath, "render_svg.py"), "-i", inpath, "-o", os.path.join(workpath, "render")], stdout=sys.stdout, stderr=sys.stderr)
 		if ret != 0:
 			print("An error has occurred.  Aborting.")
 			exit(1)
 
-	if options.optimize:
+	if options.pngcrush:
 		print("Optimizing PNGs with pngcrush...")
+		crush_args = [options.pngcrush, "-q", "-l", "9"]
+		if options.brute:
+			crush_args.append("-brute")
 		for png in glob.glob(os.path.join(workpath, "render", "*.png")):
-			#print("pngcrushing - {0}".format(png))
-			ret = subprocess.call(["pngcrush", "-q", "-l", "9", "-brute", png, "temp.png"], stdout=sys.stdout, stderr=sys.stderr)
+			ret = subprocess.call(crush_args + [png, "temp.png"], stdout=sys.stdout, stderr=sys.stderr)
 			if ret != 0:
 				print("An error has occurred.  Aborting.")
 				exit(1)

--- a/Sources/Plasma/Apps/plClient/external/makeres.py
+++ b/Sources/Plasma/Apps/plClient/external/makeres.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
 			os.rename("temp.png", png)
 
 	if options.package:
-		ret = subprocess.call(["python", os.path.join(inpath, "create_resource_dat.py"), "-i", os.path.join(workpath, "render"), "-o", os.path.join(outpath, "resource.dat")], stdout=sys.stdout, stderr=sys.stderr)
+		ret = subprocess.call([sys.executable, os.path.join(inpath, "create_resource_dat.py"), "-i", os.path.join(workpath, "render"), "-o", os.path.join(outpath, "resource.dat")], stdout=sys.stdout, stderr=sys.stderr)
 		if ret != 0:
 			print("An error has occurred.  Aborting.")
 			exit(1)

--- a/Sources/Plasma/Apps/plClient/external/requirements.txt
+++ b/Sources/Plasma/Apps/plClient/external/requirements.txt
@@ -1,4 +1,6 @@
+wheel
 https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/cp27/pycairo-1.18.2-cp27-cp27m-win32.whl; sys_platform == "win32" and python_version ~= "2.7"
-cairosvg==1.0.22 ; python_version ~= "2.7"
-cairosvg; python_version >= "3.7"
+pycairo; sys_platform == "win32" and python_version >= "3.8"
+pycairo; sys_platform != "win32"
+cairosvg==1.0.22
 pillow


### PR DESCRIPTION
This fixes our cairosvg dependency such that `pip install -r requirements.txt` works without undocumented dependencies. Further, some invalid assumptions have been corrected in makeres.py. Namely that: the python executable is named exactly `python` and that `pngcrush` is available when building an external client. This should also fix an issue where CMake would error if `CMAKE_RUNTIME_OUTPUT_DIRECTORY` is a generator expression.