### PR TITLE
Marten/enhanced chat history browsing

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1661,6 +1661,8 @@ class xKI(ptModifier):
 
         if (set == "up"):
             if (self.chatMgr.MessageHistoryIs < len(self.chatMgr.MessageHistoryList)-1):
+                if (self.chatMgr.MessageHistoryIs == -1):
+                    self.chatMgr.MessageCurrentLine = control.getString()
                 self.chatMgr.MessageHistoryIs = self.chatMgr.MessageHistoryIs +1
                 control.setStringW(self.chatMgr.MessageHistoryList[self.chatMgr.MessageHistoryIs])
                 control.end()
@@ -1669,6 +1671,11 @@ class xKI(ptModifier):
             if (self.chatMgr.MessageHistoryIs > 0):
                 self.chatMgr.MessageHistoryIs = self.chatMgr.MessageHistoryIs -1
                 control.setStringW(self.chatMgr.MessageHistoryList[self.chatMgr.MessageHistoryIs])
+                control.end()
+                control.refresh()
+            elif (self.chatMgr.MessageHistoryIs == 0):
+                self.chatMgr.MessageHistoryIs = -1
+                control.setStringW(self.chatMgr.MessageCurrentLine)
                 control.end()
                 control.refresh()
 

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -5527,6 +5527,15 @@ class xKI(ptModifier):
             ctrlID = control.getTagID()
             if ctrlID == kGUI.ChatEditboxID:
                 self.Autocomplete(control)
+        # Up or Down key to scroll in the chat history
+        elif event == kMessageHistoryUp:
+            ctrlID = control.getTagID()
+            if ctrlID == kGUI.ChatEditboxID:
+                self.MessageHistory(control, "up")
+        elif event == kMessageHistoryDown:
+            ctrlID = control.getTagID()
+            if ctrlID == kGUI.ChatEditboxID:
+                self.MessageHistory(control, "down")
 
     ## Process notifications originating from the miniKI.
     # The miniKI is the display in the top-left corner of the screen (by

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -103,6 +103,7 @@ class xKIChat(object):
         # Message History
         self.MessageHistoryIs = -1 # Current position in message history (up/down key)
         self.MessageHistoryList = [] # Contains our message history
+        self.MessageCurrentLine = "" # Hold current line while navigating message history
 
     #######
     # GUI #


### PR DESCRIPTION
Extends Filtik's chat history browsing feature:
- Allows the user to return to text they'd entered before they accessed chat history (more like Bourne shell than CMD shell)
- Adds navigation to the microKI (was originally only in miniKI)
