### PR TITLE
Make hsStream typed readers and writers type-safe

### DIFF
--- a/Sources/Plasma/Apps/plPythonPack/main.cpp
+++ b/Sources/Plasma/Apps/plPythonPack/main.cpp
@@ -295,12 +295,10 @@ void PackDirectory(const plFileName& dir, const plFileName& rootPath, const plFi
     if (!s.Open(pakName, "wb"))
         return;
 
-    s.WriteLE32(fileNames.size());
-
-    int i;
-    for (i = 0; i < fileNames.size(); i++)
+    s.WriteLE32((uint32_t)fileNames.size());
+    for (const plFileName& fn : fileNames)
     {
-        s.WriteSafeString(fileNames[i].AsString());
+        s.WriteSafeString(fn.AsString());
         s.WriteLE32(0);
     }
 
@@ -309,7 +307,7 @@ void PackDirectory(const plFileName& dir, const plFileName& rootPath, const plFi
     std::vector<uint32_t> filePositions;
     filePositions.resize(fileNames.size());
 
-    for (i = 0; i < fileNames.size(); i++)
+    for (size_t i = 0; i < fileNames.size(); i++)
     {
         // strip '.py' from the file name
         plFileName properFileName = fileNames[i].StripFileExt();
@@ -320,7 +318,7 @@ void PackDirectory(const plFileName& dir, const plFileName& rootPath, const plFi
     }
 
     s.SetPosition(sizeof(uint32_t));
-    for (i = 0; i < fileNames.size(); i++)
+    for (size_t i = 0; i < fileNames.size(); i++)
     {
         s.WriteSafeString(fileNames[i].AsString());
         s.WriteLE32(filePositions[i]);

--- a/Sources/Plasma/Apps/plPythonPack/main.cpp
+++ b/Sources/Plasma/Apps/plPythonPack/main.cpp
@@ -190,7 +190,7 @@ void WritePythonFile(const plFileName &fileName, const plFileName &path, hsStrea
 
         ST::printf(out, "\n");
 
-        s->WriteLE32(size);
+        s->WriteLE32((int32_t)size);
         s->Write(size, pycode);
         delete[] pycode;
     }

--- a/Sources/Plasma/CoreLib/hsBitVector.cpp
+++ b/Sources/Plasma/CoreLib/hsBitVector.cpp
@@ -91,7 +91,7 @@ void hsBitVector::Read(hsStream* s)
 {
     Reset();
 
-    s->ReadLE(&fNumBitVectors);
+    s->ReadLE32(&fNumBitVectors);
     if( fNumBitVectors )
     {
         delete [] fBitVectors;

--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -119,7 +119,7 @@ uint32_t hsStream::WriteSafeStringLong(const ST::string &string)
         uint32_t i;
         for (i = 0; i < len; i++)
         {
-            WriteByte(~buffp[i]);
+            WriteByte(static_cast<uint8_t>(~buffp[i]));
         }
         return i;
     }
@@ -137,9 +137,9 @@ uint32_t hsStream::WriteSafeWStringLong(const ST::string &string)
         const char16_t *buffp = wbuff.data();
         for (uint32_t i=0; i<len; i++)
         {
-            WriteLE16(~buffp[i]);
+            WriteLE16(static_cast<uint16_t>(~buffp[i]));
         }
-        WriteLE16(static_cast<char16_t>(0));
+        WriteLE16(static_cast<uint16_t>(0));
     }
     return 0;
 }
@@ -173,7 +173,7 @@ ST::string hsStream::ReadSafeWStringLong()
         retVal.allocate(numChars);
         for (int i=0; i<numChars; i++)
             retVal[i] = ReadLE16();
-        ReadLE16(); // we wrote the null out, read it back in
+        (void)ReadLE16(); // we wrote the null out, read it back in
 
         if (retVal[0] & 0x80)
         {
@@ -198,7 +198,7 @@ uint32_t hsStream::WriteSafeString(const ST::string &string)
         const char *buffp = string.c_str();
         for (i = 0; i < len; i++)
         {
-            WriteByte(~buffp[i]);
+            WriteByte(static_cast<uint8_t>(~buffp[i]));
         }
         return i;
     }
@@ -219,7 +219,7 @@ uint32_t hsStream::WriteSafeWString(const ST::string &string)
         const char16_t *buffp = wbuff.data();
         for (uint32_t i=0; i<len; i++)
         {
-            WriteLE16(~buffp[i]);
+            WriteLE16(static_cast<uint16_t>(~buffp[i]));
         }
         WriteLE16(static_cast<uint16_t>(0));
     }
@@ -235,7 +235,7 @@ ST::string hsStream::ReadSafeString()
     // Backward compat hack - remove in a week or so (from 6/30/03)
     bool oldFormat = !(numChars & 0xf000);
     if (oldFormat)
-        ReadLE16();
+        (void)ReadLE16();
 #endif
 
     numChars &= ~0xf000;
@@ -269,7 +269,7 @@ ST::string hsStream::ReadSafeWString()
         retVal.allocate(numChars);
         for (int i=0; i<numChars; i++)
             retVal[i] = ReadLE16();
-        ReadLE16(); // we wrote the null out, read it back in
+        (void)ReadLE16(); // we wrote the null out, read it back in
 
         if (retVal[0] & 0x80)
         {

--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -126,19 +126,30 @@ public:
     void            WriteLEDouble(double value);
     void            WriteLEDouble(size_t count, const double values[]);
 
-    template <typename T>
-    inline void ReadLE(T* value)
-    {
-        Read(sizeof(T), value);
-        *value = hsToLE(*value);
-    }
+    // Type-safe placement readers
+    template <typename T> inline void ReadByte(T*) = delete;
+    void ReadByte(uint8_t* v) { *v = ReadByte(); }
+    void ReadByte(int8_t* v) { *v = (int8_t)ReadByte(); }
+    template <typename T> inline void ReadLE16(T*) = delete;
+    void ReadLE16(uint16_t* v) { *v = ReadLE16(); }
+    void ReadLE16(int16_t* v) { *v = (int16_t)ReadLE16(); }
+    template <typename T> inline void ReadLE32(T*) = delete;
+    void ReadLE32(uint32_t* v) { *v = ReadLE32(); }
+    void ReadLE32(int32_t* v) { *v = (int32_t)ReadLE32(); }
+    template <typename T> inline void ReadLEFloat(T*) = delete;
+    void ReadLEFloat(float* v) { *v = ReadLEFloat(); }
+    template <typename T> inline void ReadLEDouble(T*) = delete;
+    void ReadLEDouble(double* v) { *v = ReadLEDouble(); }
 
-    template <typename T>
-    inline void WriteLE(T value)
-    {
-        value = hsToLE(value);
-        Write(sizeof(T), &value);
-    }
+    // Type-safety checks for writers
+    template <typename T> void WriteByte(T) = delete;
+    void WriteByte(int8_t v) { WriteByte((uint8_t)v); }
+    template <typename T> void WriteLE16(T) = delete;
+    void WriteLE16(int16_t v) { WriteLE16((uint16_t)v); }
+    template <typename T> void WriteLE32(T) = delete;
+    void WriteLE32(int32_t v) { WriteLE32((uint32_t)v); }
+    template <typename T> void WriteLEFloat(T) = delete;
+    template <typename T> void WriteLEDouble(T) = delete;
 };
 
 class hsStreamable {

--- a/Sources/Plasma/CoreLib/pcSmallRect.cpp
+++ b/Sources/Plasma/CoreLib/pcSmallRect.cpp
@@ -50,16 +50,16 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 void    pcSmallRect::Read( hsStream *s )
 {
-    s->ReadLE( &fX );
-    s->ReadLE( &fY );
-    s->ReadLE( &fWidth );
-    s->ReadLE( &fHeight );
+    s->ReadLE16(&fX);
+    s->ReadLE16(&fY);
+    s->ReadLE16(&fWidth);
+    s->ReadLE16(&fHeight);
 }
 
 void    pcSmallRect::Write( hsStream *s )
 {
-    s->WriteLE( fX );
-    s->WriteLE( fY );
-    s->WriteLE( fWidth );
-    s->WriteLE( fHeight );
+    s->WriteLE16(fX);
+    s->WriteLE16(fY);
+    s->WriteLE16(fWidth);
+    s->WriteLE16(fHeight);
 }

--- a/Sources/Plasma/CoreLib/plGeneric.cpp
+++ b/Sources/Plasma/CoreLib/plGeneric.cpp
@@ -110,11 +110,11 @@ int plGeneric::Write(hsStream* stream)
         break;
 
     case kInt:
-        stream->WriteLE(fIntVal);
+        stream->WriteLE32(fIntVal);
         break;
 
     case kFloat:
-        stream->WriteLE(fFloatVal);
+        stream->WriteLEDouble(fFloatVal);
         break;
 
     case kString:
@@ -138,11 +138,11 @@ int plGeneric::Read(hsStream* stream)
         break;
 
     case kInt:
-        stream->ReadLE(&fIntVal);
+        stream->ReadLE32(&fIntVal);
         break;
 
     case kFloat:
-        stream->ReadLE(&fFloatVal);
+        stream->ReadLEDouble(&fFloatVal);
         break;
 
     case kString:

--- a/Sources/Plasma/CoreLib/plLoadMask.cpp
+++ b/Sources/Plasma/CoreLib/plLoadMask.cpp
@@ -95,7 +95,7 @@ void plLoadMask::Write(hsStream* s) const
 {
     // write packed into 1 byte
     uint8_t qc = (fQuality[0]<<4) | (fQuality[1] & 0xf);
-    s->WriteLE(qc);
+    s->WriteByte(qc);
 }
 
 uint32_t plLoadMask::ValidateReps(int num, const int quals[], const int caps[])

--- a/Sources/Plasma/FeatureLib/pfConditional/plFacingConditionalObject.cpp
+++ b/Sources/Plasma/FeatureLib/pfConditional/plFacingConditionalObject.cpp
@@ -68,14 +68,14 @@ bool plFacingConditionalObject::MsgReceive(plMessage* msg)
 void plFacingConditionalObject::Write(hsStream* stream, hsResMgr* mgr)
 {
     plConditionalObject::Write(stream, mgr);
-    stream->WriteLE(fTolerance);
+    stream->WriteLEFloat(fTolerance);
     stream->WriteBool(fDirectional);
 }
 
 void plFacingConditionalObject::Read(hsStream* stream, hsResMgr* mgr)
 {
     plConditionalObject::Read(stream, mgr);
-    stream->ReadLE(&fTolerance);
+    stream->ReadLEFloat(&fTolerance);
     fDirectional = stream->ReadBool();
 }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlHandlers.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlHandlers.cpp
@@ -139,8 +139,9 @@ void    pfGUIConsoleCmdProc::IWrite( hsStream *s )
 {
     if (fCommand != nullptr)
     {
-        s->WriteLE32( strlen( fCommand ) );
-        s->Write( strlen( fCommand ), fCommand );
+        size_t cmdLen = strlen(fCommand);
+        s->WriteLE32((uint32_t)cmdLen);
+        s->Write(cmdLen, fCommand);
     }
     else
         s->WriteLE32( 0 );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
@@ -119,8 +119,8 @@ void    pfGUIColorScheme::Read( hsStream *s )
     fTransparent = s->ReadBOOL();
 
     fFontFace = s->ReadSafeString();
-    s->ReadLE( &fFontSize );
-    s->ReadLE( &fFontFlags );
+    s->ReadByte(&fFontSize);
+    s->ReadByte(&fFontFlags);
 }
 
 void    pfGUIColorScheme::Write( hsStream *s )
@@ -132,8 +132,8 @@ void    pfGUIColorScheme::Write( hsStream *s )
     s->WriteBOOL( fTransparent );
 
     s->WriteSafeString( fFontFace );
-    s->WriteLE( fFontSize );
-    s->WriteLE( fFontFlags );
+    s->WriteByte(fFontSize);
+    s->WriteByte(fFontFlags);
 }
 
 //// Destructor //////////////////////////////////////////////////
@@ -777,7 +777,7 @@ void    pfGUIControlMod::Refresh()
 void    pfGUIControlMod::Read( hsStream *s, hsResMgr *mgr )
 {
     plSingleModifier::Read(s, mgr);
-    s->ReadLE( &fTagID );
+    s->ReadLE32(&fTagID);
     fVisible = s->ReadBool();
 
     // Read the handler in
@@ -825,7 +825,7 @@ void    pfGUIControlMod::Write( hsStream *s, hsResMgr *mgr )
         ClearFlag( kHasProxy );
 
     plSingleModifier::Write( s, mgr );
-    s->WriteLE( fTagID );
+    s->WriteLE32(fTagID);
     s->WriteBool( fVisible );
 
     // Write the handler out (if it's not a writeable, damn you)

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
@@ -299,13 +299,13 @@ void    pfGUIDialogMod::Read( hsStream *s, hsResMgr *mgr )
         hsgResMgr::ResMgr()->AddViaNotify( GetKey(), refMsg, plRefFlags::kPassiveRef );     
     }
 
-    s->ReadLE( &fTagID );
+    s->ReadLE32(&fTagID);
 
     fProcReceiver = mgr->ReadKey( s );
     if (fProcReceiver != nullptr)
         SetHandler( new pfGUIDialogNotifyProc( fProcReceiver ) );
 
-    s->ReadLE( &fVersion );
+    s->ReadLE32(&fVersion);
 
     fColorScheme->Read( s );
 
@@ -323,11 +323,11 @@ void    pfGUIDialogMod::Write( hsStream *s, hsResMgr *mgr )
     for (pfGUIControlMod* ctrl : fControls)
         mgr->WriteKey(s, ctrl->GetKey());
 
-    s->WriteLE( fTagID );
+    s->WriteLE32(fTagID);
 
     mgr->WriteKey( s, fProcReceiver );
 
-    s->WriteLE( fVersion );
+    s->WriteLE32(fVersion);
 
     fColorScheme->Write( s );
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
@@ -877,16 +877,15 @@ void    pfGUISkin::Read( hsStream *s, hsResMgr *mgr )
 {
     hsKeyedObject::Read( s, mgr );
 
-    s->ReadLE( &fItemMargin );
-    s->ReadLE( &fBorderMargin );
+    s->ReadLE16(&fItemMargin);
+    s->ReadLE16(&fBorderMargin);
 
-    uint32_t i, count;
-    s->ReadLE( &count );
+    uint32_t count = s->ReadLE32();
 
-    for( i = 0; i < count; i++ )
+    for (uint32_t i = 0; i < count; i++)
         fElements[ i ].Read( s );
 
-    for( ; i < kNumElements; i++ )
+    for (uint32_t i = count; i < kNumElements; i++)
         fElements[ i ].Empty();
 
     mgr->ReadKeyNotifyMe( s, new plGenRefMsg( GetKey(), plRefMsg::kOnCreate, -1, kRefMipmap ), plRefFlags::kActiveRef );
@@ -896,13 +895,12 @@ void    pfGUISkin::Write( hsStream *s, hsResMgr *mgr )
 {
     hsKeyedObject::Write( s, mgr );
 
-    s->WriteLE( fItemMargin );
-    s->WriteLE( fBorderMargin );
+    s->WriteLE16(fItemMargin);
+    s->WriteLE16(fBorderMargin);
 
-    uint32_t i = kNumElements;
-    s->WriteLE( i );
+    s->WriteLE32((uint32_t)kNumElements);
 
-    for( i = 0; i < kNumElements; i++ )
+    for (uint32_t i = 0; i < kNumElements; i++)
         fElements[ i ].Write( s );
 
     mgr->WriteKey( s, fTexture );
@@ -926,16 +924,16 @@ bool    pfGUISkin::MsgReceive( plMessage *msg )
 
 void    pfGUISkin::pfSRect::Read( hsStream *s )
 {
-    s->ReadLE( &fX );
-    s->ReadLE( &fY );
-    s->ReadLE( &fWidth );
-    s->ReadLE( &fHeight );
+    s->ReadLE16(&fX);
+    s->ReadLE16(&fY);
+    s->ReadLE16(&fWidth);
+    s->ReadLE16(&fHeight);
 }
 
 void    pfGUISkin::pfSRect::Write( hsStream *s )
 {
-    s->WriteLE( fX );
-    s->WriteLE( fY );
-    s->WriteLE( fWidth );
-    s->WriteLE( fHeight );
+    s->WriteLE16(fX);
+    s->WriteLE16(fY);
+    s->WriteLE16(fWidth);
+    s->WriteLE16(fHeight);
 }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.cpp
@@ -179,10 +179,10 @@ void    pfGUITextBoxMod::Write( hsStream *s, hsResMgr *mgr )
         s->WriteLE32( 0 );
     else
     {
-        char *text = hsWStringToString(fText);
-        s->WriteLE32( strlen( text ) );
-        s->Write( strlen( text ), text );
-        delete [] text;
+        std::unique_ptr<char[]> text(hsWStringToString(fText));
+        size_t len = strlen(text.get());
+        s->WriteLE32((uint32_t)len);
+        s->Write(len, text.get());
     }
 
     // Make sure we only write out to use localization path if the box is checked

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIUpDownPairMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIUpDownPairMod.cpp
@@ -206,9 +206,9 @@ void    pfGUIUpDownPairMod::Read( hsStream *s, hsResMgr *mgr )
     mgr->ReadKeyNotifyMe( s, new plGenRefMsg( GetKey(), plRefMsg::kOnCreate, -1, kRefUpControl ), plRefFlags::kActiveRef );
     mgr->ReadKeyNotifyMe( s, new plGenRefMsg( GetKey(), plRefMsg::kOnCreate, -1, kRefDownControl ), plRefFlags::kActiveRef );
 
-    s->ReadLE( &fMin );
-    s->ReadLE( &fMax );
-    s->ReadLE( &fStep );
+    s->ReadLEFloat(&fMin);
+    s->ReadLEFloat(&fMax);
+    s->ReadLEFloat(&fStep);
 
     fValue = fMin;
 }
@@ -220,9 +220,9 @@ void    pfGUIUpDownPairMod::Write( hsStream *s, hsResMgr *mgr )
     mgr->WriteKey( s, fUpControl->GetKey() );
     mgr->WriteKey( s, fDownControl->GetKey() );
 
-    s->WriteLE( fMin );
-    s->WriteLE( fMax );
-    s->WriteLE( fStep );
+    s->WriteLEFloat(fMin);
+    s->WriteLEFloat(fMax);
+    s->WriteLEFloat(fStep);
 }
 
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIValueCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIValueCtrl.cpp
@@ -90,9 +90,9 @@ void    pfGUIValueCtrl::Read( hsStream *s, hsResMgr *mgr )
 {
     pfGUIControlMod::Read(s, mgr);
 
-    s->ReadLE( &fMin );
-    s->ReadLE( &fMax );
-    s->ReadLE( &fStep );
+    s->ReadLEFloat(&fMin);
+    s->ReadLEFloat(&fMax);
+    s->ReadLEFloat(&fStep);
 
     fValue = fMin;
 }
@@ -101,8 +101,8 @@ void    pfGUIValueCtrl::Write( hsStream *s, hsResMgr *mgr )
 {
     pfGUIControlMod::Write( s, mgr );
 
-    s->WriteLE( fMin );
-    s->WriteLE( fMax );
-    s->WriteLE( fStep );
+    s->WriteLEFloat(fMin);
+    s->WriteLEFloat(fMax);
+    s->WriteLEFloat(fStep);
 }
 

--- a/Sources/Plasma/FeatureLib/pfMessage/pfGameGUIMsg.cpp
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfGameGUIMsg.cpp
@@ -49,7 +49,7 @@ constexpr size_t GAME_GUI_MSG_STRING_SIZE = 128;
 void pfGameGUIMsg::Read(hsStream* s, hsResMgr* mgr)
 {
     plMessage::IMsgRead(s, mgr);
-    s->ReadLE(&fCommand);
+    s->ReadByte(&fCommand);
     char buffer[GAME_GUI_MSG_STRING_SIZE];
     s->Read(sizeof(buffer), buffer);
     buffer[GAME_GUI_MSG_STRING_SIZE - 1] = 0;
@@ -60,7 +60,7 @@ void pfGameGUIMsg::Read(hsStream* s, hsResMgr* mgr)
 void pfGameGUIMsg::Write(hsStream* s, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(s, mgr);
-    s->WriteLE(fCommand);
+    s->WriteByte(fCommand);
     char buffer[GAME_GUI_MSG_STRING_SIZE] = {};
     strncpy(buffer, fString.c_str(), GAME_GUI_MSG_STRING_SIZE);
     s->Write(sizeof(buffer), buffer);

--- a/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
@@ -187,7 +187,7 @@ class pfKIMsg : public plMessage
         void Read(hsStream* s, hsResMgr* mgr) override
         { 
             plMessage::IMsgRead( s, mgr ); 
-            s->ReadLE( &fCommand );
+            s->ReadByte(&fCommand);
             fUser = s->ReadSafeString();
             fPlayerID = s->ReadLE32();
             fString = s->ReadSafeWString();
@@ -199,7 +199,7 @@ class pfKIMsg : public plMessage
         void Write(hsStream* s, hsResMgr* mgr) override
         { 
             plMessage::IMsgWrite( s, mgr ); 
-            s->WriteLE( fCommand );
+            s->WriteByte(fCommand);
             s->WriteSafeString( fUser );
             s->WriteLE32( fPlayerID );
             s->WriteSafeWString( fString );

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -2342,11 +2342,8 @@ public:
 
                     if ( ageInfoStream && nPlayersStream )
                     {
-                        uint16_t nAgeInfoEntries;
-                        ageInfoStream->GetStream()->ReadLE( &nAgeInfoEntries );
-
-                        uint16_t nPlayerCountEntries;
-                        nPlayersStream->GetStream()->ReadLE( &nPlayerCountEntries );
+                        uint16_t nAgeInfoEntries = ageInfoStream->GetStream()->ReadLE16();
+                        uint16_t nPlayerCountEntries = nPlayersStream->GetStream()->ReadLE16();
 
                         hsAssert( nAgeInfoEntries==nPlayerCountEntries, "huh?" );
 
@@ -2356,9 +2353,8 @@ public:
                         for ( int i=0; i<nAgeInfoEntries; i++ )
                         {
                             plAgeInfoStruct ageInfo;
-                            uint32_t nPlayers;
                             ageInfo.Read(ageInfoStream->GetStream(), nullptr);
-                            nPlayersStream->GetStream()->ReadLE( &nPlayers );
+                            uint32_t nPlayers = nPlayersStream->GetStream()->ReadLE32();
                             PyObject* t = PyTuple_New(2);
                             PyTuple_SetItem(t, 0, pyAgeInfoStruct::New(&ageInfo));
                             PyTuple_SetItem(t, 1, PyLong_FromUnsignedLong(nPlayers));

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonParameter.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonParameter.h
@@ -365,7 +365,7 @@ public:
                 break;
 
             case kFloat:
-                stream->ReadLE(&datarecord.fFloatNumber);
+                stream->ReadLEFloat(&datarecord.fFloatNumber);
                 break;
 
             case kbool:
@@ -421,7 +421,7 @@ public:
                 break;
 
             case kFloat:
-                stream->WriteLE(datarecord.fFloatNumber);
+                stream->WriteLEFloat(datarecord.fFloatNumber);
                 break;
 
             case kbool:
@@ -434,7 +434,7 @@ public:
                     count = fString.size()+1;
                 else
                     count = 0;
-                stream->WriteLE(count);
+                stream->WriteLE32(count);
                 stream->Write(count, fString.c_str());
                 break;
 

--- a/Sources/Plasma/FeatureLib/pfSurface/plLayerMovie.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plLayerMovie.cpp
@@ -198,7 +198,7 @@ void plLayerMovie::Write(hsStream* s, hsResMgr* mgr)
 {
     plLayerAnimation::Write(s, mgr);
 
-    s->WriteLE32(fMovieName.GetSize());
+    s->WriteLE32((uint32_t)fMovieName.GetSize());
     s->Write(fMovieName.GetSize(), fMovieName.AsString().c_str());
 }
 

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
@@ -192,8 +192,8 @@ hsKeyedObject* plKeyImp::VerifyLoaded()
 void plKeyImp::Read(hsStream* s)
 {
     fUoid.Read(s);
-    s->ReadLE(&fStartPos);
-    s->ReadLE(&fDataLen);
+    s->ReadLE32(&fStartPos);
+    s->ReadLE32(&fDataLen);
 
     plProfile_NewMem(KeyMem, CalcKeySize(this));
 
@@ -207,15 +207,15 @@ void plKeyImp::SkipRead(hsStream* s)
 {
     plUoid tempUoid;
     tempUoid.Read(s);
-    s->ReadLE32();
-    s->ReadLE32();
+    (void)s->ReadLE32();
+    (void)s->ReadLE32();
 }
 
 void plKeyImp::Write(hsStream* s)
 {
     fUoid.Write(s);
-    s->WriteLE(fStartPos);
-    s->WriteLE(fDataLen);
+    s->WriteLE32(fStartPos);
+    s->WriteLE32(fDataLen);
 }
 
 //// WriteObject /////////////////////////////////////////////////////////////

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plUoid.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plUoid.cpp
@@ -59,14 +59,14 @@ plLocation::plLocation(const plLocation& toCopyFrom)
 
 void plLocation::Read(hsStream* s)
 {
-    s->ReadLE(&fSequenceNumber);
-    s->ReadLE(&fFlags);
+    s->ReadLE32(&fSequenceNumber);
+    s->ReadLE16(&fFlags);
 }
 
 void plLocation::Write(hsStream* s) const
 {
-    s->WriteLE(fSequenceNumber);
-    s->WriteLE(fFlags);
+    s->WriteLE32(fSequenceNumber);
+    s->WriteLE16(fFlags);
 }
 
 plLocation& plLocation::operator=(const plLocation& rhs)
@@ -166,16 +166,16 @@ void plUoid::Read(hsStream* s)
     else
         fLoadMask.SetAlways();
 
-    s->ReadLE(&fClassType);
-    s->ReadLE(&fObjectID);
+    s->ReadLE16(&fClassType);
+    s->ReadLE32(&fObjectID);
     fObjectName = s->ReadSafeString();
 
     // conditional cloneIDs read
     if (contents & kHasCloneIDs)
     {       
-        s->ReadLE(&fCloneID);
+        s->ReadLE16(&fCloneID);
         (void)s->ReadLE16(); // To avoid breaking format
-        s->ReadLE(&fClonePlayerID);
+        s->ReadLE32(&fClonePlayerID);
     }
     else
     {
@@ -198,17 +198,16 @@ void plUoid::Write(hsStream* s) const
     if (contents & kHasLoadMask)
         fLoadMask.Write(s);
 
-    s->WriteLE( fClassType );
-    s->WriteLE( fObjectID );
+    s->WriteLE16(fClassType);
+    s->WriteLE32(fObjectID);
     s->WriteSafeString( fObjectName );
 
     // conditional cloneIDs write
     if (contents & kHasCloneIDs)
     {
-        s->WriteLE(fCloneID);
-        uint16_t dummy = 0;
-        s->WriteLE(dummy); // to avoid breaking format
-        s->WriteLE(fClonePlayerID);
+        s->WriteLE16(fCloneID);
+        s->WriteLE16(uint16_t(0)); // to avoid breaking format
+        s->WriteLE32(fClonePlayerID);
     }
 }
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plAudioSysMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plAudioSysMsg.cpp
@@ -48,13 +48,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 void plAudioSysMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgRead(stream, mgr);
-    stream->ReadLE(&fAudFlag);
+    stream->ReadLE32(&fAudFlag);
     pObj = mgr->ReadKey(stream);
 }
 
 void plAudioSysMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(stream, mgr);
-    stream->WriteLE(fAudFlag);
+    stream->WriteLE32(fAudFlag);
     mgr->WriteKey(stream, pObj);
 }

--- a/Sources/Plasma/NucleusLib/pnMessage/plClientMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plClientMsg.cpp
@@ -71,13 +71,13 @@ void plClientMsg::Write(hsStream* stream, hsResMgr* mgr)
 void plClientRefMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Read(stream, mgr);
-    stream->ReadLE(&fType);
-    stream->ReadLE(&fWhich);
+    stream->ReadByte(&fType);
+    stream->ReadByte(&fWhich);
 }
 
 void plClientRefMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Write(stream, mgr);
-    stream->WriteLE(fType);
-    stream->WriteLE(fWhich);
+    stream->WriteByte(fType);
+    stream->WriteByte(fWhich);
 }

--- a/Sources/Plasma/NucleusLib/pnMessage/plNotifyMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plNotifyMsg.cpp
@@ -811,7 +811,7 @@ void plNotifyMsg::Read(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgRead(stream, mgr);
     // read in the static data
     fType = stream->ReadLE32();
-    stream->ReadLE(&fState);
+    stream->ReadLEFloat(&fState);
     fID = stream->ReadLE32();
     // read in the variable part of the message
     uint32_t numberEDs = stream->ReadLE32();
@@ -833,7 +833,7 @@ void plNotifyMsg::Write(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgWrite(stream, mgr);
     // write static data
     stream->WriteLE32(fType);
-    stream->WriteLE(fState);
+    stream->WriteLEFloat(fState);
     stream->WriteLE32(fID);
     // then write the variable data
     stream->WriteLE32((uint32_t)fEvents.size());
@@ -861,7 +861,7 @@ void plNotifyMsg::ReadVersion(hsStream* s, hsResMgr* mgr)
         fType = s->ReadLE32();
 
     if (contentFlags.IsBitSet(kNotifyMsgState))
-        s->ReadLE(&fState);
+        s->ReadLEFloat(&fState);
 
     if (contentFlags.IsBitSet(kNotifyMsgID))
         fID = s->ReadLE32();
@@ -898,7 +898,7 @@ void plNotifyMsg::WriteVersion(hsStream* s, hsResMgr* mgr)
     s->WriteLE32(fType);
 
     // kNotifyMsgState
-    s->WriteLE(fState);
+    s->WriteLEFloat(fState);
 
     // kNotifyMsgID
     s->WriteLE32(fID);
@@ -1233,7 +1233,7 @@ void proVariableEventData::IReadNumber(hsStream * stream) {
         fNumber.i = stream->ReadLE32();
         break;
     default: 
-        stream->ReadLE32(); //ignore
+        (void)stream->ReadLE32(); //ignore
         break;
     }
 }

--- a/Sources/Plasma/NucleusLib/pnMessage/plRefMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plRefMsg.cpp
@@ -84,7 +84,7 @@ plRefMsg& plRefMsg::SetOldRef(hsKeyedObject* oldRef)
 void plRefMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgRead(stream, mgr);
-    stream->ReadLE(&fContext);
+    stream->ReadByte(&fContext);
 
     plKey key;
     key = mgr->ReadKey(stream);
@@ -96,7 +96,7 @@ void plRefMsg::Read(hsStream* stream, hsResMgr* mgr)
 void plRefMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(stream, mgr);
-    stream->WriteLE(fContext);
+    stream->WriteByte(fContext);
 
     mgr->WriteKey(stream, (fRef ? fRef->GetKey() : nullptr));
     mgr->WriteKey(stream, (fOldRef ? fOldRef->GetKey() : nullptr));
@@ -106,43 +106,43 @@ void plRefMsg::Write(hsStream* stream, hsResMgr* mgr)
 void plGenRefMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Read(stream, mgr);
-    stream->ReadLE(&fType);
+    stream->ReadByte(&fType);
     fWhich = stream->ReadLE32();
 }
 
 void plGenRefMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Write(stream, mgr);
-    stream->WriteLE(fType);
+    stream->WriteByte(fType);
     stream->WriteLE32(fWhich);
 }
 
 void plIntRefMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Read(stream, mgr);
-    stream->ReadLE(&fType);
-    stream->ReadLE(&fWhich);
-    stream->ReadLE(&fIdx);
+    stream->ReadByte(&fType);
+    stream->ReadLE16(&fWhich);
+    stream->ReadByte(&fIdx);
 }
 
 void plIntRefMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Write(stream, mgr);
-    stream->WriteLE(fType);
-    stream->WriteLE(fWhich);
-    stream->WriteLE(fIdx);
+    stream->WriteByte(fType);
+    stream->WriteLE16(fWhich);
+    stream->WriteByte(fIdx);
 }
 
 void plObjRefMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Read(stream, mgr);
-    stream->ReadLE(&fType);
-    stream->ReadLE(&fWhich);
+    stream->ReadByte(&fType);
+    stream->ReadByte(&fWhich);
 }
 
 void plObjRefMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Write(stream, mgr);
-    stream->WriteLE(fType);
-    stream->WriteLE(fWhich);
+    stream->WriteByte(fType);
+    stream->WriteByte(fWhich);
 }

