### PR TITLE
Bump to cairosvg 2.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
         run: |
           brew install \
               autoconf \
+              automake \
               cairo \
               libtool \
               nasm \

--- a/Scripts/Ports/python3-cairosvg/portfile.cmake
+++ b/Scripts/Ports/python3-cairosvg/portfile.cmake
@@ -6,24 +6,85 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 set(CAIROSVG_VERSION "2.5.1")
-set(CURRENT_PYTHON3_PREFIX "${CURRENT_PACKAGES_DIR}/tools/python3")
-set(INSTALLED_PYTHON3_PREFIX "${CURRENT_INSTALLED_DIR}/tools/python3")
+set(INSTALLED_PYTHON_PREFIX "${CURRENT_INSTALLED_DIR}/tools/python3")
+
+# We are running in script mode, so no toolchains are available. Sad.
+find_program(
+    PYTHON_EXECUTABLE
+    NAMES python python3 python3.9
+    PATHS "${INSTALLED_PYTHON_PREFIX}"
+    NO_DEFAULT_PATH
+)
 
 if(EXISTS CURRENT_PACKAGES_DIR)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}")
 endif()
 
+# Figure out from Python what its roots are in a mostly platform independent way. For Windows,
+# this should be the tools/python3 directory. In other cases, it should be CURRENT_INSTALLED_DIR.
+vcpkg_execute_in_download_mode(
+    COMMAND "${PYTHON_EXECUTABLE}" -c "import sys;sys.stdout.write(sys.exec_prefix)"
+    OUTPUT_VARIABLE INSTALLED_PYTHON_PREFIX
+    LOGNAME query-prefix
+)
+vcpkg_execute_in_download_mode(
+    COMMAND "${PYTHON_EXECUTABLE}" -c "import sys,distutils.sysconfig;sys.stdout.write(distutils.sysconfig.get_python_lib(plat_specific=False,standard_lib=False))"
+    OUTPUT_VARIABLE INSTALLED_SITE_PACKAGES_DIR
+    LOGNAME query-site-packages
+)
+
+# The returned values from above are absolute paths into the installed tree. However, we cannot
+# use those right now because ports are installed into a staging directory. Therefore, we strip
+# the prefix off of site-packages and root it onto the current staging dir..............
+# Can't use CMake's relative pathing because it requires file paths, not directory paths. Grr.
+function(get_relative_path RESULT_VAR ROOT_PREFIX CHILD_PATH)
+    if(NOT ROOT_PREFIX OR NOT CHILD_PATH)
+        message(FATAL_ERROR "Got an empty path: '${ROOT_PREFIX}' not in '${CHILD_PATH}'")
+    endif()
+
+    file(TO_CMAKE_PATH "${ROOT_PREFIX}" ROOT_PREFIX)
+    file(TO_CMAKE_PATH "${CHILD_PATH}" CHILD_PATH)
+
+    string(FIND "${CHILD_PATH}" "${ROOT_PREFIX}" _FIND_ASS)
+    if(NOT _FIND_ASS EQUAL 0)
+        message(FATAL_ERROR "Relative path error: '${ROOT_PREFIX}' not in '${CHILD_PATH}'")
+    endif()
+
+    string(LENGTH "${ROOT_PREFIX}" _PREFIX_LENGTH)
+    math(EXPR _PREFIX_LENGTH "${_PREFIX_LENGTH} + 1")
+    string(LENGTH "${CHILD_PATH}" _CHILD_LENGTH)
+
+    if(_CHILD_LENGTH GREATER_EQUAL _PREFIX_LENGTH)
+        string(SUBSTRING "${CHILD_PATH}" ${_PREFIX_LENGTH} -1 _RESULT)
+    endif()
+    set(${RESULT_VAR} "${_RESULT}" PARENT_SCOPE)
+endfunction()
+
+function(join_path RESULT_VAR)
+    # Avoid directly string(JOIN ...) in case one of the path elements is empty
+    foreach(i IN LISTS ARGN)
+        if(i)
+            if(_RESULT)
+                string(APPEND _RESULT "/")
+            endif()
+            string(APPEND _RESULT "${i}")
+        endif()
+    endforeach()
+    if(_RESULT)
+        file(TO_CMAKE_PATH "${_RESULT}" _RESULT)
+    endif()
+    set(${RESULT_VAR} "${_RESULT}" PARENT_SCOPE)
+endfunction()
+
+get_relative_path(_PYTHON_DIR "${CURRENT_INSTALLED_DIR}" "${INSTALLED_PYTHON_PREFIX}")
+get_relative_path(_SITE_PACKAGES_DIR "${INSTALLED_PYTHON_PREFIX}" "${INSTALLED_SITE_PACKAGES_DIR}")
+join_path(CURRENT_PYTHON_PREFIX "${CURRENT_PACKAGES_DIR}" "${_PYTHON_DIR}")
+join_path(CURRENT_SITE_PACKAGES_DIR "${CURRENT_PACKAGES_DIR}" "${_PYTHON_DIR}" "${_SITE_PACKAGES_DIR}")
+
 # Copy over cairo.dll as libcairo-2.dll on Windows only. Other OSes should install cairo from
 # the system package manager. This will be tested by the non-platform specific bits.
 if(VCPKG_TARGET_IS_WINDOWS)
