### PR TITLE
Further work on `hsRef`

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -393,10 +393,10 @@ void DebugMsg(const char* fmt, ...);
     
     void    hsDebugMessage(const char* message, long refcon);
     #define hsDebugCode(code)                   code
-    #define hsIfDebugMessage(expr, msg, ref)    (void)( ((expr) != 0) || (hsDebugMessage(msg, ref), 0) )
-    #define hsAssert(expr, ...)                 (void)( ((expr) != 0) || (ErrorAssert(__LINE__, __FILE__, __VA_ARGS__), 0) )
-    #define ASSERT(expr)                        (void)( ((expr) != 0) || (ErrorAssert(__LINE__, __FILE__, #expr), 0) )
-    #define ASSERTMSG(expr, ...)                (void)( ((expr) != 0) || (ErrorAssert(__LINE__, __FILE__, __VA_ARGS__), 0) )
+    #define hsIfDebugMessage(expr, msg, ref)    (void)( (!!(expr)) || (hsDebugMessage(msg, ref), 0) )
+    #define hsAssert(expr, ...)                 (void)( (!!(expr)) || (ErrorAssert(__LINE__, __FILE__, __VA_ARGS__), 0) )
+    #define ASSERT(expr)                        (void)( (!!(expr)) || (ErrorAssert(__LINE__, __FILE__, #expr), 0) )
+    #define ASSERTMSG(expr, ...)                (void)( (!!(expr)) || (ErrorAssert(__LINE__, __FILE__, __VA_ARGS__), 0) )
     #define FATAL(...)                          ErrorAssert(__LINE__, __FILE__, __VA_ARGS__)
     #define DEBUG_MSG                           DebugMsg
     #define DEBUG_BREAK_IF_DEBUGGER_PRESENT     DebugBreakIfDebuggerPresent

--- a/Sources/Plasma/CoreLib/hsRefCnt.h
+++ b/Sources/Plasma/CoreLib/hsRefCnt.h
@@ -146,4 +146,49 @@ private:
     _Ref *fObj;
 };
 
+template <class _Ref>
+class hsWeakRef
+{
+public:
+    hsWeakRef() : fObj(nullptr) { }
+    hsWeakRef(std::nullptr_t) : fObj(nullptr) { }
+    hsWeakRef(_Ref *obj) : fObj(obj) { }
+
+    template <class _OtherRef>
+    hsWeakRef(const hsWeakRef<_OtherRef> &copy) : fObj(copy.Get()) { }
+
+    template <class _OtherRef>
+    hsWeakRef(const hsRef<_OtherRef> &copy) : fObj(copy.Get()) { }
+
+    hsWeakRef<_Ref> &operator=(_Ref *obj)
+    {
+        fObj = obj.Get();
+        return *this;
+    }
+
+    template <class _OtherRef>
+    hsWeakRef<_Ref> &operator=(const hsWeakRef<_OtherRef> &obj)
+    {
+        fObj = obj.Get();
+        return *this;
+    }
+
+    template <class _OtherRef>
+    hsWeakRef<_Ref> &operator=(const hsRef<_OtherRef> &obj)
+    {
+        fObj = obj.Get();
+        return *this;
+    }
+
+    _Ref &operator*() const { return *fObj; }
+    _Ref *operator->() const { return fObj; }
+    _Ref *Get() const { return fObj; }
+
+    operator bool() const { return fObj != nullptr; }
+    bool operator!() const { return fObj == nullptr; }
+
+private:
+    _Ref *fObj;
+};
+
 #endif

--- a/Sources/Plasma/CoreLib/hsRefCnt.h
+++ b/Sources/Plasma/CoreLib/hsRefCnt.h
@@ -132,13 +132,17 @@ public:
     bool operator< (const hsRef<_Ref> &other) const { return fObj <  other.fObj; }
     bool operator>=(const hsRef<_Ref> &other) const { return fObj >= other.fObj; }
     bool operator<=(const hsRef<_Ref> &other) const { return fObj <= other.fObj; }
