### PR TITLE
Kill some C-string spin-washing.

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -169,8 +169,8 @@ static std::vector<HMODULE> fLoadedDLLs;
 plClient::plClient()
     : fPipeline(), fDone(), fQuitIntro(), fWindowHndl(),
       fInputManager(), fConsole(), fCurrentNode(), fNewCamera(),
-      fpAuxInitDir(), fTransitionMgr(), fLinkEffectsMgr(),
-      fProgressBar(), fGameGUIMgr(), fWindowActive(), fAnimDebugList(),
+      fTransitionMgr(), fLinkEffectsMgr(), fProgressBar(),
+      fGameGUIMgr(), fWindowActive(), fAnimDebugList(),
       fClampCap(-1), fQuality(), fPageMgr(), fFontCache(),
       fHoldLoadRequests(), fNumLoadingRooms(), fNumPostLoadMsgs(), fPostLoadMsgInc(),
       fLastProgressUpdate(), fMessagePumpProc()
@@ -224,7 +224,6 @@ plClient::~plClient()
     plClient::SetInstance(nullptr);
 
     delete fPageMgr;
-    delete [] fpAuxInitDir;
 }
 
 template<typename T>
@@ -369,7 +368,7 @@ bool plClient::Shutdown()
 void plClient::InitAuxInits()
 {
     // Use another init directory specified in Command line Arg -i
-    if (fpAuxInitDir)
+    if (fpAuxInitDir.IsValid())
         pfConsoleDirSrc     dirSrc( fConsoleEngine, fpAuxInitDir, "*.ini" );
 }
 