--- a/Sources/Plasma/NucleusLib/pnMessage/plServerReplyMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plServerReplyMsg.cpp
@@ -46,13 +46,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 void plServerReplyMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgRead(stream, mgr);
-    stream->ReadLE(&fType);
+    stream->ReadLE32(&fType);
 }
 
 void plServerReplyMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(stream, mgr);
-    stream->WriteLE(fType);
+    stream->WriteLE32(fType);
 }
 
 enum ServerReplyFlags
@@ -68,7 +68,7 @@ void plServerReplyMsg::ReadVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Read(s);
 
     if (contentFlags.IsBitSet(kServerReplyType))
-        s->ReadLE(&fType);
+        s->ReadLE32(&fType);
 }
 
 void plServerReplyMsg::WriteVersion(hsStream* s, hsResMgr* mgr)
@@ -80,5 +80,5 @@ void plServerReplyMsg::WriteVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Write(s);
 
     // kServerReplyType
-    s->WriteLE(fType);
+    s->WriteLE32(fType);
 }

--- a/Sources/Plasma/NucleusLib/pnMessage/plSoundMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSoundMsg.cpp
@@ -62,16 +62,16 @@ void plSoundMsg::Read(hsStream* stream, hsResMgr* mgr)
     plMessageWithCallbacks::Read(stream, mgr);
 
     fCmd.Read(stream);
-    stream->ReadLE(&fBegin);
-    stream->ReadLE(&fEnd);
+    stream->ReadLEDouble(&fBegin);
+    stream->ReadLEDouble(&fEnd);
     fLoop = stream->ReadBool();
     fPlaying = stream->ReadBool();
-    stream->ReadLE(&fSpeed);
-    stream->ReadLE(&fTime);
-    stream->ReadLE(&fIndex);
-    stream->ReadLE(&fRepeats);
-    stream->ReadLE(&fNameStr);
-    stream->ReadLE(&fVolume);
+    stream->ReadLEFloat(&fSpeed);
+    stream->ReadLEDouble(&fTime);
+    stream->ReadLE32(&fIndex);
+    stream->ReadLE32(&fRepeats);
+    stream->ReadLE32(&fNameStr);
+    stream->ReadLEFloat(&fVolume);
     fFadeType = (plSoundMsg::FadeType)stream->ReadByte();
 }
 
