### PR TITLE
Fix Windows-specific path separators

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
@@ -85,7 +85,7 @@ ST::string pfFilePasswordStore::GetPassword(const ST::string& username)
 
 #ifndef PLASMA_EXTERNAL_RELEASE
     // internal builds can use the local init directory
-    plFileName local("init\\login.dat");
+    plFileName local = plFileName::Join("init", "login.dat");
     if (plFileInfo(local).Exists())
         loginDat = local;
 #endif
@@ -118,7 +118,7 @@ bool pfFilePasswordStore::SetPassword(const ST::string& username, const ST::stri
 
 #ifndef PLASMA_EXTERNAL_RELEASE
     // internal builds can use the local init directory
-    plFileName local("init\\login.dat");
+    plFileName local = plFileName::Join("init", "login.dat");
     if (plFileInfo(local).Exists())
         loginDat = local;
 #endif

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
@@ -227,8 +227,8 @@ bool plAgeLoader::ILoadAge(const ST::string& ageName)
 
     /// Step 2: Load the keys for this age, so we can find sceneNodes for them
     // exec age .fni file when data is done loading
-    fPendingAgeFniFiles.emplace_back(ST::format("dat\\{}.fni", fAgeName));
-    fPendingAgeCsvFiles.emplace_back(ST::format("dat\\{}.csv", fAgeName));
+    fPendingAgeFniFiles.emplace_back(plFileName::Join("dat", ST::format("{}.fni", fAgeName)));
+    fPendingAgeCsvFiles.emplace_back(plFileName::Join("dat", ST::format("{}.csv", fAgeName)));
 
     plSynchEnabler p( false );  // turn off dirty tracking while in this function   
 
@@ -439,7 +439,7 @@ hsStream* plAgeLoader::GetAgeDescFileStream(const ST::string& ageName)
     if (ageName.empty())
         return nullptr;
 
-    plFileName ageDescFileName = ST::format("dat\\{}.age", ageName);
+    plFileName ageDescFileName = plFileName::Join("dat", ST::format("{}.age", ageName));
 
     hsStream* stream = plEncryptedStream::OpenEncryptedFile(ageDescFileName);
     if (!stream)

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -765,7 +765,8 @@ void    plInputInterfaceMgr::WriteKeyMap()
 #ifdef PLASMA_EXTERNAL_RELEASE
     return;
 #endif
-    FILE* gKeyFile = fopen("init\\keyboard.fni", "wt");
+    plFileName fname = plFileName::Join("init", "keyboard.fni");
+    FILE* gKeyFile = plFileSystem::Open(fname, "wt");
 
     if (gKeyFile)
     {


### PR DESCRIPTION
Replace hardcoded backslashes with `plFileName::Join`