-    # We are running in script mode, so no toolchains are available. Sad.
     list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES ${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX})
-    find_program(
-        PYTHON3_EXECUTABLE
-        NAMES python python3 python3.9
-        PATHS "${INSTALLED_PYTHON3_PREFIX}"
-        NO_DEFAULT_PATH
-    )
     find_library(
         CAIRO_DLL_RELEASE
         NAMES cairo cairo-2
@@ -36,14 +97,14 @@ if(VCPKG_TARGET_IS_WINDOWS)
 
     # Python 3.8 tightened up the rules for DLL loading pretty significantly. One of the few ways to
     # make this work is to put it beside python.exe
-    file(INSTALL "${CAIRO_DLL_RELEASE}" DESTINATION "${CURRENT_PYTHON3_PREFIX}" RENAME "libcairo-2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}")
-    vcpkg_copy_tool_dependencies("${CURRENT_PYTHON3_PREFIX}")
+    file(INSTALL "${CAIRO_DLL_RELEASE}" DESTINATION "${CURRENT_PYTHON_PREFIX}" RENAME "libcairo-2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}")
+    vcpkg_copy_tool_dependencies("${CURRENT_PYTHON_PREFIX}")
 
     # Any DLLs already copied by python.exe need to be scrubbed. Otherwise, the validation will fail
     # with a conflict.
-    file(GLOB _PYTHON3_DIR_CONTENTS LIST_DIRECTORIES false RELATIVE "${INSTALLED_PYTHON3_PREFIX}" "${INSTALLED_PYTHON3_PREFIX}/*")
-    foreach(i IN LISTS _PYTHON3_DIR_CONTENTS)
-        set(_TEST_PATH "${CURRENT_PYTHON3_PREFIX}/${i}")
+    file(GLOB _PYTHON_DIR_CONTENTS LIST_DIRECTORIES false RELATIVE "${INSTALLED_PYTHON_PREFIX}" "${INSTALLED_PYTHON_PREFIX}/*")
+    foreach(i IN LISTS _PYTHON_DIR_CONTENTS)
+        set(_TEST_PATH "${CURRENT_PYTHON_PREFIX}/${i}")
         if(EXISTS "${_TEST_PATH}")
             file(REMOVE "${_TEST_PATH}")
         endif()
@@ -52,17 +113,16 @@ endif()
 
 # Use pip to install cairosvg into the staging dir.
 message(STATUS "Installing cairosvg from pip")
-file(TO_NATIVE_PATH "${CURRENT_PYTHON3_PREFIX}" _PIP_PREFIX)
+file(TO_NATIVE_PATH "${CURRENT_PYTHON_PREFIX}" _PIP_PREFIX)
 vcpkg_execute_required_process(
-    COMMAND "${PYTHON3_EXECUTABLE}" -m pip install --prefix "${_PIP_PREFIX}" "cairosvg==${CAIROSVG_VERSION}"
+    COMMAND "${PYTHON_EXECUTABLE}" -m pip install --prefix "${_PIP_PREFIX}" "cairosvg==${CAIROSVG_VERSION}"
     LOGNAME install
 )
-
 # Perform a sample import of cairosvg to ensure all this weird hacking actually works.
 message(STATUS "Testing cairosvg")
-set(ENV{PYTHONPATH} "${CURRENT_PYTHON3_PREFIX}/Lib/site-packages")
+set(ENV{PYTHONPATH} "${CURRENT_SITE_PACKAGES_DIR}")
 vcpkg_execute_required_process(
-    COMMAND "${PYTHON3_EXECUTABLE}" -c "import cairosvg"
-    WORKING_DIRECTORY "${CURRENT_PYTHON3_PREFIX}"
+    COMMAND "${PYTHON_EXECUTABLE}" -c "import cairosvg"
+    WORKING_DIRECTORY "${CURRENT_PYTHON_PREFIX}"
     LOGNAME test
 )

--- a/Scripts/Ports/python3-cairosvg/portfile.cmake
+++ b/Scripts/Ports/python3-cairosvg/portfile.cmake
@@ -1,0 +1,68 @@
+# This port doesn't include an "include" directory or a "copyright" file, so it's considered
+# empty by vcpkg. This will fail the validation unless we mark the port empty.
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Install cairo on Ubuntu with `sudo apt install libcairo2` and on macOS with `brew install cairo`.")
+endif()
+
+set(CAIROSVG_VERSION "2.5.1")
+set(CURRENT_PYTHON3_PREFIX "${CURRENT_PACKAGES_DIR}/tools/python3")
+set(INSTALLED_PYTHON3_PREFIX "${CURRENT_INSTALLED_DIR}/tools/python3")
+
+if(EXISTS CURRENT_PACKAGES_DIR)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}")
+endif()
+
+# Copy over cairo.dll as libcairo-2.dll on Windows only. Other OSes should install cairo from
+# the system package manager. This will be tested by the non-platform specific bits.
+if(VCPKG_TARGET_IS_WINDOWS)
+    # We are running in script mode, so no toolchains are available. Sad.
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES ${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX})
+    find_program(
+        PYTHON3_EXECUTABLE
+        NAMES python python3 python3.9
+        PATHS "${INSTALLED_PYTHON3_PREFIX}"
+        NO_DEFAULT_PATH
+    )
+    find_library(
+        CAIRO_DLL_RELEASE
+        NAMES cairo cairo-2
+        PATHS "${CURRENT_INSTALLED_DIR}/bin"
+    )
+
+    if(NOT CAIRO_DLL_RELEASE)
+        message(FATAL_ERROR "Unable to find cairo DLL. Be sure it was built as a shared library.")
+    endif()
+
+    # Python 3.8 tightened up the rules for DLL loading pretty significantly. One of the few ways to
+    # make this work is to put it beside python.exe
+    file(INSTALL "${CAIRO_DLL_RELEASE}" DESTINATION "${CURRENT_PYTHON3_PREFIX}" RENAME "libcairo-2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}")
+    vcpkg_copy_tool_dependencies("${CURRENT_PYTHON3_PREFIX}")
+
+    # Any DLLs already copied by python.exe need to be scrubbed. Otherwise, the validation will fail
+    # with a conflict.
+    file(GLOB _PYTHON3_DIR_CONTENTS LIST_DIRECTORIES false RELATIVE "${INSTALLED_PYTHON3_PREFIX}" "${INSTALLED_PYTHON3_PREFIX}/*")
+    foreach(i IN LISTS _PYTHON3_DIR_CONTENTS)
+        set(_TEST_PATH "${CURRENT_PYTHON3_PREFIX}/${i}")
+        if(EXISTS "${_TEST_PATH}")
+            file(REMOVE "${_TEST_PATH}")
+        endif()
+    endforeach()
+endif()
+
+# Use pip to install cairosvg into the staging dir.
+message(STATUS "Installing cairosvg from pip")
+file(TO_NATIVE_PATH "${CURRENT_PYTHON3_PREFIX}" _PIP_PREFIX)
+vcpkg_execute_required_process(
+    COMMAND "${PYTHON3_EXECUTABLE}" -m pip install --prefix "${_PIP_PREFIX}" "cairosvg==${CAIROSVG_VERSION}"
+    LOGNAME install
+)
+
+# Perform a sample import of cairosvg to ensure all this weird hacking actually works.
+message(STATUS "Testing cairosvg")
+set(ENV{PYTHONPATH} "${CURRENT_PYTHON3_PREFIX}/Lib/site-packages")
+vcpkg_execute_required_process(
+    COMMAND "${PYTHON3_EXECUTABLE}" -c "import cairosvg"
+    WORKING_DIRECTORY "${CURRENT_PYTHON3_PREFIX}"
+    LOGNAME test
+)