@@ -80,15 +80,15 @@ void plSoundMsg::Write(hsStream* stream, hsResMgr* mgr)
     plMessageWithCallbacks::Write(stream, mgr);
 
     fCmd.Write(stream);
-    stream->WriteLE(fBegin);
-    stream->WriteLE(fEnd);
+    stream->WriteLEDouble(fBegin);
+    stream->WriteLEDouble(fEnd);
     stream->WriteBool(fLoop);
     stream->WriteBool(fPlaying);
-    stream->WriteLE(fSpeed);
-    stream->WriteLE(fTime);
-    stream->WriteLE(fIndex);
-    stream->WriteLE(fRepeats);
-    stream->WriteLE(fNameStr);
-    stream->WriteLE(fVolume);
+    stream->WriteLEFloat(fSpeed);
+    stream->WriteLEDouble(fTime);
+    stream->WriteLE32(fIndex);
+    stream->WriteLE32(fRepeats);
+    stream->WriteLE32(fNameStr);
+    stream->WriteLEFloat(fVolume);
     stream->WriteByte( (uint8_t)fFadeType );
 }

--- a/Sources/Plasma/NucleusLib/pnMessage/plTimeMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plTimeMsg.cpp
@@ -69,15 +69,15 @@ plTimeMsg::~plTimeMsg()
 void plTimeMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgRead(stream, mgr);
-    stream->ReadLE(&fSeconds);
-    stream->ReadLE(&fDelSecs);
+    stream->ReadLEDouble(&fSeconds);
+    stream->ReadLEFloat(&fDelSecs);
 }
 
 void plTimeMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(stream, mgr);
-    stream->WriteLE(fSeconds);
-    stream->WriteLE(fDelSecs);
+    stream->WriteLEDouble(fSeconds);
+    stream->WriteLEFloat(fDelSecs);
 }
 
 plEvalMsg::plEvalMsg()

--- a/Sources/Plasma/NucleusLib/pnMessage/plWarpMsg.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plWarpMsg.cpp
@@ -48,12 +48,12 @@ void plWarpMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgRead(stream, mgr);
     fTransform.Read(stream);
-    stream->ReadLE(&fWarpFlags);
+    stream->ReadLE32(&fWarpFlags);
 }
 
 void plWarpMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(stream, mgr);
     fTransform.Write(stream);
