### PR TITLE
Don't use the QFileDialog native dialog backend in the Qt tools.

### DIFF
--- a/Sources/Tools/plFontConverter/plFontConverter.cpp
+++ b/Sources/Tools/plFontConverter/plFontConverter.cpp
@@ -172,7 +172,8 @@ void plFontConverter::dropEvent(QDropEvent *event)
 void plFontConverter::OpenFNT()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Choose a FNT file to convert"),
-                            QString(), "Windows FNT files (*.fnt);;All files (*.*)");
+                            QString(), tr("Windows FNT files (*.fnt);;All files (*.*)"),
+                            nullptr, QFileDialog::DontUseNativeDialog);
 
     if (!fileName.isEmpty())
         IImportFNT(fileName.toUtf8().constData());
@@ -181,7 +182,8 @@ void plFontConverter::OpenFNT()
 void plFontConverter::OpenBDF()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Choose a BDF file to convert"),
-                            QString(), "Adobe BDF files (*.bdf);;All files (*.*)");
+                            QString(), tr("Adobe BDF files (*.bdf);;All files (*.*)"),
+                            nullptr, QFileDialog::DontUseNativeDialog);
 
     if (!fileName.isEmpty())
         IImportBDF(fileName.toUtf8().constData());
@@ -190,7 +192,8 @@ void plFontConverter::OpenBDF()
 void plFontConverter::OpenFON()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Choose a FON file to convert"),
-                            QString(), "Windows FON files (*.fon *.exe);;All files (*.*)");
+                            QString(), tr("Windows FON files (*.fon *.exe);;All files (*.*)"),
+                            nullptr, QFileDialog::DontUseNativeDialog);
 
     if (!fileName.isEmpty())
         IImportFON(fileName.toUtf8().constData());
@@ -199,7 +202,8 @@ void plFontConverter::OpenFON()
 void plFontConverter::OpenTTF()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Choose a TrueType font to convert"),
-                            QString(), "TrueType files (*.ttf *.ttc);;All files (*.*)");
+                            QString(), tr("TrueType files (*.ttf *.ttc);;All files (*.*)"),
+                            nullptr, QFileDialog::DontUseNativeDialog);
 
     if (!fileName.isEmpty())
         IImportFreeType(fileName.toUtf8().constData());
@@ -208,7 +212,8 @@ void plFontConverter::OpenTTF()
 void plFontConverter::OpenP2F()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Choose a P2F file to open"),
-                            QString(), "Plasma 2 font files (*.p2f);;All files (*.*)");
+                            QString(), tr("Plasma 2 font files (*.p2f);;All files (*.*)"),
+                            nullptr, QFileDialog::DontUseNativeDialog);
 
     if (!fileName.isEmpty())
         IOpenP2F(fileName.toUtf8().constData());
@@ -226,7 +231,8 @@ void plFontConverter::ExportP2F()
     // Write out
     QString saveFile = QFileDialog::getSaveFileName(this, tr("Specify a file to export to"),
                             QString("%1-%2.p2f").arg(fFont->GetFace().c_str()).arg(fFont->GetSize()),
-                            "Plasma 2 font files (*.p2f)");
+                            tr("Plasma 2 font files (*.p2f)"), nullptr,
+                            QFileDialog::DontUseNativeDialog);
 
     if (!saveFile.isEmpty())
     {
@@ -546,7 +552,8 @@ void plFontConverter::IBatchFreeType(const plFileName &path, void *init)
 
     QString outPath = QFileDialog::getExistingDirectory(this,
                 tr("Select a path to write the P2F fonts to:"),
-                QDir::current().absolutePath(), QFileDialog::ShowDirsOnly);
+                QDir::current().absolutePath(),
+                QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog);
     if (outPath.isEmpty())
         return;
 

--- a/Sources/Tools/plLocalizationEditor/plEditDlg.cpp
+++ b/Sources/Tools/plLocalizationEditor/plEditDlg.cpp
@@ -207,7 +207,7 @@ void EditDialog::OpenDataDirectory()
     QString path = QFileDialog::getExistingDirectory(this,
                 tr("Select a localization data directory:"),
                 QDir::current().absolutePath(),
-                QFileDialog::ShowDirsOnly | QFileDialog::ReadOnly);
+                QFileDialog::ShowDirsOnly | QFileDialog::ReadOnly | QFileDialog::DontUseNativeDialog);
 
     if (!path.isEmpty())
     {
@@ -253,7 +253,7 @@ void EditDialog::SaveToDirectory()
 
     QString path = QFileDialog::getExistingDirectory(this,
                 tr("Select a directory to save the localization data to:"),
-                fCurrentSavePath, QFileDialog::ShowDirsOnly);
+                fCurrentSavePath, QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog);
 
     // save it to a new directory
     if (!path.isEmpty())

--- a/Sources/Tools/plResBrowser/plResBrowser.cpp
+++ b/Sources/Tools/plResBrowser/plResBrowser.cpp
@@ -205,7 +205,8 @@ void plResBrowser::dropEvent(QDropEvent *event)
 void plResBrowser::OpenFile()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Choose a file to browse"),
-                            QString(), "Plasma 2 Pack Files (*.prp);;All files (*.*)");
+                            QString(), tr("Plasma 2 Pack Files (*.prp);;All files (*.*)"),
+                            nullptr, QFileDialog::DontUseNativeDialog);
 
     if (!fileName.isEmpty())
         LoadPrpFile(fileName);
@@ -216,7 +217,7 @@ void plResBrowser::OpenDirectory()
     QString path = QFileDialog::getExistingDirectory(this,
                 tr("Select a Plasma 2 Data Directory:"),
                 QDir::current().absolutePath(),
-                QFileDialog::ShowDirsOnly | QFileDialog::ReadOnly);
+                QFileDialog::ShowDirsOnly | QFileDialog::ReadOnly | QFileDialog::DontUseNativeDialog);
 
     if (!path.isEmpty())
         LoadResourcePath(path);
@@ -231,7 +232,8 @@ void plResBrowser::SaveSelectedObject()
 
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export object"),
                             QString("%1.bin").arg(itemKey->GetName().c_str()),
-                            "Binary Files (*.bin);;All files (*.*)");
+                            tr("Binary Files (*.bin);;All files (*.*)"),
+                            nullptr, QFileDialog::DontUseNativeDialog);
 
     if (!fileName.isEmpty())
     {


### PR DESCRIPTION
Qt apparently has a long-standing bug that causes the native file dialog on Windows to hang indefinitely if the application initializes COM (CoInitialize[Ex]) before the dialog is shown.  Since Plasma does this for us, all file dialogs are broken with the native backend on Windows. The non-native dialog may not look as well integrated, but it works.