### PR TITLE
Don't run the full CI matrix on macOS.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,6 @@ jobs:
           - { str: macos-x64 }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
-          - { external: OFF, type: Debug, str: internal-debug }
-          - { external: ON, type: RelWithDebInfo, str: external-release }
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
At this time, the client does not compile on macOS, so running three simultaneous builds for each PR and push is excessive. We only have 5 concurrent macOS jobs available, due to our usage of the free tier.