### PR TITLE
Fix string memory leaks in pfPython.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifierGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifierGlue.cpp
@@ -72,10 +72,10 @@ PYTHON_METHOD_DEFINITION(ptSDL, setIndex, args)
 
 PYTHON_METHOD_DEFINITION(ptSDL, setIndexNow, args)
 {
-    char* key;
+    ST::string key;
     int idx;
     PyObject* value = NULL;
-    if (!PyArg_ParseTuple(args, "etiO", "utf8", &key, &idx, &value))
+    if (!PyArg_ParseTuple(args, "O&iO", PyUnicode_STStringConverter, &key, &idx, &value))
     {
         PyErr_SetString(PyExc_TypeError, "setIndexNow expects a string, int, and an object");
         PYTHON_RETURN_ERROR;
@@ -86,9 +86,9 @@ PYTHON_METHOD_DEFINITION(ptSDL, setIndexNow, args)
 
 PYTHON_METHOD_DEFINITION(ptSDL, setDefault, args)
 {
-    char* key;
+    ST::string key;
     PyObject* value = NULL;
-    if (!PyArg_ParseTuple(args, "etO", "utf8", &key, &value))
+    if (!PyArg_ParseTuple(args, "O&O", PyUnicode_STStringConverter, &key, &value))
     {
         PyErr_SetString(PyExc_TypeError, "setDefault expects a string and a tuple");
         PYTHON_RETURN_ERROR;
@@ -104,8 +104,8 @@ PYTHON_METHOD_DEFINITION(ptSDL, setDefault, args)
 
 PYTHON_METHOD_DEFINITION(ptSDL, sendToClients, args)
 {
-    char* key;
-    if (!PyArg_ParseTuple(args, "et", "utf8", &key))
+    ST::string key;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &key))
     {
         PyErr_SetString(PyExc_TypeError, "sendToClients expects a string");
         PYTHON_RETURN_ERROR;
@@ -117,9 +117,9 @@ PYTHON_METHOD_DEFINITION(ptSDL, sendToClients, args)
 PYTHON_METHOD_DEFINITION(ptSDL, setNotify, args)
 {
     PyObject* selfKeyObj;
-    char* key;
+    ST::string key;
     float tolerance;
-    if (!PyArg_ParseTuple(args, "Oetf", &selfKeyObj, "utf8", &key, &tolerance))
+    if (!PyArg_ParseTuple(args, "OO&f", &selfKeyObj, PyUnicode_STStringConverter, &key, &tolerance))
     {
         PyErr_SetString(PyExc_TypeError, "setNotify expects a ptKey, string, and float");
         PYTHON_RETURN_ERROR;
@@ -136,9 +136,9 @@ PYTHON_METHOD_DEFINITION(ptSDL, setNotify, args)
 
 PYTHON_METHOD_DEFINITION(ptSDL, setFlags, args)
 {
-    char* key;
+    ST::string key;
     char sendImmediate, skipOwnershipCheck;
-    if (!PyArg_ParseTuple(args, "etbb", "utf8", &key, &sendImmediate, &skipOwnershipCheck))
+    if (!PyArg_ParseTuple(args, "O&bb", PyUnicode_STStringConverter, &key, &sendImmediate, &skipOwnershipCheck))
     {
         PyErr_SetString(PyExc_TypeError, "setFlags expects a string and two booleans");
         PYTHON_RETURN_ERROR;
@@ -149,9 +149,9 @@ PYTHON_METHOD_DEFINITION(ptSDL, setFlags, args)
 
 PYTHON_METHOD_DEFINITION(ptSDL, setTagString, args)
 {
-    char* key;
-    char* tag;
-    if (!PyArg_ParseTuple(args, "etet", "utf8", &key, "utf8", &tag))
+    ST::string key;
+    ST::string tag;
+    if (!PyArg_ParseTuple(args, "O&O&", PyUnicode_STStringConverter, &key, PyUnicode_STStringConverter, &tag))
     {
         PyErr_SetString(PyExc_TypeError, "setTagString expects two strings");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyDynamicTextGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDynamicTextGlue.cpp
@@ -259,8 +259,8 @@ PYTHON_BASIC_METHOD_DEFINITION(ptDynamicMap, unsetWrapping, UnsetWrapping)
 PYTHON_METHOD_DEFINITION(ptDynamicMap, drawText, args)
 {
     short x, y;
-    char* text = nullptr;
-    if (!PyArg_ParseTuple(args, "hhet", &x, &y, "utf8", &text))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "hhO&", &x, &y, PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "drawText expects two short ints and a string");
         PYTHON_RETURN_ERROR;
@@ -322,8 +322,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptDynamicMap, getHeight)
 
 PYTHON_METHOD_DEFINITION(ptDynamicMap, calcTextExtents, args)
 {
-    char* text = nullptr;
-    if (!PyArg_ParseTuple(args, "et", "utf8", &text))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "calcTextExtents expects a string");
         PYTHON_RETURN_ERROR;


### PR DESCRIPTION
Any strings parsed using "et" have to be freed with `PyMem_Free()` - better to just use the new `PyUnicode_STStringConverter` and avoid the implicit conversion from `char*` to `ST::string`.