### PR TITLE
Add some target_link_libraries

### DIFF
--- a/Sources/Plasma/FeatureLib/pfAnimation/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfAnimation/CMakeLists.txt
@@ -27,5 +27,12 @@ set(pfAnimation_HEADERS
 
 add_library(pfAnimation STATIC ${pfAnimation_SOURCES} ${pfAnimation_HEADERS})
 
+target_link_libraries(pfAnimation
+    PUBLIC
+        CoreLib
+        pnModifier
+        plModifier
+)
+
 source_group("Source Files" FILES ${pfAnimation_SOURCES})
 source_group("Header Files" FILES ${pfAnimation_HEADERS})

--- a/Sources/Plasma/FeatureLib/pfAudio/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfAudio/CMakeLists.txt
@@ -11,5 +11,11 @@ set(pfAudio_HEADERS
 
 add_library(pfAudio STATIC ${pfAudio_SOURCES} ${pfAudio_HEADERS})
 
+target_link_libraries(pfAudio
+    PUBLIC
+        CoreLib
+        pfAnimation
+)
+
 source_group("Source Files" FILES ${pfAudio_SOURCES})
 source_group("Header Files" FILES ${pfAudio_HEADERS})

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/CMakeLists.txt
@@ -58,5 +58,11 @@ set(pfGameGUIMgr_HEADERS
 
 add_library(pfGameGUIMgr STATIC ${pfGameGUIMgr_SOURCES} ${pfGameGUIMgr_HEADERS})
 
+target_link_libraries(pfGameGUIMgr
+    PUBLIC
+        CoreLib
+        plClipboard
+)
+
 source_group("Source Files" FILES ${pfGameGUIMgr_SOURCES})
 source_group("Header Files" FILES ${pfGameGUIMgr_HEADERS})

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${EXPAT_INCLUDE_DIR})
-
 if(WIN32)
     add_definitions(-DWIN32)
 
@@ -21,6 +19,13 @@ set(pfLocalizationMgr_HEADERS
 )
 
 add_library(pfLocalizationMgr STATIC ${pfLocalizationMgr_SOURCES} ${pfLocalizationMgr_HEADERS})
+
+target_include_directories(pfLocalizationMgr PRIVATE ${EXPAT_INCLUDE_DIR})
+target_link_libraries(pfLocalizationMgr
+    PUBLIC
+        ${EXPAT_LIBRARY}
+        CoreLib
+)
 
 source_group("Source Files" FILES ${pfLocalizationMgr_SOURCES})
 source_group("Header Files" FILES ${pfLocalizationMgr_HEADERS})

--- a/Sources/Plasma/FeatureLib/pfMoviePlayer/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfMoviePlayer/CMakeLists.txt
@@ -22,6 +22,12 @@ set(pfMoviePlayer_WEBM
 
 add_library(pfMoviePlayer STATIC ${pfMoviePlayer_SOURCES} ${pfMoviePlayer_HEADERS} ${pfMoviePlayer_WEBM})
 
+target_link_libraries(pfMoviePlayer
+    PUBLIC
+        CoreLib
+        plAudio
+)
+
 source_group("Source Files" FILES ${pfMoviePlayer_SOURCES})
 source_group("Header Files" FILES ${pfMoviePlayer_HEADERS})
 source_group("WebM" FILES ${pfMoviePlayer_WEBM})

--- a/Sources/Plasma/FeatureLib/pfPatcher/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfPatcher/CMakeLists.txt
@@ -10,5 +10,11 @@ set(pfPatcher_HEADERS
 
 add_library(pfPatcher STATIC ${pfPatcher_SOURCES} ${pfPatcher_HEADERS})
 
+target_link_libraries(pfPatcher
+    PUBLIC
+        CoreLib
+        pnEncryption
+)
+
 source_group("Source Files" FILES ${pfPatcher_SOURCES})
 source_group("Header Files" FILES ${pfPatcher_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plAudio/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAudio/CMakeLists.txt
@@ -75,7 +75,15 @@ set(plAudio_HEADERS
 )
 
 add_library(plAudio STATIC ${plAudio_SOURCES} ${plAudio_HEADERS})
-target_link_libraries(plAudio OpenAL::OpenAL)
+
+target_link_libraries(plAudio
+    PUBLIC
+        OpenAL::OpenAL
+        CoreLib
+        plAnimation
+        plAudioCore
+        plMessage
+)
 
 source_group("Source Files" FILES ${plAudio_SOURCES})
 source_group("Header Files" FILES ${plAudio_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plDrawable/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plDrawable/CMakeLists.txt
@@ -102,5 +102,17 @@ set(plDrawable_HEADERS
 
 add_library(plDrawable STATIC ${plDrawable_SOURCES} ${plDrawable_HEADERS})
 
+target_link_libraries(plDrawable
+    PUBLIC
+        CoreLib
+        pnKeyedObject
+        plMath
+        plGLight
+        plMessage
+        plScene
+        plSDL
+        plSurface
+)
+
 source_group("Source Files" FILES ${plDrawable_SOURCES})
 source_group("Header Files" FILES ${plDrawable_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plGImage/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plGImage/CMakeLists.txt
@@ -39,5 +39,15 @@ set(plGImage_HEADERS
 
 add_library(plGImage STATIC ${plGImage_SOURCES} ${plGImage_HEADERS})
 
+target_link_libraries(plGImage
+    PUBLIC
+        ${JPEG_LIBRARY}
+        ${PNG_LIBRARY}
+        CoreLib
+        pnKeyedObject
+        plMessage
+        plResMgr
+)
+
 source_group("Source Files" FILES ${plGImage_SOURCES})
 source_group("Header Files" FILES ${plGImage_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plGLight/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plGLight/CMakeLists.txt
@@ -26,5 +26,14 @@ set(plGLight_HEADERS
 
 add_library(plGLight STATIC ${plGLight_SOURCES} ${plGLight_HEADERS})
 
+target_link_libraries(plGLight
+    PUBLIC
+        CoreLib
+        pnKeyedObject
+        pnSceneObject
+        plIntersect
+        plScene
+)
+
 source_group("Source Files" FILES ${plGLight_SOURCES})
 source_group("Header Files" FILES ${plGLight_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plInterp/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plInterp/CMakeLists.txt
@@ -22,9 +22,14 @@ set(plInterp_HEADERS
 
 add_library(plInterp STATIC ${plInterp_SOURCES} ${plInterp_HEADERS})
 
-target_link_libraries(plInterp pnFactory)
-target_link_libraries(plInterp pnNetCommon)
-target_link_libraries(plInterp plTransform)
+target_link_libraries(plInterp
+    PUBLIC
+        CoreLib
+        pnFactory
+        pnNetCommon
+        plIntersect
+        plTransform
+)
 
 source_group("Source Files" FILES ${plInterp_SOURCES})
 source_group("Header Files" FILES ${plInterp_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plIntersect/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plIntersect/CMakeLists.txt
@@ -22,5 +22,13 @@ set(plIntersect_HEADERS
 
 add_library(plIntersect STATIC ${plIntersect_SOURCES} ${plIntersect_HEADERS})
 
+target_link_libraries(plIntersect
+    PUBLIC
+        CoreLib
+        pnKeyedObject
+        pnSceneObject
+        plMessage
+)
+
 source_group("Source Files" FILES ${plIntersect_SOURCES})
 source_group("Header Files" FILES ${plIntersect_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
@@ -116,5 +116,12 @@ set(plMessage_HEADERS
 use_precompiled_header(Pch.h Pch.cpp plMessage_HEADERS plMessage_SOURCES)
 add_library(plMessage STATIC ${plMessage_SOURCES} ${plMessage_HEADERS})
 
+target_link_libraries(plMessage
+    PUBLIC
+        CoreLib
+        pnMessage
+        plNetCommon
+)
+
 source_group("Source Files" FILES ${plMessage_SOURCES})
 source_group("Header Files" FILES ${plMessage_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plModifier/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plModifier/CMakeLists.txt
@@ -48,6 +48,13 @@ set(plModifier_HEADERS
 add_library(plModifier STATIC ${plModifier_SOURCES} ${plModifier_HEADERS})
 
 target_include_directories(plModifier PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
+target_link_libraries(plModifier
+    PUBLIC
+        CoreLib
+        pnModifier
+        plNetCommon
+        plSDL
+)
 
 source_group("Source Files" FILES ${plModifier_SOURCES})
 source_group("Header Files" FILES ${plModifier_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plNetClient/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plNetClient/CMakeLists.txt
@@ -32,6 +32,16 @@ set(plNetClient_HEADERS
 add_library(plNetClient STATIC ${plNetClient_SOURCES} ${plNetClient_HEADERS})
 
 target_include_directories(plNetClient PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
+target_link_libraries(plNetClient
+    PUBLIC
+        CoreLib
+        pnNetCommon
+        plContainer
+        plNetClientComm
+        plNetClientRecorder
+        plNetTransport
+        pfMessage # Needed for pfKIMsg
+)
 
 source_group("Source Files" FILES ${plNetClient_SOURCES})
 source_group("Header Files" FILES ${plNetClient_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plNetCommon/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/CMakeLists.txt
@@ -26,6 +26,11 @@ set(plNetCommon_HEADERS
 add_library(plNetCommon STATIC ${plNetCommon_SOURCES} ${plNetCommon_HEADERS})
 
 target_include_directories(plNetCommon PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
+target_link_libraries(plNetCommon
+    PUBLIC
+        CoreLib
+        plCompression
+)
 
 source_group("Source Files" FILES ${plNetCommon_SOURCES})
 source_group("Header Files" FILES ${plNetCommon_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plPipeline/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plPipeline/CMakeLists.txt
@@ -88,17 +88,28 @@ set(plGLPipeline_HEADERS
 if(PLASMA_PIPELINE STREQUAL "DirectX")
     add_library(plPipeline STATIC ${plPipeline_SOURCES} ${plDXPipeline_SOURCES} ${plPipeline_HEADERS} ${plDXPipeline_HEADERS})
 
-    target_link_libraries(plPipeline ${DirectX_LIBRARIES})
+    target_link_libraries(plPipeline PUBLIC ${DirectX_LIBRARIES})
 endif(PLASMA_PIPELINE STREQUAL "DirectX")
 
 if(PLASMA_PIPELINE STREQUAL "OpenGL")
     add_library(plPipeline STATIC ${plPipeline_SOURCES} ${plGLPipeline_SOURCES} ${plPipeline_HEADERS} ${plGLPipeline_HEADERS})
 
-    target_link_libraries(plPipeline EGL)
-    target_link_libraries(plPipeline GLESv2)
+    target_link_libraries(plPipeline PUBLIC EGL GLESv2)
 endif(PLASMA_PIPELINE STREQUAL "OpenGL")
 
 target_include_directories(plPipeline PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
+target_link_libraries(plPipeline
+    PUBLIC
+        CoreLib
+        pnKeyedObject
+        pnNucleusInc
+        pnSceneObject
+        plClientResMgr
+        plDrawable
+        plGLight
+        plScene
+        plSurface
+)
 
 source_group("Source Files" FILES ${plPipeline_SOURCES})
 source_group("Header Files" FILES ${plPipeline_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plResMgr/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plResMgr/CMakeLists.txt
@@ -25,15 +25,19 @@ set(plResMgr_HEADERS
 )
 
 add_library(plResMgr STATIC ${plResMgr_SOURCES} ${plResMgr_HEADERS})
-target_link_libraries(plResMgr CoreLib)
-target_link_libraries(plResMgr pnDispatch)
-target_link_libraries(plResMgr pnFactory)
-target_link_libraries(plResMgr pnKeyedObject)
-target_link_libraries(plResMgr pnMessage)
-target_link_libraries(plResMgr pnTimer)
-target_link_libraries(plResMgr plAgeDescription)
-target_link_libraries(plResMgr plFile)
-target_link_libraries(plResMgr plStatusLog)
+
+target_link_libraries(plResMgr
+    PUBLIC
+        CoreLib
+        pnDispatch
+        pnFactory
+        pnKeyedObject
+        pnMessage
+        pnTimer
+        plAgeDescription
+        plFile
+        plStatusLog
+)
 
 source_group("Source Files" FILES ${plResMgr_SOURCES})
 source_group("Header Files" FILES ${plResMgr_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plSDL/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plSDL/CMakeLists.txt
@@ -29,6 +29,13 @@ set(plSDL_SDLFILES
 
 add_library(plSDL STATIC ${plSDL_SOURCES} ${plSDL_HEADERS} ${plSDL_SDLFILES})
 
+target_link_libraries(plSDL
+    PUBLIC
+        CoreLib
+        plFile
+        plNetMessage
+)
+
 source_group("Source Files" FILES ${plSDL_SOURCES})
 source_group("Header Files" FILES ${plSDL_HEADERS})
 source_group("SDL" FILES ${plSDL_SDLFILES})

--- a/Sources/Plasma/PubUtilLib/plSurface/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plSurface/CMakeLists.txt
@@ -71,6 +71,15 @@ set(plSurface_SHADERS
 
 add_library(plSurface STATIC ${plSurface_SOURCES} ${plSurface_HEADERS} ${plSurface_SHADERS})
 
+target_link_libraries(plSurface
+    PUBLIC
+        CoreLib
+        pnKeyedObject
+        plGImage
+        plInterp
+        plMessage
+)
+
 source_group("Source Files" FILES ${plSurface_SOURCES})
 source_group("Header Files" FILES ${plSurface_HEADERS})
 source_group("Shaders" FILES ${plSurface_SHADERS})


### PR DESCRIPTION
This is (very clearly) not all of the linking that needs to be done, but this is what I'd been carrying on my plGLClient branch to make it compile and link on Linux.

It seems better for these to exist on master, imperfect they may be, than to have them mixed in with GL pipeline work.