### PR TITLE
Remove remaining references to tp_print

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
@@ -98,21 +98,6 @@ static void EnumValue_dealloc(EnumValue *self)
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
-static int EnumValue_print(PyObject *self, FILE *fp, int flags)
-{
-    // convert this object to a string
-    PyObject *strObject = (flags & Py_PRINT_RAW) ? Py_TYPE(self)->tp_str(self) : Py_TYPE(self)->tp_repr(self);
-    if (strObject == NULL)
-        return -1; // failure
-
-    const char* text = PyUnicode_AsUTF8(strObject);
-    if (text == NULL)
-        return -1;
-
-    fprintf(fp, "%s", text); // and print it to the file
-    return 0;
-}
-
 static PyObject *EnumValue_repr(PyObject *self)
 {
     EnumValue *obj = (EnumValue*)self;
@@ -372,7 +357,7 @@ PYTHON_TYPE_START(EnumValue)
     sizeof(EnumValue),                  /* tp_basicsize */
     0,                                  /* tp_itemsize */
     (destructor)EnumValue_dealloc,      /* tp_dealloc */
-    PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET(EnumValue_print),
+    PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET,
     0,                                  /* tp_getattr */
     0,                                  /* tp_setattr */
     0,                                  /* tp_as_async */
@@ -416,7 +401,7 @@ PYTHON_TYPE_START(EnumValue)
     0,                                  /* tp_del */
     0,                                  /* tp_version_tag */
     0,                                  /* tp_finalize */
-    PYTHON_TP_VECTORCALL_PRINT(EnumValue_print)
+    PYTHON_TP_VECTORCALL_PRINT
 PYTHON_TYPE_END;
 
 bool IsEnumValue(PyObject *obj)
@@ -583,7 +568,7 @@ PYTHON_TYPE_START(Enum)
     sizeof(Enum),                       /* tp_basicsize */
     0,                                  /* tp_itemsize */
     (destructor)Enum_dealloc,           /* tp_dealloc */
-    PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET(0),
+    PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET,
     0,                                  /* tp_getattr */
     0,                                  /* tp_setattr */
     0,                                  /* tp_compare */
@@ -628,7 +613,7 @@ PYTHON_TYPE_START(Enum)
     0,                                  /* tp_del */
     0,                                  /* tp_version_tag */
     0,                                  /* tp_finalize */
-    PYTHON_TP_VECTORCALL_PRINT(0)
+    PYTHON_TP_VECTORCALL_PRINT
 PYTHON_TYPE_END;
 
 // creates and sets up the enum base class

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -132,7 +132,7 @@ glueClassName *glueClassName::ConvertFrom(PyObject *obj) \
 // This starts off the type definition (however most of the data still needs to be filled in by hand
 #define PYTHON_TYPE_START(pythonClassName) \
 static PyTypeObject pythonClassName##_type = { \
-    PyObject_HEAD_INIT(NULL)
+    PyVarObject_HEAD_INIT(nullptr, 0)
 
 // and easy terminator to make things look pretty
 #define PYTHON_TYPE_END }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -191,15 +191,15 @@ int pythonClassName##___init__(pythonClassName *self, PyObject *args, PyObject *
 // tp_print moved to the end, and two new vectorcall fields inserted in Python 3.8...
 // tp_print gone in Python 3.9...
 #if PY_VERSION_HEX >= 0x03080000
-#   define PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET(tp_print) 0
+#   define PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET 0
 #   if PY_VERSION_HEX >= 0x03090000
-#       define PYTHON_TP_VECTORCALL_PRINT(tp_print) 0,
+#       define PYTHON_TP_VECTORCALL_PRINT 0,
 #   else
-#       define PYTHON_TP_VECTORCALL_PRINT(tp_print) 0, tp_print,
+#       define PYTHON_TP_VECTORCALL_PRINT 0, 0,
 #   endif
 #else
-#   define PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET(tp_print) tp_print
-#   define PYTHON_TP_VECTORCALL_PRINT(tp_print)
+#   define PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET 0
+#   define PYTHON_TP_VECTORCALL_PRINT
 #endif
 
 // most glue classes can get away with this default structure
@@ -209,7 +209,7 @@ PYTHON_TYPE_START(pythonClassName) \
     sizeof(pythonClassName),            /* tp_basicsize */ \
     0,                                  /* tp_itemsize */ \
     PYTHON_DEFAULT_DEALLOC(pythonClassName),    /* tp_dealloc */ \
-    PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET(0), \
+    PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET, \
     0,                                  /* tp_getattr */ \
     0,                                  /* tp_setattr */ \
     0,                                  /* tp_as_async */ \
@@ -252,7 +252,7 @@ PYTHON_TYPE_START(pythonClassName) \
     0, /* tp_del */ \
     0, /* tp_version_tag */ \
     0, /* tp_finalize */ \
-    PYTHON_TP_VECTORCALL_PRINT(0) \
+    PYTHON_TP_VECTORCALL_PRINT \
 PYTHON_TYPE_END
 
 // default rich compare function name
@@ -292,7 +292,7 @@ PYTHON_TYPE_END
     sizeof(pythonClassName),            /* tp_basicsize */ \
     0,                                  /* tp_itemsize */ \
     PYTHON_DEFAULT_DEALLOC(pythonClassName),    /* tp_dealloc */ \
-    PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET(0), \
+    PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET, \
     0,                                  /* tp_getattr */ \
     0,                                  /* tp_setattr */ \
     0,                                  /* tp_as_async */ \
@@ -335,7 +335,7 @@ PYTHON_TYPE_END
     0, /* tp_del */ \
     0, /* tp_version_tag */ \
     0, /* tp_finalize */ \
-    PYTHON_TP_VECTORCALL_PRINT(0) \
+    PYTHON_TP_VECTORCALL_PRINT \
 PYTHON_TYPE_END
 
 // for conviencence when we just need a base class
@@ -345,7 +345,7 @@ PYTHON_TYPE_START(pythonClassName) \
     sizeof(pythonClassName),            /* tp_basicsize */ \
     0,                                  /* tp_itemsize */ \
     PYTHON_DEFAULT_DEALLOC(pythonClassName),    /* tp_dealloc */ \
-    PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET(0), \
+    PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET, \
     0,                                  /* tp_getattr */ \
     0,                                  /* tp_setattr */ \
     0,                                  /* tp_compare */ \
@@ -388,7 +388,7 @@ PYTHON_TYPE_START(pythonClassName) \
     0, /* tp_del */ \
     0, /* tp_version_tag */ \
     0, /* tp_finalize */ \
-    PYTHON_TP_VECTORCALL_PRINT(0) \
+    PYTHON_TP_VECTORCALL_PRINT \
 PYTHON_TYPE_END
 
 // small macros so that the type object can be accessed outside the glue file (for subclassing)


### PR DESCRIPTION
`tp_print` is unused since Python 3.0, and removed in Python 3.9.  There was only one actual use of it, and that class already has a `repr` implementation which will be used instead.