### PR TITLE
Improve pyEnum.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyAccountManagementGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAccountManagementGlue.cpp
@@ -132,11 +132,11 @@ void cyAccountManagement::AddPlasmaMethods(PyObject* m)
 
 void cyAccountManagement::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtAccountUpdateType);
-    PYTHON_ENUM_ELEMENT(PtAccountUpdateType, kCreatePlayer,     plAccountUpdateMsg::kCreatePlayer);
-    PYTHON_ENUM_ELEMENT(PtAccountUpdateType, kDeletePlayer,     plAccountUpdateMsg::kDeletePlayer);
-    PYTHON_ENUM_ELEMENT(PtAccountUpdateType, kUpgradePlayer,    plAccountUpdateMsg::kUpgradePlayer);
-    PYTHON_ENUM_ELEMENT(PtAccountUpdateType, kActivePlayer,     plAccountUpdateMsg::kActivePlayer);
-    PYTHON_ENUM_ELEMENT(PtAccountUpdateType, kChangePassword,   plAccountUpdateMsg::kChangePassword);
-    PYTHON_ENUM_END(m, PtAccountUpdateType);
+    PYTHON_ENUM_START(PtAccountUpdateType)
+    PYTHON_ENUM_ELEMENT(PtAccountUpdateType, kCreatePlayer,     plAccountUpdateMsg::kCreatePlayer)
+    PYTHON_ENUM_ELEMENT(PtAccountUpdateType, kDeletePlayer,     plAccountUpdateMsg::kDeletePlayer)
+    PYTHON_ENUM_ELEMENT(PtAccountUpdateType, kUpgradePlayer,    plAccountUpdateMsg::kUpgradePlayer)
+    PYTHON_ENUM_ELEMENT(PtAccountUpdateType, kActivePlayer,     plAccountUpdateMsg::kActivePlayer)
+    PYTHON_ENUM_ELEMENT(PtAccountUpdateType, kChangePassword,   plAccountUpdateMsg::kChangePassword)
+    PYTHON_ENUM_END(m, PtAccountUpdateType)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatarGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatarGlue.cpp
@@ -917,36 +917,36 @@ void cyAvatar::AddPlasmaMethods(PyObject* m)
 //
 void cyAvatar::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtBrainModes);
-    PYTHON_ENUM_ELEMENT(PtBrainModes, kGeneric,     plAvBrainGeneric::kGeneric);
-    PYTHON_ENUM_ELEMENT(PtBrainModes, kLadder,      plAvBrainGeneric::kLadder);
-    PYTHON_ENUM_ELEMENT(PtBrainModes, kSit,         plAvBrainGeneric::kSit);
-    PYTHON_ENUM_ELEMENT(PtBrainModes, kSitOnGround, plAvBrainGeneric::kSitOnGround);
-    PYTHON_ENUM_ELEMENT(PtBrainModes, kEmote,       plAvBrainGeneric::kEmote);
-    PYTHON_ENUM_ELEMENT(PtBrainModes, kAFK,         plAvBrainGeneric::kAFK);
-    PYTHON_ENUM_ELEMENT(PtBrainModes, kNonGeneric,  plAvBrainGeneric::kNonGeneric);
-    PYTHON_ENUM_END(m, PtBrainModes);
+    PYTHON_ENUM_START(PtBrainModes)
+    PYTHON_ENUM_ELEMENT(PtBrainModes, kGeneric,     plAvBrainGeneric::kGeneric)
+    PYTHON_ENUM_ELEMENT(PtBrainModes, kLadder,      plAvBrainGeneric::kLadder)
+    PYTHON_ENUM_ELEMENT(PtBrainModes, kSit,         plAvBrainGeneric::kSit)
+    PYTHON_ENUM_ELEMENT(PtBrainModes, kSitOnGround, plAvBrainGeneric::kSitOnGround)
+    PYTHON_ENUM_ELEMENT(PtBrainModes, kEmote,       plAvBrainGeneric::kEmote)
+    PYTHON_ENUM_ELEMENT(PtBrainModes, kAFK,         plAvBrainGeneric::kAFK)
+    PYTHON_ENUM_ELEMENT(PtBrainModes, kNonGeneric,  plAvBrainGeneric::kNonGeneric)
+    PYTHON_ENUM_END(m, PtBrainModes)
 
-    PYTHON_ENUM_START(PtBehaviorTypes);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeStandingJump,     plHBehavior::kBehaviorTypeStandingJump);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeWalkingJump,      plHBehavior::kBehaviorTypeWalkingJump);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeRunningJump,      plHBehavior::kBehaviorTypeRunningJump);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeAnyJump,          plHBehavior::kBehaviorTypeAnyJump);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeRunningImpact,    plHBehavior::kBehaviorTypeRunningImpact);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeGroundImpact,     plHBehavior::kBehaviorTypeGroundImpact);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeAnyImpact,        plHBehavior::kBehaviorTypeAnyImpact);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeIdle,             plHBehavior::kBehaviorTypeIdle);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeWalk,             plHBehavior::kBehaviorTypeWalk);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeRun,              plHBehavior::kBehaviorTypeRun);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeWalkBack,         plHBehavior::kBehaviorTypeWalkBack);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeTurnLeft,         plHBehavior::kBehaviorTypeTurnLeft);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeTurnRight,        plHBehavior::kBehaviorTypeTurnRight);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeSidestepLeft,     plHBehavior::kBehaviorTypeSidestepLeft);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeSidestepRight,    plHBehavior::kBehaviorTypeSidestepRight);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeFall,             plHBehavior::kBehaviorTypeFall);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeMovingTurnLeft,   plHBehavior::kBehaviorTypeMovingTurnLeft);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeMovingTurnRight,  plHBehavior::kBehaviorTypeMovingTurnRight);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeLinkIn,           plHBehavior::kBehaviorTypeLinkIn);
-    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeLinkOut,          plHBehavior::kBehaviorTypeLinkOut);
-    PYTHON_ENUM_END(m, PtBehaviorTypes);
+    PYTHON_ENUM_START(PtBehaviorTypes)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeStandingJump,     plHBehavior::kBehaviorTypeStandingJump)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeWalkingJump,      plHBehavior::kBehaviorTypeWalkingJump)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeRunningJump,      plHBehavior::kBehaviorTypeRunningJump)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeAnyJump,          plHBehavior::kBehaviorTypeAnyJump)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeRunningImpact,    plHBehavior::kBehaviorTypeRunningImpact)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeGroundImpact,     plHBehavior::kBehaviorTypeGroundImpact)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeAnyImpact,        plHBehavior::kBehaviorTypeAnyImpact)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeIdle,             plHBehavior::kBehaviorTypeIdle)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeWalk,             plHBehavior::kBehaviorTypeWalk)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeRun,              plHBehavior::kBehaviorTypeRun)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeWalkBack,         plHBehavior::kBehaviorTypeWalkBack)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeTurnLeft,         plHBehavior::kBehaviorTypeTurnLeft)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeTurnRight,        plHBehavior::kBehaviorTypeTurnRight)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeSidestepLeft,     plHBehavior::kBehaviorTypeSidestepLeft)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeSidestepRight,    plHBehavior::kBehaviorTypeSidestepRight)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeFall,             plHBehavior::kBehaviorTypeFall)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeMovingTurnLeft,   plHBehavior::kBehaviorTypeMovingTurnLeft)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeMovingTurnRight,  plHBehavior::kBehaviorTypeMovingTurnRight)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeLinkIn,           plHBehavior::kBehaviorTypeLinkIn)
+    PYTHON_ENUM_ELEMENT(PtBehaviorTypes, kBehaviorTypeLinkOut,          plHBehavior::kBehaviorTypeLinkOut)
+    PYTHON_ENUM_END(m, PtBehaviorTypes)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
@@ -479,36 +479,36 @@ void cyMisc::AddPlasmaMethods2(PyObject* m)
 
 void cyMisc::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtCCRPetitionType);