--- a/Scripts/Ports/python3-cairosvg/vcpkg.json
+++ b/Scripts/Ports/python3-cairosvg/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "python3-cairosvg",
+  "version-string": "2.5.1",
+  "description": "CairoSVG is an SVG converter based on Cairo. It can export SVG files to PDF, EPS, PS, and PNG files.",
+  "homepage": "https://cairosvg.org/",
+  "dependencies": [
+    {
+      "name": "cairo",
+      "platform": "windows"
+    },
+    "python3"
+  ]
+}

--- a/Scripts/Triplets/x64-windows-plasma.cmake
+++ b/Scripts/Triplets/x64-windows-plasma.cmake
@@ -1,7 +1,17 @@
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 
-if(${PORT} MATCHES "python[23]")
+
+# Unfortunately, we cannot include() anything from here because CMAKE_CURRENT_LIST_DIR is "wrong."
+# If you update this list, remember to synchronize x86-windows-plasma.cmake.
+set(_PLASMA_DYNAMIC_LIBRARIES
+    cairo
+    python2
+    python3
+)
+
+cmake_policy(SET CMP0057 NEW)
+if(PORT IN_LIST _PLASMA_DYNAMIC_LIBRARIES)
     set(VCPKG_LIBRARY_LINKAGE dynamic)
 else()
     set(VCPKG_LIBRARY_LINKAGE static)

