### PR TITLE
Address a few more size_t warnings

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.cpp
@@ -701,7 +701,7 @@ void pl2WayWinAudible::Read(hsStream* s, hsResMgr* mgr)
     plgDispatch::Dispatch()->RegisterForExactType(plEvalMsg::Index(), GetKey());
 }
 
-void pl2WayWinAudible::PlayNetworkedSpeech(const char* addr, int32_t size, int numFrames, unsigned char flags)
+void pl2WayWinAudible::PlayNetworkedSpeech(const char* addr, size_t size, int numFrames, unsigned char flags)
 {
     if (fVoicePlayer)
         fVoicePlayer->PlaybackVoiceMessage((uint8_t*)addr, size, numFrames, flags);

--- a/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.h
+++ b/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.h
@@ -151,7 +151,7 @@ public:
     void Activate() override;
     void DeActivate() override;
     void Read(hsStream* s, hsResMgr* mgr) override;
-    virtual void PlayNetworkedSpeech(const char* addr, int32_t size, int numFrames, unsigned char flags);
+    virtual void PlayNetworkedSpeech(const char* addr, size_t size, int numFrames, unsigned char flags);
     
     plAudible& SetTransform(const hsMatrix44& l2w, const hsMatrix44& w2l, int index = -1) override;
     void SetVelocity(const hsVector3 vel,int index = -1) override;

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
@@ -390,7 +390,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgVoice)
         m->ClassName(), m->AsStdString(), m->GetNetCoreMsgLen()) );
 */
 
-    int bufLen = m->GetVoiceDataLen();
+    size_t bufLen = m->GetVoiceDataLen();
     const char* buf = m->GetVoiceData();
     uint8_t flags = m->GetFlags();
     uint8_t numFrames = m->GetNumFrames();

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.h
@@ -93,7 +93,7 @@ public:
     plCreatable* GetItem( uint16_t id, bool unManageItem=false ) const;
     void    RemoveItem( uint16_t id, bool unManageItem=false );
     bool    ItemExists( uint16_t id ) const;
-    int     GetNumItems() const { return fItems.size();}
+    size_t  GetNumItems() const { return fItems.size();}
     // helpers for typed arguments
     void    AddString( uint16_t id, const char * value );
     void    AddString( uint16_t id, std::string & value );

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.h
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.h
@@ -693,7 +693,7 @@ public:
     uint8_t GetNumFrames() const { return fNumFrames; }
     
     void SetVoiceData(const void* data, size_t len );
-    int GetVoiceDataLen() const { return fVoiceData.length(); }
+    size_t GetVoiceDataLen() const { return fVoiceData.length(); }
     const char *GetVoiceData() const;
     
     plNetMsgReceiversListHelper* Receivers() { return &fReceivers; }


### PR DESCRIPTION
`plVoicePlayer::PlaybackVoiceMessage` already expects a `size_t`, so no change needed there