### PR TITLE
plNetTransport vectors

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -1037,8 +1037,7 @@ std::vector<PyObject*> cyMisc::GetPlayerList()
     if (!nc) // only ever really happens if they try to call us in max... I hope
         return pyPL;
 
-    int i;
-    for( i = 0; i < nc->TransportMgr().GetNumMembers(); i++ )
+    for (size_t i = 0; i < nc->TransportMgr().GetNumMembers(); i++)
     {
         plNetTransportMember *mbr = nc->TransportMgr().GetMember(i);
         plKey avkey = mbr->GetAvatarKey();

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -532,8 +532,7 @@ int cyMisc::GetClientIDFromAvatarKey(pyKey& avatar)
         return (plNetClientMgr::GetInstance()->GetPlayerID());
     }
 
-    std::vector<plNetTransportMember*> members = plNetClientMgr::GetInstance()->TransportMgr().GetMemberListDistSorted();
-    for (plNetTransportMember* mbr : members)
+    for (plNetTransportMember* mbr : plNetClientMgr::GetInstance()->TransportMgr().GetMemberList())
     {
         if (mbr != nullptr && mbr->GetAvatarKey() == avatar.getKey())
         {

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -1438,11 +1438,9 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
         PyObject* player = nullptr;
         if (pramsg->GetAvatarKey()) {
             // try to create the pyPlayer for where this message came from
-            hsSsize_t mbrIndex = plNetClientMgr::GetInstance()->TransportMgr().FindMember(pramsg->GetAvatarKey());
-            if (mbrIndex != -1) {
-                plNetTransportMember *mbr = plNetClientMgr::GetInstance()->TransportMgr().GetMember( mbrIndex );
+            plNetTransportMember *mbr = plNetClientMgr::GetInstance()->TransportMgr().GetMemberByKey(pramsg->GetAvatarKey());
+            if (mbr)
                 player = pyPlayer::New(mbr->GetAvatarKey(), mbr->GetPlayerName(), mbr->GetPlayerID(), mbr->GetDistSq());
-            }
         }
         if (!player)
             player = PyLong_FromLong(0);

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -1438,7 +1438,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
         PyObject* player = nullptr;
         if (pramsg->GetAvatarKey()) {
             // try to create the pyPlayer for where this message came from
-            int mbrIndex = plNetClientMgr::GetInstance()->TransportMgr().FindMember(pramsg->GetAvatarKey());
+            hsSsize_t mbrIndex = plNetClientMgr::GetInstance()->TransportMgr().FindMember(pramsg->GetAvatarKey());
             if (mbrIndex != -1) {
                 plNetTransportMember *mbr = plNetClientMgr::GetInstance()->TransportMgr().GetMember( mbrIndex );
                 player = pyPlayer::New(mbr->GetAvatarKey(), mbr->GetPlayerName(), mbr->GetPlayerID(), mbr->GetDistSq());
@@ -1505,7 +1505,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
     if (pkimsg && pkimsg->GetCommand() == pfKIMsg::kHACKChatMsg) {
         if (!VaultAmIgnoringPlayer(pkimsg->GetPlayerID())) {
             PyObject* player;
-            int mbrIndex = plNetClientMgr::GetInstance()->TransportMgr().FindMember(pkimsg->GetPlayerID());
+            hsSsize_t mbrIndex = plNetClientMgr::GetInstance()->TransportMgr().FindMember(pkimsg->GetPlayerID());
             if (mbrIndex != -1) {
                 plNetTransportMember *mbr = plNetClientMgr::GetInstance()->TransportMgr().GetMember( mbrIndex );
                 player = pyPlayer::New(mbr->GetAvatarKey(), pkimsg->GetUser(), mbr->GetPlayerID(), mbr->GetDistSq());

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -1505,9 +1505,8 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
     if (pkimsg && pkimsg->GetCommand() == pfKIMsg::kHACKChatMsg) {
         if (!VaultAmIgnoringPlayer(pkimsg->GetPlayerID())) {
             PyObject* player;
-            hsSsize_t mbrIndex = plNetClientMgr::GetInstance()->TransportMgr().FindMember(pkimsg->GetPlayerID());
-            if (mbrIndex != -1) {
-                plNetTransportMember *mbr = plNetClientMgr::GetInstance()->TransportMgr().GetMember( mbrIndex );
+            plNetTransportMember *mbr = plNetClientMgr::GetInstance()->TransportMgr().GetMemberByID(pkimsg->GetPlayerID());
+            if (mbr) {
                 player = pyPlayer::New(mbr->GetAvatarKey(), pkimsg->GetUser(), mbr->GetPlayerID(), mbr->GetDistSq());
             } else {
                 // else if we could not find the player in our list, then just return a string of the user's name

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
@@ -652,7 +652,7 @@ std::vector<unsigned long> plAvBrainCritter::IGetAgePlayerIDList() const
     std::vector<unsigned long> playerIDs;
     std::map<unsigned long, bool> tempMap; // slightly hacky way to remove dups
     plNetClientMgr* nc = plNetClientMgr::GetInstance();
-    for (int i = 0; i < nc->TransportMgr().GetNumMembers(); ++i)
+    for (size_t i = 0; i < nc->TransportMgr().GetNumMembers(); ++i)
     {
         plNetTransportMember* mbr = nc->TransportMgr().GetMember(i);
         unsigned long id = mbr->GetPlayerID();

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarMgr.cpp
@@ -807,7 +807,8 @@ int plAvatarMgr::FindSpawnPoint( const char *name ) const
 int plAvatarMgr::WarpPlayerToAnother(bool iMove, uint32_t remoteID)
 {
     plNetTransport &mgr = plNetClientMgr::GetInstance()->TransportMgr();
-    plNetTransportMember *mbr = mgr.GetMember(mgr.FindMember(remoteID));
+    hsSsize_t mbrIdx = mgr.FindMember(remoteID);
+    plNetTransportMember *mbr = mbrIdx >= 0 ? mgr.GetMember(mbrIdx) : nullptr;
 
     if (!mbr)
         return plCCRError::kCantFindPlayer;
@@ -852,7 +853,8 @@ int plAvatarMgr::WarpPlayerToXYZ(float x, float y, float z)
 int plAvatarMgr::WarpPlayerToXYZ(int pid, float x, float y, float z)
 {
     plNetClientMgr* nc=plNetClientMgr::GetInstance();
-    plNetTransportMember* mbr=nc->TransportMgr().GetMember(nc->TransportMgr().FindMember(pid));
+    hsSsize_t mbrIdx = nc->TransportMgr().FindMember(pid);
+    plNetTransportMember* mbr = mbrIdx >= 0 ? nc->TransportMgr().GetMember(mbrIdx) : nullptr;
     plSceneObject *player = plSceneObject::ConvertNoRef(mbr && mbr->GetAvatarKey() ? 
         mbr->GetAvatarKey()->ObjectIsLoaded() : nullptr);
     if (!player)

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarMgr.cpp
@@ -807,8 +807,7 @@ int plAvatarMgr::FindSpawnPoint( const char *name ) const
 int plAvatarMgr::WarpPlayerToAnother(bool iMove, uint32_t remoteID)
 {
     plNetTransport &mgr = plNetClientMgr::GetInstance()->TransportMgr();
-    hsSsize_t mbrIdx = mgr.FindMember(remoteID);
-    plNetTransportMember *mbr = mbrIdx >= 0 ? mgr.GetMember(mbrIdx) : nullptr;
+    plNetTransportMember* mbr = mgr.GetMemberByID(remoteID);
 
     if (!mbr)
         return plCCRError::kCantFindPlayer;
@@ -853,8 +852,7 @@ int plAvatarMgr::WarpPlayerToXYZ(float x, float y, float z)
 int plAvatarMgr::WarpPlayerToXYZ(int pid, float x, float y, float z)
 {
     plNetClientMgr* nc=plNetClientMgr::GetInstance();
-    hsSsize_t mbrIdx = nc->TransportMgr().FindMember(pid);
-    plNetTransportMember* mbr = mbrIdx >= 0 ? nc->TransportMgr().GetMember(mbrIdx) : nullptr;
+    plNetTransportMember* mbr = nc->TransportMgr().GetMemberByID(pid);
     plSceneObject *player = plSceneObject::ConvertNoRef(mbr && mbr->GetAvatarKey() ? 
         mbr->GetAvatarKey()->ObjectIsLoaded() : nullptr);
     if (!player)

--- a/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.cpp
@@ -306,8 +306,7 @@ bool    plSceneInputInterface::MsgReceive( plMessage *msg )
                             bool amCCR = plNetClientMgr::GetInstance()->GetCCRLevel();
                             
                             // is this person a NPC or CCR?
-                            hsSsize_t mbrIdx = plNetClientMgr::GetInstance()->TransportMgr().FindMember(pObj->GetKey());
-                            plNetTransportMember* pMbr = mbrIdx >= 0 ? plNetClientMgr::GetInstance()->TransportMgr().GetMember(mbrIdx) : nullptr;
+                            plNetTransportMember* pMbr = plNetClientMgr::GetInstance()->TransportMgr().GetMemberByKey(pObj->GetKey());
                             if (!pMbr) // whoops - it's a freakin' NPC !
                                 return true;
                             

--- a/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.cpp
@@ -1095,24 +1095,15 @@ void plSceneInputInterface::ISendOfferNotification(plKey& offeree, int ID, bool 
     }
     else
     {
-        plNetTransportMember **members = nullptr;
-        plNetClientMgr::GetInstance()->TransportMgr().GetMemberListDistSorted( members );
-        if (members != nullptr)
+        std::vector<plNetTransportMember*> members = plNetClientMgr::GetInstance()->TransportMgr().GetMemberListDistSorted();
+        for (plNetTransportMember* mbr : members)
         {
-            for(int i = 0; i < plNetClientMgr::GetInstance()->TransportMgr().GetNumMembers(); i++ )
+            if (mbr != nullptr && mbr->GetAvatarKey() == offeree)
             {
-                plNetTransportMember *mbr = members[ i ];
-
-                if (mbr != nullptr && mbr->GetAvatarKey() == offeree)
-                {   
-                    offereeID = mbr->GetPlayerID();
-                    break;
-                }
+                offereeID = mbr->GetPlayerID();
+                break;
             }
         }
-
-        delete [] members;
-
     }
     plNotifyMsg* pMsg = new plNotifyMsg;
     pMsg->AddOfferBookEvent(plNetClientMgr::GetInstance()->GetLocalPlayerKey(), ID, offereeID);

--- a/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.cpp
@@ -306,8 +306,8 @@ bool    plSceneInputInterface::MsgReceive( plMessage *msg )
                             bool amCCR = plNetClientMgr::GetInstance()->GetCCRLevel();
                             
                             // is this person a NPC or CCR?
-                            int mbrIdx=plNetClientMgr::GetInstance()->TransportMgr().FindMember(pObj->GetKey());
-                            plNetTransportMember* pMbr = plNetClientMgr::GetInstance()->TransportMgr().GetMember(mbrIdx);
+                            hsSsize_t mbrIdx = plNetClientMgr::GetInstance()->TransportMgr().FindMember(pObj->GetKey());
+                            plNetTransportMember* pMbr = mbrIdx >= 0 ? plNetClientMgr::GetInstance()->TransportMgr().GetMember(mbrIdx) : nullptr;
                             if (!pMbr) // whoops - it's a freakin' NPC !
                                 return true;
                             

--- a/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.cpp
@@ -1071,7 +1071,7 @@ bool plSceneInputInterface::InterpretInputEvent( plInputEventMsg *pMsg )
 
 
 //// ISendOfferNotification ////////////////////////////////////////////////////////
-void plSceneInputInterface::IManageIgnoredAvatars(plKey& offeree, bool add)
+void plSceneInputInterface::IManageIgnoredAvatars(const plKey& offeree, bool add)
 {
     // tell everyone else to be able to / not to be able to select this avatar
     plInputIfaceMgrMsg* pMsg = nullptr;
@@ -1086,7 +1086,7 @@ void plSceneInputInterface::IManageIgnoredAvatars(plKey& offeree, bool add)
     pMsg->Send();
 }   
 
-void plSceneInputInterface::ISendOfferNotification(plKey& offeree, int ID, bool net)
+void plSceneInputInterface::ISendOfferNotification(const plKey& offeree, int ID, bool net)
 {
     int offereeID = -1;
     if (offeree == plNetClientMgr::GetInstance()->GetLocalPlayerKey())
@@ -1095,8 +1095,7 @@ void plSceneInputInterface::ISendOfferNotification(plKey& offeree, int ID, bool 
     }
     else
     {
-        std::vector<plNetTransportMember*> members = plNetClientMgr::GetInstance()->TransportMgr().GetMemberListDistSorted();
-        for (plNetTransportMember* mbr : members)
+        for (plNetTransportMember* mbr : plNetClientMgr::GetInstance()->TransportMgr().GetMemberList())
         {
             if (mbr != nullptr && mbr->GetAvatarKey() == offeree)
             {

--- a/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plSceneInputInterface.h
@@ -118,8 +118,8 @@ class plSceneInputInterface : public plInputInterface
 
         bool    IWorldPosMovedSinceLastLOSCheck();
         void ClearClickableMap();
-        void ISendOfferNotification(plKey& offeree, int ID, bool net);
-        void IManageIgnoredAvatars(plKey& offeree, bool add);
+        void ISendOfferNotification(const plKey& offeree, int ID, bool net);
+        void IManageIgnoredAvatars(const plKey& offeree, bool add);
         void ISendAvatarDisabledNotification(bool enabled);
         void ILinkOffereeToAge();
     public:

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -1056,8 +1056,7 @@ ST::string plNetClientMgr::GetPlayerName(const plKey avKey) const
     if (!avKey || avKey == GetLocalPlayerKey())
         return NetCommGetPlayer()->playerName;
 
-    hsSsize_t mbrIdx = TransportMgr().FindMember(avKey);
-    plNetTransportMember* mbr = mbrIdx >= 0 ? TransportMgr().GetMember(mbrIdx) : nullptr;
+    plNetTransportMember* mbr = TransportMgr().GetMemberByKey(avKey);
     return mbr ? mbr->GetPlayerName() : ST::string();
 }
 

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -369,9 +369,8 @@ int plNetClientMgr::IPrepMsg(plNetMessage* msg)
             int i;
             for(i=0;i<rl->GetNumReceivers();i++)
             {
-                hsSsize_t idx = fTransport.FindMember(rl->GetReceiverPlayerID(i));
-                hsAssert(idx!=-1, "error finding transport mbr");
-                plNetTransportMember* tm = fTransport.GetMember(idx);
+                plNetTransportMember* tm = fTransport.GetMemberByID(rl->GetReceiverPlayerID(i));
+                hsAssert(tm, "error finding transport mbr");
                 if (tm->IsPeerToPeer())
                     fTransport.SubscribeToChannelGrp(tm, kNetChanListenListUpdate);
             }
@@ -1067,8 +1066,7 @@ ST::string plNetClientMgr::GetPlayerNameById (unsigned playerId) const {
     if (NetCommGetPlayer()->playerInt == playerId)
         return NetCommGetPlayer()->playerName;
 
-    hsSsize_t mbrIdx = TransportMgr().FindMember(playerId);
-    plNetTransportMember * mbr = mbrIdx >= 0 ? TransportMgr().GetMember(mbrIdx) : nullptr;
+    plNetTransportMember* mbr = TransportMgr().GetMemberByID(playerId);
     return mbr ? mbr->GetPlayerName() : ST::string();
 }
 
@@ -1287,12 +1285,12 @@ bool plNetClientMgr::IHandlePlayerPageMsg(plPlayerPageMsg *playerMsg)
             {
                 hsLogEntry(DebugMsg("Adding REMOTE player {}\n", playerKey->GetName()));
                 playerSO->SetNetGroupConstant(plNetGroup::kNetGroupRemotePlayer);
-                hsSsize_t mbrIdx = fTransport.FindMember(playerMsg->fClientID);
-                if (mbrIdx != -1)
+                plNetTransportMember* mbr = fTransport.GetMemberByID(playerMsg->fClientID);
+                if (mbr)
                 {
                     hsAssert(playerKey, "NIL KEY?");
                     hsAssert(!playerKey->GetName().empty(), "UNNAMED KEY");
-                    fTransport.GetMember(mbrIdx)->SetAvatarKey(playerKey);
+                    mbr->SetAvatarKey(playerKey);
                 }
                 else
                 {

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrShow.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrShow.cpp
@@ -94,11 +94,9 @@ void plNetClientMgr::IShowLists()
     int baseY=y;
     txt.DrawString(x,y,"   Members",255,255,255,255,plDebugText::kStyleBold);
     y+=yOff;
-    plNetTransportMember** members = nullptr;
-    fTransport.GetMemberListDistSorted(members);
-    for(i=0;i<fTransport.GetNumMembers();i++)
+    std::vector<plNetTransportMember*> members = fTransport.GetMemberListDistSorted();
+    for (plNetTransportMember* mbr : members)
     {
-        plNetTransportMember* mbr=members[i];
         hsAssert(mbr, "ShowLists: nil member?");
         if (mbr->IsServer())
             continue;
@@ -115,8 +113,6 @@ void plNetClientMgr::IShowLists()
             ~(plNetTransportMember::kSendingVoice|plNetTransportMember::kSendingActions));
     }
 
-    delete [] members;
-    
     // LISTENLIST
     x+=xOff;
     y=baseY;
@@ -223,8 +219,7 @@ void plNetClientMgr::IShowRelevanceRegions()
     const char* title = "Name / In / Care";
     txt.DrawString(x, y - yOff, title, 255, 255, 255, 255, plDebugText::kStyleBold);
 
-    plNetTransportMember** members = nullptr;
-    fTransport.GetMemberListDistSorted(members);
+    std::vector<plNetTransportMember*> members =  fTransport.GetMemberListDistSorted();
 
     //
     // Print out the player names in the first column
@@ -235,10 +230,8 @@ void plNetClientMgr::IShowRelevanceRegions()
     maxPlayerName = std::max(maxPlayerName, txt.CalcStringWidth(GetPlayerName().c_str()));
     y += yOff;
 
-    int i;
-    for (i = 0; i < fTransport.GetNumMembers(); i++)
+    for (plNetTransportMember* mbr : members)
     {
-        plNetTransportMember* mbr = members[i];
         hsAssert(mbr, "ShowLists: nil member?");
         if (mbr->IsServer())
             continue;
@@ -274,9 +267,8 @@ void plNetClientMgr::IShowRelevanceRegions()
         }
     }
 
-    for (i = 0; i < fTransport.GetNumMembers(); i++)
+    for (plNetTransportMember* mbr : members)
     {
-        plNetTransportMember* mbr = members[i];
         if (mbr->IsServer())
             continue;
 
@@ -296,8 +288,6 @@ void plNetClientMgr::IShowRelevanceRegions()
             }
         }
     }
-
-    delete [] members;  
 }
 
 void plNetClientMgr::IShowAvatars()
@@ -305,7 +295,7 @@ void plNetClientMgr::IShowAvatars()
     plDebugText     &txt = plDebugText::Instance();
     txt.SetFont( "Courier New", 6 );
 
-    int y,x,i;
+    int y, x;
     const int yOff=10, xOff=285, startY=100, startX=10;
     char str[256];
 
@@ -345,11 +335,9 @@ void plNetClientMgr::IShowAvatars()
     y=startY;
     x=startX;
 
-    plNetTransportMember** members = nullptr;
-    fTransport.GetMemberListDistSorted(members);
-    for(i=0;i<fTransport.GetNumMembers();i++)
+    std::vector<plNetTransportMember*> members = fTransport.GetMemberListDistSorted();
+    for (plNetTransportMember* mbr : members)
     {
-        plNetTransportMember* mbr=members[i];
         hsAssert(mbr, "ShowLists: nil member?");
         if (mbr->IsServer())
             continue;
@@ -384,8 +372,6 @@ void plNetClientMgr::IShowAvatars()
         }
 
     }
-
-    delete [] members;
 
     txt.SetFont( "Courier New", 8 );
 }

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrVoice.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrVoice.cpp
@@ -243,8 +243,7 @@ bool plNetClientMgr::IUpdateListenList(double secs)
                 hsMatrix44 l2w=locPlayer->GetCoordinateInterface()->GetLocalToWorld();
                 hsPoint3 locPlayerPos=l2w.GetTranslate();
 
-                int i;
-                for(i=0;i<fTransport.GetNumMembers();i++)
+                for (size_t i = 0; i < fTransport.GetNumMembers(); i++)
                 {
                     fTransport.GetMember(i)->SetDistSq(FLT_MAX);
 

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrVoice.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrVoice.cpp
@@ -374,21 +374,15 @@ void plNetClientMgr::IHandleNetVoiceListMsg(plNetVoiceListMsg* msg)
         // add in the members we receive from python
         for (uint32_t clientId : clientList)
         {
-            plNetTransportMember **members = nullptr;
-            plNetClientMgr::GetInstance()->TransportMgr().GetMemberListDistSorted( members );
-                    
-            if (members != nullptr)
+            std::vector<plNetTransportMember*> members = plNetClientMgr::GetInstance()->TransportMgr().GetMemberListDistSorted();
+
+            for (plNetTransportMember* mbr : members)
             {
-                for(int j= 0; j < plNetClientMgr::GetInstance()->TransportMgr().GetNumMembers(); j++ )
+                if (mbr != nullptr && mbr->GetAvatarKey() != nullptr && mbr->GetPlayerID() == clientId)
                 {
-                    plNetTransportMember *mbr = members[ j ];
-                    if (mbr != nullptr && mbr->GetAvatarKey() != nullptr && mbr->GetPlayerID() == clientId)
-                    {
-                        plNetClientMgr::GetInstance()->GetListenList()->AddMember(mbr);
-                    }
+                    plNetClientMgr::GetInstance()->GetListenList()->AddMember(mbr);
                 }
             }
-            delete [] members;
         }
     }
     else

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
@@ -334,7 +334,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgGameMessage)
                     plLoadCloneMsg* loadClone = plLoadCloneMsg::ConvertNoRef(gameMsg);
                     if (loadClone)
                     {
-                        int idx = nc->fTransport.FindMember(loadClone->GetOriginatingPlayerID());
+                        hsSsize_t idx = nc->fTransport.FindMember(loadClone->GetOriginatingPlayerID());
                         if (idx == -1)
                         {
                             hsLogEntry( nc->DebugMsg( "Ignoring load clone because player isn't in our players list: {}", loadClone->GetOriginatingPlayerID()) );
@@ -368,7 +368,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgGameMessage)
             // Debug
             if (m->GetHasPlayerID())
             {
-                int idx=nc->fTransport.FindMember(m->GetPlayerID());
+                hsSsize_t idx = nc->fTransport.FindMember(m->GetPlayerID());
                 plNetTransportMember* mbr = idx != -1 ? nc->fTransport.GetMember(idx) : nullptr;
                 if (mbr)
                     mbr->SetTransportFlags(mbr->GetTransportFlags() | plNetTransportMember::kSendingActions);
@@ -402,7 +402,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgVoice)
         return hsOK;
     }
 
-    int idx=nc->fTransport.FindMember(m->GetPlayerID());
+    hsSsize_t idx = nc->fTransport.FindMember(m->GetPlayerID());
     plNetTransportMember* mbr = idx != -1 ? nc->fTransport.GetMember(idx) : nullptr;
 
     if (mbr) {
@@ -446,28 +446,26 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgMembersList)
         m->ClassName(), m->AsStdString(), m->GetNetCoreMsgLen()) );
 */
 
-    int i;
-
     // remove existing members, except server
-    for( i=nc->fTransport.GetNumMembers()-1 ; i>=0; i--  )
+    for (hsSsize_t i = nc->fTransport.GetNumMembers() - 1; i >= 0; i--)
     {
         if (!nc->fTransport.GetMember(i)->IsServer())
         {           
-            nc->fTransport.RemoveMember(i);         
+            nc->fTransport.RemoveMember(i);
         }
-    } // for         
+    }
 
     // update the members list from the msg.
     // this app is not one of the members in the msg
-    for( i=0 ;i<m->MemberListInfo()->GetNumMembers() ;i++  )
+    for (size_t i = 0; i < m->MemberListInfo()->GetNumMembers(); i++)
     {
         plNetTransportMember* mbr = new plNetTransportMember(nc);
         IFillInTransportMember(m->MemberListInfo()->GetMember(i), mbr);
         hsLogEntry(nc->DebugMsg("\tAdding transport member, name={}, p2p={}, plrID={}\n", mbr->AsString(), mbr->IsPeerToPeer(), mbr->GetPlayerID()));
-        int idx=nc->fTransport.AddMember(mbr);
+        hsSsize_t idx = nc->fTransport.AddMember(mbr);
         hsAssert(idx>=0, "Failed adding member?");
             
-    } // for         
+    }
 
     // new player has been aded send local MembersUpdate msg
     plMemberUpdateMsg* mu = new plMemberUpdateMsg;
@@ -490,7 +488,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgMemberUpdate)
     if (m->AddingMember())
     {
         plNetTransportMember* mbr = nullptr;
-        int idx = nc->fTransport.FindMember(m->MemberInfo()->GetClientGuid()->GetPlayerID());
+        hsSsize_t idx = nc->fTransport.FindMember(m->MemberInfo()->GetClientGuid()->GetPlayerID());
         if ( idx>=0 )
             mbr = nc->fTransport.GetMember(idx);
         else
@@ -506,7 +504,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgMemberUpdate)
     }
     else
     {
-        int idx=nc->fTransport.FindMember(m->MemberInfo()->GetClientGuid()->GetPlayerID());
+        hsSsize_t idx = nc->fTransport.FindMember(m->MemberInfo()->GetClientGuid()->GetPlayerID());
         if (idx<0)
         {
             hsLogEntry( nc->DebugMsg("\tCan't find member to remove.") );
@@ -535,7 +533,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgListenListUpdate)
         m->ClassName(), m->AsStdString(), m->GetNetCoreMsgLen()) );
 */
 
-    int idx=nc->fTransport.FindMember(m->GetPlayerID());
+    hsSsize_t idx = nc->fTransport.FindMember(m->GetPlayerID());
     plNetTransportMember* tm = (idx == -1 ? nullptr : nc->fTransport.GetMember(idx));
     if(!tm)
     {

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
@@ -368,8 +368,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgGameMessage)
             // Debug
             if (m->GetHasPlayerID())
             {
-                hsSsize_t idx = nc->fTransport.FindMember(m->GetPlayerID());
-                plNetTransportMember* mbr = idx != -1 ? nc->fTransport.GetMember(idx) : nullptr;
+                plNetTransportMember* mbr = nc->fTransport.GetMemberByID(m->GetPlayerID());
                 if (mbr)
                     mbr->SetTransportFlags(mbr->GetTransportFlags() | plNetTransportMember::kSendingActions);
             }
@@ -402,8 +401,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgVoice)
         return hsOK;
     }
 
-    hsSsize_t idx = nc->fTransport.FindMember(m->GetPlayerID());
-    plNetTransportMember* mbr = idx != -1 ? nc->fTransport.GetMember(idx) : nullptr;
+    plNetTransportMember* mbr = nc->fTransport.GetMemberByID(m->GetPlayerID());
 
     if (mbr) {
         key = mbr->GetAvatarKey();
@@ -533,8 +531,7 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgListenListUpdate)
         m->ClassName(), m->AsStdString(), m->GetNetCoreMsgLen()) );
 */
 
-    hsSsize_t idx = nc->fTransport.FindMember(m->GetPlayerID());
-    plNetTransportMember* tm = (idx == -1 ? nullptr : nc->fTransport.GetMember(idx));
+    plNetTransportMember* tm = nc->fTransport.GetMemberByID(m->GetPlayerID());
     if(!tm)
     {
 #if 0

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
@@ -707,8 +707,7 @@ void plNetLinkingMgr::OfferLinkToPlayer( const plAgeLinkStruct * inInfo, uint32_
 
     plNetClientMgr* mgr = plNetClientMgr::GetInstance();
     plNetTransport& transport = mgr->TransportMgr();
-    hsSsize_t guestIdx = transport.FindMember(playerID);
-    plNetTransportMember* guestMem = guestIdx >= 0 ? transport.GetMember(guestIdx) : nullptr;
+    plNetTransportMember* guestMem = transport.GetMemberByID(playerID);
 
     if (guestMem) {
         plLinkToAgeMsg* linkM = new plLinkToAgeMsg(inInfo);
@@ -725,8 +724,7 @@ void plNetLinkingMgr::OfferLinkToPlayer( const plAgeLinkStruct * inInfo, uint32_
     plNetClientMgr *mgr = plNetClientMgr::GetInstance();
 
     plNetTransport &transport = mgr->TransportMgr();
-    int guestIdx = transport.FindMember(playerID);
-    plNetTransportMember *guestMem = transport.GetMember(guestIdx);         // -1 ?
+    plNetTransportMember* guestMem = transport.GetMemberByID(playerID);
     if (guestMem)
     {
         plLinkToAgeMsg* linkM = new plLinkToAgeMsg(inInfo);

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
@@ -707,8 +707,8 @@ void plNetLinkingMgr::OfferLinkToPlayer( const plAgeLinkStruct * inInfo, uint32_
 
     plNetClientMgr* mgr = plNetClientMgr::GetInstance();
     plNetTransport& transport = mgr->TransportMgr();
-    int guestIdx = transport.FindMember(playerID);
-    plNetTransportMember* guestMem = transport.GetMember(guestIdx);         // -1 ?
+    hsSsize_t guestIdx = transport.FindMember(playerID);
+    plNetTransportMember* guestMem = guestIdx >= 0 ? transport.GetMember(guestIdx) : nullptr;
 
     if (guestMem) {
         plLinkToAgeMsg* linkM = new plLinkToAgeMsg(inInfo);

--- a/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.cpp
@@ -136,6 +136,12 @@ plNetTransportMember* plNetTransport::GetMemberByID(uint32_t playerID) const
     return (memberIdx < 0) ? nullptr : fMembers[memberIdx];
 }
 
+plNetTransportMember* plNetTransport::GetMemberByKey(const plKey& avKey) const
+{
+    hsSsize_t memberIdx = FindMember(avKey);
+    return (memberIdx < 0) ? nullptr : fMembers[memberIdx];
+}
+
 //
 // return array index or -1
 //

--- a/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.cpp
@@ -130,6 +130,12 @@ void plNetTransport::RemoveMember(plNetTransportMember* mbr)
     IRemoveMember(mbr);
 }
 
+plNetTransportMember* plNetTransport::GetMemberByID(uint32_t playerID) const
+{
+    hsSsize_t memberIdx = FindMember(playerID);
+    return (memberIdx < 0) ? nullptr : fMembers[memberIdx];
+}
+
 //
 // return array index or -1
 //

--- a/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.cpp
@@ -348,28 +348,18 @@ void plNetTransport::SetNumChannels(int n)
         fChannelGroups.resize(n);
 }
 
-
-int compare( const void* arg1, const void *arg2 )
-{
-    plNetTransportMember** m1 = (plNetTransportMember**)arg1;
-    plNetTransportMember** m2 = (plNetTransportMember**)arg2;
-    float d1=m1 ? (*m1)->GetDistSq() : FLT_MAX;
-    float d2=m2 ? (*m2)->GetDistSq() : FLT_MAX;
-    return (int)(d1-d2);
-}
-
 //
 // create a members list sorted by dist.
-// caller must delete this when done
 //
-void plNetTransport::GetMemberListDistSorted(plNetTransportMember**& listIn) const
+std::vector<plNetTransportMember*> plNetTransport::GetMemberListDistSorted() const
 {
-    // copy members list
-    listIn = new plNetTransportMember* [fMembers.size()];
-    int i;
-    for (i=0; i<fMembers.size(); i++)
-            listIn[i]=fMembers[i];
+    std::vector<plNetTransportMember*> sortedList = fMembers;
 
-    // sort members list
-    qsort(listIn, fMembers.size(), sizeof(plNetTransportMember*), compare);
+    std::sort(sortedList.begin(), sortedList.end(),
+              [](plNetTransportMember* l, plNetTransportMember* r) {
+                  const float d1 = l ? l->GetDistSq() : FLT_MAX;
+                  const float d2 = r ? r->GetDistSq() : FLT_MAX;
+                  return d1 < d2;
+              });
+    return sortedList;
 }

--- a/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.h
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.h
@@ -54,13 +54,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 class plKey;
 class plNetTransportMember;
-typedef std::vector<plNetTransportMember*> plMembersList;
 class plNetMessage;
+
 class plNetTransport
 {
 private:
-    plMembersList fMembers;                     // master list of all members in the game, server is member[0]
-    std::vector<plMembersList> fChannelGroups;  // members grouped by channel
+    typedef std::vector<plNetTransportMember*> MembersList;
+    MembersList fMembers;                     // master list of all members in the game, server is member[0]
+    std::vector<MembersList> fChannelGroups;  // members grouped by channel
 
     void IUnSubscribeToAllChannelGrps(plNetTransportMember* mbr);
     void IRemoveMember(plNetTransportMember* mbr);
@@ -72,14 +73,14 @@ public:
     
     // master list ops
     std::vector<plNetTransportMember*> GetMemberListDistSorted() const; // allocates and sorts array
-    int FindMember(const plKey avKey) const;                    // return array index or -1
-    int FindMember(uint32_t playerID) const;                      // return array index or -1
-    int FindMember(const plNetTransportMember* mbr);            // return array index or -1
-    int AddMember(plNetTransportMember* mbr);                   // to master list, if not there
-    bool RemoveMember(plNetTransportMember* mbr);             // from master list and all channels
-    bool RemoveMember(int idx);                               // from master list and all channels
-    int GetNumMembers() const { return fMembers.size(); }
-    plNetTransportMember* GetMember(int i) const { return i >= 0 && i < fMembers.size() ? fMembers[i] : nullptr; }
+    hsSsize_t FindMember(const plKey& avKey) const;             // return array index or -1
+    hsSsize_t FindMember(uint32_t playerID) const;              // return array index or -1
+    hsSsize_t FindMember(const plNetTransportMember* mbr);      // return array index or -1
+    hsSsize_t AddMember(plNetTransportMember* mbr);             // to master list, if not there
+    void RemoveMember(plNetTransportMember* mbr);               // from master list and all channels
+    void RemoveMember(size_t idx);                              // from master list and all channels
+    size_t GetNumMembers() const { return fMembers.size(); }
+    plNetTransportMember* GetMember(size_t i) const { return i < fMembers.size() ? fMembers[i] : nullptr; }
     void ClearMembers();
 
     // channel group ops

--- a/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.h
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.h
@@ -71,7 +71,7 @@ public:
     void DumpState();
     
     // master list ops
-    void GetMemberListDistSorted(plNetTransportMember**& listPtr) const;    // allocates and sorts array
+    std::vector<plNetTransportMember*> GetMemberListDistSorted() const; // allocates and sorts array
     int FindMember(const plKey avKey) const;                    // return array index or -1
     int FindMember(uint32_t playerID) const;                      // return array index or -1
     int FindMember(const plNetTransportMember* mbr);            // return array index or -1

--- a/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.h
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.h
@@ -82,6 +82,7 @@ public:
     size_t GetNumMembers() const { return fMembers.size(); }
     plNetTransportMember* GetMember(size_t i) const { return i < fMembers.size() ? fMembers[i] : nullptr; }
     plNetTransportMember* GetMemberByID(uint32_t playerID) const;
+    plNetTransportMember* GetMemberByKey(const plKey& avKey) const;
     const std::vector<plNetTransportMember*>& GetMemberList() const { return fMembers; }
     void ClearMembers();
 

--- a/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.h
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.h
@@ -81,6 +81,7 @@ public:
     void RemoveMember(size_t idx);                              // from master list and all channels
     size_t GetNumMembers() const { return fMembers.size(); }
     plNetTransportMember* GetMember(size_t i) const { return i < fMembers.size() ? fMembers[i] : nullptr; }
+    plNetTransportMember* GetMemberByID(uint32_t playerID) const;
     const std::vector<plNetTransportMember*>& GetMemberList() const { return fMembers; }
     void ClearMembers();
 

--- a/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.h
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransport.h
@@ -81,6 +81,7 @@ public:
     void RemoveMember(size_t idx);                              // from master list and all channels
     size_t GetNumMembers() const { return fMembers.size(); }
     plNetTransportMember* GetMember(size_t i) const { return i < fMembers.size() ? fMembers[i] : nullptr; }
+    const std::vector<plNetTransportMember*>& GetMemberList() const { return fMembers; }
     void ClearMembers();
 
     // channel group ops

--- a/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransportMember.h
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransportMember.h
@@ -85,7 +85,7 @@ public:
     void SetDistSq(float s) { fDistSq=s; }
     float GetDistSq() const { return fDistSq; }
 
-    plKey GetAvatarKey() { return fAvatarKey; }
+    plKey GetAvatarKey() const { return fAvatarKey; }
     void SetAvatarKey(plKey k)
         {
             fAvatarKey=k;

--- a/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransportMember.h
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/plNetTransportMember.h
@@ -88,7 +88,7 @@ public:
     plKey GetAvatarKey() const { return fAvatarKey; }
     void SetAvatarKey(plKey k)
         {
-            fAvatarKey=k;
+            fAvatarKey=std::move(k);
         }
     void SetPlayerName(const ST::string & value) { fPlayerName=value;}
     ST::string GetPlayerName() const { return fPlayerName;}


### PR DESCRIPTION
* Clean up the final use of `qsort` by using a `vector` instead of a raw heap allocation for `plNetTransport::GetMemberListDistSorted`
* Clean up other accessors and vector use in `plNetTransport` for the existing vectors.