### PR TITLE
Use use-after-free issue in Minkata.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAvatar/CMakeLists.txt
@@ -77,6 +77,7 @@ target_link_libraries(
         pnKeyedObject
         pnModifier
         pnNetCommon
+        pnNucleusInc
         pnSceneObject
         pnTimer
         plAnimation
@@ -86,7 +87,6 @@ target_link_libraries(
     PRIVATE
         pnEncryption
         pnMessage
-        pnNucleusInc
         plAudio
         plDrawable
         plGImage

--- a/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
@@ -378,8 +378,6 @@ plWalkingStrategy::plWalkingStrategy(plAGApplicator* rootApp, plPhysicalControll
 
 static inline bool IFilterGround(const plControllerHitRecord& candidate, float zMax)
 {
-    if (!candidate.GetPhysical())
-        return false;
     if (candidate.Point.fZ >= zMax)
         return false;
     // Removes near-perpendicular turds
@@ -499,7 +497,7 @@ void plWalkingStrategy::Apply(float delSecs)
 
 void plWalkingStrategy::ICheckGroundSteepness(const plControllerHitRecord& ground)
 {
-    if (ground.GetPhysical()->GetGroup() != plSimDefs::kGroupDynamic) {
+    if (ground.GetPhysical() && ground.GetPhysical()->GetGroup() != plSimDefs::kGroupDynamic) {
         if (ground.Normal.fZ >= GetFallStopThreshold())
             fFlags &= ~kFallingNormal;
         else if (ground.Normal.fZ < GetFallStartThreshold())

--- a/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.h
@@ -69,7 +69,7 @@ struct plControllerHitRecord
     float Displacement;
 
     plControllerHitRecord()
-        : PhysHit(), Point(), Normal(), Displacement()
+        : Point(), Normal(), Displacement()
     { }
     plControllerHitRecord(plKey physHit, hsPoint3 p, hsVector3 n, float d=0.f)
         : PhysHit(std::move(physHit)), Point(std::move(p)), Normal(std::move(n)), Displacement(d)

--- a/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.h
@@ -44,8 +44,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsGeometry3.h"
 #include "hsMatrix44.h"
+#include "plPhysical.h"
 #include "hsQuat.h"
+
 #include "pnKeyedObject/plKey.h"
+
 #include "plPhysical/plSimDefs.h"
 
 #include <optional>
@@ -60,17 +63,25 @@ class plSceneObject;
 
 struct plControllerHitRecord
 {
-    plPhysical* ObjHit;
+    plKey PhysHit;
     hsPoint3 Point;
     hsVector3 Normal;
     float Displacement;
 
     plControllerHitRecord()
-        : ObjHit(), Point(), Normal(), Displacement()
+        : PhysHit(), Point(), Normal(), Displacement()
     { }
-    plControllerHitRecord(plPhysical* phys, hsPoint3 p, hsVector3 n, float d=0.f)
-        : ObjHit(phys), Point(std::move(p)), Normal(std::move(n)), Displacement(d)
-    { }
+    plControllerHitRecord(plKey physHit, hsPoint3 p, hsVector3 n, float d=0.f)
+        : PhysHit(std::move(physHit)), Point(std::move(p)), Normal(std::move(n)), Displacement(d)
+    {
+    }
+
+    plPhysical* GetPhysical() const
+    {
+        if (PhysHit)
+            return plPhysical::ConvertNoRef(PhysHit->ObjectIsLoaded());
+        return nullptr;
+    }
 };
 
 class plPhysicalControllerCore

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
@@ -315,7 +315,7 @@ std::vector<plControllerHitRecord> plPXPhysicalControllerCore::ISweepMulti(const
             for (size_t i = 0; i < nbHits; ++i) {
                 const physx::PxSweepHit& hit = buffer[i];
                 auto hitActor = static_cast<plPXActorData*>(hit.actor->userData);
-                fHits.emplace_back(hitActor->GetPhysical(),
+                fHits.emplace_back(hitActor->GetPhysical()->GetKey(),
                                    plPXConvert::Point(hit.position),
                                    plPXConvert::Vector(hit.normal),
                                    hit.distance);
@@ -361,7 +361,7 @@ std::optional<plControllerHitRecord> plPXPhysicalControllerCore::ISweepSingle(co
 
     std::optional<plControllerHitRecord> retval;
     if (buf.hasBlock) {
-        retval.emplace(static_cast<plPXActorData*>(buf.block.actor->userData)->GetPhysical(),
+        retval.emplace(static_cast<plPXActorData*>(buf.block.actor->userData)->GetPhysical()->GetKey(),
                        plPXConvert::Point(buf.block.position),
                        plPXConvert::Vector(buf.block.normal),
                        buf.block.distance);
@@ -589,7 +589,7 @@ void plPXPhysicalControllerCore::AddContact(plPXPhysical* phys, const hsPoint3& 
     fMovementStrategy->AddContact(phys, pos, normal);
 
 #ifndef PLASMA_EXTERNAL_RELEASE
-    fDbgCollisionInfo.emplace_back(phys, pos, normal);
+    fDbgCollisionInfo.emplace_back(phys->GetKey(), pos, normal);
 #endif
 
     // If this is a Plasma dynamic, we may need to take ownership of it.
@@ -632,7 +632,7 @@ void plPXPhysicalControllerCore::IDrawDebugDisplay(int controllerIdx)
     for (const auto& i : fDbgCollisionInfo) {
         float angle = hsRadiansToDegrees(acos(i.Normal * hsVector3(0.f, 0.f, 1.f)));
         debugString = ST::format("\tCollision: {}, Normal: ({.2f}, {.2f}, {.2f}), Angle({.1f})",
-                i.ObjHit->GetKeyName(),
+                i.PhysHit->GetName(),
                 i.Normal.fX, i.Normal.fY, i.Normal.fZ, angle);
         debugTxt.DrawString(x, y, debugString);
         y += lineHeight;

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.h
@@ -109,6 +109,7 @@ public:
     plPXActorData(plPXPhysical* physical);
     plPXActorData(plPXPhysicalControllerCore* controller);
 
+    /** Gets the key of the owner object. */
     [[nodiscard]]
     plKey GetKey() const { return fKey; }
 


### PR DESCRIPTION
When you touch the linking stone in Minkata, it pages the ground out from under you. Because we were not using the ground's smart pointer, we happily dereferenced freed memory (boom). Amusingly, the ground seems to be freed between `IFindGroundCandidate()` and actually using the ground information. At one point, I tried to properly ref and deref the physical object, but that added a lot of bp considering our use of `std::optional<plControllerHitRecord>`.