### PR TITLE
Fix cursor shadow rendering with CairoSVG

### DIFF
--- a/Sources/Plasma/Apps/plClient/external/scalergba.py
+++ b/Sources/Plasma/Apps/plClient/external/scalergba.py
@@ -76,7 +76,9 @@ def nonlinear2pixel(l):
 
 
 def scale(infilename, outfilename, factor):
-	inimg = Image.open(infilename)
+	scaleimg(Image.open(infilename), factor).save(outfilename, "PNG")
+
+def scaleimage(inimg, factor):
 	inpix = inimg.load()
 	
 	outw = inimg.size[0] // factor
@@ -173,7 +175,7 @@ def scale(infilename, outfilename, factor):
 						outpix[ox, oy] = tuple(clamp(int(math.floor(c + 0.5))) for c in sum) + (0,)
 						transparent[oy*outw + ox] = 0
 	
-	outimg.save(outfilename, "PNG")
+	return outimg
 
 
 if __name__ == "__main__":

--- a/Sources/Plasma/Apps/plClient/external/scalergba.py
+++ b/Sources/Plasma/Apps/plClient/external/scalergba.py
@@ -76,7 +76,7 @@ def nonlinear2pixel(l):
 
 
 def scale(infilename, outfilename, factor):
-	scaleimg(Image.open(infilename), factor).save(outfilename, "PNG")
+	scaleimage(Image.open(infilename), factor).save(outfilename, "PNG")
 
 def scaleimage(inimg, factor):
 	inpix = inimg.load()


### PR DESCRIPTION
See #800: Because CairoSVG does not support `feGaussianBlur`, do the blurring and compositing externally in _render_svg.py_.

It turns out CairoSVG also doesn’t fully support masks (it only applies the alpha of the mask, rather than the product of luminance and alpha as [specified](https://www.w3.org/TR/SVG11/masking.html#Masking)), but that doesn’t matter because the masking needs to be applied after the blurring, so we need to do it externally too anyway.

The result is not a pixel-perfect match for the old rsvg-rendered cursors, but the differences are hardly noticeable. (Mainly, in “poised” cursors, the shadow is a bit lighter in the center and a bit darker between the two rings.)

before:
![cursorsheet-2 5 1](https://user-images.githubusercontent.com/234094/107146135-88e0e780-6946-11eb-9e94-4461361c1525.png)

rsvg:
![cursorsheet-b4206e5](https://user-images.githubusercontent.com/234094/107146141-90a08c00-6946-11eb-9ab7-0c6679d0eefe.png)

new:
![cursorsheet-out](https://user-images.githubusercontent.com/234094/107146146-96966d00-6946-11eb-952d-701af55b1a0b.png)

Probably requires #801 – I only tested it with a locally self-installed CairoSVG 2.5.1 on macOS.