### PR TITLE
More hsStream cleanup

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -217,6 +217,20 @@ inline double hsSwapEndianDouble(double dvalue)
     #define hsToLEDouble(n)     hsSwapEndianDouble(n)
 #endif
 
+// Generic versions for use in templates
+template <typename T> inline T hsToLE(T value) = delete;
+template <> inline char hsToLE(char value) { return value; }
+template <> inline int8_t hsToLE(int8_t value) { return value; }
+template <> inline uint8_t hsToLE(uint8_t value) { return value; }
+template <> inline int16_t hsToLE(int16_t value) { return (int16_t)hsToLE16((uint16_t)value); }
+template <> inline uint16_t hsToLE(uint16_t value) { return hsToLE16(value); }
+template <> inline int32_t hsToLE(int32_t value) { return (int32_t)hsToLE32((uint32_t)value); }
+template <> inline uint32_t hsToLE(uint32_t value) { return hsToLE32(value); }
+template <> inline int64_t hsToLE(int64_t value) { return (int64_t)hsToLE64((uint64_t)value); }
+template <> inline uint64_t hsToLE(uint64_t value) { return hsToLE64(value); }
+template <> inline float hsToLE(float value) { return hsToLEFloat(value); }
+template <> inline double hsToLE(double value) { return hsToLEDouble(value); }
+
 //===========================================================================
 // Define a NOOP (null) statement
 //===========================================================================

--- a/Sources/Plasma/CoreLib/hsBounds.cpp
+++ b/Sources/Plasma/CoreLib/hsBounds.cpp
@@ -63,7 +63,7 @@ void hsBounds::Read(hsStream *s)
 
 void hsBounds::Write(hsStream *s) 
 {
-    s->WriteLE32((int32_t)fType);
+    s->WriteLE32((uint32_t)fType);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -623,7 +623,7 @@ void hsBoundsOriented::Write(hsStream *stream)
 {
     hsBounds::Write(stream);
     fCenter.Write(stream);
-    stream->WriteLE32(fCenterValid);
+    stream->WriteBOOL(fCenterValid);
     stream->WriteLE32(fNumPlanes);
 
     for (uint32_t i = 0; i < fNumPlanes; i++)
@@ -636,7 +636,7 @@ void hsBoundsOriented::Read(hsStream *stream)
 {
     hsBounds::Read(stream);
     fCenter.Read(stream);
-    fCenterValid = (bool)stream->ReadLE32();
+    fCenterValid = stream->ReadBOOL();
     fNumPlanes = stream->ReadLE32();
     if (fPlanes)
         delete [] fPlanes;

--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -187,11 +187,11 @@ ST::string hsStream::ReadSafeWStringLong()
 
 uint32_t hsStream::WriteSafeString(const ST::string &string)
 {
-    int len = string.size();
+    size_t len = string.size();
     hsAssert(len<0xf000, ST::format("string len of {} is too long for WriteSafeString {}, use WriteSafeStringLong",
         len, string).c_str() );
 
-    WriteLE16(len | 0xf000);
+    WriteLE16(static_cast<uint16_t>(len | 0xf000));
     if (len > 0)
     {
         uint32_t i;
@@ -209,11 +209,11 @@ uint32_t hsStream::WriteSafeString(const ST::string &string)
 uint32_t hsStream::WriteSafeWString(const ST::string &string)
 {
     ST::utf16_buffer wbuff = string.to_utf16();
-    uint32_t len = wbuff.size();
+    size_t len = wbuff.size();
     hsAssert(len<0xf000, ST::format("string len of {} is too long for WriteSafeWString, use WriteSafeWStringLong",
         len).c_str() );
 
-    WriteLE16(len | 0xf000);
+    WriteLE16(static_cast<uint16_t>(len | 0xf000));
     if (len > 0)
     {
         const char16_t *buffp = wbuff.data();
@@ -418,10 +418,10 @@ uint16_t hsStream::ReadLE16()
     return value;
 }
 
-void hsStream::ReadLE16(int count, uint16_t values[])
+void hsStream::ReadLE16(size_t count, uint16_t values[])
 {
     this->Read(count * sizeof(uint16_t), values);
-    for (int i = 0; i < count; i++)
+    for (size_t i = 0; i < count; i++)
         values[i] = hsToLE16(values[i]);
 }
 
@@ -433,10 +433,10 @@ uint32_t hsStream::ReadLE32()
     return value;
 }
 
-void hsStream::ReadLE32(int count, uint32_t values[])
+void hsStream::ReadLE32(size_t count, uint32_t values[])
 {
     this->Read(count * sizeof(uint32_t), values);
-    for (int i = 0; i < count; i++)
+    for (size_t i = 0; i < count; i++)
         values[i] = hsToLE32(values[i]);
 }
 
@@ -448,10 +448,10 @@ double hsStream::ReadLEDouble()
     return value;
 }
 
-void hsStream::ReadLEDouble(int count, double values[])
+void hsStream::ReadLEDouble(size_t count, double values[])
 {
     this->Read(count * sizeof(double), values);
-    for (int i = 0; i < count; i++)
+    for (size_t i = 0; i < count; i++)
         values[i] = hsToLEDouble(values[i]);
 }
 
@@ -464,10 +464,10 @@ float hsStream::ReadLEFloat()
     return value;
 }
 
-void hsStream::ReadLEFloat(int count, float values[])
+void hsStream::ReadLEFloat(size_t count, float values[])
 {
     this->Read(count * sizeof(float), values);
-    for (int i = 0; i < count; i++)
+    for (size_t i = 0; i < count; i++)
         values[i] = hsToLEFloat(values[i]);
 }
 
@@ -494,9 +494,9 @@ void  hsStream::WriteLE16(uint16_t value)
     this->Write(sizeof(int16_t), &value);
 }
 
-void  hsStream::WriteLE16(int count, const uint16_t values[])
+void  hsStream::WriteLE16(size_t count, const uint16_t values[])
 {
-    for (int i = 0; i < count; i++)
+    for (size_t i = 0; i < count; i++)
         this->WriteLE16(values[i]);
 }
 
@@ -506,9 +506,9 @@ void  hsStream::WriteLE32(uint32_t value)
     this->Write(sizeof(int32_t), &value);
 }
 
-void  hsStream::WriteLE32(int count, const uint32_t values[])
+void  hsStream::WriteLE32(size_t count, const uint32_t values[])
 {
-    for (int i = 0; i < count; i++)
+    for (size_t i = 0; i < count; i++)
         this->WriteLE32(values[i]);
 }
 
@@ -518,9 +518,9 @@ void hsStream::WriteLEDouble(double value)
     this->Write(sizeof(double), &value);
 }
 
-void hsStream::WriteLEDouble(int count, const double values[])
+void hsStream::WriteLEDouble(size_t count, const double values[])
 {
-    for (int i = 0; i < count; i++)
+    for (size_t i = 0; i < count; i++)
         this->WriteLEDouble(values[i]);
 }
 
@@ -530,9 +530,9 @@ void hsStream::WriteLEFloat(float value)
     this->Write(sizeof(float), &value);
 }
 
-void hsStream::WriteLEFloat(int count, const float values[])
+void hsStream::WriteLEFloat(size_t count, const float values[])
 {
-    for (int i = 0; i < count; i++)
+    for (size_t i = 0; i < count; i++)
         this->WriteLEFloat(values[i]);
 }
 

