### PR TITLE
pfPasswordStore test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,8 @@ add_subdirectory(Sources/Tools)
 
 if(PLASMA_BUILD_TESTS)
     enable_testing()
-    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION>)
+    list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
+    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} ${CMAKE_CTEST_ARGUMENTS} -C $<CONFIGURATION>)
     add_subdirectory(Sources/Tests EXCLUDE_FROM_ALL)
 endif(PLASMA_BUILD_TESTS)
 

--- a/Sources/Tests/FeatureTests/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories("${PLASMA_SOURCE_ROOT}/PubUtilLib/inc")
 include_directories("${PLASMA_SOURCE_ROOT}/FeatureLib")
 include_directories("${PLASMA_SOURCE_ROOT}/FeatureLib/inc")
 
+add_subdirectory(pfPasswordStoreTest)
 if(WIN32)
     add_subdirectory(pfPythonTest)
 endif()

--- a/Sources/Tests/FeatureTests/pfPasswordStoreTest/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/pfPasswordStoreTest/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(pfPasswordStoreTest_SOURCES
+    test_pfPasswordStore.cpp
+)
+
+add_executable(test_pfPasswordStore ${pfPasswordStoreTest_SOURCES})
+target_link_libraries(
+    test_pfPasswordStore
+    PRIVATE
+        gtest
+        gtest_main
+        pnUUID
+        pfPasswordStore
+)
+
+if(TARGET PkgConfig::LIBSECRET AND NOT TARGET Security::Security)
+    target_compile_definitions(test_pfPasswordStore PRIVATE HAVE_LIBSECRET)
+elseif(TARGET Security::Security)
+    target_compile_definitions(test_pfPasswordStore PRIVATE HAVE_SECURITY)
+endif()
+
+add_test(NAME test_pfPasswordStore COMMAND test_pfPasswordStore)
+add_dependencies(check test_pfPasswordStore)

--- a/Sources/Tests/FeatureTests/pfPasswordStoreTest/test_pfPasswordStore.cpp
+++ b/Sources/Tests/FeatureTests/pfPasswordStoreTest/test_pfPasswordStore.cpp
@@ -1,0 +1,130 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <gtest/gtest.h>
+#include <string_theory/string>
+#include "plFileSystem.h"
+#include "pnUUID/pnUUID.h"
+#include "pfPasswordStore/pfPasswordStore.h"
+#include "pfPasswordStore/pfPasswordStore_impl.h"
+
+TEST(pfPasswordStore, service)
+{
+    pfPasswordStore* store = pfPasswordStore::Instance();
+    EXPECT_NE(store, nullptr);
+
+#if defined(HS_BUILD_FOR_WIN32)
+    EXPECT_EQ(typeid(*store), typeid(pfWin32PasswordStore));
+#elif defined(HAVE_SECURITY)
+    EXPECT_EQ(typeid(*store), typeid(pfApplePasswordStore));
+#elif defined(HAVE_LIBSECRET)
+    EXPECT_EQ(typeid(*store), typeid(pfUnixPasswordStore));
+#else
+    EXPECT_EQ(typeid(*store), typeid(pfFilePasswordStore));
+#endif
+}
+
+#if defined(HS_BUILD_FOR_WIN32)
+TEST(pfWin32PasswordStore, storing_and_retrieval)
+{
+    pfWin32PasswordStore store;
+    ST::string username = "test_pfPasswordStore";
+    ST::string password = plUUID::Generate().AsString();
+
+    bool success = store.SetPassword(username, password);
+    EXPECT_EQ(success, true);
+
+    ST::string pass = store.GetPassword(username);
+    EXPECT_EQ(pass.compare(password), 0);
+}
+#endif
+
+#if defined(HAVE_SECURITY)
+TEST(pfApplePasswordStore, storing_and_retrieval)
+{
+    pfApplePasswordStore store;
+    ST::string username = "test_pfPasswordStore";
+    ST::string password = plUUID::Generate().AsString();
+
+    bool success = store.SetPassword(username, password);
+    EXPECT_EQ(success, true);
+
+    ST::string pass = store.GetPassword(username);
+    EXPECT_EQ(pass.compare(password), 0);
+}
+#endif
+
+#if defined(HAVE_LIBSECRET)
+TEST(pfUnixPasswordStore, storing_and_retrieval)
+{
+    pfUnixPasswordStore store;
+    ST::string username = "test_pfPasswordStore";
+    ST::string password = plUUID::Generate().AsString();
+
+    bool success = store.SetPassword(username, password);
+    EXPECT_EQ(success, true);
+
+    ST::string pass = store.GetPassword(username);
+    EXPECT_EQ(pass.compare(password), 0);
+}
+#endif
+
+TEST(pfFilePasswordStore, storing_and_retrieval)
+{
+    // In internal builds, if a local init/login.dat file exists, it will be
+    // used instead of the one in the User AppData folder. For testing, we'll
+    // ensure that file exists to avoid overwriting real login.dat credentials
+    // in the User AppData folder.
+    plFileSystem::CreateDir("init");
+    FILE* f = plFileSystem::Open(plFileName::Join("init", "login.dat"), "wb");
+    fclose(f);
+
+    pfFilePasswordStore store;
+    ST::string username = "test_pfPasswordStore";
+    ST::string password = plUUID::Generate().AsString();
+
+    bool success = store.SetPassword(username, password);
+    EXPECT_EQ(success, true);
+
+    ST::string pass = store.GetPassword(username);
+    EXPECT_EQ(pass.compare(password), 0);
+}


### PR DESCRIPTION
I had a test app lying around from back when we added pfPasswordStore, but it turned out to be easy to slightly restructure it as a unit test.

My only concern here is whether this will cause prompts on Windows or macOS when it tries to access the keychain, which would cause the test to hang/fail.

There are (unfortunately) lots of hoops to jump through to get the keychain to work on Linux CI 😞 