-    stream->WriteLE(fWarpFlags);
+    stream->WriteLE32(fWarpFlags);
 }

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plGenericVar.cpp
@@ -148,7 +148,7 @@ char plGenericType::IToChar() const
 
 void    plGenericType::Read(hsStream* s)
 {
-    s->ReadLE(&fType);
+    s->ReadByte(&fType);
 
     switch ( fType )
     {
@@ -160,19 +160,19 @@ void    plGenericType::Read(hsStream* s)
         fB = s->ReadBool();
         break;
     case kChar:
-        s->ReadLE( &fC );
+        fC = (char)s->ReadByte();
         break;
-    case kInt   :
-        s->ReadLE( &fI );
+    case kInt:
+        s->ReadLE32(&fI);
         break;
     case kUInt:
-        s->ReadLE( &fU );
+        s->ReadLE32(&fU);
         break;
     case kFloat:
-        s->ReadLE( &fF );
+        s->ReadLEFloat(&fF);
         break;
     case kDouble:
-        s->ReadLE( &fD );
+        s->ReadLEDouble(&fD);
         break;
     case kNone :
         break;
@@ -181,7 +181,7 @@ void    plGenericType::Read(hsStream* s)
 
 void    plGenericType::Write(hsStream* s)
 {
-    s->WriteLE(fType);
+    s->WriteByte(fType);
 
     switch ( fType )
     {
@@ -193,19 +193,19 @@ void    plGenericType::Write(hsStream* s)
         s->WriteBool(fB);
         break;
     case kChar:
-        s->WriteLE( fC );
+        s->WriteByte((uint8_t)fC);
         break;
-    case kInt   :
-        s->WriteLE( fI );
+    case kInt:
+        s->WriteLE32(fI);
         break;
     case kUInt:
-        s->WriteLE( fU );
+        s->WriteLE32(fU);
         break;
     case kFloat:
-        s->WriteLE( fF );
+        s->WriteLEFloat(fF);
         break;
     case kDouble:
-        s->WriteLE( fD );
+        s->WriteLEDouble(fD);
         break;
     case kNone :
         break;

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetGroup.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetGroup.cpp
@@ -53,11 +53,11 @@ plNetGroupId plNetGroup::kNetGroupRemotePhysicals( plLocation::MakeReserved( 4 )
 void plNetGroupId::Write(hsStream* s) const
 {
     fId.Write(s);
-    s->WriteLE(fFlags);
+    s->WriteByte(fFlags);
 }
 
 void plNetGroupId::Read(hsStream* s)
 {
     fId.Read(s);
-    s->ReadLE(&fFlags);
+    s->ReadByte(&fFlags);
 }

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedObject.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plSynchedObject.cpp
@@ -230,14 +230,12 @@ void    plSynchedObject::Read(hsStream* stream, hsResMgr* mgr)
     hsKeyedObject::Read(stream, mgr);
     fNetGroup = GetKey()->GetUoid().GetLocation();
 
-    stream->ReadLE(&fSynchFlags);
+    stream->ReadLE32(&fSynchFlags);
     if (fSynchFlags & kExcludePersistentState)
     {
-        int16_t num;
-        stream->ReadLE(&num);
+        uint16_t num = stream->ReadLE16();
         fSDLExcludeList.clear();
-        int i;
-        for(i=0;i<num;i++)
+        for (uint16_t i = 0; i < num; i++)
         {
             ST::string s;
             plMsgStdStringHelper::Peek(s, stream);
@@ -247,11 +245,9 @@ void    plSynchedObject::Read(hsStream* stream, hsResMgr* mgr)
 
     if (fSynchFlags & kHasVolatileState)
     {
-        int16_t num;
-        stream->ReadLE(&num);
+        uint16_t num = stream->ReadLE16();
         fSDLVolatileList.clear();
-        int i;
-        for(i=0;i<num;i++)
+        for (uint16_t i = 0; i < num; i++)
         {
             ST::string s;
             plMsgStdStringHelper::Peek(s, stream);
@@ -263,11 +259,11 @@ void    plSynchedObject::Read(hsStream* stream, hsResMgr* mgr)
 void    plSynchedObject::Write(hsStream* stream, hsResMgr* mgr)
 {
     hsKeyedObject::Write(stream, mgr);
-    stream->WriteLE(fSynchFlags);
+    stream->WriteLE32(fSynchFlags);
 
     if (fSynchFlags & kExcludePersistentState)
     {
-        stream->WriteLE((uint16_t)fSDLExcludeList.size());
+        stream->WriteLE16((uint16_t)fSDLExcludeList.size());
 
         SDLStateList::iterator it=fSDLExcludeList.begin();
         for(; it != fSDLExcludeList.end(); it++)
@@ -278,7 +274,7 @@ void    plSynchedObject::Write(hsStream* stream, hsResMgr* mgr)
 
     if (fSynchFlags & kHasVolatileState)
     {
-        stream->WriteLE((uint16_t)fSDLVolatileList.size());
+        stream->WriteLE16((uint16_t)fSDLVolatileList.size());
 
         SDLStateList::iterator it=fSDLVolatileList.begin();
         for(; it != fSDLVolatileList.end(); it++)

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
@@ -103,7 +103,7 @@ void plCreatableStream::Write( hsStream* stream, hsResMgr* mgr )
     fStream.Rewind();
 
     uint32_t len = fStream.GetEOF();
-    stream->WriteLE( len );
+    stream->WriteLE32(len);
 
     uint8_t* buf = new uint8_t[len];
     fStream.Read(len, (void*)buf);

--- a/Sources/Plasma/NucleusLib/pnTimer/plTimedValue.h
+++ b/Sources/Plasma/NucleusLib/pnTimer/plTimedValue.h
@@ -76,7 +76,6 @@ public:
 };
 
 // Read/Writable version of plTimedValue, for intrinsic types (e.g. int, float, bool).
-// Must be a type that hsStream has an overloaded ReadLE/WriteLE defined.
 template <class T> class plTimedSimple : public plTimedValue<T>
 {
 public:
@@ -85,8 +84,8 @@ public:
 
     plTimedSimple<T>& Set(const T& v, float secs=0) { plTimedValue<T>::Set(v, secs); return *this; }
 
-    void Read(hsStream* s);
-    void Write(hsStream* s) const;
+    inline void Read(hsStream* s);
+    inline void Write(hsStream* s) const;
 };
 
 // Read/Writable version of plTimedValue, for compound types (e.g. hsVector3, hsColorRGBA).
@@ -137,19 +136,18 @@ T plTimedValue<T>::Value() const
 }
 
 
-template <class T> 
-void plTimedSimple<T>::Read(hsStream* s)
+template <>
+void plTimedSimple<float>::Read(hsStream* s)
 {
-    T val;
-    s->ReadLE(&val);
+    float val = s->ReadLEFloat();
     Set(val, 0.f);
 }
 
-template <class T> 
-void plTimedSimple<T>::Write(hsStream* s) const
+template <>
+void plTimedSimple<float>::Write(hsStream* s) const
 {
-    T val = this->Value();
-    s->WriteLE(val);
+    float val = this->Value();
+    s->WriteLEFloat(val);
 }
 
 template <class T> 

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnim.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnim.cpp
@@ -437,14 +437,14 @@ void plATCAnim::Write(hsStream *stream, hsResMgr *mgr)
     stream->WriteLEFloat(fEaseOutMax);
     stream->WriteLEFloat(fEaseOutLength);
 
-    stream->WriteLE32(fMarkers.size());
+    stream->WriteLE32((uint32_t)fMarkers.size());
     for (MarkerMap::iterator it = fMarkers.begin(); it != fMarkers.end(); it++)
     {
         stream->WriteSafeString(it->first);
         stream->WriteLEFloat(it->second);
     }
 
-    stream->WriteLE32(fLoops.size());
+    stream->WriteLE32((uint32_t)fLoops.size());
     for (LoopMap::iterator loopIt = fLoops.begin(); loopIt != fLoops.end(); loopIt++)
     {
         stream->WriteSafeString(loopIt->first);
@@ -453,7 +453,7 @@ void plATCAnim::Write(hsStream *stream, hsResMgr *mgr)
         stream->WriteLEFloat(loop.second);
     }
 
-    stream->WriteLE32(fStopPoints.size());
+    stream->WriteLE32((uint32_t)fStopPoints.size());
     stream->WriteLEFloat(fStopPoints.size(), fStopPoints.data());
 }
 

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
@@ -94,11 +94,10 @@ void plAGMasterMod::Write(hsStream *stream, hsResMgr *mgr)
 
     int length = 0;
     stream->WriteLE32(length); // backwards compatability. Nuke on next format change.
-    stream->WriteLE32(fPrivateAnims.size());
-    int i;
-    for (i = 0; i < fPrivateAnims.size(); i++)
+    stream->WriteLE32((uint32_t)fPrivateAnims.size());
+    for (plAGAnim* anim : fPrivateAnims)
     {
-        mgr->WriteKey(stream, fPrivateAnims[i]->GetKey());
+        mgr->WriteKey(stream, anim->GetKey());
     }
     stream->WriteBool(fIsGrouped);
     stream->WriteBool(fIsGroupMaster);

--- a/Sources/Plasma/PubUtilLib/plAudio/plEAXEffects.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plEAXEffects.cpp
@@ -609,18 +609,18 @@ void    plEAXSourceSoftSettings::Reset()
 
 void    plEAXSourceSoftSettings::Read( hsStream *s )
 {
-    s->ReadLE( &fOcclusion );
-    s->ReadLE( &fOcclusionLFRatio );
-    s->ReadLE( &fOcclusionRoomRatio );
-    s->ReadLE( &fOcclusionDirectRatio );
+    s->ReadLE16(&fOcclusion);
+    s->ReadLEFloat(&fOcclusionLFRatio);
+    s->ReadLEFloat(&fOcclusionRoomRatio);
+    s->ReadLEFloat(&fOcclusionDirectRatio);
 }
 
 void    plEAXSourceSoftSettings::Write( hsStream *s )
 {
-    s->WriteLE( fOcclusion );
-    s->WriteLE( fOcclusionLFRatio );
-    s->WriteLE( fOcclusionRoomRatio );
-    s->WriteLE( fOcclusionDirectRatio );
+    s->WriteLE16(fOcclusion);
+    s->WriteLEFloat(fOcclusionLFRatio);
+    s->WriteLEFloat(fOcclusionRoomRatio);
+    s->WriteLEFloat(fOcclusionDirectRatio);
 }
 
 void    plEAXSourceSoftSettings::SetOcclusion( int16_t occ, float lfRatio, float roomRatio, float directRatio )

--- a/Sources/Plasma/PubUtilLib/plAudio/plEAXListenerMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plEAXListenerMod.cpp
@@ -209,19 +209,19 @@ void plEAXListenerMod::Write( hsStream* s, hsResMgr* mgr )
     mgr->WriteKey( s, fSoftRegion );
 
     // Write the listener params
-    s->WriteLE32( fListenerProps->ulEnvironment );
+    s->WriteLE32((uint32_t)fListenerProps->ulEnvironment);
     s->WriteLEFloat( fListenerProps->flEnvironmentSize );
     s->WriteLEFloat( fListenerProps->flEnvironmentDiffusion );
-    s->WriteLE32( fListenerProps->lRoom );
-    s->WriteLE32( fListenerProps->lRoomHF );
-    s->WriteLE32( fListenerProps->lRoomLF );
+    s->WriteLE32((int32_t)fListenerProps->lRoom);
+    s->WriteLE32((int32_t)fListenerProps->lRoomHF);
+    s->WriteLE32((int32_t)fListenerProps->lRoomLF);
     s->WriteLEFloat( fListenerProps->flDecayTime );
     s->WriteLEFloat( fListenerProps->flDecayHFRatio );
     s->WriteLEFloat( fListenerProps->flDecayLFRatio );
-    s->WriteLE32( fListenerProps->lReflections );
+    s->WriteLE32((int32_t)fListenerProps->lReflections);
     s->WriteLEFloat( fListenerProps->flReflectionsDelay );
     //s->WriteLEFloat( fListenerProps->vReflectionsPan;     // early reflections panning vector
-    s->WriteLE32( fListenerProps->lReverb );                  // late reverberation level relative to room effect
+    s->WriteLE32((int32_t)fListenerProps->lReverb);         // late reverberation level relative to room effect
     s->WriteLEFloat( fListenerProps->flReverbDelay );
     //s->WriteLEFloat( fListenerProps->vReverbPan;          // late reverberation panning vector
     s->WriteLEFloat( fListenerProps->flEchoTime );
@@ -232,7 +232,7 @@ void plEAXListenerMod::Write( hsStream* s, hsResMgr* mgr )
     s->WriteLEFloat( fListenerProps->flHFReference );
     s->WriteLEFloat( fListenerProps->flLFReference );
     s->WriteLEFloat( fListenerProps->flRoomRolloffFactor );
-    s->WriteLE32( fListenerProps->ulFlags );
+    s->WriteLE32((uint32_t)fListenerProps->ulFlags);
 }
 
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
@@ -1214,8 +1214,8 @@ void plSound::IRead( hsStream *s, hsResMgr *mgr )
     fTime = s->ReadLEDouble();
     fMaxFalloff = s->ReadLE32();
     fMinFalloff = s->ReadLE32();
-    s->ReadLE( &fCurrVolume );
-    s->ReadLE( &fDesiredVol );
+    s->ReadLEFloat(&fCurrVolume);
+    s->ReadLEFloat(&fDesiredVol);
 
     /// mcn debugging - Thanks to some of my older sound code, it's possible that a few volumes
     /// will come in too large. This will only happen with scenes that were exported with that intermediate
@@ -1231,8 +1231,8 @@ void plSound::IRead( hsStream *s, hsResMgr *mgr )
     fOuterVol = s->ReadLE32();
     fInnerCone = s->ReadLE32();
     fOuterCone = s->ReadLE32();
-    s->ReadLE( &fFadedVolume );
-    s->ReadLE( &fProperties );
+    s->ReadLEFloat(&fFadedVolume);
+    s->ReadLE32(&fProperties);
 
     fType = s->ReadByte();
     fPriority = s->ReadByte();
@@ -1264,13 +1264,13 @@ void plSound::IWrite( hsStream *s, hsResMgr *mgr )
     s->WriteLEDouble(fTime);
     s->WriteLE32(fMaxFalloff);
     s->WriteLE32(fMinFalloff);
-    s->WriteLE( fCurrVolume );
-    s->WriteLE( fDesiredVol );
+    s->WriteLEFloat(fCurrVolume);
+    s->WriteLEFloat(fDesiredVol);
     s->WriteLE32(fOuterVol);
     s->WriteLE32(fInnerCone);
     s->WriteLE32(fOuterCone);
-    s->WriteLE( fFadedVolume );
-    s->WriteLE( fProperties );
+    s->WriteLEFloat(fFadedVolume);
+    s->WriteLE32(fProperties);
     s->WriteByte( fType );
     s->WriteByte( fPriority );
     
@@ -1296,22 +1296,22 @@ void plSound::IWrite( hsStream *s, hsResMgr *mgr )
 
 void plSound::plFadeParams::Read( hsStream *s )
 {
-    s->ReadLE( &fLengthInSecs );
-    s->ReadLE( &fVolStart );
-    s->ReadLE( &fVolEnd );
-    s->ReadLE( &fType );
-    s->ReadLE( &fCurrTime );
+    s->ReadLEFloat(&fLengthInSecs);
+    s->ReadLEFloat(&fVolStart);
+    s->ReadLEFloat(&fVolEnd);
+    s->ReadByte(&fType);
+    s->ReadLEFloat(&fCurrTime);
     fStopWhenDone = s->ReadBOOL();
     fFadeSoftVol = s->ReadBOOL();
 }
 
 void plSound::plFadeParams::Write( hsStream *s )
 {
-    s->WriteLE( fLengthInSecs );
-    s->WriteLE( fVolStart );
-    s->WriteLE( fVolEnd );
-    s->WriteLE( fType );
-    s->WriteLE( fCurrTime );
+    s->WriteLEFloat(fLengthInSecs);
+    s->WriteLEFloat(fVolStart);
+    s->WriteLEFloat(fVolEnd);
+    s->WriteByte(fType);
+    s->WriteLEFloat(fCurrTime);
     s->WriteBOOL( fStopWhenDone );
     s->WriteBOOL( fFadeSoftVol );
 }

--- a/Sources/Plasma/PubUtilLib/plAudio/plVoiceCodec.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plVoiceCodec.cpp
@@ -195,7 +195,7 @@ bool plSpeex::Encode(const short* data, int numFrames, int& packedLength, void* 
         frameLength = speex_bits_write(fBits.get(), frameData.get(), fFrameSize);
 
         // write data - length and bytes
-        stream.WriteLE(frameLength);
+        stream.WriteByte(frameLength);
         packedLength += sizeof(frameLength);   // add length of encoded frame
         stream.Write(frameLength, frameData.get());
         packedLength += frameLength;           // update length
@@ -228,7 +228,7 @@ bool plSpeex::Decode(const void* data, int size, int numFrames, int& numOutputBy
 
     // Decode data
     for (int i = 0; i < numFrames; i++) {
-        stream.ReadLE(&frameLen);                                       // read the length of the current frame to be decoded
+        stream.ReadByte(&frameLen);                                     // read the length of the current frame to be decoded
         stream.Read(frameLen, frameData.get());                         // read the data
 
         memset(speexOutput.get(), 0, fFrameSize * sizeof(float));

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plSoundBuffer.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plSoundBuffer.cpp
@@ -196,16 +196,16 @@ void    plSoundBuffer::Read( hsStream *s, hsResMgr *mgr )
 {
     hsKeyedObject::Read( s, mgr );
 
-    s->ReadLE( &fFlags );
-    s->ReadLE( &fDataLength );
+    s->ReadLE32(&fFlags);
+    s->ReadLE32(&fDataLength);
     fFileName = s->ReadSafeString();
 
-    s->ReadLE( &fHeader.fFormatTag );
-    s->ReadLE( &fHeader.fNumChannels );
-    s->ReadLE( &fHeader.fNumSamplesPerSec );
-    s->ReadLE( &fHeader.fAvgBytesPerSec );
-    s->ReadLE( &fHeader.fBlockAlign );
-    s->ReadLE( &fHeader.fBitsPerSample );
+    s->ReadLE16(&fHeader.fFormatTag);
+    s->ReadLE16(&fHeader.fNumChannels);
+    s->ReadLE32(&fHeader.fNumSamplesPerSec);
+    s->ReadLE32(&fHeader.fAvgBytesPerSec);
+    s->ReadLE16(&fHeader.fBlockAlign);
+    s->ReadLE16(&fHeader.fBitsPerSample);
 
     fValid = false;
     if( !( fFlags & kIsExternal ) )
@@ -235,8 +235,8 @@ void    plSoundBuffer::Write( hsStream *s, hsResMgr *mgr )
     if (fData == nullptr)
         fFlags |= kIsExternal;
 
-    s->WriteLE( fFlags );
-    s->WriteLE( fDataLength );
+    s->WriteLE32(fFlags);
+    s->WriteLE32(fDataLength);
     
     // Truncate the path to just a file name on write
     if (fFileName.IsValid())
@@ -244,12 +244,12 @@ void    plSoundBuffer::Write( hsStream *s, hsResMgr *mgr )
     else
         s->WriteSafeString("");
 
-    s->WriteLE( fHeader.fFormatTag );
-    s->WriteLE( fHeader.fNumChannels );
-    s->WriteLE( fHeader.fNumSamplesPerSec );
-    s->WriteLE( fHeader.fAvgBytesPerSec );
-    s->WriteLE( fHeader.fBlockAlign );
-    s->WriteLE( fHeader.fBitsPerSample );
+    s->WriteLE16(fHeader.fFormatTag);
+    s->WriteLE16(fHeader.fNumChannels);
+    s->WriteLE32(fHeader.fNumSamplesPerSec);
+    s->WriteLE32(fHeader.fAvgBytesPerSec);
+    s->WriteLE16(fHeader.fBlockAlign);
+    s->WriteLE16(fHeader.fBitsPerSample);
 
     if( !( fFlags & kIsExternal ) )
         s->Write( fDataLength, fData );

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -239,9 +239,9 @@ void plArmatureModBase::Write(hsStream *stream, hsResMgr *mgr)
         mgr->WriteKey(stream, meshKey);
         
         // Should be a list per mesh key
-        stream->WriteLE32(fUnusedBones[i]->size());
-        for(int j = 0; j < fUnusedBones[i]->size(); j++)
-            mgr->WriteKey(stream, (*fUnusedBones[i])[j]);
+        stream->WriteLE32((uint32_t)fUnusedBones[i]->size());
+        for (const plKey& boneKey : *fUnusedBones[i])
+            mgr->WriteKey(stream, boneKey);
     }
     
     int nBrains = fBrains.size();
@@ -2562,9 +2562,9 @@ void plArmatureLODMod::Write(hsStream *stream, hsResMgr *mgr)
         mgr->WriteKey(stream, meshKey);
         
         // Should be a list per mesh key
-        stream->WriteLE32(fUnusedBones[i]->size());
-        for(int j = 0; j < fUnusedBones[i]->size(); j++)
-            mgr->WriteKey(stream, (*fUnusedBones[i])[j]);
+        stream->WriteLE32((uint32_t)fUnusedBones[i]->size());
+        for (const plKey& boneKey : *fUnusedBones[i])
+            mgr->WriteKey(stream, boneKey);
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrain.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrain.cpp
@@ -141,14 +141,14 @@ void plArmatureBrain::Read(hsStream *stream, hsResMgr *mgr)
     plCreatable::Read(stream, mgr);
 
     // plAvBrain
-    stream->ReadLE32();
+    (void)stream->ReadLE32();
     if (stream->ReadBool()) 
-        mgr->ReadKey(stream);
+        (void)mgr->ReadKey(stream);
 
     // plAvBrainUser
-    stream->ReadLE32();
-    stream->ReadLEFloat();
-    stream->ReadLEDouble();
+    (void)stream->ReadLE32();
+    (void)stream->ReadLEFloat();
+    (void)stream->ReadLEDouble();
 }
 
 // MSGRECEIVE

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
@@ -1450,10 +1450,10 @@ bool plClothingOutfit::WriteToFile(const plFileName &filename)
 
     RelVaultNode::RefList nodes;
     rvn->GetChildNodes(plVault::kNodeType_SDL, 1, &nodes);
-    S.WriteLE32(nodes.size());
+    S.WriteLE32((uint32_t)nodes.size());
     for (const hsRef<RelVaultNode> &node : nodes) {
         VaultSDLNode sdl(node);
-        S.WriteLE32(sdl.GetSDLDataLength());
+        S.WriteLE32((uint32_t)sdl.GetSDLDataLength());
         if (sdl.GetSDLDataLength())
             S.Write(sdl.GetSDLDataLength(), sdl.GetSDLData());
     }

--- a/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.cpp
@@ -191,7 +191,7 @@ int plZlibStream::IValidateGzHeader(uint32_t byteCount, const void* buffer)
     
     // Discard time, xflags and OS code:
     for (i = 0; i < 6; i++)
-        s.ReadByte();
+        (void)s.ReadByte();
     CheckForEnd();
     
     if ((flags & EXTRA_FIELD) != 0)
@@ -227,7 +227,7 @@ int plZlibStream::IValidateGzHeader(uint32_t byteCount, const void* buffer)
     // skip the header crc
     if ((flags & HEAD_CRC) != 0)
     {
-        s.ReadLE16();
+        (void)s.ReadLE16();
         CheckForEnd();
     }
     

--- a/Sources/Plasma/PubUtilLib/plContainer/plKeysAndValues.cpp
+++ b/Sources/Plasma/PubUtilLib/plContainer/plKeysAndValues.cpp
@@ -203,20 +203,17 @@ bool plKeysAndValues::GetValueIterators(const ST::string & key, Values::const_it
 
 void plKeysAndValues::Read(hsStream * s)
 {
-    uint16_t nkeys;
-    s->ReadLE(&nkeys);
+    uint16_t nkeys = s->ReadLE16();
     for (int ki=0; ki<nkeys; ki++)
     {
-        uint16_t strlen;
-        s->ReadLE(&strlen);
+        uint16_t strlen = s->ReadLE16();
         ST::char_buffer key;
         key.allocate(strlen);
         s->Read(strlen, key.data());
-        uint16_t nvalues;
-        s->ReadLE(&nvalues);
+        uint16_t nvalues = s->ReadLE16();
         for (int vi=0; vi<nvalues; vi++)
         {
-            s->ReadLE(&strlen);
+            strlen = s->ReadLE16();
             ST::char_buffer value;
             value.allocate(strlen);
             s->Read(strlen, value.data());
@@ -229,24 +226,24 @@ void plKeysAndValues::Read(hsStream * s)
 void plKeysAndValues::Write(hsStream * s)
 {
     // write nkeys
-    s->WriteLE((uint16_t)fKeys.size());
+    s->WriteLE16((uint16_t)fKeys.size());
     // iterate through keys
     Keys::const_iterator ki,ke;
     GetKeyIterators(ki,ke);
     for (;ki!=ke;++ki)
     {
         // write key string
-        s->WriteLE((uint16_t)ki->first.size());
+        s->WriteLE16((uint16_t)ki->first.size());
         s->Write(ki->first.size(),ki->first.c_str());
         // write nvalues for this key
-        s->WriteLE((uint16_t)ki->second.size());
+        s->WriteLE16((uint16_t)ki->second.size());
         // iterate through values for this key
         Values::const_iterator vi,ve;
         GetValueIterators(ki->first,vi,ve);
         for (;vi!=ve;++vi)
         {
             // write value string
-            s->WriteLE((uint16_t)vi->size());
+            s->WriteLE16((uint16_t)vi->size());
             s->Write(vi->size(),vi->c_str());
         }
     }

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpansExport.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpansExport.cpp
@@ -189,7 +189,7 @@ void    plDrawableSpans::Write( hsStream* s, hsResMgr* mgr )
     // Write the groups out
     count = fGroups.GetCount();
 
-    s->WriteLE( count );
+    s->WriteLE32(count);
     for( i = 0; i < count; i++ )
     {
 #ifdef VERT_LOG

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
@@ -342,7 +342,7 @@ void    plGBufferGroup::Read( hsStream *s )
     plGBufferColor  *cData;
 
 
-    s->ReadLE( &fFormat );
+    s->ReadByte(&fFormat);
     (void)s->ReadLE32();    // totalDynSize
     fStride = ICalcVertexSize( fLiteStride );
 
@@ -473,7 +473,7 @@ void    plGBufferGroup::Write( hsStream *s )
     for (auto it : fIdxBuffCounts)
         totalDynSize += sizeof( uint16_t ) * it;
 
-    s->WriteLE( fFormat );
+    s->WriteByte(fFormat);
     s->WriteLE32( totalDynSize );
 
     plVertCoder coder;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
@@ -101,7 +101,7 @@ void    plGBufferCell::Read( hsStream *s )
     fLength = s->ReadLE32();
 }
 
-void    plGBufferCell::Write( hsStream *s )
+void plGBufferCell::Write(hsStream *s) const
 {
     s->WriteLE32( fVtxStart );
     s->WriteLE32( fColorStart );
@@ -524,9 +524,9 @@ void    plGBufferGroup::Write( hsStream *s )
     /// Write out cell arrays
     for (i = 0; i < fVertBuffStorage.size(); i++)
     {
-        s->WriteLE32( fCells[ i ].size() );
-        for( j = 0; j < fCells[ i ].size(); j++ )
-            fCells[ i ][ j ].Write( s );
+        s->WriteLE32((uint32_t)fCells[i].size());
+        for (const plGBufferCell& cell : fCells[i])
+            cell.Write(s);
     }
 
 #ifdef VERT_LOG

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.h
@@ -89,7 +89,7 @@ class plGBufferCell
         plGBufferCell() {}
 
         void    Read( hsStream *s );
-        void    Write( hsStream *s );
+        void    Write(hsStream *s) const;
 };
 
 class plGBufferColor

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGeometrySpan.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGeometrySpan.cpp
@@ -531,8 +531,8 @@ void    plGeometrySpan::Read( hsStream *stream )
 
     // FIXME MAJOR VERSION
     // remove these two lines. No more patches.
-    stream->ReadLE32();
-    stream->ReadByte();
+    (void)stream->ReadLE32();
+    (void)stream->ReadByte();
 
     fDecalLevel = stream->ReadLE32();
 
@@ -624,7 +624,7 @@ void    plGeometrySpan::Write( hsStream *stream )
     // FIXME MAJOR VERSION
     // Remove these two lines.
     stream->WriteLE32(0);
-    stream->WriteByte(0);
+    stream->WriteByte(uint8_t(0));
 
     stream->WriteLE32( fDecalLevel );
 

--- a/Sources/Plasma/PubUtilLib/plDrawable/plSpaceTree.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plSpaceTree.cpp
@@ -76,7 +76,7 @@ void plSpaceTreeNode::Write(hsStream* s)
     s->WriteLE16(fChildren[0]);
     if( fFlags & kIsLeaf )
         // Temp for now to play nice with binary patches
-        s->WriteLE16( 0 );
+        s->WriteLE16(uint16_t(0));
     else
         s->WriteLE16(fChildren[1]);
 }

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
@@ -297,7 +297,7 @@ uint32_t  plDynamicTextMap::Write( hsStream *s )
     s->WriteLE32( fVisHeight );
     s->WriteBool( fHasAlpha );
 
-    s->WriteLE32(fInitBuffer != nullptr ? fVisWidth * fVisHeight * sizeof(uint32_t) : 0);
+    s->WriteLE32(fInitBuffer != nullptr ? uint32_t(fVisWidth * fVisHeight * sizeof(uint32_t)) : 0U);
     if (fInitBuffer != nullptr)
     {
         s->WriteLE32( fVisWidth * fVisHeight, fInitBuffer );

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -84,20 +84,20 @@ plFont::plCharacter::plCharacter()
 void    plFont::plCharacter::Read( hsStream *s )
 {
     // Rocket science here...
-    s->ReadLE( &fBitmapOff );
-    s->ReadLE( &fHeight );
-    s->ReadLE( &fBaseline );
-    s->ReadLE( &fLeftKern );
-    s->ReadLE( &fRightKern );
+    s->ReadLE32(&fBitmapOff);
+    s->ReadLE32(&fHeight);
+    s->ReadLE32(&fBaseline);
+    s->ReadLEFloat(&fLeftKern);
+    s->ReadLEFloat(&fRightKern);
 }
 
 void plFont::plCharacter::Write(hsStream *s) const
 {
-    s->WriteLE( fBitmapOff );
-    s->WriteLE( fHeight );
-    s->WriteLE( fBaseline );
-    s->WriteLE( fLeftKern );
-    s->WriteLE( fRightKern );
+    s->WriteLE32(fBitmapOff);
+    s->WriteLE32(fHeight);
+    s->WriteLE32(fBaseline);
+    s->WriteLEFloat(fLeftKern);
+    s->WriteLEFloat(fRightKern);
 }
 
 //// Constructor/Read/Write/Destructor/etc ////////////////////////////////////
@@ -1310,40 +1310,40 @@ bool    plFont::LoadFromFNTStream( hsStream *stream )
 
                 s->Read( sizeof( copyright ), copyright );
             
-                s->ReadLE( &type );
-                s->ReadLE( &points );
-                s->ReadLE( &vertRes );
-                s->ReadLE( &horzRes );
-                s->ReadLE( &ascent );
-                s->ReadLE( &internalLeading );
-                s->ReadLE( &externalLeading );
-                s->ReadLE( &italic );
-                s->ReadLE( &underline );
-                s->ReadLE( &strikeout );
-                s->ReadLE( &weight );
-                s->ReadLE( &charSet );
-                s->ReadLE( &pixWidth );
-                s->ReadLE( &pixHeight );
-                s->ReadLE( &pitchFamily );
-                s->ReadLE( &avgWidth );
-                s->ReadLE( &maxWidth );
-                s->ReadLE( &firstChar );
-                s->ReadLE( &lastChar );
-                s->ReadLE( &defaultChar );
-                s->ReadLE( &breakChar );
-                s->ReadLE( &widthBytes );
-                s->ReadLE( &device );
-                s->ReadLE( &face );
-                s->ReadLE( &bitsPointer );
-                s->ReadLE( &bitsOffset );
-                s->ReadLE( &reserved );
+                s->ReadLE16(&type);
+                s->ReadLE16(&points);
+                s->ReadLE16(&vertRes);
+                s->ReadLE16(&horzRes);
+                s->ReadLE16(&ascent);
+                s->ReadLE16(&internalLeading);
+                s->ReadLE16(&externalLeading);
+                s->ReadByte(&italic);
+                s->ReadByte(&underline);
+                s->ReadByte(&strikeout);
+                s->ReadLE16(&weight);
+                s->ReadByte(&charSet);
+                s->ReadLE16(&pixWidth);
+                s->ReadLE16(&pixHeight);
+                s->ReadByte(&pitchFamily);
+                s->ReadLE16(&avgWidth);
+                s->ReadLE16(&maxWidth);
+                s->ReadByte(&firstChar);
+                s->ReadByte(&lastChar);
+                s->ReadByte(&defaultChar);
+                s->ReadByte(&breakChar);
+                s->ReadLE16(&widthBytes);
+                s->ReadLE32(&device);
+                s->ReadLE32(&face);
+                s->ReadLE32(&bitsPointer);
+                s->ReadLE32(&bitsOffset);
+                s->ReadByte(&reserved);
                 if( version == 0x0300 )
                 {
-                    s->ReadLE( &flags );
-                    s->ReadLE( &aSpace );
-                    s->ReadLE( &bSpace );
-                    s->ReadLE( &cSpace );
-                    s->ReadLE( &colorPointer );
+                    s->ReadLE32(&flags);
+                    s->ReadLE16(&aSpace);
+                    s->ReadLE16(&bSpace);
+                    s->ReadLE16(&cSpace);
+                    s->ReadLE32(&colorPointer);
                     s->Read( sizeof( reserved1 ), reserved1 );
                 }
                 else
@@ -2126,11 +2126,11 @@ bool    plFont::ReadRaw( hsStream *s )
     fFace = face_buf;
 
     fSize = s->ReadByte();
-    s->ReadLE( &fFlags );
+    s->ReadLE32(&fFlags);
 
-    s->ReadLE( &fWidth );
-    s->ReadLE( &fHeight );
-    s->ReadLE( &fMaxCharHeight );
+    s->ReadLE32(&fWidth);
+    s->ReadLE32(&fHeight);
+    s->ReadLE32(&fMaxCharHeight);
 
     fBPP = s->ReadByte();
 
@@ -2143,7 +2143,7 @@ bool    plFont::ReadRaw( hsStream *s )
     else
         fBMapData = nullptr;
 
-    s->ReadLE( &fFirstChar );
+    s->ReadLE16(&fFirstChar);
 
     fCharacters.resize(s->ReadLE32());
     for (plCharacter& ch : fCharacters)
@@ -2161,11 +2161,11 @@ bool    plFont::WriteRaw( hsStream *s )
     s->Write(sizeof(face_buf), face_buf);
 
     s->WriteByte( fSize );
-    s->WriteLE( fFlags );
+    s->WriteLE32(fFlags);
 
-    s->WriteLE( fWidth );
-    s->WriteLE( fHeight );
-    s->WriteLE( fMaxCharHeight );
+    s->WriteLE32(fWidth);
+    s->WriteLE32(fHeight);
+    s->WriteLE32(fMaxCharHeight);
 
     s->WriteByte( fBPP );
 
@@ -2173,7 +2173,7 @@ bool    plFont::WriteRaw( hsStream *s )
     if( size > 0 )
         s->Write( size, fBMapData );
 
-    s->WriteLE( fFirstChar );
+    s->WriteLE16(fFirstChar);
 
     s->WriteLE32((uint32_t)fCharacters.size());
     for (const plCharacter& ch : fCharacters)

--- a/Sources/Plasma/PubUtilLib/plGImage/plJPEG.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plJPEG.cpp
@@ -321,7 +321,7 @@ bool    plJPEG::IWrite( plMipmap *source, hsStream *outStream )
         delete [] jbuffer;
 
         // jpeglib changes bufferSize and bufferAddr
-        outStream->WriteLE32( bufferSize );
+        outStream->WriteLE32((uint32_t)bufferSize);
         outStream->Write( bufferSize, bufferAddr );
     }
     catch (...)

--- a/Sources/Plasma/PubUtilLib/plGImage/plTGAWriter.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plTGAWriter.cpp
@@ -75,24 +75,24 @@ void    plTGAWriter::WriteMipmap( const char *fileName, plMipmap *mipmap )
     stream.Open( fileName, "wb" );
 
     /// Write header
-    stream.WriteByte( 0 );  // Size of ID field
-    stream.WriteByte( 0 );  // Map type
-    stream.WriteByte( 2 );  // Type 2 image - Unmapped RGB
+    stream.WriteByte(uint8_t(0));  // Size of ID field
+    stream.WriteByte(uint8_t(0));  // Map type
+    stream.WriteByte(uint8_t(2));  // Type 2 image - Unmapped RGB
 
-    stream.WriteByte( 0 );  // Color map spec
-    stream.WriteByte( 0 );  // Color map spec
-    stream.WriteByte( 0 );  // Color map spec
-    stream.WriteByte( 0 );  // Color map spec
-    stream.WriteByte( 0 );  // Color map spec
+    stream.WriteByte(uint8_t(0));  // Color map spec
+    stream.WriteByte(uint8_t(0));  // Color map spec
+    stream.WriteByte(uint8_t(0));  // Color map spec
+    stream.WriteByte(uint8_t(0));  // Color map spec
+    stream.WriteByte(uint8_t(0));  // Color map spec
 
-    stream.WriteLE16( 0 );    // xOrigin
-    stream.WriteLE16( 0 );    // yOrigin
+    stream.WriteLE16(uint16_t(0));    // xOrigin
+    stream.WriteLE16(uint16_t(0));    // yOrigin
 
     stream.WriteLE16( (uint16_t)mipmap->GetWidth() );
     stream.WriteLE16( (uint16_t)mipmap->GetHeight() );
 
-    stream.WriteByte( 24 );
-    stream.WriteByte( 0 );
+    stream.WriteByte(uint8_t(24));
+    stream.WriteByte(uint8_t(0));
 
     /// Write image data (gotta do inversed, stupid TGAs...)
     for( y = mipmap->GetHeight() - 1; y >= 0; y-- )

--- a/Sources/Plasma/PubUtilLib/plMessage/plAnimCmdMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAnimCmdMsg.cpp
@@ -78,13 +78,13 @@ void plAnimCmdMsg::Read(hsStream* stream, hsResMgr* mgr)
     plMessageWithCallbacks::Read(stream, mgr);
 
     fCmd.Read(stream);
-    stream->ReadLE(&fBegin);
-    stream->ReadLE(&fEnd);
-    stream->ReadLE(&fLoopEnd);
-    stream->ReadLE(&fLoopBegin);
-    stream->ReadLE(&fSpeed);
-    stream->ReadLE(&fSpeedChangeRate);
-    stream->ReadLE(&fTime);
+    stream->ReadLEFloat(&fBegin);
+    stream->ReadLEFloat(&fEnd);
+    stream->ReadLEFloat(&fLoopEnd);
+    stream->ReadLEFloat(&fLoopBegin);
+    stream->ReadLEFloat(&fSpeed);
+    stream->ReadLEFloat(&fSpeedChangeRate);
+    stream->ReadLEFloat(&fTime);
 
     fAnimName = stream->ReadSafeString();
     fLoopName = stream->ReadSafeString();
@@ -95,13 +95,13 @@ void plAnimCmdMsg::Write(hsStream* stream, hsResMgr* mgr)
     plMessageWithCallbacks::Write(stream, mgr);
 
     fCmd.Write(stream);
-    stream->WriteLE(fBegin);
-    stream->WriteLE(fEnd);
-    stream->WriteLE(fLoopEnd);
-    stream->WriteLE(fLoopBegin);
-    stream->WriteLE(fSpeed);
-    stream->WriteLE(fSpeedChangeRate);
-    stream->WriteLE(fTime);
+    stream->WriteLEFloat(fBegin);
+    stream->WriteLEFloat(fEnd);
+    stream->WriteLEFloat(fLoopEnd);
+    stream->WriteLEFloat(fLoopBegin);
+    stream->WriteLEFloat(fSpeed);
+    stream->WriteLEFloat(fSpeedChangeRate);
+    stream->WriteLEFloat(fTime);
 
     stream->WriteSafeString(fAnimName);
     stream->WriteSafeString(fLoopName);
@@ -119,10 +119,10 @@ void plAGCmdMsg::Read(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgRead(stream, mgr);
 
     fCmd.Read(stream);
-    stream->ReadLE(&fBlend);
-    stream->ReadLE(&fBlendRate);
-    stream->ReadLE(&fAmp);
-    stream->ReadLE(&fAmpRate);
+    stream->ReadLEFloat(&fBlend);
+    stream->ReadLEFloat(&fBlendRate);
+    stream->ReadLEFloat(&fAmp);
+    stream->ReadLEFloat(&fAmpRate);
 
     fAnimName = stream->ReadSafeString();
 }
@@ -132,10 +132,10 @@ void plAGCmdMsg::Write(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgWrite(stream, mgr);
 
     fCmd.Write(stream);
-    stream->WriteLE(fBlend);
-    stream->WriteLE(fBlendRate);
-    stream->WriteLE(fAmp);
-    stream->WriteLE(fAmpRate);
+    stream->WriteLEFloat(fBlend);
+    stream->WriteLEFloat(fBlendRate);
+    stream->WriteLEFloat(fAmp);
+    stream->WriteLEFloat(fAmpRate);
 
     stream->WriteSafeString(fAnimName);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plCCRMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plCCRMsg.cpp
@@ -59,7 +59,7 @@ void plCCRPetitionMsg::Read(hsStream* stream, hsResMgr* mgr)
     
     plMsgStdStringHelper::Peek(fNote, stream);
     plMsgStdStringHelper::Peek(fTitle, stream);
-    stream->ReadLE(&fPetitionType);
+    stream->ReadByte(&fPetitionType);
 }
 
 void plCCRPetitionMsg::Write(hsStream* stream, hsResMgr* mgr) 
@@ -68,7 +68,7 @@ void plCCRPetitionMsg::Write(hsStream* stream, hsResMgr* mgr)
 
     plMsgStdStringHelper::Poke(fNote, stream);
     plMsgStdStringHelper::Poke(fTitle, stream);
-    stream->WriteLE(fPetitionType);
+    stream->WriteByte(fPetitionType);
 }
 
 ///////////////////////////////////////////////////////////
@@ -107,7 +107,7 @@ void plCCRCommunicationMsg::Read(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgRead(stream, mgr);
     plMsgStdStringHelper::Peek(fString, stream);    
     fType = (Type)stream->ReadLE32();
-    stream->ReadLE(&fCCRPlayerID);
+    stream->ReadLE32(&fCCRPlayerID);
 }
 
 void plCCRCommunicationMsg::Write(hsStream* stream, hsResMgr* mgr) 
@@ -115,8 +115,8 @@ void plCCRCommunicationMsg::Write(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgWrite(stream, mgr);
     
     plMsgStdStringHelper::Poke(fString, stream);
-    stream->WriteLE32((int)fType);
-    stream->WriteLE(fCCRPlayerID);
+    stream->WriteLE32((uint32_t)fType);
+    stream->WriteLE32(fCCRPlayerID);
 }
 
 ///////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plMessage/plCondRefMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plCondRefMsg.cpp
@@ -47,11 +47,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 void plCondRefMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Read(stream, mgr);
-    stream->ReadLE(&fWhich);
+    stream->ReadByte(&fWhich);
 }
 
 void plCondRefMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Write(stream, mgr);
-    stream->WriteLE(fWhich);
+    stream->WriteByte(fWhich);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plConsoleMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plConsoleMsg.cpp
@@ -47,7 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 void plConsoleMsg::Read(hsStream* s, hsResMgr* mgr)
 {
     plMessage::IMsgRead(s, mgr);
-    s->ReadLE(&fCmd);
+    s->ReadLE32(&fCmd);
     // read string
     plMsgCStringHelper::Peek(fString, s);
 }
@@ -55,7 +55,7 @@ void plConsoleMsg::Read(hsStream* s, hsResMgr* mgr)
 void plConsoleMsg::Write(hsStream* s, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(s, mgr);
-    s->WriteLE(fCmd);
+    s->WriteLE32(fCmd);
     // write cmd/string
     plMsgCStringHelper::Poke(fString, s);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plDynamicTextMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plDynamicTextMsg.cpp
@@ -184,14 +184,14 @@ void    plDynamicTextMsg::Read( hsStream *s, hsResMgr *mgr )
 { 
     plMessage::IMsgRead( s, mgr ); 
 
-    s->ReadLE( &fCmd );
-    s->ReadLE( &fX );
-    s->ReadLE( &fY );
+    s->ReadLE16(&fCmd);
+    s->ReadLE16(&fX);
+    s->ReadLE16(&fY);
 
-    s->ReadLE( &fLeft );
-    s->ReadLE( &fTop );
-    s->ReadLE( &fRight );
-    s->ReadLE( &fBottom );
+    s->ReadLE16(&fLeft);
+    s->ReadLE16(&fTop);
+    s->ReadLE16(&fRight);
+    s->ReadLE16(&fBottom);
 
     fClearColor.Read( s );
     fColor.Read( s );
@@ -199,11 +199,12 @@ void    plDynamicTextMsg::Read( hsStream *s, hsResMgr *mgr )
     fString = s->ReadSafeWString();
     fImageKey = mgr->ReadKey( s );
 
-    s->ReadLE( &fFlags );
+    s->ReadLE32(&fFlags);
 
     fBlockRGB = s->ReadBOOL();
-    s->ReadLE( &fLineSpacing );
+    s->ReadLE16(&fLineSpacing);
 }
+
 void    plDynamicTextMsg::Write( hsStream *s, hsResMgr *mgr ) 
 { 
     plMessage::IMsgWrite( s, mgr ); 
@@ -215,14 +216,14 @@ void    plDynamicTextMsg::Write( hsStream *s, hsResMgr *mgr )
     }
 #endif
 
-    s->WriteLE( fCmd );
-    s->WriteLE( fX );
-    s->WriteLE( fY );
+    s->WriteLE16(fCmd);
+    s->WriteLE16(fX);
+    s->WriteLE16(fY);
     
-    s->WriteLE( fLeft );
-    s->WriteLE( fTop );
-    s->WriteLE( fRight );
-    s->WriteLE( fBottom );
+    s->WriteLE16(fLeft);
+    s->WriteLE16(fTop);
+    s->WriteLE16(fRight);
+    s->WriteLE16(fBottom);
 
     fClearColor.Write( s );
     fColor.Write( s );
@@ -231,10 +232,10 @@ void    plDynamicTextMsg::Write( hsStream *s, hsResMgr *mgr )
 
     mgr->WriteKey( s, fImageKey );
 
-    s->WriteLE( fFlags );
+    s->WriteLE32(fFlags);
 
     s->WriteBOOL(fBlockRGB);
-    s->WriteLE( fLineSpacing );
+    s->WriteLE16(fLineSpacing);
 }
 
 enum DynamicTextMsgFlags
@@ -263,19 +264,19 @@ void plDynamicTextMsg::ReadVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Read(s);
 
     if (contentFlags.IsBitSet(kDynTextMsgCmd))
-        s->ReadLE( &fCmd );
+        s->ReadLE16(&fCmd);
     if (contentFlags.IsBitSet(kDynTextMsgX))
-        s->ReadLE( &fX );
+        s->ReadLE16(&fX);
     if (contentFlags.IsBitSet(kDynTextMsgY))
-        s->ReadLE( &fY );
+        s->ReadLE16(&fY);
     if (contentFlags.IsBitSet(kDynTextMsgLeft))
-        s->ReadLE( &fLeft );
+        s->ReadLE16(&fLeft);
     if (contentFlags.IsBitSet(kDynTextMsgTop))
-        s->ReadLE( &fTop );
+        s->ReadLE16(&fTop);
     if (contentFlags.IsBitSet(kDynTextMsgRight))
-        s->ReadLE( &fRight );
+        s->ReadLE16(&fRight);
     if (contentFlags.IsBitSet(kDynTextMsgBottom))
-        s->ReadLE( &fBottom );
+        s->ReadLE16(&fBottom);
     if (contentFlags.IsBitSet(kDynTextMsgClearColor))
         fClearColor.Read( s );
     if (contentFlags.IsBitSet(kDynTextMsgColor))
@@ -285,11 +286,11 @@ void plDynamicTextMsg::ReadVersion(hsStream* s, hsResMgr* mgr)
     if (contentFlags.IsBitSet(kDynTextMsgImageKey))
         fImageKey = mgr->ReadKey( s );
     if (contentFlags.IsBitSet(kDynTextMsgFlags))
-        s->ReadLE( &fFlags );
+        s->ReadLE32(&fFlags);
     if (contentFlags.IsBitSet(kDynTextMsgBlockRGB))
         fBlockRGB = s->ReadBOOL();
     if (contentFlags.IsBitSet(kDynTextMsgLineSpacing))
-        s->ReadLE( &fLineSpacing );
+        s->ReadLE16(&fLineSpacing);
 }
 
 void plDynamicTextMsg::WriteVersion(hsStream* s, hsResMgr* mgr) 
@@ -314,20 +315,20 @@ void plDynamicTextMsg::WriteVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Write(s);
 
     // kDynTextMsgCmd
-    s->WriteLE( fCmd );
+    s->WriteLE16(fCmd);
     // kDynTextMsgX
-    s->WriteLE( fX );
+    s->WriteLE16(fX);
     // kDynTextMsgY
-    s->WriteLE( fY );
+    s->WriteLE16(fY);
     
     // kDynTextMsgLeft
-    s->WriteLE( fLeft );
+    s->WriteLE16(fLeft);
     // kDynTextMsgTop
-    s->WriteLE( fTop );
+    s->WriteLE16(fTop);
     // kDynTextMsgRight
-    s->WriteLE( fRight );
+    s->WriteLE16(fRight);
     // kDynTextMsgBottom
-    s->WriteLE( fBottom );
+    s->WriteLE16(fBottom);
 
     // kDynTextMsgClearColor
     fClearColor.Write( s );
@@ -340,12 +341,11 @@ void plDynamicTextMsg::WriteVersion(hsStream* s, hsResMgr* mgr)
     mgr->WriteKey( s, fImageKey );
 
     // kDynTextMsgFlags
-    s->WriteLE( fFlags );
+    s->WriteLE32(fFlags);
 
     // kDynTextMsgBlockRGB
     s->WriteBOOL( fBlockRGB );
     // kDynTextMsgLineSpacing
-    s->WriteLE( fLineSpacing );
-
+    s->WriteLE16(fLineSpacing);
 }
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.cpp
@@ -70,14 +70,14 @@ void plInputEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgRead(stream, mgr);
     
-    stream->ReadLE(&fEvent);
+    stream->ReadLE32(&fEvent);
 }
 
 void plInputEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(stream, mgr);
     
-    stream->WriteLE(fEvent);
+    stream->WriteLE32(fEvent);
 }
 
 enum InputEventMsgFlags
@@ -93,7 +93,7 @@ void plInputEventMsg::ReadVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Read(s);
 
     if (contentFlags.IsBitSet(kInputEventMsgEvent))
-        s->ReadLE(&fEvent);
+        s->ReadLE32(&fEvent);
 }
 
 void plInputEventMsg::WriteVersion(hsStream* s, hsResMgr* mgr)
@@ -105,7 +105,7 @@ void plInputEventMsg::WriteVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Write(s);
 
     // kInputEventMsgEvent
-    s->WriteLE(fEvent);
+    s->WriteLE32(fEvent);
 }
 
 plControlEventMsg::plControlEventMsg() : 
@@ -134,9 +134,9 @@ plControlEventMsg::~plControlEventMsg()
 void plControlEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Read(stream, mgr);
-    stream->ReadLE((int32_t*)&fControlCode);
+    fControlCode = (ControlEventCode)stream->ReadLE32();
     fControlActivated = stream->ReadBOOL();
-    stream->ReadLE(&fControlPct);
+    stream->ReadLEFloat(&fControlPct);
     fTurnToPt.Read(stream);
 
     // read cmd/string
@@ -146,9 +146,9 @@ void plControlEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 void plControlEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Write(stream, mgr);
-    stream->WriteLE((int32_t)fControlCode);
+    stream->WriteLE32((int32_t)fControlCode);
     stream->WriteBOOL(fControlActivated);
-    stream->WriteLE(fControlPct);
+    stream->WriteLEFloat(fControlPct);
     fTurnToPt.Write(stream);
     
     // write cmd/string
@@ -172,13 +172,13 @@ void plControlEventMsg::ReadVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Read(s);
 
     if (contentFlags.IsBitSet(kControlEventMsgCode))
-        s->ReadLE((int32_t*)&fControlCode);
+        fControlCode = (ControlEventCode)s->ReadLE32();
 
     if (contentFlags.IsBitSet(kControlEventMsgActivated))
         fControlActivated = s->ReadBOOL();
 
     if (contentFlags.IsBitSet(kControlEventMsgPct))
-        s->ReadLE(&fControlPct);
+        s->ReadLEFloat(&fControlPct);
 
     if (contentFlags.IsBitSet(kControlEventMsgTurnToPt))
         fTurnToPt.Read(s);
@@ -201,13 +201,13 @@ void plControlEventMsg::WriteVersion(hsStream* s, hsResMgr* mgr)
     contentFlags.Write(s);
 
     // kControlEventMsgCode,    
-    s->WriteLE((int32_t)fControlCode);
+    s->WriteLE32((int32_t)fControlCode);
 
     // kControlEventMsgActivated,
     s->WriteBOOL(fControlActivated);
 
     // kControlEventMsgPct,
-    s->WriteLE(fControlPct);
+    s->WriteLEFloat(fControlPct);
 
     // kControlEventMsgTurnToPt,
     fTurnToPt.Write(s);
@@ -233,7 +233,7 @@ plKeyEventMsg::~plKeyEventMsg()
 void plKeyEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Read(stream, mgr);
-    stream->ReadLE((int32_t*)&fKeyCode);
+    fKeyCode = (plKeyDef)stream->ReadLE32();
     fKeyDown = stream->ReadBOOL();
     fCapsLockKeyDown = stream->ReadBOOL();
     fShiftKeyDown = stream->ReadBOOL();
@@ -269,7 +269,7 @@ plDebugKeyEventMsg::~plDebugKeyEventMsg()
 void plDebugKeyEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Read(stream, mgr);
-    stream->ReadLE((int32_t*)&fKeyCode);
+    fKeyCode = (ControlEventCode)stream->ReadLE32();
     fKeyDown = stream->ReadBOOL();
     fCapsLockKeyDown = stream->ReadBOOL();
     fShiftKeyDown = stream->ReadBOOL();
@@ -279,7 +279,7 @@ void plDebugKeyEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 void plDebugKeyEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Write(stream, mgr);
-    stream->WriteLE((int32_t)fKeyCode);
+    stream->WriteLE32((int32_t)fKeyCode);
     stream->WriteBOOL(fKeyDown);
     stream->WriteBOOL(fCapsLockKeyDown);
     stream->WriteBOOL(fShiftKeyDown);
@@ -289,41 +289,41 @@ void plDebugKeyEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 void plIMouseXEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Read(stream, mgr);
-    stream->ReadLE(&fX);
-    stream->ReadLE(&fWx);
+    stream->ReadLEFloat(&fX);
+    stream->ReadLE32(&fWx);
 }
 
 void plIMouseXEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Write(stream, mgr);
-    stream->WriteLE(fX);
-    stream->WriteLE(fWx);
+    stream->WriteLEFloat(fX);
+    stream->WriteLE32(fWx);
 }
 
 void plIMouseYEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Read(stream, mgr);
-    stream->ReadLE(&fY);
-    stream->ReadLE(&fWy);
+    stream->ReadLEFloat(&fY);
+    stream->ReadLE32(&fWy);
 }
 
 void plIMouseYEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Write(stream, mgr);
-    stream->WriteLE(fY);
-    stream->WriteLE(fWy);
+    stream->WriteLEFloat(fY);
+    stream->WriteLE32(fWy);
 }
 
 void plIMouseBEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Read(stream, mgr);
-    stream->ReadLE(&fButton);
+    stream->ReadLE16(&fButton);
 }
 
 void plIMouseBEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Write(stream, mgr);
-    stream->WriteLE(fButton);
+    stream->WriteLE16(fButton);
 }
 
 plMouseEventMsg::plMouseEventMsg() : fXPos(0.0f),fYPos(0.0f),fDX(0.0f),fDY(0.0f),fButton(0)
