### PR TITLE
Clean up a handful of size_t warnings in common headers

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedObject.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedObject.h
@@ -147,8 +147,8 @@ public:
     static void PushSynchDisabled(bool b) { fSynchStateStack.push_back(b); }
     static bool PopSynchDisabled();
     static plSynchedObject* GetStaticSynchedObject() { return fStaticSynchedObj; }
-    static int32_t GetNumDirtyStates() { return fDirtyStates.size(); }
-    static plSynchedObject::StateDefn* GetDirtyState(int32_t i) { return &fDirtyStates[i]; }
+    static size_t GetNumDirtyStates() { return fDirtyStates.size(); }
+    static plSynchedObject::StateDefn* GetDirtyState(size_t i) { return &fDirtyStates[i]; }
     static void ClearDirtyState(std::vector<StateDefn>& carryOver) { fDirtyStates=carryOver; } 
 
     // IO 

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrSend.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrSend.cpp
@@ -101,18 +101,17 @@ int plNetClientMgr::ISendDirtyState(double secs)
 {
     std::vector<plSynchedObject::StateDefn> carryOvers;
 
-    int32_t num=plSynchedObject::GetNumDirtyStates();
+    size_t num = plSynchedObject::GetNumDirtyStates();
 #if 0
     if (num)
     {
         DebugMsg("{} dirty sdl state msgs queued, t={f}", num, secs);
     }
 #endif
-    int32_t i;
-    for(i=0;i<num;i++)
-    {
+
+    for (size_t i = 0; i < num; i++) {
         plSynchedObject::StateDefn* state=plSynchedObject::GetDirtyState(i);
-        
+
         plSynchedObject* obj=state->GetObject();
         if (!obj)
             continue;   // could add to carryOvers
@@ -129,7 +128,7 @@ int plNetClientMgr::ISendDirtyState(double secs)
         }
 
         obj->CallDirtyNotifiers();
-        obj->SendSDLStateMsg(state->fSDLName.c_str(), state->fSendFlags);       
+        obj->SendSDLStateMsg(state->fSDLName.c_str(), state->fSendFlags);
     }
 
     plSynchedObject::ClearDirtyState(carryOvers);

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
@@ -170,8 +170,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgGroupOwner)
     /*
     plNetOwnershipMsg* netOwnMsg = new plNetOwnershipMsg;
 
-    int i;
-    for(i=0;i<m->GetNumGroups();i++)
+    for(size_t i = 0; i < m->GetNumGroups(); i++)
     {
         plNetMsgGroupOwner::GroupInfo gr=m->GetGroupInfo(i);
         netOwnMsg->AddGroupInfo(gr);

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.h
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.h
@@ -433,9 +433,9 @@ public:
     void AddRoomLocation(plLocation loc, const ST::string& rmName);
     int FindRoomLocation(plLocation loc);
 
-    int GetNumRooms() const { return fRooms.size(); }
-    plLocation GetRoomLoc(int i) const { return fRooms[i]; }
-    ST::string GetRoomName(int i) const { return fRoomNames[i]; }      // debug
+    size_t GetNumRooms() const { return fRooms.size(); }
+    plLocation GetRoomLoc(size_t i) const { return fRooms[i]; }
+    ST::string GetRoomName(size_t i) const { return fRoomNames[i]; }      // debug
 };
 
 //
@@ -648,8 +648,8 @@ public:
     GETINTERFACE_ANY( plNetMsgGroupOwner, plNetMsgServerToClient );
 
     // getters
-    int GetNumGroups() const { return fGroups.size(); }
-    GroupInfo GetGroupInfo(int i) const { return fGroups[i]; }
+    size_t GetNumGroups() const { return fGroups.size(); }
+    GroupInfo GetGroupInfo(size_t i) const { return fGroups[i]; }
 
     // setters
     void AddGroupInfo(GroupInfo gi) { fGroups.push_back(gi); }

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMsgHelpers.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMsgHelpers.cpp
@@ -400,29 +400,28 @@ void plNetMsgObjectHelper::WriteVersion(hsStream* s, hsResMgr* mgr)
 ////////////////////////////////////////////////////////
 plNetMsgObjectListHelper::~plNetMsgObjectListHelper()
 {
-    Reset();         
+    Reset();
 }
 
 void plNetMsgObjectListHelper::Reset()
 {
-    int i;
-    for( i=0 ; i<GetNumObjects() ; i++  )
-    {
+    for (size_t i = 0; i < GetNumObjects(); i++) {
         delete GetObject(i);
         fObjects[i] = nullptr;
-    } // for    
+    }
+
     fObjects.clear();
 }
 
 int plNetMsgObjectListHelper::Poke(hsStream* stream, uint32_t peekOptions)
 {
-    int16_t num = GetNumObjects();
-    stream->WriteLE(num);
-    int i;
-    for( i=0 ;i<num  ;i++  )
-    {
+    size_t num = GetNumObjects();
+    hsAssert(num < std::numeric_limits<uint16_t>::max(), "Too many objects");
+
+    stream->WriteLE(uint16_t(num));
+
+    for (size_t i = 0; i < num; i++)
         GetObject(i)->Poke(stream, peekOptions);
-    } // for         
 
     return stream->GetPosition();
 }
@@ -478,8 +477,7 @@ int plNetMsgMemberInfoHelper::Poke(hsStream* s, const uint32_t peekOptions)
 ////////////////////////////////////////////////////////
 plNetMsgMemberListHelper::~plNetMsgMemberListHelper()
 {
-    int i;
-    for(i=0;i<GetNumMembers();i++)
+    for (size_t i = 0; i < GetNumMembers(); i++)
         delete fMembers[i];
 }
 
@@ -502,11 +500,12 @@ int plNetMsgMemberListHelper::Peek(hsStream* stream, const uint32_t peekOptions)
 
 int plNetMsgMemberListHelper::Poke(hsStream* stream, const uint32_t peekOptions)
 {
-    int16_t numMembers = (int16_t)GetNumMembers();
-    stream->WriteLE(numMembers);
+    size_t numMembers = GetNumMembers();
+    hsAssert(numMembers < std::numeric_limits<uint16_t>::max(), "Too many members");
 
-    int i;
-    for(i=0;i<numMembers;i++)
+    stream->WriteLE(uint16_t(numMembers));
+
+    for(size_t i = 0; i < numMembers; i++)
     {
         fMembers[i]->GetClientGuid()->SetClientKey("");
         fMembers[i]->GetClientGuid()->SetAccountUUID(plUUID());
@@ -542,11 +541,12 @@ int plNetMsgReceiversListHelper::Peek(hsStream* stream, const uint32_t peekOptio
 
 int plNetMsgReceiversListHelper::Poke(hsStream* stream, const uint32_t peekOptions)
 {
-    uint8_t numIDs = (uint8_t)GetNumReceivers();
-    stream->WriteLE(numIDs);
+    size_t numIDs = GetNumReceivers();
+    hsAssert(numIDs < std::numeric_limits<uint8_t>::max(), "Too many receivers");
 
-    int i;
-    for(i=0;i<numIDs;i++)
+    stream->WriteLE(uint8_t(numIDs));
+
+    for (size_t i = 0; i < numIDs; i++)
         stream->WriteLE(GetReceiverPlayerID(i));
 
     return stream->GetPosition();

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMsgHelpers.h
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMsgHelpers.h
@@ -235,12 +235,12 @@ public:
     CLASSNAME_REGISTER( plNetMsgObjectListHelper );
     GETINTERFACE_ANY(plNetMsgObjectListHelper, plCreatable);
 
-    virtual int Poke(hsStream* stream, uint32_t peekOptions=0);   
+    virtual int Poke(hsStream* stream, uint32_t peekOptions=0);
     virtual int Peek(hsStream* stream, uint32_t peekOptions=0);
 
     void Reset();
-    int GetNumObjects() const { return fObjects.size(); }
-    plNetMsgObjectHelper* GetObject(int i) { return fObjects[i]; }
+    size_t GetNumObjects() const { return fObjects.size(); }
+    plNetMsgObjectHelper* GetObject(size_t i) { return fObjects[i]; }
     void AddObject(plKey key) { fObjects.push_back(new plNetMsgObjectHelper(key)); }
 };
 
@@ -303,10 +303,10 @@ public:
     virtual int Poke(hsStream* stream, uint32_t peekOptions=0);
     virtual int Peek(hsStream* stream, uint32_t peekOptions=0);
 
-    int GetNumMembers() const { return fMembers.size(); }
-    const plNetMsgMemberInfoHelper* GetMember(int i) const { return fMembers[i]; }
+    size_t GetNumMembers() const { return fMembers.size(); }
+    const plNetMsgMemberInfoHelper* GetMember(size_t i) const { return fMembers[i]; }
     void AddMember(plNetMsgMemberInfoHelper* a) { fMembers.push_back(a); }
-    const MemberInfoHelperVec * GetMembers() const { return &fMembers;}
+    const MemberInfoHelperVec* GetMembers() const { return &fMembers;}
 };
 
 
@@ -332,8 +332,8 @@ public:
     virtual int Peek(hsStream* stream, uint32_t peekOptions=0);
 
     void Clear() { fPlayerIDList.clear();   }
-    int GetNumReceivers() const { return fPlayerIDList.size(); }
-    uint32_t GetReceiverPlayerID(int i) const { return fPlayerIDList[i]; }
+    size_t GetNumReceivers() const { return fPlayerIDList.size(); }
+    uint32_t GetReceiverPlayerID(size_t i) const { return fPlayerIDList[i]; }
     void AddReceiverPlayerID(uint32_t a) { fPlayerIDList.push_back(a); }
     bool RemoveReceiverPlayerID(uint32_t n);  // returns true if found and removed
 };


### PR DESCRIPTION
These amount to a lot of the warnings printed out by the x64 builders, because the warning is issued every time the header is included.