--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -473,13 +473,13 @@ void hsStream::ReadLEFloat(int count, float values[])
 
 void hsStream::WriteBOOL(bool value)
 {
-    uint32_t dst = value != 0;
+    uint32_t dst = value ? hsToLE32(1) : 0;
     this->Write(sizeof(uint32_t), &dst);
 }
 
 void hsStream::WriteBool(bool value)
 {
-    uint8_t dst = value != 0;
+    uint8_t dst = value ? 1 : 0;
     this->Write(sizeof(uint8_t), &dst);
 }
 

--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -119,11 +119,9 @@ public:
 
     /* Overloaded  Begin (8 & 16 & 32 int)*/
     /* yes, swapping an 8 bit value does nothing, just useful*/
-    void            ReadLE(bool* value) { *value = this->ReadByte() ? true : false; }
     void            ReadLE(uint8_t* value) { *value = this->ReadByte(); }
     void            ReadLE(uint16_t* value) { *value = this->ReadLE16(); }
     void            ReadLE(uint32_t* value) { *value = this->ReadLE32(); }
-    void            WriteLE(bool value) { this->Write(1,&value); }
     void            WriteLE(uint8_t value) { this->Write(1,&value); }
     void            WriteLE(uint16_t value) { this->WriteLE16(value); }
     void            WriteLE(uint32_t value) { this->WriteLE32(value); }

--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -116,42 +116,29 @@ public:
     void            WriteLE32(uint32_t value);
     void            WriteLE32(size_t count, const uint32_t values[]);
 
-
-    /* Overloaded  Begin (8 & 16 & 32 int)*/
-    /* yes, swapping an 8 bit value does nothing, just useful*/
-    void            ReadLE(uint8_t* value) { *value = this->ReadByte(); }
-    void            ReadLE(uint16_t* value) { *value = this->ReadLE16(); }
-    void            ReadLE(uint32_t* value) { *value = this->ReadLE32(); }
-    void            WriteLE(uint8_t value) { this->Write(1,&value); }
-    void            WriteLE(uint16_t value) { this->WriteLE16(value); }
-    void            WriteLE(uint32_t value) { this->WriteLE32(value); }
-    void            ReadLE(int8_t* value) { *value = this->ReadByte(); }
-    void            ReadLE(char* value) { *value = (char)this->ReadByte(); }
-    void            ReadLE(int16_t* value) { *value = (int16_t)this->ReadLE16(); }
-    void            ReadLE(int32_t* value) { *value = (int32_t)this->ReadLE32(); }
-    void            WriteLE(int8_t value) { this->Write(1,&value); }
-    void            WriteLE(char value) { this->Write(1,(uint8_t*)&value); }
-    void            WriteLE(int16_t value) { this->WriteLE16((uint16_t)value); }
-    void            WriteLE(int32_t value) { this->WriteLE32((uint32_t)value); }
-    /* Overloaded  End */
-
-
     float           ReadLEFloat();
     void            ReadLEFloat(size_t count, float values[]);
     double          ReadLEDouble();
     void            ReadLEDouble(size_t count, double values[]);
+
     void            WriteLEFloat(float value);
     void            WriteLEFloat(size_t count, const float values[]);
     void            WriteLEDouble(double value);
     void            WriteLEDouble(size_t count, const double values[]);
 
+    template <typename T>
+    inline void ReadLE(T* value)
+    {
+        Read(sizeof(T), value);
+        *value = hsToLE(*value);
+    }
 