@@ -343,23 +343,23 @@ plMouseEventMsg::~plMouseEventMsg()
 void plMouseEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Read(stream, mgr);
-    stream->ReadLE(&fXPos);
-    stream->ReadLE(&fYPos);
-    stream->ReadLE(&fDX);
-    stream->ReadLE(&fDY);
-    stream->ReadLE(&fButton);
-    stream->ReadLE(&fWheelDelta);
+    stream->ReadLEFloat(&fXPos);
+    stream->ReadLEFloat(&fYPos);
+    stream->ReadLEFloat(&fDX);
+    stream->ReadLEFloat(&fDY);
+    stream->ReadLE16(&fButton);
+    stream->ReadLEFloat(&fWheelDelta);
 }
 
 void plMouseEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Write(stream, mgr);
-    stream->WriteLE(fXPos);
-    stream->WriteLE(fYPos);
-    stream->WriteLE(fDX);
-    stream->WriteLE(fDY);
-    stream->WriteLE(fButton);
-    stream->WriteLE(fWheelDelta);
+    stream->WriteLEFloat(fXPos);
+    stream->WriteLEFloat(fYPos);
+    stream->WriteLEFloat(fDX);
+    stream->WriteLEFloat(fDY);
+    stream->WriteLE16(fButton);
+    stream->WriteLEFloat(fWheelDelta);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.cpp
@@ -62,8 +62,8 @@ void plInputIfaceMgrMsg::Read(hsStream* s, hsResMgr* mgr)
 {
     plMessage::IMsgRead(s, mgr);
 
-    s->ReadLE(&fCommand);
-    s->ReadLE(&fPageID);
+    s->ReadByte(&fCommand);
+    s->ReadLE32(&fPageID);
     ageName = s->ReadSafeString();
     ageFileName = s->ReadSafeString();
     spawnPoint = s->ReadSafeString();
@@ -74,8 +74,8 @@ void plInputIfaceMgrMsg::Write(hsStream* s, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(s, mgr);
 
-    s->WriteLE(fCommand);
-    s->WriteLE(fPageID);
+    s->WriteByte(fCommand);
+    s->WriteLE32(fPageID);
     s->WriteSafeString(ageName);
     s->WriteSafeString(ageFileName);
     s->WriteSafeString(spawnPoint);

--- a/Sources/Plasma/PubUtilLib/plMessage/plInterestingPing.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInterestingPing.cpp
@@ -48,9 +48,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 void plInterestingModMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgRead(stream, mgr);
-    stream->ReadLE(&fWeight);
-    stream->ReadLE(&fRadius);
-    stream->ReadLE(&fSize);
+    stream->ReadLEFloat(&fWeight);
+    stream->ReadLEFloat(&fRadius);
+    stream->ReadLEFloat(&fSize);
     fPos.Read(stream);
     fObj = mgr->ReadKey(stream);
 }
@@ -58,9 +58,9 @@ void plInterestingModMsg::Read(hsStream* stream, hsResMgr* mgr)
 void plInterestingModMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plMessage::IMsgWrite(stream, mgr);
-    stream->WriteLE(fWeight);
-    stream->WriteLE(fRadius);
-    stream->WriteLE(fSize);
+    stream->WriteLEFloat(fWeight);
+    stream->WriteLEFloat(fRadius);
+    stream->WriteLEFloat(fSize);
     fPos.Write(stream);
     mgr->WriteKey(stream, fObj);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plLOSHitMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plLOSHitMsg.cpp
@@ -52,8 +52,8 @@ void plLOSHitMsg::Read(hsStream* stream, hsResMgr* mgr)
     fObj = mgr->ReadKey(stream);
     fHitPoint.Read(stream);
     fNoHit = stream->ReadBool();
-    stream->ReadLE(&fRequestID);
-    stream->ReadLE(&fHitFlags);
+    stream->ReadLE32(&fRequestID);
+    stream->ReadLE32(&fHitFlags);
 }
 
 void plLOSHitMsg::Write(hsStream* stream, hsResMgr* mgr)
