### PR TITLE
Fix several issues with libsecret find module

### DIFF
--- a/cmake/FindLIBSECRET.cmake
+++ b/cmake/FindLIBSECRET.cmake
@@ -1,5 +1,5 @@
-if(LIBSECRET_REQUIRED)
-    list(APPEND _FIND_ARGS)
+if(LIBSECRET_FIND_REQUIRED)
+    list(APPEND _FIND_ARGS REQUIRED)
 endif()
 if(LIBSECRET_FIND_QUIETLY)
     list(APPEND _FIND_ARGS QUIET)
@@ -7,8 +7,8 @@ endif()
 
 find_package(PkgConfig ${_FIND_ARGS})
 
-if(Pkg_Config_FOUND)
-    pkg_check_modules(LIBSECRET LIBSECRET-1 IMPORTED_TARGET ${_FIND_ARGS})
+if(PkgConfig_FOUND)
+    pkg_check_modules(LIBSECRET libsecret-1 IMPORTED_TARGET ${_FIND_ARGS})
 endif()
 
 unset(_FIND_ARGS)


### PR DESCRIPTION
Fix several issues with libsecret find module:
* Incorrect test for REQUIRED flag
* Incorrect parameter name for REQUIRED flag
* Typo in PkgConfig_FOUND test
* Incorrect capitalization of pkg-config module name

This was clearly never tested, and I unfortunately didn't notice it until recently because I already had a cached copy of the required variables from before it was reworked (and broken) in 9d48c967