### PR TITLE
Fix an incorrect loop variable...

### DIFF
--- a/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
@@ -457,7 +457,7 @@ void plResponderModifier::Restore()
 
                 // Setup the sender and receiver
                 newCallbackMsg->SetSender(callbackMsg->GetSender());
-                for (int iReceiver = 0; i < callbackMsg->GetNumReceivers(); i++)
+                for (int iReceiver = 0; iReceiver < callbackMsg->GetNumReceivers(); iReceiver++)
                     newCallbackMsg->AddReceiver(callbackMsg->GetReceiver(iReceiver));
 
                 // Add the callbacks


### PR DESCRIPTION
I have no idea what it might affect, but I noticed this oddity while working on signed/unsigned comparison fixes...