@@ -63,6 +63,6 @@ void plLOSHitMsg::Write(hsStream* stream, hsResMgr* mgr)
     mgr->WriteKey(stream, fObj);
     fHitPoint.Write(stream);
     stream->WriteBool(fNoHit);
-    stream->WriteLE(fRequestID);
-    stream->WriteLE(fHitFlags);
+    stream->WriteLE32(fRequestID);
+    stream->WriteLE32(fHitFlags);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plLayRefMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plLayRefMsg.cpp
@@ -48,13 +48,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 void plLayRefMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Read(stream, mgr);
-    stream->ReadLE(&fType);
-    stream->ReadLE(&fWhich);
+    stream->ReadByte(&fType);
+    stream->ReadByte(&fWhich);
 }
 
 void plLayRefMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Write(stream, mgr);
-    stream->WriteLE(fType);
-    stream->WriteLE(fWhich);
+    stream->WriteByte(fType);
+    stream->WriteByte(fWhich);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plLinkToAgeMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plLinkToAgeMsg.cpp
@@ -151,7 +151,7 @@ void plLinkingMgrMsg::Read( hsStream* stream, hsResMgr* mgr )
     contentFlags.Read( stream );
 
     if ( contentFlags.IsBitSet( kLinkingMgrCmd ) )
-        stream->ReadLE( &fLinkingMgrCmd );
+        stream->ReadByte(&fLinkingMgrCmd);
     if ( contentFlags.IsBitSet( kLinkingMgrArgs ) )
         fArgs.Read( stream, mgr );
 }
@@ -165,7 +165,7 @@ void plLinkingMgrMsg::Write( hsStream* stream, hsResMgr* mgr )
     contentFlags.SetBit( kLinkingMgrArgs );
     contentFlags.Write( stream );
 
-    stream->WriteLE( fLinkingMgrCmd );
+    stream->WriteByte(fLinkingMgrCmd);
     fArgs.Write( stream, mgr );
 }
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plLoadAgeMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plLoadAgeMsg.cpp
@@ -51,8 +51,7 @@ void plLoadAgeMsg::Read(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgRead(stream, mgr);   
 
     // read agename
-    uint8_t len;
-    stream->ReadLE(&len);
+    uint8_t len = stream->ReadByte();
     if (len)
     {
         ST::char_buffer filename;
@@ -61,7 +60,7 @@ void plLoadAgeMsg::Read(hsStream* stream, hsResMgr* mgr)
         fAgeFilename = filename;
     }
     fUnload = stream->ReadBool();
-    stream->ReadLE(&fPlayerID);
+    stream->ReadLE32(&fPlayerID);
     fAgeGuid.Read(stream);
 }
 
@@ -71,13 +70,13 @@ void plLoadAgeMsg::Write(hsStream* stream, hsResMgr* mgr)
 
     // write agename
     uint8_t len = static_cast<uint8_t>(fAgeFilename.size());
-    stream->WriteLE(len);
+    stream->WriteByte(len);
     if (len)
     {
         stream->Write(len, fAgeFilename.c_str());
     }
     stream->WriteBool(fUnload);
-    stream->WriteLE(fPlayerID);
+    stream->WriteLE32(fPlayerID);
     fAgeGuid.Write(stream);
 }
 
@@ -106,7 +105,7 @@ void plLoadAgeMsg::ReadVersion(hsStream* s, hsResMgr* mgr)
         fUnload = s->ReadBool();
 
     if (contentFlags.IsBitSet(kLoadAgePlayerID))
-        s->ReadLE(&fPlayerID);
+        s->ReadLE32(&fPlayerID);
 
     if (contentFlags.IsBitSet(kLoadAgeAgeGuid))
         fAgeGuid.Read(s);
@@ -128,7 +127,7 @@ void plLoadAgeMsg::WriteVersion(hsStream* s, hsResMgr* mgr)
     // kLoadAgeUnload
     s->WriteBool(fUnload);
     // kLoadAgePlayerID
-    s->WriteLE(fPlayerID);
+    s->WriteLE32(fPlayerID);
     // kLoadAgeAgeGuid
     fAgeGuid.Write(s);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plMeshRefMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMeshRefMsg.cpp
@@ -47,13 +47,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 void plMeshRefMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Read(stream, mgr);
-    stream->ReadLE(&fType);
-    stream->ReadLE(&fWhich);
+    stream->ReadByte(&fType);
+    stream->ReadByte(&fWhich);
 }
 
 void plMeshRefMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
     plRefMsg::Write(stream, mgr);
-    stream->WriteLE(fType);
-    stream->WriteLE(fWhich);
+    stream->WriteByte(fType);
+    stream->WriteByte(fWhich);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plParticleUpdateMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plParticleUpdateMsg.cpp
@@ -50,7 +50,7 @@ void plParticleUpdateMsg::Read(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgRead(stream, mgr);
 
     fParamID = stream->ReadLE32();
-    stream->ReadLE(&fParamValue);
+    stream->ReadLEFloat(&fParamValue);
 }
 
 void plParticleUpdateMsg::Write(hsStream* stream, hsResMgr* mgr)
@@ -58,7 +58,7 @@ void plParticleUpdateMsg::Write(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgWrite(stream, mgr);
 
     stream->WriteLE32(fParamID);
-    stream->WriteLE(fParamValue);
+    stream->WriteLEFloat(fParamValue);
 }
 
 void plParticleTransferMsg::Read(hsStream* stream, hsResMgr* mgr)
@@ -82,7 +82,7 @@ void plParticleKillMsg::Read(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgRead(stream, mgr);
     fNumToKill = stream->ReadLEFloat();
     fTimeLeft = stream->ReadLEFloat();
-    stream->ReadLE(&fFlags);
+    stream->ReadByte(&fFlags);
 }
 
 void plParticleKillMsg::Write(hsStream* stream, hsResMgr* mgr)
@@ -90,5 +90,5 @@ void plParticleKillMsg::Write(hsStream* stream, hsResMgr* mgr)
     plMessage::IMsgWrite(stream, mgr);
     stream->WriteLEFloat(fNumToKill);
     stream->WriteLEFloat(fTimeLeft);
-    stream->WriteLE(fFlags);
+    stream->WriteByte(fFlags);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plTransitionMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plTransitionMsg.cpp
@@ -52,15 +52,15 @@ plTransitionMsg::~plTransitionMsg()
 void plTransitionMsg::Read(hsStream* s, hsResMgr* mgr)
 {
     plMessageWithCallbacks::Read(s, mgr);
-    s->ReadLE(&fEffect);
-    s->ReadLE(&fLengthInSecs);
+    s->ReadLE32(&fEffect);
+    s->ReadLEFloat(&fLengthInSecs);
     fHoldUntilNext = s->ReadBOOL();
 }
 
 void plTransitionMsg::Write(hsStream* s, hsResMgr* mgr)
 {
     plMessageWithCallbacks::Write(s, mgr);
-    s->WriteLE(fEffect);
-    s->WriteLE(fLengthInSecs);
+    s->WriteLE32(fEffect);
+    s->WriteLEFloat(fLengthInSecs);
     s->WriteBOOL(fHoldUntilNext);
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plVaultNotifyMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plVaultNotifyMsg.cpp
@@ -57,15 +57,15 @@ plVaultNotifyMsg::~plVaultNotifyMsg()
 
 void plVaultNotifyMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
-    stream->ReadLE( &fType );
-    stream->ReadLE( &fResultCode );
+    stream->ReadLE16(&fType);
+    stream->ReadByte(&fResultCode);
     fArgs.Read( stream, mgr );
 }
 
 void plVaultNotifyMsg::Write(hsStream* stream, hsResMgr* mgr)
 {
-    stream->WriteLE( fType );
-    stream->WriteLE( fResultCode );
+    stream->WriteLE16(fType);
+    stream->WriteByte(fResultCode);
     fArgs.Write( stream, mgr );
 }
 

