### PR TITLE
Add a Resize method to hsTArray which performs Expand() + SetCount().

### DIFF
--- a/Sources/Plasma/CoreLib/hsTemplates.h
+++ b/Sources/Plasma/CoreLib/hsTemplates.h
@@ -148,6 +148,13 @@ public:
     int     Count() const { return fUseCount; }
     int     GetCount() const { return fUseCount; }
     inline void SetCount(int count);
+
+    /** WARNING: By design (sigh), the new elements are not (re)initialized... */
+    void Resize(int count)
+    {
+        Expand(count);
+        SetCount(count);
+    }
     
     inline void SetCountAndZero(int count); // does block clear, don't use for types with vtbl
     inline void ExpandAndZero(int count);   // Same as set count and zero except won't decrease

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -887,8 +887,7 @@ bool    pfGUIMultiLineEditCtrl::IStoreLineStart( uint32_t line, int32_t start )
     if( fLineStarts.GetCount() <= line )
     {
         hsAssert( line == fLineStarts.GetCount(), "Trying to store a line way past the end of line starts!" );
-        fLineStarts.Expand( line + 1 );
-        fLineStarts.SetCount( line + 1 );
+        fLineStarts.Resize(line + 1);
         fLineStarts[ line ] = -1;
     }
 

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
@@ -77,8 +77,7 @@ void plMsgForwarder::Read(hsStream* s, hsResMgr* mgr)
 
     int numKeys = s->ReadLE32();
     fForwardKeys.Reset();