--- a/Scripts/Triplets/x86-windows-plasma.cmake
+++ b/Scripts/Triplets/x86-windows-plasma.cmake
@@ -1,7 +1,16 @@
 set(VCPKG_TARGET_ARCHITECTURE x86)
 set(VCPKG_CRT_LINKAGE dynamic)
 
-if(${PORT} MATCHES "python[23]")
+# Unfortunately, we cannot include() anything from here because CMAKE_CURRENT_LIST_DIR is "wrong."
+# If you update this list, remember to synchronize x64-windows-plasma.cmake.
+set(_PLASMA_DYNAMIC_LIBRARIES
+    cairo
+    python2
+    python3
+)
+
+cmake_policy(SET CMP0057 NEW)
+if(PORT IN_LIST _PLASMA_DYNAMIC_LIBRARIES)
     set(VCPKG_LIBRARY_LINKAGE dynamic)
 else()
     set(VCPKG_LIBRARY_LINKAGE static)

--- a/Sources/Plasma/Apps/plClient/external/requirements.txt
+++ b/Sources/Plasma/Apps/plClient/external/requirements.txt
@@ -1,6 +1,2 @@
-wheel
-https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/cp27/pycairo-1.18.2-cp27-cp27m-win32.whl; sys_platform == "win32" and python_version ~= "2.7"
-pycairo; sys_platform == "win32" and python_version >= "3.8"
-pycairo; sys_platform != "win32"
-cairosvg==1.0.22
+cairosvg>=2.5.1
 pillow