-    /* Overloaded  Begin (Float)*/
-    void            ReadLE(float* value) { *value = ReadLEFloat(); }
-    void            ReadLE(double* value) { *value = ReadLEDouble(); }
-    void            WriteLE(float value) { WriteLEFloat(value); }
-    void            WriteLE(double value) { WriteLEDouble(value); }
-    /* Overloaded End */
+    template <typename T>
+    inline void WriteLE(T value)
+    {
+        value = hsToLE(value);
+        Write(sizeof(T), &value);
+    }
 };
 
 class hsStreamable {

--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -103,18 +103,18 @@ public:
 
     uint8_t         ReadByte();
     uint16_t        ReadLE16();
-    void            ReadLE16(int count, uint16_t values[]);
+    void            ReadLE16(size_t count, uint16_t values[]);
     uint32_t        ReadLE32();
-    void            ReadLE32(int count, uint32_t values[]);
+    void            ReadLE32(size_t count, uint32_t values[]);
 
     void            WriteBOOL(bool value);
     void            WriteBool(bool value);
 
     void            WriteByte(uint8_t value);
     void            WriteLE16(uint16_t value);
-    void            WriteLE16(int count, const uint16_t values[]);
+    void            WriteLE16(size_t count, const uint16_t values[]);
     void            WriteLE32(uint32_t value);
-    void            WriteLE32(int count, const  uint32_t values[]);
+    void            WriteLE32(size_t count, const uint32_t values[]);
 
 
     /* Overloaded  Begin (8 & 16 & 32 int)*/
@@ -137,13 +137,13 @@ public:
 
 
     float           ReadLEFloat();
-    void            ReadLEFloat(int count, float values[]);
+    void            ReadLEFloat(size_t count, float values[]);
     double          ReadLEDouble();
-    void            ReadLEDouble(int count, double values[]);
+    void            ReadLEDouble(size_t count, double values[]);
     void            WriteLEFloat(float value);
-    void            WriteLEFloat(int count, const float values[]);
+    void            WriteLEFloat(size_t count, const float values[]);
     void            WriteLEDouble(double value);
-    void            WriteLEDouble(int count, const double values[]);
+    void            WriteLEDouble(size_t count, const double values[]);
 
 
     /* Overloaded  Begin (Float)*/

--- a/Sources/Plasma/FeatureLib/pfAnimation/pfObjectFlocker.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/pfObjectFlocker.cpp
@@ -62,8 +62,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define RAND() (float) (rand()/(RAND_MAX * 1.0))
 #define SIGN(x) (((x) < 0) ? -1 : 1)
 
-const int pfObjectFlocker::fFileVersion = 1;
-
 #define FLOCKER_SHOW_DEBUG_LINES 0
 
 #if FLOCKER_SHOW_DEBUG_LINES
@@ -915,7 +913,7 @@ bool pfObjectFlocker::MsgReceive(plMessage* msg)
         pMsg->Send();
 
         hsPoint3 pos(fTarget->GetLocalToWorld().GetTranslate());
-        for (int i = 0; i < fNumBoids; i++)
+        for (uint8_t i = 0; i < fNumBoids; i++)
         {
             plLoadCloneMsg* cloneMsg = new plLoadCloneMsg(fBoidKey->GetUoid(), GetKey(), 0);
             plKey newKey = cloneMsg->GetCloneKey();
@@ -956,7 +954,7 @@ bool pfObjectFlocker::IEval(double secs, float del, uint32_t dirty)
     fFlock.Update(fTarget, del);
 
     plSceneObject* boidSO = nullptr;
-    for (int i = 0; i < fNumBoids; i++)
+    for (uint8_t i = 0; i < fNumBoids; i++)
     {
         pfBoid* boid = fFlock.GetBoid(i);
         boidSO = plSceneObject::ConvertNoRef(boid->GetKey()->VerifyLoaded());

--- a/Sources/Plasma/FeatureLib/pfAnimation/pfObjectFlocker.h
+++ b/Sources/Plasma/FeatureLib/pfAnimation/pfObjectFlocker.h
@@ -447,10 +447,10 @@ public:
     void SetUseTargetRotation(bool val) {fUseTargetRotation = val;}
 
 protected:
-    const static int fFileVersion; // so we don't have to update the global version number when we change
+    constexpr static uint8_t fFileVersion = 1; // so we don't have to update the global version number when we change
 
     pfFlock fFlock;
-    int fNumBoids;
+    uint8_t fNumBoids;
     plKey fBoidKey;
 
     bool fUseTargetRotation;

--- a/Sources/Plasma/FeatureLib/pfAnimation/plFollowMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plFollowMod.cpp
@@ -292,7 +292,7 @@ void plFollowMod::Write(hsStream* stream, hsResMgr* mgr)
 {
     plSingleModifier::Write(stream, mgr);
 
-    stream->WriteByte(fLeaderType);
+    stream->WriteByte((uint8_t)fLeaderType);
     stream->WriteByte(fMode);
 
     mgr->WriteKey(stream, fLeader);

--- a/Sources/Plasma/FeatureLib/pfConditional/plAnimationEventConditionalObject.cpp
+++ b/Sources/Plasma/FeatureLib/pfConditional/plAnimationEventConditionalObject.cpp
@@ -90,6 +90,6 @@ void plAnimationEventConditionalObject::Write(hsStream* stream, hsResMgr* mgr)
 {
     plConditionalObject::Write(stream, mgr);
     mgr->WriteKey(stream, fTarget);
-    stream->WriteLE32(fAction); 
+    stream->WriteLE32((uint32_t)fAction);
 }
     

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlHandlers.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlHandlers.cpp
@@ -64,7 +64,7 @@ void    pfGUICtrlProcWriteableObject::Write( pfGUICtrlProcWriteableObject *obj, 
         obj->IWrite( s );
     }
     else
-        s->WriteLE32( kNull );
+        s->WriteLE32((uint32_t)kNull);
 }
 
 pfGUICtrlProcWriteableObject *pfGUICtrlProcWriteableObject::Read( hsStream *s )

--- a/Sources/Plasma/FeatureLib/pfMessage/pfMarkerMsg.cpp
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfMarkerMsg.cpp
@@ -69,7 +69,7 @@ void pfMarkerMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(stream, mgr);
 
-    stream->WriteByte(fType);
+    stream->WriteByte((uint8_t)fType);
 
     if (fType == kMarkerCaptured)
         stream->WriteLE32(fMarkerID);

--- a/Sources/Plasma/FeatureLib/pfMessage/pfMovieEventMsg.cpp
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfMovieEventMsg.cpp
@@ -56,7 +56,7 @@ void pfMovieEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(stream, mgr);
 
-    stream->WriteByte(fReason);
+    stream->WriteByte((uint8_t)fReason);
 
     stream->WriteSafeString(fMovieName.AsString());
 }

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonParameter.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonParameter.h
@@ -369,7 +369,7 @@ public:
                 break;
 
             case kbool:
-                datarecord.fBool = stream->ReadLE32();
+                datarecord.fBool = stream->ReadBOOL();
                 break;
 
             case kString:
@@ -425,7 +425,7 @@ public:
                 break;
 
             case kbool:
-                stream->WriteLE32(datarecord.fBool);
+                stream->WriteBOOL(datarecord.fBool);
                 break;
 
             case kString:

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.cpp
@@ -157,9 +157,7 @@ void    plGenericType::Read(hsStream* s)
         fS=s->ReadSafeString();
         break;
     case kBool:
-        {int8_t b;
-        s->ReadLE( &b );
-        fB = b?true:false;}
+        fB = s->ReadBool();
         break;
     case kChar:
         s->ReadLE( &fC );
@@ -192,8 +190,7 @@ void    plGenericType::Write(hsStream* s)
         s->WriteSafeString(fS);
         break;
     case kBool:
-        {int8_t b = fB?1:0;
-        s->WriteLE( b );}
+        s->WriteBool(fB);
         break;
     case kChar:
         s->WriteLE( fC );

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
@@ -96,5 +96,5 @@ void plNetAddress::Write(hsStream * s)
     s->WriteLE16(fPort);
 
     // Family is always AF_INET
-    s->WriteLE16(AF_INET);
+    s->WriteLE16((uint16_t)AF_INET);
 }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAnimStage.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAnimStage.cpp
@@ -750,10 +750,10 @@ void plAnimStage::Write(hsStream *stream, hsResMgr *mgr)
 {
     stream->WriteSafeString(fAnimName);
     stream->WriteByte(fNotify);
-    stream->WriteLE32(fForwardType);
-    stream->WriteLE32(fBackType);
-    stream->WriteLE32(fAdvanceType);
-    stream->WriteLE32(fRegressType);
+    stream->WriteLE32((uint32_t)fForwardType);
+    stream->WriteLE32((uint32_t)fBackType);
+    stream->WriteLE32((uint32_t)fAdvanceType);
+    stream->WriteLE32((uint32_t)fRegressType);
     stream->WriteLE32(fLoops);
 
     stream->WriteBool(fDoAdvanceTo);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureEffects.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureEffects.cpp
@@ -222,7 +222,7 @@ void plArmatureEffectFootSound::Write(hsStream* s, hsResMgr* mgr)
 {
     plArmatureEffect::Write(s, mgr);
 
-    s->WriteByte(plArmatureEffectsMgr::kMaxSurface);
+    s->WriteByte((uint8_t)plArmatureEffectsMgr::kMaxSurface);
     for (size_t i = 0; i < plArmatureEffectsMgr::kMaxSurface; i++)
         mgr->WriteKey(s, (fMods[i] ? fMods[i]->GetKey() : nullptr));
 }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrain.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrain.cpp
@@ -133,7 +133,7 @@ void plArmatureBrain::Write(hsStream *stream, hsResMgr *mgr)
     // plAvBrainUser
     stream->WriteLE32(0);
     stream->WriteLEFloat(0.f);
-    stream->WriteLEDouble(0.f);   
+    stream->WriteLEDouble(0.0);
 }
 
 void plArmatureBrain::Read(hsStream *stream, hsResMgr *mgr)

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainGeneric.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainGeneric.cpp
@@ -764,9 +764,9 @@ void plAvBrainGeneric::Write(hsStream *stream, hsResMgr *mgr)
     }
 
     stream->WriteLE32(fCurStage);
-    stream->WriteLE32(fType);
+    stream->WriteLE32((uint32_t)fType);
     stream->WriteLE32(fExitFlags);
