### PR TITLE
Fix some minor Windows-CI Issues.

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -19,13 +19,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/qt
-          key: qt-${{ matrix.platform.qt-version }} ${{ matrix.platform.qt-arch }}
-
       - name: Install Qt
         continue-on-error: true
         uses: jurplel/install-qt-action@v2
@@ -33,7 +26,6 @@ jobs:
           version: ${{ matrix.platform.qt-version }}
           arch: ${{ matrix.platform.qt-arch }}
           dir: ${{ github.workspace }}/qt
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
       - name: Build
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -49,8 +49,7 @@ jobs:
             -DPLASMA_VCPKG_NUGET_TOKEN="${{ secrets.GITHUB_TOKEN }}" `
             -DPLASMA_VCPKG_NUGET_RW=TRUE `
             ..
-          cmake --build . --config "${{ matrix.cfg.type }}" -j 2
-          cmake --install . --config "${{ matrix.cfg.type }}"
+          cmake --build . --target INSTALL --config "${{ matrix.cfg.type }}" -j 2
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -27,7 +27,7 @@ jobs:
           arch: ${{ matrix.platform.qt-arch }}
           dir: ${{ github.workspace }}/qt
 
-      - name: Build
+      - name: Configure
         run: |
           New-Item -ItemType Directory build | Out-Null
           Set-Location build
@@ -41,7 +41,14 @@ jobs:
             -DPLASMA_VCPKG_NUGET_TOKEN="${{ secrets.GITHUB_TOKEN }}" `
             -DPLASMA_VCPKG_NUGET_RW=TRUE `
             ..
-          cmake --build . --target INSTALL --config "${{ matrix.cfg.type }}" -j 2
+
+      - name: Build
+        run: |
+          cmake --build build --config "${{ matrix.cfg.type }}" -j 2
+
+      - name: Install
+        run: |
+          cmake --build build --target INSTALL --config "${{ matrix.cfg.type }}" -j 2
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
@@ -49,5 +56,6 @@ jobs:
           name: plasma-${{ matrix.platform.str }}-${{ matrix.cfg.str }}
           path: build/install
 
-      - name: Run Tests
-        run: cmake --build build --target check --config "${{ matrix.cfg.type }}"
+      - name: Test
+        run: |
+          cmake --build build --target check --config "${{ matrix.cfg.type }}" -j 2


### PR DESCRIPTION
Fixes two observed issues with the Windows CI:
- Runs the install target as a build step so that `python.39.dll` is properly available in the artifact bundle. Vcpkg is internally using `dumpbin.exe` for this but cannot find that executable if cmake is in install mode.
- Avoid caching the Qt install -- the cache can be poisoned if the Qt server goes down. This happened immediately on the merge of #744, causing the GUI tools to be omitted from the CI build.