--- a/cmake/VcpkgToolchain.cmake
+++ b/cmake/VcpkgToolchain.cmake
@@ -68,8 +68,10 @@ if(_HOST_IS_WINDOWS OR EXISTS "${_VCPKG_MONO}")
     _plasma_vcpkg_setup_binarycache(NAME fork PREFIX PLASMA_VCPKG_NUGET)
 endif()
 
-# Note that CMAKE_SIZEOF_VOID_P is currently undefined.
+list(APPEND VCPKG_OVERLAY_PORTS "${CMAKE_SOURCE_DIR}/Scripts/Ports")
 list(APPEND VCPKG_OVERLAY_TRIPLETS "${CMAKE_SOURCE_DIR}/Scripts/Triplets")
+
+# Note that CMAKE_SIZEOF_VOID_P is currently undefined.
 if(_HOST_IS_WINDOWS AND NOT DEFINED VCPKG_TARGET_TRIPLET)
     if(CMAKE_GENERATOR_PLATFORM MATCHES "[Ww][Ii][Nn]32")
         set(VCPKG_TARGET_TRIPLET "x86-windows-plasma" CACHE STRING "")
@@ -89,6 +91,15 @@ if(_HOST_IS_WINDOWS AND NOT DEFINED VCPKG_TARGET_TRIPLET)
     else()
         message(FATAL_ERROR "Unknown platform: '${CMAKE_GENERATOR_PLATFORM}' - set VCPKG_TARGET_TRIPLET manually.")
     endif()
+endif()
+
+# Workaround: The cairocffi Python module does not ship with libcairo-2.dll as expected. So,
+# we're going to opt-into a special manifest feature to install the vcpkg cairo.dll into
+# the python3 port. BUT only if PLASMA_BUILD_RESOURCE_DAT has not been explicitly turned OFF
+# on the command line (reminder: it may be forced OFF on subsequent cmake runs). This is a feature
+# because it's an overlay port that exists in our repository.
+if(NOT DEFINED PLASMA_BUILD_RESOURCE_DAT OR PLASMA_BUILD_RESOURCE_DAT)
+    list(APPEND VCPKG_MANIFEST_FEATURES cairosvg)
 endif()
 
 # Workaround: fixes issues where vcpkg will suggest Debug libraries for OpenSSL. Sigh.

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,11 +17,13 @@
       "openssl",
       "opus",
       "physx",
-      "python3",
       {
-        "name": "speex",
-        "platform": "!(linux | osx)"
+        "name": "python3",
+        "features": [
+          "deprecated-win7-support"
+        ]
       },
+      "speex",
       "string-theory",
       {
         "name": "libuuid",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -30,5 +30,18 @@
         "platform": "linux | osx"
       },
       "zlib"
-    ]
+    ],
+    "features": {
+      "cairosvg": {
+        "description": "Installs a functional cairosvg Python module for the resource.dat generator.",
+        "dependencies": [
+          {
+            "name": "cairo",
+            "platform": "windows",
+            "default-features": false
+          },
+          "python3-cairosvg"
+        ]
+      }
+    }
   }


### PR DESCRIPTION
This bumps the resource.dat generation scripts to cairosvg 2.5.1 to fix the garbled microphone icon as mentioned in #796 and #800. Unfortunately, modern cairosvg rely on cairocffi but do not include libcairo-2.dll on Windows. To work around that, I have written a vcpkg overlay port that builds cairo and copies it into the vcpkg python3 tools directory on Windows. Other platforms should simply install cairo from their package manager.

Currently, this will fail CI due to the vcpkg cairo port depending on fontconfig, which has dependencies that fail to build under a static triplet. I could list them all as dynamic in our triplet, but these dependencies collectively take over 30 minutes to build. So, we are blocking on upstream:
* [x] microsoft/vcpkg#15965
* [x] ~~microsoft/vcpkg#15944~~
* [x] microsoft/vcpkg#15474
* [x] #895 

Note that because the triplet files have changed, the hash of each dependency package changes as well... In case you're wondering why CI is slow here :smile: