### PR TITLE
Fix resource leaks around voice chat.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.cpp
@@ -339,6 +339,7 @@ plVoicePlayer::plVoicePlayer()
 
 plVoicePlayer::~plVoicePlayer()
 {
+    delete fOpusDecoder;
 }
 
 void plVoicePlayer::PlaybackUncompressedVoiceMessage(const void* data, size_t size, uint32_t rate)

--- a/Sources/Plasma/PubUtilLib/plAudio/plVoiceCodec.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plVoiceCodec.h
@@ -50,6 +50,8 @@ struct SpeexBits;
 class plVoiceCodec
 {
 public:
+    virtual ~plVoiceCodec() = default;
+
     virtual int GetSampleRate() const = 0;
     virtual int GetFrameSize() const = 0;
 };


### PR DESCRIPTION
Fixes a missing `delete` and virtual destructor identified by coverity. I would have used `std::unique_ptr`, but it seemed somewhat out of place in context.