### PR TITLE
Win64 CI for NuGet caching

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         platform:
           - { generator: Visual Studio 16 2019, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2,  str: windows-x86 }
-          - { generator: Visual Studio 16 2019, arch: Win64, qt-arch: win64_msvc2019, qt-version: 5.15.2,  str: windows-x64 }
+          - { generator: Visual Studio 16 2019, arch: x64, qt-arch: win64_msvc2019, qt-version: 5.15.2,  str: windows-x64 }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -8,6 +8,7 @@ jobs:
       matrix:
         platform:
           - { generator: Visual Studio 16 2019, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2,  str: windows-x86 }
+          - { generator: Visual Studio 16 2019, arch: Win64, qt-arch: win64_msvc2019, qt-version: 5.15.2,  str: windows-x64 }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -52,6 +53,7 @@ jobs:
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
+        if: ${{ matrix.arch == 'Win32' }}
         with:
           name: plasma-${{ matrix.platform.str }}-${{ matrix.cfg.str }}
           path: build/install

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -4,11 +4,12 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: windows-latest
+    name: ${{ matrix.platform.str }}-${{ matrix.cfg.str }}
     strategy:
       matrix:
         platform:
           - { generator: Visual Studio 16 2019, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2,  str: windows-x86 }
-          - { generator: Visual Studio 16 2019, arch: x64, qt-arch: win64_msvc2019, qt-version: 5.15.2,  str: windows-x64 }
+          - { generator: Visual Studio 16 2019, arch: x64, qt-arch: win64_msvc2019_64, qt-version: 5.15.2,  str: windows-x64 }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
@@ -350,7 +350,7 @@ void NetCliAuthAgeRequest (
 //============================================================================
 void NetCliAuthGetEncryptionKey (
     uint32_t      key[],
-    unsigned    size
+    size_t        size
 );
 
 //============================================================================

--- a/cmake/FindVLD.cmake
+++ b/cmake/FindVLD.cmake
@@ -13,7 +13,7 @@ if(MSVC)
 
     if(${CMAKE_SIZEOF_VOID_P} EQUAL 4)
         set(_VLD_LIB "Win32")
-    elseif(${CMAKE_SIZEOF_VOIDP} EQUAL 8)
+    elseif(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
         set(_VLD_LIB "Win64")
     endif()
 


### PR DESCRIPTION
This is primarily so that the GitHub NuGet cache will be populated with 64-bit versions of the vcpkg packages. We are **not** expecting 64-bit client builds to work, and we are deliberately not saving them as artifacts.