### PR TITLE
Port more PubUtilLibs to std::vector

### DIFF
--- a/Sources/Plasma/FeatureLib/pfAnimation/plAnimDebugList.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plAnimDebugList.cpp
@@ -120,7 +120,7 @@ void plAnimDebugList::ShowReport()
         if (!mat)
             continue;
 
-        for (uint32_t j = 0; j < mat->GetNumLayers(); j++)
+        for (size_t j = 0; j < mat->GetNumLayers(); j++)
         {
             plLayerInterface *layer = mat->GetLayer(j)->BottomOfStack();
             while (layer != nullptr)

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -2354,8 +2354,7 @@ void    pfJournalBook::IRenderPage( uint32_t page, uint32_t whichDTMap, bool sup
     if (material)
     {
         // clear any exiting layers (movies) from the material
-        int i;
-        for( i = 0; i < material->GetNumLayers(); i++ ) // remove all plLayerMovie layers
+        for (size_t i = 0; i < material->GetNumLayers(); i++) // remove all plLayerMovie layers
         {
             plLayerInterface *matLayer = material->GetLayer(i);
             plLayerAVI *movie = plLayerAVI::ConvertNoRef(matLayer);
@@ -2620,8 +2619,7 @@ void    pfJournalBook::IMoveMovies( hsGMaterial *source, hsGMaterial *dest )
     if (source && dest)
     {
         // clear any exiting layers (movies) from the material and save them to our local array
-        int i;
-        for( i = 0; i < source->GetNumLayers(); i++ ) // remove all plLayerMovie layers
+        for (size_t i = 0; i < source->GetNumLayers(); i++) // remove all plLayerMovie layers
         {
             plLayerInterface *matLayer = source->GetLayer(i);
             plLayerAVI *movie = plLayerAVI::ConvertNoRef(matLayer);
@@ -2633,7 +2631,7 @@ void    pfJournalBook::IMoveMovies( hsGMaterial *source, hsGMaterial *dest )
             }
         }
         // clear the destination's movies (if it has any)
-        for( i = 0; i < dest->GetNumLayers(); i++ ) // remove all plLayerMovie layers
+        for (size_t i = 0; i < dest->GetNumLayers(); i++) // remove all plLayerMovie layers
         {
             plLayerInterface *matLayer = dest->GetLayer(i);
             plLayerAVI *movie = plLayerAVI::ConvertNoRef(matLayer);
@@ -3087,7 +3085,7 @@ plLayerInterface *pfJournalBook::IMakeDecalLayer(pfEsHTMLChunk *decalChunk, plMi
 void pfJournalBook::ISetDecalLayers(hsGMaterial *material, const std::vector<plLayerInterface*> &layers)
 {
     // First, clear out the existing layers.
-    for (int i = material->GetNumLayers() - 1; i >= 0; i--)
+    for (hsSsize_t i = material->GetNumLayers() - 1; i >= 0; i--)
     {
         plMatRefMsg* refMsg = new plMatRefMsg(material->GetKey(), plRefMsg::kOnRemove, i, plMatRefMsg::kLayer);
         hsgResMgr::ResMgr()->SendRef(material->GetLayer(i)->GetKey(), refMsg, plRefFlags::kActiveRef);

--- a/Sources/Plasma/FeatureLib/pfSurface/plDistOpacityMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plDistOpacityMod.cpp
@@ -246,7 +246,7 @@ void plDistOpacityMod::ISetup()
     {
         hsGMaterial* mat = span.GetMaterial();
 
-        for (uint32_t j = 0; j < mat->GetNumLayers(); j++)
+        for (size_t j = 0; j < mat->GetNumLayers(); j++)
         {
             plLayerInterface* lay = mat->GetLayer(j);
             if( !j || !(lay->GetZFlags() & hsGMatState::kZNoZWrite) || (lay->GetMiscFlags() & hsGMatState::kMiscRestartPassHere) )

--- a/Sources/Plasma/FeatureLib/pfSurface/plFadeOpacityMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plFadeOpacityMod.cpp
@@ -350,8 +350,7 @@ void plFadeOpacityMod::ISetup(plSceneObject* so)
     {
         hsGMaterial* mat = src[i].GetMaterial();
 
-        int j;
-        for( j = 0; j < mat->GetNumLayers(); j++ )
+        for (size_t j = 0; j < mat->GetNumLayers(); j++)
         {
             plLayerInterface* lay = mat->GetLayer(j);
             if( !j || !(lay->GetZFlags() & hsGMatState::kZNoZWrite) || (lay->GetMiscFlags() & hsGMatState::kMiscRestartPassHere) )

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -212,7 +212,7 @@ void plAGAnimInstance::IInitAnimTimeConvert(plAnimTimeConvert* atc, plATCAnim* a
 
     for (size_t i = 0; i < anim->NumStopPoints(); i++)
     {
-        atc->GetStopPoints().Append(anim->GetStopPoint(i));
+        atc->GetStopPoints().emplace_back(anim->GetStopPoint(i));
     }
 
     atc->SetBegin(anim->GetStart());

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -1930,12 +1930,11 @@ void plArmatureMod::SynchIfLocal(double timeNow, int force)
 
 plLayerLinkAnimation *plArmatureMod::IFindLayerLinkAnim()
 {
-    int i;
     hsGMaterial *mat = fClothingOutfit->fMaterial;
     if (!mat)
         return nullptr;
 
-    for (i = 0; i < mat->GetNumLayers(); i++)
+    for (size_t i = 0; i < mat->GetNumLayers(); i++)
     {
         plLayerInterface *li = mat->GetLayer(i);
         while (li != nullptr)

--- a/Sources/Plasma/PubUtilLib/plDrawable/plCutter.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plCutter.cpp
@@ -1243,22 +1243,20 @@ void TestCutter2(const plKey& key, const hsVector3& size, const hsPoint3& pos, b
 
     std::vector<uint32_t> retIndex;
 
-    hsTArray<plDrawVisList> drawVis;
+    std::vector<plDrawVisList> drawVis;
     node->Harvest(&cutter.GetIsect(), drawVis);
-    if( !drawVis.GetCount() )
+    if (drawVis.empty())
         return;
 
     hsTArray<plAccessSpan> src;
 
     size_t numSpan = 0;
-    int iDraw;
-    for( iDraw = 0; iDraw < drawVis.GetCount(); iDraw++ )
-        numSpan += drawVis[iDraw].fVisList.size();
+    for (const plDrawVisList& dvList : drawVis)
+        numSpan += dvList.fVisList.size();
 
     src.SetCount(numSpan);
 
-    iDraw = 0;
-    size_t iSpan = 0;
+    size_t iDraw = 0, iSpan = 0;
     for (size_t i = 0; i < numSpan; i++)
     {
         plAccessGeometry::Instance()->OpenRO(drawVis[iDraw].fDrawable, drawVis[iDraw].fVisList[iSpan], src[i]);

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
@@ -1119,10 +1119,7 @@ void    plDrawableSpans::Read( hsStream* s, hsResMgr* mgr )
 
 bool    plDrawableSpans::ITestMatForSpecularity( hsGMaterial *mat )
 {
-    int     i;
-
-
-    for( i = 0; i < mat->GetNumLayers(); i++ )
+    for (size_t i = 0; i < mat->GetNumLayers(); i++)
     {
         if( mat->GetLayer( i )->GetShadeFlags() & hsGMatState::kShadeSpecular )
             return true;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpansExport.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpansExport.cpp
@@ -699,7 +699,6 @@ void    plDrawableSpans::ISortSourceSpans()
 short   plDrawableSpans::ICompareSpans( plGeometrySpan *span1, plGeometrySpan *span2 )
 {
     bool        b1, b2;
-    int         i, j, numLayers;
     plBitmap    *t1, *t2;
 
 
@@ -736,11 +735,11 @@ short   plDrawableSpans::ICompareSpans( plGeometrySpan *span1, plGeometrySpan *s
     // Next is texture (name). We do this kinda like strings: compare the first layer's
     // textures and go upwards, so that we group materials together starting with the
     // base layer's texture and going upwards
-    numLayers = span1->fMaterial->GetNumLayers();
+    size_t numLayers = span1->fMaterial->GetNumLayers();
     if( span2->fMaterial->GetNumLayers() < numLayers )
         numLayers = span2->fMaterial->GetNumLayers();
 
-    for( i = 0; i < numLayers; i++ )
+    for (size_t i = 0; i < numLayers; i++)
     {
         t1 = span1->fMaterial->GetLayer( i )->GetTexture();
         t2 = span2->fMaterial->GetLayer( i )->GetTexture();
@@ -754,18 +753,18 @@ short   plDrawableSpans::ICompareSpans( plGeometrySpan *span1, plGeometrySpan *s
         
         if( !t1->GetKeyName().empty() && !t2->GetKeyName().empty() )
         {
-            j = t1->GetKeyName().compare( t2->GetKeyName(), ST::case_insensitive );
-            if( j != 0 )
-                return (short)j;
+            int r = t1->GetKeyName().compare(t2->GetKeyName(), ST::case_insensitive);
+            if (r != 0)
+                return (short)r;
         }
     }
 
     // Finally, by material itself.
     if( !span1->fMaterial->GetKeyName().empty() && !span2->fMaterial->GetKeyName().empty() )
     {
-        j = span1->fMaterial->GetKeyName().compare( span2->fMaterial->GetKeyName(), ST::case_insensitive );
-        if( j != 0 )
-            return (short)j;
+        int r = span1->fMaterial->GetKeyName().compare(span2->fMaterial->GetKeyName(), ST::case_insensitive);
+        if (r != 0)
+            return (short)r;
     }
 
     if( span1->fLocalToWorld.fFlags != span2->fLocalToWorld.fFlags )

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.h
@@ -72,7 +72,7 @@ class plCutter;
 class plCutoutPoly;
 class plFlatGridMesh;
 
-class plDrawVisList;
+struct plDrawVisList;
 class plRenderLevel;
 
 class plAccessSpan;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
@@ -1779,7 +1779,7 @@ hsGMaterial* plWaveSet7::ICreateBumpLayersPS()
     int i;
     for( i = 0; i < kNumBumpShaders; i++ )
     {
-        int nBegin = bumpMat->GetNumLayers();
+        size_t nBegin = bumpMat->GetNumLayers();
 
         int j;
         for( j = 0; j < kBumpPerPass; j++ )
@@ -2191,8 +2191,7 @@ hsGMaterial* plWaveSet7::ICreateFixedMatPS(hsGMaterial* mat, const int numUVWs)
 
     // First, strip off whatever's on there now.
     // If this is the 
-    int i;
-    for( i = mat->GetNumLayers()-1; i > 0; i-- )
+    for (hsSsize_t i = mat->GetNumLayers()-1; i > 0; i--)
     {
         plMatRefMsg* refMsg = new plMatRefMsg(mat->GetKey(), plRefMsg::kOnRemove, i, plMatRefMsg::kLayer);
         hsgResMgr::ResMgr()->SendRef(mat->GetLayer(i)->GetKey(), refMsg, plRefFlags::kActiveRef);
@@ -3454,9 +3453,7 @@ void plWaveSet7::ICheckDecalEnvLayers(hsGMaterial* mat)
 
         plMatRefMsg* refMsg;
 
-        const int numLayers = mat->GetNumLayers();
-        int i;
-        for( i = numLayers-1; i >= 0; i-- )
+        for (hsSsize_t i = mat->GetNumLayers() - 1; i >= 0; i--)
         {
             plLayer* lay0 = plLayer::ConvertNoRef(mat->GetLayer(i)->BottomOfStack());
             lay0->SetBlendFlags(hsGMatState::kBlendAddColorTimesAlpha);
@@ -3499,8 +3496,7 @@ void plWaveSet7::ISetupDecal(hsGMaterial* mat)
     if( mat->GetLayer(0)->GetVertexShader() != vShader )
         IAddShaderToLayers(mat, 0, -1, plLayRefMsg::kVertexShader, vShader);
 
-    int i;
-    for( i = 0; i < mat->GetNumLayers(); i++ )
+    for (size_t i = 0; i < mat->GetNumLayers(); i++)
     {
         plLayer* lay = plLayer::ConvertNoRef(mat->GetLayer(i)->BottomOfStack());
         if( lay )
@@ -3534,8 +3530,7 @@ bool plWaveSet7::SetupRippleMat(hsGMaterial* mat, const plRipVSConsts& ripConsts
     if( fRipVShader && (mat->GetLayer(0)->GetVertexShader() == fRipVShader) )
         return true;
 
-    int i;
-    for( i = 0; i < mat->GetNumLayers(); i++ )
+    for (size_t i = 0; i < mat->GetNumLayers(); i++)
     {
         plLayer* lay = plLayer::ConvertNoRef(mat->GetLayer(i)->BottomOfStack());
         if( lay )

--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimPath.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimPath.cpp
@@ -146,22 +146,21 @@ void plAnimPath::ICalcBounds()
 
     plController* pc = fController->GetPosController();
 
-    int i;
     hsPoint3 pos;
-    hsTArray<float> keyTimes;
+    std::vector<float> keyTimes;
     pc->GetKeyTimes(keyTimes);
     fCenter.Set(0,0,0);
-    for( i = 0; i < keyTimes.GetCount() ; i++ )
+    for (float keyTime : keyTimes)
     {
-        pc->Interp(keyTimes[i], &pos);
+        pc->Interp(keyTime, &pos);
         fCenter += pos;
     }
-    fCenter *= hsInvert((float)keyTimes.GetCount());
+    fCenter *= hsInvert((float)keyTimes.size());
 
     fRadius = 0;
-    for( i = 0; i < keyTimes.GetCount(); i++ )
+    for (float keyTime : keyTimes)
     {
-        pc->Interp(keyTimes[i], &pos);
+        pc->Interp(keyTime, &pos);
         float rad = (pos - fCenter).Magnitude();
         if( rad > fRadius )
             fRadius = rad;
@@ -253,10 +252,9 @@ float plAnimPath::GetExtremePoint(hsPoint3 &worldPt) const
     float minDistSq = 1.e33f;
     float minTime = 0, delTime = 0;
     // start search by using the time of the closest ctrl point
-    int i;
-    hsTArray<float> keyTimes;
+    std::vector<float> keyTimes;
     pc->GetKeyTimes(keyTimes);
-    for( i = 0; i < keyTimes.GetCount(); i++ )
+    for (size_t i = 0; i < keyTimes.size(); i++)
     {
         float t = keyTimes[i];
         hsPoint3 pos;
@@ -268,7 +266,7 @@ float plAnimPath::GetExtremePoint(hsPoint3 &worldPt) const
             minTime = t;
             if( 0 == i )
                 delTime = keyTimes[i+1] - t;
-            else if( keyTimes.GetCount() - 1 == i )
+            else if (keyTimes.size() - 1 == i)
                 delTime = t - keyTimes[i - 1];
             else
             {
@@ -511,7 +509,7 @@ float plAnimPath::IShiftFore(hsPoint3 &pt) const
 // doesn't use any fancy subdivision or curvature measure when drawing.
 // Changes current time.
 //
-void plAnimPath::IMakeSegment(hsTArray<uint16_t>& idx, hsTArray<hsPoint3>& pos,
+void plAnimPath::IMakeSegment(std::vector<uint16_t>& idx, std::vector<hsPoint3>& pos,
                               hsPoint3& p1, hsPoint3& p2)
 {
     hsVector3 del(&p2, &p1);
@@ -537,54 +535,53 @@ void plAnimPath::IMakeSegment(hsTArray<uint16_t>& idx, hsTArray<hsPoint3>& pos,
 
     hsPoint3 p1out, p2out;
 
-    int baseIdx = pos.GetCount();
+    uint16_t baseIdx = (uint16_t)pos.size();
 
-    pos.Append(p1);
-    pos.Append(p2);
+    pos.emplace_back(p1);
+    pos.emplace_back(p2);
 
     p1out = p1;
     p1out += a;
     p2out = p2;
     p2out += a;
 
-    pos.Append(p1out);
-    pos.Append(p2out);
+    pos.emplace_back(p1out);
+    pos.emplace_back(p2out);
 
     p1out += -2.f * a;
     p2out += -2.f * a;
 
-    pos.Append(p1out);
-    pos.Append(p2out);
+    pos.emplace_back(p1out);
+    pos.emplace_back(p2out);
 
     p1out = p1;
     p1out += b;
     p2out = p2;
     p2out += b;
 
-    pos.Append(p1out);
-    pos.Append(p2out);
+    pos.emplace_back(p1out);
+    pos.emplace_back(p2out);
 
     p1out += -2.f * b;
     p2out += -2.f * b;
 
-    pos.Append(p1out);
-    pos.Append(p2out);
+    pos.emplace_back(p1out);
+    pos.emplace_back(p2out);
 
-    int i;
-    for( i = 0; i < 4; i++ )
+    for (uint16_t i = 0; i < 4; i++)
     {
-        int outIdx = baseIdx + 2 + i * 2;
-        idx.Append(baseIdx);
-        idx.Append(baseIdx + 1);
-        idx.Append(baseIdx + outIdx);
+        uint16_t outIdx = baseIdx + 2 + i * 2;
+        idx.emplace_back(baseIdx);
+        idx.emplace_back(baseIdx + 1);
+        idx.emplace_back(baseIdx + outIdx);
 
-        idx.Append(baseIdx + outIdx);
-        idx.Append(baseIdx + 1);
-        idx.Append(baseIdx + outIdx + 1);
+        idx.emplace_back(baseIdx + outIdx);
+        idx.emplace_back(baseIdx + 1);
+        idx.emplace_back(baseIdx + outIdx + 1);
     }
 }
 
-void plAnimPath::MakeDrawList(hsTArray<uint16_t>& idx, hsTArray<hsPoint3>& pos)
+void plAnimPath::MakeDrawList(std::vector<uint16_t>& idx, std::vector<hsPoint3>& pos)
 {
     hsMatrix44 resetL2W = GetLocalToWorld();
     hsMatrix44 resetW2L = GetWorldToLocal();
@@ -633,12 +630,11 @@ void plAnimPath::MakeDrawList(hsTArray<uint16_t>& idx, hsTArray<hsPoint3>& pos)
 //
 void plAnimPath::ComputeArcLenDeltas(int32_t numSamples)
 {
-    if (fArcLenDeltas.GetCount() >= numSamples)
+    if ((int32_t)fArcLenDeltas.size() >= numSamples)
         return;     // already computed enough samples
 
     // compute arc len deltas
-    fArcLenDeltas.Reset();
-    fArcLenDeltas.SetCount(numSamples);
+    fArcLenDeltas.resize(numSamples);
     float animLen = GetLength();
     float timeInc = animLen/(numSamples-1);  // use num-1 since we'll create the zeroth entry by hand
     float time=0;
@@ -671,7 +667,7 @@ void plAnimPath::ComputeArcLenDeltas(int32_t numSamples)
         time += timeInc;
         p1 = p2;
     }
-    hsAssert(fArcLenDeltas.GetCount()==numSamples, "arcLenArray size wrong?");
+    hsAssert((int32_t)fArcLenDeltas.size() == numSamples, "arcLenArray size wrong?");
     hsAssert(cnt==numSamples, "arcLenArray size wrong?");
 }
 
@@ -703,8 +699,7 @@ float plAnimPath::GetLookAheadTime(float startTime, float arcLengthIn, bool bwd,
 
     // find nearest (forward) arcLen sample point, use starting srch index provided
     bool found=false;
-    int32_t i;
-    for(i=(*startSrchIdx); i<fArcLenDeltas.GetCount()-1; i++)
+    for (int32_t i = (*startSrchIdx); i < (int32_t)fArcLenDeltas.size()-1; i++)
     {
         if (fArcLenDeltas[i].fT<=startTime && startTime<fArcLenDeltas[i+1].fT)
         {
@@ -717,14 +712,14 @@ float plAnimPath::GetLookAheadTime(float startTime, float arcLengthIn, bool bwd,
     if (!found)
     {
         // check if equal to last index
-        if (startTime==fArcLenDeltas[fArcLenDeltas.GetCount()-1].fT)
+        if (startTime == fArcLenDeltas.back().fT)
         {
-            *startSrchIdx=fArcLenDeltas.GetCount()-1;
+            *startSrchIdx = (int32_t)fArcLenDeltas.size() - 1;
             found=true;
         }
         else
         {
-            for(i=0; i<*startSrchIdx; i++)
+            for (int32_t i = 0; i < *startSrchIdx; i++)
             {
                 if (fArcLenDeltas[i].fT<=startTime && startTime<fArcLenDeltas[i+1].fT)
                 {
@@ -756,7 +751,8 @@ float plAnimPath::GetLookAheadTime(float startTime, float arcLengthIn, bool bwd,
     // now sum distance deltas until we exceed the desired arcLen
     if (curArcLen<arcLengthIn)
     {
-        for(i=bwd ? nearestIdx : nearestIdx+inc; i<fArcLenDeltas.GetCount() && i>=0; i+=inc)
+        int32_t i = bwd ? nearestIdx : nearestIdx+inc;
+        for (; i < (int32_t)fArcLenDeltas.size() && i >= 0; i += inc)
         {
             if (curArcLen+fArcLenDeltas[i].fArcLenDelta>arcLengthIn)
             {
@@ -768,7 +764,7 @@ float plAnimPath::GetLookAheadTime(float startTime, float arcLengthIn, bool bwd,
             curArcLen += fArcLenDeltas[i].fArcLenDelta;
         }   
         
-        if ( (i==fArcLenDeltas.GetCount() && !bwd) || (i<0 && bwd) )
+        if ((i == (int32_t)fArcLenDeltas.size() && !bwd) || (i < 0 && bwd))
         {
             quit=true;
             timeOut = bwd ? 0 : GetLength();

--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimPath.h
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimPath.h
@@ -43,7 +43,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plAnimPath_inc
 #define plAnimPath_inc
 
-#include "hsTemplates.h"
+#include <vector>
+
 #include "hsGeometry3.h"
 #include "hsMatrix44.h"
 #include "plTransform/hsAffineParts.h"
@@ -116,8 +117,8 @@ protected:
                                                             : fNextTime); }
 
     // Visualization helper
-    void IMakeSegment(hsTArray<uint16_t>& idx, hsTArray<hsPoint3>& pos,
-                                  hsPoint3& p1, hsPoint3& p2);
+    void IMakeSegment(std::vector<uint16_t>& idx, std::vector<hsPoint3>& pos,
+                      hsPoint3& p1, hsPoint3& p2);
     
     // For computing arclen
     struct ArcLenDeltaInfo
@@ -125,9 +126,9 @@ protected:
         float    fT;
         float    fArcLenDelta;   // arc len distance from prev sample point (array entry)
         ArcLenDeltaInfo(float t, float del) : fT(t),fArcLenDelta(del) {}
-        ArcLenDeltaInfo() : fT(0),fArcLenDelta(0) {}
+        ArcLenDeltaInfo() : fT(), fArcLenDelta() { }
     };
-    hsTArray<ArcLenDeltaInfo>   fArcLenDeltas;
+    std::vector<ArcLenDeltaInfo> fArcLenDeltas;
 public:
     plAnimPath();
     virtual ~plAnimPath();
@@ -142,7 +143,7 @@ public:
     const hsMatrix44& GetWorldToLocal() const { return fWorldToLocal; }
 
     // Visualization helper
-    void MakeDrawList(hsTArray<uint16_t>& idx, hsTArray<hsPoint3>& pos);
+    void MakeDrawList(std::vector<uint16_t>& idx, std::vector<hsPoint3>& pos);
 
     void SetAnimPathFlags(uint32_t f) { fAnimPathFlags=f; }
     uint32_t GetAnimPathFlags() const { return fAnimPathFlags; }

--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.h
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.h
@@ -43,8 +43,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plAnimTimeConvert_inc
 
 #include <list>
+#include <vector>
+
 #include "pnFactory/plCreatable.h"
-#include "hsTemplates.h"
 
 class plSynchedObject;
 class plAnimCmdMsg;
@@ -78,8 +79,8 @@ protected:
     typedef std::list<plATCState *> plATCStateList;
     plATCStateList fStates;
     
-    hsTArray<float>              fStopPoints;
-    hsTArray<plEventCallbackMsg*>   fCallbackMsgs;
+    std::vector<float>               fStopPoints;
+    std::vector<plEventCallbackMsg*> fCallbackMsgs;
 
     /////////////////////////
     // Ease In/Out stuff
@@ -100,7 +101,7 @@ protected:
 
     void        ICheckTimeCallbacks(float frameStart, float frameStop);
     bool        ITimeInFrame(float secs, float start, float stop);
-    void        ISendCallback(int i);
+    void        ISendCallback(hsSsize_t i);
 
     plAnimTimeConvert& IStop(double time, float animTime);
     bool IIsStoppedAt(const double &wSecs, const uint32_t &flags, const plATCEaseCurve *curve) const;
@@ -155,7 +156,7 @@ public:
     float GetInitialBegin() const { return fInitialBegin; }
     float GetInitialEnd() const { return fInitialEnd; }
     float GetSpeed() const { return fSpeed; }
-    hsTArray<float> &GetStopPoints() { return fStopPoints; }
+    std::vector<float> &GetStopPoints() { return fStopPoints; }
     float GetBestStopDist(float min, float max, float norm, float time) const;
     int GetCurrentEaseCurve() const;    // returns  0=nil, 1=easeIn, 2=easeOut, 3=speed
 

--- a/Sources/Plasma/PubUtilLib/plInterp/plController.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plController.cpp
@@ -374,29 +374,29 @@ hsMatrix44Key *plLeafController::GetMatrix44Key(uint32_t i) const
     return (hsMatrix44Key *)((uint8_t *)fKeys + i * sizeof(hsMatrix44Key));
 }
 
-void plLeafController::GetKeyTimes(hsTArray<float> &keyTimes) const
+void plLeafController::GetKeyTimes(std::vector<float> &keyTimes) const
 {
-    int cIdx = 0;
-    int kIdx = 0;
+    uint32_t cIdx = 0;
+    auto kIter = keyTimes.begin();
     uint32_t stride = GetStride();
     uint8_t *keyPtr = (uint8_t *)fKeys;
-    while (cIdx < fNumKeys && kIdx < keyTimes.GetCount())
+    while (cIdx < fNumKeys && kIter != keyTimes.end())
     {
-        float kTime = keyTimes[kIdx];
+        float kTime = *kIter;
         float cTime = ((hsKeyFrame*)(keyPtr + cIdx * stride))->fFrame / MAX_FRAMES_PER_SEC;
         if (cTime < kTime)
         {
-            keyTimes.Insert(kIdx, cTime);
+            kIter = keyTimes.insert(kIter, cTime);
             cIdx++;
-            kIdx++;
+            kIter++;
         }
         else if (cTime > kTime)
         {
-            kIdx++;
+            kIter++;
         }
         else
         {
-            kIdx++;
+            kIter++;
             cIdx++;
         }
     }
@@ -405,7 +405,7 @@ void plLeafController::GetKeyTimes(hsTArray<float> &keyTimes) const
     for (; cIdx < fNumKeys; cIdx++)
     {
         float cTime = ((hsKeyFrame*)(keyPtr + cIdx * stride))->fFrame / MAX_FRAMES_PER_SEC;
-        keyTimes.Append(cTime);
+        keyTimes.emplace_back(cTime);
     }
 }
 
@@ -850,7 +850,7 @@ float plCompoundController::GetLength() const
     return len;
 }
 
-void plCompoundController::GetKeyTimes(hsTArray<float> &keyTimes) const
+void plCompoundController::GetKeyTimes(std::vector<float> &keyTimes) const
 {
     if (fXController)
         fXController->GetKeyTimes(keyTimes);

--- a/Sources/Plasma/PubUtilLib/plInterp/plController.h
+++ b/Sources/Plasma/PubUtilLib/plInterp/plController.h
@@ -42,11 +42,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef HSCONTROLLER_inc
 #define HSCONTROLLER_inc
 
+#include <vector>
+
 #include "HeadSpin.h"
 #include "pnFactory/plCreatable.h"
 #include "hsColorRGBA.h"
 #include "hsKeys.h"
-#include "hsTemplates.h"
 
 class hsResMgr;
 
@@ -109,7 +110,7 @@ public:
 
     virtual plControllerCacheInfo* CreateCache() const { return nullptr; } // Caller must handle deleting the pointer.
     virtual float GetLength() const = 0;
-    virtual void GetKeyTimes(hsTArray<float> &keyTimes) const = 0;
+    virtual void GetKeyTimes(std::vector<float> &keyTimes) const = 0;
     virtual bool AllKeysMatch() const = 0;
 
     // Checks each of our subcontrollers (if we have any) and deletes any that
@@ -166,7 +167,7 @@ public:
     uint8_t GetType() const { return fType; }
     uint32_t GetNumKeys() const { return fNumKeys; }
     void *GetKeyBuffer() const { return fKeys; }
-    void GetKeyTimes(hsTArray<float> &keyTimes) const override;
+    void GetKeyTimes(std::vector<float> &keyTimes) const override;
     void AllocKeys(uint32_t n, uint8_t type);
     void QuickScalarController(int numKeys, float* times, float* values, uint32_t valueStrides);
     bool AllKeysMatch() const override;
@@ -210,7 +211,7 @@ public:
     plController *GetScaleController() const { return fZController; }
     plController *GetController(int32_t i) const;
     float GetLength() const override;
-    void GetKeyTimes(hsTArray<float> &keyTimes) const override;
+    void GetKeyTimes(std::vector<float> &keyTimes) const override;
     bool AllKeysMatch() const override;
     bool PurgeRedundantSubcontrollers() override;
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plMatRefMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMatRefMsg.h
@@ -55,7 +55,7 @@ public:
     };
 
     plMatRefMsg() {}
-    plMatRefMsg(const plKey &r, uint8_t flags, int8_t which, int8_t type) : plGenRefMsg(r, flags, which, type) {}
+    plMatRefMsg(const plKey &r, uint8_t flags, int32_t which, int8_t type) : plGenRefMsg(r, flags, which, type) {}
 
     CLASSNAME_REGISTER( plMatRefMsg );
     GETINTERFACE_ANY( plMatRefMsg, plGenRefMsg );

--- a/Sources/Plasma/PubUtilLib/plNetClient/Pch.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/Pch.h
@@ -44,12 +44,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <algorithm>
 #include <list>
+#include <vector>
 #include <string_theory/string>
 
 #include "plgDispatch.h"
 #include "hsResMgr.h"
 #include "hsStream.h"
-#include "hsTemplates.h"
 #include "hsTimer.h"
 
 #include "pnKeyedObject/plKey.h"

--- a/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.h
@@ -42,7 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plLinkEffectsMgr_inc
 #define plLinkEffectsMgr_inc
 
-#include "hsTemplates.h"
+#include <vector>
 
 #include "pnKeyedObject/hsKeyedObject.h"
 
@@ -55,19 +55,19 @@ class plLinkEffectsMgr : public hsKeyedObject
 {
 protected:
     // Collection of links in progress (in or out)
-    hsTArray<plLinkEffectsTriggerMsg *> fLinks;
+    std::vector<plLinkEffectsTriggerMsg *> fLinks;
 
     // Players we know exist, but aren't ready to link yet
-    hsTArray<plLinkEffectsTriggerMsg *> fWaitlist; 
+    std::vector<plLinkEffectsTriggerMsg *> fWaitlist;
 
     // Queue of delayed messages from people linking in that 
     // we haven't received yet but are no longer necessary, 
     // because we either received the trigger from them, or
     // they're no longer in the age.
-    hsTArray<plLinkEffectsTriggerMsg *> fDeadlist;
+    std::vector<plLinkEffectsTriggerMsg *> fDeadlist;
     
     // queue of pseudo link messages
-    hsTArray<plPseudoLinkEffectMsg *> fPseudolist;
+    std::vector<plPseudoLinkEffectMsg *> fPseudolist;
 
     plLinkEffectsTriggerMsg *IFindLinkTriggerMsg(plKey avatarKey);
     void IAddLink(plLinkEffectsTriggerMsg *msg);

--- a/Sources/Plasma/PubUtilLib/plPhysical/plPhysicalSndGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plPhysicalSndGroup.cpp
@@ -76,12 +76,12 @@ plPhysicalSndGroup::~plPhysicalSndGroup()
 
 bool plPhysicalSndGroup::HasSlideSound(uint32_t against)
 {
-    return against < fSlideSounds.GetCount();
+    return against < fSlideSounds.size();
 }
 
 bool plPhysicalSndGroup::HasImpactSound(uint32_t against)
 {
-    return against < fImpactSounds.GetCount();
+    return against < fImpactSounds.size();
 }
 
 bool    plPhysicalSndGroup::MsgReceive( plMessage *pMsg )
@@ -95,17 +95,18 @@ void plPhysicalSndGroup::Read( hsStream *s, hsResMgr *mgr )
 
     s->ReadLE( &fGroup );
 
-    uint32_t i, count = s->ReadLE32();
-    fImpactSounds.Reset();
+    uint32_t count = s->ReadLE32();
+    fImpactSounds.clear();
+    fImpactSounds.reserve(count);
 
-    for( i = 0; i < count; i++ )
-        fImpactSounds.Append( mgr->ReadKey( s ) );
+    for (uint32_t i = 0; i < count; i++)
+        fImpactSounds.emplace_back(mgr->ReadKey(s));
 
     count = s->ReadLE32();
-    fSlideSounds.Reset();
-    for( i = 0; i < count; i++ )
-        fSlideSounds.Append( mgr->ReadKey( s ) );
-
+    fSlideSounds.clear();
+    fSlideSounds.reserve(count);
+    for (uint32_t i = 0; i < count; i++)
+        fSlideSounds.emplace_back(mgr->ReadKey(s));
 }
 
 void plPhysicalSndGroup::Write( hsStream *s, hsResMgr *mgr )
@@ -114,35 +115,34 @@ void plPhysicalSndGroup::Write( hsStream *s, hsResMgr *mgr )
 
     s->WriteLE( fGroup );
 
-    uint32_t i;
-    s->WriteLE32( fImpactSounds.GetCount() );
-    for( i = 0; i < fImpactSounds.GetCount(); i++ )
-        mgr->WriteKey( s, fImpactSounds[ i ] );
+    s->WriteLE32((uint32_t)fImpactSounds.size());
+    for (const plKey& key : fImpactSounds)
+        mgr->WriteKey(s, key);
 
-    s->WriteLE32( fSlideSounds.GetCount() );
-    for( i = 0; i < fSlideSounds.GetCount(); i++ )
-        mgr->WriteKey( s, fSlideSounds[ i ] );
+    s->WriteLE32((uint32_t)fSlideSounds.size());
+    for (const plKey& key : fSlideSounds)
+        mgr->WriteKey(s, key);
 }
 
 void    plPhysicalSndGroup::AddImpactSound( uint32_t against, plKey receiver )
 {
-    if( fImpactSounds.GetCount() <= against )
-        fImpactSounds.Resize(against + 1);
+    if (fImpactSounds.size() <= against)
+        fImpactSounds.resize(against + 1);
 
-    fImpactSounds[ against ] = receiver;
+    fImpactSounds[against] = std::move(receiver);
 }
 
 void    plPhysicalSndGroup::AddSlideSound( uint32_t against, plKey receiver )
 {
-    if( fSlideSounds.GetCount() <= against )
-        fSlideSounds.Resize(against + 1);
+    if (fSlideSounds.size() <= against)
+        fSlideSounds.resize(against + 1);
 
-    fSlideSounds[ against ] = receiver;
+    fSlideSounds[against] = std::move(receiver);
 }
 
 void plPhysicalSndGroup::PlaySlideSound(uint32_t against)
 {
-    if(against >= fSlideSounds.Count())
+    if (against >= fSlideSounds.size())
         return;
     plAnimCmdMsg* animMsg = new plAnimCmdMsg;
     animMsg->SetCmd(plAnimCmdMsg::kContinue);
@@ -152,7 +152,7 @@ void plPhysicalSndGroup::PlaySlideSound(uint32_t against)
 
 void plPhysicalSndGroup::StopSlideSound(uint32_t against)
 {
-    if(against >= fSlideSounds.Count())
+    if (against >= fSlideSounds.size())
         return;
     plAnimCmdMsg *animMsg = new plAnimCmdMsg;
     animMsg->SetCmd(plAnimCmdMsg::kStop);
@@ -162,7 +162,7 @@ void plPhysicalSndGroup::StopSlideSound(uint32_t against)
 
 void plPhysicalSndGroup::PlayImpactSound(uint32_t against)
 {
-    if(against >= fImpactSounds.Count())
+    if (against >= fImpactSounds.size())
         return;
     plAnimCmdMsg* animMsg = new plAnimCmdMsg;
     animMsg->SetCmd(plAnimCmdMsg::kContinue);
@@ -171,11 +171,10 @@ void plPhysicalSndGroup::PlayImpactSound(uint32_t against)
 
 void plPhysicalSndGroup::SetSlideSoundVolume(uint32_t against, float volume)
 {
-    if(against >= fSlideSounds.Count())
+    if (against >= fSlideSounds.size())
         return;
     plAnimCmdMsg* animMsg = new plAnimCmdMsg;
     animMsg->SetCmd(plAnimCmdMsg::kSetSpeed);
     animMsg->fSpeed = volume;
     animMsg->Send(fSlideSounds[against]);
-
 }

--- a/Sources/Plasma/PubUtilLib/plPhysical/plPhysicalSndGroup.h
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plPhysicalSndGroup.h
@@ -52,8 +52,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //                                                                          //
 //////////////////////////////////////////////////////////////////////////////
 
+#include <vector>
+
 #include "HeadSpin.h"
-#include "hsTemplates.h"
 
 #include "pnKeyedObject/hsKeyedObject.h"
 
@@ -110,9 +111,8 @@ protected:
     bool fPlayingSlideSound;
 
     // Sound key arrays for, well, our sounds!
-    hsTArray<plKey> fImpactSounds;
-    hsTArray<plKey> fSlideSounds;
+    std::vector<plKey> fImpactSounds;
+    std::vector<plKey> fSlideSounds;
 };
-
 
 #endif //_plPhysicalSndGroup_h

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -5449,8 +5449,7 @@ void plDXPipeline::IPushPiggyBacks(hsGMaterial* mat)
     if( fView.fRenderState & plPipeline::kRenderNoPiggyBacks )
         return;
 
-    int i;
-    for( i = 0; i < mat->GetNumPiggyBacks(); i++ )
+    for (size_t i = 0; i < mat->GetNumPiggyBacks(); i++)
     {
         if( !mat->GetPiggyBack(i) )
             continue;

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -8943,9 +8943,8 @@ hsCpuFunctionDispatcher<plDXPipeline::blend_vert_buffer_ptr> plDXPipeline::blend
 // Note that the lighting pipe constants are NOT implemented.
 void plDXPipeline::ISetPipeConsts(plShader* shader)
 {
-    int n = shader->GetNumPipeConsts(); 
-    int i;
-    for( i = 0; i < n; i++ )
+    size_t n = shader->GetNumPipeConsts();
+    for (size_t i = 0; i < n; i++)
     {
         const plPipeConst& pc = shader->GetPipeConst(i);
         switch( pc.fType )

--- a/Sources/Plasma/PubUtilLib/plPipeline/plCullTree.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plCullTree.h
@@ -46,6 +46,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsBounds.h"
 #include "hsGeometry3.h"
 #include "hsBitVector.h"
+#include "hsTemplates.h"
 #include "plCuller.h"
 #include "plScene/plCullPoly.h"
 

--- a/Sources/Plasma/PubUtilLib/plScene/plCullPoly.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plCullPoly.cpp
@@ -139,7 +139,7 @@ void plCullPoly::Read(hsStream* s, hsResMgr* mgr)
         fVerts[i].Read(s);
 }
 
-void plCullPoly::Write(hsStream* s, hsResMgr* mgr)
+void plCullPoly::Write(hsStream* s, hsResMgr* mgr) const
 {
     s->WriteLE32(fFlags);
 

--- a/Sources/Plasma/PubUtilLib/plScene/plCullPoly.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plCullPoly.cpp
@@ -52,7 +52,7 @@ plCullPoly& plCullPoly::InitFromVerts(uint32_t f)
 {
     fFlags = f;
 
-    hsAssert(fVerts.GetCount() > 2, "Initializing from degenerate poly");
+    hsAssert(fVerts.size() > 2, "Initializing from degenerate poly");
 
     hsVector3 a(&fVerts[1], &fVerts[0]);
     hsVector3 b(&fVerts[2], &fVerts[0]);
@@ -61,12 +61,11 @@ plCullPoly& plCullPoly::InitFromVerts(uint32_t f)
     fDist = -(fNorm.InnerProduct(fVerts[0]));
 
     fCenter.Set(0,0,0);
-    int i;
-    for( i = 0; i < fVerts.GetCount(); i++ )
+    for (const hsPoint3& vert : fVerts)
     {
-        fCenter += fVerts[i];
+        fCenter += vert;
     }
-    fCenter *= 1.f / float(fVerts.GetCount());
+    fCenter *= 1.f / float(fVerts.size());
 
     fRadius = ICalcRadius();
 
@@ -76,10 +75,9 @@ plCullPoly& plCullPoly::InitFromVerts(uint32_t f)
 float plCullPoly::ICalcRadius() const
 {
     float radSq = 0;
-    int i;
-    for( i = 0; i < fVerts.GetCount(); i++ )
+    for (const hsPoint3& vert : fVerts)
     {
-        float tmpSq = hsVector3(&fVerts[i], &fCenter).MagnitudeSquared();
+        float tmpSq = hsVector3(&vert, &fCenter).MagnitudeSquared();
         if( tmpSq > radSq )
             radSq = tmpSq;
     }
@@ -95,11 +93,8 @@ plCullPoly& plCullPoly::Flip(const plCullPoly& p)
     fCenter = p.fCenter;
     fRadius = p.fRadius;
 
-    int n = p.fVerts.GetCount();
-    fVerts.SetCount(n);
-    int i;
-    for( i = 0; i < n; i++ )
-        fVerts[n-i-1] = p.fVerts[i];
+    fVerts = p.fVerts;
+    std::reverse(fVerts.begin(), fVerts.end());
 
     return *this;
 }
@@ -111,10 +106,9 @@ plCullPoly& plCullPoly::Transform(const hsMatrix44& l2w, const hsMatrix44& w2l, 
 
     dst.fFlags = fFlags;
 
-    dst.fVerts.SetCount(fVerts.GetCount());
+    dst.fVerts.resize(fVerts.size());
 
-    int i;
-    for( i = 0; i < fVerts.GetCount(); i++ )
+    for (size_t i = 0; i < fVerts.size(); i++)
     {
         dst.fVerts[i] = l2w * fVerts[i];
     }
@@ -139,10 +133,9 @@ void plCullPoly::Read(hsStream* s, hsResMgr* mgr)
 
     fRadius = s->ReadLEScalar();
 
-    int n = s->ReadLE32();
-    fVerts.SetCount(n);
-    int i;
-    for( i = 0; i < n; i++ )
+    uint32_t n = s->ReadLE32();
+    fVerts.resize(n);
+    for (uint32_t i = 0; i < n; i++)
         fVerts[i].Read(s);
 }
 
@@ -156,10 +149,9 @@ void plCullPoly::Write(hsStream* s, hsResMgr* mgr)
 
     s->WriteLEScalar(fRadius);
 
-    s->WriteLE32(fVerts.GetCount());
-    int i;
-    for( i = 0; i < fVerts.GetCount(); i++ )
-        fVerts[i].Write(s);
+    s->WriteLE32((uint32_t)fVerts.size());
+    for (const hsPoint3& vert : fVerts)
+        vert.Write(s);
 }
 
 #ifdef HS_DEBUGGING
@@ -173,15 +165,14 @@ bool plCullPoly::Validate() const
     float magSq = fNorm.MagnitudeSquared();
     if( magSq < kMinMag )
         return false;
-    if( fVerts.GetCount() < 3 )
+    if (fVerts.size() < 3)
         return false;
     hsVector3 norm = hsVector3(&fVerts[1], &fVerts[0]) % hsVector3(&fVerts[2], &fVerts[0]);
     magSq = norm.MagnitudeSquared();
     if( magSq < kMinMag )
         return false;
     norm *= hsFastMath::InvSqrtAppr(magSq);
-    int i;
-    for( i = 3; i < fVerts.GetCount(); i++ )
+    for (size_t i = 3; i < fVerts.size(); i++)
     {
         hsVector3 nextNorm = hsVector3(&fVerts[i-1], &fVerts[0]) % hsVector3(&fVerts[i], &fVerts[0]);
         magSq = nextNorm.MagnitudeSquared();

--- a/Sources/Plasma/PubUtilLib/plScene/plCullPoly.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plCullPoly.h
@@ -99,7 +99,7 @@ public:
     plCullPoly&             Transform(const hsMatrix44& l2w, const hsMatrix44& w2l, plCullPoly& dst) const;
 
     void                    Read(hsStream* s, hsResMgr* mgr);
-    void                    Write(hsStream* s, hsResMgr* mgr);
+    void                    Write(hsStream* s, hsResMgr* mgr) const;
 
     bool                    DegenerateVert(const hsPoint3& p) const
     {

--- a/Sources/Plasma/PubUtilLib/plScene/plCullPoly.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plCullPoly.h
@@ -43,9 +43,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plCullPoly_inc
 #define plCullPoly_inc
 
+#include <vector>
+
 #include "hsBitVector.h"
 #include "hsGeometry3.h"
-#include "hsTemplates.h"
 
 struct hsMatrix44;
 class hsStream;
@@ -65,7 +66,7 @@ public:
     uint32_t                  fFlags;
     mutable hsBitVector     fClipped; // fClipped[i] => edge(fVerts[i], fVerts[(i+1)%n])
 
-    hsTArray<hsPoint3>      fVerts;
+    std::vector<hsPoint3>   fVerts;
     hsVector3               fNorm;
     float                fDist;
     hsPoint3                fCenter;
@@ -83,7 +84,7 @@ public:
     plCullPoly& Init(const plCullPoly& p)
     {
         fClipped.Clear();
-        fVerts.SetCount(0);
+        fVerts.clear();
         fFlags = p.fFlags;
         fNorm = p.fNorm;
         fDist = p.fDist;
@@ -102,8 +103,8 @@ public:
 
     bool                    DegenerateVert(const hsPoint3& p) const
     {
-        if (fVerts.GetCount())
-            return (kCullPolyDegen > hsVector3(&p, &fVerts[fVerts.GetCount() - 1]).MagnitudeSquared());
+        if (!fVerts.empty())
+            return (kCullPolyDegen > hsVector3(&p, &fVerts.back()).MagnitudeSquared());
         return false;
     }
 

--- a/Sources/Plasma/PubUtilLib/plScene/plOccluder.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plOccluder.cpp
@@ -163,8 +163,7 @@ plDrawableSpans* plOccluder::CreateProxy(hsGMaterial* mat, std::vector<uint32_t>
         pos.emplace_back(polys[i].fVerts[1]);
         norm.emplace_back(polys[i].fNorm);
         color.emplace_back(col);
-        int j;
-        for( j = 2; j < polys[i].fVerts.GetCount(); j++ )
+        for (size_t j = 2; j < polys[i].fVerts.size(); j++)
         {
             uint16_t idxCurr = (uint16_t)pos.size();
             pos.emplace_back(polys[i].fVerts[j]);
@@ -236,9 +235,8 @@ void plOccluder::IComputeBounds()
     int i;
     for( i =0 ; i < polys.GetCount(); i++ )
     {
-        int j;
-        for( j = 0; j < polys[i].fVerts.GetCount(); j++ )
-            fWorldBounds.Union(&polys[i].fVerts[j]);
+        for (const hsPoint3& vert : polys[i].fVerts)
+            fWorldBounds.Union(&vert);
     }
 }
 
@@ -249,8 +247,7 @@ float plOccluder::IComputeSurfaceArea()
     int i;
     for( i =0 ; i < polys.GetCount(); i++ )
     {
-        int j;
-        for( j = 2; j < polys[i].fVerts.GetCount(); j++ )
+        for (size_t j = 2; j < polys[i].fVerts.size(); j++)
         {
             area += (hsVector3(&polys[i].fVerts[j], &polys[i].fVerts[j-2]) % hsVector3(&polys[i].fVerts[j-1], &polys[i].fVerts[j-2])).Magnitude();
         }

--- a/Sources/Plasma/PubUtilLib/plScene/plOccluder.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plOccluder.cpp
@@ -101,10 +101,9 @@ void plOccluder::IAddVisRegion(plVisRegion* reg)
 {
     if( reg )
     {
-        int idx = fVisRegions.Find(reg);
-        if( fVisRegions.kMissingIndex == idx )
+        if (std::find(fVisRegions.cbegin(), fVisRegions.cend(), reg) == fVisRegions.cend())
         {
-            fVisRegions.Append(reg);
+            fVisRegions.emplace_back(reg);
             if( reg->GetProperty(plVisRegion::kIsNot) )
                 fVisNot.SetBit(reg->GetIndex());
             else
@@ -121,10 +120,10 @@ void plOccluder::IRemoveVisRegion(plVisRegion* reg)
 {
     if( reg )
     {
-        int idx = fVisRegions.Find(reg);
-        if( fVisRegions.kMissingIndex != idx )
+        auto iter = std::find(fVisRegions.cbegin(), fVisRegions.cend(), reg);
+        if (iter != fVisRegions.cend())
         {
-            fVisRegions.Remove(idx);
+            fVisRegions.erase(iter);
             if( reg->GetProperty(plVisRegion::kIsNot) )
                 fVisNot.ClearBit(reg->GetIndex());
             else
@@ -144,12 +143,11 @@ plDrawableSpans* plOccluder::CreateProxy(hsGMaterial* mat, std::vector<uint32_t>
     if( lay )
         lay->SetMiscFlags(lay->GetMiscFlags() & ~hsGMatState::kMiscTwoSided);
 
-    const hsTArray<plCullPoly>& polys = GetLocalPolyList();
-    int i;
-    for( i = 0; i < polys.GetCount(); i++ )
+    const std::vector<plCullPoly>& polys = GetLocalPolyList();
+    for (const plCullPoly& poly : polys)
     {
         hsColorRGBA col;
-        if( polys[i].IsHole() )
+        if (poly.IsHole())
             col.Set(0,0,0,1.f);
         else
             col.Set(1.f, 1.f, 1.f, 1.f);
@@ -157,24 +155,24 @@ plDrawableSpans* plOccluder::CreateProxy(hsGMaterial* mat, std::vector<uint32_t>
         size_t triStart = tris.size();
 
         uint16_t idx0 = (uint16_t)pos.size();
-        pos.emplace_back(polys[i].fVerts[0]);
-        norm.emplace_back(polys[i].fNorm);
+        pos.emplace_back(poly.fVerts[0]);
+        norm.emplace_back(poly.fNorm);
         color.emplace_back(col);
-        pos.emplace_back(polys[i].fVerts[1]);
-        norm.emplace_back(polys[i].fNorm);
+        pos.emplace_back(poly.fVerts[1]);
+        norm.emplace_back(poly.fNorm);
         color.emplace_back(col);
-        for (size_t j = 2; j < polys[i].fVerts.size(); j++)
+        for (size_t j = 2; j < poly.fVerts.size(); j++)
         {
             uint16_t idxCurr = (uint16_t)pos.size();
-            pos.emplace_back(polys[i].fVerts[j]);
-            norm.emplace_back(polys[i].fNorm);
+            pos.emplace_back(poly.fVerts[j]);
+            norm.emplace_back(poly.fNorm);
             color.emplace_back(col);
             tris.emplace_back(idx0);
             tris.emplace_back(idxCurr-1);
             tris.emplace_back(idxCurr);
         }
 #if 1
-        if( polys[i].IsTwoSided() )
+        if (poly.IsTwoSided())
         {
             size_t n = tris.size();
             // triStart can be 0...
@@ -231,11 +229,10 @@ void plOccluder::IComputeBounds()
 {
     fWorldBounds.MakeEmpty();
 
-    const hsTArray<plCullPoly>& polys = GetLocalPolyList();
-    int i;
-    for( i =0 ; i < polys.GetCount(); i++ )
+    const std::vector<plCullPoly>& polys = GetLocalPolyList();
+    for (const plCullPoly& poly : polys)
     {
-        for (const hsPoint3& vert : polys[i].fVerts)
+        for (const hsPoint3& vert : poly.fVerts)
             fWorldBounds.Union(&vert);
     }
 }
@@ -243,13 +240,12 @@ void plOccluder::IComputeBounds()
 float plOccluder::IComputeSurfaceArea()
 {
     float area = 0;
-    const hsTArray<plCullPoly>& polys = GetLocalPolyList();
-    int i;
-    for( i =0 ; i < polys.GetCount(); i++ )
+    const std::vector<plCullPoly>& polys = GetLocalPolyList();
+    for (const plCullPoly& poly : polys)
     {
-        for (size_t j = 2; j < polys[i].fVerts.size(); j++)
+        for (size_t j = 2; j < poly.fVerts.size(); j++)
         {
-            area += (hsVector3(&polys[i].fVerts[j], &polys[i].fVerts[j-2]) % hsVector3(&polys[i].fVerts[j-1], &polys[i].fVerts[j-2])).Magnitude();
+            area += (hsVector3(&poly.fVerts[j], &poly.fVerts[j-2]) % hsVector3(&poly.fVerts[j-1], &poly.fVerts[j-2])).Magnitude();
         }
     }
     area *= 0.5f;
@@ -257,13 +253,9 @@ float plOccluder::IComputeSurfaceArea()
     return fPriority = area;
 }
 
-void plOccluder::SetPolyList(const hsTArray<plCullPoly>& list)
+void plOccluder::SetPolyList(const std::vector<plCullPoly>& list)
 {
-    uint16_t n = list.GetCount();
-    fPolys.SetCount(n);
-    int i;
-    for( i = 0; i < n; i++ )
-        fPolys[i] = list[i];
+    fPolys = list;
 }
 
 void plOccluder::ISetSceneNode(plKey node)
@@ -290,19 +282,18 @@ void plOccluder::Read(hsStream* s, hsResMgr* mgr)
     fWorldBounds.Read(s);
     fPriority = s->ReadLEScalar();
 
-    hsTArray<plCullPoly>& localPolys = IGetLocalPolyList();
+    std::vector<plCullPoly>& localPolys = IGetLocalPolyList();
     uint16_t n = s->ReadLE16();
-    localPolys.SetCount(n);
-    int i;
-    for( i = 0; i < n; i++ )
+    localPolys.resize(n);
+    for (uint16_t i = 0; i < n; i++)
         localPolys[i].Read(s, mgr);
 
     plKey nodeKey = mgr->ReadKey(s);
     ISetSceneNode(nodeKey);
 
     n = s->ReadLE16();
-    fVisRegions.SetCountAndZero(n);
-    for( i = 0; i < n; i++ )
+    fVisRegions.assign(n, nullptr);
+    for (uint16_t i = 0; i < n; i++)
         mgr->ReadKeyNotifyMe(s, new plGenRefMsg(GetKey(), plRefMsg::kOnCreate, 0, kRefVisRegion), plRefFlags::kActiveRef);
 }
 
@@ -313,17 +304,18 @@ void plOccluder::Write(hsStream* s, hsResMgr* mgr)
     fWorldBounds.Write(s);
     s->WriteLEScalar(fPriority);
 
-    hsTArray<plCullPoly>& localPolys = IGetLocalPolyList();
-    s->WriteLE16(localPolys.GetCount());
-    int i;
-    for( i = 0; i < localPolys.GetCount(); i++ )
-        localPolys[i].Write(s, mgr);
+    std::vector<plCullPoly>& localPolys = IGetLocalPolyList();
+    hsAssert(localPolys.size() < std::numeric_limits<uint16_t>::max(), "Too many polys");
+    s->WriteLE16((uint16_t)localPolys.size());
+    for (const plCullPoly& poly : localPolys)
+        poly.Write(s, mgr);
 
     mgr->WriteKey(s, fSceneNode);
 
-    s->WriteLE16(fVisRegions.GetCount());
-    for( i = 0; i < fVisRegions.GetCount(); i++ )
-        mgr->WriteKey(s, fVisRegions[i]);
+    hsAssert(fVisRegions.size() < std::numeric_limits<uint16_t>::max(), "Too many vis regions");
+    s->WriteLE16((uint16_t)fVisRegions.size());
+    for (plVisRegion* region : fVisRegions)
+        mgr->WriteKey(s, region);
 }
 
 plMobileOccluder::plMobileOccluder()
@@ -348,28 +340,20 @@ void plMobileOccluder::SetTransform(const hsMatrix44& l2w, const hsMatrix44& w2l
     fLocalToWorld = l2w;
     fWorldToLocal = w2l;
 
-    if( fPolys.GetCount() != fOrigPolys.GetCount() )
-        fPolys.SetCount(fOrigPolys.GetCount());
+    if (fPolys.size() != fOrigPolys.size())
+        fPolys.resize(fOrigPolys.size());
 
-    int i;
-    for( i = 0; i < fPolys.GetCount(); i++ )
+    for (size_t i = 0; i < fPolys.size(); i++)
         fOrigPolys[i].Transform(l2w, w2l, fPolys[i]);
 
     if( fProxyGen )
         fProxyGen->SetTransform(l2w, w2l);
 }
 
-void plMobileOccluder::SetPolyList(const hsTArray<plCullPoly>& list)
+void plMobileOccluder::SetPolyList(const std::vector<plCullPoly>& list)
 {
-    uint16_t n = list.GetCount();
-    fOrigPolys.SetCount(n);
-    fPolys.SetCount(n);
-
-    int i;
-    for( i = 0; i < n; i++ )
-    {
-        fPolys[i] = fOrigPolys[i] = list[i];
-    }
+    fPolys = list;
+    fOrigPolys = list;
 }
 
 void plMobileOccluder::Read(hsStream* s, hsResMgr* mgr)
@@ -381,7 +365,7 @@ void plMobileOccluder::Read(hsStream* s, hsResMgr* mgr)
 
     fLocalBounds.Read(s);
 
-    fPolys.SetCount(fOrigPolys.GetCount());
+    fPolys.resize(fOrigPolys.size());
 
     SetTransform(fLocalToWorld, fWorldToLocal);
 }

--- a/Sources/Plasma/PubUtilLib/plScene/plOccluder.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plOccluder.h
@@ -43,10 +43,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plOccluder_inc
 #define plOccluder_inc
 
+#include <vector>
+
 #include "hsBounds.h"
 #include "hsBitVector.h"
 #include "hsMatrix44.h"
-#include "hsTemplates.h"
 
 #include "pnSceneObject/plObjInterface.h"
 
@@ -68,12 +69,12 @@ public:
         kRefVisRegion
     };
 protected:
-    hsTArray<plCullPoly>        fPolys;
+    std::vector<plCullPoly>     fPolys;
 
     plOccluderProxy*            fProxyGen;
 
     hsBitVector                 fVisSet;
-    hsTArray<plVisRegion*>      fVisRegions;
+    std::vector<plVisRegion*>   fVisRegions;
     hsBitVector                 fVisNot;
 
     float                    fPriority;
@@ -84,7 +85,7 @@ protected:
     virtual float            IComputeSurfaceArea();
     virtual void                IComputeBounds();
 
-    virtual hsTArray<plCullPoly>& IGetLocalPolyList() { return fPolys; }
+    virtual std::vector<plCullPoly>& IGetLocalPolyList() { return fPolys; }
 
     void    ISetSceneNode(plKey node) override;
 
@@ -111,9 +112,9 @@ public:
     virtual const hsMatrix44& GetLocalToWorld() const;
     virtual const hsMatrix44& GetWorldToLocal() const;
 
-    virtual void SetPolyList(const hsTArray<plCullPoly>& list);
-    virtual const hsTArray<plCullPoly>& GetWorldPolyList() const { return fPolys; }
-    virtual const hsTArray<plCullPoly>& GetLocalPolyList() const { return fPolys; }
+    virtual void SetPolyList(const std::vector<plCullPoly>& list);
+    virtual const std::vector<plCullPoly>& GetWorldPolyList() const { return fPolys; }
+    virtual const std::vector<plCullPoly>& GetLocalPolyList() const { return fPolys; }
 
     int32_t   GetNumProperties() const override { return kNumProps; }
 
@@ -138,11 +139,11 @@ protected:
 
     hsBounds3Ext            fLocalBounds;
 
-    hsTArray<plCullPoly>    fOrigPolys;
+    std::vector<plCullPoly> fOrigPolys;
 
     void            IComputeBounds() override;
 
-    hsTArray<plCullPoly>& IGetLocalPolyList() override { return fOrigPolys; }
+    std::vector<plCullPoly>& IGetLocalPolyList() override { return fOrigPolys; }
 
 public:
 
@@ -156,9 +157,9 @@ public:
     const hsMatrix44& GetLocalToWorld() const override { return fLocalToWorld; }
     const hsMatrix44& GetWorldToLocal() const override { return fWorldToLocal; }
 
-    void SetPolyList(const hsTArray<plCullPoly>& list) override;
+    void SetPolyList(const std::vector<plCullPoly>& list) override;
 
-    const hsTArray<plCullPoly>& GetLocalPolyList() const override { return fOrigPolys; }
+    const std::vector<plCullPoly>& GetLocalPolyList() const override { return fOrigPolys; }
 
     void Read(hsStream* s, hsResMgr* mgr) override;
     void Write(hsStream* s, hsResMgr* mgr) override;

--- a/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.cpp
@@ -540,12 +540,11 @@ void plPageTreeMgr::AddOccluderList(const hsTArray<plOccluder*> occList)
 
 }
 
-void plPageTreeMgr::IAddCullPolyList(const hsTArray<plCullPoly>& polyList)
+void plPageTreeMgr::IAddCullPolyList(const std::vector<plCullPoly>& polyList)
 {
     int iStart = fCullPolys.GetCount();
-    fCullPolys.Resize(iStart + polyList.GetCount());
-    int i;
-    for( i = 0; i < polyList.GetCount(); i++ )
+    fCullPolys.Resize(iStart + polyList.size());
+    for (size_t i = 0; i < polyList.size(); i++)
     {
         fCullPolys[i + iStart] = &polyList[i];
     }

--- a/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.cpp
@@ -47,7 +47,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plDrawable.h"
 #include "plPipeline.h"
 #include "plProfile.h"
-#include "hsTemplates.h"
 #include "plTweak.h"
 
 #include <algorithm>
@@ -115,9 +114,9 @@ void plPageTreeMgr::ITrashSpaceTree()
     fSpaceTree = nullptr;
 }
 
-bool plPageTreeMgr::Harvest(plVolumeIsect* isect, hsTArray<plDrawVisList>& levList)
+bool plPageTreeMgr::Harvest(plVolumeIsect* isect, std::vector<plDrawVisList>& levList)
 {
-    levList.SetCount(0);
+    levList.clear();
     if( !(GetSpaceTree() || IBuildSpaceTree()) )
         return false;
 
@@ -130,7 +129,7 @@ bool plPageTreeMgr::Harvest(plVolumeIsect* isect, hsTArray<plDrawVisList>& levLi
         fNodes[idx]->Harvest(isect, levList);
     }
 
-    return levList.GetCount() > 0;
+    return !levList.empty();
 }
 
 #include "plProfile.h"
@@ -165,8 +164,8 @@ int plPageTreeMgr::Render(plPipeline* pipe)
     IGetOcclusion(pipe, list);
     pipe->HarvestVisible(GetSpaceTree(), list);
 
-    static hsTArray<plDrawVisList> levList;
-    levList.SetCount(0);
+    static std::vector<plDrawVisList> levList;
+    levList.clear();
     for (int16_t idx : list)
     {
         fNodes[idx]->CollectForRender(pipe, levList, visMgr);
@@ -184,19 +183,19 @@ int plPageTreeMgr::Render(plPipeline* pipe)
 
 }
 
-int plPageTreeMgr::IRenderVisList(plPipeline* pipe, hsTArray<plDrawVisList>& levList)
+size_t plPageTreeMgr::IRenderVisList(plPipeline* pipe, std::vector<plDrawVisList>& levList)
 {
     // Sort levList into sortedDrawList, which is just a list
     // of drawable/visList pairs in ascending render priority order.
     // visLists are just lists of span indices, but only of the
     // spans which are visible (on screen and non-occluded and non-disabled).
-    static hsTArray<plDrawVisList> sortedDrawList;
+    static std::vector<plDrawVisList> sortedDrawList;
     if( !ISortByLevel(pipe, levList, sortedDrawList) )
     {
         return 0;
     }
 
-    int numDrawn = 0;
+    size_t numDrawn = 0;
 
     plVisMgr* visMgr = fDisableVisMgr ? nullptr : fVisMgr;
 
@@ -208,8 +207,7 @@ int plPageTreeMgr::IRenderVisList(plPipeline* pipe, hsTArray<plDrawVisList>& lev
     // span sorting, we sort its spans with the spans of the next N drawables in
     // the sorted list which have the same render priority and which also want their
     // spans sorted.
-    int i;
-    for( i = 0; i < sortedDrawList.GetCount(); i++ )
+    for (size_t i = 0; i < sortedDrawList.size(); i++)
     {
         plDrawable* p = sortedDrawList[i].fDrawable;
 
@@ -238,18 +236,17 @@ int plPageTreeMgr::IRenderVisList(plPipeline* pipe, hsTArray<plDrawVisList>& lev
     return numDrawn;
 }
 
-bool plPageTreeMgr::ISortByLevel(plPipeline* pipe, hsTArray<plDrawVisList>& drawList, hsTArray<plDrawVisList>& sortedDrawList)
+bool plPageTreeMgr::ISortByLevel(plPipeline* pipe, std::vector<plDrawVisList>& drawList, std::vector<plDrawVisList>& sortedDrawList)
 {
-    sortedDrawList.SetCount(0);
+    sortedDrawList.clear();
 
-    if( !drawList.GetCount() )
+    if (drawList.empty())
         return false;
 
-    scratchList.resize(drawList.GetCount());
+    scratchList.resize(drawList.size());
 
     hsRadixSort::Elem* listTrav = nullptr;
-    int i;
-    for( i = 0; i < drawList.GetCount(); i++ )
+    for (size_t i = 0; i < drawList.size(); i++)
     {
         listTrav = &scratchList[i];
         listTrav->fBody = (void*)&drawList[i];
@@ -266,7 +263,7 @@ bool plPageTreeMgr::ISortByLevel(plPipeline* pipe, hsTArray<plDrawVisList>& draw
     while( listTrav )
     {
         plDrawVisList& drawVis = *(plDrawVisList*)listTrav->fBody;
-        sortedDrawList.Append(drawVis);
+        sortedDrawList.emplace_back(drawVis);
         
         listTrav = listTrav->fNext;
     }
@@ -277,12 +274,12 @@ bool plPageTreeMgr::ISortByLevel(plPipeline* pipe, hsTArray<plDrawVisList>& draw
 // Render from iDrawStart in drawVis list all drawables with the sort by spans property, well, sorting
 // by spans.
 // Returns the index of the last one drawn.
-int plPageTreeMgr::IPrepForRenderSortingSpans(plPipeline* pipe, hsTArray<plDrawVisList>& drawVis, int& iDrawStart)
+size_t plPageTreeMgr::IPrepForRenderSortingSpans(plPipeline* pipe, std::vector<plDrawVisList>& drawVis, size_t& iDrawStart)
 {
     uint32_t renderLevel = drawVis[iDrawStart].fDrawable->GetRenderLevel().Level();
 
-    static hsTArray<plDrawVisList*> drawables;
-    static hsTArray<plDrawSpanPair> pairs;
+    static std::vector<plDrawVisList*> drawables;
+    static std::vector<plDrawSpanPair> pairs;
 
     // Given the input drawVisList (list of drawable/visList pairs), we make two new
     // lists. The list "drawables" is just the excerpted sub-list from drawVis starting
@@ -293,78 +290,77 @@ int plPageTreeMgr::IPrepForRenderSortingSpans(plPipeline* pipe, hsTArray<plDrawV
     // So pairs[i] resolves into 
     // drawables[pairs[i].fDrawable].fDrawable->GetSpan(pairs[i].fSpan)
 
-    drawables.Append(&drawVis[iDrawStart]);
+    drawables.emplace_back(&drawVis[iDrawStart]);
     for (int16_t idx : drawVis[iDrawStart].fVisList)
     {
-        plDrawSpanPair* pair = pairs.Push();
-        pair->fDrawable = 0;
-        pair->fSpan = idx;
+        plDrawSpanPair& pair = pairs.emplace_back();
+        pair.fDrawable = 0;
+        pair.fSpan = idx;
     }
 
-    int iDraw;
-    for( iDraw = iDrawStart+1; 
-        (iDraw < drawVis.GetCount())
-        && (drawVis[iDraw].fDrawable->GetRenderLevel().Level() == renderLevel)
-        && drawVis[iDraw].fDrawable->GetNativeProperty(plDrawable::kPropSortSpans);
-        iDraw++ )
+    size_t iDraw;
+    for (iDraw = iDrawStart + 1;
+            (iDraw < drawVis.size())
+                && (drawVis[iDraw].fDrawable->GetRenderLevel().Level() == renderLevel)
+                && drawVis[iDraw].fDrawable->GetNativeProperty(plDrawable::kPropSortSpans);
+            iDraw++)
     {
         for (int16_t idx : drawVis[iDraw].fVisList)
         {
-            plDrawSpanPair* pair = pairs.Push();
-            pair->fDrawable = drawables.GetCount();
-            pair->fSpan = idx;
+            plDrawSpanPair& pair = pairs.emplace_back();
+            pair.fDrawable = (uint16_t)drawables.size();
+            pair.fSpan = idx;
         }
-        drawables.Append(&drawVis[iDraw]);
+        drawables.emplace_back(&drawVis[iDraw]);
     }
 
     // Now that we have them in a more convenient format, sort them and render.
     IRenderSortingSpans(pipe, drawables, pairs);
 
-    int numDrawn = pairs.GetCount();
+    size_t numDrawn = pairs.size();
 
-    drawables.SetCount(0);
-    pairs.SetCount(0);
+    drawables.clear();
+    pairs.clear();
 
     iDrawStart = iDraw - 1;
 
     return numDrawn;
 }
 
-bool plPageTreeMgr::IRenderSortingSpans(plPipeline* pipe, hsTArray<plDrawVisList*>& drawList, hsTArray<plDrawSpanPair>& pairs)
+bool plPageTreeMgr::IRenderSortingSpans(plPipeline* pipe, std::vector<plDrawVisList*>& drawList, std::vector<plDrawSpanPair>& pairs)
 {
 
-    if( !pairs.GetCount() )
+    if (pairs.empty())
         return false;
 
     hsPoint3 viewPos = pipe->GetViewPositionWorld();
 
     plProfile_BeginTiming(DrawObjSort);
-    plProfile_IncCount(DrawObjSorted, pairs.GetCount());
+    plProfile_IncCount(DrawObjSorted, pairs.size());
 
     hsRadixSort::Elem* listTrav;
-    scratchList.resize(pairs.GetCount());
+    scratchList.resize(pairs.size());
 
     // First, sort on distance to the camera (squared).
     listTrav = nullptr;
     int iSort = 0;
-    int i;
-    for( i = 0; i < pairs.GetCount(); i++ )
+    for (const plDrawSpanPair& pair : pairs)
     {
-        plDrawable* drawable = drawList[pairs[i].fDrawable]->fDrawable;
+        plDrawable* drawable = drawList[pair.fDrawable]->fDrawable;
 
         listTrav = &scratchList[iSort++];
-        listTrav->fBody = (void*)&pairs[i];
+        listTrav->fBody = (void*)&pair;
         listTrav->fNext = listTrav + 1;
 
         if( drawable->GetNativeProperty(plDrawable::kPropSortAsOne) )
         {
             const hsBounds3Ext& bnd = drawable->GetSpaceTree()->GetNode(drawable->GetSpaceTree()->GetRoot()).fWorldBounds;
             plConst(float) kDistFudge(1.e-1f);
-            listTrav->fKey.fFloat = -(bnd.GetCenter() - viewPos).MagnitudeSquared() + float(pairs[i].fSpan) * kDistFudge;
+            listTrav->fKey.fFloat = -(bnd.GetCenter() - viewPos).MagnitudeSquared() + float(pair.fSpan) * kDistFudge;
         }
         else
         {
-            const hsBounds3Ext& bnd = drawable->GetSpaceTree()->GetNode(pairs[i].fSpan).fWorldBounds;
+            const hsBounds3Ext& bnd = drawable->GetSpaceTree()->GetNode(pair.fSpan).fWorldBounds;
             listTrav->fKey.fFloat = -(bnd.GetCenter() - viewPos).MagnitudeSquared();
         }
     }
@@ -396,8 +392,8 @@ bool plPageTreeMgr::IRenderSortingSpans(plPipeline* pipe, hsTArray<plDrawVisList
     // isn't appropriate for rendering (because it doesn't let us switch back and forth 
     // from a drawable, but it's right for the PrepForRenderCall (which does things like
     // face sorting).
-    for( i = 0; i < drawList.GetCount(); i++ )
-        drawList[i]->fVisList.clear();
+    for (plDrawVisList* dvList : drawList)
+        dvList->fVisList.clear();
     listTrav = sortedList;
     while( listTrav )
     {
@@ -405,9 +401,9 @@ bool plPageTreeMgr::IRenderSortingSpans(plPipeline* pipe, hsTArray<plDrawVisList
         drawList[curPair.fDrawable]->fVisList.emplace_back(curPair.fSpan);
         listTrav = listTrav->fNext;
     }
-    for( i = 0; i < drawList.GetCount(); i++ )
+    for (plDrawVisList* dvList : drawList)
     {
-        pipe->PrepForRender(drawList[i]->fDrawable, drawList[i]->fVisList, visMgr);
+        pipe->PrepForRender(dvList->fDrawable, dvList->fVisList, visMgr);
     }
 
     // We'd like to call Render once on a drawable for each contiguous
@@ -448,8 +444,8 @@ bool plPageTreeMgr::IRenderSortingSpans(plPipeline* pipe, hsTArray<plDrawVisList
     int curDraw = curPair.fDrawable;
     listTrav = listTrav->fNext;
 
-    static hsTArray<uint32_t> numDrawn;
-    numDrawn.SetCountAndZero(drawList.GetCount());
+    static std::vector<uint32_t> numDrawn;
+    numDrawn.assign(drawList.size(), 0);
 
     visList.emplace_back(drawList[curDraw]->fVisList[numDrawn[curDraw]++]);
 
@@ -509,10 +505,10 @@ bool plPageTreeMgr::IRefreshTree(plPipeline* pipe)
     return true;
 }
 
-void plPageTreeMgr::AddOccluderList(const hsTArray<plOccluder*> occList)
+void plPageTreeMgr::AddOccluderList(const std::vector<plOccluder*> occList)
 {
-    int iStart = fOccluders.GetCount();
-    fOccluders.Resize(iStart + occList.GetCount());
+    size_t iStart = fOccluders.size();
+    fOccluders.resize(iStart + occList.size());
 
     plVisMgr* visMgr = fDisableVisMgr ? nullptr : fVisMgr;
 
@@ -520,30 +516,27 @@ void plPageTreeMgr::AddOccluderList(const hsTArray<plOccluder*> occList)
     {
         const hsBitVector& visSet = visMgr->GetVisSet();
         const hsBitVector& visNot = visMgr->GetVisNot();
-        int i;
-        for( i = 0; i < occList.GetCount(); i++ )
+        for (plOccluder* occluder : occList)
         {
-            if( occList[i] && !occList[i]->InVisNot(visNot) && occList[i]->InVisSet(visSet) )
-                fOccluders[iStart++] = occList[i];
+            if (occluder && !occluder->InVisNot(visNot) && occluder->InVisSet(visSet))
+                fOccluders[iStart++] = occluder;
         }
     }
     else
     {
-        int i;
-        for( i = 0; i < occList.GetCount(); i++ )
+        for (plOccluder* occluder : occList)
         {
-            if( occList[i] )
-                fOccluders[iStart++] = occList[i];
+            if (occluder)
+                fOccluders[iStart++] = occluder;
         }
     }
-    fOccluders.SetCount(iStart);
-
+    fOccluders.resize(iStart);
 }
 
 void plPageTreeMgr::IAddCullPolyList(const std::vector<plCullPoly>& polyList)
 {
-    int iStart = fCullPolys.GetCount();
-    fCullPolys.Resize(iStart + polyList.size());
+    size_t iStart = fCullPolys.size();
+    fCullPolys.resize(iStart + polyList.size());
     for (size_t i = 0; i < polyList.size(); i++)
     {
         fCullPolys[i + iStart] = &polyList[i];
@@ -553,7 +546,7 @@ void plPageTreeMgr::IAddCullPolyList(const std::vector<plCullPoly>& polyList)
 void plPageTreeMgr::ISortCullPolys(plPipeline* pipe)
 {
     fSortedCullPolys.clear();
-    if( !fCullPolys.GetCount() )
+    if (fCullPolys.empty())
         return;
 
     constexpr size_t kMaxCullPolys = 300;
@@ -562,25 +555,25 @@ void plPageTreeMgr::ISortCullPolys(plPipeline* pipe)
     hsPoint3 viewPos = pipe->GetViewPositionWorld();
 
     hsRadixSort::Elem* listTrav;
-    scratchList.resize(fCullPolys.GetCount());
-    for (int i = 0; i < fCullPolys.GetCount(); i++)
+    scratchList.resize(fCullPolys.size());
+    for (const plCullPoly* poly : fCullPolys)
     {
-        bool backFace = fCullPolys[i]->fNorm.InnerProduct(viewPos) + fCullPolys[i]->fDist <= 0;
+        bool backFace = poly->fNorm.InnerProduct(viewPos) + poly->fDist <= 0;
         if( backFace )
         {
-            if( !fCullPolys[i]->IsHole() && !fCullPolys[i]->IsTwoSided() )
+            if (!poly->IsHole() && !poly->IsTwoSided())
                 continue;
         }
         else
         {
-            if( fCullPolys[i]->IsHole() )
+            if (poly->IsHole())
                 continue;
         }
 
         listTrav = &scratchList[numSubmit];
-        listTrav->fBody = (void*)fCullPolys[i];
+        listTrav->fBody = (void*)poly;
         listTrav->fNext = listTrav + 1;
-        listTrav->fKey.fFloat = (fCullPolys[i]->GetCenter() - viewPos).MagnitudeSquared();
+        listTrav->fKey.fFloat = (poly->GetCenter() - viewPos).MagnitudeSquared();
 
         numSubmit++;
     }
@@ -607,28 +600,27 @@ void plPageTreeMgr::ISortCullPolys(plPipeline* pipe)
 
 bool plPageTreeMgr::IGetCullPolys(plPipeline* pipe)
 {
-    if( !fOccluders.GetCount() )
+    if (fOccluders.empty())
         return false;
 
     plProfile_BeginTiming(DrawOccSort);
 
     hsRadixSort::Elem* listTrav = nullptr;
-    scratchList.resize(fOccluders.GetCount());
+    scratchList.resize(fOccluders.size());
 
     hsPoint3 viewPos = pipe->GetViewPositionWorld();
 
     // cull test the occluders submitted
-    int numSubmit = 0;
-    int i;
-    for( i = 0; i < fOccluders.GetCount(); i++ )
+    uint32_t numSubmit = 0;
+    for (const plOccluder* occluder : fOccluders)
     {
-        if( pipe->TestVisibleWorld(fOccluders[i]->GetWorldBounds()) )
+        if( pipe->TestVisibleWorld(occluder->GetWorldBounds()) )
         {
-            float invDist = -hsFastMath::InvSqrtAppr((viewPos - fOccluders[i]->GetWorldBounds().GetCenter()).MagnitudeSquared());
+            float invDist = -hsFastMath::InvSqrtAppr((viewPos - occluder->GetWorldBounds().GetCenter()).MagnitudeSquared());
             listTrav = &scratchList[numSubmit++];
-            listTrav->fBody = (void*)fOccluders[i];
+            listTrav->fBody = (void*)occluder;
             listTrav->fNext = listTrav+1;
-            listTrav->fKey.fFloat = fOccluders[i]->GetPriority() * invDist;
+            listTrav->fKey.fFloat = occluder->GetPriority() * invDist;
         }
     }
     if( !listTrav )
@@ -645,14 +637,14 @@ bool plPageTreeMgr::IGetCullPolys(plPipeline* pipe)
     hsRadixSort::Elem* sortedList = rad.Sort(scratchList.data(), 0);
     listTrav = sortedList;
 
-    const uint32_t kMaxOccluders = 1000;
-    if( numSubmit > kMaxOccluders )
+    constexpr uint32_t kMaxOccluders = 1000;
+    if (numSubmit > kMaxOccluders)
         numSubmit = kMaxOccluders;
 
     plProfile_IncCount(DrawOccUsed, numSubmit);
 
     // Take the polys from the first N of them
-    for( i = 0; i < numSubmit; i++ )
+    for (uint32_t i = 0; i < numSubmit; i++)
     {
         plOccluder* occ = (plOccluder*)listTrav->fBody;
         IAddCullPolyList(occ->GetWorldPolyList());
@@ -662,15 +654,15 @@ bool plPageTreeMgr::IGetCullPolys(plPipeline* pipe)
 
     plProfile_EndTiming(DrawOccSort);
 
-    return fCullPolys.GetCount() > 0;
+    return !fCullPolys.empty();
 }
 
 bool plPageTreeMgr::IGetOcclusion(plPipeline* pipe, std::vector<int16_t>& list)
 {
     plProfile_BeginTiming(DrawOccBuild);
 
-    fCullPolys.SetCount(0);
-    fOccluders.SetCount(0);
+    fCullPolys.clear();
+    fOccluders.clear();
     for (plSceneNode* node : fNodes)
         node->SubmitOccluders(this);
 
@@ -680,7 +672,7 @@ bool plPageTreeMgr::IGetOcclusion(plPipeline* pipe, std::vector<int16_t>& list)
         return false;
     }
 
-    plProfile_IncCount(DrawOccPolyProc, fCullPolys.GetCount());
+    plProfile_IncCount(DrawOccPolyProc, fCullPolys.size());
 
     plProfile_BeginTiming(DrawOccPolySort);
     ISortCullPolys(pipe);
@@ -696,6 +688,6 @@ bool plPageTreeMgr::IGetOcclusion(plPipeline* pipe, std::vector<int16_t>& list)
 
 void plPageTreeMgr::IResetOcclusion(plPipeline* pipe)
 {
-    fCullPolys.SetCount(0);
+    fCullPolys.clear();
     fSortedCullPolys.clear();
 }

--- a/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.cpp
@@ -292,11 +292,7 @@ size_t plPageTreeMgr::IPrepForRenderSortingSpans(plPipeline* pipe, std::vector<p
 
     drawables.emplace_back(&drawVis[iDrawStart]);
     for (int16_t idx : drawVis[iDrawStart].fVisList)
-    {
-        plDrawSpanPair& pair = pairs.emplace_back();
-        pair.fDrawable = 0;
-        pair.fSpan = idx;
-    }
+        pairs.emplace_back(0, idx);
 
     size_t iDraw;
     for (iDraw = iDrawStart + 1;
@@ -306,11 +302,7 @@ size_t plPageTreeMgr::IPrepForRenderSortingSpans(plPipeline* pipe, std::vector<p
             iDraw++)
     {
         for (int16_t idx : drawVis[iDraw].fVisList)
-        {
-            plDrawSpanPair& pair = pairs.emplace_back();
-            pair.fDrawable = (uint16_t)drawables.size();
-            pair.fSpan = idx;
-        }
+            pairs.emplace_back((uint16_t)drawables.size(), idx);
         drawables.emplace_back(&drawVis[iDraw]);
     }
 

--- a/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.h
@@ -51,7 +51,6 @@ class plPipeline;
 class plCullPoly;
 class plOccluder;
 class plDrawable;
-class plDrawVisList;
 class plVolumeIsect;
 class plVisMgr;
 
@@ -63,16 +62,13 @@ struct plDrawSpanPair
     uint16_t      fSpan;
 };
 
-class plDrawVisList
+struct plDrawVisList
 {
-public:
-    plDrawVisList() : fDrawable() { }
+    plDrawVisList(plDrawable* drawable = nullptr) : fDrawable(drawable) { }
     virtual ~plDrawVisList() {}
 
     plDrawable*         fDrawable;
     std::vector<int16_t>  fVisList;
-
-    plDrawVisList& operator=(const plDrawVisList& v) { fDrawable = v.fDrawable; fVisList = v.fVisList; return *this; }
 };
 
 class plPageTreeMgr

--- a/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.h
@@ -43,7 +43,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plPageTreeMgr_inc
 #define plPageTreeMgr_inc
 
-#include "hsTemplates.h"
 #include <vector>
 
 class plSceneNode;
@@ -80,15 +79,15 @@ public:
 class plPageTreeMgr
 {
 protected:
-    std::vector<plSceneNode*>      fNodes;
+    std::vector<plSceneNode*>   fNodes;
 
     plSpaceTree*                fSpaceTree;
     plVisMgr*                   fVisMgr;
 
     static bool                 fDisableVisMgr;
 
-    hsTArray<const plOccluder*> fOccluders;
-    hsTArray<const plCullPoly*> fCullPolys;
+    std::vector<const plOccluder*> fOccluders;
+    std::vector<const plCullPoly*> fCullPolys;
     std::vector<const plCullPoly*> fSortedCullPolys;
 
     void                        ITrashSpaceTree();
@@ -100,10 +99,10 @@ protected:
     void                        IResetOcclusion(plPipeline* pipe);
     void                        IAddCullPolyList(const std::vector<plCullPoly>& polyList);
 
-    bool                        ISortByLevel(plPipeline* pipe, hsTArray<plDrawVisList>& drawList, hsTArray<plDrawVisList>& sortedDrawList);
-    int                         IPrepForRenderSortingSpans(plPipeline* pipe, hsTArray<plDrawVisList>& drawVis, int& iDrawStart);
-    bool                        IRenderSortingSpans(plPipeline* pipe, hsTArray<plDrawVisList*>& drawList, hsTArray<plDrawSpanPair>& pairs);
-    int                         IRenderVisList(plPipeline* pipe, hsTArray<plDrawVisList>& visList);
+    bool                        ISortByLevel(plPipeline* pipe, std::vector<plDrawVisList>& drawList, std::vector<plDrawVisList>& sortedDrawList);
+    size_t                      IPrepForRenderSortingSpans(plPipeline* pipe, std::vector<plDrawVisList>& drawVis, size_t& iDrawStart);
+    bool                        IRenderSortingSpans(plPipeline* pipe, std::vector<plDrawVisList*>& drawList, std::vector<plDrawSpanPair>& pairs);
+    size_t                      IRenderVisList(plPipeline* pipe, std::vector<plDrawVisList>& visList);
 
 public:
     plPageTreeMgr();
@@ -118,9 +117,9 @@ public:
 
     virtual int     Render(plPipeline* pipe);
 
-    bool            Harvest(plVolumeIsect* isect, hsTArray<plDrawVisList>& levList);
+    bool            Harvest(plVolumeIsect* isect, std::vector<plDrawVisList>& levList);
 
-    void            AddOccluderList(const hsTArray<plOccluder*> occList);
+    void            AddOccluderList(const std::vector<plOccluder*> occList);
 
     plSpaceTree*    GetSpaceTree() { if( !fSpaceTree ) IBuildSpaceTree(); return fSpaceTree; }
 

--- a/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.h
@@ -98,7 +98,7 @@ protected:
     bool                        IGetOcclusion(plPipeline* pipe, std::vector<int16_t>& list);
     bool                        IGetCullPolys(plPipeline* pipe);
     void                        IResetOcclusion(plPipeline* pipe);
-    void                        IAddCullPolyList(const hsTArray<plCullPoly>& polyList);
+    void                        IAddCullPolyList(const std::vector<plCullPoly>& polyList);
 
     bool                        ISortByLevel(plPipeline* pipe, hsTArray<plDrawVisList>& drawList, hsTArray<plDrawVisList>& sortedDrawList);
     int                         IPrepForRenderSortingSpans(plPipeline* pipe, hsTArray<plDrawVisList>& drawVis, int& iDrawStart);

--- a/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.h
@@ -55,9 +55,8 @@ class plDrawVisList;
 class plVolumeIsect;
 class plVisMgr;
 
-class plDrawSpanPair
+struct plDrawSpanPair
 {
-public:
     plDrawSpanPair() : fDrawable(), fSpan() { }
     plDrawSpanPair(uint16_t d, uint16_t s) : fDrawable(d), fSpan(s) { }
     uint16_t      fDrawable;

--- a/Sources/Plasma/PubUtilLib/plScene/plRelevanceMgr.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plRelevanceMgr.h
@@ -42,7 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plRelevanceMgr_inc
 #define plRelevanceMgr_inc
 
-#include "hsTemplates.h"
+#include <vector>
 
 #include "pnKeyedObject/hsKeyedObject.h"
 
@@ -64,7 +64,7 @@ public:
     static void DeInit();   
 
 protected:
-    hsTArray<plRelevanceRegion*> fRegions;  
+    std::vector<plRelevanceRegion*> fRegions;
     bool fEnabled;
 
     void IAddRegion(plRelevanceRegion *);

--- a/Sources/Plasma/PubUtilLib/plScene/plSceneNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plSceneNode.cpp
@@ -141,8 +141,7 @@ void plSceneNode::Harvest(plVolumeIsect* isect, std::vector<plDrawVisList>& levL
         fDrawPool[idx]->GetSpaceTree()->HarvestLeaves(isect, visSpans);
         if (!visSpans.empty())
         {
-            plDrawVisList& drawVis = levList.emplace_back();
-            drawVis.fDrawable = fDrawPool[idx];
+            plDrawVisList& drawVis = levList.emplace_back(fDrawPool[idx]);
             drawVis.fVisList.swap(visSpans);
         }
     }
@@ -160,8 +159,7 @@ void plSceneNode::CollectForRender(plPipeline* pipe, std::vector<plDrawVisList>&
     {
         if( pipe->PreRender(fDrawPool[idx], visSpans, visMgr) )
         {
-            plDrawVisList& drawVis = levList.emplace_back();
-            drawVis.fDrawable = fDrawPool[idx];
+            plDrawVisList& drawVis = levList.emplace_back(fDrawPool[idx]);
             drawVis.fVisList.swap(visSpans);
         }
     }

--- a/Sources/Plasma/PubUtilLib/plScene/plSceneNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plSceneNode.cpp
@@ -128,7 +128,7 @@ void plSceneNode::Write(hsStream* s, hsResMgr* mgr)
         mgr->WriteKey(s, fGenericPool[i]);
 }
 
-void plSceneNode::Harvest(plVolumeIsect* isect, hsTArray<plDrawVisList>& levList)
+void plSceneNode::Harvest(plVolumeIsect* isect, std::vector<plDrawVisList>& levList)
 {
     static std::vector<int16_t> visList;
     visList.clear();
@@ -141,14 +141,14 @@ void plSceneNode::Harvest(plVolumeIsect* isect, hsTArray<plDrawVisList>& levList
         fDrawPool[idx]->GetSpaceTree()->HarvestLeaves(isect, visSpans);
         if (!visSpans.empty())
         {
-            plDrawVisList* drawVis = levList.Push();
-            drawVis->fDrawable = fDrawPool[idx];
-            drawVis->fVisList.swap(visSpans);
+            plDrawVisList& drawVis = levList.emplace_back();
+            drawVis.fDrawable = fDrawPool[idx];
+            drawVis.fVisList.swap(visSpans);
         }
     }
 }
 
-void plSceneNode::CollectForRender(plPipeline* pipe, hsTArray<plDrawVisList>& levList, plVisMgr* visMgr)
+void plSceneNode::CollectForRender(plPipeline* pipe, std::vector<plDrawVisList>& levList, plVisMgr* visMgr)
 {
     static std::vector<int16_t> visList;
     visList.clear();
@@ -160,9 +160,9 @@ void plSceneNode::CollectForRender(plPipeline* pipe, hsTArray<plDrawVisList>& le
     {
         if( pipe->PreRender(fDrawPool[idx], visSpans, visMgr) )
         {
-            plDrawVisList* drawVis = levList.Push();
-            drawVis->fDrawable = fDrawPool[idx];
-            drawVis->fVisList.swap(visSpans);
+            plDrawVisList& drawVis = levList.emplace_back();
+            drawVis.fDrawable = fDrawPool[idx];
+            drawVis.fVisList.swap(visSpans);
         }
     }
 }
@@ -276,9 +276,9 @@ void plSceneNode::ISetLight(plLightInfo* l)
 
 void plSceneNode::ISetOccluder(plOccluder* o)
 {
-    if( fOccluders.kMissingIndex == fOccluders.Find(o) )
+    if (std::find(fOccluders.cbegin(), fOccluders.cend(), o) == fOccluders.cend())
     {
-        fOccluders.Append(o);
+        fOccluders.emplace_back(o);
     }
 }
 
@@ -345,9 +345,9 @@ void plSceneNode::IRemoveLight(plLightInfo* l)
 
 void plSceneNode::IRemoveOccluder(plOccluder* o)
 {
-    int idx = fOccluders.Find(o);
-    if( idx != fOccluders.kMissingIndex )
-        fOccluders.Remove(idx);
+    auto iter = std::find(fOccluders.cbegin(), fOccluders.cend(), o);
+    if (iter != fOccluders.cend())
+        fOccluders.erase(iter);
 }
 
 void plSceneNode::IRemoveGeneric(hsKeyedObject* k)
@@ -453,18 +453,17 @@ void    plSceneNode::ICleanUp()
 
     if (fFilterGenerics)
     {
-        int i;
-        for ( i = fSceneObjects.size() - 1; i >= 0; i--)
+        for (hsSsize_t i = fSceneObjects.size() - 1; i >= 0; i--)
             GetKey()->Release(fSceneObjects[i]->GetKey());
-        for ( i = fDrawPool.size() - 1; i >= 0; i--)
+        for (hsSsize_t i = fDrawPool.size() - 1; i >= 0; i--)
             GetKey()->Release(fDrawPool[i]->GetKey());
-        for ( i = fSimulationPool.size() - 1; i >= 0; i--)
+        for (hsSsize_t i = fSimulationPool.size() - 1; i >= 0; i--)
             GetKey()->Release(fSimulationPool[i]->GetKey());
-        for ( i = fAudioPool.size() - 1; i >= 0; i--)
+        for (hsSsize_t i = fAudioPool.size() - 1; i >= 0; i--)
             GetKey()->Release(fAudioPool[i]->GetKey());
-        for ( i = fOccluders.GetCount() - 1; i >= 0; i--)
+        for (hsSsize_t i = fOccluders.size() - 1; i >= 0; i--)
             GetKey()->Release(fOccluders[i]->GetKey());
-        for ( i = fLightPool.size() - 1; i >= 0; i--)
+        for (hsSsize_t i = fLightPool.size() - 1; i >= 0; i--)
             GetKey()->Release(fLightPool[i]->GetKey());
     }
 

--- a/Sources/Plasma/PubUtilLib/plScene/plSceneNode.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plSceneNode.h
@@ -44,7 +44,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plSceneNode_inc
 
 #include "pnKeyedObject/hsKeyedObject.h"
-#include "hsTemplates.h"
 #include <vector>
 
 
@@ -83,7 +82,7 @@ protected:
     std::vector<plPhysical*>               fSimulationPool;
     std::vector<plAudible*>                fAudioPool;
 
-    hsTArray<plOccluder*>                  fOccluders;
+    std::vector<plOccluder*>               fOccluders;
 
     std::vector<plLightInfo*>              fLightPool;
 
@@ -127,8 +126,8 @@ public:
     void Read(hsStream* s, hsResMgr* mgr) override;
     void Write(hsStream* s, hsResMgr* mgr) override;
 
-    virtual void Harvest(plVolumeIsect* isect, hsTArray<plDrawVisList>& levList);
-    virtual void CollectForRender(plPipeline* pipe, hsTArray<plDrawVisList>& levList, plVisMgr* visMgr);
+    virtual void Harvest(plVolumeIsect* isect, std::vector<plDrawVisList>& levList);
+    virtual void CollectForRender(plPipeline* pipe, std::vector<plDrawVisList>& levList, plVisMgr* visMgr);
 
     virtual void SubmitOccluders(plPageTreeMgr* pageMgr) const;
 

--- a/Sources/Plasma/PubUtilLib/plScene/plSceneNode.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plSceneNode.h
@@ -56,7 +56,7 @@ class plPipeline;
 class plNodeRefMsg;
 class plDispatchBase;
 class plSpaceTree;
-class plDrawSpanPair;
+struct plDrawSpanPair;
 class plDrawVisList;
 class plOccluder;
 class plPageTreeMgr;

--- a/Sources/Plasma/PubUtilLib/plScene/plSceneNode.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plSceneNode.h
@@ -57,7 +57,7 @@ class plNodeRefMsg;
 class plDispatchBase;
 class plSpaceTree;
 struct plDrawSpanPair;
-class plDrawVisList;
+struct plDrawVisList;
 class plOccluder;
 class plPageTreeMgr;
 class plDrawableCriteria;

--- a/Sources/Plasma/PubUtilLib/plScene/plVisMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plVisMgr.cpp
@@ -78,7 +78,7 @@ void plVisMgr::Register(plVisRegion* reg, bool bnot)
 {
     // This should happen pretty infrequently, or
     // I wouldn't be doing it so cloth-headed-ly.
-    hsTArray<plVisRegion*>& regions = bnot ? fNotRegions : fRegions;
+    std::vector<plVisRegion*>& regions = bnot ? fNotRegions : fRegions;
     hsBitVector& indices = bnot ? fIdxNot : fIdxSet;
     int& maxIdx = bnot ? fMaxNot : fMaxSet;
     int i;
@@ -91,7 +91,7 @@ void plVisMgr::Register(plVisRegion* reg, bool bnot)
 
             indices.SetBit(i);
             reg->SetIndex(i);
-            regions.Append(reg);
+            regions.emplace_back(reg);
             return;
         }
     }
@@ -105,26 +105,25 @@ void plVisMgr::UnRegister(plVisRegion* reg, bool bnot)
     indices.ClearBit(reg->GetIndex());
 
     // Nuke the region from our list.
-    hsTArray<plVisRegion*>& regions = bnot ? fNotRegions : fRegions;
-    int idx = regions.Find(reg);
-    if( regions.kMissingIndex != idx )
-        regions.Remove(idx);
+    std::vector<plVisRegion*>& regions = bnot ? fNotRegions : fRegions;
+    auto iter = std::find(regions.cbegin(), regions.cend(), reg);
+    if (iter != regions.cend())
+        regions.erase(iter);
 }
 
 void plVisMgr::Eval(const hsPoint3& pos)
 {
     fVisSet = fOnBitSet;
 
-    int i;
-    for( i = 0; i < fRegions.GetCount(); i++ )
+    for (plVisRegion* region : fRegions)
     {
-        hsAssert(fRegions[i], "Nil region in list");
-        if( !fOffBitSet.IsBitSet(fRegions[i]->GetIndex()) )
+        hsAssert(region, "Nil region in list");
+        if (!fOffBitSet.IsBitSet(region->GetIndex()))
         {
-            if( fRegions[i]->Eval(pos) )
+            if (region->Eval(pos))
             {
-                fVisSet.SetBit(fRegions[i]->GetIndex());
-                if( fRegions[i]->DisableNormal() )
+                fVisSet.SetBit(region->GetIndex());
+                if (region->DisableNormal())
                 {
                     fVisSet.ClearBit(kNormal);
                     fVisSet.SetBit(kCharacter);
@@ -135,14 +134,14 @@ void plVisMgr::Eval(const hsPoint3& pos)
 
     fVisNot = fOnBitNot;
 
-    for( i = 0; i < fNotRegions.GetCount(); i++ )
+    for (plVisRegion* region : fNotRegions)
     {
-        hsAssert(fNotRegions[i], "Nil region in list");
-        if( !fOffBitNot.IsBitSet(fNotRegions[i]->GetIndex()) )
+        hsAssert(region, "Nil region in list");
+        if (!fOffBitNot.IsBitSet(region->GetIndex()))
         {
-            if( fNotRegions[i]->Eval(pos) )
+            if (region->Eval(pos))
             {
-                fVisNot.SetBit(fNotRegions[i]->GetIndex());
+                fVisNot.SetBit(region->GetIndex());
             }
         }
     }

--- a/Sources/Plasma/PubUtilLib/plScene/plVisMgr.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plVisMgr.h
@@ -43,8 +43,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plVisMgr_inc
 #define plVisMgr_inc
 
+#include <vector>
+
 #include "pnKeyedObject/hsKeyedObject.h"
-#include "hsTemplates.h"
 #include "hsBitVector.h"
 
 class hsStream;
@@ -64,8 +65,8 @@ public:
         kNumReserved
     };
 protected:
-    hsTArray<plVisRegion*>          fRegions;
-    hsTArray<plVisRegion*>          fNotRegions;
+    std::vector<plVisRegion*>       fRegions;
+    std::vector<plVisRegion*>       fNotRegions;
 
     hsBitVector                     fVisSet;
     hsBitVector                     fVisNot;

--- a/Sources/Plasma/PubUtilLib/plSurface/hsGMaterial.h
+++ b/Sources/Plasma/PubUtilLib/plSurface/hsGMaterial.h
@@ -42,9 +42,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef hsGCompMatDefined
 #define hsGCompMatDefined
 
+#include <vector>
+
 #include "hsColorRGBA.h"
 #include "hsGMatState.h"
-#include "hsTemplates.h"
 
 #include "pnNetCommon/plSynchedObject.h"
 
@@ -83,8 +84,8 @@ public:
 
 protected:
     uint32_t                  fLOD;
-    hsTArray<plLayerInterface*>     fLayers;
-    hsTArray<plLayerInterface*>     fPiggyBacks;
+    std::vector<plLayerInterface*> fLayers;
+    std::vector<plLayerInterface*> fPiggyBacks;
 
     uint32_t                  fCompFlags;
     uint32_t                  fLoadFlags;
@@ -92,7 +93,7 @@ protected:
     float                fLastUpdateTime;
 
     void                IClearLayers();
-    uint32_t              IMakeExtraLayer();
+    size_t              IMakeExtraLayer();
 
     void                    InsertLayer(plLayerInterface* lay, int32_t which = 0, bool piggyBack = false);
     void                    SetLayer(plLayerInterface* lay, int32_t which = 0, bool insert=false, bool piggyBack=false);
@@ -106,13 +107,12 @@ public:
     virtual hsGMaterial*    CloneNoLayers(); // For things like blending copies, that manipulate layers directly.
                                              // copies no keyed objects.
     plLayer*                MakeBaseLayer();
-    plLayerInterface*       GetLayer(uint32_t which);
-    plLayerInterface*       GetPiggyBack(uint32_t which);
-    uint32_t                  AddLayerViaNotify(plLayerInterface* lay);
-    uint32_t                  GetNumLayers() const        { return fLayers.GetCount(); }
-    void                    SetNumLayers(int cnt);
-    uint32_t                  GetNumPiggyBacks() const    { return fPiggyBacks.GetCount(); }
-    void                    SetNumPiggyBacks();
+    plLayerInterface*       GetLayer(size_t which);
+    plLayerInterface*       GetPiggyBack(size_t which);
+    uint32_t                AddLayerViaNotify(plLayerInterface* lay);
+    size_t                  GetNumLayers() const        { return fLayers.size(); }
+    void                    SetNumLayers(size_t cnt);
+    size_t                  GetNumPiggyBacks() const    { return fPiggyBacks.size(); }
 
     void                    SetLOD(uint32_t l)            { fLOD = l; }
     uint32_t                  GetLOD() const              { return fLOD; }

--- a/Sources/Plasma/PubUtilLib/plSurface/plShader.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plShader.cpp
@@ -58,7 +58,7 @@ void plShaderConst::Read(hsStream* s)
     fW = s->ReadLEScalar();
 }
 
-void plShaderConst::Write(hsStream* s)
+void plShaderConst::Write(hsStream* s) const
 {
     s->WriteLEScalar(fX);
     s->WriteLEScalar(fY);
@@ -90,7 +90,7 @@ void plShader::SetDeviceRef(hsGDeviceRef* ref) const
 }
 
 
-void plShader::SetMatrix(int i, const plFloat44& xfm)
+void plShader::SetMatrix(size_t i, const plFloat44& xfm)
 {
     // Stuff in the transpose
     SetVector(i+0, xfm.m[0][0], xfm.m[1][0], xfm.m[2][0], xfm.m[3][0]);
@@ -99,7 +99,7 @@ void plShader::SetMatrix(int i, const plFloat44& xfm)
     SetVector(i+3, xfm.m[0][3], xfm.m[1][3], xfm.m[2][3], xfm.m[3][3]);
 }
 
-void plShader::SetMatrix3(int i, const plFloat44& xfm)
+void plShader::SetMatrix3(size_t i, const plFloat44& xfm)
 {
     // Stuff in the transpose
     SetVector(i+0, xfm.m[0][0], xfm.m[1][0], xfm.m[2][0], xfm.m[3][0]);
@@ -107,7 +107,7 @@ void plShader::SetMatrix3(int i, const plFloat44& xfm)
     SetVector(i+2, xfm.m[0][2], xfm.m[1][2], xfm.m[2][2], xfm.m[3][2]);
 }
 
-void plShader::SetMatrix44(int i, const hsMatrix44& xfm)
+void plShader::SetMatrix44(size_t i, const hsMatrix44& xfm)
 {
     // hsMatrix44 is already transpose of the rest of the world
     SetVector(i+0, xfm.fMap[0][0], xfm.fMap[0][1], xfm.fMap[0][2], xfm.fMap[0][3]);
@@ -116,7 +116,7 @@ void plShader::SetMatrix44(int i, const hsMatrix44& xfm)
     SetVector(i+3, xfm.fMap[3][0], xfm.fMap[3][1], xfm.fMap[3][2], xfm.fMap[3][3]);
 }
 
-void plShader::SetMatrix34(int i, const hsMatrix44& xfm)
+void plShader::SetMatrix34(size_t i, const hsMatrix44& xfm)
 {
     // hsMatrix44 is already transpose of the rest of the world
     SetVector(i+0, xfm.fMap[0][0], xfm.fMap[0][1], xfm.fMap[0][2], xfm.fMap[0][3]);
@@ -124,19 +124,19 @@ void plShader::SetMatrix34(int i, const hsMatrix44& xfm)
     SetVector(i+2, xfm.fMap[2][0], xfm.fMap[2][1], xfm.fMap[2][2], xfm.fMap[2][3]);
 }
 
-void plShader::SetMatrix24(int i, const hsMatrix44& xfm)
+void plShader::SetMatrix24(size_t i, const hsMatrix44& xfm)
 {
     // hsMatrix44 is already transpose of the rest of the world
     SetVector(i+0, xfm.fMap[0][0], xfm.fMap[0][1], xfm.fMap[0][2], xfm.fMap[0][3]);
     SetVector(i+1, xfm.fMap[1][0], xfm.fMap[1][1], xfm.fMap[1][2], xfm.fMap[1][3]);
 }
 
-void plShader::SetColor(int i, const hsColorRGBA& col)
+void plShader::SetColor(size_t i, const hsColorRGBA& col)
 {
     SetVector(i, col.r, col.g, col.b, col.a);
 }
 
-void plShader::SetVector(int i, const hsScalarTriple& vec)
+void plShader::SetVector(size_t i, const hsScalarTriple& vec)
 {
     /* Doesn't touch .fW */
     fConsts[i].fX = vec.fX;
@@ -144,7 +144,7 @@ void plShader::SetVector(int i, const hsScalarTriple& vec)
     fConsts[i].fZ = vec.fZ;
 }
 
-void plShader::SetVector(int i, float x, float y, float z, float w)
+void plShader::SetVector(size_t i, float x, float y, float z, float w)
 {
     fConsts[i].x = x;
     fConsts[i].y = y;
@@ -152,12 +152,12 @@ void plShader::SetVector(int i, float x, float y, float z, float w)
     fConsts[i].w = w;
 }
 
-void plShader::SetFloat(int i, int chan, float v)
+void plShader::SetFloat(size_t i, int chan, float v)
 {
     fConsts[i].fArray[chan] = v;
 }
 
-void plShader::SetFloat4(int i, const float* const f)
+void plShader::SetFloat4(size_t i, const float* const f)
 {
     fConsts[i].fX = f[0];
     fConsts[i].fY = f[1];
@@ -165,7 +165,7 @@ void plShader::SetFloat4(int i, const float* const f)
     fConsts[i].fW = f[3];
 }
 
-plFloat44 plShader::GetMatrix(int i) const
+plFloat44 plShader::GetMatrix(size_t i) const
 {
     // untranspose
     plFloat44 xfm;
@@ -179,7 +179,7 @@ plFloat44 plShader::GetMatrix(int i) const
     return xfm;
 }
 
-plFloat44 plShader::GetMatrix3(int i) const
+plFloat44 plShader::GetMatrix3(size_t i) const
 {
     // untranspose
     plFloat44 xfm;
@@ -195,7 +195,7 @@ plFloat44 plShader::GetMatrix3(int i) const
     return xfm;
 }
 
-hsMatrix44 plShader::GetMatrix44(int i) const
+hsMatrix44 plShader::GetMatrix44(size_t i) const
 {
     hsMatrix44 xfm;
     xfm.NotIdentity();
@@ -210,7 +210,7 @@ hsMatrix44 plShader::GetMatrix44(int i) const
     return xfm;
 }
 
-hsMatrix44 plShader::GetMatrix34(int i) const
+hsMatrix44 plShader::GetMatrix34(size_t i) const
 {
     hsMatrix44 xfm;
     xfm.NotIdentity();
@@ -227,7 +227,7 @@ hsMatrix44 plShader::GetMatrix34(int i) const
     return xfm;
 }
 
-hsMatrix44 plShader::GetMatrix24(int i) const
+hsMatrix44 plShader::GetMatrix24(size_t i) const
 {
     hsMatrix44 xfm;
     xfm.NotIdentity();
@@ -245,22 +245,22 @@ hsMatrix44 plShader::GetMatrix24(int i) const
     return xfm;
 }
 
-hsColorRGBA plShader::GetColor(int i) const
+hsColorRGBA plShader::GetColor(size_t i) const
 {
     return hsColorRGBA().Set(fConsts[i].r, fConsts[i].g, fConsts[i].b, fConsts[i].a);
 }
 
-hsPoint3 plShader::GetPosition(int i) const
+hsPoint3 plShader::GetPosition(size_t i) const
 {
     return hsPoint3(fConsts[i].fX, fConsts[i].fY, fConsts[i].fZ);
 }
 
-hsVector3 plShader::GetVector(int i) const
+hsVector3 plShader::GetVector(size_t i) const
 {
     return hsVector3(fConsts[i].fX, fConsts[i].fY, fConsts[i].fZ);
 }
 
-void plShader::GetVector(int i, float& x, float& y, float& z, float& w) const
+void plShader::GetVector(size_t i, float& x, float& y, float& z, float& w) const
 {
     x = fConsts[i].x;
     y = fConsts[i].y;
@@ -268,12 +268,12 @@ void plShader::GetVector(int i, float& x, float& y, float& z, float& w) const
     w = fConsts[i].w;
 }
 
-float plShader::GetFloat(int i, int chan) const
+float plShader::GetFloat(size_t i, int chan) const
 {
     return fConsts[i].fArray[chan];
 }
 
-const float* plShader::GetFloat4(int i) const
+const float* plShader::GetFloat4(size_t i) const
 {
     return fConsts[i].fArray;
 }
@@ -285,9 +285,8 @@ void plShader::Read(hsStream* s, hsResMgr* mgr)
     hsKeyedObject::Read(s, mgr);
 
     uint32_t n = s->ReadLE32();
-    fConsts.SetCount(n);
-    int i;
-    for( i = 0; i < n; i++ )
+    fConsts.resize(n);
+    for (uint32_t i = 0; i < n; i++)
         fConsts[i].Read(s);
 
     plShaderID::ID id = plShaderID::ID(s->ReadLE32());
@@ -301,10 +300,9 @@ void plShader::Write(hsStream* s, hsResMgr* mgr)
 {
     hsKeyedObject::Write(s, mgr);
 
-    s->WriteLE32(fConsts.GetCount());
-    int i;
-    for( i = 0; i < fConsts.GetCount(); i++ )
-        fConsts[i].Write(s);
+    s->WriteLE32((uint32_t)fConsts.size());
+    for (const plShaderConst& konst : fConsts)
+        konst.Write(s);
 
     s->WriteLE32(fDecl->GetID());
 
@@ -322,7 +320,7 @@ void plShader::SetDecl(plShaderID::ID id)
     SetDecl(plShaderTable::Decl(id));
 }
 
-void plShader::SetNumPipeConsts(int n)
+void plShader::SetNumPipeConsts(size_t n)
 {
-    fPipeConsts.Resize(n);
+    fPipeConsts.resize(n);
 }

--- a/Sources/Plasma/PubUtilLib/plSurface/plShader.h
+++ b/Sources/Plasma/PubUtilLib/plSurface/plShader.h
@@ -43,11 +43,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plShader_inc
 #define plShader_inc
 
+#include <vector>
+
 #include "plShaderTable.h"
 
 #include "hsGeometry3.h"
 #include "hsMatrix44.h"
-#include "hsTemplates.h"
 
 #include "pnKeyedObject/hsKeyedObject.h"
 
@@ -105,7 +106,7 @@ public:
     float operator[](int i) const { return fArray[i]; }
 
     void Read(hsStream* s);
-    void Write(hsStream* s);
+    void Write(hsStream* s) const;
 };
 
 class plShaderDecl;
@@ -192,7 +193,7 @@ public:
 protected:
     mutable uint32_t              fFlags;
 
-    hsTArray<plShaderConst>     fConsts;
+    std::vector<plShaderConst>  fConsts;
 
     mutable hsGDeviceRef*       fDeviceRef;
 
@@ -201,7 +202,7 @@ protected:
     uint8_t                       fInput;
     uint8_t                       fOutput;
 
-    hsTArray<plPipeConst>       fPipeConsts;
+    std::vector<plPipeConst>    fPipeConsts;
 
 public:
     plShader();
@@ -214,35 +215,35 @@ public:
     void            Read(hsStream* s, hsResMgr* mgr) override;
     void            Write(hsStream* s, hsResMgr* mgr) override;
 
-    void                    SetNumConsts(int cnt) { fConsts.SetCount(cnt); }
-    uint32_t                  GetNumConsts() const { return fConsts.GetCount(); }
-    plShaderConst&          GetConst(int i) { return fConsts[i]; }
-    const plShaderConst&    GetConst(int i) const { return fConsts[i]; }
-    void                    SetConst(int i, const plShaderConst& c) { fConsts[i] = c; }
+    void                    SetNumConsts(size_t cnt) { fConsts.resize(cnt); }
+    size_t                  GetNumConsts() const { return fConsts.size(); }
+    plShaderConst&          GetConst(size_t i) { return fConsts[i]; }
+    const plShaderConst&    GetConst(size_t i) const { return fConsts[i]; }
+    void                    SetConst(size_t i, const plShaderConst& c) { fConsts[i] = c; }
 
-    plFloat44               GetMatrix(int i) const; // Will untranspose
-    plFloat44               GetMatrix3(int i) const; // Will untranspose
-    hsMatrix44              GetMatrix44(int i) const;
-    hsMatrix44              GetMatrix34(int i) const;
-    hsMatrix44              GetMatrix24(int i) const;
-    hsColorRGBA             GetColor(int i) const;
-    hsPoint3                GetPosition(int i) const;
-    hsVector3               GetVector(int i) const;
-    void                    GetVector(int i, float& x, float& y, float& z, float& w) const;
-    float                   GetFloat(int i, int chan) const;
-    const float*            GetFloat4(int i) const;
+    plFloat44               GetMatrix(size_t i) const; // Will untranspose
+    plFloat44               GetMatrix3(size_t i) const; // Will untranspose
+    hsMatrix44              GetMatrix44(size_t i) const;
+    hsMatrix44              GetMatrix34(size_t i) const;
+    hsMatrix44              GetMatrix24(size_t i) const;
+    hsColorRGBA             GetColor(size_t i) const;
+    hsPoint3                GetPosition(size_t i) const;
+    hsVector3               GetVector(size_t i) const;
+    void                    GetVector(size_t i, float& x, float& y, float& z, float& w) const;
+    float                   GetFloat(size_t i, int chan) const;
+    const float*            GetFloat4(size_t i) const;
 
-    void                    SetMatrix(int i, const plFloat44& xfm); // Will transpose
-    void                    SetMatrix3(int i, const plFloat44& xfm); // Will transpose
-    void                    SetMatrix44(int i, const hsMatrix44& xfm);
-    void                    SetMatrix34(int i, const hsMatrix44& xfm);
-    void                    SetMatrix24(int i, const hsMatrix44& xfm);
-    void                    SetColor(int i, const hsColorRGBA& col);
-    void                    SetVector(int i, const hsScalarTriple& vec); /* Doesn't touch .fW */
-    void                    SetVectorW(int i, const hsScalarTriple& vec, float w=1.f) { SetVector(i, vec.fX, vec.fY, vec.fZ, w); }
-    void                    SetVector(int i, float x, float y, float z, float w);
-    void                    SetFloat(int i, int chan, float v);
-    void                    SetFloat4(int i, const float* const f);
+    void                    SetMatrix(size_t i, const plFloat44& xfm); // Will transpose
+    void                    SetMatrix3(size_t i, const plFloat44& xfm); // Will transpose
+    void                    SetMatrix44(size_t i, const hsMatrix44& xfm);
+    void                    SetMatrix34(size_t i, const hsMatrix44& xfm);
+    void                    SetMatrix24(size_t i, const hsMatrix44& xfm);
+    void                    SetColor(size_t i, const hsColorRGBA& col);
+    void                    SetVector(size_t i, const hsScalarTriple& vec); /* Doesn't touch .fW */
+    void                    SetVectorW(size_t i, const hsScalarTriple& vec, float w=1.f) { SetVector(i, vec.fX, vec.fY, vec.fZ, w); }
+    void                    SetVector(size_t i, float x, float y, float z, float w);
+    void                    SetFloat(size_t i, int chan, float v);
+    void                    SetFloat4(size_t i, const float* const f);
 
     const plShaderDecl*     GetDecl() const { return fDecl; }
 
@@ -260,7 +261,7 @@ public:
     hsGDeviceRef*           GetDeviceRef() const { return fDeviceRef; }
     void                    SetDeviceRef(hsGDeviceRef* ref) const;
 
-    const void*             GetConstBasePtr() const { return fConsts.GetCount() ? &fConsts[0] : nullptr; }
+    const void*             GetConstBasePtr() const { return !fConsts.empty() ? &fConsts[0] : nullptr; }
 
     void                    CopyConsts(const plShader* src) { fConsts = src->fConsts; }
 
@@ -270,16 +271,16 @@ public:
     uint8_t                   GetInputFormat() const { return fInput; }
     uint8_t                   GetOutputFormat() const { return fOutput; }
 
-    uint32_t                  GetNumPipeConsts() const { return fPipeConsts.GetCount(); }
-    const plPipeConst&      GetPipeConst(int i) const { return fPipeConsts[i]; }
-    plPipeConst::Type       GetPipeConstType(int i) const { return fPipeConsts[i].fType; }
-    uint16_t                  GetPipeConstReg(int i) const { return fPipeConsts[i].fReg; }
+    size_t                  GetNumPipeConsts() const { return fPipeConsts.size(); }
+    const plPipeConst&      GetPipeConst(size_t i) const { return fPipeConsts[i]; }
+    plPipeConst::Type       GetPipeConstType(size_t i) const { return fPipeConsts[i].fType; }
+    uint16_t                GetPipeConstReg(size_t i) const { return fPipeConsts[i].fReg; }
 
-    void                    SetNumPipeConsts(int n);
-    void                    SetPipeConst(int i, const plPipeConst& c) { fPipeConsts[i] = c; }
-    void                    SetPipeConst(int i, plPipeConstType t, uint16_t r) { fPipeConsts[i].fType = t; fPipeConsts[i].fReg = r; }
-    void                    SetPipeConstType(int i, plPipeConstType t) { fPipeConsts[i].fType = t; }
-    void                    SetPipeConstReg(int i, uint16_t r) { fPipeConsts[i].fReg = r; }
+    void                    SetNumPipeConsts(size_t n);
+    void                    SetPipeConst(size_t i, const plPipeConst& c) { fPipeConsts[i] = c; }
+    void                    SetPipeConst(size_t i, plPipeConstType t, uint16_t r) { fPipeConsts[i].fType = t; fPipeConsts[i].fReg = r; }
+    void                    SetPipeConstType(size_t i, plPipeConstType t) { fPipeConsts[i].fType = t; }
+    void                    SetPipeConstReg(size_t i, uint16_t r) { fPipeConsts[i].fReg = r; }
 };
 
 #endif // plShader_inc

--- a/Sources/Tools/MaxComponent/plGUIComponents.cpp
+++ b/Sources/Tools/MaxComponent/plGUIComponents.cpp
@@ -1675,7 +1675,7 @@ bool plGUIControlBase::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         {
             hsGMaterial *plasmaMat = (*mtlArray)[ 0 ].fMaterial;
 
-            for (uint32_t j = 0; j < plasmaMat->GetNumLayers(); j++)
+            for (size_t j = 0; j < plasmaMat->GetNumLayers(); j++)
             {
                 layerIFace = plasmaMat->GetLayer( j );
                 dynText = plDynamicTextMap::ConvertNoRef( layerIFace->GetTexture() );
@@ -4047,8 +4047,7 @@ bool plGUIDynDisplayComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         for (const hsMaterialConverter::DoneMaterialData& mat : materials)
         {
             hsGMaterial *curMaterial = mat.fHsMaterial;
-            uint32_t lay;
-            for (lay=0; lay<curMaterial->GetNumLayers(); lay++)
+            for (size_t lay = 0; lay < curMaterial->GetNumLayers(); lay++)
             {
                 if (layIface->BottomOfStack() == curMaterial->GetLayer(lay))
                 {

--- a/Sources/Tools/MaxComponent/plMiscComponents.cpp
+++ b/Sources/Tools/MaxComponent/plMiscComponents.cpp
@@ -2248,7 +2248,7 @@ void plNetSyncComponent::ISetNetSync(plSynchedObject* so)
 
 void plNetSyncComponent::ISetMtl(hsGMaterial* mtl)
 {
-    for (int i = 0; i < mtl->GetNumLayers(); i++)
+    for (size_t i = 0; i < mtl->GetNumLayers(); i++)
     {
         plLayerInterface* layer = mtl->GetLayer(i);
         while (layer)

--- a/Sources/Tools/MaxComponent/plResponderMtl.cpp
+++ b/Sources/Tools/MaxComponent/plResponderMtl.cpp
@@ -280,7 +280,7 @@ void ISearchLayerRecur(plLayerInterface *layer, const ST::string &segName, std::
 
 size_t ISearchLayerRecur(hsGMaterial* mat, const ST::string &segName, std::vector<plKey>& keys)
 {
-    for (uint32_t i = 0; i < mat->GetNumLayers(); i++)
+    for (size_t i = 0; i < mat->GetNumLayers(); i++)
         ISearchLayerRecur(mat->GetLayer(i), segName, keys);
     return keys.size();
 }

--- a/Sources/Tools/MaxConvert/hsVertexShader.cpp
+++ b/Sources/Tools/MaxConvert/hsVertexShader.cpp
@@ -166,7 +166,6 @@ void hsVertexShader::IShadeSpan( plGeometrySpan *span, INode* node )
 {
     hsColorRGBA         preDiffuse, rtDiffuse, matAmbient;
     hsBitVector         dirtyVector;
-    int                 i;
     bool                translucent, shadeIt, addingIt;
     plLayerInterface    *layer = nullptr;
 
@@ -196,7 +195,7 @@ void hsVertexShader::IShadeSpan( plGeometrySpan *span, INode* node )
             addingIt = true;
     }
     float opacity = 1.f;
-    for( i = 0; i < span->fMaterial->GetNumLayers(); i++ )
+    for (size_t i = 0; i < span->fMaterial->GetNumLayers(); i++)
     {
         plLayerInterface* lay = span->fMaterial->GetLayer(i);
         if( (lay->GetBlendFlags() & hsGMatState::kBlendAlpha)
@@ -217,7 +216,7 @@ void hsVertexShader::IShadeSpan( plGeometrySpan *span, INode* node )
         IShadeVertices( span, &dirtyVector, node, translucent );
     else
     {
-        for( i = 0; i < span->fNumVerts; i++ )  
+        for (uint32_t i = 0; i < span->fNumVerts; i++)
         {
             /// This is good for the old way, but not sure about the new way. Test once new way is in again -mcn
 //          fShadeColorTable[ i ].Set( 1, 1, 1, 1 );
@@ -262,7 +261,7 @@ void hsVertexShader::IShadeSpan( plGeometrySpan *span, INode* node )
 
     /// Multiply by the material color, and scale by opacity if we're additive blending
     /// Apply colors now, multiplying by the material color as we go
-    for( i = 0; i < span->fNumVerts; i++ )
+    for (uint32_t i = 0; i < span->fNumVerts; i++)
     {
         fShadeColorTable[ i ] *= matDiffuse;
         fShadeColorTable[ i ] += matAmbient;
@@ -272,7 +271,7 @@ void hsVertexShader::IShadeSpan( plGeometrySpan *span, INode* node )
 
     if( addingIt )
     {
-        for( i = 0; i < span->fNumVerts; i++ )
+        for (uint32_t i = 0; i < span->fNumVerts; i++)
         {
             float opacity = fShadeColorTable[ i ].a;
             fShadeColorTable[ i ] *= opacity;
@@ -288,7 +287,7 @@ void hsVertexShader::IShadeSpan( plGeometrySpan *span, INode* node )
         span->fProps |= plGeometrySpan::kDiffuseFoldedIn;
         if( !shadeIt )
         {
-            for( i = 0; i < span->fNumVerts; i++ )
+            for (uint32_t i = 0; i < span->fNumVerts; i++)
             {
                 fIllumColorTable[ i ].a = 0;
                 fShadeColorTable[ i ] = (fShadeColorTable[ i ] * rtDiffuse) + fIllumColorTable[ i ];
@@ -297,7 +296,7 @@ void hsVertexShader::IShadeSpan( plGeometrySpan *span, INode* node )
         }
         else
         {
-            for( i = 0; i < span->fNumVerts; i++ )
+            for (uint32_t i = 0; i < span->fNumVerts; i++)
             {
                 fIllumColorTable[ i ].a = 1.f;
                 // Following needs to be changed to allow user input vertex colors to modulate
@@ -313,7 +312,7 @@ void hsVertexShader::IShadeSpan( plGeometrySpan *span, INode* node )
         if( !shadeIt )
         {
             // Not shaded, so runtime lit, so we want BLACK vertex colors
-            for( i = 0; i < span->fNumVerts; i++ )
+            for (uint32_t i = 0; i < span->fNumVerts; i++)
             {
                 fShadeColorTable[ i ].Set( 0, 0, 0, 0 );
                 fIllumColorTable[ i ].Set( 0, 0, 0, 0 );
@@ -321,7 +320,7 @@ void hsVertexShader::IShadeSpan( plGeometrySpan *span, INode* node )
         }
         else
         {
-            for( i = 0; i < span->fNumVerts; i++ )
+            for (uint32_t i = 0; i < span->fNumVerts; i++)
             {
                 fShadeColorTable[ i ] *= fIllumColorTable[ i ];
                 fIllumColorTable[ i ].Set( 0, 0, 0, 0 );
@@ -331,7 +330,7 @@ void hsVertexShader::IShadeSpan( plGeometrySpan *span, INode* node )
 #endif
 
     /// Loop and stuff
-    for( i = 0; i < span->fNumVerts; i++ )
+    for (uint32_t i = 0; i < span->fNumVerts; i++)
         span->StuffVertex( i, fShadeColorTable + i, fIllumColorTable + i );
 
     delete [] fShadeColorTable;       

--- a/Sources/Tools/MaxConvert/plLayerConverter.h
+++ b/Sources/Tools/MaxConvert/plLayerConverter.h
@@ -53,6 +53,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef _plLayerConverter_h
 #define _plLayerConverter_h
 
+#include "hsTemplates.h"
 
 //// Class Definition /////////////////////////////////////////////////////////
 

--- a/Sources/Tools/MaxConvert/plLightMapGen.cpp
+++ b/Sources/Tools/MaxConvert/plLightMapGen.cpp
@@ -447,8 +447,6 @@ bool plLightMapGen::IShadeSpan(plMaxNode* node, const hsMatrix44& l2w, const hsM
     if( !lay || !lay->GetTexture() )//|| !lay->GetTexture()->GetBitmap() )
         return false;
 
-    int i;
-
     if( !(span.fProps & plGeometrySpan::kDiffuseFoldedIn) )
     {
         bool foldin = 0 != (span.fProps & plGeometrySpan::kLiteVtxNonPreshaded);
@@ -464,7 +462,7 @@ bool plLightMapGen::IShadeSpan(plMaxNode* node, const hsMatrix44& l2w, const hsM
             // emissive layer (since emissive layers ignore lightmapping).
             // If we are using kLiteMaterial, we still need to copy from InitColor to Stuff,
             // just don't do the modulate.
-            for( i = 0; i < span.fMaterial->GetNumLayers(); i++ )
+            for (size_t i = 0; i < span.fMaterial->GetNumLayers(); i++)
             {
                 if( span.fMaterial->GetLayer(i)->GetBlendFlags() & hsGMatState::kBlendAlpha )
                 {
@@ -472,7 +470,7 @@ bool plLightMapGen::IShadeSpan(plMaxNode* node, const hsMatrix44& l2w, const hsM
                     break;
                 }
             }
-            for( i = 0; i < span.fMaterial->GetNumLayers(); i++ )
+            for (size_t i = 0; i < span.fMaterial->GetNumLayers(); i++)
             {
                 if( !(span.fMaterial->GetLayer(i)->GetShadeFlags() & hsGMatState::kShadeEmissive) )
                 {
@@ -481,7 +479,7 @@ bool plLightMapGen::IShadeSpan(plMaxNode* node, const hsMatrix44& l2w, const hsM
                 }
             }
         }
-        for( i = 0; i < span.fNumVerts; i++ )
+        for (uint32_t i = 0; i < span.fNumVerts; i++)
         {
             hsColorRGBA multColor, addColor;
             span.ExtractInitColor( i, &multColor, &addColor);
@@ -505,7 +503,7 @@ bool plLightMapGen::IShadeSpan(plMaxNode* node, const hsMatrix44& l2w, const hsM
     }
     else
     {
-        for( i = 0; i < span.fNumVerts; i++ )
+        for (uint32_t i = 0; i < span.fNumVerts; i++)
         {
             hsColorRGBA multColor, addColor;
             span.ExtractInitColor( i, &multColor, &addColor);
@@ -523,8 +521,8 @@ bool plLightMapGen::IShadeSpan(plMaxNode* node, const hsMatrix44& l2w, const hsM
     plMipmap* accum = IMakeAccumBitmap(lay);
 
     bool retVal = false;
-    int nFaces = span.fNumIndices / 3;
-    for( i = 0; i < nFaces; i++ )
+    uint32_t nFaces = span.fNumIndices / 3;
+    for (uint32_t i = 0; i < nFaces; i++)
     {
         retVal |= IShadeFace(node, l2w, w2l, span, i, accum);
     }
@@ -1218,8 +1216,7 @@ plLayerInterface* plLightMapGen::IMakeLightMapLayer(plMaxNode* node, plGeometryS
 {
     hsGMaterial* mat = span.fMaterial;
 
-    int i;
-    for( i = 0; i < mat->GetNumPiggyBacks(); i++ )
+    for (size_t i = 0; i < mat->GetNumPiggyBacks(); i++)
     {
         if( mat->GetPiggyBack(i)->GetMiscFlags() & hsGMatState::kMiscLightMap )
             return mat->GetPiggyBack(i);
@@ -1232,7 +1229,7 @@ plLayerInterface* plLightMapGen::IMakeLightMapLayer(plMaxNode* node, plGeometryS
     if( matKey )
     {
         mat = hsGMaterial::ConvertNoRef(matKey->ObjectIsLoaded());
-        for( i = 0; i < mat->GetNumPiggyBacks(); i++ )
+        for (size_t i = 0; i < mat->GetNumPiggyBacks(); i++)
         {
             if( mat->GetPiggyBack(i)->GetMiscFlags() & hsGMatState::kMiscLightMap )
             {
@@ -1254,7 +1251,7 @@ plLayerInterface* plLightMapGen::IMakeLightMapLayer(plMaxNode* node, plGeometryS
         objMat = new hsGMaterial;
         hsgResMgr::ResMgr()->NewKey(newMatName, objMat, nodeLoc);
 
-        for( i = 0; i < mat->GetNumLayers(); i++ )
+        for (size_t i = 0; i < mat->GetNumLayers(); i++)
             hsgResMgr::ResMgr()->AddViaNotify(mat->GetLayer(i)->GetKey(), new plMatRefMsg(objMat->GetKey(), plRefMsg::kOnCreate, -1, plMatRefMsg::kLayer), plRefFlags::kActiveRef);
     }
 

--- a/Sources/Tools/MaxConvert/plMeshConverter.cpp
+++ b/Sources/Tools/MaxConvert/plMeshConverter.cpp
@@ -712,7 +712,7 @@ bool plMeshConverter::CreateSpans(plMaxNode *node, std::vector<plGeometrySpan *>
                 if (currData.fMaterial == nullptr)
                     continue;
                 
-                for (uint32_t k = 0; k < currData.fMaterial->GetNumLayers(); k++)
+                for (size_t k = 0; k < currData.fMaterial->GetNumLayers(); k++)
                 {
                     plLayerInterface    *layer = currData.fMaterial->GetLayer( k );
 
@@ -1661,12 +1661,11 @@ void plMeshConverter::ISetBumpUvSrcs(hsTArray<std::vector<plExportMaterialData> 
 
 
         hsGMaterial* ourMat = ourMaterials[i]->front().fMaterial;
-        int j;
-        for( j = 0; j < ourMat->GetNumLayers(); j++ )
+        for (size_t j = 0; j < ourMat->GetNumLayers(); j++)
         {
             if( ourMat->GetLayer(j)->GetMiscFlags() & hsGMatState::kMiscBumpLayer )
             {
-                bumpLayIdx[i] = j;
+                bumpLayIdx[i] = (int16_t)j;
                 bumpLayChan[i] = ourMat->GetLayer(j)->GetUVWSrc();
             }
 

--- a/Sources/Tools/MaxMain/plMaxNode.cpp
+++ b/Sources/Tools/MaxMain/plMaxNode.cpp
@@ -1994,7 +1994,7 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
     Matrix3 maxL2V = GetLocalToVert(TimeValue(0));
     Matrix3 maxV2L = GetVertToLocal(TimeValue(0));
 
-    hsTArray<plCullPoly> polys;
+    std::vector<plCullPoly> polys;
 
     uint32_t polyInitFlags = plCullPoly::kNone;
     if( isHole )
@@ -2040,8 +2040,8 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
 
             mnMesh.Transform(maxV2L);
 
-            polys.SetCount(mesh.getNumFaces());
-            polys.SetCount(0);
+            polys.clear();
+            polys.reserve(mesh.getNumFaces());
 
             // Unfortunate problem here. Max is assuming that eventually this will get rendered, and so
             // we need to avoid T-junctions. Fact is, T-junctions don't bother us at all, where-as colinear
@@ -2069,7 +2069,7 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
 
                 int lastAdded = 2;
 
-                plCullPoly* poly = polys.Push();
+                plCullPoly* poly = &polys.emplace_back();
                 poly->fVerts.clear();
 
                 Point3 p;
@@ -2118,8 +2118,8 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
                     {
                         poly->InitFromVerts(polyInitFlags);
 
-                        poly = polys.Push();
-                        plCullPoly* lastPoly = &polys[polys.GetCount()-2];
+                        plCullPoly* lastPoly = &polys.back();
+                        poly = &polys.emplace_back();
                         poly->fVerts.clear();
                         poly->fVerts.emplace_back(lastPoly->fVerts[0]);
                         poly->fVerts.emplace_back(lastPoly->fVerts[lastAdded]);
@@ -2136,7 +2136,7 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
         }
     }
 
-    if( polys.GetCount() )
+    if (!polys.empty())
     {
         plOccluder* occ = nullptr;
         plMobileOccluder* mob = nullptr;

--- a/Sources/Tools/MaxMain/plMaxNode.cpp
+++ b/Sources/Tools/MaxMain/plMaxNode.cpp
@@ -2070,22 +2070,22 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
                 int lastAdded = 2;
 
                 plCullPoly* poly = polys.Push();
-                poly->fVerts.SetCount(0);
+                poly->fVerts.clear();
 
                 Point3 p;
                 hsPoint3 pt;
 
                 p = facePts[0];
                 pt.Set(p.x, p.y, p.z);
-                poly->fVerts.Append(pt);
+                poly->fVerts.emplace_back(pt);
 
                 p = facePts[1];
                 pt.Set(p.x, p.y, p.z);
-                poly->fVerts.Append(pt);
+                poly->fVerts.emplace_back(pt);
 
                 p = facePts[2];
                 pt.Set(p.x, p.y, p.z);
-                poly->fVerts.Append(pt);
+                poly->fVerts.emplace_back(pt);
 
                 for( j = lastAdded+1; j < facePts.GetCount(); j++ )
                 {
@@ -2120,14 +2120,14 @@ bool plMaxNode::ConvertToOccluder(plErrorMsg* pErrMsg, bool twoSided, bool isHol
 
                         poly = polys.Push();
                         plCullPoly* lastPoly = &polys[polys.GetCount()-2];
-                        poly->fVerts.SetCount(0);
-                        poly->fVerts.Append(lastPoly->fVerts[0]);
-                        poly->fVerts.Append(lastPoly->fVerts[lastAdded]);
+                        poly->fVerts.clear();
+                        poly->fVerts.emplace_back(lastPoly->fVerts[0]);
+                        poly->fVerts.emplace_back(lastPoly->fVerts[lastAdded]);
     
                         lastAdded = 1;
                     }
 
-                    poly->fVerts.Append(pt);
+                    poly->fVerts.emplace_back(pt);
                     lastAdded++;
                 }
 

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthConvert.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthConvert.cpp
@@ -88,7 +88,7 @@ static void ISearchLayerRecur(plLayerInterface *layer, const ST::string &segName
 static size_t ISearchLayerRecur(hsGMaterial* mat, const ST::string &segName, std::vector<plKey>& keys)
 {
     ST::string name = ( segName.compare( ENTIRE_ANIMATION_NAME ) == 0 ) ? ST::string() : segName;
-    for (uint32_t i = 0; i < mat->GetNumLayers(); i++)
+    for (size_t i = 0; i < mat->GetNumLayers(); i++)
         ISearchLayerRecur(mat->GetLayer(i), name, keys);
     return keys.size();
 }

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthConvert.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthConvert.cpp
@@ -172,7 +172,7 @@ void    plAnimStealthNode::GetLoopPoints( float &start, float &end ) const
         GetSegMapAnimTime( loopName, fCachedSegMap, SegmentSpec::kLoop, start, end );
 }
 
-void    plAnimStealthNode::GetAllStopPoints( hsTArray<float> &out )
+void    plAnimStealthNode::GetAllStopPoints(std::vector<float> &out)
 {
     if (fCachedSegMap == nullptr)
         return;
@@ -182,7 +182,7 @@ void    plAnimStealthNode::GetAllStopPoints( hsTArray<float> &out )
         SegmentSpec *spec = it->second;
         if( spec->fType == SegmentSpec::kStopPoint )
         {
-            out.Append( spec->fStart );
+            out.emplace_back(spec->fStart);
         }
     }
 }

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.h
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.h
@@ -51,7 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef _plAnimStealthNode_h
 #define _plAnimStealthNode_h
 
-#include "hsTemplates.h"
+#include <vector>
 
 #include "MaxComponent/plAnimObjInterface.h"
 #include "MaxComponent/plMaxAnimUtils.h"
@@ -217,7 +217,7 @@ public:
     void        SetEaseOut( uint8_t type, float length, float min, float max );
 
     // Conversion stuff
-    void        GetAllStopPoints( hsTArray<float> &out );
+    void        GetAllStopPoints(std::vector<float> &out);
     float       GetSegStart() const;
     float       GetSegEnd() const;
     void        GetLoopPoints( float &start, float &end ) const;


### PR DESCRIPTION
With this change, only the "hard" parts are left:  plDrawable, plGLight (does funny stuff with the uninitialized but allocated objects after the end of the array), plPipeline, MaxConvert, MaxMain