-    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kGeneralHelp,plNetCommon::PetitionTypes::kGeneralHelp);
-    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kBug,        plNetCommon::PetitionTypes::kBug);
-    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kFeedback,   plNetCommon::PetitionTypes::kFeedback);
-    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kExploit,    plNetCommon::PetitionTypes::kExploit);
-    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kHarass,     plNetCommon::PetitionTypes::kHarass);
-    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kStuck,      plNetCommon::PetitionTypes::kStuck);
-    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kTechnical,  plNetCommon::PetitionTypes::kTechnical);
-    PYTHON_ENUM_END(m, PtCCRPetitionType);
-    
-    PYTHON_ENUM_START(PtLanguage);
-    PYTHON_ENUM_ELEMENT(PtLanguage, kEnglish,       plLocalization::kEnglish);
-    PYTHON_ENUM_ELEMENT(PtLanguage, kFrench,        plLocalization::kFrench);
-    PYTHON_ENUM_ELEMENT(PtLanguage, kGerman,        plLocalization::kGerman);
-    PYTHON_ENUM_ELEMENT(PtLanguage, kSpanish,       plLocalization::kSpanish);
-    PYTHON_ENUM_ELEMENT(PtLanguage, kItalian,       plLocalization::kItalian);
-    PYTHON_ENUM_ELEMENT(PtLanguage, kJapanese,      plLocalization::kJapanese);
-    PYTHON_ENUM_ELEMENT(PtLanguage, kNumLanguages,  plLocalization::kNumLanguages);
-    PYTHON_ENUM_END(m, PtLanguage);
-    
-    PYTHON_ENUM_START(PtLOSReportType);
-    PYTHON_ENUM_ELEMENT(PtLOSReportType, kReportHit,        plLOSRequestMsg::kReportHit);
-    PYTHON_ENUM_ELEMENT(PtLOSReportType, kReportMiss,       plLOSRequestMsg::kReportMiss);
-    PYTHON_ENUM_ELEMENT(PtLOSReportType, kReportHitOrMiss,  plLOSRequestMsg::kReportHitOrMiss);
-    PYTHON_ENUM_END(m, PtLOSReportType);
-    
-    PYTHON_ENUM_START(PtLOSObjectType);
-    PYTHON_ENUM_ELEMENT(PtLOSObjectType, kClickables,       kClickables);
-    PYTHON_ENUM_ELEMENT(PtLOSObjectType, kCameraBlockers,   kCameraBlockers);
-    PYTHON_ENUM_ELEMENT(PtLOSObjectType, kCustom,           kCustom);
-    PYTHON_ENUM_ELEMENT(PtLOSObjectType, kShootable,        kShootable);
-    PYTHON_ENUM_END(m, PtLOSObjectType);
+    PYTHON_ENUM_START(PtCCRPetitionType)
+    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kGeneralHelp,plNetCommon::PetitionTypes::kGeneralHelp)
+    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kBug,        plNetCommon::PetitionTypes::kBug)
+    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kFeedback,   plNetCommon::PetitionTypes::kFeedback)
+    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kExploit,    plNetCommon::PetitionTypes::kExploit)
+    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kHarass,     plNetCommon::PetitionTypes::kHarass)
+    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kStuck,      plNetCommon::PetitionTypes::kStuck)
+    PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kTechnical,  plNetCommon::PetitionTypes::kTechnical)
+    PYTHON_ENUM_END(m, PtCCRPetitionType)
+
+    PYTHON_ENUM_START(PtLanguage)
+    PYTHON_ENUM_ELEMENT(PtLanguage, kEnglish,       plLocalization::kEnglish)
+    PYTHON_ENUM_ELEMENT(PtLanguage, kFrench,        plLocalization::kFrench)
+    PYTHON_ENUM_ELEMENT(PtLanguage, kGerman,        plLocalization::kGerman)
+    PYTHON_ENUM_ELEMENT(PtLanguage, kSpanish,       plLocalization::kSpanish)
+    PYTHON_ENUM_ELEMENT(PtLanguage, kItalian,       plLocalization::kItalian)
+    PYTHON_ENUM_ELEMENT(PtLanguage, kJapanese,      plLocalization::kJapanese)
+    PYTHON_ENUM_ELEMENT(PtLanguage, kNumLanguages,  plLocalization::kNumLanguages)
+    PYTHON_ENUM_END(m, PtLanguage)
+
+    PYTHON_ENUM_START(PtLOSReportType)
+    PYTHON_ENUM_ELEMENT(PtLOSReportType, kReportHit,        plLOSRequestMsg::kReportHit)
+    PYTHON_ENUM_ELEMENT(PtLOSReportType, kReportMiss,       plLOSRequestMsg::kReportMiss)
+    PYTHON_ENUM_ELEMENT(PtLOSReportType, kReportHitOrMiss,  plLOSRequestMsg::kReportHitOrMiss)
+    PYTHON_ENUM_END(m, PtLOSReportType)
+
+    PYTHON_ENUM_START(PtLOSObjectType)
+    PYTHON_ENUM_ELEMENT(PtLOSObjectType, kClickables,       kClickables)
+    PYTHON_ENUM_ELEMENT(PtLOSObjectType, kCameraBlockers,   kCameraBlockers)
+    PYTHON_ENUM_ELEMENT(PtLOSObjectType, kCustom,           kCustom)
+    PYTHON_ENUM_ELEMENT(PtLOSObjectType, kShootable,        kShootable)
+    PYTHON_ENUM_END(m, PtLOSObjectType)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
@@ -55,11 +55,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 void pyAIMsg::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtAIMsgType);
-    PYTHON_ENUM_ELEMENT(PtAIMsgType, kUnknown, plAIMsg::kAIMsg_Unknown);
-    PYTHON_ENUM_ELEMENT(PtAIMsgType, kBrainCreated, plAIMsg::kAIMsg_BrainCreated);
-    PYTHON_ENUM_ELEMENT(PtAIMsgType, kArrivedAtGoal, plAIMsg::kAIMsg_ArrivedAtGoal);
-    PYTHON_ENUM_END(m, PtAIMsgType);
+    PYTHON_ENUM_START(PtAIMsgType)
+    PYTHON_ENUM_ELEMENT(PtAIMsgType, kUnknown, plAIMsg::kAIMsg_Unknown)
+    PYTHON_ENUM_ELEMENT(PtAIMsgType, kBrainCreated, plAIMsg::kAIMsg_BrainCreated)
+    PYTHON_ENUM_ELEMENT(PtAIMsgType, kArrivedAtGoal, plAIMsg::kAIMsg_ArrivedAtGoal)
+    PYTHON_ENUM_END(m, PtAIMsgType)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/pyDrawControlGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDrawControlGlue.cpp
@@ -142,8 +142,8 @@ void pyDrawControl::AddPlasmaMethods(PyObject* m)
 
 /*void pyDrawControl::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtMovieType);
-    PYTHON_ENUM_ELEMENT(PtMovieType, kUnknownTypeMovie, pyMoviePlayer::kUnknownTypeMovie);
-    PYTHON_ENUM_ELEMENT(PtMovieType, kBinkMovie,        pyMoviePlayer::kBinkMovie);
-    PYTHON_ENUM_END;
+    PYTHON_ENUM_START(PtMovieType)
+    PYTHON_ENUM_ELEMENT(PtMovieType, kUnknownTypeMovie, pyMoviePlayer::kUnknownTypeMovie)
+    PYTHON_ENUM_ELEMENT(PtMovieType, kBinkMovie,        pyMoviePlayer::kBinkMovie)
+    PYTHON_ENUM_END
 }*/

--- a/Sources/Plasma/FeatureLib/pfPython/pyDynamicTextGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDynamicTextGlue.cpp
@@ -449,15 +449,15 @@ void pyDynamicText::AddPlasmaClasses(PyObject *m)
 
 void pyDynamicText::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtJustify);
-    PYTHON_ENUM_ELEMENT(PtJustify, kCenter, plDynamicTextMap::kCenter);
-    PYTHON_ENUM_ELEMENT(PtJustify, kLeftJustify, plDynamicTextMap::kLeftJustify);
-    PYTHON_ENUM_ELEMENT(PtJustify, kRightJustify, plDynamicTextMap::kRightJustify);
-    PYTHON_ENUM_END(m, PtJustify);
+    PYTHON_ENUM_START(PtJustify)
+    PYTHON_ENUM_ELEMENT(PtJustify, kCenter, plDynamicTextMap::kCenter)
+    PYTHON_ENUM_ELEMENT(PtJustify, kLeftJustify, plDynamicTextMap::kLeftJustify)
+    PYTHON_ENUM_ELEMENT(PtJustify, kRightJustify, plDynamicTextMap::kRightJustify)
+    PYTHON_ENUM_END(m, PtJustify)
 
-    PYTHON_ENUM_START(PtFontFlags);
-    PYTHON_ENUM_ELEMENT(PtFontFlags, kFontBold, plDynamicTextMap::kFontBold);
-    PYTHON_ENUM_ELEMENT(PtFontFlags, kFontItalic, plDynamicTextMap::kFontItalic);
-    PYTHON_ENUM_ELEMENT(PtFontFlags, kFontShadowed, plDynamicTextMap::kFontShadowed);
-    PYTHON_ENUM_END(m, PtFontFlags);
+    PYTHON_ENUM_START(PtFontFlags)
+    PYTHON_ENUM_ELEMENT(PtFontFlags, kFontBold, plDynamicTextMap::kFontBold)
+    PYTHON_ENUM_ELEMENT(PtFontFlags, kFontItalic, plDynamicTextMap::kFontItalic)
+    PYTHON_ENUM_ELEMENT(PtFontFlags, kFontShadowed, plDynamicTextMap::kFontShadowed)
+    PYTHON_ENUM_END(m, PtFontFlags)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
@@ -82,20 +82,21 @@ static PyObject* EnumValue_new(PyTypeObject* type, PyObject* args, PyObject*)
     return (PyObject*)self;
 }
 
-static int EnumValue_clear(EnumValue* self)
+static int EnumValue_clear(PyObject* self)
 {
-    Py_CLEAR(self->name);
+    Py_CLEAR(((EnumValue*)self)->name);
     return 0;
 }
 
-static void EnumValue_dealloc(EnumValue* self)
+static void EnumValue_dealloc(PyObject* self)
 {
     EnumValue_clear(self);
-    Py_TYPE(self)->tp_free((PyObject*)self);
+    Py_TYPE(self)->tp_free(self);
 }
 
