### PR TITLE
Break the pnMessage->plSDL dependency with new msg

### DIFF
--- a/Sources/Plasma/NucleusLib/inc/plCreatableIndex.h
+++ b/Sources/Plasma/NucleusLib/inc/plCreatableIndex.h
@@ -955,6 +955,7 @@ CLASS_INDEX_LIST_START
     CLASS_INDEX(plLoadClothingMsg),
     CLASS_INDEX(pl3DPipeline),
     CLASS_INDEX(plGLPipeline),
+    CLASS_INDEX(plSDLModifierStateMsg),
 CLASS_INDEX_LIST_END
 
 #endif // plCreatableIndex_inc

--- a/Sources/Plasma/NucleusLib/pnMessage/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnMessage/CMakeLists.txt
@@ -78,8 +78,6 @@ target_link_libraries(
         pnKeyedObject
         pnNetCommon
         pnNucleusInc
-    PRIVATE
-        plSDL # :(
 )
 
 source_group("Header Files" FILES ${pnMessage_HEADERS})

--- a/Sources/Plasma/NucleusLib/pnMessage/plSDLModifierMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSDLModifierMsg.h
@@ -48,7 +48,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 // A msg sent to an SDL modifier to tell it send or recv state.
 //
-class plStateDataRecord;
 class plSDLModifierMsg : public plMessage
 {
 public:
@@ -63,14 +62,11 @@ public:
 protected:
     ST::string fSDLName;            // the state descriptor name (ie. "physical")
     Action fAction;
-    plStateDataRecord* fState;      // for recving state
-    bool fManageStateMem;           // delete fState?
     uint32_t fPlayerID;
     uint32_t fFlags;
 
 public:
     plSDLModifierMsg(const ST::string& sdlName={}, Action a=kActionNone);
-    ~plSDLModifierMsg();
 
     CLASSNAME_REGISTER(plSDLModifierMsg);
     GETINTERFACE_ANY(plSDLModifierMsg, plMessage);
@@ -80,9 +76,6 @@ public:
 
     Action GetAction() const { return fAction; }
     void SetAction(Action t) { fAction=t; }
-
-    plStateDataRecord* GetState(bool unManageState=false) { if ( unManageState ) fManageStateMem=false; return fState; }
-    void SetState(plStateDataRecord* s, bool manageState) { fState=s; fManageStateMem=manageState; }
 
     ST::string GetSDLName() const { return fSDLName; }
     void SetSDLName(const ST::string& s) { fSDLName=s; }

--- a/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
@@ -40,6 +40,7 @@ set(plMessage_SOURCES
     plRideAnimatedPhysMsg.cpp
     plRippleShapeMsg.cpp
     plRoomLoadNotifyMsg.cpp
+    plSDLModifierStateMsg.cpp
     plSimStateMsg.cpp
     plSwimMsg.cpp
     plSynchEnableMsg.cpp
@@ -113,6 +114,7 @@ set(plMessage_HEADERS
     plRideAnimatedPhysMsg.h
     plRippleShapeMsg.h
     plRoomLoadNotifyMsg.h
+    plSDLModifierStateMsg.h
     plShadowCastMsg.h
     plSimStateMsg.h
     plSpawnModMsg.h
@@ -150,6 +152,7 @@ target_link_libraries(plMessage
         plGImage
         plInputCore # plInputIfaceMgrMsg
         plNetGameLib
+        plSDL # plSDLModifierStateMsg
     INTERFACE
         pnFactory
 )

--- a/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
@@ -267,6 +267,9 @@ REGISTER_CREATABLE(plRippleShapeMsg);
 #include "plRoomLoadNotifyMsg.h"
 REGISTER_CREATABLE(plRoomLoadNotifyMsg);
 
+#include "plSDLModifierStateMsg.h"
+REGISTER_CREATABLE(plSDLModifierStateMsg);
+
 #include "plShadowCastMsg.h"
 REGISTER_CREATABLE(plShadowCastMsg);
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plSDLModifierStateMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plSDLModifierStateMsg.cpp
@@ -39,13 +39,33 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
       Mead, WA   99021
 
 *==LICENSE==*/
-#include "plSDLModifierMsg.h"
 
-plSDLModifierMsg::plSDLModifierMsg(const ST::string& sdlName, Action a) :
-    fSDLName(sdlName),
-    fAction(a),
-    fPlayerID(),
-    fFlags()
+#include "plSDLModifierStateMsg.h"
+#include "plSDL/plSDL.h"
+
+
+plSDLModifierStateMsg::plSDLModifierStateMsg(const ST::string& sdlName, Action a) :
+    plSDLModifierMsg(sdlName, a),
+    fState(),
+    fManageStateMem()
+{ }
+
+plSDLModifierStateMsg::~plSDLModifierStateMsg()
 {
-    SetBCastFlag(plMessage::kPropagateToModifiers);
+    if (fManageStateMem)
+        delete fState;
+}
+
+plStateDataRecord* plSDLModifierStateMsg::GetState(bool unManageState)
+{
+    if (unManageState)
+        fManageStateMem = false;
+
+    return fState;
+}
+
+void plSDLModifierStateMsg::SetState(plStateDataRecord* s, bool manageState)
+{
+    fState = s;
+    fManageStateMem = manageState;
 }

--- a/Sources/Plasma/PubUtilLib/plMessage/plSDLModifierStateMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plSDLModifierStateMsg.h
@@ -39,13 +39,28 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
       Mead, WA   99021
 
 *==LICENSE==*/
-#include "plSDLModifierMsg.h"
+#ifndef plSDLModifierStateMsg_h
+#define plSDLModifierStateMsg_h
 
-plSDLModifierMsg::plSDLModifierMsg(const ST::string& sdlName, Action a) :
-    fSDLName(sdlName),
-    fAction(a),
-    fPlayerID(),
-    fFlags()
+#include "pnMessage/plSDLModifierMsg.h"
+
+class plStateDataRecord;
+
+class plSDLModifierStateMsg : public plSDLModifierMsg
 {
-    SetBCastFlag(plMessage::kPropagateToModifiers);
-}
+protected:
+    plStateDataRecord* fState;      // for recving state
+    bool fManageStateMem;           // delete fState?
+
+public:
+    plSDLModifierStateMsg(const ST::string& sdlName={}, Action a=kActionNone);
+    ~plSDLModifierStateMsg();
+
+    CLASSNAME_REGISTER(plSDLModifierStateMsg);
+    GETINTERFACE_ANY(plSDLModifierStateMsg, plSDLModifierMsg);
+
+    plStateDataRecord* GetState(bool unManageState=false);
+    void SetState(plStateDataRecord* s, bool manageState);
+};
+
+#endif //plSDLModifierStateMsg_h

--- a/Sources/Plasma/PubUtilLib/plModifier/plSDLModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plSDLModifier.cpp
@@ -45,6 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnSceneObject/plSceneObject.h"
 #include "pnMessage/plSDLModifierMsg.h"
 
+#include "plMessage/plSDLModifierStateMsg.h"
 #include "plNetCommon/plNetObjectDebugger.h"
 #include "plNetMessage/plNetMessage.h"
 #include "plSDL/plSDL.h"
@@ -158,8 +159,11 @@ bool plSDLModifier::MsgReceive(plMessage* msg)
         else
         if (sdlMsg->GetAction()==plSDLModifierMsg::kRecv)
         {
-            plStateDataRecord* sdRec=sdlMsg->GetState();
-            plStateChangeNotifier::SetCurrentPlayerID(sdlMsg->GetPlayerID());   // remote player changed the state
+            plSDLModifierStateMsg* stateMsg = plSDLModifierStateMsg::ConvertNoRef(msg);
+            hsAssert(stateMsg != nullptr, "Malformed SDL State Message");
+
+            plStateDataRecord* sdRec=stateMsg->GetState();
+            plStateChangeNotifier::SetCurrentPlayerID(stateMsg->GetPlayerID());   // remote player changed the state
             ReceiveState(sdRec);
         }
 

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -52,7 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnMessage/plClientMsg.h"
 #include "pnMessage/plPlayerPageMsg.h"
-#include "pnMessage/plSDLModifierMsg.h"
 #include "pnMessage/plTimeMsg.h"
 #include "pnNetCommon/pnNetCommon.h"
 #include "pnSceneObject/plCoordinateInterface.h"
@@ -67,6 +66,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plMessage/plNetClientMgrMsg.h"
 #include "plMessage/plNetVoiceListMsg.h"
 #include "plMessage/plResPatcherMsg.h"
+#include "plMessage/plSDLModifierStateMsg.h"
 #include "plMessage/plSynchEnableMsg.h"
 #include "plMessage/plVaultNotifyMsg.h"
 #include "plModifier/plResponderModifier.h"
@@ -555,7 +555,7 @@ void plNetClientMgr::ICheckPendingStateLoad(double secs)
         plSynchedObject* synchObj = plSynchedObject::ConvertNoRef(load->fKey->ObjectIsLoaded());
         if (synchObj && synchObj->IsFinal())
         {
-            plSDLModifierMsg* msg = new plSDLModifierMsg(load->fSDRec->GetDescriptor()->GetName(), plSDLModifierMsg::kRecv);
+            plSDLModifierStateMsg* msg = new plSDLModifierStateMsg(load->fSDRec->GetDescriptor()->GetName(), plSDLModifierMsg::kRecv);
             msg->SetState(load->fSDRec, true);
             load->fSDRec = nullptr;
             msg->SetPlayerID(load->fPlayerID);


### PR DESCRIPTION
plSDLModifierStateMsg is a subclass of plSDLModifierMsg that contains the state variable handling. It lives in plMessage, which can safely link against plSDL, and is used only by PubUtilLib classes.