### PR TITLE
Fix gtest CMake IPO warning on Linux.

### DIFF
--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -11,6 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
 endif()
 
 # Use LTCG if available.
+cmake_policy(SET CMP0069 NEW)   # gtest projects use old cmake compatibility...
 if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
     include(CheckIPOSupported)
     check_ipo_supported(RESULT _IPO_SUPPORTED LANGUAGES CXX OUTPUT _IPO_OUTPUT)


### PR DESCRIPTION
The gtest subproject currently uses CMake 2.8 compatibility, which only enables IPO (LTCG) for the Intel compiler, and emits an annoying warning for any other configuration, by default.  This fixes both the warning and the IPO enablement for those targets by forcing policy CMP0069 to NEW.