### PR TITLE
Enable more tidy checks.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@ Checks: >-
   -*,
   bugprone-bool-pointer-implicit-conversion,
   bugprone-inaccurate-erase,
+  bugprone-unused-raii,
   modernize-use-nullptr,
   modernize-use-override
 CheckOptions:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 Checks: >-
   -*,
   bugprone-bool-pointer-implicit-conversion,
+  bugprone-inaccurate-erase,
   modernize-use-nullptr,
   modernize-use-override
 CheckOptions:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,8 @@
-Checks: '-*,modernize-use-override,modernize-use-nullptr'
+Checks: >-
+  -*,
+  bugprone-bool-pointer-implicit-conversion,
+  modernize-use-nullptr,
+  modernize-use-override
 CheckOptions:
     - key: modernize-use-override.IgnoreDestructors
       value: '1'

--- a/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.cpp
@@ -96,6 +96,10 @@ static inline void InverseOfPureRotTran(const hsMatrix44& src, hsMatrix44& inv)
 // Point first
 ////////////////////////////////////////////////////////////////////////////////////
 
+plPointShadowMaster::plPointShadowMaster()
+{
+}
+
 plPointShadowMaster::~plPointShadowMaster()
 {
 }

--- a/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.h
+++ b/Sources/Plasma/PubUtilLib/plGLight/plPointShadowMaster.h
@@ -69,7 +69,7 @@ protected:
     void IBeginRender() override;
 
 public:
-    plPointShadowMaster() { }
+    plPointShadowMaster();
     virtual ~plPointShadowMaster();
 
     CLASSNAME_REGISTER( plPointShadowMaster );


### PR DESCRIPTION
Slowly increasing the level of checks, enabling:
- bugprone-bool-pointer-implicit-conversion
- bugprone-inaccurate-erase,
- bugprone-unused-raii

These checks required no code changes. I did find that bugprone-parent-virtual-call reveals many issues, some of which are intentional, some of which are bugs. I elected to not include that one for now.