### PR TITLE
Fix some x64 compatibility issues

### DIFF
--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -653,7 +653,8 @@ static void SaveUserPass(LoginDialogParam* pLoginParam, wchar_t* password)
     HKEY hKey;
     RegCreateKeyEx(HKEY_CURRENT_USER, ST::format("Software\\Cyan, Inc.\\{}\\{}", plProduct::LongName(), GetServerDisplayName()).c_str(), 0, nullptr, REG_OPTION_NON_VOLATILE, KEY_WRITE, nullptr, &hKey, nullptr);
     RegSetValueExW(hKey, L"LastAccountName", 0, REG_SZ, (LPBYTE) pLoginParam->username, sizeof(pLoginParam->username));
-    RegSetValueEx(hKey, "RememberPassword", 0, REG_DWORD, (LPBYTE) &(pLoginParam->remember), sizeof(LPBYTE));
+    uint32_t rememberAccount = pLoginParam->remember;
+    RegSetValueExW(hKey, L"RememberPassword", 0, REG_DWORD, (LPBYTE) &rememberAccount, sizeof(rememberAccount));
     RegCloseKey(hKey);
 
     // If the password field is the fake string
@@ -684,7 +685,7 @@ static void LoadUserPass(LoginDialogParam *pLoginParam)
     DWORD acctLen = sizeof(accountName), remLen = sizeof(rememberAccount);
     RegOpenKeyEx(HKEY_CURRENT_USER, ST::format("Software\\Cyan, Inc.\\{}\\{}", plProduct::LongName(), GetServerDisplayName()).c_str(), 0, KEY_QUERY_VALUE, &hKey);
     RegQueryValueExW(hKey, L"LastAccountName", nullptr, nullptr, (LPBYTE) &accountName, &acctLen);
-    RegQueryValueEx(hKey, "RememberPassword", nullptr, nullptr, (LPBYTE) &rememberAccount, &remLen);
+    RegQueryValueExW(hKey, L"RememberPassword", nullptr, nullptr, (LPBYTE) &rememberAccount, &remLen);
     RegCloseKey(hKey);
 
     pLoginParam->remember = false;

--- a/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.cpp
@@ -92,7 +92,7 @@ void plDispatchLog::LogStatusBarChange(const char* name, const char* action)
     memset(&mbi, 0, sizeof(MEMORY_BASIC_INFORMATION));
 
     // Note: this will return shared mem too on Win9x.  There's a way to catch that, but it's too slow -Colin
