### PR TITLE
Floating point constants

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -59,6 +59,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <cctype>
 #include <cstdarg>
 #include <cstdint>
+#include <type_traits>
 
 //======================================
 // Winblows Hacks
@@ -105,9 +106,26 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define kPosInfinity32      (0x7fffffff)
 #define kNegInfinity32      (0x80000000)
 
-#ifndef M_PI
-#   define M_PI       3.14159265358979323846
-#endif
+// Based on std::numbers from C++20
+namespace hsConstants
+{
+    template <typename T>
+    inline constexpr T pi =
+        std::enable_if_t<std::is_floating_point_v<T>, T>(3.141592653589793238462643383279502884L);
+
+    template <typename T>
+    inline constexpr T half_pi = pi<T> / T(2.0);
+
+    template <typename T>
+    inline constexpr T two_pi = pi<T> * T(2.0);
+
+    template <typename T>
+    inline constexpr T sqrt2 =
+        std::enable_if_t<std::is_floating_point_v<T>, T>(1.414213562373095048801688724209698079L);
+
+    template <typename T>
+    inline constexpr T inv_sqrt2 = T(1.0) / hsConstants::sqrt2<T>;
+}
 
 #ifndef nil
 #   define nil (nullptr)
@@ -359,8 +377,8 @@ int hsMessageBoxWithOwner(hsWindowHndl owner, const wchar_t* message, const wcha
 #define MAX_EXT     (256)
 
 // Useful floating point utilities
-inline float hsDegreesToRadians(float deg) { return float(deg * (M_PI / 180)); }
-inline float hsRadiansToDegrees(float rad) { return float(rad * (180 / M_PI)); }
+constexpr float hsDegreesToRadians(float deg) { return deg * (hsConstants::pi<float> / 180.f); }
+constexpr float hsRadiansToDegrees(float rad) { return rad * (180.f / hsConstants::pi<float>); }
 #define hsInvert(a) (1 / (a))
 
 #ifdef _MSC_VER

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -379,7 +379,7 @@ int hsMessageBoxWithOwner(hsWindowHndl owner, const wchar_t* message, const wcha
 // Useful floating point utilities
 constexpr float hsDegreesToRadians(float deg) { return deg * (hsConstants::pi<float> / 180.f); }
 constexpr float hsRadiansToDegrees(float rad) { return rad * (180.f / hsConstants::pi<float>); }
-#define hsInvert(a) (1 / (a))
+constexpr float hsInvert(float a) { return 1.f / a; }
 
 #ifdef _MSC_VER
 #   define ALIGN(n) __declspec(align(n))

--- a/Sources/Plasma/CoreLib/hsBounds.cpp
+++ b/Sources/Plasma/CoreLib/hsBounds.cpp
@@ -292,11 +292,11 @@ void hsBounds3::MakeTriMeshSphere(hsGTriMesh* tMesh, hsPoint3* cornersIn) const
     {
         for( j = 0; j < nLati; j++ )
         {
-            float theta = (float(i) / nLong) * 2.f * M_PI;
+            float theta = (float(i) / nLong) * hsConstants::two_pi<float>;
             float cosTheta = cos(theta);
             float sinTheta = sin(theta);
 
-            float phi = (float(j+1) / (nLati+1)) * M_PI;
+            float phi = (float(j+1) / (nLati+1)) * hsConstants::pi<float>;
             float cosPhi = cos(phi);
             float sinPhi = sin(phi);
 

--- a/Sources/Plasma/CoreLib/hsBounds.cpp
+++ b/Sources/Plasma/CoreLib/hsBounds.cpp
@@ -215,7 +215,7 @@ void hsBounds3::InscribeSphere()
     if( fType != kBoundsNormal )
         return;
 
-    const float ooSix = hsInvert(2.f * 3.f);
+    constexpr float ooSix = hsInvert(2.f * 3.f);
     float a = GetMaxDim() * ooSix;
     hsPoint3 p = GetCenter();
     p.fX += a;

--- a/Sources/Plasma/CoreLib/hsFastMath.cpp
+++ b/Sources/Plasma/CoreLib/hsFastMath.cpp
@@ -46,20 +46,16 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsGeometry3.h"
 #include "hsFastMath.h"
 
-const float hsFastMath::kSqrtTwo = sqrt(2.f);
-const float hsFastMath::kInvSqrtTwo = hsInvert(hsFastMath::kSqrtTwo);
-const float hsFastMath::kTwoPI = M_PI * 2.f;
-
 hsPoint2 statCosSinTable[9] = // must match length in inline
 {
     { 1.f, 0.f },
-    { hsFastMath::kInvSqrtTwo, hsFastMath::kInvSqrtTwo },
+    { hsConstants::inv_sqrt2<float>, hsConstants::inv_sqrt2<float> },
     { 0.f, 1.f },
-    { -hsFastMath::kInvSqrtTwo, hsFastMath::kInvSqrtTwo },
+    { -hsConstants::inv_sqrt2<float>, hsConstants::inv_sqrt2<float> },
     { -1.f, 0.f },
-    { -hsFastMath::kInvSqrtTwo, -hsFastMath::kInvSqrtTwo },
+    { -hsConstants::inv_sqrt2<float>, -hsConstants::inv_sqrt2<float> },
     { 0.f, -1.f },
-    { hsFastMath::kInvSqrtTwo, -hsFastMath::kInvSqrtTwo },
+    { hsConstants::inv_sqrt2<float>, -hsConstants::inv_sqrt2<float> },
     { 1.f, 0.f }
 };
 

--- a/Sources/Plasma/CoreLib/hsFastMath.h
+++ b/Sources/Plasma/CoreLib/hsFastMath.h
@@ -51,10 +51,6 @@ protected:
     static const hsPoint2* fCosSinTable;
 
 public:
-    static const float kSqrtTwo;
-    static const float kInvSqrtTwo;
-    static const float kTwoPI;
-
     static float IATan2OverTwoPi(float y, float x);
 
     static inline float InvSqrtAppr(float x);
@@ -157,16 +153,16 @@ inline float hsFastMath::InvSqrt(float x)
 
 inline void hsFastMath::SinCosAppr(float rads, float& sinRads, float& cosRads)
 {
-    rads = fmodf(rads, kTwoPI);
+    rads = fmodf(rads, hsConstants::two_pi<float>);
     if( rads < 0 )
-        rads += kTwoPI;
+        rads += hsConstants::two_pi<float>;
     SinCosInRangeAppr(rads, sinRads, cosRads);
 }
 
 inline void hsFastMath::SinCosInRangeAppr(float rads, float& sinRads, float& cosRads)
 {
-    const int kNumSinCosEntries = 8;
-    const float kNumEntriesOverTwoPI = kNumSinCosEntries * 0.5f / M_PI;
+    constexpr int kNumSinCosEntries = 8;
+    constexpr float kNumEntriesOverTwoPI = kNumSinCosEntries * 0.5f / hsConstants::pi<float>;
     float t = rads * kNumEntriesOverTwoPI;
     int iLo = (int)t;
     t -= iLo;
@@ -186,18 +182,18 @@ inline void hsFastMath::SinCosInRangeAppr(float rads, float& sinRads, float& cos
 
 inline float hsFastMath::Sin(float rads)
 {
-    rads = fmodf(rads, kTwoPI);
+    rads = fmodf(rads, hsConstants::two_pi<float>);
     if( rads < 0 )
-        rads += kTwoPI;
+        rads += hsConstants::two_pi<float>;
 
     return SinInRange(rads);
 }
 
 inline float hsFastMath::Cos(float rads)
 {
-    rads = fmodf(rads, kTwoPI);
+    rads = fmodf(rads, hsConstants::two_pi<float>);
     if( rads < 0 )
-        rads += kTwoPI;
+        rads += hsConstants::two_pi<float>;
 
     return CosInRange(rads);
 }
@@ -206,9 +202,9 @@ inline float hsFastMath::SinInRange(float ang)
 {
     float sgn = 1.f;
 
-    if(ang >= (0.75f * kTwoPI))
-        ang -= kTwoPI;
-    else if(ang >= (0.25f * kTwoPI))
+    if (ang >= (0.75f * hsConstants::two_pi<float>))
+        ang -= hsConstants::two_pi<float>;
+    else if (ang >= (0.25f * hsConstants::two_pi<float>))
     {
         ang -= 3.141592654f;
         sgn = -1.0f;
@@ -221,9 +217,9 @@ inline float hsFastMath::CosInRange(float ang)
 {
     float sgn = 1.f;
     
-    if(ang >= (0.75f * kTwoPI))
-        ang -= kTwoPI;
-    else if(ang >= (0.25f * kTwoPI))
+    if (ang >= (0.75f * hsConstants::two_pi<float>))
+        ang -= hsConstants::two_pi<float>;
+    else if (ang >= (0.25f * hsConstants::two_pi<float>))
     {
         ang -= 3.141592654f;
         sgn = -1.0f;
@@ -234,9 +230,9 @@ inline float hsFastMath::CosInRange(float ang)
 
 inline void hsFastMath::SinCos(float rads, float& sinRads, float& cosRads)
 {
-    rads = fmodf(rads, kTwoPI);
+    rads = fmodf(rads, hsConstants::two_pi<float>);
     if( rads < 0 )
-        rads += kTwoPI;
+        rads += hsConstants::two_pi<float>;
     SinCosInRange(rads, sinRads, cosRads);
 }
 
@@ -244,9 +240,9 @@ inline void hsFastMath::SinCosInRange(float ang, float& sinRads, float& cosRads)
 {
     float sgn = 1.f;
     
-    if(ang >= (0.75f * kTwoPI))
-        ang -= kTwoPI;
-    else if(ang >= (0.25f * kTwoPI))
+    if (ang >= (0.75f * hsConstants::two_pi<float>))
+        ang -= hsConstants::two_pi<float>;
+    else if (ang >= (0.25f * hsConstants::two_pi<float>))
     {
         ang -= 3.141592654f;
         sgn = -1.0f;

--- a/Sources/Plasma/CoreLib/hsFastMath.h
+++ b/Sources/Plasma/CoreLib/hsFastMath.h
@@ -206,7 +206,7 @@ inline float hsFastMath::SinInRange(float ang)
         ang -= hsConstants::two_pi<float>;
     else if (ang >= (0.25f * hsConstants::two_pi<float>))
     {
-        ang -= 3.141592654f;
+        ang -= hsConstants::pi<float>;
         sgn = -1.0f;
     }
     
@@ -221,7 +221,7 @@ inline float hsFastMath::CosInRange(float ang)
         ang -= hsConstants::two_pi<float>;
     else if (ang >= (0.25f * hsConstants::two_pi<float>))
     {
-        ang -= 3.141592654f;
+        ang -= hsConstants::pi<float>;
         sgn = -1.0f;
     }
     
@@ -244,7 +244,7 @@ inline void hsFastMath::SinCosInRange(float ang, float& sinRads, float& cosRads)
         ang -= hsConstants::two_pi<float>;
     else if (ang >= (0.25f * hsConstants::two_pi<float>))
     {
-        ang -= 3.141592654f;
+        ang -= hsConstants::pi<float>;
         sgn = -1.0f;
     }
     
@@ -291,7 +291,7 @@ float ang, sgn;
                 ang -= TwoPI;
         else if(ang >= (0.25f * TwoPI))
         {
-                ang -= 3.141592654f;
+                ang -= hsConstants::pi<float>;
                 sgn = -1.0f;
         }
 

--- a/Sources/Plasma/CoreLib/hsQuat.cpp
+++ b/Sources/Plasma/CoreLib/hsQuat.cpp
@@ -58,7 +58,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 hsQuat::hsQuat(float rad, const hsVector3* axis)
 {
-    // hsAssert(rad >= -M_PI && rad <= M_PI, "Quat: Angle should be between -PI and PI");
+    // hsAssert(rad >= -hsConstants::pi<float> && rad <= hsConstants::pi<float>,
+    //          "Quat: Angle should be between -PI and PI");
 
     fW = cos(rad*0.5f);
 
@@ -317,7 +318,7 @@ void hsQuat::SetFromSlerp(const hsQuat &a, const hsQuat &b, float alpha, int spi
     {               /* normal case */
 //      hsAssert((cos_t >= -1) && (cos_t <= 1), "Invalid acos argument");
         theta   = acos(cos_t);
-        phi     = theta + spin * M_PI;
+        phi     = theta + spin * hsConstants::pi<float>;
         sin_t   = sin(theta);
         hsAssert(sin_t != 0.0, "Invalid sin value in quat slerp");
         beta    = sin(theta - alpha*phi) / sin_t;

--- a/Sources/Plasma/FeatureLib/pfAnimation/pfObjectFlocker.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/pfObjectFlocker.cpp
@@ -61,14 +61,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pfObjectFlocker.h"
 
-#define PI        3.14159f
-#define HALF_PI   (PI/2)
-#define GRAVITY   9.806650f  // meters/second
-#ifdef INFINITY
-#undef INFINITY
-#endif
-#define INFINITY  999999.0f
-
 #define RAND() (float) (rand()/(RAND_MAX * 1.0))
 #define SIGN(x) (((x) < 0) ? -1 : 1)
 

--- a/Sources/Plasma/FeatureLib/pfAnimation/plBlower.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plBlower.cpp
@@ -218,8 +218,8 @@ void plBlower::IInitOscillators()
     for( i = 0; i < fOscillators.GetCount(); i++ )
     {
         float fi = float(i+1);
-        fOscillators[i].fFrequency = fi / M_PI * fRandom.RandRangeF(0.75f, 1.25f);
-//      fOscillators[i].fFrequency = 1.f / M_PI * fRandom.RandRangeF(0.5f, 1.5f);
+        fOscillators[i].fFrequency = fi / hsConstants::pi<float> * fRandom.RandRangeF(0.75f, 1.25f);
+//      fOscillators[i].fFrequency = 1.f / hsConstants::pi<float> * fRandom.RandRangeF(0.5f, 1.5f);
         fOscillators[i].fPhase = fRandom.RandZeroToOne();
         fOscillators[i].fPower = kBasePower * fRandom.RandRangeF(0.75f, 1.25f);
     }

--- a/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
@@ -1617,7 +1617,6 @@ bool plCameraBrain1_Fixed::MsgReceive(plMessage* msg)
 //
 //
 // circle camera crap
-static const float kTwoPI    = 2.0f*M_PI;
 
 plCameraBrain1_Circle::plCameraBrain1_Circle() : plCameraBrain1_Fixed()
 { 
@@ -1692,18 +1691,18 @@ hsPoint3 plCameraBrain1_Circle::MoveTowardsFromGoal(const hsPoint3* fromGoal, do
     {
         float dist = fabs(fGoalRad-fCurRad);
     
-        hsAssert(dist>=0 && dist<=kTwoPI, "illegal radian diff");
-        bool mustWrap = (dist > M_PI);  // go opposite direction for shortcut and wrap
+        hsAssert(dist >= 0.f && dist <= hsConstants::two_pi<float>, "illegal radian diff");
+        bool mustWrap = (dist > hsConstants::pi<float>);  // go opposite direction for shortcut and wrap
 
         // compute speed
         float speed; 
         if (warp)
-            speed = (float)(kTwoPI * 100 * secs);
+            speed = (float)(hsConstants::two_pi<float> * 100 * secs);
         else
-            speed = (float)(kTwoPI * fCirPerSec * secs);
+            speed = (float)(hsConstants::two_pi<float> * fCirPerSec * secs);
 
         // move towards goalRad
-        hsAssert(fCurRad>=0 && fCurRad<=kTwoPI, "illegal radian value");
+        hsAssert(fCurRad >= 0.f && fCurRad <= hsConstants::two_pi<float>, "illegal radian value");
 
         if (fCurRad<fGoalRad)
         {
@@ -1714,7 +1713,7 @@ hsPoint3 plCameraBrain1_Circle::MoveTowardsFromGoal(const hsPoint3* fromGoal, do
                 while(fCurRad<0)
                 {
                     didWrap=true;
-                    fCurRad+=kTwoPI;
+                    fCurRad += hsConstants::two_pi<float>;
                 }
                 if (fCurRad<fGoalRad && didWrap)
                     fCurRad=fGoalRad;
@@ -1732,10 +1731,10 @@ hsPoint3 plCameraBrain1_Circle::MoveTowardsFromGoal(const hsPoint3* fromGoal, do
             {
                 fCurRad+=speed;
                 bool didWrap=false;
-                while(fCurRad>kTwoPI)
+                while (fCurRad > hsConstants::two_pi<float>)
                 {
                     didWrap=true;
-                    fCurRad-=kTwoPI;
+                    fCurRad -= hsConstants::two_pi<float>;
                 }
                 if (fCurRad>fGoalRad && didWrap)
                     fCurRad=fGoalRad;
@@ -1748,7 +1747,7 @@ hsPoint3 plCameraBrain1_Circle::MoveTowardsFromGoal(const hsPoint3* fromGoal, do
             }
         }
     }
-    hsAssert(fCurRad>=0 && fCurRad<=kTwoPI, "illegal radian value");
+    hsAssert(fCurRad >= 0.f && fCurRad <= hsConstants::two_pi<float>, "illegal radian value");
     
     hsPoint3 x;
     x = GetCenterPoint() + hsVector3((float)cos(fCurRad)*fRadius, (float)sin(fCurRad)*fRadius, 0.0f);
@@ -1772,10 +1771,11 @@ hsPoint3 plCameraBrain1_Circle::IGetClosestPointOnCircle(const hsPoint3* toThis)
     }
     v.Normalize();
     fGoalRad = (float)atan2(v.fY, v.fX); // -pi to pi
-    hsAssert(fGoalRad>=-M_PI && fGoalRad<=M_PI, "Illegal atan2 val");
+    hsAssert(fGoalRad >= -hsConstants::pi<float> && fGoalRad <= hsConstants::pi<float>,
+             "Illegal atan2 val");
     if (fGoalRad<0)
-        fGoalRad = kTwoPI + fGoalRad;   // 0 to 2pi
-    hsAssert(fGoalRad>=0 && fGoalRad<=kTwoPI, "Illegal atan2 val");
+        fGoalRad = hsConstants::two_pi<float> + fGoalRad;   // 0 to 2pi
+    hsAssert(fGoalRad >= 0.f && fGoalRad <= hsConstants::two_pi<float>, "Illegal atan2 val");
     v = v * fRadius;
     center = center + v;
     center.fZ = fCamera->GetTargetPos().fZ;

--- a/Sources/Plasma/FeatureLib/pfCamera/plVirtualCamNeu.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plVirtualCamNeu.cpp
@@ -680,15 +680,15 @@ void plVirtualCam1::AdjustForInput()
 
     float scaledX;
     if (fFirstPersonOverride)
-        scaledX = 3.14159;
+        scaledX = hsConstants::pi<float>;
     else
-        scaledX = (float)(3.14159 - (fXPanLimit * ( (fX - 0.5f) / 0.5f)));
+        scaledX = hsConstants::pi<float> - (fXPanLimit * ( (fX - 0.5f) / 0.5f));
 
     float scaledZ; 
     if (fFirstPersonOverride)
-        scaledZ = (float)(3.14159 - (0.872f * ( (fY - 0.5f) / 0.5f)));
+        scaledZ = hsConstants::pi<float> - (0.872f * ( (fY - 0.5f) / 0.5f));
     else
-        scaledZ = (float)(3.14159 - (fZPanLimit * ( (fY - 0.5f) / 0.5f)));
+        scaledZ = hsConstants::pi<float> - (fZPanLimit * ( (fY - 0.5f) / 0.5f));
 
     hsMatrix44 mX;
     hsMatrix44 mZ;

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -4078,8 +4078,8 @@ namespace plWaveCmd {
 
 typedef void PrintFunk(const char* str);
 
-static constexpr float FracToPercent(float f) { return 1.e2f * f; }
-static constexpr float PercentToFrac(float f) { return 1.e-2f * f; }
+static constexpr float FracToPercent(float f) { return 100.f * f; }
+static constexpr float PercentToFrac(float f) { return f / 100.f; }
 
 static void IDisplayWaveVal(PrintFunk PrintString, plWaveSet7* wave, plWaveCmd::Cmd cmd)
 {

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -1276,7 +1276,7 @@ PF_CONSOLE_CMD( Graphics_Renderer, Gamma2, "float g", "Set gamma value (alternat
     for( i = 0; i < 256; i++ )
     {
         float t = float(i) / 255.f;
-        float sinT = sin(t * M_PI / 2.f);
+        float sinT = std::sin(t * hsConstants::pi<float> / 2.f);
 
         float remap = t + (sinT - t) * g;
         if( remap < 0 )

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -4078,11 +4078,8 @@ namespace plWaveCmd {
 
 typedef void PrintFunk(const char* str);
 
-static inline float FracToPercent(float f) { return (float)(1.e2 * f); }
-static inline float PercentToFrac(float f) { return (float)(1.e-2 * f); }
-
-static inline float RadToDeg(float r) { return r * 180.f / M_PI; }
-static inline float DegToRad(float d) { return d * M_PI / 180.f; }
+static constexpr float FracToPercent(float f) { return 1.e2f * f; }
+static constexpr float PercentToFrac(float f) { return 1.e-2f * f; }
 
 static void IDisplayWaveVal(PrintFunk PrintString, plWaveSet7* wave, plWaveCmd::Cmd cmd)
 {
@@ -4110,7 +4107,7 @@ static void IDisplayWaveVal(PrintFunk PrintString, plWaveSet7* wave, plWaveCmd::
         msg = ST::format("Geo Wave Amplitude to Length Ratio (%) = {f}", FracToPercent(wave->GetGeoAmpOverLen()));
         break;
     case kGeoAngle:
-        msg = ST::format("Geo Spread of waves about Wind Dir = {f} degrees", RadToDeg(wave->GetGeoAngleDev()));
+        msg = ST::format("Geo Spread of waves about Wind Dir = {f} degrees", hsRadiansToDegrees(wave->GetGeoAngleDev()));
         break;
 
     case kTexLen:
@@ -4123,7 +4120,7 @@ static void IDisplayWaveVal(PrintFunk PrintString, plWaveSet7* wave, plWaveCmd::
         msg = ST::format("Tex Wave Amplitude to Length Ratio = {f}%", FracToPercent(wave->GetTexAmpOverLen()));
         break;
     case kTexAngle:
-        msg = ST::format("Tex Spread of waves about Wind Dir = {f} degrees", RadToDeg(wave->GetTexAngleDev()));
+        msg = ST::format("Tex Spread of waves about Wind Dir = {f} degrees", hsRadiansToDegrees(wave->GetTexAngleDev()));
         break;
     
     case kNoise:
@@ -4263,7 +4260,7 @@ static bool ISendWaveCmd1f(PrintFunk PrintString, pfConsoleCmdParam* params, int
         wave->SetGeoAmpOverLen(PercentToFrac(val), secs);
         break;
     case kGeoAngle:
-        wave->SetGeoAngleDev(DegToRad(val), secs);
+        wave->SetGeoAngleDev(hsDegreesToRadians(val), secs);
         break;
 
     case kTexChop:
@@ -4273,7 +4270,7 @@ static bool ISendWaveCmd1f(PrintFunk PrintString, pfConsoleCmdParam* params, int
         wave->SetTexAmpOverLen(PercentToFrac(val), secs);
         break;
     case kTexAngle:
-        wave->SetTexAngleDev(DegToRad(val), secs);
+        wave->SetTexAngleDev(hsDegreesToRadians(val), secs);
         break;
 
     case kNoise:

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
@@ -276,8 +276,8 @@ static bool     CreateConvexHull( hsPoint3 *inPoints, int &numPoints )
         
         // If the angle is < 180, then it's a good angle and we can advance all our points by 1...
         // Note: we have a tolerance so that we don't get points that form edges that are pretty darned close...
-        const float tolerance = M_PI / 90.f;
-        if( angle > tolerance && angle < M_PI - tolerance )
+        constexpr float tolerance = hsConstants::pi<float> / 90.f;
+        if (angle > tolerance && angle < hsConstants::pi<float> - tolerance)
         {
             pointA++;
             pointB++;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.cpp
@@ -464,8 +464,8 @@ pfGUIDialogMod  *pfGUICtrlGenerator::IGenerateDialog( const char *name, float sc
     fovX = atan( scrnWidth / ( 2.f * 100.f ) ) * 2.f;
     fovY = fovX;// * 3.f / 4.f;
 
-    renderMod->SetFovX( fovX * 180.f / M_PI );
-    renderMod->SetFovY( fovY * 180.f / M_PI );
+    renderMod->SetFovX( fovX * 180.f / hsConstants::pi<float> );
+    renderMod->SetFovY( fovY * 180.f / hsConstants::pi<float> );
 
     // Create the sceneNode to go with it
     node = new plSceneNode;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.cpp
@@ -464,8 +464,8 @@ pfGUIDialogMod  *pfGUICtrlGenerator::IGenerateDialog( const char *name, float sc
     fovX = atan( scrnWidth / ( 2.f * 100.f ) ) * 2.f;
     fovY = fovX;// * 3.f / 4.f;
 
-    renderMod->SetFovX( fovX * 180.f / hsConstants::pi<float> );
-    renderMod->SetFovY( fovY * 180.f / hsConstants::pi<float> );
+    renderMod->SetFovX(hsRadiansToDegrees(fovX));
+    renderMod->SetFovY(hsRadiansToDegrees(fovY));
 
     // Create the sceneNode to go with it
     node = new plSceneNode;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
@@ -777,8 +777,8 @@ pfGUIPopUpMenu  *pfGUIPopUpMenu::Build( const char *name, pfGUIDialogMod *parent
     fovX = atan( scrnWidth / ( 2.f * 100.f ) ) * 2.f;
     fovY = fovX;// * 3.f / 4.f;
 
-    renderMod->SetFovX( fovX * 180.f / M_PI );
-    renderMod->SetFovY( fovY * 180.f / M_PI );
+    renderMod->SetFovX( fovX * 180.f / hsConstants::pi<float> );
+    renderMod->SetFovY( fovY * 180.f / hsConstants::pi<float> );
 
     // Create the sceneNode to go with it
     menu->fParentNode= new plSceneNode;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
@@ -777,8 +777,8 @@ pfGUIPopUpMenu  *pfGUIPopUpMenu::Build( const char *name, pfGUIDialogMod *parent
     fovX = atan( scrnWidth / ( 2.f * 100.f ) ) * 2.f;
     fovY = fovX;// * 3.f / 4.f;
 
-    renderMod->SetFovX( fovX * 180.f / hsConstants::pi<float> );
-    renderMod->SetFovY( fovY * 180.f / hsConstants::pi<float> );
+    renderMod->SetFovX(hsRadiansToDegrees(fovX));
+    renderMod->SetFovY(hsRadiansToDegrees(fovY));
 
     // Create the sceneNode to go with it
     menu->fParentNode= new plSceneNode;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
@@ -483,6 +483,4 @@ protected:
     BoneMapImp *fImp;       // the thing that actually holds our map
 };
 
-#define TWO_PI (M_PI * 2)
-
 #endif //plArmatureMod_inc

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
@@ -131,7 +131,7 @@ plAvBrainCritter::plAvBrainCritter(): fWalkingStrategy(nil), fCurMode(kIdle), fN
     fAvoidingAvatars(false), fFinalGoalPos(0, 0, 0), fImmediateGoalPos(0, 0, 0), fDotGoal(0),
     fAngRight(0)
 {
-    SightCone(M_PI/2); // 90deg
+    SightCone(hsConstants::half_pi<float>); // 90deg
     StopDistance(1);
     SightDistance(10);
     HearingDistance(10);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
@@ -1301,7 +1301,7 @@ void Push::Process(double time, float elapsed)
     hsPoint3 lookAt;
     fHuBrain->fWalkingStrategy->GetPushingPhysical()->GetPositionSim(lookAt);
     hsVector3 up(0.f, 0.f, 1.f);
-    float angle = atan2(lookAt.fY - pos.fY, lookAt.fX - pos.fX) + M_PI / 2;
+    float angle = std::atan2(lookAt.fY - pos.fY, lookAt.fX - pos.fX) + hsConstants::half_pi<float>;
     hsQuat targRot(angle, &up);
     
     const float kTurnSpeed = 3.f;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvTaskSeek.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvTaskSeek.cpp
@@ -201,7 +201,7 @@ void plAvTaskSeek::SetTarget(hsPoint3 &pos, hsPoint3 &lookAt)
 {
     fSeekPos = pos;
     hsVector3 up(0.f, 0.f, 1.f);
-    float angle = atan2(lookAt.fY - pos.fY, lookAt.fX - pos.fX) + M_PI / 2;
+    float angle = std::atan2(lookAt.fY - pos.fY, lookAt.fX - pos.fX) + hsConstants::half_pi<float>;
     fSeekRot.SetAngleAxis(angle, up);
 }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarMgr.cpp
@@ -954,8 +954,7 @@ void plAvatarMgr::PointToDniCoordinate(hsPoint3 pt, plDniCoordinateInfo* ret)
                 float dotView = retVec * zeroVec;
                 float dotRight = retVec * zeroRight;
 
-                float deg = acosf(dotView);
-                deg *= (180.f / hsConstants::pi<float>);
+                float deg = hsRadiansToDegrees(acosf(dotView));
                 // account for being > 180
                 if (dotRight < 0.0f) 
                 {

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarMgr.cpp
@@ -955,7 +955,7 @@ void plAvatarMgr::PointToDniCoordinate(hsPoint3 pt, plDniCoordinateInfo* ret)
                 float dotRight = retVec * zeroRight;
 
                 float deg = acosf(dotView);
-                deg*=(180/3.141592);
+                deg *= (180.f / hsConstants::pi<float>);
                 // account for being > 180
                 if (dotRight < 0.0f) 
                 {

--- a/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
@@ -110,9 +110,9 @@ void plPhysicalControllerCore::IncrementAngle(float deltaAngle)
 
     // make sure we wrap around
     if (angle < 0.0f)
-        angle = hsConstants::two_pi<float> + angle; // angle is -, so this works like a subtract
+        angle += hsConstants::two_pi<float>; // angle is -, so this works like a subtract
     if (angle >= hsConstants::two_pi<float>)
-        angle = angle - hsConstants::two_pi<float>;
+        angle -= hsConstants::two_pi<float>;
 
     // set the new angle
     axis.Set(0.0f, 0.0f, 1.0f);
@@ -345,13 +345,13 @@ void plAnimatedMovementStrategy::IRecalcAngularVelocity(float elapsed, hsMatrix4
     float angleSincePrev = AngleRad2d(curForward.fX, curForward.fY, prevForward.fX, prevForward.fY);
     bool sincePrevSign = angleSincePrev > 0.0f;
     if (angleSincePrev > hsConstants::pi<float>)
-        angleSincePrev = angleSincePrev - hsConstants::two_pi<float>;
+        angleSincePrev -= hsConstants::two_pi<float>;
 
     const hsVector3 startForward = hsVector3(0.0f, -1.0f, 0.0f);    // the Y orientation of a "resting" armature....
     float angleSinceStart = AngleRad2d(curForward.fX, curForward.fY, startForward.fX, startForward.fY);
     bool sinceStartSign = angleSinceStart > 0.0f;
     if (angleSinceStart > hsConstants::pi<float>)
-        angleSinceStart = angleSinceStart - hsConstants::two_pi<float>;
+        angleSinceStart -= hsConstants::two_pi<float>;
 
     // HANDLING ANIMATION WRAPPING:
     // under normal conditions, the angle from rest to the current frame will have the same
@@ -776,18 +776,15 @@ static float AngleRad2d( float x1, float y1, float x3, float y3 )
     x = ( x1 ) * ( x3 ) + ( y1 ) * ( y3 );
     y = ( x1 ) * ( y3 ) - ( y1 ) * ( x3 );
 
-    if ( x == 0.0 && y == 0.0 ) {
-        value = 0.0;
+    if (x == 0.f && y == 0.f) {
+        value = 0.f;
     }
     else
     {
         value = atan2 ( y, x );
 
-        if ( value < 0.0 )
-        {
-            value += (float)(value + hsConstants::two_pi<double>);
-        }
+        if (value < 0.f)
+            value += hsConstants::two_pi<float>;
     }
     return value;
 }
-

--- a/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
@@ -104,15 +104,15 @@ void plPhysicalControllerCore::IncrementAngle(float deltaAngle)
     fLocalRotation.NormalizeIfNeeded();
     fLocalRotation.GetAngleAxis(&angle, &axis);
     if (axis.fZ < 0)
-        angle = (2.0f * float(M_PI)) - angle; // axis is backwards, so reverse the angle too
+        angle = hsConstants::two_pi<float> - angle; // axis is backwards, so reverse the angle too
 
     angle += deltaAngle;
 
     // make sure we wrap around
     if (angle < 0.0f)
-        angle = (2.0f * float(M_PI)) + angle; // angle is -, so this works like a subtract
-    if (angle >= (2.0f * float(M_PI)))
-        angle = angle - (2.0f * float(M_PI));
+        angle = hsConstants::two_pi<float> + angle; // angle is -, so this works like a subtract
+    if (angle >= hsConstants::two_pi<float>)
+        angle = angle - hsConstants::two_pi<float>;
 
     // set the new angle
     axis.Set(0.0f, 0.0f, 1.0f);
@@ -344,14 +344,14 @@ void plAnimatedMovementStrategy::IRecalcAngularVelocity(float elapsed, hsMatrix4
 
     float angleSincePrev = AngleRad2d(curForward.fX, curForward.fY, prevForward.fX, prevForward.fY);
     bool sincePrevSign = angleSincePrev > 0.0f;
-    if (angleSincePrev > float(M_PI))
-        angleSincePrev = angleSincePrev - TWO_PI;
+    if (angleSincePrev > hsConstants::pi<float>)
+        angleSincePrev = angleSincePrev - hsConstants::two_pi<float>;
 
     const hsVector3 startForward = hsVector3(0.0f, -1.0f, 0.0f);    // the Y orientation of a "resting" armature....
     float angleSinceStart = AngleRad2d(curForward.fX, curForward.fY, startForward.fX, startForward.fY);
     bool sinceStartSign = angleSinceStart > 0.0f;
-    if (angleSinceStart > float(M_PI))
-        angleSinceStart = angleSinceStart - TWO_PI;
+    if (angleSinceStart > hsConstants::pi<float>)
+        angleSinceStart = angleSinceStart - hsConstants::two_pi<float>;
 
     // HANDLING ANIMATION WRAPPING:
     // under normal conditions, the angle from rest to the current frame will have the same
@@ -785,7 +785,7 @@ static float AngleRad2d( float x1, float y1, float x3, float y3 )
 
         if ( value < 0.0 )
         {
-            value = (float)(value + TWO_PI);
+            value += (float)(value + hsConstants::two_pi<double>);
         }
     }
     return value;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableGenerator.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableGenerator.cpp
@@ -313,13 +313,13 @@ plDrawableSpans     *plDrawableGenerator::GenerateSphericalDrawable( const hsPoi
     /// Generate points
     for( i = 0; i <= numDivisions; i++ )
     {
-        angle = (float)i * ( M_PI ) / (float)numDivisions;
+        angle = float(i) * hsConstants::pi<float> / float(numDivisions);
         hsFastMath::SinCosInRange( angle, internRad, z );
         internRad *= radius;
                 
         for( j = 0; j < numDivisions; j++ )
         {
-            angle = (float)j * ( 2 * M_PI ) / (float)numDivisions;
+            angle = float(j) * hsConstants::two_pi<float> / float(numDivisions);
             hsFastMath::SinCosInRange( angle, x, y );
 
             point.Set( pos.fX + x * internRad, pos.fY + y * internRad, pos.fZ + z * radius );
@@ -603,7 +603,7 @@ plDrawableSpans     *plDrawableGenerator::GenerateConicalDrawable( hsPoint3 &ape
     normals.Append( -direction );
     for( i = 0; i < numDivisions; i++ )
     {
-        angle = (float)i * ( M_PI * 2.f ) / (float)numDivisions;
+        angle = float(i) * hsConstants::two_pi<float> / float(numDivisions);
         hsFastMath::SinCosInRange( angle, x, y );
 
         points.Append( baseCenter + ( xVec * x * radius ) + ( yVec * y * radius ) );

--- a/Sources/Plasma/PubUtilLib/plDrawable/plSpaceTreeMaker.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plSpaceTreeMaker.cpp
@@ -487,7 +487,7 @@ void plSpaceTreeMaker::TestTree()
     tree->SetViewPos(*hsPoint3().Set(0,0,0));
 
     plConeIsect cone;
-    cone.SetAngle(M_PI*0.25f);
+    cone.SetAngle(hsConstants::pi<float> * 0.25f);
     cone.SetTransform(liX, invLiX);
 
     StartTimer(kHarvestCone);
@@ -498,7 +498,7 @@ void plSpaceTreeMaker::TestTree()
     StopTimer(kHarvestCone);
 
     plConeIsect capped;
-    capped.SetAngle(M_PI*0.25f);
+    capped.SetAngle(hsConstants::pi<float> * 0.25f);
     capped.SetLength(0.5f);
     capped.SetTransform(liX, invLiX);
 

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
@@ -1228,13 +1228,13 @@ void plWaveSet7::IInitState()
     plConst(float) kGeoMinLen(3.f);
     plConst(float) kGeoMaxLen(8.f);
     plConst(float) kGeoAmpOverLen(0.1f);
-    plConst(float) kGeoAngleDev(30.f * hsConstants::pi<float> / 180.f);
+    plConst(float) kGeoAngleDev(hsDegreesToRadians(30.f));
     plConst(float) kGeoChop(1.f);
 
     plConst(float) kTexMinLen(4.f);
     plConst(float) kTexMaxLen(30.f);
     plConst(float) kTexAmpOverLen(0.1f);
-    plConst(float) kTexAngleDev(30.f * hsConstants::pi<float> / 180.f);
+    plConst(float) kTexAngleDev(hsDegreesToRadians(30.f));
     plConst(float) kTexChop(1.f);
 
     plFixedWaterState7 state;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
@@ -116,8 +116,8 @@ using namespace plShaderID;
 
 static constexpr float kGravConst = 30.f;
 
-static constexpr float FreqToLen(float f) { return 2.f * hsConstants::pi<float> / f; }
-static constexpr float LenToFreq(float l) { return 2.f * hsConstants::pi<float> / l; }
+static constexpr float FreqToLen(float f) { return hsConstants::two_pi<float> / f; }
+static constexpr float LenToFreq(float l) { return hsConstants::two_pi<float> / l; }
 
 static constexpr float MPH2FPS(float f) { return f * 5280.f / 3600.f; }
 static constexpr float FPS2MPH(float f) { return f / 5280.f * 3600.f; }
@@ -4416,5 +4416,4 @@ void plWaveSet7::IUpdateGraphShaders(plPipeline* pipe, float dt)
         }
     }
 }
-
 

--- a/Sources/Plasma/PubUtilLib/plGLight/plLightInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plLightInfo.cpp
@@ -887,8 +887,8 @@ plDrawableSpans* plOmniLightInfo::CreateProxy(hsGMaterial* mat, hsTArray<uint32_
 // Spot
 plSpotLightInfo::plSpotLightInfo()
 :   fFalloff(1.f),
-    fSpotInner(M_PI * 0.125f),
-    fSpotOuter(M_PI * 0.25f),
+    fSpotInner(hsConstants::pi<float> * 0.125f),
+    fSpotOuter(hsConstants::pi<float> * 0.25f),
     fCone(nil)
 {
 }

--- a/Sources/Plasma/PubUtilLib/plInterp/plATCEaseCurves.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plATCEaseCurves.cpp
@@ -303,14 +303,13 @@ float plSplineEaseCurve::TimeGivenVelocity(float velocity) const
     if (D >= 0) 
     {   
         // 3 roots, find the one in the range [0, 1]
-        const float pi = 3.14159;
         double theta = acos(R / sqrt(Q3));
         double sqrtQ = sqrt(Q);
 
-        root = (float)(-2 * sqrtQ * cos((theta + 4 * pi) / 3) - c / 3); // Middle root, most likely to match
+        root = (float)(-2 * sqrtQ * cos((theta + 4 * hsConstants::pi<float>) / 3) - c / 3); // Middle root, most likely to match
         if (root < 0.f || root > 1.f)
         {
-            root = (float)(-2 * sqrtQ * cos((theta + 2 * pi) / 3) - c / 3); // Lower root
+            root = (float)(-2 * sqrtQ * cos((theta + 2 * hsConstants::pi<float>) / 3) - c / 3); // Lower root
             if (root < 0.f || root > 1.f)
             {
                 root = (float)(-2 * sqrtQ * cos(theta / 3) - c / 3); // Upper root

--- a/Sources/Plasma/PubUtilLib/plIntersect/plVolumeIsect.cpp
+++ b/Sources/Plasma/PubUtilLib/plIntersect/plVolumeIsect.cpp
@@ -171,7 +171,7 @@ void plSphereIsect::Write(hsStream* s, hsResMgr* mgr)
 ///////////////////////////////////////////////////////////////////////////
 
 plConeIsect::plConeIsect()
-:   fLength(kDefLength), fRadAngle(M_PI*0.25f), fCapped(false)
+:   fLength(kDefLength), fRadAngle(hsConstants::pi<float> * 0.25f), fCapped(false)
 {
     ISetup();
 }

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleApplicator.cpp
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleApplicator.cpp
@@ -47,8 +47,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plMessage/plParticleUpdateMsg.h"
 #include "pnSceneObject/plSceneObject.h"
 
-#define PI 3.14159
-
 plParticleGenerator *plParticleApplicator::IGetParticleGen(plSceneObject *so)
 {
     uint32_t numMods = so->GetNumModifiers();
@@ -88,7 +86,7 @@ void plParticleAngleApplicator::IApply(const plAGModifier *mod, double time)
 {
     plScalarChannel *chan = plScalarChannel::ConvertNoRef(fChannel);
     IGetParticleGen(mod->GetTarget(0))->UpdateParam(plParticleUpdateMsg::kParamInitPitchRange,
-                                                    (float)(chan->Value(time) * PI / 180.f));
+                                                    chan->Value(time) * hsConstants::pi<float> / 180.f);
 }
 
 void plParticleVelMinApplicator::IApply(const plAGModifier *mod, double time)

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleApplicator.cpp
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleApplicator.cpp
@@ -86,7 +86,7 @@ void plParticleAngleApplicator::IApply(const plAGModifier *mod, double time)
 {
     plScalarChannel *chan = plScalarChannel::ConvertNoRef(fChannel);
     IGetParticleGen(mod->GetTarget(0))->UpdateParam(plParticleUpdateMsg::kParamInitPitchRange,
-                                                    chan->Value(time) * hsConstants::pi<float> / 180.f);
+                                                    hsDegreesToRadians(chan->Value(time)));
 }
 
 void plParticleVelMinApplicator::IApply(const plAGModifier *mod, double time)

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleEffect.cpp
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleEffect.cpp
@@ -608,9 +608,8 @@ void plParticleUniformWind::PrepareEffect(const plEffectTargetInfo& target)
     {
         static plRandom random;
 
-        const double kTwoPi = M_PI * 2.0;
         double t0 = fFreqCurr * fLastFreqSecs + fCurrPhase;
-        float t1 = (float)fmod(t0, kTwoPi);
+        float t1 = (float)std::fmod(t0, hsConstants::two_pi<double>);
         fCurrPhase -= t0 - t1;
 
         fFreqCurr += fFreqRate * target.fContext.fDelSecs * random.RandZeroToOne();

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleEmitter.cpp
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleEmitter.cpp
@@ -418,7 +418,7 @@ void plParticleEmitter::IUpdateParticles(float delta)
         else if( fParticleExts[i].fRadsPerSec != 0 )
         {
             float sinX, cosX;
-            hsFastMath::SinCos(fParticleExts[i].fLife * fParticleExts[i].fRadsPerSec * 2.f * M_PI, sinX, cosX);
+            hsFastMath::SinCos(fParticleExts[i].fLife * fParticleExts[i].fRadsPerSec * hsConstants::two_pi<float>, sinX, cosX);
             fParticleCores[i].fOrientation.Set(sinX, -cosX, 0);
         }
 

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleGenerator.cpp
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleGenerator.cpp
@@ -72,7 +72,6 @@ void plParticleGenerator::ComputeDirection(float pitch, float yaw, hsVector3 &di
 // pitch and yaw (angles for the unit Z vector) to get there.
 void plParticleGenerator::ComputePitchYaw(float &pitch, float &yaw, const hsVector3 &dir)
 {
-    const float PI = 3.14159f;
     pitch = asin(dir.fY);
     float cos_pitch = cos(pitch);
     if (cos_pitch == 0)
@@ -87,7 +86,7 @@ void plParticleGenerator::ComputePitchYaw(float &pitch, float &yaw, const hsVect
         inv = -1.0f;
     yaw = asin(inv);
     if (dir.fZ < 0)
-        yaw = PI - yaw;
+        yaw = hsConstants::pi<float> - yaw;
 }
 
 plSimpleParticleGenerator::plSimpleParticleGenerator()

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
@@ -190,7 +190,7 @@ void plPXPhysicalControllerCore::GetState(hsPoint3& pos, float& zRot)
     fLocalRotation.GetAngleAxis(&zRot, (hsVector3*)&pos);
 
     if (pos.fZ < 0)
-        zRot = (2 * float(M_PI)) - zRot; // axis is backwards, so reverse the angle too
+        zRot = hsConstants::two_pi<float> - zRot; // axis is backwards, so reverse the angle too
 
     pos = fLocalPosition;
 }

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXDeviceRefs.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXDeviceRefs.cpp
@@ -289,7 +289,7 @@ void    plDXLightRef::UpdateD3DInfo( IDirect3DDevice9 *dev, plDXLightSettings *s
 
             fD3DInfo.Falloff = spotOwner->GetFalloff();
             fD3DInfo.Theta = spotOwner->GetSpotInner() * 2;
-//          fD3DInfo.Phi = spotOwner->GetProjection() ? M_PI : spotOwner->GetSpotOuter() * 2;
+//          fD3DInfo.Phi = spotOwner->GetProjection() ? hsConstants::pi<float> : spotOwner->GetSpotOuter() * 2;
             // D3D doesn't seem to like a Phi of PI, even though that's supposed to be the
             // largest legal value. Symptom is an erratic, intermitant, unpredictable failure
             // of the light to light, with bizarreness like lighting one object but not the object

--- a/Sources/Plasma/PubUtilLib/plScene/plPostEffectMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plPostEffectMod.cpp
@@ -64,8 +64,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 plPostEffectMod::plPostEffectMod()
 :   fHither(1.f),
     fYon(100.f),
-    fFovX(M_PI * 0.25f),
-    fFovY(M_PI * 0.25f * 0.75f),
+    fFovX(hsConstants::pi<float> * 0.25f),
+    fFovY(hsConstants::pi<float> * 0.25f * 0.75f),
     fPageMgr(nil),
     fRenderTarget(nil),
     fRenderRequest(nil)

--- a/Sources/Plasma/PubUtilLib/plSurface/plGrassShaderMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plGrassShaderMod.cpp
@@ -234,7 +234,10 @@ void plGrassShaderMod::ISetupShaders()
 
         vShader->SetNumConsts(plGrassVS::kNumConsts);
         vShader->SetVector(plGrassVS::kNumericConsts, 0.f, 0.5f, 1.f, 2.f);
-        vShader->SetVector(plGrassVS::kPiConsts, 1.f / (8.f*M_PI*4.f*4.f), M_PI/2.f, M_PI, M_PI*2.f);
+        vShader->SetVector(plGrassVS::kPiConsts, 1.f / (8.f*hsConstants::pi<float>*4.f*4.f),
+                                                 hsConstants::half_pi<float>,
+                                                 hsConstants::pi<float>,
+                                                 hsConstants::two_pi<float>);
         vShader->SetVector(plGrassVS::kSinConsts, -1.f/6.f, 1.f/120.f, -1.f/5040.f, 1.f/362880.f);
 
         IRefreshWaves(vShader);

--- a/Sources/Tools/MaxComponent/plCameraComponents.cpp
+++ b/Sources/Tools/MaxComponent/plCameraComponents.cpp
@@ -851,7 +851,7 @@ plCameraModifier1* plCameraBaseComponent::ICreateCameraModifier(plMaxNode* pNode
     // radians
     FOVvalue = theCam->GetFOV(Now);
     // convert
-    FOVvalue = FOVvalue*(180/3.141592);
+    FOVvalue *= 180.f / hsConstants::pi<float>;
     int FOVType = theCam->GetFOVType();
     float wDeg, hDeg;
     switch(FOVType)

--- a/Sources/Tools/MaxComponent/plCameraComponents.cpp
+++ b/Sources/Tools/MaxComponent/plCameraComponents.cpp
@@ -847,11 +847,7 @@ plCameraModifier1* plCameraBaseComponent::ICreateCameraModifier(plMaxNode* pNode
     
     hsVector3 pt;   
     
-    float FOVvalue= 0.0;            //Currently in Radians
-    // radians
-    FOVvalue = theCam->GetFOV(Now);
-    // convert
-    FOVvalue *= 180.f / hsConstants::pi<float>;
+    float FOVvalue = hsRadiansToDegrees(theCam->GetFOV(Now));
     int FOVType = theCam->GetFOVType();
     float wDeg, hDeg;
     switch(FOVType)

--- a/Sources/Tools/MaxComponent/plGUIComponents.cpp
+++ b/Sources/Tools/MaxComponent/plGUIComponents.cpp
@@ -1298,8 +1298,8 @@ bool plGUIDialogComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         }
         break;
     }
-    fovX *= 180.f / hsConstants::pi<float>;
-    fovY *= 180.f / hsConstants::pi<float>;
+    fovX = hsRadiansToDegrees(fovX);
+    fovY = hsRadiansToDegrees(fovY);
     mod->SetFovX(fovX);
     mod->SetFovY(fovY);
 
@@ -4983,8 +4983,8 @@ bool plGUIMenuComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     float fovX = atan( scrnWidth / ( 2.f * 100.f ) ) * 2.f;
     float fovY = fovX;// * 3.f / 4.f;
 
-    renderMod->SetFovX( fovX * 180.f / hsConstants::pi<float> );
-    renderMod->SetFovY( fovY * 180.f / hsConstants::pi<float> );
+    renderMod->SetFovX(hsRadiansToDegrees(fovX));
+    renderMod->SetFovY(hsRadiansToDegrees(fovY));
 
 
     hsgResMgr::ResMgr()->AddViaNotify( renderMod->GetKey(), new plNodeRefMsg( fConvertedNode, plRefMsg::kOnCreate, -1, plNodeRefMsg::kGeneric ), plRefFlags::kActiveRef );

--- a/Sources/Tools/MaxComponent/plGUIComponents.cpp
+++ b/Sources/Tools/MaxComponent/plGUIComponents.cpp
@@ -1298,8 +1298,8 @@ bool plGUIDialogComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         }
         break;
     }
-    fovX *= 180.f / M_PI;
-    fovY *= 180.f / M_PI;
+    fovX *= 180.f / hsConstants::pi<float>;
+    fovY *= 180.f / hsConstants::pi<float>;
     mod->SetFovX(fovX);
     mod->SetFovY(fovY);
 
@@ -4983,8 +4983,8 @@ bool plGUIMenuComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     float fovX = atan( scrnWidth / ( 2.f * 100.f ) ) * 2.f;
     float fovY = fovX;// * 3.f / 4.f;
 
-    renderMod->SetFovX( fovX * 180.f / M_PI );
-    renderMod->SetFovY( fovY * 180.f / M_PI );
+    renderMod->SetFovX( fovX * 180.f / hsConstants::pi<float> );
+    renderMod->SetFovY( fovY * 180.f / hsConstants::pi<float> );
 
 
     hsgResMgr::ResMgr()->AddViaNotify( renderMod->GetKey(), new plNodeRefMsg( fConvertedNode, plRefMsg::kOnCreate, -1, plNodeRefMsg::kGeneric ), plRefFlags::kActiveRef );

--- a/Sources/Tools/MaxComponent/plMiscComponents.cpp
+++ b/Sources/Tools/MaxComponent/plMiscComponents.cpp
@@ -1400,8 +1400,8 @@ bool plCamViewComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         }
         break;
     }
-    fovX *= 180.f / M_PI;
-    fovY *= 180.f / M_PI;
+    fovX *= 180.f / hsConstants::pi<float>;
+    fovY *= 180.f / hsConstants::pi<float>;
     mod->SetFovX(fovX);
     mod->SetFovY(fovY);
 

--- a/Sources/Tools/MaxComponent/plMiscComponents.cpp
+++ b/Sources/Tools/MaxComponent/plMiscComponents.cpp
@@ -1400,8 +1400,8 @@ bool plCamViewComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         }
         break;
     }
-    fovX *= 180.f / hsConstants::pi<float>;
-    fovY *= 180.f / hsConstants::pi<float>;
+    fovX = hsRadiansToDegrees(fovX);
+    fovY = hsRadiansToDegrees(fovY);
     mod->SetFovX(fovX);
     mod->SetFovY(fovY);
 

--- a/Sources/Tools/MaxComponent/plParticleComponents.cpp
+++ b/Sources/Tools/MaxComponent/plParticleComponents.cpp
@@ -205,7 +205,7 @@ bool plParticleCoreComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     float partLifeMin, partLifeMax;
     float pps            = fUserInput.fPPS; 
     hsPoint3 pos(0, 0, 0);
-    float pitch          = PI;
+    float pitch          = hsConstants::pi<float>;
     float yaw            = 0; 
     float angleRange     = hsDegreesToRadians(fUserInput.fConeAngle);
     float velMin         = fUserInput.fVelocityMin;

--- a/Sources/Tools/MaxComponent/plParticleComponents.cpp
+++ b/Sources/Tools/MaxComponent/plParticleComponents.cpp
@@ -207,7 +207,7 @@ bool plParticleCoreComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     hsPoint3 pos(0, 0, 0);
     float pitch          = PI;
     float yaw            = 0; 
-    float angleRange     = fUserInput.fConeAngle * PI / 180.f;
+    float angleRange     = hsDegreesToRadians(fUserInput.fConeAngle);
     float velMin         = fUserInput.fVelocityMin;
     float velMax         = fUserInput.fVelocityMax;
     float xSize          = fUserInput.fHSize;
@@ -218,7 +218,7 @@ bool plParticleCoreComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     float drag           = fUserInput.fDrag / 100.f;
     float windMult       = fUserInput.fWindMult / 100.f;
     float massRange      = fUserInput.fMassRange;
-    float rotRange       = fUserInput.fRotRange * PI / 180.f;
+    float rotRange       = hsDegreesToRadians(fUserInput.fRotRange);
 
     uint32_t xTiles = fUserInput.fXTiles; 
     uint32_t yTiles = fUserInput.fYTiles; 

--- a/Sources/Tools/MaxComponent/plWaterComponent.cpp
+++ b/Sources/Tools/MaxComponent/plWaterComponent.cpp
@@ -74,7 +74,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plScene/plVisRegion.h"
 
 static constexpr float kPercentToFrac(1.e-2f);
-static constexpr float kDegreeToRad(hsConstants::pi<float> / 180.f);
 
 
 // Preliminary setup bookkeeping
@@ -635,14 +634,14 @@ bool plWaterComponent::IMakeWaveSet(plMaxNode* node, plErrorMsg* pErrMsg)
     geoState.fMinLength = fCompPB->GetFloat(kGeoMinLen);
     geoState.fAmpOverLen = fCompPB->GetFloat(kGeoAmpOverLen) * kPercentToFrac;
     geoState.fChop = fCompPB->GetFloat(kGeoChop) * kPercentToFrac;
-    geoState.fAngleDev = fCompPB->GetFloat(kGeoAngleDev) * kDegreeToRad;
+    geoState.fAngleDev = hsDegreesToRadians(fCompPB->GetFloat(kGeoAngleDev));
 
     plFixedWaterState7::WaveState& texState = ws.fTexState;
     texState.fMaxLength = fCompPB->GetFloat(kTexMaxLen);
     texState.fMinLength = fCompPB->GetFloat(kTexMinLen);
     texState.fAmpOverLen = fCompPB->GetFloat(kTexAmpOverLen) * kPercentToFrac;
     texState.fChop = fCompPB->GetFloat(kTexChop) * kPercentToFrac;
-    texState.fAngleDev = fCompPB->GetFloat(kTexAngleDev) * kDegreeToRad;
+    texState.fAngleDev = hsDegreesToRadians(fCompPB->GetFloat(kTexAngleDev));
 
     hsVector3 specVec;
     specVec[ws.kNoise] = fCompPB->GetFloat(kNoise) * kPercentToFrac;

--- a/Sources/Tools/MaxComponent/plWaterComponent.cpp
+++ b/Sources/Tools/MaxComponent/plWaterComponent.cpp
@@ -73,8 +73,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plScene/plVisRegion.h"
 
-static const float kPercentToFrac(1.e-2f);
-static const float kDegreeToRad(M_PI/180.f);
+static constexpr float kPercentToFrac(1.e-2f);
+static constexpr float kDegreeToRad(hsConstants::pi<float> / 180.f);
 
 
 // Preliminary setup bookkeeping

--- a/Sources/Tools/MaxConvert/hsControlConverter.cpp
+++ b/Sources/Tools/MaxConvert/hsControlConverter.cpp
@@ -266,7 +266,7 @@ plLeafController* hsControlConverter::MakeMatrix44Controller(StdUVGen* uvGen, co
     CompositeKeyTimes(vAngCtl, kTimes);
     CompositeKeyTimes(wAngCtl, kTimes);
 
-    constexpr float kMaxRads = 30.f * hsConstants::pi<float> / 180.f;
+    constexpr float kMaxRads = hsDegreesToRadians(30.f);
     MaxSampleAngles(nodeName, uAngCtl, kTimes, kMaxRads);
     MaxSampleAngles(nodeName, vAngCtl, kTimes, kMaxRads);
     MaxSampleAngles(nodeName, wAngCtl, kTimes, kMaxRads);
@@ -2107,8 +2107,7 @@ void hsControlConverter::IExportAnimatedCameraFOV(plMaxNode* node, hsTArray <hsG
     {
         TimeValue t = TimeValue(GetTicksPerFrame() * (kfArray[0][i].fFrame));
         theCam = (GenCamera *) obj->ConvertToType(t, Class_ID(LOOKAT_CAM_CLASS_ID, 0));
-        float FOVvalue= theCam->GetFOV(t); // in radians
-        FOVvalue *= 180.f / hsConstants::pi<float>; // to degrees
+        float FOVvalue = hsRadiansToDegrees(theCam->GetFOV(t));
         int FOVType = theCam->GetFOVType();
         float wDeg, hDeg;
         switch(FOVType)

--- a/Sources/Tools/MaxConvert/hsControlConverter.cpp
+++ b/Sources/Tools/MaxConvert/hsControlConverter.cpp
@@ -793,7 +793,7 @@ plLeafController* hsControlConverter::ICreateQuatController(plMaxNode* node, Con
         {
             // Get key
             ikeys->GetKey(i, key.get());
-            constexpr float kMaxRads = hsConstants::pi<float> * 0.5f;
+            constexpr float kMaxRads = hsConstants::half_pi<float>;
             Tab<TimeValue> kTimes;
             kTimes.ZeroCount();
             if( rotation )

--- a/Sources/Tools/MaxConvert/hsControlConverter.cpp
+++ b/Sources/Tools/MaxConvert/hsControlConverter.cpp
@@ -266,7 +266,7 @@ plLeafController* hsControlConverter::MakeMatrix44Controller(StdUVGen* uvGen, co
     CompositeKeyTimes(vAngCtl, kTimes);
     CompositeKeyTimes(wAngCtl, kTimes);
 
-    const float kMaxRads = 30.f * M_PI / 180.f;
+    constexpr float kMaxRads = 30.f * hsConstants::pi<float> / 180.f;
     MaxSampleAngles(nodeName, uAngCtl, kTimes, kMaxRads);
     MaxSampleAngles(nodeName, vAngCtl, kTimes, kMaxRads);
     MaxSampleAngles(nodeName, wAngCtl, kTimes, kMaxRads);
@@ -793,7 +793,7 @@ plLeafController* hsControlConverter::ICreateQuatController(plMaxNode* node, Con
         {
             // Get key
             ikeys->GetKey(i, key.get());
-            const float kMaxRads = M_PI*  0.5f;
+            constexpr float kMaxRads = hsConstants::pi<float> * 0.5f;
             Tab<TimeValue> kTimes;
             kTimes.ZeroCount();
             if( rotation )
@@ -2108,7 +2108,7 @@ void hsControlConverter::IExportAnimatedCameraFOV(plMaxNode* node, hsTArray <hsG
         TimeValue t = TimeValue(GetTicksPerFrame() * (kfArray[0][i].fFrame));
         theCam = (GenCamera *) obj->ConvertToType(t, Class_ID(LOOKAT_CAM_CLASS_ID, 0));
         float FOVvalue= theCam->GetFOV(t); // in radians
-        FOVvalue *= (float)(180.f / M_PI); // to degrees
+        FOVvalue *= 180.f / hsConstants::pi<float>; // to degrees
         int FOVType = theCam->GetFOVType();
         float wDeg, hDeg;
         switch(FOVType)

--- a/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
+++ b/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
@@ -3972,22 +3972,22 @@ static BMM_Color_64 ICubeSample(plErrorMsg* const msg, Bitmap *bitmap[6], double
     }
     else
     {
-        if( (theta <= (M_PI / 2.0 - M_PI/4.0))
-            ||(theta >= (M_PI * 2.0 - M_PI/4.0)) )
+        if( (theta <= (hsConstants::half_pi<double> - hsConstants::pi<double>/4.0))
+            ||(theta >= (hsConstants::two_pi<double> - hsConstants::pi<double>/4.0)) )
         {
             map = bitmap[VIEW_FR];
             xMap = x / y;
             yMap = -z / y;
         }
         else
-        if( theta <= (M_PI - M_PI/4.0) )
+        if( theta <= (hsConstants::pi<double> - hsConstants::pi<double>/4.0) )
         {
             map = bitmap[VIEW_LF];
             xMap = -y / x;
             yMap = -z / x;
         }
         else
-        if( theta <= (M_PI * 3.0/2.0 - M_PI/4.0) )
+        if( theta <= (hsConstants::pi<double> * 3.0/2.0 - hsConstants::pi<double>/4.0) )
         {
             map = bitmap[VIEW_BK];
             xMap = x / y;

--- a/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
+++ b/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
@@ -3932,10 +3932,13 @@ static BMM_Color_64 ICubeSample(plErrorMsg* const msg, Bitmap *bitmap[6], double
 {
     hsGuardBegin("hsMaterialConverter::ICubeSample");
 
-    theta = fmod(theta, (double)TWOPI);
-    if( theta < 0 )theta += TWOPI;
-    if( phi < 0 )phi = 0;
-    else if( phi > PI )phi = PI;
+    theta = fmod(theta, hsConstants::two_pi<double>);
+    if (theta < 0)
+        theta += hsConstants::two_pi<double>;
+    if (phi < 0)
+        phi = 0;
+    else if (phi > hsConstants::pi<double>)
+        phi = hsConstants::pi<double>;
 
     Bitmap *map = nil;
 
@@ -4021,8 +4024,8 @@ void hsMaterialConverter::IBuildSphereMap(Bitmap *bitmap[6], Bitmap *bm)
     hsGuardBegin("hsMaterialConverter::IBuildSphereMap");
 
     int i, j;
-    double delPhi = PI / bm->Height();
-    double delThe = TWOPI / bm->Width();
+    double delPhi = hsConstants::pi<double> / bm->Height();
+    double delThe = hsConstants::two_pi<double> / bm->Width();
     PixelBuf l64(bm->Width());
     BMM_Color_64 *pb=l64.Ptr();
     for( j = 0; j < bm->Height(); j++ )
@@ -4032,7 +4035,7 @@ void hsMaterialConverter::IBuildSphereMap(Bitmap *bitmap[6], Bitmap *bm)
             double phi, theta; // phi is up/down
 
             phi = (0.5 + j) * delPhi;
-            theta = PI - (0.5 + i) * delThe;
+            theta = hsConstants::pi<double> - (0.5 + i) * delThe;
 
             pb[i] = ICubeSample(fErrorMsg, bitmap, phi, theta);
         }

--- a/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
+++ b/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
@@ -3935,10 +3935,7 @@ static BMM_Color_64 ICubeSample(plErrorMsg* const msg, Bitmap *bitmap[6], double
     theta = fmod(theta, hsConstants::two_pi<double>);
     if (theta < 0)
         theta += hsConstants::two_pi<double>;
-    if (phi < 0)
-        phi = 0;
-    else if (phi > hsConstants::pi<double>)
-        phi = hsConstants::pi<double>;
+    phi = std::clamp(phi, 0, hsConstants::pi<double>);
 
     Bitmap *map = nil;
 

--- a/Sources/Tools/MaxConvert/plDistributor.cpp
+++ b/Sources/Tools/MaxConvert/plDistributor.cpp
@@ -144,7 +144,7 @@ void plDistributor::IClear()
 
     fPolarRange = 0;
     fTanPolarRange = 0;
-    fAzimuthRange = M_PI;
+    fAzimuthRange = hsConstants::pi<float>;
 
     fOverallProb = 1.f;
 
@@ -236,8 +236,8 @@ void plDistributor::ISetAngProbCosines() const
     if( transAng > (maxAng - minAng) * 0.5f )
         transAng = (maxAng - minAng) * 0.5f;
 
-    float transAngMax = maxAng < M_PI ? transAng : 0;
-    float transAngMin = minAng > 0 ? transAng : 0;
+    float transAngMax = maxAng < hsConstants::pi<float> ? transAng : 0.f;
+    float transAngMin = minAng > 0.f ? transAng : 0.f;
 
     fCosAngProbHi = cos(minAng);
     fCosAngProbLo = cos(maxAng);
@@ -746,7 +746,7 @@ Matrix3 plDistributor::IGenerateTransform(int iRepNode, int iFace, const Point3&
     Point3 out = dir ^ norm;
     if( out.LengthSquared() < kMinVecLengthSq )
     {
-        if( fAzimuthRange < M_PI * 0.5f )
+        if (fAzimuthRange < hsConstants::half_pi<float>)
         {
             l2w.IdentityMatrix();
             return l2w;

--- a/Sources/Tools/MaxConvert/plLayerConverter.cpp
+++ b/Sources/Tools/MaxConvert/plLayerConverter.cpp
@@ -907,10 +907,10 @@ plLayerInterface* plLayerConverter::IConvertAngleAttenLayer(plPlasmaMAXLayer *la
     }
     plAngleAttenLayer* aaLay = (plAngleAttenLayer*)layer;
     Box3 fade = aaLay->GetFade();
-    float tr0 = cosf(DegToRad(180.f - fade.Min().x));
-    float op0 = cosf(DegToRad(180.f - fade.Min().y));
-    float tr1 = cosf(DegToRad(180.f - fade.Max().x));
-    float op1 = cosf(DegToRad(180.f - fade.Max().y));
+    float tr0 = cosf(hsDegreesToRadians(180.f - fade.Min().x));
+    float op0 = cosf(hsDegreesToRadians(180.f - fade.Min().y));
+    float tr1 = cosf(hsDegreesToRadians(180.f - fade.Max().x));
+    float op1 = cosf(hsDegreesToRadians(180.f - fade.Max().y));
 
     int loClamp = aaLay->GetLoClamp();
     int hiClamp = aaLay->GetHiClamp();

--- a/Sources/Tools/MaxConvert/plLightMapGen.cpp
+++ b/Sources/Tools/MaxConvert/plLightMapGen.cpp
@@ -195,7 +195,7 @@ bool plLightMapGen::Open(Interface* ip, TimeValue t, bool forceRegen)
         vp.yon = 30.f;
         vp.distance = 1.f;
         vp.zoom = 1.f;
-        vp.fov = M_PI / 4.f;
+        vp.fov = hsConstants::pi<float> / 4.f;
         vp.nearRange = 1.f;
         vp.farRange = 30.f;
 
@@ -947,7 +947,7 @@ bool plLightMapGen::ISpotAffectsNode(plLightMapInfo* liInfo, LightObject* liObj,
     liObj->EvalLightState(TimeValue(0), FOREVER, &ls);
 
     float coneRad[2];
-    coneRad[0] = (float)(ls.fallsize * M_PI / 180.f);
+    coneRad[0] = ls.fallsize * hsConstants::pi<float> / 180.f;
     coneRad[1] = coneRad[0];
     if( ls.shape == RECT_LIGHT )
         coneRad[1] /= ls.aspect;

--- a/Sources/Tools/MaxConvert/plLightMapGen.cpp
+++ b/Sources/Tools/MaxConvert/plLightMapGen.cpp
@@ -947,7 +947,7 @@ bool plLightMapGen::ISpotAffectsNode(plLightMapInfo* liInfo, LightObject* liObj,
     liObj->EvalLightState(TimeValue(0), FOREVER, &ls);
 
     float coneRad[2];
-    coneRad[0] = ls.fallsize * hsConstants::pi<float> / 180.f;
+    coneRad[0] = hsDegreesToRadians(ls.fallsize);
     coneRad[1] = coneRad[0];
     if( ls.shape == RECT_LIGHT )
         coneRad[1] /= ls.aspect;

--- a/Sources/Tools/MaxConvert/plRenderInstance.cpp
+++ b/Sources/Tools/MaxConvert/plRenderInstance.cpp
@@ -58,7 +58,7 @@ public:
     plNilView() 
     {       
         projType = 1;
-        fov = M_PI * 0.25f;
+        fov = hsConstants::pi<float> * 0.25f;
         pixelSize = 1.f;
         affineTM.IdentityMatrix();
         worldToView.IdentityMatrix();

--- a/Sources/Tools/MaxMain/plMaxNode.cpp
+++ b/Sources/Tools/MaxMain/plMaxNode.cpp
@@ -2070,7 +2070,7 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
 //          mnMesh.MakeConvexPolyMesh();
             mnMesh.MakePolyMesh();
             mnMesh.MakeConvex();
-//          mnMesh.MakePlanar(1.f * hsConstants::pi<float> / 180.f); // Completely ineffective. Winding up with majorly non-planar polys.
+//          mnMesh.MakePlanar(hsDegreesToRadians(1.f)); // Completely ineffective. Winding up with majorly non-planar polys.
 
             mnMesh.Transform(maxV2L);
 

--- a/Sources/Tools/MaxMain/plMaxNode.cpp
+++ b/Sources/Tools/MaxMain/plMaxNode.cpp
@@ -2046,11 +2046,11 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
 
             Mesh mesh(meshObj->mesh);
             
-            const float kNormThresh = M_PI / 20.f;
-            const float kEdgeThresh = M_PI / 20.f;
-            const float kBias = 0.1f;
-            const float kMaxEdge = -1.f;
-            const DWORD kOptFlags = OPTIMIZE_SAVESMOOTHBOUNDRIES; 
+            constexpr float kNormThresh = hsConstants::pi<float> / 20.f;
+            constexpr float kEdgeThresh = hsConstants::pi<float> / 20.f;
+            constexpr float kBias = 0.1f;
+            constexpr float kMaxEdge = -1.f;
+            constexpr DWORD kOptFlags = OPTIMIZE_SAVESMOOTHBOUNDRIES;
 
             mesh.Optimize(
                 kNormThresh, // threshold of normal differences to preserve
@@ -2070,7 +2070,7 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
 //          mnMesh.MakeConvexPolyMesh();
             mnMesh.MakePolyMesh();
             mnMesh.MakeConvex();
-//          mnMesh.MakePlanar(1.f * M_PI / 180.f); // Completely ineffective. Winding up with majorly non-planar polys.
+//          mnMesh.MakePlanar(1.f * hsConstants::pi<float> / 180.f); // Completely ineffective. Winding up with majorly non-planar polys.
 
             mnMesh.Transform(maxV2L);
 

--- a/Sources/Tools/MaxPlasmaLights/plRealTimeLightBase.cpp
+++ b/Sources/Tools/MaxPlasmaLights/plRealTimeLightBase.cpp
@@ -317,7 +317,7 @@ void plRTLightBase::BuildSpotMesh(float coneSize)
     int nfaces = 8;
     spotMesh.setNumVerts(nverts);
     spotMesh.setNumFaces(nfaces);
-    double radang = 3.1415926 * coneSize / 360.0;
+    double radang = hsConstants::pi<double> * coneSize / 360.0;
     float h = 20.0f;                    // hypotenuse
     float d = -h * (float)cos(radang);  // dist from origin to cone circle
     float r = h * (float)sin(radang);   // radius of cone circle
@@ -727,7 +727,7 @@ void plRTLightBase::GetAttenPoints(TimeValue t, float rad, Point3 *q)
     float sn, cs;
     for(int i = 0; i < NUM_CIRC_PTS; i++) 
     {
-        a = (double)i * 2.0 * 3.1415926 / (double)NUM_CIRC_PTS;
+        a = double(i) * hsConstants::two_pi<double> / double(NUM_CIRC_PTS);
         sn = rad * (float)sin(a);
         cs = rad * (float)cos(a);
         q[i+0*NUM_CIRC_PTS] = Point3(sn, cs, 0.0f);
@@ -1051,7 +1051,7 @@ void plRTLightBase::GetConePoints(TimeValue t, float aspect, float angle, float 
             rad = angle;
         int i;
         for(i = 0; i < NUM_CIRC_PTS; i++) {
-            a = (double)i * 2.0 * 3.1415926 / (double)NUM_CIRC_PTS;
+            a = double(i) * hsConstants::two_pi<double> / double(NUM_CIRC_PTS);
             q[i] = Point3(rad*(float)sin(a), rad*(float)cos(a), -dist);
             }
         q[i] = q[0] + Point3(0.0f, 15.0f, 0.0f);

--- a/Sources/Tools/MaxPlasmaLights/plRealTimeLights.cpp
+++ b/Sources/Tools/MaxPlasmaLights/plRealTimeLights.cpp
@@ -235,12 +235,12 @@ static Point3 MapToDir(Point3 p, int k) {
 static void GetMatrixForDir(Matrix3 &origm, Matrix3 &tm, int k ) {
     tm = origm;
     switch(k) {
-        case 0: tm.PreRotateY(-HALFPI); break;  // Map 0: +X axis   
-        case 1: tm.PreRotateY( HALFPI); break;  // Map 1: -X axis   
-        case 2: tm.PreRotateX( HALFPI); break;  // Map 2: +Y axis   
-        case 3: tm.PreRotateX(-HALFPI); break;  // Map 3: -Y axis   
-        case 4: tm.PreRotateY(   PI  ); break;  // Map 4: +Z axis   
-        case 5:                         break;  // Map 5: -Z axis   
+        case 0: tm.PreRotateY(-hsConstants::half_pi<float>); break;  // Map 0: +X axis
+        case 1: tm.PreRotateY( hsConstants::half_pi<float>); break;  // Map 1: -X axis
+        case 2: tm.PreRotateX( hsConstants::half_pi<float>); break;  // Map 2: +Y axis
+        case 3: tm.PreRotateX(-hsConstants::half_pi<float>); break;  // Map 3: -Y axis
+        case 4: tm.PreRotateY( hsConstants::pi<float>);      break;  // Map 4: +Z axis
+        case 5:                                              break;  // Map 5: -Z axis
         }
     }
 

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plStaticEnvLayer.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plStaticEnvLayer.cpp
@@ -561,24 +561,24 @@ Matrix3 plStaticEnvLayer::IGetViewTM( int i )
     switch( i ) 
     {
         case kTopFace:
-            m.RotateX( -hsConstants::pi<float> );
+            m.RotateX(-hsConstants::pi<float>);
             break;
         case kBottomFace:
             break;
         case kLeftFace:
-            m.RotateX( -hsConstants::half_pi<float> );
-            m.RotateY( -hsConstants::half_pi<float> );
+            m.RotateX(-hsConstants::half_pi<float>);
+            m.RotateY(-hsConstants::half_pi<float>);
             break;
         case kRightFace:
-            m.RotateX( -hsConstants::half_pi<float> );
-            m.RotateY( +hsConstants::half_pi<float> );
+            m.RotateX(-hsConstants::half_pi<float>);
+            m.RotateY(hsConstants::half_pi<float>);
             break;
         case kFrontFace:
-            m.RotateX( -hsConstants::half_pi<float> );
-            m.RotateY( hsConstants::pi<float> );
+            m.RotateX(-hsConstants::half_pi<float>);
+            m.RotateY(hsConstants::pi<float>);
             break;
         case kBackFace:
-            m.RotateX( -hsConstants::half_pi<float> );
+            m.RotateX(-hsConstants::half_pi<float>);
             break;
     }
     return m;

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plStaticEnvLayer.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plStaticEnvLayer.cpp
@@ -561,24 +561,24 @@ Matrix3 plStaticEnvLayer::IGetViewTM( int i )
     switch( i ) 
     {
         case kTopFace:
-            m.RotateX( -M_PI );   
+            m.RotateX( -hsConstants::pi<float> );
             break;
         case kBottomFace:
             break;
         case kLeftFace:
-            m.RotateX( -.5f * M_PI ); 
-            m.RotateY( -.5f * M_PI );
+            m.RotateX( -hsConstants::half_pi<float> );
+            m.RotateY( -hsConstants::half_pi<float> );
             break;
         case kRightFace:
-            m.RotateX( -.5f * M_PI ); 
-            m.RotateY( +.5f * M_PI );
+            m.RotateX( -hsConstants::half_pi<float> );
+            m.RotateY( +hsConstants::half_pi<float> );
             break;
         case kFrontFace:
-            m.RotateX( -.5f * M_PI ); 
-            m.RotateY( M_PI );
+            m.RotateX( -hsConstants::half_pi<float> );
+            m.RotateY( hsConstants::pi<float> );
             break;
         case kBackFace:
-            m.RotateX( -.5f * M_PI ); 
+            m.RotateX( -hsConstants::half_pi<float> );
             break;
     }
     return m;
@@ -652,7 +652,7 @@ void    plStaticEnvLayer::RenderCubicMap( INode *node )
     vp.projType = PROJ_PERSPECTIVE;
     vp.hither = .001f;
     vp.yon = 1.0e30f;
-    vp.fov = M_PI/2.0f;
+    vp.fov = hsConstants::half_pi<float>;
     if( fBitmapPB->GetInt( kBmpUseMAXAtmosphere ) )
     {
         vp.nearRange = 0;

--- a/Sources/Tools/MaxPlasmaMtls/Shaders.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Shaders.cpp
@@ -278,7 +278,7 @@ void MetalShader::Illum(ShadeContext &sc, SIllumParams &ip) {
                 
                 // Beckman distribution  (from Cook-Torrance paper)
                 sec2 = 1.0f/(NH*NH);  // 1/sqr(cos) 
-                float D = (.5f/PI)*sec2*sec2*m2inv*(float)exp((1.0f-sec2)*m2inv);                   
+                float D = (.5f/hsConstants::pi<float>)*sec2*sec2*m2inv*(float)exp((1.0f-sec2)*m2inv);
                 if (G>1.0f) G = 1.0f;
                 float Rs = ip.sh_str*D*G/(NV+.05f); 
                 ip.specIllum += fcol*Rs*lightCol;
@@ -297,8 +297,8 @@ void MetalShader::SetShininess(float shininess, float shineStr) {
 }
 
 float MetalShader::EvalHilite(float x) {
-    float c = (float)cos(x*PI);
+    float c = (float)cos(x*hsConstants::pi<float>);
     float sec2 = 1.0f/(c*c);      /* 1/sqr(cos) */
-    return fshin_str*(.5f/PI)*sec2*sec2*fm2inv*(float)exp((1.0f-sec2)*fm2inv);                      
+    return fshin_str*(.5f/hsConstants::pi<float>)*sec2*sec2*fm2inv*(float)exp((1.0f-sec2)*fm2inv);
 }
 

--- a/Sources/Tools/MaxPlasmaMtls/Shaders.h
+++ b/Sources/Tools/MaxPlasmaMtls/Shaders.h
@@ -97,7 +97,7 @@ public:
         shin_str = shineStr;
     }
     float EvalHilite(float x) {
-        return shin_str*(float)pow((double)cos(x*M_PI),(double)fs);  
+        return shin_str*(float)pow(std::cos(x*hsConstants::pi<double>),(double)fs);
     }
 };
 
@@ -116,7 +116,7 @@ public:
         shin_str = shineStr;
     }
     float EvalHilite(float x) {
-        return shin_str*(float)pow((double)cos(x*M_PI),(double)fs); 
+        return shin_str*(float)pow(std::cos(x*hsConstants::pi<double>),(double)fs);
     }
 };
 
@@ -148,7 +148,7 @@ public:
         shin_str = shineStr;
     }
     float EvalHilite(float x) {
-        return shin_str*(float)pow((double)cos(x*M_PI),(double)fs);  
+        return shin_str*(float)pow(std::cos(x*hsConstants::pi<double>),(double)fs);
     }
 };
 


### PR DESCRIPTION
This introduces a `hsConstants` namespace inspired by C++20's `std::numbers` (but with specific constants that are used across Plasma).  These constants are template variables (strongly typed), and also replace many duplicate constants used throughout the code.

In addition, some `constexpr` has been added where appropriate.