### PR TITLE
Fix some HRESULT -> bool conversions

### DIFF
--- a/Sources/Plasma/FeatureLib/pfSurface/plLayerAVI.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plLayerAVI.cpp
@@ -98,7 +98,7 @@ bool plLayerAVI::IInit()
     if( !(fAVIInfo->fGetFrame = AVIStreamGetFrameOpen(fAVIInfo->fAVIStream, NULL)) )
         return ISetFault("Error positioning AVI");
 
-    if( AVIStreamInfo(fAVIInfo->fAVIStream, &fAVIInfo->fAVIStreamInfo, sizeof(AVISTREAMINFO)) )
+    if (FAILED(AVIStreamInfo(fAVIInfo->fAVIStream, &fAVIInfo->fAVIStreamInfo, sizeof(AVISTREAMINFO))))
         return ISetFault("Error getting AVI info");
 
     BITMAPINFO* bmi;

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXEnumerate.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXEnumerate.cpp
@@ -61,7 +61,7 @@ const D3DFORMAT hsGDirect3DTnLEnumerate::kDisplayFormats[] =
         D3DFMT_X8R8G8B8,
 };
 
-HRESULT hsGDirect3DTnLEnumerate::SelectFromDevMode(const hsG3DDeviceRecord* devRec, const hsG3DDeviceMode* devMode)
+bool hsGDirect3DTnLEnumerate::SelectFromDevMode(const hsG3DDeviceRecord* devRec, const hsG3DDeviceMode* devMode)
 {
 
     int i;

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXEnumerate.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXEnumerate.h
@@ -148,7 +148,7 @@ public:
 
     char* GetErrorString() { return (fEnumeErrorStr[0] ? fEnumeErrorStr : nil); }
 
-    HRESULT SelectFromDevMode(const hsG3DDeviceRecord* devRec, const hsG3DDeviceMode* devMode);
+    bool SelectFromDevMode(const hsG3DDeviceRecord* devRec, const hsG3DDeviceMode* devMode);
     HRESULT D3DEnum_SelectDefaultMode(int width, int height, int depth);
     HRESULT D3DEnum_SelectDefaultDriver( DWORD dwFlags );
 


### PR DESCRIPTION
It's not safe to treat an HRESULT as a boolean, and Microsoft provides the `FAILED()` macro to specifically check if the result is an error.

In the case of the DirectX Enumerate, it was actually returning bool but the function declaration said it returned an HRESULT.