-    fForwardKeys.Expand(numKeys);
-    fForwardKeys.SetCount(numKeys);
+    fForwardKeys.Resize(numKeys);
     for (int i = 0; i < numKeys; i++)
     {
         plKey key = mgr->ReadKey(s);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
@@ -297,7 +297,7 @@ bool plClothingItem::MsgReceive(plMessage* msg)
                 if (fTextures.GetCount() <= eMsg->fWhich)
                     fTextures.ExpandAndZero(eMsg->fWhich + 1);
                 if (fElementNames.GetCount() <= eMsg->fWhich)
-                    fElementNames.Expand(eMsg->fWhich + 1);
+                    fElementNames.Resize(eMsg->fWhich + 1);
                 
                 if (fElementNames.Get(eMsg->fWhich).empty())
                     fElementNames.Set(eMsg->fWhich, eMsg->fElementName);

--- a/Sources/Plasma/PubUtilLib/plDrawable/plAccessGeometry.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plAccessGeometry.cpp
@@ -150,8 +150,7 @@ void plAccessGeometry::OpenRO(const plDrawInterface* di, hsTArray<plAccessSpan>&
                 int k;
                 for( k = 0; k < diIndex.GetCount(); k++ )
                 {
-                    accs.Expand(numGot+1);
-                    accs.SetCount(numGot+1);
+                    accs.Resize(numGot+1);
                     OpenRO(dr, diIndex[k], accs[numGot++]);
                 }
             }
@@ -178,8 +177,7 @@ void plAccessGeometry::OpenRW(const plDrawInterface* di, hsTArray<plAccessSpan>&
                 int k;
                 for( k = 0; k < diIndex.GetCount(); k++ )
                 {
-                    accs.Expand(numGot+1);
-                    accs.SetCount(numGot+1);
+                    accs.Resize(numGot+1);
                     OpenRW(dr, diIndex[k], accs[numGot++], idxToo);
                 }
             }

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
@@ -2398,11 +2398,7 @@ uint32_t  plDrawableSpans::AppendDISpans( hsTArray<plGeometrySpan *> &spans, uin
         else if( !doNotAddToSource )
         {
             if( fSourceSpans.GetCount() < fSpans.GetCount() )
-            {
-                fSourceSpans.Expand( fSpans.GetCount() );
-                // Since that does not change the use count, we still have to do that ourselves. ARGH!
-                fSourceSpans.SetCount( fSpans.GetCount() );
-            }
+                fSourceSpans.Resize(fSpans.GetCount());
 
             fSourceSpans[ spans[ i ]->fSpanRefIndex ] = spans[ i ];
         }

--- a/Sources/Plasma/PubUtilLib/plPhysical/plPhysicalSndGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plPhysicalSndGroup.cpp
@@ -123,10 +123,7 @@ void plPhysicalSndGroup::Write( hsStream *s, hsResMgr *mgr )
 void    plPhysicalSndGroup::AddImpactSound( uint32_t against, plKey receiver )
 {
     if( fImpactSounds.GetCount() <= against )
-    {
-        fImpactSounds.Expand( against + 1 );
-        fImpactSounds.SetCount( against + 1 );
-    }
+        fImpactSounds.Resize(against + 1);
 
     fImpactSounds[ against ] = receiver;
 }
@@ -134,10 +131,7 @@ void    plPhysicalSndGroup::AddImpactSound( uint32_t against, plKey receiver )
 void    plPhysicalSndGroup::AddSlideSound( uint32_t against, plKey receiver )
 {
     if( fSlideSounds.GetCount() <= against )
-    {
-        fSlideSounds.Expand( against + 1 );
-        fSlideSounds.SetCount( against + 1 );
-    }
+        fSlideSounds.Resize(against + 1);
 
     fSlideSounds[ against ] = receiver;
 }

--- a/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.cpp
@@ -514,8 +514,7 @@ bool plPageTreeMgr::IRefreshTree(plPipeline* pipe)
 void plPageTreeMgr::AddOccluderList(const hsTArray<plOccluder*> occList)
 {
     int iStart = fOccluders.GetCount();
-    fOccluders.Expand(iStart + occList.GetCount());
-    fOccluders.SetCount(iStart + occList.GetCount());
+    fOccluders.Resize(iStart + occList.GetCount());
 
     plVisMgr* visMgr = fDisableVisMgr ? nil : fVisMgr;
 
@@ -546,8 +545,7 @@ void plPageTreeMgr::AddOccluderList(const hsTArray<plOccluder*> occList)
 void plPageTreeMgr::IAddCullPolyList(const hsTArray<plCullPoly>& polyList)
 {
     int iStart = fCullPolys.GetCount();
-    fCullPolys.Expand(iStart + polyList.GetCount());
-    fCullPolys.SetCount(iStart + polyList.GetCount());
+    fCullPolys.Resize(iStart + polyList.GetCount());
     int i;
     for( i = 0; i < polyList.GetCount(); i++ )
     {

--- a/Sources/Plasma/PubUtilLib/plSurface/plShader.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plShader.cpp
@@ -326,11 +326,5 @@ void plShader::SetDecl(plShaderID::ID id)
 
 void plShader::SetNumPipeConsts(int n)
 {
-    int nOld = fPipeConsts.GetCount();
-    if( n > nOld )
-    {
-        // This will copy forward any existing entries.
-        fPipeConsts.Expand(n);
-    }
-    fPipeConsts.SetCount(n);
+    fPipeConsts.Resize(n);
 }

--- a/Sources/Tools/MaxComponent/plAudioComponents.cpp
+++ b/Sources/Tools/MaxComponent/plAudioComponents.cpp
@@ -2297,12 +2297,9 @@ bool    plSound3DEmitterComponent::ConvertGrouped( plMaxNode *baseNode, hsTArray
         }
 
         // Grab the data from this buffer and merge it
-        // HACK: SetCount() won't copy the old data over, Expand() won't up the use count, so do
-        // an expand-and-setCount combo.
         uint32_t pos = mergedData.GetCount();
         startPoses.Append( pos );
-        mergedData.Expand( pos + buffer->GetDataLength() );
-        mergedData.SetCount( pos + buffer->GetDataLength() );
+        mergedData.Resize(pos + buffer->GetDataLength());
         memcpy( &mergedData[ pos ], buffer->GetData(), buffer->GetDataLength() );
 
         delete buffer;


### PR DESCRIPTION
This also fixes a bug introduced years ago where a call to ExpandAndZero() was replaced with Expand().  The former automatically adjusts the use count, whereas the latter does not :(.