### PR TITLE
Fix CI regression

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,9 @@ install:
     git pull 2> $null
     bootstrap-vcpkg.bat
     vcpkg upgrade --no-dry-run
-    vcpkg install curl[sspi] expat freetype libjpeg-turbo libogg libpng libtheora libvorbis libvpx openal-soft `
-                  opus pcre physx speex string-theory zlib --triplet x86-windows-static-md
+    vcpkg install --recurse curl[sspi] expat freetype libjpeg-turbo libogg `
+            libpng libtheora libvorbis libvpx openal-soft opus pcre physx speex `
+            string-theory zlib --triplet x86-windows-static-md
     vcpkg integrate install
     Write-Host "OK" -foregroundColor Green
 


### PR DESCRIPTION
vcpkg was refusing to rebuild/install new packages because it wants the `--recurse` option (in order to rebuild freetype).