### PR TITLE
More pfLocalizationMgr optimizations.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
@@ -180,20 +180,16 @@ XML_Memory_Handling_Suite gHeapAllocator = {
 
 void XMLCALL LocalizationXMLFile::StartTag(void *userData, const XML_Char *element, const XML_Char **attributes)
 {
-    ST::string wElement = element;
     LocalizationXMLFile *file = (LocalizationXMLFile*)userData;
-    std::map<ST::string, ST::string> wAttributes;
 
-    for (int i = 0; attributes[i]; i += 2)
-        wAttributes[attributes[i]] = attributes[i+1];
+    LocalizationXMLFile::tagInfo newTag;
+    newTag.fTag = element;
+    for (size_t i = 0; attributes[i]; i += 2)
+        newTag.fAttributes[attributes[i]] = attributes[i+1];
 
     LocalizationXMLFile::tagInfo parentTag;
     if (!file->fTagStack.empty())
         parentTag = file->fTagStack.top();
-
-    LocalizationXMLFile::tagInfo newTag;
-    newTag.fTag = wElement;
-    newTag.fAttributes = wAttributes;
 
     file->fTagStack.push(newTag);
 
@@ -201,18 +197,18 @@ void XMLCALL LocalizationXMLFile::StartTag(void *userData, const XML_Char *eleme
         return;
 
     // now we handle this tag
-    if (wElement == "localizations")
+    if (newTag.fTag == "localizations")
         file->IHandleLocalizationsTag(parentTag, newTag);
-    else if (wElement == "age")
+    else if (newTag.fTag == "age")
         file->IHandleAgeTag(parentTag, newTag);
-    else if (wElement == "set")
+    else if (newTag.fTag == "set")
         file->IHandleSetTag(parentTag, newTag);
-    else if (wElement == "element")
+    else if (newTag.fTag == "element")
         file->IHandleElementTag(parentTag, newTag);
-    else if (wElement == "translation")
+    else if (newTag.fTag == "translation")
         file->IHandleTranslationTag(parentTag, newTag);
     else
-        file->AddError(ST::format("Unknown tag {} found", wElement));
+        file->AddError(ST::format("Unknown tag {} found", newTag.fTag));
 }
 
 void XMLCALL LocalizationXMLFile::EndTag(void *userData, const XML_Char *element)

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
@@ -184,10 +184,6 @@ void XMLCALL LocalizationXMLFile::StartTag(void *userData, const XML_Char *eleme
 {
     LocalizationXMLFile *file = (LocalizationXMLFile*)userData;
 
-    // Need a dummy parent tag on the stack at minimum
-    if (file->fTagStack.empty())
-        file->fTagStack.emplace();
-
     const auto& parentTag = file->fTagStack.top();
     auto& newTag = file->fTagStack.emplace();
     newTag.fTag = element;
@@ -365,6 +361,7 @@ bool LocalizationXMLFile::Parse(const plFileName& fileName)
 
     while (!fTagStack.empty())
         fTagStack.pop();
+    fTagStack.emplace();
 
     fCurrentAge = "";
     fCurrentSet = "";
@@ -545,7 +542,7 @@ void LocalizationDatabase::IMergeData()
 
 void LocalizationDatabase::IVerifyElement(const ST::string &ageName, const ST::string &setName, LocalizationXMLFile::set::iterator& curElement)
 {
-    std::unordered_set<ST::string, ST::hash> languageNames;
+    std::unordered_set<ST::string> languageNames;
     ST::string defaultLanguage = plLocalization::GetLanguageName((plLocalization::Language)0);
 
     int numLocales = plLocalization::GetNumLocales();

--- a/Sources/Tools/CMakeLists.txt
+++ b/Sources/Tools/CMakeLists.txt
@@ -84,7 +84,7 @@ include_directories("${PLASMA_SOURCE_ROOT}/NucleusLib")
 include_directories("${PLASMA_SOURCE_ROOT}/PubUtilLib")
 
 if(PLASMA_BUILD_TOOLS)
-    _add_tools(TOOLS plLocalizationBenchmark SoundDecompress)
+    _add_tools(TOOLS SoundDecompress)
 
     if(Qt5_FOUND)
         _add_tools(GUI TOOLS plLocalizationEditor plResBrowser)
@@ -100,6 +100,8 @@ if(PLASMA_BUILD_TOOLS)
 
     _deploy_qt()
 endif()
+
+add_subdirectory(plLocalizationBenchmark)
 
 # Max Stuff goes below here...
 if(3dsm_FOUND AND 3dsm_BUILD_PLUGIN)

--- a/Sources/Tools/CMakeLists.txt
+++ b/Sources/Tools/CMakeLists.txt
@@ -84,7 +84,7 @@ include_directories("${PLASMA_SOURCE_ROOT}/NucleusLib")
 include_directories("${PLASMA_SOURCE_ROOT}/PubUtilLib")
 
 if(PLASMA_BUILD_TOOLS)
-    _add_tools(TOOLS SoundDecompress)
+    _add_tools(TOOLS plLocalizationBenchmark SoundDecompress)
 
     if(Qt5_FOUND)
         _add_tools(GUI TOOLS plLocalizationEditor plResBrowser)

--- a/Sources/Tools/plLocalizationBenchmark/CMakeLists.txt
+++ b/Sources/Tools/plLocalizationBenchmark/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(plLocalizationBenchmark main.cpp)
+target_link_libraries(
+    plLocalizationBenchmark
+    PRIVATE
+        CoreLib
+        pfLocalizationMgr
+        string_theory
+)

--- a/Sources/Tools/plLocalizationBenchmark/CMakeLists.txt
+++ b/Sources/Tools/plLocalizationBenchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(plLocalizationBenchmark main.cpp)
+add_executable(plLocalizationBenchmark EXCLUDE_FROM_ALL main.cpp)
 target_link_libraries(
     plLocalizationBenchmark
     PRIVATE

--- a/Sources/Tools/plLocalizationBenchmark/main.cpp
+++ b/Sources/Tools/plLocalizationBenchmark/main.cpp
@@ -1,0 +1,118 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <chrono>
+#include <string_theory/stdio>
+
+#include "plCmdParser.h"
+#include "plFileSystem.h"
+
+#include "pfLocalizationMgr/pfLocalizationMgr.h"
+
+enum CmdLineArgs
+{
+    kArgCount,
+    kArgDirectory,
+};
+
+static const plCmdArgDef s_cmdLineArgs[] = {
+    { (kCmdTypeUint | kCmdArgFlagged), "Count", kArgCount },
+    { (kCmdTypeString | kCmdArgOptional), "Database", kArgDirectory },
+};
+
+using ClockT = std::chrono::steady_clock;
+
+int main(int argc, char* argv[])
+{
+    std::vector<ST::string> args;
+    for (int i = 0; i < argc; ++i)
+        args.emplace_back(argv[i]);
+
+    plCmdParser parser(s_cmdLineArgs, std::size(s_cmdLineArgs));
+    parser.Parse(args);
+
+    plFileName locDir;
+    if (parser.IsSpecified(kArgDirectory))
+        locDir = parser.GetString(kArgDirectory);
+    else
+        locDir = plFileSystem::GetCWD();
+
+    if (!locDir.IsValid() || !plFileInfo(locDir).IsDirectory()) {
+        ST::printf(stderr, "The directory '{}' does not exist.\n", locDir);
+        return 1;
+    }
+
+    int32_t count = 1000;
+    if (parser.IsSpecified(kArgCount))
+        count = parser.GetInt(kArgCount);
+    if (count <= 0) {
+        ST::printf(stderr, "Cannot iterate less than 1 time.\n");
+        return 1;
+    }
+
+    ST::printf("Parsing the localization database from '{}'...\n", locDir);
+
+    auto elapsed = ClockT::duration::zero();
+    for (int32_t i = 0; i < count; ++i) {
+        ST::printf("\r... Running iteration {} of {}", i + 1, count);
+        auto begin = ClockT::now();
+        pfLocalizationMgr::Initialize(locDir);
+        auto end = ClockT::now();
+        elapsed += end - begin;
+
+        // Who cares how long this takes...
+        pfLocalizationMgr::Shutdown();
+    }
+
+    ST::printf("\n... Done!\n\n");
+
+    auto total_us = std::chrono::duration_cast<std::chrono::microseconds>(elapsed);
+    auto avg_us = std::chrono::duration_cast<std::chrono::microseconds>(elapsed / count);
+    auto total_sec = std::chrono::duration_cast<std::chrono::duration<double>>(elapsed);
+    auto avg_sec = std::chrono::duration_cast<std::chrono::duration<double>>(elapsed / count);
+
+    ST::printf("Results:\n");
+    ST::printf("Total: {.4f} seconds ({} us)\n", total_sec.count(), total_us.count());
+    ST::printf("Average: {.4f} seconds ({} us)\n", avg_sec.count(), avg_us.count());
+    ST::printf("Have a nice day!\n");
+    return 0;
+}

--- a/Sources/Tools/plLocalizationBenchmark/main.cpp
+++ b/Sources/Tools/plLocalizationBenchmark/main.cpp
@@ -56,7 +56,7 @@ enum CmdLineArgs
 
 static const plCmdArgDef s_cmdLineArgs[] = {
     { (kCmdTypeUint | kCmdArgFlagged), "Count", kArgCount },
-    { (kCmdTypeString | kCmdArgOptional), "Database", kArgDirectory },
+    { (kCmdTypeString | kCmdArgOptional), "Directory", kArgDirectory },
 };
 
 using ClockT = std::chrono::steady_clock;


### PR DESCRIPTION
This is a minor performance increase to one of the client init hot paths. The goal was to remove lots of data copying. As a bonus, there is now a benchmarking tool for this in plLocalizationBenchmark. I'm OK with removing this tool, but I would like for it to at least live in the repo history somewhere.

I tested before and after on both the MOULa and GULP (aka "hell") localization data sets -- 100 iterations (not 1000), times in seconds:
```csv
,Before Total,After Total
MOULa,12.4428,11.0254
GULP,34.0057,29.9308
,,
,Before Avg,After Avg
MOULa,0.1244,0.1103
GULP,0.3401,0.2993
```

I did try using `std::unordered_map`, but that seemed to cause a performance regression... likely due to the constant iteration over the maps. The only ways to squeeze more out of this code might be to move to a DOM parser (eg pugixml) to avoid all the function calls and selectively reduce the validations, which only print warnings to the log.