### PR TITLE
CoreLib warning fixes

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -238,12 +238,12 @@ void hsStatusMessage(const char* message)
   } else {
 #if HS_BUILD_FOR_UNIX
     printf("%s",message);
-    int len = strlen(message);
+    size_t len = strlen(message);
     if (len>0 && message[len-1]!='\n')
         printf("\n");
 #elif HS_BUILD_FOR_WIN32
     OutputDebugString(message);
-    int len = strlen(message);
+    size_t len = strlen(message);
     if (len>0 && message[len-1]!='\n')
         OutputDebugString("\n");
 #endif
@@ -435,8 +435,8 @@ void hsStrLower(char *s)
 {
     if (s)
     {
-        int i;
-        for (i = 0; i < strlen(s); i++)
+        size_t len = strlen(s);
+        for (size_t i = 0; i < len; i++)
             s[i] = tolower(s[i]);
     }
 }
@@ -447,9 +447,9 @@ void hsStrLower(char *s)
 wchar_t *hsStringToWString( const char *str )
 {
     // convert the char string to a wchar_t string
-    int len = strlen(str);
+    size_t len = strlen(str);
     wchar_t *wideString = new wchar_t[len+1];
-    for (int i=0; i<len; i++)
+    for (size_t i = 0; i < len; i++)
         wideString[i] = btowc(str[i]);
     wideString[len] = L'\0';
     return wideString;
@@ -461,11 +461,10 @@ wchar_t *hsStringToWString( const char *str )
 char    *hsWStringToString( const wchar_t *str )
 {
     // convert the wchar_t string to a char string
-    int len = wcslen(str);
+    size_t len = wcslen(str);
     char *sStr = new char[len+1];
 
-    int i;
-    for (i = 0; i < len; i++)
+    for (size_t i = 0; i < len; i++)
     {
         char temp = wctob(str[i]);
         if (temp == EOF)

--- a/Sources/Plasma/CoreLib/hsBounds.cpp
+++ b/Sources/Plasma/CoreLib/hsBounds.cpp
@@ -540,8 +540,8 @@ bool hsBoundsOriented::IsInside(const hsPoint3* pos) const
         return false;
     if(fType == kBoundsFull)
         return true;
-    int i;
-    for( i = 0; i < fNumPlanes; i++ )
+ 
+    for (uint32_t i = 0; i < fNumPlanes; i++)
     {
         float dis = fPlanes[i].fN.InnerProduct(pos);
         dis += fPlanes[i].fD;
@@ -566,8 +566,7 @@ void hsBoundsOriented::SetPlane(uint32_t i, hsPlane3 *pln)
         hsPlane3 *newPlanes = new hsPlane3[i+1];
         if( fPlanes )
         {
-            int k;
-            for( k = 0; k < fNumPlanes; k++ )
+            for (uint32_t k = 0; k < fNumPlanes; k++)
                 *newPlanes++ = *fPlanes++;
             delete [] fPlanes;
         }
@@ -619,8 +618,8 @@ void hsBoundsOriented::Write(hsStream *stream)
     fCenter.Write(stream);
     stream->WriteLE32(fCenterValid);
     stream->WriteLE32(fNumPlanes);
-    int i;
-    for( i = 0; i < fNumPlanes; i++ )
+
+    for (uint32_t i = 0; i < fNumPlanes; i++)
     {
         fPlanes[i].Write(stream);
     }
@@ -635,8 +634,8 @@ void hsBoundsOriented::Read(hsStream *stream)
     if (fPlanes)
         delete [] fPlanes;
     fPlanes = new hsPlane3[fNumPlanes];
-    int i;
-    for( i = 0; i < fNumPlanes; i++ )
+
+    for (uint32_t i = 0; i < fNumPlanes; i++)
     {
         fPlanes[i].Read(stream);
     }

--- a/Sources/Plasma/CoreLib/plCmdParser.cpp
+++ b/Sources/Plasma/CoreLib/plCmdParser.cpp
@@ -84,9 +84,9 @@ class plCmdParserImpl
 protected:
     ST::string                  fProgramName;
     std::vector<plCmdArgData>   fArgArray;
-    std::vector<uint32_t>       fLookupArray;
-    std::vector<uint32_t>       fUnflaggedArray;
-    uint32_t                    fRequiredCount;
+    std::vector<size_t>         fLookupArray;
+    std::vector<size_t>         fUnflaggedArray;
+    size_t                      fRequiredCount;
     CmdError                    fError;
 
     void SetDefaultValue(plCmdArgData& arg);

--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -535,6 +535,7 @@ plFileName plFileSystem::GetCurrentAppPath()
         return appPath;
 
     FATAL("Your OS doesn't make life easy, does it?");
+    return ".";
 #endif
 }
 

--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -502,10 +502,10 @@ plFileName plFileSystem::GetCurrentAppPath()
     // Neither OS makes this one simple...
 #if HS_BUILD_FOR_WIN32
     wchar_t path[MAX_PATH];
-    size_t size = GetModuleFileNameW(nullptr, path, MAX_PATH);
+    DWORD size = GetModuleFileNameW(nullptr, path, MAX_PATH);
     if (size >= MAX_PATH) {
         // Buffer not big enough
-        size_t bigger = MAX_PATH;
+        DWORD bigger = MAX_PATH;
         do {
             bigger *= 2;
             wchar_t *path_lg = new wchar_t[bigger];


### PR DESCRIPTION
Fixes a bunch of easy spots where there were comparisons between signed and unsigned integers, or where the wrong size of integer was being used