### PR TITLE
Prevent "coning" by using PhysX dominance groups.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXSimDefs.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXSimDefs.h
@@ -177,6 +177,10 @@ public:
             filter.SetGroups(1 << group);
             shape->setQueryFilterData(filter);
         }
+
+        // Per the PhysX documentation, there can only be 32 dominance groups.
+        static_assert(plSimDefs::kGroupMax < 32, "Too many groups -- need to refactor dominance.");
+        actor->setDominanceGroup(group);
     }
 
     /**
@@ -217,6 +221,8 @@ public:
         actor->getShapes(&shape, 1);
         shape->setSimulationFilterData(data);
         shape->setQueryFilterData(data);
+
+        actor->setDominanceGroup(collideGroup);
     }
 };
 

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
@@ -598,6 +598,8 @@ physx::PxScene* plPXSimulation::InitSubworld(const plKey& world)
     }
 #endif
 
+    scene->setDominanceGroupPair(plSimDefs::kGroupAvatar, plSimDefs::kGroupDynamic, { 0, 1 });
+
     auto it = fWorlds.try_emplace(world, scene);
     return it.first->second;
 }


### PR DESCRIPTION
This fixes an observed issue by which other players can be moved around by pushing cones (or fire marbles...) into their character controllers.