--- a/Sources/Plasma/PubUtilLib/plModifier/plMaintainersMarkerModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plMaintainersMarkerModifier.cpp
@@ -60,11 +60,11 @@ void plMaintainersMarkerModifier::RemoveTarget(plSceneObject* so)
 void plMaintainersMarkerModifier::Read(hsStream *stream, hsResMgr *mgr)
 {
     plMultiModifier::Read(stream, mgr);
-    stream->ReadLE(&fCalibrated);
+    stream->ReadLE32(&fCalibrated);
 }
 
 void plMaintainersMarkerModifier::Write(hsStream *stream, hsResMgr *mgr)
 {
     plMultiModifier::Write(stream, mgr);
-    stream->WriteLE(fCalibrated);
+    stream->WriteLE32(fCalibrated);
 }

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plClientGuid.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plClientGuid.cpp
@@ -304,25 +304,25 @@ ST::string plClientGuid::AsLogString() const
 
 void plClientGuid::Read(hsStream * s, hsResMgr* mgr)
 {
-    s->ReadLE(&fFlags);
+    s->ReadLE16(&fFlags);
     if (IsFlagSet(kAccountUUID))
         fAccountUUID.Read( s );
     if (IsFlagSet(kPlayerID))
-        s->ReadLE(&fPlayerID);
+        s->ReadLE32(&fPlayerID);
     else if (IsFlagSet(kTempPlayerID))
-        s->ReadLE(&fPlayerID);
+        s->ReadLE32(&fPlayerID);
     if (IsFlagSet(kPlayerName))
         plMsgStdStringHelper::Peek( fPlayerName, s );
     if (IsFlagSet(kCCRLevel))
-        s->ReadLE(&fCCRLevel);
+        s->ReadByte(&fCCRLevel);
     if (IsFlagSet(kProtectedLogin))
         fProtectedLogin = s->ReadBool();
     if (IsFlagSet(kBuildType))
-        s->ReadLE(&fBuildType);
+        s->ReadByte(&fBuildType);
     if (IsFlagSet(kSrcAddr))
-        s->ReadLE(&fSrcAddr);
+        s->ReadLE32(&fSrcAddr);
     if (IsFlagSet(kSrcPort))
-        s->ReadLE(&fSrcPort);
+        s->ReadLE16(&fSrcPort);
     if (IsFlagSet(kReserved))
         fReserved = s->ReadBool();
     if (IsFlagSet(kClientKey))
@@ -331,25 +331,25 @@ void plClientGuid::Read(hsStream * s, hsResMgr* mgr)
 
 void plClientGuid::Write(hsStream * s, hsResMgr* mgr)
 {
-    s->WriteLE(fFlags);
+    s->WriteLE16(fFlags);
     if (IsFlagSet(kAccountUUID))
         fAccountUUID.Write( s );
     if (IsFlagSet(kPlayerID))
-        s->WriteLE(fPlayerID);
+        s->WriteLE32(fPlayerID);
     else if (IsFlagSet(kTempPlayerID))
-        s->WriteLE(fPlayerID);
+        s->WriteLE32(fPlayerID);
     if (IsFlagSet(kPlayerName))
         plMsgStdStringHelper::Poke( fPlayerName, s );
     if (IsFlagSet(kCCRLevel))
-        s->WriteLE(fCCRLevel);
+        s->WriteByte(fCCRLevel);
     if (IsFlagSet(kProtectedLogin))
         s->WriteBool(fProtectedLogin);
     if (IsFlagSet(kBuildType))
-        s->WriteLE(fBuildType);
+        s->WriteByte(fBuildType);
     if (IsFlagSet(kSrcAddr))
-        s->WriteLE(fSrcAddr);
+        s->WriteLE32(fSrcAddr);
     if (IsFlagSet(kSrcPort))
-        s->WriteLE(fSrcPort);
+        s->WriteLE16(fSrcPort);
     if (IsFlagSet(kReserved))
         s->WriteBool(fReserved);
     if (IsFlagSet(kClientKey))

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.cpp
@@ -186,7 +186,7 @@ void plCreatableListHelper::Read( hsStream* s, hsResMgr* mgr )
 {
     IClearItems();
 
-    s->ReadLE(&fFlags);
+    s->ReadByte(&fFlags);
 
     fFlags &= ~kWritten;
 
@@ -215,14 +215,11 @@ void plCreatableListHelper::Read( hsStream* s, hsResMgr* mgr )
 
     hsReadOnlyStream ram( bufSz, (void*)buf.data() );
 
-    uint16_t nItems;
-    ram.ReadLE( &nItems );
-    for ( int i=0; i<nItems; i++ )
+    uint16_t nItems = ram.ReadLE16();
+    for (uint16_t i = 0; i < nItems; i++)
     {
-        uint16_t id;
-        uint16_t classIdx;
-        ram.ReadLE( &id );
-        ram.ReadLE( &classIdx );
+        uint16_t id = ram.ReadLE16();
+        uint16_t classIdx = ram.ReadLE16();
         plCreatable * object = plFactory::Create( classIdx );
         hsAssert( object,"plCreatableListHelper: Failed to create plCreatable object (invalid class index?)" );
         if ( object )
@@ -242,13 +239,13 @@ void plCreatableListHelper::Write( hsStream* s, hsResMgr* mgr )
         hsRAMStream ram;
         size_t nItems = fItems.size();
         hsAssert(nItems < std::numeric_limits<uint16_t>::max(), "Too many items");
-        ram.WriteLE(uint16_t(nItems));
+        ram.WriteLE16(uint16_t(nItems));
         for (const auto& ii : fItems) {
             uint16_t id = ii.first;
             plCreatable* item = ii.second;
             uint16_t classIdx = item->ClassIndex();
-            ram.WriteLE( id );
-            ram.WriteLE( classIdx );
+            ram.WriteLE16(id);
+            ram.WriteLE16(classIdx);
             item->Write( &ram, mgr );
         }
 
@@ -280,13 +277,13 @@ void plCreatableListHelper::Write( hsStream* s, hsResMgr* mgr )
 
         ram.Truncate();
 
-        ram.WriteLE( fFlags );
-        ram.WriteLE( bufSz );
+        ram.WriteByte(fFlags);
+        ram.WriteLE32(bufSz);
 
         if ( fFlags&kCompressed )
         {
             uint32_t zBufSz = buf.size();
-            ram.WriteLE( zBufSz );
+            ram.WriteLE32(zBufSz);
         }
 
         ram.Write( buf.size(), buf.data() );

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetServerSessionInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetServerSessionInfo.cpp
@@ -58,7 +58,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 void plAgeInfoStruct::Read( hsStream * s, hsResMgr* )
 {
-    s->ReadLE(&fFlags);
+    s->ReadByte(&fFlags);
     if (IsFlagSet(kHasAgeFilename))
         plMsgStdStringHelper::Peek(fAgeFilename,s);
     if (IsFlagSet(kHasAgeInstanceName))
@@ -68,18 +68,18 @@ void plAgeInfoStruct::Read( hsStream * s, hsResMgr* )
     if (IsFlagSet(kHasAgeUserDefinedName))
         plMsgStdStringHelper::Peek(fAgeUserDefinedName,s);
     if (IsFlagSet(kHasAgeSequenceNumber))
-        s->ReadLE(&fAgeSequenceNumber);
+        s->ReadLE32(&fAgeSequenceNumber);
     if (IsFlagSet(kHasAgeDescription))
         plMsgStdStringHelper::Peek(fAgeDescription,s);
     if (IsFlagSet(kHasAgeLanguage))
-        s->ReadLE(&fAgeLanguage);
+        s->ReadLE32(&fAgeLanguage);
     UpdateFlags();
 }
 
 void plAgeInfoStruct::Write( hsStream * s, hsResMgr* )
 {
     UpdateFlags();
-    s->WriteLE( fFlags );
+    s->WriteByte(fFlags);
     if ( IsFlagSet( kHasAgeFilename ) )
         plMsgStdStringHelper::Poke(fAgeFilename,s);
     if ( IsFlagSet( kHasAgeInstanceName ) )
@@ -89,11 +89,11 @@ void plAgeInfoStruct::Write( hsStream * s, hsResMgr* )
     if ( IsFlagSet( kHasAgeUserDefinedName ) )
         plMsgStdStringHelper::Poke(fAgeUserDefinedName,s);
     if ( IsFlagSet( kHasAgeSequenceNumber ) )
-        s->WriteLE( fAgeSequenceNumber );
+        s->WriteLE32(fAgeSequenceNumber);
     if ( IsFlagSet( kHasAgeDescription ) )
         plMsgStdStringHelper::Poke(fAgeDescription,s);
     if ( IsFlagSet( kHasAgeLanguage ) )
-        s->WriteLE( fAgeLanguage );
+        s->WriteLE32(fAgeLanguage);
 }
 
 bool plAgeInfoStruct::IsEqualTo( const plAgeInfoStruct * other ) const
@@ -362,11 +362,11 @@ plAgeLinkStruct::plAgeLinkStruct()
 
 void plAgeLinkStruct::Read( hsStream * s, hsResMgr* m)
 {
-    s->ReadLE(&fFlags);
+    s->ReadLE16(&fFlags);
     if (IsFlagSet(kHasAgeInfo))
         fAgeInfo.Read( s,m );
     if ( IsFlagSet( kHasLinkingRules ) )
-        s->ReadLE(&fLinkingRules);
+        s->ReadByte(&fLinkingRules);
     if ( IsFlagSet( kHasSpawnPt_DEAD ) )
     {
         ST::string str;
@@ -390,7 +390,7 @@ void plAgeLinkStruct::Read( hsStream * s, hsResMgr* m)
         fSpawnPoint.Read( s );
     }
     if ( IsFlagSet( kHasAmCCR ) )
-        s->ReadLE(&fAmCCR);
+        s->ReadByte(&fAmCCR);
 
     if ( IsFlagSet( kHasParentAgeFilename ) )
         plMsgStdStringHelper::Peek(fParentAgeFilename,s);
@@ -398,15 +398,15 @@ void plAgeLinkStruct::Read( hsStream * s, hsResMgr* m)
 
 void plAgeLinkStruct::Write( hsStream * s, hsResMgr* m)
 {
-    s->WriteLE( fFlags );
+    s->WriteLE16(fFlags);
     if ( IsFlagSet( kHasAgeInfo ) )
         fAgeInfo.Write( s,m );
     if ( IsFlagSet( kHasLinkingRules ) )
-        s->WriteLE( fLinkingRules );
+        s->WriteByte(fLinkingRules);
     if ( IsFlagSet( kHasSpawnPt ) )
         fSpawnPoint.Write( s );
     if ( IsFlagSet( kHasAmCCR ) )
-        s->WriteLE( fAmCCR );
+        s->WriteByte(fAmCCR);
     if ( IsFlagSet( kHasParentAgeFilename ) )
         plMsgStdStringHelper::Poke(fParentAgeFilename,s);
 }

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.cpp
@@ -837,9 +837,9 @@ int plNetMsgRoomsList::IPokeBuffer(hsStream* stream, uint32_t peekOptions)
     int bytes=plNetMessage::IPokeBuffer(stream, peekOptions);
     if (bytes)
     {
-        int i, numRooms=fRooms.size();
-        stream->WriteLE(numRooms);
-        for(i=0;i<numRooms;i++)
+        size_t numRooms = fRooms.size();
+        stream->WriteLE32((uint32_t)numRooms);
+        for (size_t i = 0; i < numRooms; i++)
         {
             fRooms[i].Write(stream);
             
@@ -942,10 +942,9 @@ int plNetMsgGroupOwner::IPokeBuffer(hsStream* stream, uint32_t peekOptions)
     int bytes=plNetMsgServerToClient::IPokeBuffer(stream, peekOptions);
     if (bytes)
     {
-        int i, numGroups=fGroups.size();
-        stream->WriteLE(numGroups);
-        for(i=0;i<numGroups;i++)
-            fGroups[i].Write(stream);
+        stream->WriteLE32((uint32_t)fGroups.size());
+        for (const GroupInfo& group : fGroups)
+            group.Write(stream);
         
         bytes=stream->GetPosition();
     }

--- a/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
@@ -280,10 +280,9 @@ void plCameraRegionDetector::Read(hsStream* stream, hsResMgr* mgr)
 void plCameraRegionDetector::Write(hsStream* stream, hsResMgr* mgr)
 {
     plDetectorModifier::Write(stream, mgr);
-    stream->WriteLE32(fMessages.size());
-    for(plCameraMsgVec::iterator it = fMessages.begin(); it != fMessages.end(); ++it)
-        mgr->WriteCreatable( stream, *it );
-
+    stream->WriteLE32((uint32_t)fMessages.size());
+    for (plCameraMsg* msg : fMessages)
+        mgr->WriteCreatable(stream, msg);
 }
 
 void plCameraRegionDetector::IHandleEval(plEvalMsg*)

--- a/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
@@ -213,12 +213,12 @@ bool plCollisionDetector::MsgReceive(plMessage* msg)
 void plCollisionDetector::Read(hsStream* stream, hsResMgr* mgr)
 {
     plDetectorModifier::Read(stream, mgr);
-    stream->ReadLE(&fType);
+    stream->ReadByte(&fType);
 }
 void plCollisionDetector::Write(hsStream* stream, hsResMgr* mgr)
 {
     plDetectorModifier::Write(stream, mgr);
-    stream->WriteLE(fType);
+    stream->WriteByte(fType);
 }
 
 /////////////////////////////////
@@ -773,7 +773,7 @@ void plSwimDetector::Write(hsStream *stream, hsResMgr *mgr)
 {
     plSimpleRegionSensor::Write(stream, mgr);
 
-    stream->WriteByte(0);
+    stream->WriteByte(uint8_t(0));
     stream->WriteLEFloat(0.f);
     stream->WriteLEFloat(0.f);
 }
@@ -782,10 +782,11 @@ void plSwimDetector::Read(hsStream *stream, hsResMgr *mgr)
 {
     plSimpleRegionSensor::Read(stream, mgr);
 
-    stream->ReadByte();
-    stream->ReadLEFloat();
-    stream->ReadLEFloat();
+    (void)stream->ReadByte();
+    (void)stream->ReadLEFloat();
+    (void)stream->ReadLEFloat();
 }
+
 bool plSwimDetector::MsgReceive(plMessage *msg)
 {
     plCollideMsg* pCollMsg = plCollideMsg::ConvertNoRef(msg);

--- a/Sources/Plasma/PubUtilLib/plPhysical/plPhysicalSndGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plPhysicalSndGroup.cpp
@@ -93,7 +93,7 @@ void plPhysicalSndGroup::Read( hsStream *s, hsResMgr *mgr )
 {
     hsKeyedObject::Read( s, mgr );
 
-    s->ReadLE( &fGroup );
+    s->ReadLE32(&fGroup);
 
     uint32_t count = s->ReadLE32();
     fImpactSounds.clear();
@@ -113,7 +113,7 @@ void plPhysicalSndGroup::Write( hsStream *s, hsResMgr *mgr )
 {
     hsKeyedObject::Write( s, mgr );
 
-    s->WriteLE( fGroup );
+    s->WriteLE32(fGroup);
 
     s->WriteLE32((uint32_t)fImpactSounds.size());
     for (const plKey& key : fImpactSounds)

--- a/Sources/Plasma/PubUtilLib/plResMgr/plPageInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plPageInfo.cpp
@@ -140,21 +140,18 @@ void plPageInfo::Read( hsStream *s )
             s->ReadSafeString(); // fChapter was never used, and always "District".
         fPage = s->ReadSafeString();
 
-        s->ReadLE( &fMajorVersion );
+        s->ReadLE16(&fMajorVersion);
 
         if (version < 6)
         {
-            uint16_t unusedMinorVersion;
-            s->ReadLE(&unusedMinorVersion);
-            int32_t unusedReleaseVersion;
-            s->ReadLE(&unusedReleaseVersion); // This was always zero... yanked.
-            uint32_t unusedFlags;
-            s->ReadLE(&unusedFlags);
+            (void)s->ReadLE16(); // unused: major version
+            (void)s->ReadLE32(); // unused: release version.  This was always zero... yanked.
+            (void)s->ReadLE32(); // unused: flags
         }
 
-        s->ReadLE( &fChecksum );
-        s->ReadLE( &fDataStart );
-        s->ReadLE( &fIndexStart );
+        s->ReadLE32(&fChecksum);
+        s->ReadLE32(&fDataStart);
+        s->ReadLE32(&fIndexStart);
     }
 
     if (version >= 6)
@@ -177,10 +174,10 @@ void    plPageInfo::Write( hsStream *s )
     fLocation.Write( s );
     s->WriteSafeString( fAge );
     s->WriteSafeString( fPage );
-    s->WriteLE( fMajorVersion );
-    s->WriteLE( fChecksum );
-    s->WriteLE( fDataStart );
-    s->WriteLE( fIndexStart );
+    s->WriteLE16(fMajorVersion);
+    s->WriteLE32(fChecksum);
+    s->WriteLE32(fDataStart);
+    s->WriteLE32(fIndexStart);
     uint16_t numClassVersions = uint16_t(fClassVersions.size());
     s->WriteLE16(numClassVersions);
     for (uint16_t i = 0; i < numClassVersions; i++)

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.cpp
@@ -249,7 +249,8 @@ void plRegistryKeyList::Write(hsStream* s)
     // Rewind and write out data size and key count
     uint32_t endPos = s->GetPosition();
     s->SetPosition(beginPos);
-    s->WriteLE32(endPos-beginPos-sizeof(uint32_t));
+    uint32_t objSize = endPos - beginPos - sizeof(uint32_t);
+    s->WriteLE32(objSize);
     s->SetPosition(countPos);
     s->WriteLE32(keyCount);
     s->SetPosition(endPos);

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.cpp
@@ -205,7 +205,7 @@ void plRegistryKeyList::Read(hsStream* s)
 
     // deprecated flags. used to indicate alphabetically sorted keys for some "optimization"
     // that really appeared to do nothing. no loss.
-    s->ReadByte();
+    (void)s->ReadByte();
 
     uint32_t numKeys = s->ReadLE32();
     fKeys.reserve((numKeys * 3) / 2);
@@ -228,7 +228,7 @@ void plRegistryKeyList::Write(hsStream* s)
     // Save space for the length of our data
     uint32_t beginPos = s->GetPosition();
     s->WriteLE32(0);
-    s->WriteByte(0); // Deprecated flags
+    s->WriteByte(uint8_t(0)); // Deprecated flags
 
     // We only write out keys with data. Fill this value in later...
     uint32_t countPos = s->GetPosition();

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
@@ -245,7 +245,7 @@ void plRegistryPageNode::Write()
     fPageInfo.SetIndexStart(fStream.GetPosition());
 
     // Write our keys
-    fStream.WriteLE32(fKeyLists.size());
+    fStream.WriteLE32((uint32_t)fKeyLists.size());
     for (it = fKeyLists.begin(); it != fKeyLists.end(); it++)
     {
         plRegistryKeyList* keyList = it->second;

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDLMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDLMgr.cpp
@@ -149,7 +149,7 @@ int plSDLMgr::Write(hsStream* s, const plSDL::DescriptorList* dl)
 
     size_t num = dl->size();
     hsAssert(num < std::numeric_limits<uint16_t>::max(), "Too many descriptors");
-    s->WriteLE(uint16_t(num));
+    s->WriteLE16(uint16_t(num));
 
     plSDL::DescriptorList::const_iterator it;
     for (const plStateDescriptor* desc : *dl)
@@ -181,7 +181,7 @@ int plSDLMgr::Read(hsStream* s, plSDL::DescriptorList* dl)
     try
     {       
         // read dtor list
-        s->ReadLE(&num);
+        s->ReadLE16(&num);
 
         int i;
         for(i=0;i<num;i++)

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateDataRecord.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateDataRecord.cpp
@@ -409,8 +409,7 @@ void plStateDataRecord::Write(hsStream* s, float timeConvert, uint32_t writeOpti
 //
 bool plStateDataRecord::ReadStreamHeader(hsStream* s, ST::string* name, int* version, plUoid* objUoid)
 {
-    uint16_t savFlags;
-    s->ReadLE(&savFlags);
+    uint16_t savFlags = s->ReadLE16();
     if (!(savFlags & plSDL::kAddedVarLengthIO))     // using to establish a new version in the header, can delete in 8/03
     {
         *name = "";
@@ -448,7 +447,7 @@ void plStateDataRecord::WriteStreamHeader(hsStream* s, plUoid* objUoid) const
     if (objUoid)
         savFlags |= plSDL::kHasUoid;
 
-    s->WriteLE(savFlags);
+    s->WriteLE16(savFlags);
     s->WriteSafeString(GetDescriptor()->GetName());         
     s->WriteLE16((int16_t)GetDescriptor()->GetVersion());
     if (objUoid)

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateDescriptor.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateDescriptor.cpp
@@ -87,8 +87,7 @@ plVarDescriptor* plStateDescriptor::FindVar(const ST::string& name, int* idx) co
 // 
 bool plStateDescriptor::Read(hsStream* s)
 {
-    uint8_t rwVersion;
-    s->ReadLE(&rwVersion);
+    uint8_t rwVersion = s->ReadByte();
     if (rwVersion != kVersion)
     {
         plNetApp::StaticWarningMsg("StateDescriptor Read/Write version mismatch, mine {}, read {}", kVersion, rwVersion);
@@ -127,16 +126,15 @@ bool plStateDescriptor::Read(hsStream* s)
 // 
 void plStateDescriptor::Write(hsStream* s) const
 {
-    s->WriteLE(kVersion);
+    s->WriteByte(kVersion);
     
     s->WriteSafeString(fName);
 
-    uint16_t version=fVersion;
-    s->WriteLE(version);
+    s->WriteLE16((uint16_t)fVersion);
 
     size_t numVars = fVarsList.size();
     hsAssert(numVars < std::numeric_limits<uint16_t>::max(), "Too many variables");
-    s->WriteLE(uint16_t(numVars));
+    s->WriteLE16(uint16_t(numVars));
 
     VarsList::const_iterator it;
     for (const plVarDescriptor* desc : fVarsList) {

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
@@ -114,8 +114,7 @@ void plStateVarNotificationInfo::Read(hsStream* s, uint32_t readOptions)
 
 void plStateVarNotificationInfo::Write(hsStream* s, uint32_t writeOptions) const
 {
-    uint8_t saveFlags=0;              // unused   
-    s->WriteLE(saveFlags);
+    (void)s->WriteByte(uint8_t(0));   // unused: saveFlags
     s->WriteSafeString(fHintString);
 }
 
@@ -124,8 +123,7 @@ void plStateVarNotificationInfo::Write(hsStream* s, uint32_t writeOptions) const
 /////////////////////////////////////////////////////
 bool plStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t readOptions)
 {
-    uint8_t saveFlags;
-    s->ReadLE(&saveFlags);
+    uint8_t saveFlags = s->ReadByte();
     if (saveFlags & plSDL::kHasNotificationInfo)
     {
         GetNotificationInfo().Read(s, readOptions);
@@ -141,7 +139,7 @@ bool plStateVariable::WriteData(hsStream* s, float timeConvert, uint32_t writeOp
     if (writeNotificationInfo)
         saveFlags |= plSDL::kHasNotificationInfo;
 
-    s->WriteLE(saveFlags);
+    s->WriteByte(saveFlags);
     if (writeNotificationInfo)
     {
         GetNotificationInfo().Write(s, writeOptions);
@@ -1848,7 +1846,7 @@ bool plSimpleStateVariable::IWriteData(hsStream* s, float timeConvert, int idx, 
         {
             hsAssert(fVar.GetAtomicCount()==1, "invalid atomic count");
             plCreatable* cre = fC[j];
-            s->WriteLE16(cre ? cre->ClassIndex() : 0x8000);   // creatable class index
+            s->WriteLE16(cre ? cre->ClassIndex() : uint16_t(0x8000));   // creatable class index
             if (cre)
             {
                 hsRAMStream ramStream;
@@ -1992,7 +1990,7 @@ bool plSimpleStateVariable::WriteData(hsStream* s, float timeConvert, uint32_t w
 
     if (sameAsDefaults)
         saveFlags |= plSDL::kSameAsDefault;
-    s->WriteLE(saveFlags);
+    s->WriteByte(saveFlags);
     
     if (needTimeStamp) {
         // timestamp on write
@@ -2030,8 +2028,7 @@ bool plSimpleStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t re
     plUnifiedTime ut;
     ut.ToEpoch();
     
-    uint8_t saveFlags;
-    s->ReadLE(&saveFlags);
+    uint8_t saveFlags = s->ReadByte();
 
     bool isDirty = ( saveFlags & plSDL::kHasDirtyFlag )!=0;
     bool setDirty = ( isDirty && ( readOptions & plSDL::kKeepDirty ) ) || ( readOptions & plSDL::kMakeDirty );
@@ -2052,8 +2049,7 @@ bool plSimpleStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t re
         // read list size
         if (GetVarDescriptor()->IsVariableLength())
         {
-            uint32_t cnt;
-            s->ReadLE(&cnt);      // have to read as long since we don't know how big the list is
+            uint32_t cnt = s->ReadLE32(); // have to read as long since we don't know how big the list is
 
             if (cnt<plSDL::kMaxListSize)
                 fVar.SetCount(cnt);
@@ -2609,14 +2605,12 @@ bool plSDStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t readOp
 {
     plStateVariable::ReadData(s, timeConvert, readOptions);
 
-    uint8_t saveFlags;
-    s->ReadLE(&saveFlags);    // unused
+    (void)s->ReadByte();    // unused: saveFlags
 
     // read total list size
     if (GetVarDescriptor()->IsVariableLength())
     {
-        uint32_t total;
-        s->ReadLE(&total);
+        uint32_t total = s->ReadLE32();
         Resize(total);
     }
     
@@ -2654,13 +2648,12 @@ bool plSDStateVariable::WriteData(hsStream* s, float timeConvert, uint32_t write
 {   
     plStateVariable::WriteData(s, timeConvert, writeOptions);
 
-    uint8_t saveFlags=0;  // unused   
-    s->WriteLE(saveFlags);
+    s->WriteByte(uint8_t(0));  // unused: saveFlags
 
     // write total list size
     uint32_t total=GetCount();
     if (GetVarDescriptor()->IsVariableLength())
-        s->WriteLE(total);
+        s->WriteLE32(total);
 
     // write dirty list size
     bool dirtyOnly = (writeOptions & plSDL::kDirtyOnly) != 0;

--- a/Sources/Plasma/PubUtilLib/plSDL/plVarDescriptor.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plVarDescriptor.cpp
@@ -149,8 +149,7 @@ void plVarDescriptor::CopyFrom(const plVarDescriptor* other)
 //
 bool plVarDescriptor::Read(hsStream* s) 
 {
-    uint8_t version;
-    s->ReadLE(&version);
+    uint8_t version = s->ReadByte();
     if (version != kVersion)
     {
         if (plSDLMgr::GetInstance()->GetNetApp())
@@ -178,7 +177,7 @@ bool plVarDescriptor::Read(hsStream* s)
 //
 void plVarDescriptor::Write(hsStream* s) const
 {
-    s->WriteLE(kVersion);
+    s->WriteByte(kVersion);
     s->WriteSafeString(fName);
     plMsgStdStringHelper::Poke(fDisplayOptions, s);
     s->WriteLE32(fCount);
@@ -391,5 +390,5 @@ void plSDVarDescriptor::Write(hsStream* s) const
 
     s->WriteSafeString(GetStateDescriptor()->GetName());
     uint16_t version=GetStateDescriptor()->GetVersion();
-    s->WriteLE(version);
+    s->WriteLE16(version);
 }

--- a/Sources/Plasma/PubUtilLib/plScene/plSceneNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plSceneNode.cpp
@@ -117,15 +117,13 @@ void plSceneNode::Write(hsStream* s, hsResMgr* mgr)
 {
     hsKeyedObject::Write(s, mgr);
 
-    int i;
+    s->WriteLE32((uint32_t)fSceneObjects.size());
+    for (plSceneObject* sceneObject : fSceneObjects)
+        mgr->WriteKey(s, sceneObject);
 
-    s->WriteLE32(fSceneObjects.size());
-    for( i = 0; i < fSceneObjects.size(); i++ )
-        mgr->WriteKey(s,fSceneObjects[i]);
-
-    s->WriteLE32(fGenericPool.size());
-    for( i = 0; i < fGenericPool.size(); i++ )
-        mgr->WriteKey(s, fGenericPool[i]);
+    s->WriteLE32((uint32_t)fGenericPool.size());
+    for (hsKeyedObject* generic : fGenericPool)
+        mgr->WriteKey(s, generic);
 }
 
 void plSceneNode::Harvest(plVolumeIsect* isect, std::vector<plDrawVisList>& levList)

--- a/Sources/Plasma/PubUtilLib/plStatGather/plProfileManagerFull.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plProfileManagerFull.cpp
@@ -410,7 +410,7 @@ void plProfileManagerFull::IPrintGroup(hsStream* s, const char* groupName, bool 
                 var->PrintAvg(buf, false);
 
             s->Write(strlen(buf), buf);
-            s->WriteByte(',');
+            s->WriteByte((uint8_t)',');
         }
     }
 }
@@ -460,27 +460,27 @@ void plProfileManagerFull::ILogStats()
         {
             static const char kSpawn[] = "Spawn";
             s.Write(strlen(kSpawn), kSpawn);
-            s.WriteByte(',');
+            s.WriteByte((uint8_t)',');
 
             for (it = groups.begin(); it != groups.end(); it++)
             {
                 ST::string groupName = *it;
                 IPrintGroup(&s, groupName.c_str(), true);
             }
-            s.WriteByte('\r');
-            s.WriteByte('\n');
+            s.WriteByte((uint8_t)'\r');
+            s.WriteByte((uint8_t)'\n');
         }
 
         s.Write(fLogSpawnName.size(), fLogSpawnName.c_str());
-        s.WriteByte(',');
+        s.WriteByte((uint8_t)',');
 
         for (it = groups.begin(); it != groups.end(); it++)
         {
             ST::string groupName = *it;
             IPrintGroup(&s, groupName.c_str());
         }
-        s.WriteByte('\r');
-        s.WriteByte('\n');
+        s.WriteByte((uint8_t)'\r');
+        s.WriteByte((uint8_t)'\n');
 
         s.Close();
     }

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.cpp
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.cpp
@@ -379,14 +379,14 @@ double plUnifiedTime::GetSecsDouble() const
 void plUnifiedTime::Read(hsStream* s)
 {
     fSecs = (time_t)s->ReadLE32();
-    s->ReadLE(&fMicros);
+    s->ReadLE32(&fMicros);
     // preserve fMode
 }
 
 void plUnifiedTime::Write(hsStream* s) const
 {
-    s->WriteLE((uint32_t)fSecs);
-    s->WriteLE(fMicros);
+    s->WriteLE32((uint32_t)fSecs);
+    s->WriteLE32(fMicros);
     // preserve fMode
 }
 

--- a/Sources/Plasma/PubUtilLib/plVault/plDniCoordinateInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plDniCoordinateInfo.cpp
@@ -71,22 +71,21 @@ void plDniCoordinateInfo::CopyFrom( const plDniCoordinateInfo * other )
 
 void plDniCoordinateInfo::Read( hsStream* s, hsResMgr* mgr )
 {
-    uint8_t streamVer;
-    s->ReadLE( &streamVer );
+    uint8_t streamVer = s->ReadByte();
     if ( streamVer==StreamVersion )
     {
-        s->ReadLE( &fHSpans );
-        s->ReadLE( &fVSpans );
-        s->ReadLE( &fTorans );
+        s->ReadLE32(&fHSpans);
+        s->ReadLE32(&fVSpans);
+        s->ReadLE32(&fTorans);
     }
 }
 
 void plDniCoordinateInfo::Write( hsStream* s, hsResMgr* mgr )
 {
-    s->WriteLE( StreamVersion );
-    s->WriteLE( fHSpans );
-    s->WriteLE( fVSpans );
-    s->WriteLE( fTorans );
+    s->WriteByte(StreamVersion);
+    s->WriteLE32(fHSpans);
+    s->WriteLE32(fVSpans);
+    s->WriteLE32(fTorans);
 }
 
 ST::string plDniCoordinateInfo::AsString( int level ) const

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.cpp
@@ -456,12 +456,12 @@ void VaultMarkerGameNode::GetMarkerData(std::vector<VaultMarker>& data) const
 void VaultMarkerGameNode::SetMarkerData(const std::vector<VaultMarker>& data)
 {
     hsVectorStream stream;
-    stream.WriteLE32(data.size());
-    for (auto it = data.begin(); it != data.end(); ++it) {
-        stream.WriteLE32(it->id);
-        stream.WriteSafeString(it->age);
-        it->pos.Write(&stream);
-        stream.WriteSafeString(it->description);
+    stream.WriteLE32((uint32_t)data.size());
+    for (const VaultMarker& marker : data) {
+        stream.WriteLE32(marker.id);
+        stream.WriteSafeString(marker.age);
+        marker.pos.Write(&stream);
+        stream.WriteSafeString(marker.description);
     }
 
     // copies the buffer

--- a/Sources/Tools/MaxComponent/plMultistageStage.cpp
+++ b/Sources/Tools/MaxComponent/plMultistageStage.cpp
@@ -92,13 +92,13 @@ ST::string plBaseStage::GetName()
 
 void plBaseStage::Read(hsStream *stream)
 {
-    stream->ReadLE16();
+    (void)stream->ReadLE16();
     fName = stream->ReadSafeString();
 }
 
 void plBaseStage::Write(hsStream *stream)
 {
-    stream->WriteLE16(1);
+    stream->WriteLE16(uint16_t(1));
     stream->WriteSafeString(fName);
 }
 
@@ -157,7 +157,7 @@ void plStandardStage::Write(hsStream *stream)
 {
     plBaseStage::Write(stream);
 
-    stream->WriteLE16(2);
+    stream->WriteLE16(uint16_t(2));
 
     stream->WriteSafeString(fAnimName);
     stream->WriteLE32(fNumLoops);


### PR DESCRIPTION
This should prevent future surprises when trying to change the type of a member variable which is also streamed, and also ensures compatibility with 64-bit builds.