### PR TITLE
Introduce hsPoolVector for plShadowMaster's object pools.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plGLight/plDirectShadowMaster.h
+++ b/Sources/Plasma/PubUtilLib/plGLight/plDirectShadowMaster.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plDirectShdowMaster_inc
 #define plDirectShdowMaster_inc
 
+#include <memory>
 
 #include "plShadowMaster.h"
 #include "hsGeometry3.h"
@@ -53,15 +54,15 @@ class plBoundsIsect;
 class plDirectShadowMaster : public plShadowMaster
 {
 protected:
-    mutable hsPoolVector<plBoundsIsect*> fIsectPool;
-    hsPoolVector<plShadowSlave*>         fPerspSlavePool;
+    mutable hsPoolVector<std::unique_ptr<plBoundsIsect>> fIsectPool;
+    hsPoolVector<std::unique_ptr<plShadowSlave>>         fPerspSlavePool;
 
     void IComputeWorldToLight(const hsBounds3Ext& bnd, plShadowSlave* slave) const override;
     void IComputeProjections(plShadowCastMsg* castMsg, plShadowSlave* slave) const override;
     void IComputeISect(const hsBounds3Ext& bnd, plShadowSlave* slave) const override;
     void IComputeBounds(const hsBounds3Ext& bnd, plShadowSlave* slave) const override;
 
-    plShadowSlave* INewSlave(const plShadowCaster* caster) override;
+    std::unique_ptr<plShadowSlave> INewSlave(const plShadowCaster* caster) override;
     plShadowSlave* INextSlave(const plShadowCaster* caster) override;
     plShadowSlave* IRecycleSlave(plShadowSlave* slave) override;
 

--- a/Sources/Plasma/PubUtilLib/plGLight/plDirectShadowMaster.h
+++ b/Sources/Plasma/PubUtilLib/plGLight/plDirectShadowMaster.h
@@ -53,8 +53,8 @@ class plBoundsIsect;
 class plDirectShadowMaster : public plShadowMaster
 {
 protected:
-    mutable hsTArray<plBoundsIsect*>    fIsectPool;
-    hsTArray<plShadowSlave*>            fPerspSlavePool;
+    mutable hsPoolVector<plBoundsIsect*> fIsectPool;
+    hsPoolVector<plShadowSlave*>         fPerspSlavePool;
 
     void IComputeWorldToLight(const hsBounds3Ext& bnd, plShadowSlave* slave) const override;
     void IComputeProjections(plShadowCastMsg* castMsg, plShadowSlave* slave) const override;

--- a/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.cpp
@@ -98,10 +98,8 @@ static inline void InverseOfPureRotTran(const hsMatrix44& src, hsMatrix44& inv)
 
 plPointShadowMaster::~plPointShadowMaster()
 {
-    fIsectPool.SetCount(fIsectPool.GetNumAlloc());
-    int i;
-    for( i = 0; i < fIsectPool.GetCount(); i++ )
-        delete fIsectPool[i];
+    for (plBoundsIsect* isect : fIsectPool.pool())
+        delete isect;
 }
 
 plShadowSlave* plPointShadowMaster::INewSlave(const plShadowCaster* caster)
@@ -113,7 +111,7 @@ void plPointShadowMaster::IBeginRender()
 {
     plShadowMaster::IBeginRender();
 
-    fIsectPool.SetCount(0);
+    fIsectPool.clear();
 }
 
 void plPointShadowMaster::IComputeWorldToLight(const hsBounds3Ext& bnd, plShadowSlave* slave) const
@@ -169,13 +167,7 @@ void plPointShadowMaster::IComputeProjections(plShadowCastMsg* castMsg, plShadow
 
 void plPointShadowMaster::IComputeISect(const hsBounds3Ext& bnd, plShadowSlave* slave) const
 {
-    int iIsect = fIsectPool.GetCount();
-    fIsectPool.ExpandAndZero(iIsect+1);
-    if( !fIsectPool[iIsect] )
-    {
-        fIsectPool[iIsect] = new plBoundsIsect;
-    }
-    plBoundsIsect* isect = fIsectPool[iIsect];
+    plBoundsIsect* isect = fIsectPool.next([] { return new plBoundsIsect; });
 
     const hsBounds3Ext& wBnd = slave->fWorldBounds;
 

--- a/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.cpp
@@ -98,13 +98,11 @@ static inline void InverseOfPureRotTran(const hsMatrix44& src, hsMatrix44& inv)
 
 plPointShadowMaster::~plPointShadowMaster()
 {
-    for (plBoundsIsect* isect : fIsectPool.pool())
-        delete isect;
 }
 
-plShadowSlave* plPointShadowMaster::INewSlave(const plShadowCaster* caster)
+std::unique_ptr<plShadowSlave> plPointShadowMaster::INewSlave(const plShadowCaster* caster)
 {
-    return new plPointShadowSlave;
+    return std::make_unique<plPointShadowSlave>();
 }
 
 void plPointShadowMaster::IBeginRender()
@@ -167,7 +165,7 @@ void plPointShadowMaster::IComputeProjections(plShadowCastMsg* castMsg, plShadow
 
 void plPointShadowMaster::IComputeISect(const hsBounds3Ext& bnd, plShadowSlave* slave) const
 {
-    plBoundsIsect* isect = fIsectPool.next([] { return new plBoundsIsect; });
+    plBoundsIsect* isect = fIsectPool.next([] { return new plBoundsIsect; }).get();
 
     const hsBounds3Ext& wBnd = slave->fWorldBounds;
 

--- a/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.h
+++ b/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.h
@@ -43,6 +43,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plPointShadowMaster_inc
 #define plPointShadowMaster_inc
 
+#include <memory>
+
 #include "plShadowMaster.h"
 #include "hsGeometry3.h"
 
@@ -53,14 +55,14 @@ class plPointShadowMaster : public plShadowMaster
 protected:
     mutable hsVector3                   fLastUp;
 
-    mutable hsPoolVector<plBoundsIsect*> fIsectPool;
+    mutable hsPoolVector<std::unique_ptr<plBoundsIsect>> fIsectPool;
 
     void IComputeWorldToLight(const hsBounds3Ext& bnd, plShadowSlave* slave) const override;
     void IComputeProjections(plShadowCastMsg* castMsg, plShadowSlave* slave) const override;
     void IComputeISect(const hsBounds3Ext& bnd, plShadowSlave* slave) const override;
     void IComputeBounds(const hsBounds3Ext& bnd, plShadowSlave* slave) const override;
 
-    plShadowSlave* INewSlave(const plShadowCaster* caster) override;
+    std::unique_ptr<plShadowSlave> INewSlave(const plShadowCaster* caster) override;
 
     void IBeginRender() override;
 

--- a/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.h
+++ b/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.h
@@ -53,7 +53,7 @@ class plPointShadowMaster : public plShadowMaster
 protected:
     mutable hsVector3                   fLastUp;
 
-    mutable hsTArray<plBoundsIsect*>    fIsectPool;
+    mutable hsPoolVector<plBoundsIsect*> fIsectPool;
 
     void IComputeWorldToLight(const hsBounds3Ext& bnd, plShadowSlave* slave) const override;
     void IComputeProjections(plShadowCastMsg* castMsg, plShadowSlave* slave) const override;

--- a/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.cpp
@@ -116,10 +116,8 @@ plShadowMaster::~plShadowMaster()
 {
     Deactivate();
 
-    fSlavePool.SetCount(fSlavePool.GetNumAlloc());
-    int i;
-    for( i = 0; i < fSlavePool.GetCount(); i++ )
-        delete fSlavePool[i];
+    for (plShadowSlave* slave : fSlavePool.pool())
+        delete slave;
 }
 
 void plShadowMaster::Read(hsStream* stream, hsResMgr* mgr)
@@ -198,7 +196,7 @@ bool plShadowMaster::MsgReceive(plMessage* msg)
 
 void plShadowMaster::IBeginRender()
 {
-    fSlavePool.SetCount(0);
+    fSlavePool.clear();
     if( ISetLightInfo() ) 
         fLightInfo->ClearSlaveBits();
 }
@@ -308,14 +306,7 @@ void plShadowMaster::IComputeCasterBounds(const plShadowCaster* caster, hsBounds
 
 plShadowSlave* plShadowMaster::INextSlave(const plShadowCaster* caster)
 {
-    int iSlave = fSlavePool.GetCount();
-    fSlavePool.ExpandAndZero(iSlave+1);
-    plShadowSlave* slave = fSlavePool[iSlave];
-    if( !slave )
-    {
-        fSlavePool[iSlave] = slave = INewSlave(caster);
-    }
-    return slave;
+    return fSlavePool.next([this, caster] { return INewSlave(caster); });
 }
 
 plShadowSlave* plShadowMaster::ICreateShadowSlave(plShadowCastMsg* castMsg, const hsBounds3Ext& casterBnd, float power)
@@ -359,7 +350,7 @@ plShadowSlave* plShadowMaster::ICreateShadowSlave(plShadowCastMsg* castMsg, cons
 
 plShadowSlave* plShadowMaster::IRecycleSlave(plShadowSlave* slave)
 {
-    fSlavePool.SetCount(fSlavePool.GetCount()-1);
+    fSlavePool.pop_back();
     return nullptr;
 }
 

--- a/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.cpp
@@ -115,9 +115,6 @@ plShadowMaster::plShadowMaster()
 plShadowMaster::~plShadowMaster()
 {
     Deactivate();
-
-    for (plShadowSlave* slave : fSlavePool.pool())
-        delete slave;
 }
 
 void plShadowMaster::Read(hsStream* stream, hsResMgr* mgr)
@@ -306,7 +303,7 @@ void plShadowMaster::IComputeCasterBounds(const plShadowCaster* caster, hsBounds
 
 plShadowSlave* plShadowMaster::INextSlave(const plShadowCaster* caster)
 {
-    return fSlavePool.next([this, caster] { return INewSlave(caster); });
+    return fSlavePool.next([this, caster] { return INewSlave(caster); }).get();
 }
 
 plShadowSlave* plShadowMaster::ICreateShadowSlave(plShadowCastMsg* castMsg, const hsBounds3Ext& casterBnd, float power)

--- a/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.h
+++ b/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plShadowMaster_inc
 #define plShadowMaster_inc
 
+#include <memory>
 #include <vector>
 
 #include "pnSceneObject/plObjInterface.h"
@@ -141,7 +142,7 @@ protected:
     float                        fPower;
 
     // Temp data used for one frame and recycled.
-    hsPoolVector<plShadowSlave*>    fSlavePool;
+    hsPoolVector<std::unique_ptr<plShadowSlave>> fSlavePool;
     plLightInfo*                    fLightInfo;
 
     // These are specific to the projection type (perspective or orthogonal), so have to
@@ -163,7 +164,7 @@ protected:
 
     virtual plShadowSlave* ICreateShadowSlave(plShadowCastMsg* castMsg, const hsBounds3Ext& casterBnd, float power);
 
-    virtual plShadowSlave* INewSlave(const plShadowCaster* caster) = 0;
+    virtual std::unique_ptr<plShadowSlave> INewSlave(const plShadowCaster* caster) = 0;
     virtual plShadowSlave* INextSlave(const plShadowCaster* caster);
 
     virtual plShadowSlave* IRecycleSlave(plShadowSlave* slave);

--- a/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.h
+++ b/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.h
@@ -43,7 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plShadowMaster_inc
 #define plShadowMaster_inc
 
-#include "hsTemplates.h"
+#include <vector>
 
 #include "pnSceneObject/plObjInterface.h"
 
@@ -58,6 +58,59 @@ class plMessage;
 class plLightInfo;
 class plShadowCastMsg;
 
+// This helper class was borne out of the pl*ShadowMaster classes' abuse
+// of the implementation details of hsTArray<T>. This pool type allows a
+// user to track a subset of "in-use" items separately from the full set
+// of allocated items in a collection. TODO: Eliminate the need for this
+// ugly hack altogether.
+template <class T>
+class hsPoolVector
+{
+public:
+    hsPoolVector() : fUsed() { }
+
+    // Access the underlying pool
+    std::vector<T>& pool() { return fPool; }
+    const std::vector<T>& pool() const { return fPool; }
+
+    size_t size() const noexcept { return fUsed; }
+    bool empty() const noexcept { return fUsed == 0; }
+
+    T& front() { return fPool.front(); }
+    const T& front() const { return fPool.front(); }
+    T& back() { return fPool[fUsed - 1]; }
+    const T& back() const { return fPool[fUsed - 1]; }
+
+    T& operator[](size_t pos) { return fPool[pos]; }
+    const T& operator[](size_t pos) const { return fPool[pos]; }
+
+    // Return an existing item after the last used, or add a new
+    // element with the specified createItem() callback if we're
+    // already at capacity.
+    template <class CreateItem>
+    T& next(CreateItem createItem)
+    {
+        if (fUsed == fPool.size()) {
+            fUsed++;
+            return fPool.emplace_back(createItem());
+        }
+        return fPool[fUsed++];
+    }
+
+    void pop_back() noexcept
+    {
+        fUsed--;
+    }
+
+    void clear() noexcept
+    {
+        fUsed = 0;
+    }
+
+private:
+    std::vector<T>  fPool;
+    size_t          fUsed;
+};
 
 class plShadowMaster : public plObjInterface
 {
@@ -88,7 +141,7 @@ protected:
     float                        fPower;
 
     // Temp data used for one frame and recycled.
-    hsTArray<plShadowSlave*>        fSlavePool;
+    hsPoolVector<plShadowSlave*>    fSlavePool;
     plLightInfo*                    fLightInfo;
 
     // These are specific to the projection type (perspective or orthogonal), so have to


### PR DESCRIPTION
hsPoolVector caters to the specific (ab)use of hsTArray's peculiar allocation quirks to reuse items in a pool separately from tracking its
size.  Unlike hsTArray, this class makes the intent clear to the reader, rather than relying on hidden and non-obvious implementation details.

This is currently only used by plShadowMaster and its children.