+    inline bool operator==(const hsWeakRef<_Ref> &other) const;
+    inline bool operator!=(const hsWeakRef<_Ref> &other) const;
     bool operator==(_Ref *other) const { return fObj == other; }
     bool operator!=(_Ref *other) const { return fObj != other; }
 
     _Ref &operator*() const { return *fObj; }
     _Ref *operator->() const { return fObj; }
-    operator _Ref *() const { return fObj; }
     _Ref *Get() const { return fObj; }
+
+    operator bool() const { return fObj != nullptr; }
+    bool operator!() const { return fObj == nullptr; }
 
     void Steal(_Ref *obj)
     {
@@ -220,6 +224,18 @@ hsRef<_Ref> &hsRef<_Ref>::operator=(const hsWeakRef<_Ref> &weak)
         fObj->UnRef();
     fObj = weakObj;
     return *this;
+}
+
+template <class _Ref>
+bool hsRef<_Ref>::operator==(const hsWeakRef<_Ref> &other) const
+{
+    return fObj == other.Get();
+}
+
+template <class _Ref>
+bool hsRef<_Ref>::operator!=(const hsWeakRef<_Ref> &other) const
+{
+    return fObj != other.Get();
 }
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -206,7 +206,8 @@ public:
     {
     }
 
-    void AddedChildNode(RelVaultNode* parentNode, RelVaultNode* childNode)
+    void AddedChildNode(const hsRef<RelVaultNode>& parentNode,
+                        const hsRef<RelVaultNode>& childNode) override
     {
         if (fPyFileMod && fPyFileMod->fPyFunctionInstances[fFunctionIdx]) {
             PyObject* ptuple = PyTuple_New(1);
@@ -215,7 +216,8 @@ public:
         }
     }
 
-    void RemovingChildNode(RelVaultNode* parentNode, RelVaultNode* childNode)
+    void RemovingChildNode(const hsRef<RelVaultNode>& parentNode,
+                           const hsRef<RelVaultNode>& childNode) override
     {
         if (fPyFileMod && fPyFileMod->fPyFunctionInstances[fFunctionIdx]) {
             PyObject* ptuple = PyTuple_New(1);
@@ -224,7 +226,7 @@ public:
         }
     }
 
