### PR TITLE
Fix Python 3.x compatibility with a couple of inline Python strings.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -6082,7 +6082,7 @@ PF_CONSOLE_CMD( Python,
     // now evaluate this mess they made
     PyObject* mymod = PythonInterface::FindModule("__main__");
 
-    PythonInterface::RunString("import xCheat;xc=[x for x in dir(xCheat) if not x.startswith('_')]\nfor i in range((len(xc)/4)+1): print xc[i*4:(i*4)+4]\n",mymod);
+    PythonInterface::RunString("import xCheat;xc=[x for x in dir(xCheat) if not x.startswith('_')]\nfor i in range((len(xc)//4)+1): print(xc[i*4:(i*4)+4])\n",mymod);
     std::string output;
     // get the messages
     PythonInterface::getOutputAndReset(&output);

--- a/Sources/Tools/MaxMain/plPythonMgr.cpp
+++ b/Sources/Tools/MaxMain/plPythonMgr.cpp
@@ -234,7 +234,7 @@ bool plPythonMgr::IQueryPythonFile(const char *fileName)
     if (module)
     {
         // attach the glue python code to the end
-        if ( !PythonInterface::RunString("execfile('.\\python\\plasma\\glue.py')", module) )
+        if (!PythonInterface::RunString("with open('.\\python\\plasma\\glue.py') as f: glue = f.read()\nexec(glue)", module))
         {
             // display any output (NOTE: this would be disabled in production)
             // get the messages


### PR DESCRIPTION
Note: I have not tested the MaxMain one, and I'm not even sure it's still relevant...