### PR TITLE
Really don't install gtest.

### DIFF
--- a/Sources/Tests/CMakeLists.txt
+++ b/Sources/Tests/CMakeLists.txt
@@ -11,7 +11,7 @@ set(gtest_disable_pthreads OFF CACHE INTERNAL "Override gtest default")
 set(gtest_hide_internal_symbols ON CACHE INTERNAL "Override gtest default")
 
 set(GOOGLETEST_VERSION 1.10.0)
-set(INSTALL_GTEST OFF)
+set(INSTALL_GTEST OFF CACHE INTERNAL "Override gtest default" FORCE)
 add_subdirectory(gtest EXCLUDE_FROM_ALL)
 
 include_directories(${GTEST_INCLUDE_DIR})


### PR DESCRIPTION
This setting was being overridden in GTest's CMakeLists.txt. While this was generally not too terrible, if the vcpkg toolchain is in use and X_VCPKG_APPLOCAL_DEPS_INSTALL was enabled, then the configure process would fail.