### PR TITLE
Fix PhysX bounds/geometry mismatch.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
@@ -209,7 +209,10 @@ bool plPXPhysical::InitActor()
         actorType = plPXActorType::kDynamicActor;
     physx::PxTransform globalPose = plPXConvert::Transform(fRecipe.l2sP, fRecipe.l2sQ);
 
-    switch (fRecipe.bounds) {
+    // Reminder: fRecipe.bounds represents what the artist wanted. This may
+    // be adjusted by our smarter code such that you do not have the shape
+    // described by fRecipe.bounds after a read-in. Use fBounds.
+    switch (fBounds) {
     case plSimDefs::kBoxBounds:
     {
         physx::PxBoxGeometry geometry(plPXConvert::Point(fRecipe.bDimensions));
@@ -253,7 +256,7 @@ bool plPXPhysical::InitActor()
     }
     break;
 
-    DEFAULT_FATAL(fRecipe.bounds)
+    DEFAULT_FATAL(fBounds)
     }
 
     fActor->userData = new plPXActorData(this);

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
@@ -175,7 +175,7 @@ void plPXPhysical::ISanityCheckBounds()
     case plSimDefs::kProxyBounds:
     case plSimDefs::kExplicitBounds:
         if (IsDynamic()) {
-            plSimulationMgr::LogYellow("WARNING: '{}' is a dyanmic triangle mesh; this is not "
+            plSimulationMgr::LogYellow("WARNING: '{}' is a dynamic triangle mesh; this is not "
                                        "supported in PhysX 4... forcing to convex hull, sorry.",
                                        GetKeyName());
             fBounds = plSimDefs::kHullBounds;


### PR DESCRIPTION
This was exposed by a dynamic triangle mesh in Ahnonay Sphere 2. The actual object in question is some kind of dummy object that never appears in Age -- possibly because it starts falling immediately.