### PR TITLE
Fix a crash introduced by c19ae73a

### DIFF
--- a/Sources/Plasma/CoreLib/hsPoolVector.h
+++ b/Sources/Plasma/CoreLib/hsPoolVector.h
@@ -94,6 +94,12 @@ public:
         fUsed = 0;
     }
 
+    void reset() noexcept
+    {
+        fPool.clear();
+        fUsed = 0;
+    }
+
 private:
     std::vector<T>  fPool;
     size_t          fUsed;

--- a/Sources/Plasma/CoreLib/hsPoolVector.h
+++ b/Sources/Plasma/CoreLib/hsPoolVector.h
@@ -71,9 +71,11 @@ public:
     T& operator[](size_t pos) { return fPool[pos]; }
     const T& operator[](size_t pos) const { return fPool[pos]; }
 
-    // Return an existing item after the last used, or add a new
-    // element with the specified createItem() callback if we're
-    // already at capacity.
+    /**
+     * Return an existing item after the last used, or add a new
+     * element with the specified createItem() callback if we're
+     * already at capacity in the underlying storage.
+     */
     template <class CreateItem>
     T& next(CreateItem createItem)
     {
@@ -89,12 +91,20 @@ public:
         fUsed--;
     }
 
+    /**
+     * Clear the in-use count, so the next element is picked from the
+     * beginning of the pool.
+     */
     void clear() noexcept
     {
         fUsed = 0;
     }
 
-    void reset() noexcept
+    /**
+     * Reset both the in-use count and the underlying storage back to empty,
+     * so the next element is guaranteed to be freshly created.
+     */
+    void release_and_clear() noexcept
     {
         fPool.clear();
         fUsed = 0;

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -5228,7 +5228,7 @@ void    plDXLightSettings::Release()
         hsRefCnt_SafeUnRef(shadowLight);
         shadowLight = nullptr;
     }
-    fShadowLights.clear();
+    fShadowLights.reset();
 }
 
 //// ReserveD3DIndex //////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -5228,7 +5228,7 @@ void    plDXLightSettings::Release()
         hsRefCnt_SafeUnRef(shadowLight);
         shadowLight = nullptr;
     }
-    fShadowLights.reset();
+    fShadowLights.release_and_clear();
 }
 
 //// ReserveD3DIndex //////////////////////////////////////////////////////////


### PR DESCRIPTION
The pool vector only calls the createItem code when adding a new element to the pool, but plDXPipeline will explicitly null out items in the pool prior to resetting its use count. This change adds a reset method which also clears the pool (note: per the C++17 standard, clear() will not cause a reallocation of the underlying storage, so this is not a performance regression).