### PR TITLE
Fix syntax errors hosing Python.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -490,18 +490,13 @@ bool plPythonFileMod::ILoadPythonCode()
         if (PythonInterface::RunFile(pyfile, fModule)) {
             // we've loaded the code into our module
             // now attach the glue python code to the end
-            if (!PythonInterface::RunFile(gluefile, fModule)) {
-                // display any output (NOTE: this would be disabled in production)
-                DisplayPythonOutput();
-                return false;
-            } else {
+            if (PythonInterface::RunFile(gluefile, fModule))
                 return true;
-            }
         }
-        DisplayPythonOutput();
 
         ST::string errMsg = ST::format("Python file {}.py had errors!!! Could not load.", fPythonFile);
         PythonInterface::WriteToLog(errMsg);
+        ReportError();
         return false;
     }
 #endif  //PLASMA_EXTERNAL_RELEASE
@@ -512,10 +507,10 @@ bool plPythonFileMod::ILoadPythonCode()
     if (pythonCode && PythonInterface::RunPYC(pythonCode, fModule))
         return true;
 
-    DisplayPythonOutput();
-
     ST::string errMsg = ST::format("Python file {}.py was not found.", fPythonFile);
     PythonInterface::WriteToLog(errMsg);
+    if (PyErr_Occurred())
+        ReportError();
     return false;
 }
 


### PR DESCRIPTION
If a single unpacked Python file has a syntax error, Python will be hosed for an indeterminate time due to the loader not properly processing errors. This fixes that issue. Related: `DisplayPythonOutput()` does nothing - all calls to this method need to be audited (in another PR) for intent and corrections applied where needed.

This issue was discovered when VS Code "helpfully" inserted an invalid `import` statement at the top of a file I was working on.