-    stream->WriteByte(fMode);
+    stream->WriteByte((uint8_t)fMode);
     stream->WriteBool(fForward);
 
     if(fStartMessage) {
@@ -785,8 +785,8 @@ void plAvBrainGeneric::Write(hsStream *stream, hsResMgr *mgr)
 
     stream->WriteLEFloat(fFadeIn);
     stream->WriteLEFloat(fFadeOut);
-    stream->WriteByte(fMoveMode);
-    stream->WriteByte(fBodyUsage);
+    stream->WriteByte((uint8_t)fMoveMode);
+    stream->WriteByte((uint8_t)fBodyUsage);
     mgr->WriteKey(stream, fRecipient);
 }
 

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
@@ -1067,7 +1067,7 @@ void    plDrawableSpans::Read( hsStream* s, hsResMgr* mgr )
     {
         fDIIndices[ i ] = new plDISpanIndex;
         
-        fDIIndices[ i ]->fFlags = (uint8_t)(s->ReadLE32());
+        fDIIndices[i]->fFlags = s->ReadLE32();
         count2 = s->ReadLE32();
         fDIIndices[ i ]->SetCountAndZero( count2 );
         for( j = 0; j < count2; j++ )

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.h
@@ -98,7 +98,7 @@ public:
         kMatrixOnly             = 0x1,
         kDontTransformSpans     = 0x2       // Only used for particle systems right now
     };
-    uint8_t               fFlags;
+    uint32_t              fFlags;
     hsTArray<uint32_t>    fIndices;
 
     bool        IsMatrixOnly() const { return 0 != (fFlags & kMatrixOnly); }

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.cpp
@@ -210,8 +210,8 @@ void plDynaDecalMgr::Read(hsStream* stream, hsResMgr* mgr)
         mgr->ReadKeyNotifyMe(stream, new plGenRefMsg(GetKey(), plRefMsg::kOnCreate, 0, kRefPartyObject), plRefFlags::kPassiveRef);
     }
 
-    fMaxNumVerts = (uint16_t)(stream->ReadLE32());
-    fMaxNumIdx = (uint16_t)(stream->ReadLE32());
+    fMaxNumVerts = stream->ReadLE32();
+    fMaxNumIdx = stream->ReadLE32();
 
     fWaitOnEnable = stream->ReadLE32();
 

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.h
@@ -152,8 +152,8 @@ protected:
 
     float                    fPartyTime;
 
-    uint16_t                      fMaxNumVerts;
-    uint16_t                      fMaxNumIdx;
+    uint32_t                      fMaxNumVerts;
+    uint32_t                      fMaxNumIdx;
 
     uint32_t                      fWaitOnEnable;
     

--- a/Sources/Plasma/PubUtilLib/plDrawable/plSpaceTree.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plSpaceTree.cpp
@@ -534,7 +534,7 @@ void plSpaceTree::Read(hsStream* s, hsResMgr* mgr)
 
     fRoot = s->ReadLE16();
 
-    fNumLeaves = uint16_t(s->ReadLE32());
+    fNumLeaves = s->ReadLE32();
 
     uint32_t n = s->ReadLE32();
     fTree.SetCount(n);

--- a/Sources/Plasma/PubUtilLib/plDrawable/plSpaceTree.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plSpaceTree.h
@@ -101,8 +101,8 @@ private:
     hsTArray<plSpaceTreeNode>       fTree;
     const hsBitVector*              fCache;
 
+    int32_t                           fNumLeaves;
     int16_t                           fRoot;
-    int16_t                           fNumLeaves;
 
     uint16_t                          fHarvestFlags;
 
@@ -176,7 +176,7 @@ public:
     bool IsDirty() const { return 0 != (GetNode(GetRoot()).fFlags & plSpaceTreeNode::kDirty); }
     void MakeDirty() { fTree[GetRoot()].fFlags |= plSpaceTreeNode::kDirty; }
 
-    int16_t GetNumLeaves() const { return fNumLeaves; }
+    int32_t GetNumLeaves() const { return fNumLeaves; }
 
     void Read(hsStream* s, hsResMgr* mgr) override;
     void Write(hsStream* s, hsResMgr* mgr) override;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plSpanTypes.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plSpanTypes.cpp
@@ -68,7 +68,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 void    plSpan::Read( hsStream *stream )
 {
-    fSubType = (uint16_t)(stream->ReadLE32());
+    fSubType = stream->ReadLE32();
     fFogEnvironment = nullptr;
 
     fMaterialIdx = stream->ReadLE32();
@@ -78,7 +78,7 @@ void    plSpan::Read( hsStream *stream )
     fLocalBounds.Read( stream );
     fWorldBounds.Read( stream );
 
-    fNumMatrices = (uint8_t)(stream->ReadLE32());
+    fNumMatrices = stream->ReadLE32();
     fBaseMatrix = stream->ReadLE32();
 
     fLocalUVWChans = stream->ReadLE16();

--- a/Sources/Plasma/PubUtilLib/plDrawable/plSpanTypes.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plSpanTypes.h
@@ -122,12 +122,12 @@ class plSpan
         };
 
         uint16_t              fTypeMask; // For safe casting. Or it with the type you want to cast to, don't check equality
-        uint16_t              fSubType; // Or'ed from plDrawable::plDrawableSubType
+        uint32_t              fSubType; // Or'ed from plDrawable::plDrawableSubType
         uint32_t              fMaterialIdx;       // Index into drawable's material array
         hsMatrix44          fLocalToWorld;
         hsMatrix44          fWorldToLocal;
         uint32_t              fBaseMatrix;
