### PR TITLE
Fix SIMD usage on GCC/clang.

### DIFF
--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -62,6 +62,7 @@ set(CoreLib_HEADERS
     hsPoint2.h
     hsQuat.h
     hsRefCnt.h
+    hsSIMD.h
     hsSTLStream.h
     hsStream.h
     hsStringTokenizer.h
@@ -85,6 +86,7 @@ plasma_library(CoreLib
     SOURCES ${CoreLib_SOURCES} ${CoreLib_HEADERS}
     PRECOMPILED_HEADERS _CoreLibPch.h
 )
+plasma_target_simd_sources(CoreLib SSE3 hsMatrix44_SSE3.cpp)
 target_link_libraries(
     CoreLib
     PUBLIC

--- a/Sources/Plasma/CoreLib/hsCpuID.h
+++ b/Sources/Plasma/CoreLib/hsCpuID.h
@@ -47,16 +47,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 //     == Example Usage ==
 //
-//  #ifdef HS_SIMD_INCLUDE
-//  #   include HS_SIMD_INCLUDE
-//  #endif
+//  #include "hsSIMD.h"
 //
 //  float my_func_fpu() {
 //    ...
 //  }
 //
 //  float my_func_avx() {
-//  #ifdef HS_AVX
+//  #ifdef HAVE_AVX
 //    ...
 //  #endif
 //  }
@@ -75,55 +73,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef hsCpuID_inc
 #define hsCpuID_inc
 
-#if defined __AVX2__ || _MSC_VER >= 1600
-#define HS_AVX2
-#ifndef HS_SIMD_INCLUDE
-# define HS_SIMD_INCLUDE "immintrin.h"
-#endif
-#endif
-#if defined __AVX__ || _MSC_VER >= 1600
-#define HS_AVX
-#ifndef HS_SIMD_INCLUDE
-# define HS_SIMD_INCLUDE "immintrin.h"
-#endif
-#endif
-#if defined __SSE4_2__ || _MSC_VER >= 1600
-#define HS_SSE42
-#ifndef HS_SIMD_INCLUDE
-# define HS_SIMD_INCLUDE "nmmintrin.h"
-#endif
-#endif
-#if defined __SSE4_1__ || _MSC_VER >= 1600
-#define HS_SSE41
-#ifndef HS_SIMD_INCLUDE
-# define HS_SIMD_INCLUDE "smmintrin.h"
-#endif
-#endif
-#if defined __SSSE3__ || _MSC_VER >= 1600
-#define HS_SSSE3
-#ifndef HS_SIMD_INCLUDE
-# define HS_SIMD_INCLUDE "tmmintrin.h"
-#endif
-#endif
-#if defined __SSE3__ || _MSC_VER >= 1400
-#define HS_SSE3
-#ifndef HS_SIMD_INCLUDE
-# define HS_SIMD_INCLUDE "pmmintrin.h"
-#endif
-#endif
-#if defined __SSE2__ || _MSC_VER >= 1300
-#define HS_SSE2
-#ifndef HS_SIMD_INCLUDE
-# define HS_SIMD_INCLUDE "emmintrin.h"
-#endif
-#endif
-#if defined __SSE__ || _MSC_VER >= 1300
-#define HS_SSE1
-#ifndef HS_SIMD_INCLUDE
-# define HS_SIMD_INCLUDE "xmmintrin.h"
-#endif
-#endif
-
+#include "hsConfig.h"
 
 struct hsCpuId {
     bool has_sse1;
@@ -153,42 +103,42 @@ struct hsCpuFunctionDispatcher {
     {
         hsAssert(fpu, "FPU fallback function required.");
         const hsCpuId& cpu = hsCpuId::Instance();
-#ifdef HS_AVX2
+#ifdef HAVE_AVX2
         if (cpu.has_avx2 && avx2) {
             call = avx2;
         } else
 #endif
-#ifdef HS_AVX
+#ifdef HAVE_AVX
         if (cpu.has_avx && avx) {
             call = avx;
         } else
 #endif
-#ifdef HS_SSE42
+#ifdef HAVE_SSE42
         if (cpu.has_sse42 && sse42) {
             call = sse42;
         } else
 #endif
-#ifdef HS_SSE41
+#ifdef HAVE_SSE41
         if (cpu.has_sse41 && sse41) {
             call = sse41;
         } else
 #endif
-#ifdef HS_SSSE3
+#ifdef HAVE_SSSE3
         if (cpu.has_ssse3 && ssse3) {
             call = ssse3;
         } else
 #endif
-#ifdef HS_SSE3
+#ifdef HAVE_SSE3
         if (cpu.has_sse3 && sse3) {
             call = sse3;
         } else
 #endif
-#ifdef HS_SSE2
+#ifdef HAVE_SSE2
         if (cpu.has_sse2 && sse2) {
             call = sse2;
         } else
 #endif
-#ifdef HS_SSE1
+#ifdef HAVE_SSE1
         if (cpu.has_sse1 && sse1) {
             call = sse1;
         } else

--- a/Sources/Plasma/CoreLib/hsMatrix44.h
+++ b/Sources/Plasma/CoreLib/hsMatrix44.h
@@ -156,9 +156,13 @@ struct hsMatrix44 {
     void Read(hsStream *stream);
     void Write(hsStream *stream);
 
+private:
     //  CPU-optimized functions
     typedef hsMatrix44(*mat_mult_ptr)(const hsMatrix44&, const hsMatrix44&);
     static hsCpuFunctionDispatcher<mat_mult_ptr> mat_mult;
+
+    static hsMatrix44 mult_fpu(const hsMatrix44& a, const hsMatrix44& b);
+    static hsMatrix44 mult_sse3(const hsMatrix44& a, const hsMatrix44& b);
 };
 
 ST_DECL_FORMAT_TYPE(const hsMatrix44&);

--- a/Sources/Plasma/CoreLib/hsMatrix44_SSE3.cpp
+++ b/Sources/Plasma/CoreLib/hsMatrix44_SSE3.cpp
@@ -34,31 +34,75 @@ work.
 
 You can contact Cyan Worlds, Inc. by email legal@cyan.com
  or by snail mail at:
-      Cyan Worlds, Inc.
+      Cyan Worlds, I
+      nc.
       14617 N Newport Hwy
       Mead, WA   99021
 
 *==LICENSE==*/
 
-#ifndef HeadSpinConfigHDefined
-#define HeadSpinConfigHDefined
+#include "hsMatrix44.h"
 
-/* Compiler settings */
-#cmakedefine HAVE_CPUID
-#cmakedefine HAVE_AVX2
-#cmakedefine HAVE_AVX
-#cmakedefine HAVE_SSE42
-#cmakedefine HAVE_SSSE3
-#cmakedefine HAVE_SSE41
-#cmakedefine HAVE_SSE4
-#cmakedefine HAVE_SSE3
-#cmakedefine HAVE_SSE2
-#cmakedefine HAVE_SSE1
+#ifdef HAVE_SSE3
+#   include <pmmintrin.h>
 
-/* External library usage */
-#cmakedefine USE_SPEEX
-#cmakedefine USE_OPUS
-#cmakedefine USE_VPX
-#cmakedefine USE_WEBM
-
+#   define MULTBEGIN(i) \
+        xmm[0]   = _mm_loadu_ps(a.fMap[i]);
+#   define MULTCELL(i, j) \
+        xmm[1]   = _mm_set_ps(b.fMap[3][j], b.fMap[2][j], b.fMap[1][j], b.fMap[0][j]); \
+        xmm[j+2] = _mm_mul_ps(xmm[0], xmm[1]);
+#   define MULTFINISH(i) \
+        xmm[6] = _mm_hadd_ps(xmm[2], xmm[3]); \
+        xmm[7] = _mm_hadd_ps(xmm[4], xmm[5]); \
+        xmm[1] = _mm_hadd_ps(xmm[6], xmm[7]); \
+        _mm_storeu_ps(c.fMap[i], xmm[1]);
 #endif
+
+hsMatrix44 hsMatrix44::mult_sse3(const hsMatrix44& a, const hsMatrix44& b)
+{
+    hsMatrix44 c;
+
+#ifdef HAVE_SSE3
+    if (a.fFlags & b.fFlags & hsMatrix44::kIsIdent) {
+        c.Reset();
+        return c;
+    }
+
+    if (a.fFlags & hsMatrix44::kIsIdent)
+        return b;
+    if (b.fFlags & hsMatrix44::kIsIdent)
+        return a;
+
+    __m128 xmm[8];
+
+    MULTBEGIN(0);
+    MULTCELL(0, 0);
+    MULTCELL(0, 1);
+    MULTCELL(0, 2);
+    MULTCELL(0, 3);
+    MULTFINISH(0);
+
+    MULTBEGIN(1);
+    MULTCELL(1, 0);
+    MULTCELL(1, 1);
+    MULTCELL(1, 2);
+    MULTCELL(1, 3);
+    MULTFINISH(1);
+
+    MULTBEGIN(2);
+    MULTCELL(2, 0);
+    MULTCELL(2, 1);
+    MULTCELL(2, 2);
+    MULTCELL(2, 3);
+    MULTFINISH(2);
+
+    MULTBEGIN(3);
+    MULTCELL(3, 0);
+    MULTCELL(3, 1);
+    MULTCELL(3, 2);
+    MULTCELL(3, 3);
+    MULTFINISH(3);
+#endif
+
+    return c;
+}

--- a/Sources/Plasma/CoreLib/hsSIMD.h
+++ b/Sources/Plasma/CoreLib/hsSIMD.h
@@ -40,25 +40,44 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#ifndef HeadSpinConfigHDefined
-#define HeadSpinConfigHDefined
+#ifndef hsSIMD_Defined
+#define hsSIMD_Defined
 
-/* Compiler settings */
-#cmakedefine HAVE_CPUID
-#cmakedefine HAVE_AVX2
-#cmakedefine HAVE_AVX
-#cmakedefine HAVE_SSE42
-#cmakedefine HAVE_SSSE3
-#cmakedefine HAVE_SSE41
-#cmakedefine HAVE_SSE4
-#cmakedefine HAVE_SSE3
-#cmakedefine HAVE_SSE2
-#cmakedefine HAVE_SSE1
+/**
+ * \file hsSIMD.h
+ * Wrapper header to include all SIMD headers supported by the current compiler. This is needed
+ * because the LLVM immintrin.h for MSVC does not include everything like you expect, breaking
+ * clang-tidy on any target using SIMD instructions. x86intrin.h is also "broken".
+ */
 
-/* External library usage */
-#cmakedefine USE_SPEEX
-#cmakedefine USE_OPUS
-#cmakedefine USE_VPX
-#cmakedefine USE_WEBM
+#include "hsConfig.h"
+
+#if defined(HAVE_AVX2) || defined(HAVE_AVX)
+#   include <immintrin.h>
+#endif
+
+#ifdef HAVE_SSE42
+#   include <nmmintrin.h>
+#endif
+
+#ifdef HAVE_SSE41
+#   include <smmintrin.h>
+#endif
+
+#ifdef HAVE_SSE4
+#   include <tmmintrin.h>
+#endif
+
+#ifdef HAVE_SSE3
+#   include <pmmintrin.h>
+#endif
+
+#ifdef HAVE_SSE2
+#   include <emmintrin.h>
+#endif
+
+#ifdef HAVE_SSE1
+#   include <xmmintrin.h>
+#endif
 
 #endif

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -75,6 +75,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plProfile.h"
 #include "plQuality.h"
 #include "hsResMgr.h"
+#include "hsSIMD.h"
 #include "hsTemplates.h"
 #include "hsTimer.h"
 #include "plTweak.h"
@@ -126,10 +127,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfCamera/plVirtualCamNeu.h"
 
 #include <algorithm>
-
-#ifdef HS_SIMD_INCLUDE
-#  include HS_SIMD_INCLUDE
-#endif
 
 //#define MF_TOSSER
 
@@ -8796,7 +8793,7 @@ static inline void ISkinVertexFPU(const hsMatrix44& xfm, float wgt,
     }
 }
 
-#ifdef HS_SSE3
+#ifdef HAVE_SSE3
 static inline void ISkinDpSSE3(const float* src, float* dst, const __m128& mc0,
                                const __m128& mc1, const __m128& mc2, const __m128& mwt)
 {
@@ -8812,13 +8809,13 @@ static inline void ISkinDpSSE3(const float* src, float* dst, const __m128& mc0,
     _dst = _mm_add_ps(_dst, hbuf1);
     _mm_store_ps(dst, _dst);
 }
-#endif // HS_SSE3
+#endif // HAVE_SSE3
 
 static inline void ISkinVertexSSE3(const hsMatrix44& xfm, float wgt,
                                    const float* pt_src, float* pt_dst,
                                    const float* vec_src, float* vec_dst)
 {
-#ifdef HS_SSE3
+#ifdef HAVE_SSE3
     __m128 mc0 = _mm_load_ps(xfm.fMap[0]);
     __m128 mc1 = _mm_load_ps(xfm.fMap[1]);
     __m128 mc2 = _mm_load_ps(xfm.fMap[2]);
@@ -8826,10 +8823,10 @@ static inline void ISkinVertexSSE3(const hsMatrix44& xfm, float wgt,
 
     ISkinDpSSE3(pt_src, pt_dst, mc0, mc1, mc2, mwt);
     ISkinDpSSE3(vec_src, vec_dst, mc0, mc1, mc2, mwt);
-#endif // HS_SSE3
+#endif // HAVE_SSE3
 }
 
-#ifdef HS_SSE41
+#ifdef HAVE_SSE41
 static inline void ISkinDpSSE41(const float* src, float* dst, const __m128& mc0,
                                 const __m128& mc1, const __m128& mc2, const __m128& mwt)
 {
@@ -8844,13 +8841,13 @@ static inline void ISkinDpSSE41(const float* src, float* dst, const __m128& mc0,
     _dst = _mm_add_ps(_dst, _mm_mul_ps(_r, mwt));
     _mm_store_ps(dst, _dst);
 }
-#endif // HS_SSE41
+#endif // HAVE_SSE41
 
 static inline void ISkinVertexSSE41(const hsMatrix44& xfm, float wgt,
                                     const float* pt_src, float* pt_dst,
                                     const float* vec_src, float* vec_dst)
 {
-#ifdef HS_SSE41
+#ifdef HAVE_SSE41
     __m128 mc0 = _mm_load_ps(xfm.fMap[0]);
     __m128 mc1 = _mm_load_ps(xfm.fMap[1]);
     __m128 mc2 = _mm_load_ps(xfm.fMap[2]);
@@ -8858,7 +8855,7 @@ static inline void ISkinVertexSSE41(const hsMatrix44& xfm, float wgt,
 
     ISkinDpSSE41(pt_src, pt_dst, mc0, mc1, mc2, mwt);
     ISkinDpSSE41(vec_src, vec_dst, mc0, mc1, mc2, mwt);
-#endif // HS_SSE41
+#endif // HAVE_SSE41
 }
 
 typedef void(*skin_vert_ptr)(const hsMatrix44&, float, const float*, float*, const float*, float*);

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -23,11 +23,65 @@ if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
     endif()
 endif()
 
+
 # Check for CPUID headers
 try_compile(HAVE_CPUID ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_cpuid.cpp)
-if(HAVE_CPUID)
-    message(STATUS "CPUID header found -- using hardware math acceleration when available")
-else()
-    message(STATUS "CPUID header not found -- using software math")
-endif()
+
+# Check for SIMD headers
+CHECK_INCLUDE_FILE("immintrin.h" HAVE_AVX2)
+CHECK_INCLUDE_FILE("immintrin.h" HAVE_AVX)
+CHECK_INCLUDE_FILE("nmmintrin.h" HAVE_SSE42)
+CHECK_INCLUDE_FILE("tmmintrin.h" HAVE_SSSE3)
+CHECK_INCLUDE_FILE("smmintrin.h" HAVE_SSE41)
+CHECK_INCLUDE_FILE("tmmintrin.h" HAVE_SSE4)
+CHECK_INCLUDE_FILE("pmmintrin.h" HAVE_SSE3)
+CHECK_INCLUDE_FILE("emmintrin.h" HAVE_SSE2)
+CHECK_INCLUDE_FILE("xmmintrin.h" HAVE_SSE1)
+
+# GCC requires us to set the -m<instructionset> flag for the source file using the intrinsics.
+# We can't do that project-wide or we'll just crash on launch with an illegal instruction on some
+# systems. So, we have another helper method...
+function(plasma_target_simd_sources TARGET)
+    set(_INSTRUCTION_SETS "SSE1;SSE2;SSE3;SSE4;SSE41;SSSE3;SSE42;AVX;AVX2")
+    set(_GCC_ARGS "-msse;-msse2;-msse3;-msse4;-msse4.1;-mssse3;-msse4.2;-mavx;-mavx2")
+    cmake_parse_arguments(PARSE_ARGV 1 _passf "" "SOURCE_GROUP" "${_INSTRUCTION_SETS}")
+
+    # Hack: if we ever bump to CMake 3.17, use ZIP_LISTS.
+    list(LENGTH _INSTRUCTION_SETS _LENGTH)
+    math(EXPR _LENGTH "${_LENGTH} - 1")
+
+    foreach(i RANGE ${_LENGTH})
+        # foreach(i IN ZIP_LISTS _INSTRUCTION_SETS _GCC_ARGS)
+        list(GET _INSTRUCTION_SETS ${i} _CURRENT_INSTRUCTION_SET)
+        list(GET _GCC_ARGS ${i} _CURRENT_COMPILE_OPTION)
+
+        set(_CURRENT_SOURCE_FILES ${_passf_${_CURRENT_INSTRUCTION_SET}})
+        if(_CURRENT_SOURCE_FILES)
+            target_sources(${TARGET} PRIVATE ${_CURRENT_SOURCE_FILES})
+            if(_passf_SOURCE_GROUP)
+                source_group(${_passf_SOURCE_GROUP} FILES ${_CURRENT_SOURCE_FILES})
+            endif()
+            if(HAVE_${_CURRENT_INSTRUCTION_SET} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+                set_source_files_properties(
+                    ${_CURRENT_SOURCE_FILES} PROPERTIES
+                    COMPILE_OPTIONS ${_CURRENT_COMPILE_OPTION}
+                )
+                # Can't use the precompiled header for these files due to the changed flags.
+                if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
+                    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+                        get_target_property(_UNITY_MODE ${TARGET} UNITY_BUILD_MODE)
+                        string(COMPARE EQUAL "${_UNITY_MODE}" "BATCH" _SKIP_UNITY)
+                    else()
+                        set(_SKIP_UNITY TRUE)
+                    endif()
+                    set_source_files_properties(
+                        ${_CURRENT_SOURCE_FILES} PROPERTIES
+                        SKIP_PRECOMPILE_HEADERS TRUE
+                        SKIP_UNITY_BUILD_INCLUSION ${_SKIP_UNITY}
+                    )
+                endif()
+            endif()
+        endif()
+    endforeach()
+endfunction()

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -23,7 +23,6 @@ if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
     endif()
 endif()
 
-
 # Check for CPUID headers
 try_compile(HAVE_CPUID ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_cpuid.cpp)

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -63,8 +63,8 @@ function(plasma_target_simd_sources TARGET)
                 source_group(${_passf_SOURCE_GROUP} FILES ${_CURRENT_SOURCE_FILES})
             endif()
             if(HAVE_${_CURRENT_INSTRUCTION_SET} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-                set_source_files_properties(
-                    ${_CURRENT_SOURCE_FILES} PROPERTIES
+                set_property(
+                    SOURCE ${_CURRENT_SOURCE_FILES} APPEND PROPERTY
                     COMPILE_OPTIONS ${_CURRENT_COMPILE_OPTION}
                 )
                 # Can't use the precompiled header for these files due to the changed flags.


### PR DESCRIPTION
This is needed for clang-tidy to be able to parse files built with MSVC.

If the -m(instruction set) flag is not set when compiling a source file, then intrinsics from that instruction set are not available. This means that when parsing a source file that uses, eg, SSE3, then the file will fail to compile. Unfortunately, we can't just turn on every instruction set we want to use because that will allow the compiler to emit the given instruction set anywhere. This will result in fun-to-debug illegal instruction crashes for our end users.

Anyway, if you have a file that needs to compile with gcc, be sure to jail any SIMD code to its own file and add it to the target using `plasma_target_simd_sources(TARGET [instruction set] [files...])`.