### PR TITLE
First class clang-tidy support.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,5 @@
+Checks: '-*,modernize-use-override,modernize-use-nullptr'
+CheckOptions:
+    - key: modernize-use-override.IgnoreDestructors
+      value: '1'
+HeaderFilterRegex: 'Sources[\\|\/].*'

--- a/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //          class
 //
 
+#include <Python.h>
 #include <structmember.h>
 
 #include <string_theory/format>

--- a/Sources/Plasma/PubUtilLib/plMessage/plConnectedToVaultMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plConnectedToVaultMsg.h
@@ -58,8 +58,8 @@ public:
    plConnectedToVaultMsg() { SetBCastFlag(kBCastByType);   }
 
    // IO 
-   void Read(hsStream* stream, hsResMgr* mgr) { plMessage::IMsgRead(stream, mgr); }
-   void Write(hsStream* stream, hsResMgr* mgr)  {   plMessage::IMsgWrite(stream, mgr); }
+   void Read(hsStream* stream, hsResMgr* mgr) override { plMessage::IMsgRead(stream, mgr); }
+   void Write(hsStream* stream, hsResMgr* mgr) override { plMessage::IMsgWrite(stream, mgr); }
 };
 
 #endif      // plConnectedToVaultMsg

--- a/Sources/Plasma/PubUtilLib/plMessage/plSpawnModMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plSpawnModMsg.h
@@ -68,14 +68,14 @@ public:
     plUoid      fObj;
 
     // IO 
-    void Read(hsStream* stream, hsResMgr* mgr)
+    void Read(hsStream* stream, hsResMgr* mgr) override
     {
         plMessage::IMsgRead(stream, mgr);
         fPos.Read(stream);
         fObj.Read(stream);
     }
 
-    void Write(hsStream* stream, hsResMgr* mgr)
+    void Write(hsStream* stream, hsResMgr* mgr) override
     {
         plMessage::IMsgWrite(stream, mgr);
         fPos.Write(stream);

--- a/Sources/Plasma/PubUtilLib/plMessage/plSpawnRequestMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plSpawnRequestMsg.h
@@ -63,12 +63,12 @@ public:
     GETINTERFACE_ANY( plSpawnRequestMsg, plMessage );
     
     // IO 
-    void Read(hsStream* stream, hsResMgr* mgr)
+    void Read(hsStream* stream, hsResMgr* mgr) override
     {
         plMessage::IMsgRead(stream, mgr);
     }
 
-    void Write(hsStream* stream, hsResMgr* mgr)
+    void Write(hsStream* stream, hsResMgr* mgr) override
     {
         plMessage::IMsgWrite(stream, mgr);
     }

--- a/Sources/Plasma/PubUtilLib/plMessage/plTriggerMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plTriggerMsg.h
@@ -62,8 +62,8 @@ public:
     GETINTERFACE_ANY( plTriggerMsg, plMessage );
 
     // IO 
-    void Read(hsStream* stream, hsResMgr* mgr) {    plMessage::IMsgRead(stream, mgr);   }
-    void Write(hsStream* stream, hsResMgr* mgr) {   plMessage::IMsgWrite(stream, mgr);  }
+    void Read(hsStream* stream, hsResMgr* mgr) override { plMessage::IMsgRead(stream, mgr); }
+    void Write(hsStream* stream, hsResMgr* mgr) override { plMessage::IMsgWrite(stream, mgr); }
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXBufferRefs.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXBufferRefs.h
@@ -121,7 +121,7 @@ class plDXVertexBufferRef : public plDXDeviceRef
         }
 
         virtual ~plDXVertexBufferRef();
-        void    Release();
+        void    Release() override;
 };
 
 class plDXIndexBufferRef : public plDXDeviceRef
@@ -167,7 +167,7 @@ class plDXIndexBufferRef : public plDXDeviceRef
         }
 
         virtual ~plDXIndexBufferRef();
-        void    Release();
+        void    Release() override;
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXLightRef.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXLightRef.h
@@ -83,7 +83,7 @@ class plDXLightRef : public plDXDeviceRef
         { }
 
         virtual ~plDXLightRef();