-        uint8_t               fNumMatrices;
+        uint32_t              fNumMatrices;
         uint16_t              fLocalUVWChans;
         uint16_t              fMaxBoneIdx;
         uint16_t              fPenBoneIdx;

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
@@ -117,8 +117,8 @@ void    plDynamicTextMap::Create( uint32_t width, uint32_t height, bool hasAlpha
     SetConfig( hasAlpha ? kARGB32Config : kRGB32Config );
 
 
-    fVisWidth = (uint16_t)width;
-    fVisHeight = (uint16_t)height;
+    fVisWidth = width;
+    fVisHeight = height;
     fHasAlpha = hasAlpha;
     fPremultipliedAlpha = premultipliedAlpha;
 
@@ -262,8 +262,8 @@ uint32_t  plDynamicTextMap::Read( hsStream *s )
     // The funny thing is that we don't read anything like a mipmap; we just
     // keep the width and height and call Create() after we read those in
 
-    fVisWidth = (uint16_t)(s->ReadLE32());
-    fVisHeight = (uint16_t)(s->ReadLE32());
+    fVisWidth = s->ReadLE32();
+    fVisHeight = s->ReadLE32();
     fHasAlpha = s->ReadBool();
     totalRead += 2 * 4;
 

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.h
@@ -91,7 +91,7 @@ class plDynamicTextMap : public plMipmap
 {
     protected:
 
-        uint16_t      fVisWidth, fVisHeight;
+        uint32_t      fVisWidth, fVisHeight;
 
         uint32_t  Read(hsStream *s) override;
         uint32_t  Write(hsStream *s) override;
@@ -187,8 +187,8 @@ class plDynamicTextMap : public plMipmap
 
         bool    MsgReceive(plMessage *msg) override;
 
-        uint16_t  GetVisibleWidth() { return fVisWidth; }
-        uint16_t  GetVisibleHeight() { return fVisHeight; }
+        uint32_t  GetVisibleWidth() { return fVisWidth; }
+        uint32_t  GetVisibleHeight() { return fVisHeight; }
 
         // Since the dynamic text can actually create a texture bigger than you were expecting,
         // you want to be able to apply a layer texture transform that will compensate. This

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.h
@@ -187,8 +187,8 @@ class plDynamicTextMap : public plMipmap
 
         bool    MsgReceive(plMessage *msg) override;
 
-        uint32_t  GetVisibleWidth() { return fVisWidth; }
-        uint32_t  GetVisibleHeight() { return fVisHeight; }
+        uint32_t  GetVisibleWidth() const { return fVisWidth; }
+        uint32_t  GetVisibleHeight() const { return fVisHeight; }
 
         // Since the dynamic text can actually create a texture bigger than you were expecting,
         // you want to be able to apply a layer texture transform that will compensate. This

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -83,7 +83,7 @@ plProfile_CreateTimer("Input", "Update", Input);
 
 void plCtrlCmd::Write(hsStream* stream, hsResMgr* mgr)
 {
-    stream->WriteLE32( fControlCode );
+    stream->WriteLE32((uint32_t)fControlCode);
     stream->WriteBool( fControlActivated );
     fPt.Write(stream);
 

--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
@@ -285,7 +285,7 @@ plAnimTimeConvert& plAnimTimeConvert::IProcessStateChange(double worldTime, floa
 
     state->fStartWorldTime = fLastStateChange;
     state->fStartAnimTime = (animTime < 0 ? WorldToAnimTimeNoUpdate(fLastStateChange) : animTime);
-    state->fFlags = (uint8_t)fFlags;
+    state->fFlags = fFlags;
     state->fBegin = fBegin;
     state->fEnd = fEnd;
     state->fLoopBegin = fLoopBegin;
@@ -371,8 +371,8 @@ void plAnimTimeConvert::SetOwner(plSynchedObject* o)
     fOwner = o; 
 }
 
-bool plAnimTimeConvert::IIsStoppedAt(const double &wSecs, const uint32_t &flags, 
-                                       const plATCEaseCurve *curve) const       
+bool plAnimTimeConvert::IIsStoppedAt(double wSecs, uint32_t flags,
+                                     const plATCEaseCurve *curve) const
 {
     if (flags & kStopped)
         return !(flags & kForcedMove); // If someone called SetCurrentAnimTime(), we need to say we moved.
@@ -816,7 +816,7 @@ void plAnimTimeConvert::Read(hsStream* s, hsResMgr* mgr)
 {
     plCreatable::Read(s, mgr);
 
-    fFlags = (uint16_t)(s->ReadLE32());
+    fFlags = s->ReadLE32();
 
     fBegin = fInitialBegin = s->ReadLEFloat();
     fEnd = fInitialEnd = s->ReadLEFloat();
@@ -1264,7 +1264,7 @@ void plATCState::Read(hsStream *s, hsResMgr *mgr)
     fStartWorldTime = s->ReadLEDouble();
     fStartAnimTime = s->ReadLEFloat();
 
-    fFlags = (uint8_t)(s->ReadLE32());
+    fFlags = s->ReadLE32();
     fEnd = s->ReadLEFloat();
     fLoopBegin = s->ReadLEFloat();
     fLoopEnd = s->ReadLEFloat();

--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.h
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.h
@@ -62,7 +62,7 @@ class plAnimTimeConvert : public plCreatable
     friend class plAGAnimInstance;
 
 protected:
-    uint16_t                  fFlags;
+    uint32_t             fFlags;
     float                fBegin;
     float                fEnd;
     float                fLoopEnd;
@@ -104,14 +104,14 @@ protected:
     void        ISendCallback(hsSsize_t i);
 
     plAnimTimeConvert& IStop(double time, float animTime);
-    bool IIsStoppedAt(const double &wSecs, const uint32_t &flags, const plATCEaseCurve *curve) const;
+    bool IIsStoppedAt(double wSecs, uint32_t flags, const plATCEaseCurve *curve) const;
     plAnimTimeConvert& IProcessStateChange(double worldTime, float animTime = -1);
     void IFlushOldStates();
     void IClearAllStates();
     plATCState *IGetState(double wSecs) const;
     plATCState *IGetLatestState() const;
     
-    plAnimTimeConvert& SetFlag(uint8_t f, bool on) { if(on)fFlags |= f; else fFlags &= ~f; return *this; }
+    plAnimTimeConvert& SetFlag(uint32_t f, bool on) { if (on) fFlags |= f; else fFlags &= ~f; return *this; }
 
 public:
     plAnimTimeConvert()
@@ -164,7 +164,7 @@ public:
     void ResetWrap();
 
     plAnimTimeConvert& ClearFlags() { fFlags = kNone; return *this; }
-    bool GetFlag(uint8_t f) const { return (fFlags & f) ? true : false; }
+    bool GetFlag(uint32_t f) const { return (fFlags & f) ? true : false; }
 
     plAnimTimeConvert& InitStop(); // Called when initializing an anim that doesn't autostart
     plAnimTimeConvert& Stop(bool on);
@@ -318,7 +318,7 @@ public:
     double fStartWorldTime;
     float fStartAnimTime;
 
-    uint8_t fFlags;
+    uint32_t fFlags;
     float fBegin;
     float fEnd;
     float fLoopBegin;

--- a/Sources/Plasma/PubUtilLib/plIntersect/plVolumeIsect.cpp
+++ b/Sources/Plasma/PubUtilLib/plIntersect/plVolumeIsect.cpp
@@ -324,7 +324,7 @@ void plConeIsect::SetLength(float d)
 
 void plConeIsect::Read(hsStream* s, hsResMgr* mgr)
 {
-    fCapped = s->ReadLE32();
+    fCapped = s->ReadBOOL();
 
     fRadAngle = s->ReadLEFloat();
     fLength = s->ReadLEFloat();
@@ -346,7 +346,7 @@ void plConeIsect::Read(hsStream* s, hsResMgr* mgr)
 
 void plConeIsect::Write(hsStream* s, hsResMgr* mgr)
 {
-    s->WriteLE32(fCapped);
+    s->WriteBOOL(fCapped);
 
     s->WriteLEFloat(fRadAngle);
     s->WriteLEFloat(fLength);

--- a/Sources/Plasma/PubUtilLib/plMessage/plAvCoopMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAvCoopMsg.cpp
@@ -118,5 +118,5 @@ void plAvCoopMsg::Write(hsStream *stream, hsResMgr *mgr)
     stream->WriteLE32(fInitiatorID);
     stream->WriteLE16(fInitiatorSerial);
 
-    stream->WriteLE16(fCommand);
+    stream->WriteLE16((uint16_t)fCommand);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plAvatarMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAvatarMsg.cpp
@@ -392,7 +392,7 @@ plAvBrainGenericMsg::plAvBrainGenericMsg(plKey sender, plKey receiver,
 void plAvBrainGenericMsg::Write(hsStream *stream, hsResMgr *mgr)
 {
     plAvatarMsg::Write(stream, mgr);
-    stream->WriteLE32(fType);
+    stream->WriteLE32((uint32_t)fType);
     stream->WriteLE32(fWhichStage);
     stream->WriteBool(fSetTime);
     stream->WriteLEFloat(fNewTime);
@@ -439,7 +439,7 @@ void plAvBrainGenericMsg::WriteVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Write(s);
 
     // kAvBrainGenericType
-    s->WriteLE32(fType);
+    s->WriteLE32((uint32_t)fType);
     // kAvBrainGenericWhich 
     s->WriteLE32(fWhichStage);
     // kAvBrainGenericSetTime   

--- a/Sources/Plasma/PubUtilLib/plMessage/plSynchEnableMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plSynchEnableMsg.cpp
@@ -54,13 +54,13 @@ plSynchEnableMsg::plSynchEnableMsg(bool push, bool enable) : fPush(push), fEnabl
 void plSynchEnableMsg::Read(hsStream* stream, hsResMgr* mgr) 
 { 
     plMessage::IMsgRead( stream, mgr ); 
-    stream->WriteLE(fEnable);
-    stream->WriteLE(fPush);
+    stream->WriteBool(fEnable);
+    stream->WriteBool(fPush);
 }
 
 void plSynchEnableMsg::Write(hsStream* stream, hsResMgr* mgr)
 { 
     plMessage::IMsgWrite( stream, mgr ); 
-    stream->ReadLE(&fEnable);
-    stream->ReadLE(&fPush);
+    fEnable = stream->ReadBool();
+    fPush = stream->ReadBool();
 }

--- a/Sources/Plasma/PubUtilLib/plModifier/plAnimTimeConvertSDLModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plAnimTimeConvertSDLModifier.cpp
@@ -60,7 +60,7 @@ char plAnimTimeConvertSDLModifier::AnimTimeConvertVarNames::kStrLastStateChange[
 void plAnimTimeConvertSDLModifier::IPutATC(plStateDataRecord* atcStateDataRec, plAnimTimeConvert* animTimeConvert)
 {
     plATCState *lastState = animTimeConvert->fStates.front();
-    atcStateDataRec->FindVar(AnimTimeConvertVarNames::kStrFlags)->Set(animTimeConvert->fFlags);     
+    atcStateDataRec->FindVar(AnimTimeConvertVarNames::kStrFlags)->Set((int)animTimeConvert->fFlags);
     atcStateDataRec->FindVar(AnimTimeConvertVarNames::kStrLastStateAnimTime)->Set(lastState->fStartAnimTime);       
     atcStateDataRec->FindVar(AnimTimeConvertVarNames::kStrLoopEnd)->Set(animTimeConvert->fLoopEnd);     
     atcStateDataRec->FindVar(AnimTimeConvertVarNames::kStrLoopBegin)->Set(animTimeConvert->fLoopBegin);     

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plClientGuid.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plClientGuid.cpp
@@ -316,7 +316,7 @@ void plClientGuid::Read(hsStream * s, hsResMgr* mgr)
     if (IsFlagSet(kCCRLevel))
         s->ReadLE(&fCCRLevel);
     if (IsFlagSet(kProtectedLogin))
-        s->ReadLE(&fProtectedLogin);
+        fProtectedLogin = s->ReadBool();
     if (IsFlagSet(kBuildType))
         s->ReadLE(&fBuildType);
     if (IsFlagSet(kSrcAddr))
@@ -324,7 +324,7 @@ void plClientGuid::Read(hsStream * s, hsResMgr* mgr)
     if (IsFlagSet(kSrcPort))
         s->ReadLE(&fSrcPort);
     if (IsFlagSet(kReserved))
-        s->ReadLE(&fReserved);
+        fReserved = s->ReadBool();
     if (IsFlagSet(kClientKey))
         plMsgStdStringHelper::Peek( fClientKey, s );
 }
@@ -343,7 +343,7 @@ void plClientGuid::Write(hsStream * s, hsResMgr* mgr)
     if (IsFlagSet(kCCRLevel))
         s->WriteLE(fCCRLevel);
     if (IsFlagSet(kProtectedLogin))
-        s->WriteLE(fProtectedLogin);
+        s->WriteBool(fProtectedLogin);
     if (IsFlagSet(kBuildType))
         s->WriteLE(fBuildType);
     if (IsFlagSet(kSrcAddr))
@@ -351,7 +351,7 @@ void plClientGuid::Write(hsStream * s, hsResMgr* mgr)
     if (IsFlagSet(kSrcPort))
         s->WriteLE(fSrcPort);
     if (IsFlagSet(kReserved))
-        s->WriteLE(fReserved);
+        s->WriteBool(fReserved);
     if (IsFlagSet(kClientKey))
         plMsgStdStringHelper::Poke( fClientKey, s );
 }

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.cpp
@@ -459,11 +459,11 @@ int plNetMsgGameMessage::IPokeBuffer(hsStream* stream, uint32_t peekOptions)
     {
         if (fDeliveryTime.AtEpoch())
         {
-            stream->WriteByte(0);   // not sending
+            stream->WriteBool(false);   // not sending
         }
         else
         {
-            stream->WriteByte(1);   // sending
+            stream->WriteBool(true);   // sending
             fDeliveryTime.Write(stream);
         }
         bytes=stream->GetPosition();
@@ -476,7 +476,7 @@ int plNetMsgGameMessage::IPeekBuffer(hsStream* stream, uint32_t peekOptions)
     int bytes=plNetMsgStream::IPeekBuffer(stream, peekOptions);
     if (bytes)
     {
-        if (stream->ReadByte())
+        if (stream->ReadBool())
             fDeliveryTime.Read(stream);
         bytes=stream->GetPosition();
     }
@@ -499,7 +499,7 @@ void plNetMsgGameMessage::ReadVersion(hsStream* s, hsResMgr* mgr)
     
     if (contentFlags.IsBitSet(kNetGameMsgDeliveryTime))
     {
-        if (s->ReadByte())
+        if (s->ReadBool())
             fDeliveryTime.Read(s);
     }
     
@@ -530,11 +530,11 @@ void plNetMsgGameMessage::WriteVersion(hsStream* s, hsResMgr* mgr)
     // kNetGameMsgDeliveryTime
     if (fDeliveryTime.AtEpoch())
     {
-        s->WriteByte(0);    // not sending
+        s->WriteBool(false);    // not sending
     }
     else
     {
-        s->WriteByte(1);    // sending
+        s->WriteBool(true);    // sending
         fDeliveryTime.Write(s);
     }
     
@@ -1121,7 +1121,7 @@ int plNetMsgMemberUpdate::IPokeBuffer(hsStream* stream, uint32_t peekOptions)
         fMemberInfo.GetClientGuid()->SetClientKey("");
         fMemberInfo.GetClientGuid()->SetAccountUUID(plUUID());
         fMemberInfo.Poke(stream, peekOptions);
-        stream->WriteByte(fAddMember);
+        stream->WriteBool(fAddMember);
         
         bytes=stream->GetPosition();
     }
@@ -1134,7 +1134,7 @@ int plNetMsgMemberUpdate::IPeekBuffer(hsStream* stream, uint32_t peekOptions)
     if (bytes)
     {
         fMemberInfo.Peek(stream, peekOptions);
-        fAddMember = stream->ReadByte();
+        fAddMember = stream->ReadBool();
         
         bytes=stream->GetPosition();
     }

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.cpp
@@ -736,18 +736,18 @@ int plNetMsgSDLState::IPokeBuffer(hsStream* stream, uint32_t peekOptions)
 {
     ISetDescName();     // stash away the descName before poke/compress
     plNetMsgStreamedObject::IPokeBuffer(stream, peekOptions);
-    stream->WriteLE( fIsInitialState );
-    stream->WriteLE(fPersistOnServer);
-    stream->WriteLE(fIsAvatarState);
+    stream->WriteBool(fIsInitialState);
+    stream->WriteBool(fPersistOnServer);
+    stream->WriteBool(fIsAvatarState);
     return stream->GetPosition();
 }
 
 int plNetMsgSDLState::IPeekBuffer(hsStream* stream, uint32_t peekOptions)
 {
     plNetMsgStreamedObject::IPeekBuffer(stream, peekOptions);
-    stream->ReadLE(&fIsInitialState);
-    stream->ReadLE(&fPersistOnServer);
-    stream->ReadLE(&fIsAvatarState);
+    fIsInitialState = stream->ReadBool();
+    fPersistOnServer = stream->ReadBool();
+    fIsAvatarState = stream->ReadBool();
     ISetDescName();     // stash away the descName after peek/uncompress
     return stream->GetPosition();
 }
@@ -769,11 +769,11 @@ void plNetMsgSDLState::ReadVersion(hsStream* s, hsResMgr* mgr)
         StreamInfo()->SetStreamBuf(buf);
     }
     if (contentFlags.IsBitSet(kSDLIsInitialState))
-        s->ReadLE(&fIsInitialState);
+        fIsInitialState = s->ReadBool();
     if (contentFlags.IsBitSet(kSDLPersist))
-        s->ReadLE(&fPersistOnServer);
+        fPersistOnServer = s->ReadBool();
     if (contentFlags.IsBitSet(kSDLAvatarState))
-        s->ReadLE(&fIsAvatarState);
+        fIsAvatarState = s->ReadBool();
 }
 
 void plNetMsgSDLState::WriteVersion(hsStream* s, hsResMgr* mgr)
@@ -790,9 +790,9 @@ void plNetMsgSDLState::WriteVersion(hsStream* s, hsResMgr* mgr)
     // kSDLStateStream
     s->WriteLE32(StreamInfo()->GetStreamLen());
     s->Write(StreamInfo()->GetStreamLen(), StreamInfo()->GetStreamBuf());
-    s->WriteLE( fIsInitialState );
-    s->WriteLE(fPersistOnServer);
-    s->WriteLE(fIsAvatarState);
+    s->WriteBool(fIsInitialState);
+    s->WriteBool(fPersistOnServer);
+    s->WriteBool(fIsAvatarState);
 }
 
 ////////////////////////////////////////////////////////
@@ -984,7 +984,7 @@ int plNetMsgSharedState::IPokeBuffer(hsStream* stream, uint32_t peekOptions)
     int bytes=plNetMsgStreamedObject::IPokeBuffer(stream, peekOptions);
     if (bytes)
     {
-        stream->WriteLE(fLockRequest);
+        stream->WriteBool(fLockRequest);
         bytes=stream->GetPosition();
     }
     return bytes;
@@ -995,7 +995,7 @@ int plNetMsgSharedState::IPeekBuffer(hsStream* stream, uint32_t peekOptions)
     int bytes=plNetMsgStreamedObject::IPeekBuffer(stream, peekOptions);
     if (bytes)
     {
-        stream->ReadLE(&fLockRequest);
+        fLockRequest = stream->ReadBool();
         bytes=stream->GetPosition();
     }
     return bytes;
@@ -1009,7 +1009,7 @@ void plNetMsgSharedState::ReadVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Read(s);
     
     if (contentFlags.IsBitSet(kLockRequest))
-        s->ReadLE(&fLockRequest);
+        fLockRequest = s->ReadBool();
 }
 
 void plNetMsgSharedState::WriteVersion(hsStream* s, hsResMgr* mgr)
@@ -1020,7 +1020,7 @@ void plNetMsgSharedState::WriteVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.SetBit(kLockRequest);
     contentFlags.Write(s);
     
-    s->WriteLE(fLockRequest);
+    s->WriteBool(fLockRequest);
 }
 
 ST::string plNetMsgSharedState::AsString() const
@@ -1227,7 +1227,7 @@ ST::string plNetMsgVoice::AsString() const
 int plNetMsgListenListUpdate::IPokeBuffer(hsStream* stream, uint32_t peekOptions)
 {
     plNetMessage::IPokeBuffer(stream, peekOptions);
-    stream->WriteLE(fAdding);
+    stream->WriteBool(fAdding);
     fReceivers.Poke(stream, peekOptions);
     return stream->GetPosition();
 }
@@ -1237,7 +1237,7 @@ int plNetMsgListenListUpdate::IPeekBuffer(hsStream* stream, uint32_t peekOptions
     int bytes=plNetMessage::IPeekBuffer(stream, peekOptions);
     if (bytes)
     {
-        stream->ReadLE(&fAdding);
+        fAdding = stream->ReadBool();
         fReceivers.Peek(stream, peekOptions);
         bytes=stream->GetPosition();
     }
@@ -1251,7 +1251,7 @@ int plNetMsgListenListUpdate::IPeekBuffer(hsStream* stream, uint32_t peekOptions
 int plNetMsgPlayerPage::IPokeBuffer( hsStream* stream, uint32_t peekOptions )
 {
     plNetMessage::IPokeBuffer( stream, peekOptions );
-    stream->WriteLE( fUnload );
+    stream->WriteBool(fUnload);
     fUoid.Write(stream);
     
     return stream->GetPosition();
@@ -1262,7 +1262,7 @@ int plNetMsgPlayerPage::IPeekBuffer( hsStream* stream, uint32_t peekOptions )
     int bytes = plNetMessage::IPeekBuffer(stream, peekOptions );
     if ( bytes )
     {
-        stream->ReadLE(&fUnload);
+        fUnload = stream->ReadBool();
         fUoid.Read(stream);
         bytes = stream->GetPosition();
     }
@@ -1280,9 +1280,9 @@ int plNetMsgLoadClone::IPokeBuffer( hsStream* stream, uint32_t peekOptions )
     if ( bytes )
     {
         fObjectHelper.Poke(stream, peekOptions);
-        stream->WriteLE( fIsPlayer );
-        stream->WriteLE( fIsLoading );
-        stream->WriteLE( fIsInitialState );
+        stream->WriteBool(fIsPlayer);
+        stream->WriteBool(fIsLoading);
+        stream->WriteBool(fIsInitialState);
         bytes = stream->GetPosition();
     }
     return bytes;   
@@ -1295,9 +1295,9 @@ int plNetMsgLoadClone::IPeekBuffer( hsStream* stream, uint32_t peekOptions )
     {
         fObjectHelper.Peek(stream, peekOptions);
         
-        stream->ReadLE(&fIsPlayer);
-        stream->ReadLE(&fIsLoading);
-        stream->ReadLE(&fIsInitialState);
+        fIsPlayer = stream->ReadBool();
+        fIsLoading = stream->ReadBool();
+        fIsInitialState = stream->ReadBool();
         
         bytes = stream->GetPosition();
     }
@@ -1314,11 +1314,11 @@ void plNetMsgLoadClone::ReadVersion(hsStream* s, hsResMgr* mgr)
     if (contentFlags.IsBitSet(kObjectHelper))
         fObjectHelper.ReadVersion(s,mgr);
     if (contentFlags.IsBitSet(kIsPlayer))
-        s->ReadLE(&fIsPlayer);
+        fIsPlayer = s->ReadBool();
     if (contentFlags.IsBitSet(kIsLoading))
-        s->ReadLE(&fIsLoading);
+        fIsLoading = s->ReadBool();
     if (contentFlags.IsBitSet(kIsInitialState))
-        s->ReadLE(&fIsInitialState);
+        fIsInitialState = s->ReadBool();
 }
 
 void plNetMsgLoadClone::WriteVersion(hsStream* s, hsResMgr* mgr)
@@ -1333,9 +1333,9 @@ void plNetMsgLoadClone::WriteVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Write(s);
     
     fObjectHelper.WriteVersion(s,mgr);
-    s->WriteLE(fIsPlayer);
-    s->WriteLE(fIsLoading);
-    s->WriteLE(fIsInitialState);
+    s->WriteBool(fIsPlayer);
+    s->WriteBool(fIsLoading);
+    s->WriteBool(fIsInitialState);
 }
 
 ST::string plNetMsgLoadClone::AsString() const

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleEffect.cpp
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleEffect.cpp
@@ -807,7 +807,7 @@ void plParticleFlockEffect::Write(hsStream *s, hsResMgr *mgr)
     s->WriteLEFloat(fGoalChaseStr);
     s->WriteLEFloat(fMaxOrbitSpeed);
     s->WriteLEFloat(fMaxChaseSpeed);
-    s->WriteLEFloat(fMaxParticles);
+    s->WriteLEFloat((float)fMaxParticles);
 }
 
 bool plParticleFlockEffect::MsgReceive(plMessage *msg)

--- a/Sources/Plasma/PubUtilLib/plPhysX/plGenericPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plGenericPhysical.cpp
@@ -384,8 +384,8 @@ void plPXPhysical::Write(hsStream* stream, hsResMgr* mgr)
     stream->WriteLEFloat(fRecipe.mass);
     stream->WriteLEFloat(fRecipe.friction);
     stream->WriteLEFloat(fRecipe.restitution);
-    stream->WriteByte(fRecipe.bounds);
-    stream->WriteByte(fGroup);
+    stream->WriteByte((uint8_t)fRecipe.bounds);
+    stream->WriteByte((uint8_t)fGroup);
     stream->WriteLE32(fReportsOn);
     stream->WriteLE16(fLOSDBs);
     mgr->WriteKey(stream, fObjectKey);

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXCooking.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXCooking.cpp
@@ -320,5 +320,5 @@ void plPXCooking::WriteTriMesh(hsStream* s, uint32_t nfaces, const uint16_t* con
         verts[i].Write(s);
     s->WriteLE32(nfaces);
     for (size_t i = 0; i < nfaces * 3; ++i)
-        s->WriteLE32(tris[i]);
+        s->WriteLE32((uint32_t)tris[i]);
 }

--- a/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
@@ -775,8 +775,8 @@ void plSwimDetector::Write(hsStream *stream, hsResMgr *mgr)
     plSimpleRegionSensor::Write(stream, mgr);
 
     stream->WriteByte(0);
-    stream->WriteLEFloat(0);
-    stream->WriteLEFloat(0);
+    stream->WriteLEFloat(0.f);
+    stream->WriteLEFloat(0.f);
 }
 
 void plSwimDetector::Read(hsStream *stream, hsResMgr *mgr)

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDynamicEnvMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDynamicEnvMap.cpp
@@ -426,7 +426,7 @@ void plDynamicEnvMap::Read(hsStream* s, hsResMgr* mgr)
 
     sz += sizeof(fPos) + sizeof(fHither) + sizeof(fYon) + sizeof(fFogStart) + sizeof(fColor) + sizeof(fRefreshRate);
 
-    fIncCharacters = s->ReadByte();
+    fIncCharacters = s->ReadBool();
     SetIncludeCharacters(fIncCharacters);
     int nVis = s->ReadLE32();
     int i;
@@ -462,7 +462,7 @@ void plDynamicEnvMap::Write(hsStream* s, hsResMgr* mgr)
 
     sz += sizeof(fPos) + sizeof(fHither) + sizeof(fYon) + sizeof(fFogStart) + sizeof(fColor) + sizeof(fRefreshRate);
 
-    s->WriteByte(fIncCharacters);
+    s->WriteBool(fIncCharacters);
     s->WriteLE32(fVisRegions.GetCount());
     int i;
     for( i = 0; i < fVisRegions.GetCount(); i++ )
@@ -952,11 +952,12 @@ void plDynamicCamMap::Write(hsStream* s, hsResMgr* mgr)
     fColor.Write(s);
 
     s->WriteLEFloat(fRefreshRate);
-    s->WriteByte(fIncCharacters);
+    s->WriteBool(fIncCharacters);
     mgr->WriteKey(s, (fCamera ? fCamera->GetKey() : nullptr));
     mgr->WriteKey(s, (fRootNode ? fRootNode->GetKey() : nullptr));
 
-    s->WriteByte(fTargetNodes.GetCount());
+    hsAssert(fTargetNodes.GetCount() < std::numeric_limits<uint8_t>::max(), "Too many target nodes");
+    s->WriteByte((uint8_t)fTargetNodes.GetCount());
     int i;
     for (i = 0; i < fTargetNodes.GetCount(); i++)
         mgr->WriteKey(s, fTargetNodes[i]);
@@ -972,8 +973,9 @@ void plDynamicCamMap::Write(hsStream* s, hsResMgr* mgr)
     }
 
     mgr->WriteKey(s, fDisableTexture ? fDisableTexture->GetKey() : nullptr);
-    
-    s->WriteByte(fMatLayers.GetCount());
+
+    hsAssert(fMatLayers.GetCount() < std::numeric_limits<uint8_t>::max(), "Too many mat layers");
+    s->WriteByte((uint8_t)fMatLayers.GetCount());
     for (i = 0; i < fMatLayers.GetCount(); i++)
     {
         mgr->WriteKey(s, fMatLayers[i]->GetKey());

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateDataRecord.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateDataRecord.cpp
@@ -80,13 +80,13 @@ void plSDL::VariableLengthWrite(hsStream* s, int size, int val)
     if (size < (1<<8))
     {
         hsAssert(val < (1<<8), "SDL data loss");
-        s->WriteByte(val);
+        s->WriteByte((uint8_t)val);
     }
     else
     if (size < (1<<16))
     {
         hsAssert(val < (1<<16), "SDL data loss");
-        s->WriteLE16(val);
+        s->WriteLE16((uint16_t)val);
     }
     else
         s->WriteLE32(val);

--- a/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plPageTreeMgr_inc
 #define plPageTreeMgr_inc
 
+#include <cstdint>
 #include <vector>
 
 class plSceneNode;

--- a/Sources/Plasma/PubUtilLib/plSurface/plShader.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plShader.cpp
@@ -304,7 +304,7 @@ void plShader::Write(hsStream* s, hsResMgr* mgr)
     for (const plShaderConst& konst : fConsts)
         konst.Write(s);
 
-    s->WriteLE32(fDecl->GetID());
+    s->WriteLE32((uint32_t)fDecl->GetID());
 
     s->WriteByte(fInput);
     s->WriteByte(fOutput);


### PR DESCRIPTION
* Always make bool I/O explicit, since we can stream both `bool`s and `BOOL`s (😢)
* Convert overloaded type readers and writers to a template
* Fix several cases of mismatched I/O type vs. its underlying storage.