### PR TITLE
Clean up hsBitVector and add some unit tests

### DIFF
--- a/Sources/Plasma/CoreLib/hsBitVector.cpp
+++ b/Sources/Plasma/CoreLib/hsBitVector.cpp
@@ -50,31 +50,33 @@ void hsBitVector::IGrow(uint32_t newNumBitVectors)
     hsAssert(newNumBitVectors > fNumBitVectors, "Growing smaller");
     uint32_t *old = fBitVectors;
     fBitVectors = new uint32_t[newNumBitVectors];
-    int i;
-    for( i = 0; i < fNumBitVectors; i++ )
+
+    uint32_t i;
+    for (i = 0; i < fNumBitVectors; i++)
         fBitVectors[i] = old[i];
-    for( ; i < newNumBitVectors; i++ )
+    for (; i < newNumBitVectors; i++)
         fBitVectors[i] = 0;
-    delete [] old;
+    delete[] old;
     fNumBitVectors = newNumBitVectors;
 }
 
 hsBitVector& hsBitVector::Compact()
 {
-    if( !fBitVectors )
+    if (!fBitVectors)
         return *this;
 
-    if( fBitVectors[fNumBitVectors-1] )
+    if (fBitVectors[fNumBitVectors-1])
         return *this;
 
-    int hiVec = 0;
-    for( hiVec = fNumBitVectors-1; (hiVec >= 0)&& !fBitVectors[hiVec]; --hiVec );
-    if( hiVec >= 0 )
+    uint32_t hiVec = 0;
+    for (hiVec = fNumBitVectors-1; (int32_t(hiVec) >= 0) && !fBitVectors[hiVec]; --hiVec)
+        ;
+
+    if (hiVec >= 0)
     {
         uint32_t *old = fBitVectors;
         fBitVectors = new uint32_t[++hiVec];
-        int i;
-        for( i = 0; i < hiVec; i++ )
+        for (uint32_t i = 0; i < hiVec; i++)
             fBitVectors[i] = old[i];
         fNumBitVectors = hiVec;
         delete [] old;
@@ -92,12 +94,11 @@ void hsBitVector::Read(hsStream* s)
     Reset();
 
     s->LogReadLE(&fNumBitVectors,"NumBitVectors");
-    if( fNumBitVectors )
+    if (fNumBitVectors)
     {
-        delete [] fBitVectors;
+        delete[] fBitVectors;
         fBitVectors = new uint32_t[fNumBitVectors];
-        int i;
-        for( i = 0; i < fNumBitVectors; i++ )
+        for (uint32_t i = 0; i < fNumBitVectors; i++)
             s->LogReadLE(&fBitVectors[i],"BitVector");
     }
 }
@@ -106,8 +107,7 @@ void hsBitVector::Write(hsStream* s) const
 {
     s->WriteLE32(fNumBitVectors);
 
-    int i;
-    for( i = 0; i < fNumBitVectors; i++ )
+    for (uint32_t i = 0; i < fNumBitVectors; i++)
         s->WriteLE32(fBitVectors[i]);
 }
 
@@ -115,10 +115,10 @@ std::vector<int16_t>& hsBitVector::Enumerate(std::vector<int16_t>& dst) const
 {
     dst.clear();
     hsBitIterator iter(*this);
-    int i = iter.Begin();
-    while( i >= 0 )
+    int32_t i = iter.Begin();
+    while (i >= 0)
     {
-        dst.emplace_back(i);
+        dst.emplace_back(int16_t(i));
         i = iter.Advance();
     }
     return dst;
@@ -126,7 +126,7 @@ std::vector<int16_t>& hsBitVector::Enumerate(std::vector<int16_t>& dst) const
 
 //////////////////////////////////////////////////////////////////////////
 
-int hsBitIterator::IAdvanceVec()
+bool hsBitIterator::IAdvanceVec()
 {
     hsAssert((fCurrVec >= 0) && (fCurrVec < fBits.fNumBitVectors), "Invalid state to advance from");
 
@@ -135,9 +135,9 @@ int hsBitIterator::IAdvanceVec()
     return fCurrVec < fBits.fNumBitVectors;
 }
 
-int hsBitIterator::IAdvanceBit()
+bool hsBitIterator::IAdvanceBit()
 {
-    do 
+    do
     {
         if( ++fCurrBit > 31 )
         {
@@ -150,30 +150,30 @@ int hsBitIterator::IAdvanceBit()
     return true;
 }
 
-int hsBitIterator::Advance()
+int32_t hsBitIterator::Advance()
 {
-    if( End() )
+    if (End())
         return -1;
 
-    if( !IAdvanceBit() )
+    if (!IAdvanceBit())
         return fCurrVec = -1;
 
     return fCurrent = (fCurrVec << 5) + fCurrBit;
 }
 
-int hsBitIterator::Begin()
+int32_t hsBitIterator::Begin()
 {
     fCurrent = -1;
     fCurrVec = -1;
-    int i;
-    for( i = 0; i < fBits.fNumBitVectors; i++ )
+
+    for (uint32_t i = 0; i < fBits.fNumBitVectors; i++)
     {
-        if( fBits.fBitVectors[i] )
+        if (fBits.fBitVectors[i])
         {
-            int j;
-            for( j = 0; j < 32; j++ )
+            uint32_t j;
+            for (j = 0; j < 32; j++)
             {
-                if( fBits.fBitVectors[i] & (1 << j) )
+                if (fBits.fBitVectors[i] & (1 << j))
                 {
                     fCurrVec = i;
                     fCurrBit = j;

--- a/Sources/Plasma/CoreLib/hsBitVector.h
+++ b/Sources/Plasma/CoreLib/hsBitVector.h
@@ -311,7 +311,7 @@ inline bool hsBitVector::ToggleBit(uint32_t which)
     uint32_t major = which >> 5;
     uint32_t minor = 1 << (which & 0x1f);
     if (major >= fNumBitVectors)
-        IGrow(major);
+        IGrow(major+1);
     bool ret = 0 != (fBitVectors[major] & minor);
     if (ret)
         fBitVectors[major] &= ~minor;
@@ -351,22 +351,22 @@ class hsBitIterator
 protected:
     const hsBitVector&  fBits;
 
-    int                 fCurrent;
+    int32_t             fCurrent;
 
-    int                 fCurrVec;
-    int                 fCurrBit;
+    int32_t             fCurrVec;
+    int32_t             fCurrBit;
 
-    int                 IAdvanceBit();
-    int                 IAdvanceVec();
+    bool                IAdvanceBit();
+    bool                IAdvanceVec();
 
 public:
     // Must call begin after instanciating.
     hsBitIterator(const hsBitVector& bits) : fBits(bits), fCurrent(), fCurrVec(), fCurrBit() { }
 
-    int                 Begin();
-    int                 Current() const { return fCurrent; }
-    int                 Advance();
-    int                 End() const { return fCurrVec < 0; }
+    int32_t             Begin();
+    int32_t             Current() const { return fCurrent; }
+    int32_t             Advance();
+    bool                End() const { return fCurrVec < 0; }
 };
 
 

--- a/Sources/Tests/CoreTests/CMakeLists.txt
+++ b/Sources/Tests/CoreTests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(CoreLibTest_SOURCES
+    test_hsBitVector.cpp
     test_plCmdParser.cpp
 )
 

--- a/Sources/Tests/CoreTests/test_hsBitVector.cpp
+++ b/Sources/Tests/CoreTests/test_hsBitVector.cpp
@@ -1,0 +1,258 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <cstring>
+#include <gtest/gtest.h>
+
+#include "HeadSpin.h"
+#include "hsBitVector.h"
+
+TEST(hsBitVector, empty_vector)
+{
+    hsBitVector bv;
+
+    EXPECT_EQ(bv.Empty(), true);
+    EXPECT_EQ(bv.GetSize(), 0);
+    EXPECT_EQ(bv.GetNumBitVectors(), 0);
+}
+
+TEST(hsBitVector, bit_setting)
+{
+    hsBitVector bv;
+
+    bv.SetBit(1, true);
+
+    EXPECT_EQ(bv.Empty(), false);
+    EXPECT_EQ(bv.GetSize(), 32);
+    EXPECT_EQ(bv.GetNumBitVectors(), 1);
+    EXPECT_NE(bv.GetBitVector(0), 0);
+
+    EXPECT_EQ(bv.IsBitSet(1), true);
+    EXPECT_EQ(bv.IsBitSet(2), false);
+    EXPECT_EQ(bv[1], true);
+    EXPECT_EQ(bv[2], false);
+}
+
+TEST(hsBitVector, bit_setting_larger)
+{
+    hsBitVector bv;
+
+    bv.SetBit(48, true);
+
+    EXPECT_EQ(bv.Empty(), false);
+    EXPECT_EQ(bv.GetSize(), 64);
+    EXPECT_EQ(bv.GetNumBitVectors(), 2);
+    EXPECT_EQ(bv.GetBitVector(0), 0);
+    EXPECT_NE(bv.GetBitVector(1), 0);
+
+    EXPECT_EQ(bv.IsBitSet(48), true);
+    EXPECT_EQ(bv[48], true);
+}
+
+TEST(hsBitVector, bit_toggle)
+{
+    hsBitVector bv;
+
+    EXPECT_EQ(bv.Empty(), true);
+    EXPECT_EQ(bv.GetSize(), 0);
+    EXPECT_EQ(bv.IsBitSet(1), false);
+
+    bv.ToggleBit(1);
+
+    EXPECT_EQ(bv.Empty(), false);
+    EXPECT_EQ(bv.GetSize(), 32);
+    EXPECT_EQ(bv.IsBitSet(1), true);
+
+    bv.ToggleBit(1);
+
+    EXPECT_EQ(bv.Empty(), true);
+    EXPECT_EQ(bv.GetSize(), 32);
+    EXPECT_EQ(bv.IsBitSet(1), false);
+}
+
+TEST(hsBitVector, bit_clearing)
+{
+    hsBitVector bv;
+
+    bv.SetBit(1);
+    bv.SetBit(2);
+    bv.SetBit(3);
+
+    EXPECT_EQ(bv.IsBitSet(1), true);
+    EXPECT_EQ(bv.IsBitSet(2), true);
+    EXPECT_EQ(bv.IsBitSet(3), true);
+
+    bv.ClearBit(2);
+
+    EXPECT_EQ(bv.IsBitSet(1), true);
+    EXPECT_EQ(bv.IsBitSet(2), false);
+    EXPECT_EQ(bv.IsBitSet(3), true);
+
+    bv.Clear();
+
+    EXPECT_EQ(bv.IsBitSet(1), false);
+    EXPECT_EQ(bv.IsBitSet(2), false);
+    EXPECT_EQ(bv.IsBitSet(3), false);
+    EXPECT_EQ(bv.Empty(), true);
+    EXPECT_EQ(bv.GetSize(), 32);
+
+    bv.Reset();
+
+    EXPECT_EQ(bv.IsBitSet(1), false);
+    EXPECT_EQ(bv.IsBitSet(2), false);
+    EXPECT_EQ(bv.IsBitSet(3), false);
+    EXPECT_EQ(bv.Empty(), true);
+    EXPECT_EQ(bv.GetSize(), 0);
+}
+
+TEST(hsBitVector, overlap)
+{
+    hsBitVector bv1, bv2;
+
+    bv1.SetBit(1);
+    bv1.SetBit(2);
+
+    bv2.SetBit(1);
+    bv2.SetBit(3);
+
+    EXPECT_EQ(bv1.Overlap(bv2), true);
+
+    bv2.ClearBit(1);
+
+    EXPECT_EQ(bv1.Overlap(bv2), false);
+}
+
+TEST(hsBitVector, bitwise_and)
+{
+    hsBitVector bv1, bv2;
+
+    bv1.SetBit(1);
+    bv1.SetBit(2);
+
+    bv2.SetBit(1);
+    bv2.SetBit(3);
+
+    hsBitVector bv = bv1 & bv2;
+
+    EXPECT_EQ(bv[1], true);
+    EXPECT_EQ(bv[2], false);
+    EXPECT_EQ(bv[3], false);
+}
+
+TEST(hsBitVector, bitwise_or)
+{
+    hsBitVector bv1, bv2;
+
+    bv1.SetBit(1);
+    bv1.SetBit(2);
+
+    bv2.SetBit(1);
+    bv2.SetBit(3);
+
+    hsBitVector bv = bv1 | bv2;
+
+    EXPECT_EQ(bv[1], true);
+    EXPECT_EQ(bv[2], true);
+    EXPECT_EQ(bv[3], true);
+}
+
+TEST(hsBitVector, bitwise_xor)
+{
+    hsBitVector bv1, bv2;
+
+    bv1.SetBit(1);
+    bv1.SetBit(2);
+
+    bv2.SetBit(1);
+    bv2.SetBit(3);
+
+    hsBitVector bv = bv1 ^ bv2;
+
+    EXPECT_EQ(bv[1], false);
+    EXPECT_EQ(bv[2], true);
+    EXPECT_EQ(bv[3], true);
+}
+
+TEST(hsBitVector, subtraction)
+{
+    hsBitVector bv1, bv2;
+
+    bv1.SetBit(1);
+    bv1.SetBit(2);
+
+    bv2.SetBit(1);
+    bv2.SetBit(3);
+
+    hsBitVector bv = bv1 - bv2;
+
+    EXPECT_EQ(bv[1], false);
+    EXPECT_EQ(bv[2], true);
+    EXPECT_EQ(bv[3], false);
+}
+
+TEST(hsBitVector, compacting)
+{
+    hsBitVector bv;
+
+    bv.SetBit(24, true);
+    bv.SetBit(48, true);
+
+    EXPECT_EQ(bv.Empty(), false);
+    EXPECT_EQ(bv.GetSize(), 64);
+    EXPECT_EQ(bv.GetNumBitVectors(), 2);
+
+    bv.ClearBit(48);
+
+    EXPECT_EQ(bv.GetSize(), 64);
+    EXPECT_EQ(bv.GetNumBitVectors(), 2);
+
+    bv.Compact();
+
+    EXPECT_EQ(bv.GetSize(), 32);
+    EXPECT_EQ(bv.GetNumBitVectors(), 1);
+
+    bv.ClearBit(24);
+    bv.Compact();
+
+    EXPECT_EQ(bv.GetSize(), 0);
+    EXPECT_EQ(bv.GetNumBitVectors(), 0);
+}


### PR DESCRIPTION
* Fixes a bug where `ToggleBit` didn't actually work if the bitvector was empty
* Fixes some signed/unsigned integer comparison issues (although some still exist in hsBitIterator)
* Adds some basic unit tests because tests are good and they uncover bugs (see point 1)