-        void    Release();
+        void    Release() override;
 
         void    UpdateD3DInfo( IDirect3DDevice9 *dev, plDXLightSettings *settings );
 };

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -11576,7 +11576,7 @@ void plDXPipeline::IRenderShadowsOntoSpan(const plRenderPrimFunc& render, const 
                 if( selfShadowNow )
                 {
                     plConst(float) kMaxSelfPower = 0.3f;
-                    float power = fShadows[i]->fPower > kMaxSelfPower ? kMaxSelfPower : fShadows[i]->fPower;
+                    float power = fShadows[i]->fPower > kMaxSelfPower ? (float)kMaxSelfPower : fShadows[i]->fPower;
                     lRef->fD3DInfo.Diffuse.r 
                         = lRef->fD3DInfo.Diffuse.g 
                         = lRef->fD3DInfo.Diffuse.b

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -2332,7 +2332,8 @@ bool  plDXPipeline::PreRender(plDrawable* drawable, std::vector<int16_t>& visLis
         int i;
         for( i = 0; i < bndList.GetCount(); i++ )
         {
-            IAddBoundsSpan( fBoundsSpans, &hsBounds3Ext(drawable->GetSpaceTree()->GetNode(bndList[i]).GetWorldBounds()), 0xff000000 | (0xf << ((fSettings.fBoundsDrawLevel % 6) << 2)) );
+            const hsBounds3Ext& nodeBounds = drawable->GetSpaceTree()->GetNode(bndList[i]).GetWorldBounds();
+            IAddBoundsSpan( fBoundsSpans, &nodeBounds, 0xff000000 | (0xf << ((fSettings.fBoundsDrawLevel % 6) << 2)) );
         }
     }
 #endif // MF_BOUNDS_LEVEL_ICE
@@ -6627,7 +6628,8 @@ void plDXPipeline::ISetBumpMatrices(const plLayerInterface* layer, const plSpan*
     float uvwScale = kUVWScale;
     if( fLayerState[0].fBlendFlags & hsGMatState::kBlendAdd )
     {
-        hsVector3 cam2span(&GetViewPositionWorld(), &spanPos);
+        hsPoint3 viewPos = GetViewPositionWorld();
+        hsVector3 cam2span(&viewPos, &spanPos);
         hsFastMath::NormalizeAppr(cam2span);
         liDir += cam2span;
         hsFastMath::NormalizeAppr(liDir);

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXRenderTargetRef.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXRenderTargetRef.h
@@ -97,7 +97,7 @@ class plDXRenderTargetRef: public plDXTextureRef
         }
 
         virtual ~plDXRenderTargetRef();
-        void    Release();
+        void    Release() override;
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXTextureRef.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXTextureRef.h
@@ -115,7 +115,7 @@ class plDXTextureRef : public plDXDeviceRef
         void            Link( plDXTextureRef **back ) { plDXDeviceRef::Link( (plDXDeviceRef **)back ); }
         plDXTextureRef  *GetNext() { return (plDXTextureRef *)fNext; }
 
-        void    Release();
+        void    Release() override;
 };
 
 class plDXCubeTextureRef : public plDXTextureRef

--- a/Sources/Tools/MaxComponent/CMakeLists.txt
+++ b/Sources/Tools/MaxComponent/CMakeLists.txt
@@ -169,6 +169,7 @@ plasma_library(MaxComponent
     SOURCES ${MaxComponent_HEADERS} ${MaxComponent_RESOURCES} ${MaxComponent_SOURCES}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h
+    NO_SANITIZE # The 3ds Max headers are full of clang diagnostic errors.
 )
 target_link_libraries(
     MaxComponent

--- a/Sources/Tools/MaxConvert/CMakeLists.txt
+++ b/Sources/Tools/MaxConvert/CMakeLists.txt
@@ -41,6 +41,7 @@ set(MaxConvert_SOURCES
 plasma_library(MaxConvert
     SOURCES ${MaxConvert_HEADERS} ${MaxConvert_SOURCES}
     PRECOMPILED_HEADERS Pch.h
+    NO_SANITIZE # The 3ds Max headers are full of clang diagnostic errors.
 )
 target_link_libraries(
     MaxConvert

--- a/Sources/Tools/MaxExport/CMakeLists.txt
+++ b/Sources/Tools/MaxExport/CMakeLists.txt
@@ -20,6 +20,7 @@ set(MaxExport_SOURCES
 plasma_library(MaxExport
     SOURCES ${MaxExport_HEADERS} ${MaxExport_SOURCES}
     PRECOMPILED_HEADERS Pch.h
+    NO_SANITIZE # The 3ds Max headers are full of clang diagnostic errors.
 )
 target_link_libraries(
     MaxExport

--- a/Sources/Tools/MaxMain/CMakeLists.txt
+++ b/Sources/Tools/MaxMain/CMakeLists.txt
@@ -70,6 +70,7 @@ set(MaxMain_SOURCES
 plasma_library(MaxMain SHARED
     SOURCES ${MaxMain_HEADERS} ${MaxMain_RESOURCES} ${MaxMain_SOURCES}
     PRECOMPILED_HEADERS Pch.h
+    NO_SANITIZE # The 3ds Max headers are full of clang diagnostic errors.
 )
 target_link_libraries(
     MaxMain

--- a/Sources/Tools/MaxPlasmaLights/CMakeLists.txt
+++ b/Sources/Tools/MaxPlasmaLights/CMakeLists.txt
@@ -25,6 +25,7 @@ set(MaxPlasmaLights_SOURCES
 plasma_library(MaxPlasmaLights SHARED
     SOURCES ${MaxPlasmaLights_HEADERS} ${MaxPlasmaLights_RESOURCES} ${MaxPlasmaLights_SOURCES}
     PRECOMPILED_HEADERS Pch.h
+    NO_SANITIZE # The 3ds Max headers are full of clang diagnostic errors.
 )
 target_link_libraries(
     MaxPlasmaLights

--- a/Sources/Tools/MaxPlasmaMtls/CMakeLists.txt
+++ b/Sources/Tools/MaxPlasmaMtls/CMakeLists.txt
@@ -113,6 +113,7 @@ plasma_library(MaxPlasmaMtls
             ${MaxPlasmaMtls_SOURCES_Layers}
             ${MaxPlasmaMtls_SOURCES_Materials}
     PRECOMPILED_HEADERS Pch.h
+    NO_SANITIZE # The 3ds Max headers are full of clang diagnostic errors.
 )
 target_link_libraries(
     MaxPlasmaMtls

--- a/cmake/PlasmaTargets.cmake
+++ b/cmake/PlasmaTargets.cmake
@@ -1,11 +1,11 @@
 include(QtDeployment)
-#TODO (#854): include(Sanitizers)
+include(Sanitizers)
 
 cmake_dependent_option(
     PLASMA_USE_PCH
     "Enable precompiled headers?"
     ON
-    [[${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16"]]
+    "CMAKE_VERSION VERSION_GREATER_EQUAL 3.16;ALLOW_BUILD_OPTIMIZATIONS"
     OFF
 )
 
@@ -13,13 +13,13 @@ cmake_dependent_option(
     PLASMA_UNITY_BUILD
     "Enable unity build?"
     ON
-    [[${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16"]]
+    "CMAKE_VERSION VERSION_GREATER_EQUAL 3.16;ALLOW_BUILD_OPTIMIZATIONS"
     OFF
 )
 
 function(plasma_executable TARGET)
     cmake_parse_arguments(PARSE_ARGV 1 _pex
-        "WIN32;CLIENT;TOOL;QT_GUI;EXCLUDE_FROM_ALL"
+        "WIN32;CLIENT;TOOL;QT_GUI;EXCLUDE_FROM_ALL;NO_SANITIZE"
         ""
         "SOURCES"
     )
@@ -60,12 +60,14 @@ function(plasma_executable TARGET)
         set_property(GLOBAL APPEND PROPERTY _PLASMA_GUI_TOOLS ${TARGET})
     endif()
 
-    #TODO (#854): plasma_sanitize_target(${TARGET})
+    if(NOT _pex_NO_SANITIZE)
+        plasma_sanitize_target(${TARGET})
+    endif()
 endfunction()
 
 function(plasma_library TARGET)
     cmake_parse_arguments(PARSE_ARGV 1 _plib
-        "UNITY_BUILD;SHARED"
+        "UNITY_BUILD;SHARED;NO_SANITIZE"
         ""
         "PRECOMPILED_HEADERS;SOURCES"
     )
@@ -85,7 +87,9 @@ function(plasma_library TARGET)
         set_target_properties(${TARGET} PROPERTIES UNITY_BUILD TRUE)
     endif()
 
-    #TODO (#854): plasma_sanitize_target(${TARGET})
+    if(NOT _plib_NO_SANITIZE)
+        plasma_sanitize_target(${TARGET})
+    endif()
 endfunction()
 
 function(plasma_test TARGET)

--- a/cmake/PlasmaTargets.cmake
+++ b/cmake/PlasmaTargets.cmake
@@ -93,7 +93,7 @@ function(plasma_library TARGET)
 endfunction()
 
 function(plasma_test TARGET)
-    plasma_executable(${TARGET} ${ARGN})
+    plasma_executable(${TARGET} NO_SANTIZE ${ARGN})
     add_test(NAME ${TARGET} COMMAND ${TARGET})
     add_dependencies(check ${TARGET})
 endfunction()

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,0 +1,97 @@
+find_program(CLANG_APPLY_EXE NAMES "clang-apply-replacements" DOC "Path to clang-apply-replacements executable")
+find_program(CLANG_TIDY_EXE NAMES "clang-tidy" DOC "Path to clang-tidy executable")
+
+if(CMAKE_GENERATOR MATCHES "Makefile|Ninja")
+    set(USE_SANITIZE_TARGETS TRUE)
+    # Default such that we don't clobber PlasmaTargets.
+    set(SANITIZE_DEFAULT_VALUE OFF)
+else()
+    set(SANITIZE_DEFAULT_VALUE ON)
+endif()
+
+# Conditional that evaluates to whether or not build optimizations are allowed.
+# This is due to the sanitizers needing the compile commands of each file, not
+# the unity files. CMake will generate files like cmake_pch.cxx, and unity_0.cxx.
+# Both of these files are listed in the compile commands JSON, however, with
+# the current tidy target implementation, the sanitizer cannot know about them.
+# This results in bad/corrupted PCH errors and missing compile commands (errors)
+# for source files included in unity builds.
+if(USE_SANITIZE_TARGETS AND USE_CLANG_TIDY)
+    set(ALLOW_BUILD_OPTIMIZATIONS FALSE)
+else()
+    set(ALLOW_BUILD_OPTIMIZATIONS TRUE)
+endif()
+
+cmake_dependent_option(
+    USE_CLANG_TIDY
+    "Allow the codebase to use the clang-tidy sanitizer"
+    ${SANITIZE_DEFAULT_VALUE}
+    "CLANG_TIDY_EXE"
+    OFF
+)
+
+if(USE_CLANG_TIDY)
+    # Don't set CMAKE_CXX_CLANG_TIDY. CMake+Ninja+MSVC+clang-tidy are broken in this mode, see:
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/20512
+    # https://bugs.llvm.org/show_bug.cgi?id=45356
+    # Use the tidy target instead.
+    if(USE_SANITIZE_TARGETS)
+        set(_TIDY_REPLACEMENTS_DIR "${CMAKE_BINARY_DIR}/clang-tidy-replacements")
+        add_custom_target(tidy_init
+            COMMENT "Preparing to tidy..."
+            COMMAND ${CMAKE_COMMAND} -E remove_directory "${_TIDY_REPLACEMENTS_DIR}"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${_TIDY_REPLACEMENTS_DIR}"
+        )
+        add_custom_target(tidy DEPENDS tidy_init)
+        if(CLANG_APPLY_EXE)
+            add_custom_target(fix
+                DEPENDS tidy
+                COMMENT "Applying fixes..."
+                COMMAND ${CLANG_APPLY_EXE} "${_TIDY_REPLACEMENTS_DIR}"
+                WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            )
+        endif()
+
+        # If we were on CMake 3.20, we could do this per-target...
+        set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+    endif()
+endif()
+
+function(plasma_sanitize_target TARGET)
+    if(USE_CLANG_TIDY)
+        # CMake only natively supports CXX_CLANG_TIDY with Unix Makefiles and Ninja generator as of
+        # CMake 3.19. But most everyone is using Visual Studio, so we'll reset the code analysis
+        # type to clang-tidy. This is a huge win given how terrible MS's code analysis is.
+        if(CMAKE_GENERATOR MATCHES "Visual Studio")
+            set_target_properties(
+                ${TARGET} PROPERTIES
+                VS_GLOBAL_ClangTidyToolExe "${CLANG_TIDY_EXE}"
+                VS_GLOBAL_EnableClangTidyCodeAnalysis TRUE
+                VS_GLOBAL_EnableMicrosoftCodeAnalysis FALSE
+            )
+        endif()
+
+        if(USE_SANITIZE_TARGETS)
+            get_target_property(_TARGET_SOURCES ${TARGET} SOURCES)
+            get_target_property(_TARGET_SOURCE_DIR ${TARGET} SOURCE_DIR)
+            foreach(_SOURCE_FILE IN LISTS _TARGET_SOURCES)
+                # Prevent CMake from stoopidly feeding Python files and bitmaps to clang-tidy.
+                # Yes, CMake actually does try to do that...
+                if(_SOURCE_FILE MATCHES [[\.c$|\.cpp$|\.cxx$|\.cc$]])
+                    list(APPEND _TIDY_SOURCES "${_TARGET_SOURCE_DIR}/${_SOURCE_FILE}")
+                endif()
+            endforeach()
+
+            set(_TARGET_FIXES_FILE "${_TIDY_REPLACEMENTS_DIR}/${TARGET}.yaml")
+            add_custom_target(tidy_${TARGET}
+                DEPENDS tidy_init
+                COMMENT "Running clang-tidy on ${TARGET}..."
+                COMMAND_EXPAND_LISTS
+                COMMAND ${CLANG_TIDY_EXE} --quiet -p "${CMAKE_BINARY_DIR}" "-export-fixes=${_TARGET_FIXES_FILE}" "${_TIDY_SOURCES}"
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                BYPRODUCTS "${_TARGET_FIXES_FILE}"
+            )
+            add_dependencies(tidy tidy_${TARGET})
+        endif()
+    endif()
+endfunction()


### PR DESCRIPTION
This adds first class support for clang-tidy for Makefile, Ninja, and Visual Studio generators. It is loosely based on the implementation found in DIRTSAND. ~~Currently, only the modernize-use-nullptr check is enabled; modernize-use-override is still complaining about some destructors, which is outside the scope of this PR.~~

To use clang-tidy:
- If using a Visual Studio **solution**, click `Analyze` > `Run Code Analsys` > `On Solution` - this will run clang-tidy now instead of the Microsoft code analysis.
- In other generators, including Visual Studio CMake, build the `tidy` target. Any checks with fixers can be applied by building the `fix` target.

I had to clean up the SIMD/CPUID stuff a bit for clang-tidy+MSVC to not blow up on the CoreLib and plPipeline targets. As a side effect, SIMD is now used on GCC and Clang, where it evidently was not before.  Due to the way GCC does SIMD intrinsics, each SIMD instruction set must be limited to its own file for cross-platform code; otherwise, GCC may emit instructions that the end user's CPU does not implement. (NOTE: SIMD stuff was split off to #862)

Potentially outside the scope of this PR, but relevant: which checks should we be using? Many of them look useful (eg bugprone-unused-raii) but others are actually legitimate (anti-)patterns we use (eg modernize-avoid-c-arrays).