-    uint32_t processMemUsed = 0;
+    size_t processMemUsed = 0;
     void* curAddress = nullptr;
     while (VirtualQuery(curAddress, &mbi, sizeof(MEMORY_BASIC_INFORMATION)) == sizeof(MEMORY_BASIC_INFORMATION))
     {

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -344,7 +344,7 @@ bool    pfConsoleEngine::RunCommand( char *line, void (*PrintFn)( const char * )
             pfConsoleContext    &context = pfConsoleContext::GetRootContext();
 
             // Potential variable, see if we can find it
-            int32_t idx = context.FindVar( ptr + 1 );
+            hsSsize_t idx = context.FindVar( ptr + 1 );
             if( idx == -1 )
             {
                 ISetErrorMsg( "Invalid console variable name" );

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Nt/pnAceNt.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Nt/pnAceNt.cpp
@@ -175,11 +175,7 @@ static void NtWorkerThreadProc() {
             (void) GetQueuedCompletionStatus(
                 s_ioPort,
                 &bytes,
-            #ifdef _WIN64
                 (PULONG_PTR) &ntObj,
-            #else
-                (LPDWORD) &ntObj,
-            #endif
                 (LPOVERLAPPED *) &op,
                 sleepMs
             );
@@ -209,11 +205,7 @@ void INtConnPostOperation (NtObject * ntObj, Operation * op, unsigned bytes) {
     PostQueuedCompletionStatus(
         s_ioPort,
         bytes,
-        #ifdef _WIN64
-            (ULONG_PTR) ntObj,
-        #else
-            (DWORD) ntObj,
-        #endif
+        (ULONG_PTR) ntObj,
         &op->overlapped
     );
 }
@@ -228,7 +220,7 @@ AsyncId INtConnSequenceStart (NtObject * ntObj) {
 
 //===========================================================================
 bool INtConnInitialize (NtObject * ntObj) {
-    if (!CreateIoCompletionPort(ntObj->handle, s_ioPort, (DWORD) ntObj, 0)) {
+    if (!CreateIoCompletionPort(ntObj->handle, s_ioPort, (ULONG_PTR) ntObj, 0)) {
         LogMsg(kLogFatal, "CreateIoCompletionPort failed");
         return false;
     }

--- a/Sources/Plasma/NucleusLib/pnNetCli/Intern.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/Intern.h
@@ -75,7 +75,7 @@ const NetMsgInitRecv * NetMsgChannelFindRecvMessage (
 );
 const NetMsgInitSend * NetMsgChannelFindSendMessage (
     NetMsgChannel * channel,
-    unsigned        messageId
+    uintptr_t       messageId
 );
 void NetMsgChannelGetDhConstants (
     const NetMsgChannel *   channel,

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcChannel.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcChannel.cpp
@@ -346,7 +346,7 @@ const NetMsgInitRecv * NetMsgChannelFindRecvMessage (
 //============================================================================
 const NetMsgInitSend * NetMsgChannelFindSendMessage (
     NetMsgChannel * channel,
-    unsigned        messageId
+    uintptr_t       messageId
 ) {
     // Is message in range?
     ASSERT(messageId < channel->m_sendMsgs.size());

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.cpp
@@ -554,7 +554,7 @@ plDynaDecalInfo& plDynaDecalMgr::IGetDecalInfo(uintptr_t id, const plKey& key)
     return iter->second;
 }
 
-void plDynaDecalMgr::IRemoveDecalInfo(uint32_t id)
+void plDynaDecalMgr::IRemoveDecalInfo(uintptr_t id)
 {
     plDynaDecalMap::iterator iter = fDecalMap.find(id);
     if( iter != fDecalMap.end() )

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.h
@@ -190,7 +190,7 @@ protected:
     void                IWetInfo(plDynaDecalInfo& info, const plDynaDecalEnableMsg* enaMsg) const;
     float            IHowWet(plDynaDecalInfo& info, double t) const;
     plDynaDecalInfo&    IGetDecalInfo(uintptr_t id, const plKey& key);
-    void                IRemoveDecalInfo(uint32_t id);
+    void                IRemoveDecalInfo(uintptr_t id);
     void                IRemoveDecalInfos(const plKey& key);
 
     hsGMaterial*        ISetAuxMaterial(plAuxSpan* aux, hsGMaterial* mat, bool rtLit);

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -1128,7 +1128,7 @@ void    plFont::IRenderChar8To32AlphaPremShadow( const plFont::plCharacter &c )
     y = fRenderInfo.fClipRect.fY - fRenderInfo.fY + (int16_t)c.fBaseline;
     if( y < -2 )
         y = -2;
-    destBasePtr = (uint32_t *)( (uint8_t *)destBasePtr + y*fRenderInfo.fDestStride );
+    destBasePtr = (uint32_t *)((uint8_t *)destBasePtr + y * int32_t(fRenderInfo.fDestStride));
 
     thisHeight = fRenderInfo.fMaxHeight + (int16_t)c.fBaseline;
     if( thisHeight > (int16_t)c.fHeight + 2 )

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -746,7 +746,7 @@ void    plFont::IRenderLoop( const wchar_t *string, int32_t maxCount )
 void    plFont::IRenderChar1To32( const plFont::plCharacter &c )
 {
     uint8_t   bitMask, *src = fBMapData + c.fBitmapOff;
-    uint32_t  *destPtr, *destBasePtr = (uint32_t *)( fRenderInfo.fDestPtr - c.fBaseline * fRenderInfo.fDestStride );
+    uint32_t  *destPtr, *destBasePtr = (uint32_t *)(fRenderInfo.fDestPtr - c.fBaseline * int32_t(fRenderInfo.fDestStride));
     uint16_t  x, y;
 
     

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
@@ -603,7 +603,7 @@ bool plStatusLog::IPrintLineToFile( const char *line, uint32_t count )
             }
             if (fFlags & kThreadID)
             {
-                snprintf(work, std::size(work), "[t=%lu] ", hsThread::ThisThreadHash());
+                snprintf(work, std::size(work), "[t=%zu] ", hsThread::ThisThreadHash());
                 buf.append(work);
             }
 


### PR DESCRIPTION
~~If you stub out font rendering, it is possible to link to Personal with an x64 build with these changes.  I haven't figured out why font rendering explodes in x64 yet, unfortunately :/~~

It's now possible to link to Relto (and a few other ages I tried) without modification.  Is this sufficient to close #34?  Probably not if you include Max plugin support...