-    void ChangedNode(RelVaultNode* changedNode)
+    void ChangedNode(const hsRef<RelVaultNode>& changedNode) override
     {
         if (fPyFileMod && fPyFileMod->fPyFunctionInstances[fFunctionIdx]) {
             PyObject* ptuple = PyTuple_New(1);

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.cpp
@@ -264,7 +264,8 @@ void pyAgeVault::UpdateAgeSDL( pySDLStateDataRecord & pyrec )
 PyObject* pyAgeVault::FindNode( pyVaultNode* templateNode ) const
 {
     if (hsRef<RelVaultNode> rvn = VaultGetAgeNode()) {
-        hsRef<RelVaultNode> find = rvn->GetChildNode(templateNode->fNode, 1);
+        hsWeakRef<NetVaultNode> node(templateNode->fNode);
+        hsRef<RelVaultNode> find = rvn->GetChildNode(node, 1);
         if (find)
             return pyVaultNode::New(find);
     }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
@@ -505,7 +505,7 @@ void pyVault::UnRegisterVisitAge( const char * guidstr )
 }
 
 //============================================================================
-void _InvitePlayerToAge(ENetError result, void* state, void* param, RelVaultNode* node)
+void _InvitePlayerToAge(ENetError result, void* state, void* param, hsWeakRef<RelVaultNode> node)
 {
     if (result == kNetSuccess)
         VaultSendNode(node, (uint32_t)((uintptr_t)param));
@@ -522,7 +522,7 @@ void pyVault::InvitePlayerToAge( const pyAgeLinkStruct & link, uint32_t playerID
 }
 
 //============================================================================
-void _UninvitePlayerToAge(ENetError result, void* state, void* param, RelVaultNode* node)
+void _UninvitePlayerToAge(ENetError result, void* state, void* param, hsWeakRef<RelVaultNode> node)
 {
     if (result == kNetSuccess)
         VaultSendNode(node, (uint32_t)((uintptr_t)param));
@@ -619,12 +619,13 @@ PyObject* pyVault::GetGlobalInbox()
 PyObject* pyVault::FindNode( pyVaultNode* templateNode ) const
 {
     // See if we already have a matching node locally
-    if (hsRef<RelVaultNode> rvn = VaultGetNode(templateNode->GetNode()))
+    hsWeakRef<NetVaultNode> node(templateNode->GetNode());
+    if (hsRef<RelVaultNode> rvn = VaultGetNode(node))
         return pyVaultNode::New(rvn);
     
     // See if a matching node exists on the server
     TArray<unsigned> nodeIds;
-    VaultFindNodesAndWait(templateNode->GetNode(), &nodeIds);
+    VaultFindNodesAndWait(node, &nodeIds);
     
     if (nodeIds.Count()) {
         // Only fetch the first matching node since this function returns a single node

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
@@ -81,7 +81,7 @@ static PyObject * GetChildFolder (RelVaultNode * node, unsigned type) {
 */
 
 //============================================================================
-static PyObject * GetChildPlayerInfoList (RelVaultNode * node, unsigned type) {
+static PyObject * GetChildPlayerInfoList(hsWeakRef<RelVaultNode> node, unsigned type) {
     PyObject * result = nil;
     if (hsRef<RelVaultNode> rvn = node->GetChildPlayerInfoListNode(type, 1))
         result = pyVaultPlayerInfoListNode::New(rvn);
@@ -89,7 +89,7 @@ static PyObject * GetChildPlayerInfoList (RelVaultNode * node, unsigned type) {
 }
 
 //============================================================================
-static PyObject * GetChildAgeInfoList (RelVaultNode * node, unsigned type) {
+static PyObject * GetChildAgeInfoList(hsWeakRef<RelVaultNode> node, unsigned type) {
     PyObject * result = nil;
     if (hsRef<RelVaultNode> rvn = node->GetChildAgeInfoListNode(type, 1))
         result = pyVaultAgeInfoListNode::New(rvn);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -185,7 +185,7 @@ bool pyVaultNode::operator==(const pyVaultNode &vaultNode) const
         return false;
     if (ours->GetNodeId() == theirs->GetNodeId())
         return true;
-    return ours->Matches(theirs);
+    return ours->Matches(theirs.Get());
 }
 
 // public getters
@@ -609,7 +609,8 @@ PyObject* pyVaultNode::FindNode( pyVaultNode * templateNode )
     PyObject * result = nil;
     if ( fNode && templateNode->fNode )
     {
-        if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(templateNode->fNode, 1))
+        hsWeakRef<NetVaultNode> node(templateNode->fNode);
+        if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(node, 1))
             result = pyVaultNode::New(rvn);
     }
     

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -148,8 +148,8 @@ void pyVaultNode::pyVaultNodeOperationCallback::VaultOperationComplete( uint32_t
     delete this;  // commit hara-kiri
 }
 
-void pyVaultNode::pyVaultNodeOperationCallback::SetNode (RelVaultNode * rvn) {
-    fNode = rvn;
+void pyVaultNode::pyVaultNodeOperationCallback::SetNode(hsRef<RelVaultNode> rvn) {
+    fNode = std::move(rvn);
 }
 
 hsRef<RelVaultNode> pyVaultNode::pyVaultNodeOperationCallback::GetNode() const {
@@ -592,9 +592,9 @@ PyObject * pyVaultNode::GetNode2( uint32_t nodeID ) const
     PyObject * result = nil;
     if ( fNode )
     {
-        hsRef<RelVaultNode> templateNode = new RelVaultNode;
-        templateNode->SetNodeId(nodeID);
-        if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(templateNode, 1))
+        RelVaultNode templateNode;
+        templateNode.SetNodeId(nodeID);
+        if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(&templateNode, 1))
             result = pyVaultNodeRef::New(fNode, rvn);
     }
     

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
@@ -94,7 +94,7 @@ public:
         void VaultOperationComplete(uint32_t context, int resultCode);
         void VaultOperationComplete(int resultCode) { VaultOperationComplete(fContext, resultCode); }
         
-        void SetNode (RelVaultNode * rvn);
+        void SetNode(hsRef<RelVaultNode> rvn);
         hsRef<RelVaultNode> GetNode() const;
     };
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.cpp
@@ -61,15 +61,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 
 // should only be created from C++ side
-pyVaultNodeRef::pyVaultNodeRef(RelVaultNode * parent, RelVaultNode * child)
-: fParent(parent)
-, fChild(child)
-{
-}
+pyVaultNodeRef::pyVaultNodeRef(hsRef<RelVaultNode> parent, hsRef<RelVaultNode> child)
+    : fParent(std::move(parent)), fChild(std::move(child))
+{ }
 
-pyVaultNodeRef::pyVaultNodeRef(int)
-{
-}
+pyVaultNodeRef::pyVaultNodeRef(std::nullptr_t)
+{ }
 
 hsRef<RelVaultNode> pyVaultNodeRef::GetParentNode() const
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRef.h
@@ -61,8 +61,8 @@ class pyVaultNodeRef
 
 protected:
     // should only be created from C++ side
-    pyVaultNodeRef(RelVaultNode * parent, RelVaultNode * child);
-    pyVaultNodeRef(int =0 );
+    pyVaultNodeRef(hsRef<RelVaultNode> parent, hsRef<RelVaultNode> child);
+    pyVaultNodeRef(std::nullptr_t = nullptr);
 
 public:
     hsRef<RelVaultNode> GetParentNode() const;
@@ -71,7 +71,7 @@ public:
     // required functions for PyObject interoperability
     PYTHON_EXPOSE_TYPE; // so we can subclass
     PYTHON_CLASS_NEW_FRIEND(ptVaultNodeRef);
-    static PyObject *New(RelVaultNode * parent, RelVaultNode * child);
+    static PyObject *New(hsRef<RelVaultNode> parent, hsRef<RelVaultNode> child);
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyVaultNodeRef object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyVaultNodeRef); // converts a PyObject to a pyVaultNodeRef (throws error if not correct type)
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRefGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeRefGlue.cpp
@@ -123,11 +123,11 @@ PLASMA_CUSTOM_TYPE(ptVaultNodeRef, "Vault node relationship pseudo class");
 PYTHON_EXPOSE_TYPE_DEFINITION(ptVaultNodeRef, pyVaultNodeRef);
 
 // required functions for PyObject interoperability
-PyObject *pyVaultNodeRef::New(RelVaultNode * parent, RelVaultNode * child)
+PyObject *pyVaultNodeRef::New(hsRef<RelVaultNode> parent, hsRef<RelVaultNode> child)
 {
     ptVaultNodeRef *newObj = (ptVaultNodeRef*)ptVaultNodeRef_type.tp_new(&ptVaultNodeRef_type, NULL, NULL);
-    newObj->fThis->fParent = parent;
-    newObj->fThis->fChild = child;
+    newObj->fThis->fParent = std::move(parent);
+    newObj->fThis->fChild = std::move(child);
     return (PyObject*)newObj;
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
@@ -86,7 +86,7 @@ bool pyVaultPlayerInfoListNode::HasPlayer( uint32_t playerID )
 
 static void IAddPlayer_NodesFound(ENetError result, void* param, unsigned nodeIdCount, const unsigned nodeIds[])
 {
-    hsRef<NetVaultNode> parent = static_cast<NetVaultNode*>(param);
+    hsWeakRef<NetVaultNode> parent = static_cast<NetVaultNode*>(param);
     if (nodeIdCount)
         VaultAddChildNode(parent->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr, nullptr);
 }
@@ -108,7 +108,7 @@ void pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
     if (nodeIds.Count())
         VaultAddChildNode(fNode->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr, nullptr);
     else
-        VaultFindNodes(&templateNode, IAddPlayer_NodesFound, (NetVaultNode *)fNode);
+        VaultFindNodes(&templateNode, IAddPlayer_NodesFound, fNode.Get());
 }
 
 void pyVaultPlayerInfoListNode::RemovePlayer( uint32_t playerID )

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
@@ -925,7 +925,7 @@ void plClothingOutfit::WriteToVault(const TArray<plStateDataRecord*> & SDRs)
                 nodes.pop_front();
             }
             else {
-                node = new RelVaultNode;
+                node.Steal(new RelVaultNode);
                 node->SetNodeType(plVault::kNodeType_SDL);
                 templates.push_back(node);
             }
@@ -1630,7 +1630,7 @@ void plClothingMgr::AddItemsToCloset(hsTArray<plClosetItem> &items)
         plStateDataRecord rec(plClothingSDLModifier::GetClothingItemSDRName());
         plClothingSDLModifier::PutSingleItemIntoSDR(&items[i], &rec);
         
-        hsRef<RelVaultNode> templateNode = new RelVaultNode;
+        hsRef<RelVaultNode> templateNode(new RelVaultNode, hsStealRef);
         templateNode->SetNodeType(plVault::kNodeType_SDL);
         
         VaultSDLNode sdl(templateNode);

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -1073,7 +1073,7 @@ void NetCommSetActivePlayer (//--> plNetCommActivePlayerMsg
             VaultPlayerInfoNode pInfo(rvn);
             pInfo.SetAgeInstUuid(kNilUuid);
             pInfo.SetOnline(false);
-            NetCliAuthVaultNodeSave(rvn, nil, nil);
+            NetCliAuthVaultNodeSave(rvn.Get(), nil, nil);
         }
 
         VaultCull(s_player->playerInt);

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -3964,7 +3964,7 @@ void VaultFetchNodeTrans::Post () {
     m_callback(
         m_result,
         m_param,
-        m_node
+        m_node.Get()
     );
 }
 

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -119,26 +119,15 @@ struct RelVaultNode : NetVaultNode {
         TArray<unsigned> *  nodeIds,
         unsigned            maxDepth
     );
-    
-    void GetMatchingChildNodeIds (
-        NetVaultNode *      templateNode,
-        TArray<unsigned> *  nodeIds,
-        unsigned            maxDepth
-    );
-    void GetMatchingParentNodeIds (
-        NetVaultNode *      templateNode,
-        TArray<unsigned> *  nodeIds,
-        unsigned            maxDepth
-    );
 
     // returns first matching node found
     hsRef<RelVaultNode> GetParentNode (
-        NetVaultNode *      templateNode,
-        unsigned            maxDepth
+        hsWeakRef<NetVaultNode> templateNode,
+        unsigned                maxDepth
     );
     hsRef<RelVaultNode> GetChildNode (
-        NetVaultNode *      templateNode,
-        unsigned            maxDepth
+        hsWeakRef<NetVaultNode> templateNode,
+        unsigned                maxDepth
     );
     hsRef<RelVaultNode> GetChildNode (
         unsigned            nodeType,
@@ -163,7 +152,7 @@ struct RelVaultNode : NetVaultNode {
         RefList *               nodes
     );
     void GetChildNodes (
-        NetVaultNode *          templateNode,
+        hsWeakRef<NetVaultNode> templateNode,
         unsigned                maxDepth,
         RefList *               nodes
     );
@@ -210,7 +199,7 @@ void VaultUpdate ();
 ***/
 
 hsRef<RelVaultNode> VaultGetNode(unsigned nodeId);
-hsRef<RelVaultNode> VaultGetNode(NetVaultNode * templateNode);
+hsRef<RelVaultNode> VaultGetNode(hsWeakRef<NetVaultNode> templateNode);
 
 // VaultAddChildNode will download the child node if necessary
 // the parent exists locally before making the callback.
@@ -252,15 +241,15 @@ void VaultPublishNode (
     const ST::string& deviceName
 );
 void VaultSendNode (
-    RelVaultNode*   srcNode,
-    unsigned        dstPlayerId
+    hsWeakRef<RelVaultNode> srcNode,
+    unsigned                dstPlayerId
 );
 
 typedef void (*FVaultCreateNodeCallback)(
     ENetError       result,
     void *          state,
     void *          param,
-    RelVaultNode *  node
+    hsWeakRef<RelVaultNode> node
 );
 void VaultCreateNode (          // non-blocking
     plVault::NodeTypes          nodeType,
@@ -269,7 +258,7 @@ void VaultCreateNode (          // non-blocking
     void *                      param
 );
 void VaultCreateNode (          // non-blocking
-    NetVaultNode *              templateNode,
+    hsWeakRef<NetVaultNode>     templateNode,
     FVaultCreateNodeCallback    callback,
     void *                      state,
     void *                      param
@@ -279,11 +268,11 @@ hsRef<RelVaultNode> VaultCreateNodeAndWait (   // block until completion. return
     ENetError *                 result
 );
 hsRef<RelVaultNode> VaultCreateNodeAndWait (   // block until completion. returns node. nil --> failure
-    NetVaultNode *              templateNode,
+    hsWeakRef<NetVaultNode>     templateNode,
     ENetError *                 result
 );
 void VaultForceSaveNodeAndWait (
-    NetVaultNode *      node
+    hsWeakRef<NetVaultNode>     node
 );
 
 typedef void (*FVaultFindNodeCallback)(
@@ -293,16 +282,16 @@ typedef void (*FVaultFindNodeCallback)(
     const unsigned      nodeIds[]
 );
 void VaultFindNodes (
-    NetVaultNode *          templateNode,
+    hsWeakRef<NetVaultNode> templateNode,
     FVaultFindNodeCallback  callback,
     void *                  param
 );
 void VaultFindNodesAndWait (
-    NetVaultNode *          templateNode,
+    hsWeakRef<NetVaultNode> templateNode,
     TArray<unsigned> *      nodeIds
 );
 void VaultLocalFindNodes (
-    NetVaultNode *          templateNode,
+    hsWeakRef<NetVaultNode> templateNode,
     TArray<unsigned> *      nodeIds
 );
 void VaultFetchNodesAndWait (   // Use VaultGetNode to access the fetched nodes
@@ -348,7 +337,7 @@ hsRef<RelVaultNode> VaultGetOwnedAgeInfo(const plAgeInfoStruct * info);
 bool                VaultGetOwnedAgeLink(const plAgeInfoStruct * info, plAgeLinkStruct * link);
 bool                VaultAddOwnedAgeSpawnPoint(const plUUID& ageInstId, const plSpawnPointInfo & spawnPt);
 bool                VaultSetOwnedAgePublicAndWait(const plAgeInfoStruct * info, bool publicOrNot);
-bool                VaultSetAgePublicAndWait(NetVaultNode * ageInfoNode, bool publicOrNot);
+bool                VaultSetAgePublicAndWait(hsWeakRef<NetVaultNode> ageInfoNode, bool publicOrNot);
 hsRef<RelVaultNode> VaultGetVisitAgeLink(const plAgeInfoStruct * info);
 bool                VaultGetVisitAgeLink(const plAgeInfoStruct * info, class plAgeLinkStruct * link);
 bool                VaultRegisterOwnedAgeAndWait(const plAgeLinkStruct * link);

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -69,17 +69,17 @@ struct VaultCallback {
     virtual ~VaultCallback() { }
 
     virtual void AddedChildNode (
-        RelVaultNode *  parent,
-        RelVaultNode *  child
+        const hsRef<RelVaultNode>& parent,
+        const hsRef<RelVaultNode>& child
     ) = 0;
 
     virtual void RemovingChildNode (
-        RelVaultNode *  parent,
-        RelVaultNode *  child
+        const hsRef<RelVaultNode>& parent,
+        const hsRef<RelVaultNode>& child
     ) = 0;
 
     virtual void ChangedNode (
-        RelVaultNode * changedNode
+        const hsRef<RelVaultNode>& changedNode
     ) = 0;
 };
 

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.h
@@ -70,9 +70,9 @@ typedef std::vector<plSpawnPointInfo>   plSpawnPointVec;
 // NetVaultNodeAccess
 //============================================================================
 struct NetVaultNodeAccess {
-    NetVaultNode *  base;
+    hsWeakRef<NetVaultNode> base;
 
-    NetVaultNodeAccess (NetVaultNode * node) : base(node) { }
+    NetVaultNodeAccess(hsWeakRef<NetVaultNode> node) : base(node) { }
 
 private:
     NetVaultNodeAccess (const NetVaultNodeAccess &) { }
@@ -104,7 +104,7 @@ struct VaultPlayerNode : NetVaultNodeAccess {
     VNODE_ACCESSOR(plUUID,          AccountUuid,        Uuid_1);
     VNODE_ACCESSOR(plUUID,          InviteUuid,         Uuid_2);
 
-    VaultPlayerNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultPlayerNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 };
 
 
@@ -119,7 +119,7 @@ struct VaultPlayerInfoNode : NetVaultNodeAccess {
     VNODE_ACCESSOR(int32_t,         Online,             Int32_1);       // whether or not player is online
     VNODE_ACCESSOR(int32_t,         CCRLevel,           Int32_2);
 
-    VaultPlayerInfoNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultPlayerInfoNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 };
 
 
@@ -130,7 +130,7 @@ struct VaultFolderNode : NetVaultNodeAccess {
     VNODE_ACCESSOR(int32_t,         FolderType,         Int32_1);
     VNODE_STRING  (                 FolderName,         String64_1);
 
-    VaultFolderNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultFolderNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 };
 
 
@@ -138,14 +138,14 @@ struct VaultFolderNode : NetVaultNodeAccess {
 // VaultPlayerInfoListNode
 //============================================================================
 struct VaultPlayerInfoListNode : VaultFolderNode {
-    VaultPlayerInfoListNode (NetVaultNode * node) : VaultFolderNode(node) { }
+    VaultPlayerInfoListNode(hsWeakRef<NetVaultNode> node) : VaultFolderNode(node) { }
 };
 
 //============================================================================
 // VaultAgeInfoListNode
 //============================================================================
 struct VaultAgeInfoListNode : VaultFolderNode {
-    VaultAgeInfoListNode (NetVaultNode * node) : VaultFolderNode(node) { }
+    VaultAgeInfoListNode(hsWeakRef<NetVaultNode> node) : VaultFolderNode(node) { }
 };
 
 //============================================================================
@@ -156,7 +156,7 @@ struct VaultChronicleNode : NetVaultNodeAccess {
     VNODE_STRING  (                 EntryName,          String64_1);
     VNODE_STRING  (                 EntryValue,         Text_1);
 
-    VaultChronicleNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultChronicleNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 };
 
 
@@ -168,7 +168,7 @@ struct VaultSDLNode : NetVaultNodeAccess {
     VNODE_ACCESSOR(int32_t,         SDLIdent,           Int32_1);
     VNODE_BLOB    (                 SDLData,            Blob_1);
 
-    VaultSDLNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultSDLNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 
 #ifdef CLIENT
     bool GetStateDataRecord (class plStateDataRecord * out, unsigned readOptions = 0);
@@ -185,7 +185,7 @@ struct VaultAgeLinkNode : NetVaultNodeAccess {
     VNODE_ACCESSOR(int32_t,         Volatile,           Int32_2);
     VNODE_BLOB    (                 SpawnPoints,        Blob_1);
 
-    VaultAgeLinkNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultAgeLinkNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 
 #ifdef CLIENT
     bool CopyTo (plAgeLinkStruct * link);
@@ -208,7 +208,7 @@ struct VaultImageNode : NetVaultNodeAccess {
     VNODE_STRING  (                 ImageTitle,         String64_1);
     VNODE_BLOB    (                 ImageData,          Blob_1);
 
-    VaultImageNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultImageNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 
 #ifdef CLIENT
     void StuffImage (class plMipmap * src, int dstType=kJPEG);
@@ -223,7 +223,7 @@ struct VaultImageNode : NetVaultNodeAccess {
 struct VaultCliImageNode : VaultImageNode {
     class plMipmap * fMipmap;
 
-    VaultCliImageNode (NetVaultNode * node) : VaultImageNode(node) { }
+    VaultCliImageNode(hsWeakRef<NetVaultNode> node) : VaultImageNode(node) { }
 };
 #endif // def CLIENT
 
@@ -236,7 +236,7 @@ struct VaultTextNoteNode : NetVaultNodeAccess {
     VNODE_STRING  (                 NoteTitle,          String64_1);
     VNODE_STRING  (                 NoteText,           Text_1);
 
-    VaultTextNoteNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultTextNoteNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 
 #ifdef CLIENT
     // for kNoteType_Visit/UnVisit
@@ -253,7 +253,7 @@ struct VaultAgeNode : NetVaultNodeAccess {
     VNODE_ACCESSOR(plUUID,          ParentAgeInstanceGuid,  Uuid_2);
     VNODE_STRING  (                 AgeName,                String64_1);
 
-    VaultAgeNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultAgeNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 };
 
 //============================================================================
@@ -275,7 +275,7 @@ struct VaultAgeInfoNode : NetVaultNodeAccess {
     // WARNING: Do not set this. The age will not be set public this way. Use NetCliAuthSetAgePublic instead (changes this field's value in the process).
     VNODE_ACCESSOR(int32_t,         IsPublic,               Int32_2);
 
-    VaultAgeInfoNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultAgeInfoNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 
 #ifdef CLIENT
     const class plUnifiedTime * GetAgeTime () const;
@@ -290,7 +290,7 @@ struct VaultAgeInfoNode : NetVaultNodeAccess {
 struct VaultSystemNode : NetVaultNodeAccess {
     VNODE_ACCESSOR(int32_t,         CCRStatus,          Int32_1);
 
-    VaultSystemNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultSystemNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 };
 
 
@@ -316,7 +316,7 @@ struct VaultMarkerGameNode : NetVaultNodeAccess {
     VNODE_STRING  (                 Reward,             Text_2);
     VNODE_ACCESSOR(plUUID,          GameGuid,           Uuid_1);
 
-    VaultMarkerGameNode (NetVaultNode * node) : NetVaultNodeAccess(node) { }
+    VaultMarkerGameNode(hsWeakRef<NetVaultNode> node) : NetVaultNodeAccess(node) { }
 
     void GetMarkerData(std::vector<VaultMarker>& data) const;
     void SetMarkerData(const std::vector<VaultMarker>& data);


### PR DESCRIPTION
This adds an `hsWeakRef` class which makes (lack of) ownership more clear in several APIs.  Furthermore, construction of an `hsRef` from a raw pointer is now disallowed.  You must either convert it to an `hsWeakRef` (which gets reffed when converted to an `hsRef`, matching the old conversion behavior), or steal it with the APIs added in #625.

In the process, this should plug a couple more leaks, but should be tested to ensure I didn't accidentally plug something that wasn't a leak.