@@ -2204,7 +2203,7 @@ void plClient::IOnAsyncInitComplete () {
 #endif
 
     // run fni in the Aux Init dir
-    if (fpAuxInitDir)
+    if (fpAuxInitDir.IsValid())
     {
         dirSrc.ParseDirectory(fpAuxInitDir, "net*.fni");   // connect to net first
         dirSrc.ParseDirectory(fpAuxInitDir, "*.fni");

--- a/Sources/Plasma/Apps/plClient/plClient.h
+++ b/Sources/Plasma/Apps/plClient/plClient.h
@@ -47,9 +47,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //#define NEW_CAMERA_CODE
 
 #include "HeadSpin.h"
-#include <list>
-
 #include "hsBitVector.h"
+#include "plFileSystem.h"
+
+#include <list>
 
 #include "pnKeyedObject/hsKeyedObject.h"
 #include "pnKeyedObject/plUoid.h"
@@ -139,7 +140,7 @@ protected:
     plVirtualCam1*          fNewCamera;
 
     static plClient*        fInstance;
-    char *                  fpAuxInitDir;
+    plFileName              fpAuxInitDir;
     static bool             fDelayMS;
 
     int                     fClampCap;
@@ -264,7 +265,7 @@ public:
 
     pfConsoleEngine *GetConsoleEngine() { return fConsoleEngine; }
 
-    void SetAuxInitDir(const char *p) { delete [] fpAuxInitDir; fpAuxInitDir = hsStrcpy(p); }
+    void SetAuxInitDir(plFileName dir) { fpAuxInitDir = std::move(dir); }
 
     static void EnableClientDelay() { plClient::fDelayMS = true; }
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -310,7 +310,7 @@ bool    pfConsole::MsgReceive( plMessage *msg )
     }
 
     plConsoleMsg *cmd = plConsoleMsg::ConvertNoRef( msg );
-    if (cmd != nullptr && cmd->GetString() != nullptr)
+    if (cmd != nullptr && !cmd->GetString().empty())
     {
         if( cmd->GetCmd() == plConsoleMsg::kExecuteFile )
         {
@@ -332,10 +332,12 @@ bool    pfConsole::MsgReceive( plMessage *msg )
             }
         }
         else if( cmd->GetCmd() == plConsoleMsg::kAddLine )
-            IAddParagraph( cmd->GetString() );
+            IAddParagraph( cmd->GetString().c_str() );
         else if( cmd->GetCmd() == plConsoleMsg::kExecuteLine )
         {
-            if( !fEngine->RunCommand( (char *)cmd->GetString(), IAddLineCallback ) )
+            ST::char_buffer cmdBuf;
+            cmd->GetString().to_buffer(cmdBuf);
+            if( !fEngine->RunCommand(cmdBuf.data(), IAddLineCallback))
             {
                 // Change the following line once we have a better way of reporting
                 // errors in the parsing

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -840,13 +840,13 @@ PF_CONSOLE_CMD( Console, ClearAllVars, "", "Wipes the global console variable co
 
 PF_CONSOLE_CMD( Console, ExecuteFile, "string filename", "Runs the given file as if it were an .ini or .fni file" )
 {
-    plConsoleMsg *cMsg = new plConsoleMsg( plConsoleMsg::kExecuteFile, params[ 0 ] );
+    plConsoleMsg *cMsg = new plConsoleMsg( plConsoleMsg::kExecuteFile, ST::string(params[ 0 ]) );
     cMsg->Send();
 }
 
 PF_CONSOLE_CMD( Console, ExecuteFileDelayed, "string filename, float timeInSecs", "Runs the given file as if it were an .ini or .fni file, but at some given point in the future" )
 {
-    plConsoleMsg *cMsg = new plConsoleMsg( plConsoleMsg::kExecuteFile, params[ 0 ] );
+    plConsoleMsg *cMsg = new plConsoleMsg( plConsoleMsg::kExecuteFile, ST::string(params[ 0 ]) );
     cMsg->SetTimeStamp( hsTimer::GetSysSeconds() + (float)params[ 1 ] );
     cMsg->Send();
 }
@@ -3642,15 +3642,14 @@ PF_CONSOLE_CMD( Access,
     
 }
 
-char *gCurrMorph = nullptr;
+static ST::string gCurrMorph;
 
 PF_CONSOLE_CMD( Access,
                 SetMorphItem,
                 "string itemName",
                 "Set which clothing item we want to morph" )
 {
-    delete [] gCurrMorph;
-    gCurrMorph = hsStrcpy(nullptr, params[0]);
+    gCurrMorph = params[0];
 }
 
 PF_CONSOLE_CMD( Access,

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
@@ -224,7 +224,7 @@ PF_CONSOLE_CMD( Net,        // groupName
         text += ST::string::from_utf8( (char*)params[i] );
         text += " ";
     }
-    plConsoleMsg    *cMsg = new plConsoleMsg( plConsoleMsg::kAddLine, text.c_str() );
+    plConsoleMsg    *cMsg = new plConsoleMsg( plConsoleMsg::kAddLine, text );
     cMsg->SetBCastFlag(plMessage::kNetPropagate | plMessage::kNetForce);
     cMsg->SetBCastFlag(plMessage::kLocalPropagate, 0);
     plgDispatch::MsgSend( cMsg );

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.h
@@ -50,6 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include "hsBiExpander.h"
+#include "plFileSystem.h"
 
 #include <string_theory/format>
 
@@ -157,6 +158,7 @@ class pfConsoleCmdParam
         operator bool() const { return IToBool(); }
         operator CharPtr() const { return IToString(); }
         operator char() const { return IToChar(); }
+        operator plFileName() const { return IToString(); }
 
         uint8_t   GetType() { return fType; }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(
         plPipeline
         plResMgr
         plScene
+        plStatusLog
         plSurface
         pfLocalizationMgr
         pfMessage

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.h
@@ -60,6 +60,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnKeyedObject/plKey.h"
 #include "pnKeyedObject/hsKeyedObject.h"
 
+#include <string_theory/string>
 #include <vector>
 
 class pfGameUIInputInterface;
@@ -92,13 +93,14 @@ class pfGUITag
 class pfDialogNameSetKey
 {
 private:
-    char    *fName;
-    plKey   fKey;
+    ST::string fName;
+    plKey      fKey;
+
 public:
-    pfDialogNameSetKey(const char *name, plKey key)
-        : fName(hsStrcpy(name)), fKey(std::move(key)) { }
-    ~pfDialogNameSetKey() { delete [] fName; }
-    const char *GetName() const { return fName; }
+    pfDialogNameSetKey(ST::string name, plKey key)
+        : fName(std::move(name)), fKey(std::move(key)) { }
+
+    ST::string GetName() const { return fName; }
     plKey GetKey() const { return fKey; }
 };
 
@@ -140,10 +142,6 @@ class pfGameGUIMgr : public hsKeyedObject
         std::vector<pfGUIDialogMod *>  fDialogs;
         pfGUIDialogMod              *fActiveDialogs;
 
-        // These two lists help us manage when dialogs get told to load or unload versus when they actually *do*
-        std::vector<pfDialogNameSetKey *>  fDlgsPendingLoad;
-        std::vector<pfDialogNameSetKey *>  fDlgsPendingUnload;
-
         bool    fActivated;
         uint32_t  fActiveDlgCount;
 
@@ -161,7 +159,6 @@ class pfGameGUIMgr : public hsKeyedObject
         // LoadDialog adds an entry and MsgReceive removes it
         std::vector<pfDialogNameSetKey *>  fDialogToSetKeyOf;
 
-        void    ILoadDialog( const char *name );
         void    IShowDialog( const char *name );
         void    IHideDialog( const char *name );
 
@@ -198,7 +195,7 @@ class pfGameGUIMgr : public hsKeyedObject
 
         bool    MsgReceive(plMessage* pMsg) override;
 
-        void    LoadDialog(const char *name, plKey recvrKey = {}, const char *ageName = nullptr);  // AgeName = nil defaults to "GUI"
+        void    LoadDialog(const ST::string& name, plKey recvrKey = {}, const char *ageName = nullptr);  // AgeName = nil defaults to "GUI"
         void    ShowDialog( const char *name ) { IShowDialog(name); }
         void    HideDialog( const char *name ) { IHideDialog(name); }
         void    UnloadDialog( const char *name );

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -406,7 +406,7 @@ void pfBookData::LoadGUI()
     // has the dialog been loaded yet?
     if (!pfGameGUIMgr::GetInstance()->IsDialogLoaded(fGUIName.c_str()))
         // no then load and set handler
-        pfGameGUIMgr::GetInstance()->LoadDialog(fGUIName.c_str(), GetKey(), "GUI");
+        pfGameGUIMgr::GetInstance()->LoadDialog(fGUIName, GetKey(), "GUI");
     else
         // yes then just set the handler
         pfGameGUIMgr::GetInstance()->SetDialogToNotify(fGUIName.c_str(), GetKey());

--- a/Sources/Plasma/FeatureLib/pfPython/cyAnimation.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAnimation.cpp
@@ -66,24 +66,9 @@ cyAnimation::cyAnimation(const pyKey& sender)
     SetSender(sender);
 }
 
-// copy constructor
-cyAnimation::cyAnimation(const cyAnimation& anim)
-{
-    fSender = anim.fSender;
-    fRecvr = anim.fRecvr;
-    // here is why we needed the copy constructor
-    fAnimName = hsStrcpy(anim.fAnimName);       // make our own copy of this string
-    fNetForce = anim.fNetForce;
-}
-
 // clean up on the way out
 cyAnimation::~cyAnimation()
 {
-    if (fAnimName != nullptr)
-    {
-        delete [] fAnimName;
-        fAnimName = nullptr;
-    }
 }
 
 
@@ -103,13 +88,6 @@ PyObject* cyAnimation::GetFirstRecvr()
     if (!fRecvr.empty())
         return pyKey::New(fRecvr[0]);
     return nullptr;
-}
-
-void cyAnimation::SetAnimName(const char* name)
-{
-    if (fAnimName != nullptr)
-        delete [] fAnimName;
-    fAnimName = hsStrcpy(name);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/cyAnimation.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAnimation.h
@@ -49,6 +49,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // PURPOSE: Class wrapper to map animation functions to plasma2 message
 //
 
+#include <string_theory/string>
+
 #include "pyGlueHelpers.h"
 
 class cyAnimation
@@ -56,7 +58,7 @@ class cyAnimation
 
     plKey           fSender;
     std::vector<plKey> fRecvr;
-    char*           fAnimName;
+    ST::string      fAnimName;
     bool            fNetForce;
 
     virtual void IRunOneCmd(int cmd);
@@ -65,8 +67,6 @@ protected:
     cyAnimation();
     cyAnimation(const pyKey& sender);
 
-    // copy constructor
-    cyAnimation(const cyAnimation& anim);
 public:
 
     // clean up on the way out
@@ -85,7 +85,7 @@ public:
     // setters
     virtual void SetSender(const pyKey& sender);
     virtual void AddRecvr(const pyKey& recvr);
-    virtual void SetAnimName(const char* name);
+    virtual void SetAnimName(ST::string name) { fAnimName = std::move(name); }
 
     virtual PyObject* GetFirstRecvr();
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyAnimationGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAnimationGlue.cpp
@@ -127,8 +127,8 @@ PYTHON_METHOD_DEFINITION(ptAnimation, netForce, args)
 
 PYTHON_METHOD_DEFINITION(ptAnimation, setAnimName, args)
 {
-    char *name = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &name)) // name points at the internal buffer SO DON'T DELETE IT
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "setAnimName requires a string argument");
         PYTHON_RETURN_ERROR;
@@ -306,7 +306,6 @@ PyObject *cyAnimation::New(PyObject *sender)
     ptAnimation *newObj = (ptAnimation*)ptAnimation_type.tp_new(&ptAnimation_type, nullptr, nullptr);
     pyKey *key = pyKey::ConvertFrom(sender);
     newObj->fThis->SetSender(*key);
-    newObj->fThis->fAnimName = nullptr;
     newObj->fThis->fNetForce = false;
     return (PyObject*)newObj;
 }
@@ -316,7 +315,7 @@ PyObject *cyAnimation::New(cyAnimation &obj)
     ptAnimation *newObj = (ptAnimation*)ptAnimation_type.tp_new(&ptAnimation_type, nullptr, nullptr);
     newObj->fThis->fSender = obj.fSender;
     newObj->fThis->fRecvr = obj.fRecvr;
-    newObj->fThis->fAnimName = hsStrcpy(obj.fAnimName);
+    newObj->fThis->fAnimName = obj.fAnimName;
     newObj->fThis->fNetForce = obj.fNetForce;
     return (PyObject*)newObj;
 }

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
@@ -403,7 +403,7 @@ void plAgeLoader::ExecPendingAgeFniFiles()
     int i;
     for (i=0;i<PendingAgeFniFiles().size(); i++)
     {
-        plConsoleMsg    *cMsg = new plConsoleMsg( plConsoleMsg::kExecuteFile, fPendingAgeFniFiles[i].AsString().c_str() );
+        plConsoleMsg    *cMsg = new plConsoleMsg( plConsoleMsg::kExecuteFile, fPendingAgeFniFiles[i].AsString() );
         plgDispatch::MsgSend( cMsg );
     }
     fPendingAgeFniFiles.clear();
@@ -414,7 +414,7 @@ void plAgeLoader::ExecPendingAgeCsvFiles()
     int i;
     for (i=0;i<PendingAgeCsvFiles().size(); i++)
     {
-        hsStream* stream = plEncryptedStream::OpenEncryptedFile(fPendingAgeCsvFiles[i].AsString().c_str());
+        hsStream* stream = plEncryptedStream::OpenEncryptedFile(fPendingAgeCsvFiles[i].AsString());
         if (stream)
         {
             plRelevanceMgr::Instance()->ParseCsvInput(stream);

--- a/Sources/Plasma/PubUtilLib/plMessage/plConsoleMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plConsoleMsg.h
@@ -54,7 +54,7 @@ class plConsoleMsg : public plMessage
 protected:
 
     uint32_t      fCmd;
-    char        *fString;
+    ST::string    fString;
 
 public:
 
@@ -65,21 +65,20 @@ public:
         kExecuteLine
     };
 
-    plConsoleMsg() : plMessage(nullptr, nullptr, nullptr), fCmd(), fString() { SetBCastFlag(kBCastByExactType); }
-    plConsoleMsg( uint32_t cmd, const char *str ) : 
-                plMessage(nullptr, nullptr, nullptr), fCmd(cmd), fString(hsStrcpy(str))
-                { SetBCastFlag( kBCastByExactType ); }
-    
-    ~plConsoleMsg() { free(fString); }
+    plConsoleMsg(uint32_t cmd = 0, ST::string str = {})
+        :  plMessage(nullptr, nullptr, nullptr), fCmd(cmd), fString(std::move(str))
+    {
+        SetBCastFlag( kBCastByExactType );
+    }
 
     CLASSNAME_REGISTER( plConsoleMsg );
     GETINTERFACE_ANY( plConsoleMsg, plMessage );
 
     uint32_t      GetCmd() const { return fCmd; }
-    const char  *GetString() const { return fString; };
-    
+    ST::string    GetString() const { return fString; };
+
     void SetCmd (uint32_t cmd) { fCmd = cmd; }
-    void SetString (const char str[]) { free(fString); fString = hsStrcpy(str); }
+    void SetString(ST::string str) { fString = std::move(str); }
 
     void Read(hsStream* s, hsResMgr* mgr) override;
     void Write(hsStream* s, hsResMgr* mgr) override;


### PR DESCRIPTION
This eradicates some spin-washing of strings from `ST::string` to `char*` back to `ST::string` by removing some uses of `hsStrcpy` in favor of `ST::string` itself. Note this does not remove all uses of `hsStrcpy`.