-static PyObject* EnumValue_repr(EnumValue* self)
+static PyObject* EnumValue_repr(PyObject* obj)
 {
+    EnumValue* self = (EnumValue*)obj;
     if (self->name == nullptr) {
         // no name, so just output our value
         return PyUnicode_FromFormat("%s(%ld)", Py_TYPE(self)->tp_name, self->value);
@@ -292,12 +293,12 @@ PYTHON_TYPE_START(EnumValue)
     "PlasmaConstants.EnumValue",
     sizeof(EnumValue),                  /* tp_basicsize */
     0,                                  /* tp_itemsize */
-    (destructor)EnumValue_dealloc,      /* tp_dealloc */
+    EnumValue_dealloc,                  /* tp_dealloc */
     PYTHON_TP_PRINT_OR_VECTORCALL_OFFSET,
     nullptr,                            /* tp_getattr */
     nullptr,                            /* tp_setattr */
     nullptr,                            /* tp_as_async */
-    (reprfunc)EnumValue_repr,           /* tp_repr */
+    EnumValue_repr,                     /* tp_repr */
     PYTHON_DEFAULT_AS_NUMBER(EnumValue),/* tp_as_number */
     nullptr,                            /* tp_as_sequence */
     nullptr,                            /* tp_as_mapping */
@@ -311,7 +312,7 @@ PYTHON_TYPE_START(EnumValue)
     | Py_TPFLAGS_BASETYPE,              /* tp_flags */
     "A basic enumeration value",        /* tp_doc */
     nullptr,                            /* tp_traverse */
-    (inquiry)EnumValue_clear,           /* tp_clear */
+    EnumValue_clear,                    /* tp_clear */
     EnumValue_richCompare,              /* tp_richcompare */
     0,                                  /* tp_weaklistoffset */
     nullptr,                            /* tp_iter */

--- a/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
@@ -47,8 +47,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //          class
 //
 
-#include "HeadSpin.h"
-#include <Python.h>
 #include <structmember.h>
 
 #include <string_theory/format>
@@ -59,7 +57,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 struct EnumValue {
     PyObject_HEAD
-    hsSsize_t value{};
+    Py_ssize_t value{};
     PyObject* name{};
 };
 
@@ -132,7 +130,7 @@ int EnumValue_nonzero(EnumValue* v)
 PyObject *EnumValue_and(PyObject* v, PyObject* w)
 {
     EnumValue* obj = nullptr;
-    hsSsize_t other = 0;
+    Py_ssize_t other = 0;
     if (IsEnumValue(v)) {
         obj = (EnumValue*)v;
         if (!PyLong_Check(w))
@@ -152,7 +150,7 @@ PyObject *EnumValue_and(PyObject* v, PyObject* w)
 PyObject* EnumValue_xor(PyObject* v, PyObject* w)
 {
     EnumValue *obj = nullptr;
-    hsSsize_t other = 0;
+    Py_ssize_t other = 0;
     if (IsEnumValue(v)) {
         obj = (EnumValue*)v;
         if (!PyLong_Check(w))
@@ -172,7 +170,7 @@ PyObject* EnumValue_xor(PyObject* v, PyObject* w)
 PyObject* EnumValue_or(PyObject *v, PyObject *w)
 {
     EnumValue* obj = nullptr;
-    hsSsize_t other = 0;
+    Py_ssize_t other = 0;
     if (IsEnumValue(v)) {
         obj = (EnumValue*)v;
         if (!PyLong_Check(w))
@@ -241,14 +239,14 @@ PYTHON_END_AS_NUMBER_TABLE;
 
 PYTHON_RICH_COMPARE_DEFINITION(EnumValue, v, w, compareType)
 {
-    hsSsize_t i = 0;
-    hsSsize_t j = 0;
+    Py_ssize_t i = 0;
+    Py_ssize_t j = 0;
     if (IsEnumValue(v)) {
         i = ((EnumValue*)v)->value;
         if (PyLong_Check(w))
             j = PyLong_AsSsize_t(w);
         else if (PyFloat_Check(w))
-            j = (hsSsize_t)PyFloat_AsDouble(w);
+            j = (Py_ssize_t)PyFloat_AsDouble(w);
         else if (IsEnumValue(w))
             j = ((EnumValue*)w)->value;
         else
@@ -259,7 +257,7 @@ PYTHON_RICH_COMPARE_DEFINITION(EnumValue, v, w, compareType)
         if (PyLong_Check(v))
             i = PyLong_AsSsize_t(v);
         else if (PyFloat_Check(v))
-            i = (hsSsize_t)PyFloat_AsDouble(v);
+            i = (Py_ssize_t)PyFloat_AsDouble(v);
         else if (IsEnumValue(v))
             i = ((EnumValue*)v)->value;
         else
@@ -347,7 +345,7 @@ bool IsEnumValue(PyObject* obj)
     return PyObject_TypeCheck(obj, &EnumValue_type);
 }
 
-PyObject* NewEnumValue(const ST::string& name, hsSsize_t value)
+PyObject* NewEnumValue(const ST::string& name, Py_ssize_t value)
 {
     pyObjectRef tempArgs = Py_BuildValue("(ns)", value, name.c_str());
     EnumValue* newObj = (EnumValue*)EnumValue_type.tp_new(&EnumValue_type, tempArgs.Get(), nullptr);
@@ -545,7 +543,7 @@ void pyEnum::AddPlasmaConstantsClasses(PyObject* m)
 }
 
 // makes an enum object using the specified name and values
-void pyEnum::MakeEnum(PyObject* m, const char* name, const std::vector<std::tuple<ST::string, hsSsize_t>>& values)
+void pyEnum::MakeEnum(PyObject* m, const char* name, const std::vector<std::tuple<ST::string, Py_ssize_t>>& values)
 {
     if (m == nullptr)
         return;
@@ -560,7 +558,7 @@ void pyEnum::MakeEnum(PyObject* m, const char* name, const std::vector<std::tupl
         ST::string enumValueName = ST::format("{}.{}", name, key);
 
         pyObjectRef newValue = NewEnumValue(enumValueName, value);
-        pyObjectRef valueObj = PyLong_FromSsize_t((Py_ssize_t)value);
+        pyObjectRef valueObj = PyLong_FromSsize_t(value);
         pyObjectRef keyObj = PyUnicode_FromSTString(key);
         PyDict_SetItem(newEnum->values, valueObj.Get(), newValue.Get());
         PyDict_SetItem(newEnum->lookup, keyObj.Get(), newValue.Get());

--- a/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
@@ -50,212 +50,151 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include <Python.h>
 #include <structmember.h>
-#include "pyGlueHelpers.h"
+
+#include <string_theory/format>
 
 #include "pyEnum.h"
-#include <string_theory/format>
+#include "pyGlueHelpers.h"
+#include "pyObjectRef.h"
 
 struct EnumValue {
     PyObject_HEAD
-    long value;
-    char* name;
+    hsSsize_t value{};
+    PyObject* name{};
 };
 
-PyObject *NewEnumValue(char const* name, long value);
-
-static PyObject *EnumValue_new(PyTypeObject *type, PyObject *args, PyObject *)
+static PyObject* EnumValue_new(PyTypeObject* type, PyObject* args, PyObject*)
 {
     EnumValue *self = (EnumValue*)type->tp_alloc(type, 0);
-    if (self != nullptr)
-    {
-        char *nameTemp = nullptr;
-        long value;
-        if (!PyArg_ParseTuple(args, "l|s", &value, &nameTemp))
-        {
+    if (self != nullptr) {
+        if (!PyArg_ParseTuple(args, "n|O", &self->value, &self->name)) {
             Py_DECREF(self);
             return nullptr;
         }
 
-        if (nameTemp) // copy the value if it was passed
-        {
-            self->name = new char[strlen(nameTemp) + 1];
-            strcpy(self->name, nameTemp);
-            self->name[strlen(nameTemp)] = '\0';
+        if (self->name && !PyUnicode_Check(self->name)) {
+            Py_DECREF(self->name);
+            Py_DECREF(self);
+            return nullptr;
         }
-        else
-            self->name = nullptr;
-        self->value = value;
+
+        Py_XINCREF(self->name);
     }
 
     return (PyObject*)self;
 }
 
-static void EnumValue_dealloc(EnumValue *self)
+static int EnumValue_clear(EnumValue* self)
 {
-    if (self->name)
-        delete [] self->name;
+    Py_CLEAR(self->name);
+    return 0;
+}
+
+static void EnumValue_dealloc(EnumValue* self)
+{
+    EnumValue_clear(self);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
-static PyObject *EnumValue_repr(PyObject *self)
+static PyObject* EnumValue_repr(EnumValue* self)
 {
-    EnumValue *obj = (EnumValue*)self;
-    if (obj->name == nullptr)
-    {
+    if (self->name == nullptr) {
         // no name, so just output our value
-        return PyUnicode_FromFormat("%s(%ld)", Py_TYPE(obj)->tp_name, obj->value);
-    }
-    else
-    {
+        return PyUnicode_FromFormat("%s(%ld)", Py_TYPE(self)->tp_name, self->value);
+    } else {
         // we have a name, so output it
-        return PyUnicode_FromString(obj->name);
-    }
-}
-
-static PyObject* EnumValue_str(PyObject* self)
-{
-    EnumValue *obj = (EnumValue*)self;
-    if (obj->name == nullptr)
-    {
-        // no name, so return our value
-        return PyUnicode_FromFormat("%s(%ld)", Py_TYPE(obj)->tp_name, obj->value);
-    }
-    else
-    {
-        // just return the name
-        return PyUnicode_FromString(obj->name);
+        Py_INCREF(self->name);
+        return self->name;
     }
 }
 
 // forward def because the type object isn't defined yet
-bool IsEnumValue(PyObject *obj);
+bool IsEnumValue(PyObject* obj);
 
-Py_hash_t EnumValue_hash(PyObject *v)
+Py_hash_t EnumValue_hash(PyObject* v)
 {
     // stolen from python's int class
-    if (!IsEnumValue(v))
-    {
+    if (!IsEnumValue(v)) {
         PyErr_SetString(PyExc_TypeError, "hash was passed a non enum value (this would be weird)");
-        return 0;
+        return -1;
     }
-    long x = ((EnumValue*)v)->value;
+    Py_hash_t x = (Py_hash_t)((EnumValue*)v)->value;
     if (x == -1)
         x = -2;
     return x;
 }
 
-int EnumValue_nonzero(EnumValue *v)
+int EnumValue_nonzero(EnumValue* v)
 {
     return v->value != 0;
 }
 
-PyObject *EnumValue_and(PyObject *v, PyObject *w)
+PyObject *EnumValue_and(PyObject* v, PyObject* w)
 {
-    EnumValue *obj = nullptr;
-    long other = 0;
-    if (IsEnumValue(v))
-    {
+    EnumValue* obj = nullptr;
+    hsSsize_t other = 0;
+    if (IsEnumValue(v)) {
         obj = (EnumValue*)v;
         if (!PyLong_Check(w))
-        {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        other = PyLong_AsLong(w);
-    }
-    else if (IsEnumValue(w))
-    {
+            PYTHON_RETURN_NOT_IMPLEMENTED;
+        other = PyLong_AsSsize_t(w);
+    } else if (IsEnumValue(w)) {
         obj = (EnumValue*)w;
         if (!PyLong_Check(v))
-        {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        other = PyLong_AsLong(v);
+            PYTHON_RETURN_NOT_IMPLEMENTED;
+        other = PyLong_AsSsize_t(v);
+    } else {
+        PYTHON_RETURN_NOT_IMPLEMENTED;
     }
-    else
-    {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
-    }
-    return PyLong_FromLong(obj->value & other);
+    return PyLong_FromSsize_t(obj->value & other);
 }
 
-PyObject *EnumValue_xor(PyObject *v, PyObject *w)
+PyObject* EnumValue_xor(PyObject* v, PyObject* w)
 {
     EnumValue *obj = nullptr;
-    long other = 0;
-    if (IsEnumValue(v))
-    {
+    hsSsize_t other = 0;
+    if (IsEnumValue(v)) {
         obj = (EnumValue*)v;
         if (!PyLong_Check(w))
-        {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        other = PyLong_AsLong(w);
-    }
-    else if (IsEnumValue(w))
-    {
+            PYTHON_RETURN_NOT_IMPLEMENTED;
+        other = PyLong_AsSsize_t(w);
+    } else if (IsEnumValue(w)) {
         obj = (EnumValue*)w;
         if (!PyLong_Check(v))
-        {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        other = PyLong_AsLong(v);
+            PYTHON_RETURN_NOT_IMPLEMENTED;
+        other = PyLong_AsSsize_t(v);
+    } else {
+        PYTHON_RETURN_NOT_IMPLEMENTED;
     }
-    else
-    {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
-    }
-    return PyLong_FromLong(obj->value ^ other);
+    return PyLong_FromSsize_t(obj->value ^ other);
 }
 
-PyObject *EnumValue_or(PyObject *v, PyObject *w)
+PyObject* EnumValue_or(PyObject *v, PyObject *w)
 {
-    EnumValue *obj = nullptr;
-    long other = 0;
-    if (IsEnumValue(v))
-    {
+    EnumValue* obj = nullptr;
+    hsSsize_t other = 0;
+    if (IsEnumValue(v)) {
         obj = (EnumValue*)v;
         if (!PyLong_Check(w))
-        {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        other = PyLong_AsLong(w);
-    }
-    else if (IsEnumValue(w))
-    {
+            PYTHON_RETURN_NOT_IMPLEMENTED;
+        other = PyLong_AsSsize_t(w);
+    } else if (IsEnumValue(w)) {
         obj = (EnumValue*)w;
         if (!PyLong_Check(v))
-        {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        other = PyLong_AsLong(v);
-    }
-    else
-    {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
+            PYTHON_RETURN_NOT_IMPLEMENTED;
+        other = PyLong_AsSsize_t(v);
+    } else {
+        PYTHON_RETURN_NOT_IMPLEMENTED;
     }
     return PyLong_FromLong(obj->value | other);
 }
 
-PyObject *EnumValue_int(EnumValue *v)
+PyObject* EnumValue_long(EnumValue* v)
 {
-    return PyLong_FromLong(v->value);
+    return PyLong_FromSsize_t((v->value));
 }
 
-PyObject *EnumValue_long(EnumValue *v)
-{
-    return PyLong_FromLong((v->value));
-}
-
-PyObject *EnumValue_float(EnumValue *v)
+PyObject* EnumValue_float(EnumValue* v)
 {
     return PyFloat_FromDouble((double)(v->value));
 }
@@ -302,14 +241,14 @@ PYTHON_END_AS_NUMBER_TABLE;
 
 PYTHON_RICH_COMPARE_DEFINITION(EnumValue, v, w, compareType)
 {
-    long i = 0;
-    long j = 0;
+    hsSsize_t i = 0;
+    hsSsize_t j = 0;
     if (IsEnumValue(v)) {
         i = ((EnumValue*)v)->value;
         if (PyLong_Check(w))
-            j = PyLong_AsLong(w);
+            j = PyLong_AsSsize_t(w);
         else if (PyFloat_Check(w))
-            j = (long)PyFloat_AsDouble(w);
+            j = (hsSsize_t)PyFloat_AsDouble(w);
         else if (IsEnumValue(w))
             j = ((EnumValue*)w)->value;
         else
@@ -318,9 +257,9 @@ PYTHON_RICH_COMPARE_DEFINITION(EnumValue, v, w, compareType)
     } else if (IsEnumValue(w)) {
         j = ((EnumValue*)w)->value;
         if (PyLong_Check(v))
-            i = PyLong_AsLong(v);
+            i = PyLong_AsSsize_t(v);
         else if (PyFloat_Check(v))
-            i = (long)PyFloat_AsDouble(v);
+            i = (hsSsize_t)PyFloat_AsDouble(v);
         else if (IsEnumValue(v))
             i = ((EnumValue*)v)->value;
         else
@@ -360,13 +299,13 @@ PYTHON_TYPE_START(EnumValue)
     nullptr,                            /* tp_getattr */
     nullptr,                            /* tp_setattr */
     nullptr,                            /* tp_as_async */
-    EnumValue_repr,                     /* tp_repr */
+    (reprfunc)EnumValue_repr,           /* tp_repr */
     PYTHON_DEFAULT_AS_NUMBER(EnumValue),/* tp_as_number */
     nullptr,                            /* tp_as_sequence */
     nullptr,                            /* tp_as_mapping */
     EnumValue_hash,                     /* tp_hash */
     nullptr,                            /* tp_call */
-    EnumValue_str,                      /* tp_str */
+    nullptr,                            /* tp_str */
     nullptr,                            /* tp_getattro */
     nullptr,                            /* tp_setattro */
     nullptr,                            /* tp_as_buffer */
@@ -374,7 +313,7 @@ PYTHON_TYPE_START(EnumValue)
     | Py_TPFLAGS_BASETYPE,              /* tp_flags */
     "A basic enumeration value",        /* tp_doc */
     nullptr,                            /* tp_traverse */
-    nullptr,                            /* tp_clear */
+    (inquiry)EnumValue_clear,           /* tp_clear */
     EnumValue_richCompare,              /* tp_richcompare */
     0,                                  /* tp_weaklistoffset */
     nullptr,                            /* tp_iter */
@@ -403,20 +342,15 @@ PYTHON_TYPE_START(EnumValue)
     PYTHON_TP_VECTORCALL_PRINT
 PYTHON_TYPE_END;
 
-bool IsEnumValue(PyObject *obj)
+bool IsEnumValue(PyObject* obj)
 {
     return PyObject_TypeCheck(obj, &EnumValue_type);
 }
 
-PyObject *NewEnumValue(char const* name, long value)
+PyObject* NewEnumValue(const ST::string& name, hsSsize_t value)
 {
-    PyObject *tempArgs = nullptr;
-    if (name)
-        tempArgs = Py_BuildValue("(ls)", value, name); // args are value, name
-    else
-        tempArgs = Py_BuildValue("(l)", value); // args are value only
-    EnumValue *newObj = (EnumValue*)EnumValue_type.tp_new(&EnumValue_type, tempArgs, nullptr);
-    Py_DECREF(tempArgs); // clean up the temps
+    pyObjectRef tempArgs = Py_BuildValue("(ns)", value, name.c_str());
+    EnumValue* newObj = (EnumValue*)EnumValue_type.tp_new(&EnumValue_type, tempArgs.Get(), nullptr);
     return (PyObject*)newObj;
 }
 
@@ -425,14 +359,14 @@ PyObject *NewEnumValue(char const* name, long value)
 struct Enum
 {
     PyObject_HEAD
-    PyObject *values; // the values list
-    PyObject *lookup; // the enum values, key is enum, value is enum value
-    PyObject *reverseLookup; // the enum values, key is enum value, value is enum
+    PyObject* values; // the values list
+    PyObject* lookup; // the enum values, key is enum, value is enum value
+    PyObject* reverseLookup; // the enum values, key is enum value, value is enum
 };
 
-static PyObject *Enum_new(PyTypeObject *type, PyObject *, PyObject *)
+static PyObject *Enum_new(PyTypeObject* type, PyObject*, PyObject*)
 {
-    Enum *self = (Enum*)type->tp_alloc(type, 0);
+    Enum* self = (Enum*)type->tp_alloc(type, 0);
     if (self != nullptr)
     {
         self->values = PyDict_New();
@@ -458,27 +392,19 @@ static PyObject *Enum_new(PyTypeObject *type, PyObject *, PyObject *)
     return (PyObject*)self;
 }
 
-static int Enum_traverse(Enum *self, visitproc visit, void *arg)
+static int Enum_traverse(Enum* self, visitproc visit, void* arg)
 {
-    if (self->values && visit(self->values, arg) < 0)
-        return -1;
-    if (self->lookup && visit(self->lookup, arg) < 0)
-        return -1;
-    if (self->reverseLookup && visit(self->reverseLookup, arg) < 0)
-        return -1;
-
+    Py_VISIT(self->values);
+    Py_VISIT(self->lookup);
+    Py_VISIT(self->reverseLookup);
     return 0;
 }
 
-static int Enum_clear(Enum *self)
+static int Enum_clear(Enum* self)
 {
-    Py_XDECREF(self->values);
-    self->values = nullptr;
-    Py_XDECREF(self->lookup);
-    self->lookup = nullptr;
-    Py_XDECREF(self->reverseLookup);
-    self->reverseLookup = nullptr;
-
+    Py_CLEAR(self->values);
+    Py_CLEAR(self->lookup);
+    Py_CLEAR(self->reverseLookup);
     return 0;
 }
 
@@ -488,72 +414,66 @@ static void Enum_dealloc(Enum *self)
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
-static PyObject *Enum_getattro(PyObject *self, PyObject *attr_name)
+static PyObject* Enum_getattro(PyObject* self, PyObject* attr_name)
 {
-    if (!PyUnicode_Check(attr_name))
-    {
+    if (!PyUnicode_Check(attr_name)) {
         PyErr_SetString(PyExc_TypeError, "getattro expects a string argument");
         PYTHON_RETURN_ERROR;
     }
-    Enum *theEnum = (Enum*)self;
-    PyObject *item = PyDict_GetItem(theEnum->lookup, attr_name);
-    if (!item)
-    {
-        PyErr_Clear(); // wasn't in the dictionary, check to see if they want the values or lookup dict
-        const char *name = PyUnicode_AsUTF8(attr_name);
-        if (strcmp(name, "values") == 0)
-        {
+
+    Enum* theEnum = (Enum*)self;
+    PyObject* item = PyDict_GetItemWithError(theEnum->lookup, attr_name);
+    if (PyErr_Occurred())
+        PYTHON_RETURN_ERROR;
+
+    if (!item) {
+        ST::string name = PyUnicode_AsSTString(attr_name);
+        if (name == "values") {
             Py_INCREF(theEnum->values);
             return theEnum->values;
-        }
-        else if (strcmp(name, "lookup") == 0)
-        {
+        } else if (name == "lookup") {
             Py_INCREF(theEnum->lookup);
             return theEnum->lookup;
-        }
-        else if (strcmp(name, "reverseLookup") == 0)
-        {
+        } else if (name == "reverseLookup") {
             Py_INCREF(theEnum->reverseLookup);
             return theEnum->reverseLookup;
+        } else {
+            return PyObject_GenericGetAttr(self, attr_name);
         }
-        return PyObject_GenericGetAttr(self, attr_name); // let the default method handle it
     }
     Py_INCREF(item);
     return item;
 }
 
-static int Enum_setattro(PyObject *self, PyObject *attr_name, PyObject *value)
+static int Enum_setattro(PyObject* self, PyObject* attr_name, PyObject* value)
 {
-    if (!PyUnicode_Check(attr_name))
-    {
+    if (!PyUnicode_Check(attr_name)) {
         PyErr_SetString(PyExc_TypeError, "setattro expects a string argument");
         return -1;;
     }
-    Enum *theEnum = (Enum*)self;
-    PyObject *item = PyDict_GetItem(theEnum->lookup, attr_name);
-    if (!item)
-    {
-        PyErr_Clear(); // wasn't in the dictionary, check to see if they want the values or lookup dict
-        const char *name = PyUnicode_AsUTF8(attr_name);
-        if (strcmp(name, "values") == 0)
-        {
+
+    Enum* theEnum = (Enum*)self;
+    PyObject* item = PyDict_GetItemWithError(theEnum->lookup, attr_name);
+    if (PyErr_Occurred())
+        return -1;
+
+    if (!item) {
+        ST::string name = PyUnicode_AsSTString(attr_name);
+        if (name == "values") {
             PyErr_SetString(PyExc_RuntimeError, "Cannot set the value attribute");
             return -1;
-        }
-        else if (strcmp(name, "lookup") == 0)
-        {
+        } else if (name == "lookup") {
             PyErr_SetString(PyExc_RuntimeError, "Cannot set the lookup attribute");
             return -1;
-        }
-        else if (strcmp(name, "reverseLookup") == 0)
-        {
+        } else if (name == "reverseLookup") {
             PyErr_SetString(PyExc_RuntimeError, "Cannot set the reverseLookup attribute");
             return -1;
+        } else {
+            // they aren't trying to set an enum value or any of our special values, so let them
+            return PyObject_GenericSetAttr(self, attr_name, value);
         }
-        // they aren't trying to set an enum value or any of our special values, so let them
-        return PyObject_GenericSetAttr(self, attr_name, value); // let the default method handle it
     }
-    PyErr_SetString(PyExc_RuntimeError, "Cannot set any enum value");
+    PyErr_SetString(PyExc_RuntimeError, "Cannot set an enum value");
     return -1;
 }
 
@@ -616,7 +536,7 @@ PYTHON_TYPE_START(Enum)
 PYTHON_TYPE_END;
 
 // creates and sets up the enum base class
-void pyEnum::AddPlasmaConstantsClasses(PyObject *m)
+void pyEnum::AddPlasmaConstantsClasses(PyObject* m)
 {
     PYTHON_CLASS_IMPORT_START(m);
     PYTHON_CLASS_IMPORT(m, EnumValue);
@@ -625,40 +545,30 @@ void pyEnum::AddPlasmaConstantsClasses(PyObject *m)
 }
 
 // makes an enum object using the specified name and values
-void pyEnum::MakeEnum(PyObject *m, const char* name, std::map<std::string, int> values)
+void pyEnum::MakeEnum(PyObject* m, const char* name, const std::vector<std::tuple<ST::string, hsSsize_t>>& values)
 {
     if (m == nullptr)
         return;
 
-    Enum *newEnum = (Enum*)Enum_type.tp_new(&Enum_type, nullptr, nullptr);
-    if (newEnum == nullptr)
-    {
-        std::string errorStr = "Could not create enum named ";
-        errorStr += name;
-        PyErr_SetString(PyExc_RuntimeError, errorStr.c_str());
+    Enum* newEnum = (Enum*)Enum_type.tp_new(&Enum_type, nullptr, nullptr);
+    if (newEnum == nullptr) {
+        PyErr_Format(PyExc_RuntimeError, "Could not create enum named '%s'", name);
         return;
     }
 
-    PyObject *valuesDict = newEnum->values;
-    PyObject *lookupDict = newEnum->lookup;
-    PyObject *reverseLookupDict = newEnum->reverseLookup;
-    for (std::map<std::string, int>::iterator curValue = values.begin(); curValue != values.end(); curValue++)
-    {
-        std::string key = curValue->first;
-        int value = curValue->second;
-
+    for (const auto& [key, value] : values) {
         ST::string enumValueName = ST::format("{}.{}", name, key);
 
-        PyObject *newValue = NewEnumValue(enumValueName.c_str(), value);
-        PyObject *valueObj = PyLong_FromLong((long)value);
-        PyObject* keyObj = PyUnicode_FromStdString(key);
-        PyDict_SetItem(valuesDict, valueObj, newValue);
-        PyDict_SetItem(lookupDict, keyObj, newValue);
-        PyDict_SetItem(reverseLookupDict, newValue, keyObj);
-        Py_DECREF(keyObj);
-        Py_DECREF(valueObj);
-        Py_DECREF(newValue);
+        pyObjectRef newValue = NewEnumValue(enumValueName, value);
+        pyObjectRef valueObj = PyLong_FromSsize_t((Py_ssize_t)value);
+        pyObjectRef keyObj = PyUnicode_FromSTString(key);
+        PyDict_SetItem(newEnum->values, valueObj.Get(), newValue.Get());
+        PyDict_SetItem(newEnum->lookup, keyObj.Get(), newValue.Get());
+        PyDict_SetItem(newEnum->reverseLookup, newValue.Get(), keyObj.Get());
     }
 
-    PyModule_AddObject(m, name, (PyObject*)newEnum);
+    if (PyModule_AddObject(m, name, (PyObject*)newEnum) < 0) {
+        PyErr_Format(PyExc_RuntimeError, "Could not add enum named '%s' to module", name);
+        Py_DECREF((PyObject*)newEnum);
+    }
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyEnum.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyEnum.h
@@ -42,10 +42,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef pyEnum_h
 #define pyEnum_h
 
-#include <map>
-#include <string>
+#include <tuple>
+#include <vector>
 
 typedef struct _object PyObject;
+namespace ST { class string; }
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -58,8 +59,7 @@ class pyEnum
 {
 public:
     static void AddPlasmaConstantsClasses(PyObject *m);
-    static void RemovePlasmaConstantsClasses(PyObject *m);
-    static void MakeEnum(PyObject *m, const char* name, std::map<std::string, int> values);
+    static void MakeEnum(PyObject *m, const char* name, const std::vector<std::tuple<ST::string, hsSsize_t>>& values);
 };
 
 #endif  // pyEnum_h

--- a/Sources/Plasma/FeatureLib/pfPython/pyEnum.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyEnum.h
@@ -42,10 +42,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef pyEnum_h
 #define pyEnum_h
 
+#include "HeadSpin.h"
+
 #include <tuple>
 #include <vector>
 
-typedef struct _object PyObject;
+#include <Python.h>
+
 namespace ST { class string; }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -59,7 +62,7 @@ class pyEnum
 {
 public:
     static void AddPlasmaConstantsClasses(PyObject *m);
-    static void MakeEnum(PyObject *m, const char* name, const std::vector<std::tuple<ST::string, hsSsize_t>>& values);
+    static void MakeEnum(PyObject *m, const char* name, const std::vector<std::tuple<ST::string, Py_ssize_t>>& values);
 };
 
 #endif  // pyEnum_h

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlButtonGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlButtonGlue.cpp
@@ -136,9 +136,9 @@ void pyGUIControlButton::AddPlasmaClasses(PyObject *m)
 
 void pyGUIControlButton::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtButtonNotifyTypes);
-    PYTHON_ENUM_ELEMENT(PtButtonNotifyTypes, kNotifyOnUp,           pfGUIButtonMod::kNotifyOnUp);
-    PYTHON_ENUM_ELEMENT(PtButtonNotifyTypes, kNotifyOnDown,         pfGUIButtonMod::kNotifyOnDown);
-    PYTHON_ENUM_ELEMENT(PtButtonNotifyTypes, kNotifyOnUpAndDown,    pfGUIButtonMod::kNotifyOnUpAndDown);
-    PYTHON_ENUM_END(m, PtButtonNotifyTypes);
+    PYTHON_ENUM_START(PtButtonNotifyTypes)
+    PYTHON_ENUM_ELEMENT(PtButtonNotifyTypes, kNotifyOnUp,           pfGUIButtonMod::kNotifyOnUp)
+    PYTHON_ENUM_ELEMENT(PtButtonNotifyTypes, kNotifyOnDown,         pfGUIButtonMod::kNotifyOnDown)
+    PYTHON_ENUM_ELEMENT(PtButtonNotifyTypes, kNotifyOnUpAndDown,    pfGUIButtonMod::kNotifyOnUpAndDown)
+    PYTHON_ENUM_END(m, PtButtonNotifyTypes)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
@@ -456,18 +456,18 @@ void pyGUIControlMultiLineEdit::AddPlasmaClasses(PyObject *m)
 
 void pyGUIControlMultiLineEdit::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtGUIMultiLineDirection);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kLineStart,        pfGUIMultiLineEditCtrl::kLineStart);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kLineEnd,          pfGUIMultiLineEditCtrl::kLineEnd);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kBufferStart,      pfGUIMultiLineEditCtrl::kBufferStart);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kBufferEnd,        pfGUIMultiLineEditCtrl::kBufferEnd);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneBack,          pfGUIMultiLineEditCtrl::kOneBack);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneForward,       pfGUIMultiLineEditCtrl::kOneForward);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneWordBack,      pfGUIMultiLineEditCtrl::kOneWordBack);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneWordForward,   pfGUIMultiLineEditCtrl::kOneWordForward);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneLineUp,        pfGUIMultiLineEditCtrl::kOneLineUp);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneLineDown,      pfGUIMultiLineEditCtrl::kOneLineDown);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kPageUp,           pfGUIMultiLineEditCtrl::kPageUp);
-    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kPageDown,         pfGUIMultiLineEditCtrl::kPageDown);
-    PYTHON_ENUM_END(m, PtGUIMultiLineDirection);
+    PYTHON_ENUM_START(PtGUIMultiLineDirection)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kLineStart,        pfGUIMultiLineEditCtrl::kLineStart)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kLineEnd,          pfGUIMultiLineEditCtrl::kLineEnd)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kBufferStart,      pfGUIMultiLineEditCtrl::kBufferStart)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kBufferEnd,        pfGUIMultiLineEditCtrl::kBufferEnd)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneBack,          pfGUIMultiLineEditCtrl::kOneBack)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneForward,       pfGUIMultiLineEditCtrl::kOneForward)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneWordBack,      pfGUIMultiLineEditCtrl::kOneWordBack)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneWordForward,   pfGUIMultiLineEditCtrl::kOneWordForward)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneLineUp,        pfGUIMultiLineEditCtrl::kOneLineUp)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kOneLineDown,      pfGUIMultiLineEditCtrl::kOneLineDown)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kPageUp,           pfGUIMultiLineEditCtrl::kPageUp)
+    PYTHON_ENUM_ELEMENT(PtGUIMultiLineDirection, kPageDown,         pfGUIMultiLineEditCtrl::kPageDown)
+    PYTHON_ENUM_END(m, PtGUIMultiLineDirection)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameScoreGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameScoreGlue.cpp
@@ -409,21 +409,21 @@ void pyGameScore::AddPlasmaClasses(PyObject *m)
 
 void pyGameScore::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtGameScoreTypes);
-    PYTHON_ENUM_ELEMENT(PtGameScoreTypes, kFixed, kScoreTypeFixed);
-    PYTHON_ENUM_ELEMENT(PtGameScoreTypes, kAccumulative, kScoreTypeAccumulative);
-    PYTHON_ENUM_ELEMENT(PtGameScoreTypes, kAccumAllowNegative, kScoreTypeAccumAllowNegative);
-    PYTHON_ENUM_END(m, PtGameScoreTypes);
+    PYTHON_ENUM_START(PtGameScoreTypes)
+    PYTHON_ENUM_ELEMENT(PtGameScoreTypes, kFixed, kScoreTypeFixed)
+    PYTHON_ENUM_ELEMENT(PtGameScoreTypes, kAccumulative, kScoreTypeAccumulative)
+    PYTHON_ENUM_ELEMENT(PtGameScoreTypes, kAccumAllowNegative, kScoreTypeAccumAllowNegative)
+    PYTHON_ENUM_END(m, PtGameScoreTypes)
 
-    PYTHON_ENUM_START(PtScoreRankGroups);
-    PYTHON_ENUM_ELEMENT(PtScoreRankGroups, kIndividual, kScoreRankGroupIndividual);
-    PYTHON_ENUM_ELEMENT(PtScoreRankGroups, kNeighborhood, kScoreRankGroupNeighborhood);
-    PYTHON_ENUM_END(m, PtScoreRankGroups);
+    PYTHON_ENUM_START(PtScoreRankGroups)
+    PYTHON_ENUM_ELEMENT(PtScoreRankGroups, kIndividual, kScoreRankGroupIndividual)
+    PYTHON_ENUM_ELEMENT(PtScoreRankGroups, kNeighborhood, kScoreRankGroupNeighborhood)
+    PYTHON_ENUM_END(m, PtScoreRankGroups)
 
-    PYTHON_ENUM_START(PtScoreTimePeriods);
-    PYTHON_ENUM_ELEMENT(PtScoreTimePeriods, kOverall, kScoreTimePeriodOverall);
-    PYTHON_ENUM_ELEMENT(PtScoreTimePeriods, kYear, kScoreTimePeriodYear);
-    PYTHON_ENUM_ELEMENT(PtScoreTimePeriods, kMonth, kScoreTimePeriodMonth);
-    PYTHON_ENUM_ELEMENT(PtScoreTimePeriods, kDay, kScoreTimePeriodDay);
-    PYTHON_ENUM_END(m, PtScoreTimePeriods);
+    PYTHON_ENUM_START(PtScoreTimePeriods)
+    PYTHON_ENUM_ELEMENT(PtScoreTimePeriods, kOverall, kScoreTimePeriodOverall)
+    PYTHON_ENUM_ELEMENT(PtScoreTimePeriods, kYear, kScoreTimePeriodYear)
+    PYTHON_ENUM_ELEMENT(PtScoreTimePeriods, kMonth, kScoreTimePeriodMonth)
+    PYTHON_ENUM_ELEMENT(PtScoreTimePeriods, kDay, kScoreTimePeriodDay)
+    PYTHON_ENUM_END(m, PtScoreTimePeriods)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -611,12 +611,12 @@ static PyObject *methodName(PyObject *self) /* and now for the actual function *
 /////////////////////////////////////////////////////////////////////
 
 // the start of an enum block
-#define PYTHON_ENUM_START(enumName) std::map<std::string, int> enumName##_enumValues
+#define PYTHON_ENUM_START(enumName) std::vector<std::tuple<ST::string, hsSsize_t>> enumName##_enumValues{
 
 // for each element of the enum
-#define PYTHON_ENUM_ELEMENT(enumName, elementName, elementValue) enumName##_enumValues[#elementName] = elementValue
+#define PYTHON_ENUM_ELEMENT(enumName, elementName, elementValue) std::make_tuple(ST_LITERAL(#elementName), elementValue),
 
 // to finish off and define the enum
-#define PYTHON_ENUM_END(m, enumName) pyEnum::MakeEnum(m, #enumName, enumName##_enumValues)
+#define PYTHON_ENUM_END(m, enumName) }; pyEnum::MakeEnum(m, #enumName, enumName##_enumValues);
 
 #endif // _pyGlueHelpers_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -611,7 +611,7 @@ static PyObject *methodName(PyObject *self) /* and now for the actual function *
 /////////////////////////////////////////////////////////////////////
 
 // the start of an enum block
-#define PYTHON_ENUM_START(enumName) std::vector<std::tuple<ST::string, hsSsize_t>> enumName##_enumValues{
+#define PYTHON_ENUM_START(enumName) std::vector<std::tuple<ST::string, Py_ssize_t>> enumName##_enumValues{
 
 // for each element of the enum
 #define PYTHON_ENUM_ELEMENT(enumName, elementName, elementValue) std::make_tuple(ST_LITERAL(#elementName), elementValue),

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
@@ -350,13 +350,13 @@ void pyJournalBook::AddPlasmaMethods(PyObject* m)
 
 void pyJournalBook::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtBookEventTypes);
-    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyImageLink,         pfJournalBook::kNotifyImageLink);
-    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyShow,              pfJournalBook::kNotifyShow);
-    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyHide,              pfJournalBook::kNotifyHide);
-    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyNextPage,          pfJournalBook::kNotifyNextPage);
-    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyPreviousPage,      pfJournalBook::kNotifyPreviousPage);
-    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyCheckUnchecked,    pfJournalBook::kNotifyCheckUnchecked);
-    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyClose,             pfJournalBook::kNotifyClose);
-    PYTHON_ENUM_END(m, PtBookEventTypes);
+    PYTHON_ENUM_START(PtBookEventTypes)
+    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyImageLink,         pfJournalBook::kNotifyImageLink)
+    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyShow,              pfJournalBook::kNotifyShow)
+    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyHide,              pfJournalBook::kNotifyHide)
+    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyNextPage,          pfJournalBook::kNotifyNextPage)
+    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyPreviousPage,      pfJournalBook::kNotifyPreviousPage)
+    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyCheckUnchecked,    pfJournalBook::kNotifyCheckUnchecked)
+    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyClose,             pfJournalBook::kNotifyClose)
+    PYTHON_ENUM_END(m, PtBookEventTypes)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyMarkerMgrGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyMarkerMgrGlue.cpp
@@ -199,7 +199,7 @@ void pyMarkerMgr::AddPlasmaClasses(PyObject *m)
 
 void pyMarkerMgr::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtMarkerMsgType);
-    PYTHON_ENUM_ELEMENT(PtMarkerMsgType, kMarkerCaptured,   pfMarkerMsg::kMarkerCaptured);
-    PYTHON_ENUM_END(m, PtMarkerMsgType);
+    PYTHON_ENUM_START(PtMarkerMsgType)
+    PYTHON_ENUM_ELEMENT(PtMarkerMsgType, kMarkerCaptured,   pfMarkerMsg::kMarkerCaptured)
+    PYTHON_ENUM_END(m, PtMarkerMsgType)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyMoviePlayerGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyMoviePlayerGlue.cpp
@@ -186,7 +186,7 @@ void pyMoviePlayer::AddPlasmaClasses(PyObject *m)
 
 void pyMoviePlayer::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtMovieEventReason);
-    PYTHON_ENUM_ELEMENT(PtMovieEventReason, kMovieDone, pfMovieEventMsg::kMovieDone);
-    PYTHON_ENUM_END(m, PtMovieEventReason);
+    PYTHON_ENUM_START(PtMovieEventReason)
+    PYTHON_ENUM_ELEMENT(PtMovieEventReason, kMovieDone, pfMovieEventMsg::kMovieDone)
+    PYTHON_ENUM_END(m, PtMovieEventReason)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyNetLinkingMgrGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyNetLinkingMgrGlue.cpp
@@ -196,12 +196,12 @@ void pyNetLinkingMgr::AddPlasmaClasses(PyObject *m)
 
 void pyNetLinkingMgr::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtLinkingRules);
-    PYTHON_ENUM_ELEMENT(PtLinkingRules, kBasicLink,     plNetCommon::LinkingRules::kBasicLink);
-    PYTHON_ENUM_ELEMENT(PtLinkingRules, kOriginalBook,  plNetCommon::LinkingRules::kOriginalBook);
-    PYTHON_ENUM_ELEMENT(PtLinkingRules, kSubAgeBook,    plNetCommon::LinkingRules::kSubAgeBook);
-    PYTHON_ENUM_ELEMENT(PtLinkingRules, kOwnedBook,     plNetCommon::LinkingRules::kOwnedBook);
-    PYTHON_ENUM_ELEMENT(PtLinkingRules, kVisitBook,     plNetCommon::LinkingRules::kVisitBook);
-    PYTHON_ENUM_ELEMENT(PtLinkingRules, kChildAgeBook,  plNetCommon::LinkingRules::kChildAgeBook);
-    PYTHON_ENUM_END(m, PtLinkingRules);
+    PYTHON_ENUM_START(PtLinkingRules)
+    PYTHON_ENUM_ELEMENT(PtLinkingRules, kBasicLink,     plNetCommon::LinkingRules::kBasicLink)
+    PYTHON_ENUM_ELEMENT(PtLinkingRules, kOriginalBook,  plNetCommon::LinkingRules::kOriginalBook)
+    PYTHON_ENUM_ELEMENT(PtLinkingRules, kSubAgeBook,    plNetCommon::LinkingRules::kSubAgeBook)
+    PYTHON_ENUM_ELEMENT(PtLinkingRules, kOwnedBook,     plNetCommon::LinkingRules::kOwnedBook)
+    PYTHON_ENUM_ELEMENT(PtLinkingRules, kVisitBook,     plNetCommon::LinkingRules::kVisitBook)
+    PYTHON_ENUM_ELEMENT(PtLinkingRules, kChildAgeBook,  plNetCommon::LinkingRules::kChildAgeBook)
+    PYTHON_ENUM_END(m, PtLinkingRules)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyNotifyGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyNotifyGlue.cpp
@@ -454,42 +454,42 @@ void pyNotify::AddPlasmaClasses(PyObject *m)
 
 void pyNotify::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtNotificationType);
-    PYTHON_ENUM_ELEMENT(PtNotificationType, kActivator,             plNotifyMsg::kActivator);
-    PYTHON_ENUM_ELEMENT(PtNotificationType, kVarNotification,       plNotifyMsg::kVarNotification);
-    PYTHON_ENUM_ELEMENT(PtNotificationType, kNotifySelf,            plNotifyMsg::kNotifySelf);
-    PYTHON_ENUM_ELEMENT(PtNotificationType, kResponderFF,           plNotifyMsg::kResponderFF);
-    PYTHON_ENUM_ELEMENT(PtNotificationType, kResponderChangeState,  plNotifyMsg::kResponderChangeState);
-    PYTHON_ENUM_END(m, PtNotificationType);
+    PYTHON_ENUM_START(PtNotificationType)
+    PYTHON_ENUM_ELEMENT(PtNotificationType, kActivator,             plNotifyMsg::kActivator)
+    PYTHON_ENUM_ELEMENT(PtNotificationType, kVarNotification,       plNotifyMsg::kVarNotification)
+    PYTHON_ENUM_ELEMENT(PtNotificationType, kNotifySelf,            plNotifyMsg::kNotifySelf)
+    PYTHON_ENUM_ELEMENT(PtNotificationType, kResponderFF,           plNotifyMsg::kResponderFF)
+    PYTHON_ENUM_ELEMENT(PtNotificationType, kResponderChangeState,  plNotifyMsg::kResponderChangeState)
+    PYTHON_ENUM_END(m, PtNotificationType)
 
-    PYTHON_ENUM_START(PtEventType);
-    PYTHON_ENUM_ELEMENT(PtEventType, kCollision,        proEventData::kCollision);
-    PYTHON_ENUM_ELEMENT(PtEventType, kPicked,           proEventData::kPicked);
-    PYTHON_ENUM_ELEMENT(PtEventType, kControlKey,       proEventData::kControlKey);
-    PYTHON_ENUM_ELEMENT(PtEventType, kVariable,         proEventData::kVariable);
-    PYTHON_ENUM_ELEMENT(PtEventType, kFacing,           proEventData::kFacing);
-    PYTHON_ENUM_ELEMENT(PtEventType, kContained,        proEventData::kContained);
-    PYTHON_ENUM_ELEMENT(PtEventType, kActivate,         proEventData::kActivate);
-    PYTHON_ENUM_ELEMENT(PtEventType, kCallback,         proEventData::kCallback);
-    PYTHON_ENUM_ELEMENT(PtEventType, kResponderState,   proEventData::kResponderState);
-    PYTHON_ENUM_ELEMENT(PtEventType, kMultiStage,       proEventData::kMultiStage);
-    PYTHON_ENUM_ELEMENT(PtEventType, kSpawned,          proEventData::kSpawned);
-    PYTHON_ENUM_ELEMENT(PtEventType, kClickDrag,        proEventData::kClickDrag);
-    PYTHON_ENUM_ELEMENT(PtEventType, kOfferLinkingBook, proEventData::kOfferLinkingBook);
-    PYTHON_ENUM_ELEMENT(PtEventType, kBook,             proEventData::kBook);
-    PYTHON_ENUM_END(m, PtEventType);
+    PYTHON_ENUM_START(PtEventType)
+    PYTHON_ENUM_ELEMENT(PtEventType, kCollision,        proEventData::kCollision)
+    PYTHON_ENUM_ELEMENT(PtEventType, kPicked,           proEventData::kPicked)
+    PYTHON_ENUM_ELEMENT(PtEventType, kControlKey,       proEventData::kControlKey)
+    PYTHON_ENUM_ELEMENT(PtEventType, kVariable,         proEventData::kVariable)
+    PYTHON_ENUM_ELEMENT(PtEventType, kFacing,           proEventData::kFacing)
+    PYTHON_ENUM_ELEMENT(PtEventType, kContained,        proEventData::kContained)
+    PYTHON_ENUM_ELEMENT(PtEventType, kActivate,         proEventData::kActivate)
+    PYTHON_ENUM_ELEMENT(PtEventType, kCallback,         proEventData::kCallback)
+    PYTHON_ENUM_ELEMENT(PtEventType, kResponderState,   proEventData::kResponderState)
+    PYTHON_ENUM_ELEMENT(PtEventType, kMultiStage,       proEventData::kMultiStage)
+    PYTHON_ENUM_ELEMENT(PtEventType, kSpawned,          proEventData::kSpawned)
+    PYTHON_ENUM_ELEMENT(PtEventType, kClickDrag,        proEventData::kClickDrag)
+    PYTHON_ENUM_ELEMENT(PtEventType, kOfferLinkingBook, proEventData::kOfferLinkingBook)
+    PYTHON_ENUM_ELEMENT(PtEventType, kBook,             proEventData::kBook)
+    PYTHON_ENUM_END(m, PtEventType)
 
-    PYTHON_ENUM_START(PtNotifyDataType);
-    PYTHON_ENUM_ELEMENT(PtNotifyDataType, kFloat,  proEventData::kFloat);
-    PYTHON_ENUM_ELEMENT(PtNotifyDataType, kInt,  proEventData::kInt);
-    PYTHON_ENUM_ELEMENT(PtNotifyDataType, kNull,  proEventData::kNull);
-    PYTHON_ENUM_ELEMENT(PtNotifyDataType, kKey,     proEventData::kKey);
-    PYTHON_ENUM_END(m, PtNotifyDataType);
+    PYTHON_ENUM_START(PtNotifyDataType)
+    PYTHON_ENUM_ELEMENT(PtNotifyDataType, kFloat,  proEventData::kFloat)
+    PYTHON_ENUM_ELEMENT(PtNotifyDataType, kInt,  proEventData::kInt)
+    PYTHON_ENUM_ELEMENT(PtNotifyDataType, kNull,  proEventData::kNull)
+    PYTHON_ENUM_ELEMENT(PtNotifyDataType, kKey,     proEventData::kKey)
+    PYTHON_ENUM_END(m, PtNotifyDataType)
 
-    PYTHON_ENUM_START(PtMultiStageEventType);
-    PYTHON_ENUM_ELEMENT(PtMultiStageEventType, kEnterStage,         proEventData::kEnterStage);
-    PYTHON_ENUM_ELEMENT(PtMultiStageEventType, kBeginingOfLoop,     proEventData::kBeginingOfLoop);
-    PYTHON_ENUM_ELEMENT(PtMultiStageEventType, kAdvanceNextStage,   proEventData::kAdvanceNextStage);
-    PYTHON_ENUM_ELEMENT(PtMultiStageEventType, kRegressPrevStage,   proEventData::kRegressPrevStage);
-    PYTHON_ENUM_END(m, PtMultiStageEventType);
+    PYTHON_ENUM_START(PtMultiStageEventType)
+    PYTHON_ENUM_ELEMENT(PtMultiStageEventType, kEnterStage,         proEventData::kEnterStage)
+    PYTHON_ENUM_ELEMENT(PtMultiStageEventType, kBeginingOfLoop,     proEventData::kBeginingOfLoop)
+    PYTHON_ENUM_ELEMENT(PtMultiStageEventType, kAdvanceNextStage,   proEventData::kAdvanceNextStage)
+    PYTHON_ENUM_ELEMENT(PtMultiStageEventType, kRegressPrevStage,   proEventData::kRegressPrevStage)
+    PYTHON_ENUM_END(m, PtMultiStageEventType)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pySDLGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySDLGlue.cpp
@@ -49,34 +49,34 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 void pySDL::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtSDLReadWriteOptions);
-    PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kDirtyOnly,              plSDL::kDirtyOnly);
-    PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kSkipNotificationInfo,   plSDL::kSkipNotificationInfo);
-    PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kBroadcast,              plSDL::kBroadcast);
-    //PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kWriteTimeStamps,      plSDL::kWriteTimeStamps);
-    PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kTimeStampOnRead,        plSDL::kTimeStampOnRead);
-    //PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kTimeStampDirtyOnRead, plSDL::kTimeStampDirtyOnRead);
-    PYTHON_ENUM_END(m, PtSDLReadWriteOptions);
+    PYTHON_ENUM_START(PtSDLReadWriteOptions)
+    PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kDirtyOnly,              plSDL::kDirtyOnly)
+    PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kSkipNotificationInfo,   plSDL::kSkipNotificationInfo)
+    PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kBroadcast,              plSDL::kBroadcast)
+    //PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kWriteTimeStamps,      plSDL::kWriteTimeStamps)
+    PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kTimeStampOnRead,        plSDL::kTimeStampOnRead)
+    //PYTHON_ENUM_ELEMENT(PtSDLReadWriteOptions, kTimeStampDirtyOnRead, plSDL::kTimeStampDirtyOnRead)
+    PYTHON_ENUM_END(m, PtSDLReadWriteOptions)
     
-    PYTHON_ENUM_START(PtSDLVarType);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kNone,            plVarDescriptor::kNone);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kInt,             plVarDescriptor::kInt);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kFloat,           plVarDescriptor::kFloat);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kBool,            plVarDescriptor::kBool);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kString32,        plVarDescriptor::kString32);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kKey,             plVarDescriptor::kKey);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kStateDescriptor, plVarDescriptor::kStateDescriptor);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kCreatable,       plVarDescriptor::kCreatable);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kDouble,          plVarDescriptor::kDouble);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kTime,            plVarDescriptor::kTime);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kVector3,         plVarDescriptor::kVector3);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kPoint3,          plVarDescriptor::kPoint3);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kRGB,             plVarDescriptor::kRGB);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kRGBA,            plVarDescriptor::kRGBA);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kQuaternion,      plVarDescriptor::kQuaternion);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kByte,            plVarDescriptor::kByte);
-    PYTHON_ENUM_ELEMENT(PtSDLVarType, kShort,           plVarDescriptor::kShort);
-    PYTHON_ENUM_END(m, PtSDLVarType);
+    PYTHON_ENUM_START(PtSDLVarType)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kNone,            plVarDescriptor::kNone)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kInt,             plVarDescriptor::kInt)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kFloat,           plVarDescriptor::kFloat)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kBool,            plVarDescriptor::kBool)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kString32,        plVarDescriptor::kString32)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kKey,             plVarDescriptor::kKey)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kStateDescriptor, plVarDescriptor::kStateDescriptor)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kCreatable,       plVarDescriptor::kCreatable)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kDouble,          plVarDescriptor::kDouble)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kTime,            plVarDescriptor::kTime)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kVector3,         plVarDescriptor::kVector3)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kPoint3,          plVarDescriptor::kPoint3)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kRGB,             plVarDescriptor::kRGB)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kRGBA,            plVarDescriptor::kRGBA)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kQuaternion,      plVarDescriptor::kQuaternion)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kByte,            plVarDescriptor::kByte)
+    PYTHON_ENUM_ELEMENT(PtSDLVarType, kShort,           plVarDescriptor::kShort)
+    PYTHON_ENUM_END(m, PtSDLVarType)
 }
 
 // glue functions

--- a/Sources/Plasma/FeatureLib/pfPython/pyStatusLogGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyStatusLogGlue.cpp
@@ -140,16 +140,16 @@ void pyStatusLog::AddPlasmaClasses(PyObject *m)
 
 void pyStatusLog::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtStatusLogFlags);
-    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kFilledBackground,    plStatusLog::kFilledBackground);
-    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kAppendToLast,        plStatusLog::kAppendToLast);
-    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kDontWriteFile,       plStatusLog::kDontWriteFile);
-    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kDeleteForMe,         plStatusLog::kDeleteForMe);
-    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kAlignToTop,          plStatusLog::kAlignToTop);
-    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kDebugOutput,         plStatusLog::kDebugOutput);
-    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kTimestamp,           plStatusLog::kTimestamp);
-    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kStdout,              plStatusLog::kStdout);
-    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kTimeInSeconds,       plStatusLog::kTimeInSeconds);
-    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kTimeAsDouble,        plStatusLog::kTimeAsDouble);
-    PYTHON_ENUM_END(m, PtStatusLogFlags);
+    PYTHON_ENUM_START(PtStatusLogFlags)
+    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kFilledBackground,    plStatusLog::kFilledBackground)
+    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kAppendToLast,        plStatusLog::kAppendToLast)
+    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kDontWriteFile,       plStatusLog::kDontWriteFile)
+    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kDeleteForMe,         plStatusLog::kDeleteForMe)
+    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kAlignToTop,          plStatusLog::kAlignToTop)
+    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kDebugOutput,         plStatusLog::kDebugOutput)
+    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kTimestamp,           plStatusLog::kTimestamp)
+    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kStdout,              plStatusLog::kStdout)
+    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kTimeInSeconds,       plStatusLog::kTimeInSeconds)
+    PYTHON_ENUM_ELEMENT(PtStatusLogFlags, kTimeAsDouble,        plStatusLog::kTimeAsDouble)
+    PYTHON_ENUM_END(m, PtStatusLogFlags)
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultGlue.cpp
@@ -545,76 +545,76 @@ void pyVault::AddPlasmaClasses(PyObject *m)
 
 void pyVault::AddPlasmaConstantsClasses(PyObject *m)
 {
-    PYTHON_ENUM_START(PtVaultNodeTypes);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kInvalidNode,             plVault::kNodeType_Invalid);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kVNodeMgrPlayerNode,      plVault::kNodeType_VNodeMgrPlayer);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kVNodeMgrAgeNode,         plVault::kNodeType_VNodeMgrAge);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kFolderNode,              plVault::kNodeType_Folder);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kPlayerInfoNode,          plVault::kNodeType_PlayerInfo);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kImageNode,               plVault::kNodeType_Image);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kTextNoteNode,            plVault::kNodeType_TextNote);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kSDLNode,                 plVault::kNodeType_SDL);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kAgeLinkNode,             plVault::kNodeType_AgeLink);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kChronicleNode,           plVault::kNodeType_Chronicle);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kPlayerInfoListNode,      plVault::kNodeType_PlayerInfoList);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kAgeInfoNode,             plVault::kNodeType_AgeInfo);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kAgeInfoListNode,         plVault::kNodeType_AgeInfoList);
-    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kMarkerGameNode,          plVault::kNodeType_MarkerGame);
-    PYTHON_ENUM_END(m, PtVaultNodeTypes);
+    PYTHON_ENUM_START(PtVaultNodeTypes)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kInvalidNode,             plVault::kNodeType_Invalid)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kVNodeMgrPlayerNode,      plVault::kNodeType_VNodeMgrPlayer)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kVNodeMgrAgeNode,         plVault::kNodeType_VNodeMgrAge)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kFolderNode,              plVault::kNodeType_Folder)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kPlayerInfoNode,          plVault::kNodeType_PlayerInfo)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kImageNode,               plVault::kNodeType_Image)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kTextNoteNode,            plVault::kNodeType_TextNote)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kSDLNode,                 plVault::kNodeType_SDL)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kAgeLinkNode,             plVault::kNodeType_AgeLink)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kChronicleNode,           plVault::kNodeType_Chronicle)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kPlayerInfoListNode,      plVault::kNodeType_PlayerInfoList)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kAgeInfoNode,             plVault::kNodeType_AgeInfo)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kAgeInfoListNode,         plVault::kNodeType_AgeInfoList)
+    PYTHON_ENUM_ELEMENT(PtVaultNodeTypes, kMarkerGameNode,          plVault::kNodeType_MarkerGame)
+    PYTHON_ENUM_END(m, PtVaultNodeTypes)
 
-    PYTHON_ENUM_START(PtVaultStandardNodes);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kUserDefinedNode,             plVault::kUserDefinedNode);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kInboxFolder,                 plVault::kInboxFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kBuddyListFolder,             plVault::kBuddyListFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kIgnoreListFolder,            plVault::kIgnoreListFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kPeopleIKnowAboutFolder,      plVault::kPeopleIKnowAboutFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kChronicleFolder,             plVault::kChronicleFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAvatarOutfitFolder,          plVault::kAvatarOutfitFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgeTypeJournalFolder,        plVault::kAgeTypeJournalFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kSubAgesFolder,               plVault::kSubAgesFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kHoodMembersFolder,           plVault::kHoodMembersFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAllPlayersFolder,            plVault::kAllPlayersFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAllAgeGlobalSDLNodesFolder,  plVault::kAllAgeGlobalSDLNodesFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgeMembersFolder,            plVault::kAgeMembersFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgeJournalsFolder,           plVault::kAgeJournalsFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgeInstanceSDLNode,          plVault::kAgeInstanceSDLNode);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kCanVisitFolder,              plVault::kCanVisitFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgeOwnersFolder,             plVault::kAgeOwnersFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kPlayerInfoNode,              plVault::kPlayerInfoNode);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kPublicAgesFolder,            plVault::kPublicAgesFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgesIOwnFolder,              plVault::kAgesIOwnFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgesICanVisitFolder,         plVault::kAgesICanVisitFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAvatarClosetFolder,          plVault::kAvatarClosetFolder);
-    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kGlobalInboxFolder,           plVault::kGlobalInboxFolder);
-    PYTHON_ENUM_END(m, PtVaultStandardNodes);
+    PYTHON_ENUM_START(PtVaultStandardNodes)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kUserDefinedNode,             plVault::kUserDefinedNode)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kInboxFolder,                 plVault::kInboxFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kBuddyListFolder,             plVault::kBuddyListFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kIgnoreListFolder,            plVault::kIgnoreListFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kPeopleIKnowAboutFolder,      plVault::kPeopleIKnowAboutFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kChronicleFolder,             plVault::kChronicleFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAvatarOutfitFolder,          plVault::kAvatarOutfitFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgeTypeJournalFolder,        plVault::kAgeTypeJournalFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kSubAgesFolder,               plVault::kSubAgesFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kHoodMembersFolder,           plVault::kHoodMembersFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAllPlayersFolder,            plVault::kAllPlayersFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAllAgeGlobalSDLNodesFolder,  plVault::kAllAgeGlobalSDLNodesFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgeMembersFolder,            plVault::kAgeMembersFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgeJournalsFolder,           plVault::kAgeJournalsFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgeInstanceSDLNode,          plVault::kAgeInstanceSDLNode)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kCanVisitFolder,              plVault::kCanVisitFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgeOwnersFolder,             plVault::kAgeOwnersFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kPlayerInfoNode,              plVault::kPlayerInfoNode)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kPublicAgesFolder,            plVault::kPublicAgesFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgesIOwnFolder,              plVault::kAgesIOwnFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAgesICanVisitFolder,         plVault::kAgesICanVisitFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kAvatarClosetFolder,          plVault::kAvatarClosetFolder)
+    PYTHON_ENUM_ELEMENT(PtVaultStandardNodes, kGlobalInboxFolder,           plVault::kGlobalInboxFolder)
+    PYTHON_ENUM_END(m, PtVaultStandardNodes)
 
-    PYTHON_ENUM_START(PtVaultTextNoteTypes);
-    PYTHON_ENUM_ELEMENT(PtVaultTextNoteTypes, kGeneric,     plVault::kNoteType_Generic);
-    PYTHON_ENUM_ELEMENT(PtVaultTextNoteTypes, kCCRPetition, plVault::kNoteType_CCRPetition);
-    PYTHON_ENUM_END(m, PtVaultTextNoteTypes);
+    PYTHON_ENUM_START(PtVaultTextNoteTypes)
+    PYTHON_ENUM_ELEMENT(PtVaultTextNoteTypes, kGeneric,     plVault::kNoteType_Generic)
+    PYTHON_ENUM_ELEMENT(PtVaultTextNoteTypes, kCCRPetition, plVault::kNoteType_CCRPetition)
+    PYTHON_ENUM_END(m, PtVaultTextNoteTypes)
     
-    PYTHON_ENUM_START(PtVaultTextNoteSubTypes);
-    PYTHON_ENUM_ELEMENT(PtVaultTextNoteSubTypes, kGeneric, plVault::kNoteSubType_Generic);
-    PYTHON_ENUM_END(m, PtVaultTextNoteSubTypes);
+    PYTHON_ENUM_START(PtVaultTextNoteSubTypes)
+    PYTHON_ENUM_ELEMENT(PtVaultTextNoteSubTypes, kGeneric, plVault::kNoteSubType_Generic)
+    PYTHON_ENUM_END(m, PtVaultTextNoteSubTypes)
 
-    PYTHON_ENUM_START(PtVaultCallbackTypes);
-    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultConnected,          pyVault::kVaultConnected);
-    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultNodeSaved,          pyVault::kVaultNodeSaved);
-    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultNodeRefAdded,       pyVault::kVaultNodeRefAdded);
-    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultRemovingNodeRef,    pyVault::kVaultRemovingNodeRef);
-    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultNodeRefRemoved,     pyVault::kVaultNodeRefRemoved);
-    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultNodeInitialized,    pyVault::kVaultNodeInitialized);
-    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultOperationFailed,    pyVault::kVaultOperationFailed);
-    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultNodeAdded,          pyVault::kVaultNodeAdded);
-    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultDisconnected,       pyVault::kVaultDisconnected);
-    PYTHON_ENUM_END(m, PtVaultCallbackTypes);
+    PYTHON_ENUM_START(PtVaultCallbackTypes)
+    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultConnected,          pyVault::kVaultConnected)
+    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultNodeSaved,          pyVault::kVaultNodeSaved)
+    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultNodeRefAdded,       pyVault::kVaultNodeRefAdded)
+    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultRemovingNodeRef,    pyVault::kVaultRemovingNodeRef)
+    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultNodeRefRemoved,     pyVault::kVaultNodeRefRemoved)
+    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultNodeInitialized,    pyVault::kVaultNodeInitialized)
+    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultOperationFailed,    pyVault::kVaultOperationFailed)
+    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultNodeAdded,          pyVault::kVaultNodeAdded)
+    PYTHON_ENUM_ELEMENT(PtVaultCallbackTypes, kVaultDisconnected,       pyVault::kVaultDisconnected)
+    PYTHON_ENUM_END(m, PtVaultCallbackTypes)
 
-    PYTHON_ENUM_START(PtVaultNotifyTypes);
-    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kRegisteredOwnedAge, plVaultNotifyMsg::kRegisteredOwnedAge);
-    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kRegisteredVisitAge, plVaultNotifyMsg::kRegisteredVisitAge);
-    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kUnRegisteredOwnedAge, plVaultNotifyMsg::kUnRegisteredOwnedAge);
-    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kUnRegisteredVisitAge, plVaultNotifyMsg::kUnRegisteredVisitAge);
-    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kPublicAgeCreated, plVaultNotifyMsg::kPublicAgeCreated);
-    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kPublicAgeRemoved, plVaultNotifyMsg::kPublicAgeRemoved);
-    PYTHON_ENUM_END(m, PtVaultNotifyTypes);
+    PYTHON_ENUM_START(PtVaultNotifyTypes)
+    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kRegisteredOwnedAge, plVaultNotifyMsg::kRegisteredOwnedAge)
+    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kRegisteredVisitAge, plVaultNotifyMsg::kRegisteredVisitAge)
+    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kUnRegisteredOwnedAge, plVaultNotifyMsg::kUnRegisteredOwnedAge)
+    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kUnRegisteredVisitAge, plVaultNotifyMsg::kUnRegisteredVisitAge)
+    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kPublicAgeCreated, plVaultNotifyMsg::kPublicAgeCreated)
+    PYTHON_ENUM_ELEMENT(PtVaultNotifyTypes, kPublicAgeRemoved, plVaultNotifyMsg::kPublicAgeRemoved)
+    PYTHON_ENUM_END(m, PtVaultNotifyTypes)
 }


### PR DESCRIPTION
The following issues were corrected:
- Fixed a ~hypothetical~ memory leak when adding the enum object to the module fails. (Apparently this leak is not so hypothetical. VLD says this fixes many leaks.)
- Fixed the failure return for EnumValue_hash to actually indicate failure.
- Avoided copying an std::map.
- Replaced an std::map used only for iteration with a vector of tuples.
- Fixed the code style such that I no longer want to stab my eyes out.

Sorry about the noise from all the semicolon removals 😞 