### PR TITLE
Add some missing includes required when PCH/unity builds are disabled.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.h
@@ -42,6 +42,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plLinkEffectsMgr_inc
 #define plLinkEffectsMgr_inc
 
+#include "hsTemplates.h"
+
 #include "pnKeyedObject/hsKeyedObject.h"
 
 class plKey;

--- a/Sources/Tools/MaxConvert/plDistTree.h
+++ b/Sources/Tools/MaxConvert/plDistTree.h
@@ -43,6 +43,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plDistTree_inc
 #define plDistTree_inc
 
+#include "hsTemplates.h"
+
 class plDistNode
 {
 public:

--- a/Sources/Tools/MaxMain/plAgeDescInterface.h
+++ b/Sources/Tools/MaxMain/plAgeDescInterface.h
@@ -40,6 +40,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+#include "hsTemplates.h"
+#include "hsWindows.h"
+
+#include <vector>
+
 class plAgeDescription;
 class plAgeFile;
 class MaxAssBranchAccess;

--- a/Sources/Tools/MaxMain/plCommonObjLib.h
+++ b/Sources/Tools/MaxMain/plCommonObjLib.h
@@ -65,6 +65,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef _plCommonObjLib_h
 #define _plCommonObjLib_h
 
+#include "hsTemplates.h"
+
 class plCommonObjLibList;
 class plKey;
 class hsKeyedObject;

--- a/Sources/Tools/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.cpp
@@ -55,6 +55,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include "hsResMgr.h"
+#include "hsTemplates.h"
 
 #include "MaxMain/MaxAPI.h"
 

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.h
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.h
@@ -51,6 +51,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef _plAnimStealthNode_h
 #define _plAnimStealthNode_h
 
+#include "hsTemplates.h"
+
 #include "MaxComponent/plAnimObjInterface.h"
 #include "MaxComponent/plMaxAnimUtils.h"
 


### PR DESCRIPTION
Coverity builds seem to work again with the latest cov-build, but PCH and unity builds cause the build output to be about 10x larger (and slower to build)...  These changes fix the build with those features disabled.