### PR TITLE
Confirmation (Yes/No/OK/Quit/Logout) Overhaul

### DIFF
--- a/Scripts/Python/ki/xKIConstants.py
+++ b/Scripts/Python/ki/xKIConstants.py
@@ -503,23 +503,7 @@ class kGUI:
     BKEditFieldJRNTitle = 0
     BKEditFieldJRNNote = 1
     BKEditFieldPICTitle = 2
-    
-    # Yes/No dialog.
-    YesNoTextID=12
-    YesButtonID = 10
-    NoButtonID = 11
-    YesButtonTextID = 60
-    NoButtonTextID = 61
-    YesNoLogoutButtonID = 62
-    YesNoLogoutTextID = 63
-    YNQuit = 0
-    YNDelete = 1
-    YNOfferLink = 2
-    YNOutside = 3
-    YNKIFull = 4
-    YNWanaPlay = 5
-    YNNoReason = 6
-    
+
     # Question note dialog.
     QNTitle = 100
     QNMessage = 101

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -40,6 +40,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
       Mead, WA   99021
 
  *==LICENSE==* """
+
+from __future__ import annotations
+from typing import Callable, Tuple, Union
+
 def PtAcceptInviteInGame(friendName,inviteKey):
     """Sends a VaultTask to the server to perform the invite"""
     pass
@@ -631,6 +635,12 @@ def PtLocalAvatarRunKeyDown():
     """Returns true if the run key is being held down for the local avatar"""
     pass
 
+def PtLocalizedYesNoDialog(cb: Union[None, Callable, ptKey], path: str, *args, /, *, dialogType: int = PtConfirmationType.YesNo) -> None:
+    """This will display a confirmation dialog to the user with the localized text `path`
+       with any optional localization `args` applied. This dialog _has_ to be answered by the user,
+       and their answer will be returned in a Notify message or callback given by `cb`."""
+    ...
+
 def PtMaxListenDistSq():
     """Returns the maximum distance (squared) of the listen range"""
     pass
@@ -872,11 +882,11 @@ def PtWhatGUIControlType(guiKey):
     """Returns the control type of the key passed in"""
     pass
 
-def PtYesNoDialog(selfkey,dialogMessage):
-    """This will display a Yes/No dialog to the user with the text dialogMessage
-This dialog _has_ to be answered by the user.
-And their answer will be returned in a Notify message."""
-    pass
+def PtYesNoDialog(cb: Union[None, ptKey, Callable], message: str, /, dialogType: int = PtConfirmationType.YesNo) -> None:
+    """This will display a confirmation dialog to the user with the text `message`. This dialog
+       _has_ to be answered by the user, and their answer will be returned in a Notify message
+       or callback given by `cb`."""
+    ...
 
 class ptAgeInfoStruct:
     """Class to hold AgeInfo struct data"""

--- a/Scripts/Python/plasma/PlasmaConstants.py
+++ b/Scripts/Python/plasma/PlasmaConstants.py
@@ -114,6 +114,20 @@ class PtButtonNotifyTypes:
     kNotifyOnDown = 1
     kNotifyOnUpAndDown = 2
 
+class PtConfirmationResult:
+    OK = 1
+    Cancel = 0
+    Yes = 1
+    No = 0
+    Quit = 1
+    Logout = 62
+
+class PtConfirmationType:
+    OK = 0
+    ConfirmQuit = 1
+    ForceQuit = 2
+    YesNo = 3
+
 class PtCCRPetitionType:
     """(none)"""
     kGeneralHelp = 0

--- a/Scripts/Python/xDialogStartUp.py
+++ b/Scripts/Python/xDialogStartUp.py
@@ -217,12 +217,6 @@ class xDialogStartUp(ptResponder):
             PtHideDialog("GUIDialog06a")
 
     ###########################
-    def OnNotify(self,state,id,events):
-        if id==(-1): ## callback from delete yes/no dialog (hopefully) ##
-            if state:
-                PtConsole("App.Quit")
-
-    ###########################
     def OnGUINotify(self,id,control,event):
         global gSelectedSlot
         global gPlayerList
@@ -245,7 +239,7 @@ class xDialogStartUp(ptResponder):
                     PtShowDialog("GUIDialog05")
 
                 elif  tagID == k4aQuitID: ## Quit ##
-                    PtYesNoDialog(self.key,"Are you sure you want to quit?")
+                    PtLocalizedYesNoDialog(None, "KI.Messages.LeaveGame", dialogType=PtConfirmationType.ConfirmQuit)
 
                 elif  tagID == k4aPlayer01: ## Click Event ##
                     if gPlayerList[0]:
@@ -280,7 +274,7 @@ class xDialogStartUp(ptResponder):
                     ## Or Else?? ##
 
                 elif  tagID == k4bQuitID: ## Quit ##
-                    PtYesNoDialog(self.key,"Are you sure you want to quit?")
+                    PtLocalizedYesNoDialog(None, "KI.Messages.LeaveGame", dialogType=PtConfirmationType.ConfirmQuit)
 
                 elif  tagID == k4bDeleteID: ## Delete Explorer ##
                     if gSelectedSlot:
@@ -322,7 +316,7 @@ class xDialogStartUp(ptResponder):
         elif id == GUIDiag6.id:
             if event == kAction or event == kValueChanged:
                 if  tagID == k6QuitID: ## Quit ##
-                    PtYesNoDialog(self.key,"Are you sure you want to quit?")
+                    PtLocalizedYesNoDialog(None, "KI.Messages.LeaveGame", dialogType=PtConfirmationType.ConfirmQuit)
 
                 elif  tagID == k6BackID: ## Back To Player Select ##
                     PtHideDialog("GUIDialog06")

--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -135,6 +135,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfAnimation/plAnimDebugList.h"
 #include "pfAudio/plListener.h"
 #include "pfCamera/plVirtualCamNeu.h"
+#include "pfCharacter/pfConfirmationMgr.h"
 #include "pfCharacter/pfMarkerMgr.h"
 #include "pfConsole/pfConsole.h"
 #include "pfConsole/pfConsoleDirSrc.h"
@@ -245,6 +246,9 @@ bool plClient::Shutdown()
 
     // Let the resmanager know we're going to be shutting down.
     hsgResMgr::ResMgr()->BeginShutdown();
+
+    // This guy may send callbacks that release resources
+    pfConfirmationMgr::Shutdown();
 
     // Must kill off all movies before shutting down audio.
     IKillMovies();
@@ -1385,6 +1389,9 @@ bool plClient::StartInit()
     fGameGUIMgr = new pfGameGUIMgr();
     fGameGUIMgr->RegisterAs( kGameGUIMgr_KEY );
     fGameGUIMgr->Init();
+
+    // Yes/No dialog handler
+    pfConfirmationMgr::Init();
 
     plgAudioSys::Activate(true);
 

--- a/Sources/Plasma/FeatureLib/pfCharacter/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfCharacter/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(pfCharacter_SOURCES
+    pfConfirmationMgr.cpp
     pfMarkerInfo.cpp
     pfMarkerMgr.cpp
 )
 
 set(pfCharacter_HEADERS
     pfCharacterCreatable.h
+    pfConfirmationMgr.h
     pfMarkerInfo.h
     pfMarkerMgr.h
 )
@@ -15,15 +17,18 @@ target_link_libraries(
     PUBLIC
         CoreLib
         pnKeyedObject
+        plMessage
     PRIVATE
         pnMessage
+        pnNetCommon
         pnNucleusInc
         pnSceneObject
-        plMessage
         plModifier
         plNetClient
         plResMgr
         plStatusLog
+        pfGameGUIMgr
+        pfLocalizationMgr
         pfMessage
     INTERFACE
         pnFactory

--- a/Sources/Plasma/FeatureLib/pfCharacter/pfConfirmationMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfCharacter/pfConfirmationMgr.cpp
@@ -1,0 +1,453 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "pfConfirmationMgr.h"
+
+#include <type_traits>
+
+#include "plgDispatch.h"
+#include "plTimerCallbackManager.h"
+
+#include "pnMessage/plNotifyMsg.h"
+#include "pnNetCommon/plNetApp.h"
+
+#include "plMessage/plConfirmationMsg.h"
+#include "plMessage/plConsoleMsg.h"
+#include "plMessage/plLinkToAgeMsg.h"
+#include "plMessage/plTimerCallbackMsg.h"
+
+#include "pfGameGUIMgr/pfGameGUIMgr.h"
+#include "pfGameGUIMgr/pfGUIDialogHandlers.h"
+#include "pfGameGUIMgr/pfGUIDialogMod.h"
+#include "pfGameGUIMgr/pfGUIControlMod.h"
+#include "pfGameGUIMgr/pfGUITextBoxMod.h"
+#include "pfLocalizationMgr/pfLocalizationMgr.h"
+#include "pfMessage/pfGameGUIMsg.h"
+#include "pfMessage/pfGUINotifyMsg.h"
+#include "pfMessage/pfKIMsg.h"
+
+using namespace ST::literals;
+
+////////////////////////////////////////////////////////////////////////////////
+
+// From GUI_District_KIYesNo.prp, so don't change them.
+constexpr uint32_t kMessageTextTag = 12U;
+constexpr uint32_t kLogoutTextTag = 63U; // Leftmost
+constexpr uint32_t kYesTextTag = 60U; // Center
+constexpr uint32_t kNoTextTag = 61U; // Rightmost
+constexpr uint32_t kLogoutButtonTag = 62U;
+constexpr uint32_t kYesButtonTag = 10U;
+constexpr uint32_t kNoButtonTag = 11U;
+
+////////////////////////////////////////////////////////////////////////////////
+
+class pfConfirmationDialogProc : public pfGUIDialogProc
+{
+    friend class pfConfirmationMgr;
+    pfConfirmationMgr* fMgr;
+
+    inline void ISetText(const ST::string& text, uint32_t tagID)
+    {
+        pfGUITextBoxMod* mod = pfGUITextBoxMod::ConvertNoRef(fDialog->GetControlFromTag(tagID));
+        hsAssert(mod != nullptr, "You sure about this, boss?");
+        mod->SetText(text.to_wchar().data());
+    }
+
+    inline void ISetLocalizedText(const ST::string& path, uint32_t tagID)
+    {
+        ISetText(pfLocalizationMgr::Instance().GetString(path), tagID);
+    }
+
+    void ILayoutYesNo(const ST::string& text)
+    {
+        fDialog->GetControlFromTag(kLogoutTextTag)->SetVisible(false);
+        fDialog->GetControlFromTag(kLogoutButtonTag)->SetVisible(false);
+        fDialog->GetControlFromTag(kYesTextTag)->SetVisible(true);
+        fDialog->GetControlFromTag(kYesButtonTag)->SetVisible(true);
+        fDialog->GetControlFromTag(kNoTextTag)->SetVisible(true);
+        fDialog->GetControlFromTag(kNoButtonTag)->SetVisible(true);
+        ISetLocalizedText("KI.YesNoDialog.YESButton"_st, kYesTextTag);
+        ISetLocalizedText("KI.YesNoDialog.NoButton"_st, kNoTextTag);
+        ISetText(text, kMessageTextTag);
+    }
+
+    void ILayoutSingle(const ST::string& message, const ST::string& button)
+    {
+        fDialog->GetControlFromTag(kLogoutTextTag)->SetVisible(false);
+        fDialog->GetControlFromTag(kLogoutButtonTag)->SetVisible(false);
+        fDialog->GetControlFromTag(kYesTextTag)->SetVisible(false);
+        fDialog->GetControlFromTag(kYesButtonTag)->SetVisible(false);
+        fDialog->GetControlFromTag(kNoTextTag)->SetVisible(true);
+        fDialog->GetControlFromTag(kNoButtonTag)->SetVisible(true);
+        ISetLocalizedText(button, kNoTextTag);
+        ISetText(message, kMessageTextTag);
+    }
+
+    void ILayoutQuit(const ST::string& text)
+    {
+        bool canLogout = plNetClientApp::GetInstance()->GetPlayerID() != 0;
+        fDialog->GetControlFromTag(kLogoutTextTag)->SetVisible(canLogout);
+        fDialog->GetControlFromTag(kLogoutButtonTag)->SetVisible(canLogout);
+        fDialog->GetControlFromTag(kYesTextTag)->SetVisible(true);
+        fDialog->GetControlFromTag(kYesButtonTag)->SetVisible(true);
+        fDialog->GetControlFromTag(kNoTextTag)->SetVisible(true);
+        fDialog->GetControlFromTag(kNoButtonTag)->SetVisible(true);
+        if (canLogout)
+            ISetText("Logout"_st, kLogoutTextTag); // FIXME: This is missing from the LOC files.
+        ISetLocalizedText("KI.YesNoDialog.QuitButton"_st, kYesTextTag);
+        ISetLocalizedText("KI.YesNoDialog.NoButton"_st, kNoTextTag);
+        ISetText(text, kMessageTextTag);
+    }
+
+public:
+    pfConfirmationDialogProc(pfConfirmationMgr* mgr)
+        : fMgr(mgr)
+    { }
+
+    ~pfConfirmationDialogProc() = default;
+
+    void OnInit() override
+    {
+        if (!fMgr->fPending.empty())
+            fDialog->Show();
+    }
+
+    void OnShow() override
+    {
+        // Prevent dialog trolling...
+        if (fMgr->fPending.empty()) {
+            fDialog->Hide();
+            return;
+        }
+
+        fMgr->fState = pfConfirmationMgr::State::WaitingForInput;
+
+        const auto& msg = fMgr->fPending.front();
+        ST::string text;
+        if (auto locMsg = plLocalizedConfirmationMsg::ConvertNoRef(msg.Get()); locMsg != nullptr)
+            text = pfLocalizationMgr::Instance().GetString(locMsg->GetText(), locMsg->GetArgs());
+        else
+            text = msg->GetText();
+
+        switch (msg->GetType()) {
+        case plConfirmationMsg::Type::ConfirmQuit:
+            ILayoutQuit(text);
+            break;
+        case plConfirmationMsg::Type::ForceQuit:
+            ILayoutSingle(text, "KI.YesNoDialog.QuitButton"_st);
+            break;
+        case plConfirmationMsg::Type::OK:
+            ILayoutSingle(text, "KI.YesNoDialog.OKButton"_st);
+            break;
+        case plConfirmationMsg::Type::YesNo:
+            ILayoutYesNo(text);
+            break;
+        DEFAULT_FATAL(msg->GetType());
+        }
+    }
+
+    void OnHide() override
+    {
+        switch (fMgr->fState) {
+        case pfConfirmationMgr::State::WaitingForInput:
+            // Prevent dialog trolling...
+            fDialog->Show();
+            break;
+        case pfConfirmationMgr::State::Ready:
+            // If another confirmation is already available, we don't want to just show it now.
+            // Instead, wait a short period of time, then re-process.
+            plgTimerCallbackMgr::NewTimer(.5f, new plTimerCallbackMsg(fMgr->GetKey(), (int32_t)fMgr->fState));
+            fMgr->fState = pfConfirmationMgr::State::Delaying;
+            break;
+        }
+    }
+
+    void DoSomething(pfGUIControlMod* ctrl) override
+    {
+        plConfirmationMsg::Result result;
+        switch (ctrl->GetTagID()) {
+        case kLogoutButtonTag:
+            result = plConfirmationMsg::Result::Logout;
+            break;
+        case kYesButtonTag:
+            result = plConfirmationMsg::Result::Yes;
+            break;
+        case kNoButtonTag:
+            switch (fMgr->fPending.front()->GetType()) {
+            case plConfirmationMsg::Type::ForceQuit:
+            case plConfirmationMsg::Type::OK:
+                result = plConfirmationMsg::Result::OK;
+                break;
+            default:
+                result = plConfirmationMsg::Result::No;
+                break;
+            }
+            break;
+        DEFAULT_FATAL(ctrl->GetTagID());
+        }
+
+        fMgr->ISendResult(result, pfConfirmationMgr::State::Ready);
+        fDialog->Hide();
+    }
+
+    void OnDestroy() override
+    {
+        // Crap... Someone has thrown the dialog away from underneath us.
+        // If anybody is still around, cancel anything waiting on input.
+        fMgr->ISendResult(plConfirmationMsg::Result::Cancel, pfConfirmationMgr::State::Alive);
+    }
+
+    void OnControlEvent(ControlEvt event) override
+    {
+        // There is only one control event, atm... Someone pressed escape
+        // thereby closing the dialog. Therefore, just send a cancel.
+        if (event == kExitMode) {
+            fMgr->ISendResult(plConfirmationMsg::Result::Cancel, pfConfirmationMgr::State::Ready);
+            fDialog->Hide();
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+pfConfirmationMgr::pfConfirmationMgr()
+    : fState(State::Alive),
+      fProc(new pfConfirmationDialogProc(this))
+{
+    // Prevent the GUI system from killing us. Screw that comment in the GUI header.
+    fProc->IncRef();
+}
+
+pfConfirmationMgr::~pfConfirmationMgr()
+{
+    // Any pending items that are callbacks fire now as being cancelled.
+    while (!fPending.empty()) {
+        const auto& msg = fPending.front();
+        std::visit([](auto&& arg) {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, std::function<void(plConfirmationMsg::Result)>>)
+                arg(plConfirmationMsg::Result::Cancel);
+        }, msg->GetCallback());
+        fPending.pop();
+    }
+
+    if (fProc->fDialog) {
+        fProc->fDialog->SetHandler(nullptr);
+        if (pfGameGUIMgr::GetInstance())
+            pfGameGUIMgr::GetInstance()->UnloadDialog(fProc->fDialog);
+    }
+
+    if (fProc->DecRef())
+        delete fProc;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void pfConfirmationMgr::ISendResult(plConfirmationMsg::Result result, State newState)
+{
+    if (fPending.empty())
+        return;
+
+    fState = pfConfirmationMgr::State::ProcessingInput;
+
+    const auto& msg = fPending.front();
+
+    // If a quit was requested, don't rely on any downstream processing. Just post
+    // a quit message to happen on the next dispatcher pump.
+    bool wantQuit = (msg->GetType() == plConfirmationMsg::Type::ConfirmQuit &&
+                     result == plConfirmationMsg::Result::Quit);
+    bool forceQuit = msg->GetType() == plConfirmationMsg::Type::ForceQuit;
+    if (wantQuit || forceQuit) {
+        plConsoleMsg* quitMsg = new plConsoleMsg(plConsoleMsg::kExecuteLine, "App.Quit"_st);
+        plgDispatch::Dispatch()->MsgQueue(quitMsg);
+    }
+
+    // Again, don't rely on bugprone Python code to handle critical functionality.
+    bool wantLogout = (msg->GetType() == plConfirmationMsg::Type::ConfirmQuit &&
+                       result == plConfirmationMsg::Result::Logout);
+    if (wantLogout) {
+        plLinkToAgeMsg* logoutMsg = new plLinkToAgeMsg();
+        logoutMsg->AddReceiver(plNetClientApp::GetInstance()->GetKey());
+        logoutMsg->PlayLinkSfx(false, false);
+        logoutMsg->GetAgeLink()->GetAgeInfo()->SetAgeFilename("StartUp"_st);
+        logoutMsg->GetAgeLink()->SpawnPoint().SetTitle("Default"_st);
+        logoutMsg->GetAgeLink()->SpawnPoint().SetName("LinkInPointDefault"_st);
+        plgDispatch::Dispatch()->MsgQueue(logoutMsg);
+    }
+
+    std::visit([result](auto&& arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, std::function<void(plConfirmationMsg::Result)>>) {
+            // New: High level, potentially stateful functor
+            arg(result);
+        } else if constexpr (std::is_same_v<T, plKey>) {
+            // Old: Send a notify message to whoever called (probably) `PtYesNoDialog()`
+            plNotifyMsg* notifyMsg = new plNotifyMsg;
+            notifyMsg->AddReceiver(arg);
+            notifyMsg->SetBCastFlag(plMessage::kNetPropagate, false);
+            notifyMsg->SetState((float)result);
+            notifyMsg->AddVariableEvent("YesNo"_st, (int32_t)result);
+            notifyMsg->Send();
+        } else {
+            static_assert(std::is_same_v<T, std::monostate>, "non-exhaustive visitor");
+        }
+    }, msg->GetCallback());
+
+    fPending.pop();
+    fState = newState;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void pfConfirmationMgr::ILoadDialog()
+{
+    // We need to be particularly careful that some old xKI.py doesn't run wild
+    // over us.
+    pfGameGUIMgr* gui = pfGameGUIMgr::GetInstance();
+    pfGUIDialogMod* dialog = gui->GetDialogFromString("KIYesNo");
+    if (dialog) {
+        fState = State::Ready;
+        dialog->SetHandler(fProc);
+
+        // The default pfGUIDialogMod proc ate the OnInit() call. So, here's another one.
+        fProc->OnInit();
+    } else {
+        fState = State::WaitingForDialogLoad;
+        gui->LoadDialog("KIYesNo"_st, GetKey(), "GUI");
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool pfConfirmationMgr::MsgReceive(plMessage* msg)
+{
+    plConfirmationMsg* confirmMsg = plConfirmationMsg::ConvertNoRef(msg);
+    if (confirmMsg) {
+        fPending.emplace(confirmMsg);
+        if (fState == State::Ready)
+            fProc->fDialog->Show();
+        else if (fState == State::Alive)
+            ILoadDialog();
+        return true;
+    }
+
+    pfKIMsg* kiMsg = pfKIMsg::ConvertNoRef(msg);
+    if (kiMsg) {
+        // This seems a little objectionable, IMO, but it keeps the behavior consistent.
+        // When the disable KI message comes in, we force-cancel any confirmations, but
+        // the old behavior did not "remember" this and allows any new dialogs to pop up,
+        // even though the KI is supposedly disabled.
+        if (kiMsg->GetCommand() == pfKIMsg::kDisableKIandBB) {
+            if (fState == State::WaitingForInput) {
+                while (!fPending.empty())
+                    ISendResult(plConfirmationMsg::Result::Cancel, State::Ready);
+                fProc->fDialog->Hide();
+            }
+        }
+        return true;
+    }
+
+    pfGUINotifyMsg* guiNotifyMsg = pfGUINotifyMsg::ConvertNoRef(msg);
+    if (guiNotifyMsg) {
+        // Handle the dialog LOAD so we can insert our own dialog proc
+        if (guiNotifyMsg->GetEvent() == pfGUINotifyMsg::kDialogLoaded) {
+            hsAssert(fState == State::WaitingForDialogLoad, "Unexpected dialog load");
+            fState = State::Ready;
+            pfGUIDialogMod* dialog = pfGUIDialogMod::ConvertNoRef(guiNotifyMsg->GetControlKey()->VerifyLoaded());
+            dialog->SetHandler(fProc);
+
+            // The default pfGUIDialogMod proc ate the OnInit() call. So, here's another one.
+            fProc->OnInit();
+        } else {
+            hsAssert(false, "Unexpected GUINotifyMsg");
+        }
+
+        // No other GUI notify messages should come though because we have
+        // changed out the notify proc to one that does not send messages.
+        return true;
+    }
+
+    plTimerCallbackMsg* timerMsg = plTimerCallbackMsg::ConvertNoRef(msg);
+    if (timerMsg) {
+        // Someone might delete the dialog out from under us eg by PtUnLoadDialog("KIYesNo")...
+        if (fState == State::Delaying)
+            fState = (State)timerMsg->fID;
+
+        if (!fPending.empty()) {
+            if (fState == State::Alive)
+                ILoadDialog();
+            else if (fState == State::Ready)
+                fProc->fDialog->Show();
+            else
+                hsAssert(false, "Unexpected state on timer callback");
+        }
+        return true;
+    }
+
+    return hsKeyedObject::MsgReceive(msg);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void pfConfirmationMgr::Init()
+{
+    if (s_instance == nullptr) {
+        s_instance = new pfConfirmationMgr;
+        s_instance->RegisterAs(kConfirmationMgr_KEY);
+
+        plgDispatch::Dispatch()->RegisterForType(plConfirmationMsg::Index(), s_instance->GetKey());
+        plgDispatch::Dispatch()->RegisterForExactType(pfKIMsg::Index(), s_instance->GetKey());
+    }
+}
+
+void pfConfirmationMgr::Shutdown()
+{
+    if (s_instance) {
+        plgDispatch::Dispatch()->UnRegisterForType(plConfirmationMsg::Index(), s_instance->GetKey());
+        plgDispatch::Dispatch()->UnRegisterForExactType(pfKIMsg::Index(), s_instance->GetKey());
+
+        s_instance->UnRegisterAs(kConfirmationMgr_KEY); // UnRefs us
+        s_instance = nullptr;
+    }
+}
+
+pfConfirmationMgr* pfConfirmationMgr::s_instance{};

--- a/Sources/Plasma/FeatureLib/pfConsole/pfGameConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfGameConsoleCommands.cpp
@@ -81,6 +81,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plAvatar/plAvatarMgr.h"
 #include "plGImage/plMipmap.h"
 #include "plMessage/plAvatarMsg.h"
+#include "plMessage/plConfirmationMsg.h"
 #include "plPipeline/plCaptureRender.h"
 
 #include "pfConsoleCore/pfConsoleCmd.h"
@@ -217,6 +218,38 @@ PF_CONSOLE_CMD( Game_GUI, CreateDialog, "string name", "" )
     pfGUICtrlGenerator::Instance().GenerateDialog( params[ 0 ] );
 }
 
+PF_CONSOLE_CMD(Game_GUI, Confirm, "int type", "Shows a sample confirmation dialog")
+{
+    plConfirmationMsg* msg;
+    auto type = (plConfirmationMsg::Type)(int32_t)params[0];
+
+    switch (type) {
+    case plConfirmationMsg::Type::ConfirmQuit:
+        msg = new plLocalizedConfirmationMsg("KI.Messages.LeaveGame");
+        break;
+    case plConfirmationMsg::Type::ForceQuit:
+        msg = new plConfirmationMsg("Time to die, my friend.");
+        break;
+    case plConfirmationMsg::Type::YesNo:
+        msg = new plConfirmationMsg("Do you understand me?");
+        msg->SetCallback(
+            [PrintString](plConfirmationMsg::Result result) {
+                if (result == plConfirmationMsg::Result::No) {
+                    PrintString("Well that's too bad.");
+                } else {
+                    PrintString("Woo-hoo!");
+                }
+            }
+        );
+        break;
+    default:
+        msg = new plConfirmationMsg("Whatever, man.");
+        break;
+    }
+
+    msg->SetType(type);
+    msg->Send();
+}
 
 #endif
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
@@ -607,7 +607,7 @@ void    pfGUIDialogMod::Hide()
 
 //// GetControlFromTag ///////////////////////////////////////////////////////
 
-pfGUIControlMod *pfGUIDialogMod::GetControlFromTag( uint32_t tagID )
+pfGUIControlMod *pfGUIDialogMod::GetControlFromTag( uint32_t tagID ) const
 {
     for (pfGUIControlMod* ctrl : fControls)
     {

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.h
@@ -182,8 +182,8 @@ class pfGUIDialogMod : public plSingleModifier
         pfGUIControlMod *GetFocus() { return fFocusCtrl; }
 
         pfGUIDialogMod  *GetNext() { return fNext; }
-        uint32_t          GetTagID() { return fTagID; }
-        pfGUIControlMod *GetControlFromTag( uint32_t tagID );
+        uint32_t          GetTagID() const { return fTagID; }
+        pfGUIControlMod *GetControlFromTag( uint32_t tagID ) const;
 
         void            SetHandler( pfGUIDialogProc *hdlr );
         pfGUIDialogProc *GetHandler() const { return fHandler; }

--- a/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
@@ -95,6 +95,7 @@ set(pfPython_HEADERS
     cyParticleSys.h
     cyPhysics.h
     cyPythonInterface.h
+    plPythonCallable.h
     pfPythonCreatable.h
     plPythonFileMod.h
     plPythonHelpers.h

--- a/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
@@ -263,6 +263,7 @@ target_link_libraries(
     PUBLIC
         CoreLib
         pnNucleusInc
+        plMessage
     PRIVATE
         pnEncryption
         pnInputCore

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -1248,28 +1248,6 @@ void cyMisc::SendKIRegisterImagerMsg(const char* imagerName, pyKey& sender)
 
 /////////////////////////////////////////////////////////////////////////////
 //
-//  Function   : YesNoDialog
-//  PARAMETERS : sender    - who set this and will get the notify
-//             : message   - message to put up in YesNo dialog
-//
-//  PURPOSE    : Put up Yes/No dialog
-//
-//  RETURNS    : nothing
-//
-
-void cyMisc::YesNoDialog(pyKey& sender, const ST::string& thestring)
-{
-    // create the mesage to send
-    pfKIMsg *msg = new pfKIMsg( pfKIMsg::kYesNoDialog );
-
-    msg->SetSender(sender.getKey());
-    msg->SetString(thestring);
-    // send it off
-    plgDispatch::MsgSend( msg );
-}
-
-/////////////////////////////////////////////////////////////////////////////
-//
 //  Function   : RateIt
 //  PARAMETERS : chonicleName    - where to store the rating
 //             : thestring       - the message in the RateIt dialog

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -506,18 +506,6 @@ public:
 
     /////////////////////////////////////////////////////////////////////////////
     //
-    //  Function   : YesNoDialog
-    //  PARAMETERS : sender    - sender's key (to get the reply)
-    //             : value     - extra value
-    //
-    //  PURPOSE    : Send message to the KI, to tell it things to do
-    //
-    //  RETURNS    : nothing
-    //
-    static void YesNoDialog(pyKey& sender, const ST::string& thestring);
-
-    /////////////////////////////////////////////////////////////////////////////
-    //
     //  Function   : RateIt
     //  PARAMETERS : chonicleName    - where to store the rating
     //             : thestring       - the message in the RateIt dialog

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
@@ -44,6 +44,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <Python.h>
 
+#include <string_view>
+
 #include "pyEnum.h"
 #include "pyColor.h"
 #include "pyGlueHelpers.h"
@@ -58,7 +60,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 namespace plPythonCallable
 {
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, plConfirmationMsg::Result value)
+    template<>
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, plConfirmationMsg::Result value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyLong_FromSsize_t((Py_ssize_t)value));
     }

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
@@ -40,34 +40,151 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#include <Python.h>
-#include "pyKey.h"
-
 #include "cyMisc.h"
-#include "pyGlueHelpers.h"
-#include "pyColor.h"
-#include "pyPlayer.h"
-#include "pyEnum.h"
 
-// for enums
+#include <Python.h>
+
+#include "pyEnum.h"
+#include "pyColor.h"
+#include "pyGlueHelpers.h"
+#include "pyKey.h"
+#include "pyPlayer.h"
+#include "plPythonCallable.h"
+
+#include "plMessage/plConfirmationMsg.h"
 #include "plNetCommon/plNetCommon.h"
 #include "plResMgr/plLocalization.h"
 #include "plMessage/plLOSRequestMsg.h"
 
-
-PYTHON_GLOBAL_METHOD_DEFINITION(PtYesNoDialog, args, "Params: selfkey,dialogMessage\nThis will display a Yes/No dialog to the user with the text dialogMessage\n"
-            "This dialog _has_ to be answered by the user.\n"
-            "And their answer will be returned in a Notify message.")
+namespace plPythonCallable
 {
-    PyObject* keyObj = nullptr;
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, plConfirmationMsg::Result value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyLong_FromSsize_t((Py_ssize_t)value));
+    }
+};
+
+PYTHON_GLOBAL_METHOD_DEFINITION_WKEY(PtYesNoDialog, args, kwargs,
+            "Params: cb, message, /, dialogType\n"
+            "This will display a confirmation dialog to the user with the text `message` "
+            "This dialog _has_ to be answered by the user, "
+            "and their answer will be returned in a Notify message or callback given by `cb`.")
+{
+    const char* keywords[]{ "", "", "dialogType", nullptr };
+    constexpr std::string_view kErrorMsg = "PtYesNoDialog expects a ptKey or callable, "
+                                           "a string or localization path, and an optional int.";
+    PyObject* cbObj;
     ST::string text;
-    if (!PyArg_ParseTuple(args, "OO&", &keyObj, PyUnicode_STStringConverter, &text) || !pyKey::Check(keyObj)) {
-        PyErr_SetString(PyExc_TypeError, "PtYesNoDialog expects a ptKey and a string");
+    plConfirmationMsg::Type dialogType = plConfirmationMsg::Type::YesNo;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs,
+                                     "OO&|I", const_cast<char**>(keywords),
+                                     &cbObj,
+                                     PyUnicode_STStringConverter, &text,
+                                     &dialogType)) {
+        PyErr_SetString(PyExc_TypeError, kErrorMsg.data());
         PYTHON_RETURN_ERROR;
     }
-    pyKey* key = pyKey::ConvertFrom(keyObj);
-    cyMisc::YesNoDialog(*key, text);
-    PYTHON_RETURN_NONE
+
+    plConfirmationMsg::Callback cb;
+    if (pyKey::Check(cbObj)) {
+        cb = pyKey::ConvertFrom(cbObj)->getKey();
+    } else if (PyCallable_Check(cbObj)) {
+        plPythonCallable::BuildCallback<1>("PtYesNoDialog", cbObj, cb);
+    } else if (cbObj != Py_None) {
+        PyErr_SetString(PyExc_TypeError, kErrorMsg.data());
+        PYTHON_RETURN_ERROR;
+    }
+
+    // We already have the message class definition included, so just send from here.
+    auto msg = new plConfirmationMsg(std::move(text), dialogType, std::move(cb));
+    msg->Send();
+
+    PYTHON_RETURN_NONE;
+}
+
+PYTHON_GLOBAL_METHOD_DEFINITION_WKEY(PtLocalizedYesNoDialog, args, kwargs,
+    "Params: cb, path, *args, /, *, dialogType\n"
+    "This will display a confirmation dialog to the user with the localized text `path` "
+    "with any optional localization `args` applied. This dialog _has_ to be answered by the user, "
+    "and their answer will be returned in a Notify message or callback given by `cb`.")
+{
+    constexpr std::string_view kErrorMsg = "PtLocalizedYesNoDialog expects a ptKey or callable, "
+                                           "a string, optional localization arguments, and an "
+                                           "optional int.";
+
+    // We cannot use PyArg_ParseTuple or PyArg_ParseTupleAndKeywords due to our usage
+    // of *args. While we could accept a single sequence for our localization arguments
+    // and get that functionality back, the interface would not be very Pythonic.
+    if (!PyTuple_Check(args) || PyTuple_Size(args) < 2) {
+        PyErr_SetString(PyExc_TypeError, kErrorMsg.data());
+        PYTHON_RETURN_ERROR;
+    }
+
+    PyObject* cbObj = PyTuple_GET_ITEM(args, 0);
+    plConfirmationMsg::Callback cb;
+    if (pyKey::Check(cbObj)) {
+        cb = pyKey::ConvertFrom(cbObj)->getKey();
+    } else if (PyCallable_Check(cbObj)) {
+        plPythonCallable::BuildCallback<1>("PtLocalizedYesNoDialog", cbObj, cb);
+    } else if (cbObj != Py_None) {
+        PyErr_SetString(PyExc_TypeError, kErrorMsg.data());
+        PYTHON_RETURN_ERROR;
+    }
+
+    PyObject* pathObj = PyTuple_GET_ITEM(args, 1);
+    if (!PyUnicode_Check(pathObj)) {
+        PyErr_SetString(PyExc_TypeError, kErrorMsg.data());
+        PYTHON_RETURN_ERROR;
+    }
+    ST::string path = PyUnicode_AsSTString(pathObj);
+
+    constexpr Py_ssize_t kLocArgOffset = 2;
+    const Py_ssize_t totalArgs = PyTuple_Size(args);
+    std::vector<ST::string> locArgs(totalArgs - kLocArgOffset);
+    for (Py_ssize_t i = kLocArgOffset; i < totalArgs; ++i) {
+        PyObject* arg = PyTuple_GET_ITEM(args, i);
+        if (PyUnicode_Check(arg)) {
+            locArgs[i - kLocArgOffset] = PyUnicode_AsSTString(arg);
+        } else {
+            pyObjectRef argStr = PyObject_Str(arg);
+            if (!argStr)
+                // Don't blow away the internal error state
+                PYTHON_RETURN_ERROR;
+            locArgs[i - kLocArgOffset] = PyUnicode_AsSTString(argStr.Get());
+        }
+    }
+
+    plConfirmationMsg::Type dialogType = plConfirmationMsg::Type::YesNo;
+    if (kwargs) {
+        if (!PyArg_ValidateKeywordArguments(kwargs)) {
+            PyErr_SetString(PyExc_TypeError, kErrorMsg.data());
+            PYTHON_RETURN_ERROR;
+        }
+
+        PyObject* dialogTypeObj = PyDict_GetItemString(kwargs, "dialogType");
+        if (dialogTypeObj != nullptr) {
+            if (PyLong_Check(dialogTypeObj)) {
+                dialogType = (plConfirmationMsg::Type)PyLong_AsLong(dialogTypeObj);
+            } else if (PyNumber_Check(dialogTypeObj)) {
+                // The weird internal enum type isn't an int but implements the number protocol.
+                pyObjectRef dialogTypeLong = PyNumber_Long(dialogTypeObj);
+                if (!dialogTypeLong) {
+                    PyErr_SetString(PyExc_TypeError, kErrorMsg.data());
+                    PYTHON_RETURN_ERROR;
+                }
+                dialogType = (plConfirmationMsg::Type)PyLong_AsLong(dialogTypeLong.Get());
+            } else {
+                PyErr_SetString(PyExc_TypeError, kErrorMsg.data());
+                PYTHON_RETURN_ERROR;
+            }
+        }
+    }
+
+    auto msg = new plLocalizedConfirmationMsg(std::move(path), std::move(locArgs), dialogType, std::move(cb));
+    msg->Send();
+
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtRateIt, args, "Params: chronicleName,dialogPrompt,onceFlag\nShows a dialog with dialogPrompt and stores user input rating into chronicleName")
@@ -442,6 +559,7 @@ void cyMisc::AddPlasmaMethods2(PyObject* m)
 {
     PYTHON_START_GLOBAL_METHOD_TABLE(cyMisc2)
         PYTHON_GLOBAL_METHOD(PtYesNoDialog)
+        PYTHON_GLOBAL_METHOD(PtLocalizedYesNoDialog)
         PYTHON_GLOBAL_METHOD(PtRateIt)
 
         PYTHON_GLOBAL_METHOD(PtExcludeRegionSet)
@@ -479,6 +597,22 @@ void cyMisc::AddPlasmaMethods2(PyObject* m)
 
 void cyMisc::AddPlasmaConstantsClasses(PyObject *m)
 {
+    PYTHON_ENUM_START(PtConfirmationResult)
+    PYTHON_ENUM_ELEMENT(PtConfirmationResult, OK, plConfirmationMsg::Result::OK)
+    PYTHON_ENUM_ELEMENT(PtConfirmationResult, Cancel, plConfirmationMsg::Result::Cancel)
+    PYTHON_ENUM_ELEMENT(PtConfirmationResult, Yes, plConfirmationMsg::Result::Yes)
+    PYTHON_ENUM_ELEMENT(PtConfirmationResult, No, plConfirmationMsg::Result::No)
+    PYTHON_ENUM_ELEMENT(PtConfirmationResult, Quit, plConfirmationMsg::Result::Quit)
+    PYTHON_ENUM_ELEMENT(PtConfirmationResult, Logout, plConfirmationMsg::Result::Logout)
+    PYTHON_ENUM_END(m, PtConfirmationResult)
+
+    PYTHON_ENUM_START(PtConfirmationType)
+    PYTHON_ENUM_ELEMENT(PtConfirmationType, OK, plConfirmationMsg::Type::OK)
+    PYTHON_ENUM_ELEMENT(PtConfirmationType, ConfirmQuit, plConfirmationMsg::Type::ConfirmQuit)
+    PYTHON_ENUM_ELEMENT(PtConfirmationType, ForceQuit, plConfirmationMsg::Type::ForceQuit)
+    PYTHON_ENUM_ELEMENT(PtConfirmationType, YesNo, plConfirmationMsg::Type::YesNo)
+    PYTHON_ENUM_END(m, PtConfirmationType)
+
     PYTHON_ENUM_START(PtCCRPetitionType)
     PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kGeneralHelp,plNetCommon::PetitionTypes::kGeneralHelp)
     PYTHON_ENUM_ELEMENT(PtCCRPetitionType, kBug,        plNetCommon::PetitionTypes::kBug)

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
@@ -1,0 +1,144 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef _pyPythonCallable_h_
+#define _pyPythonCallable_h_
+
+#include <Python.h>
+#include <string_theory/string>
+
+#include "cyPythonInterface.h"
+#include "pyGlueHelpers.h"
+#include "pyObjectRef.h"
+
+namespace plPythonCallable
+{
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, bool value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyBool_FromLong(value ? 1 : 0));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, char value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromFormat("%c", (int)value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, const char* value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromString(value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, double value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyFloat_FromDouble(value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, float value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyFloat_FromDouble(value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, int8_t value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong(value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, int16_t value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong(value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, int32_t value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong(value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, PyObject* value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, value);
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, pyObjectRef& value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, value.Release());
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, const ST::string& value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromSTString(value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint8_t value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyLong_FromSize_t(value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint16_t value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyLong_FromSize_t(value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint32_t value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyLong_FromSize_t(value));
+    }
+
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, wchar_t value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromFormat("%c", (int)value));
+    }
+
+    template<size_t Size, typename Arg>
+    static inline void BuildTupleArgs(PyObject* tuple, Arg&& arg)
+    {
+        IBuildTupleArg(tuple, (Size - 1), std::forward<Arg>(arg));
+    }
+
+    template<size_t Size, typename Arg0, typename... Args>
+    static inline void BuildTupleArgs(PyObject* tuple, Arg0&& arg0, Args&&... args)
+    {
+        IBuildTupleArg(tuple, (Size - (sizeof...(args) + 1)), std::forward<Arg0>(arg0));
+        BuildTupleArgs<Size>(tuple, std::forward<Args>(args)...);
+    }
+};
+
+#endif

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
@@ -48,7 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <variant>
 
 #include <Python.h>
-#include <string_theory/string>
+#include <string_theory/format>
 
 #include "plProfile.h"
 
@@ -60,89 +60,92 @@ plProfile_Extern(PythonUpdate);
 
 namespace plPythonCallable
 {
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, bool value)
+    template<typename ArgT>
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, ArgT value) = delete;
+
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, bool value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyBool_FromLong(value ? 1 : 0));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, char value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, char value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromFormat("%c", (int)value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, const char* value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, const char* value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromString(value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, double value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, double value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyFloat_FromDouble(value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, float value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, float value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyFloat_FromDouble(value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, int8_t value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, int8_t value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong(value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, int16_t value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, int16_t value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong(value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, int32_t value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, int32_t value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong(value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, PyObject* value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, PyObject* value)
     {
         PyTuple_SET_ITEM(tuple, idx, value);
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, pyObjectRef& value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, pyObjectRef& value)
     {
         PyTuple_SET_ITEM(tuple, idx, value.Release());
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, const ST::string& value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, const ST::string& value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromSTString(value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint8_t value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint8_t value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyLong_FromSize_t(value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint16_t value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint16_t value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyLong_FromSize_t(value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint32_t value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint32_t value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyLong_FromSize_t(value));
     }
 
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, wchar_t value)
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, wchar_t value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromFormat("%c", (int)value));
     }
 
     template<size_t Size, typename Arg>
-    static inline void BuildTupleArgs(PyObject* tuple, Arg&& arg)
+    inline void BuildTupleArgs(PyObject* tuple, Arg&& arg)
     {
         IBuildTupleArg(tuple, (Size - 1), std::forward<Arg>(arg));
     }
 
     template<size_t Size, typename Arg0, typename... Args>
-    static inline void BuildTupleArgs(PyObject* tuple, Arg0&& arg0, Args&&... args)
+    inline void BuildTupleArgs(PyObject* tuple, Arg0&& arg0, Args&&... args)
     {
         IBuildTupleArg(tuple, (Size - (sizeof...(args) + 1)), std::forward<Arg0>(arg0));
         BuildTupleArgs<Size>(tuple, std::forward<Args>(args)...);
@@ -150,7 +153,7 @@ namespace plPythonCallable
 
     template<typename... _CBArgsT>
     [[nodiscard]]
-    static inline std::function<void(_CBArgsT...)> BuildCallback(ST::string parentCall, PyObject* callable)
+    inline std::function<void(_CBArgsT...)> BuildCallback(ST::string parentCall, PyObject* callable)
     {
         hsAssert(PyCallable_Check(callable) != 0, "BuildCallback() expects a Python callable.");
 
@@ -179,15 +182,15 @@ namespace plPythonCallable
     }
 
     template<typename... _CBArgsT>
-    static inline void BuildCallback(ST::string parentCall, PyObject* callable,
-                                     std::function<void(_CBArgsT...)>& cb)
+    inline void BuildCallback(ST::string parentCall, PyObject* callable,
+                              std::function<void(_CBArgsT...)>& cb)
     {
         cb = BuildCallback<_CBArgsT...>(std::move(parentCall), callable);
     }
 
     template<size_t _AlternativeN, typename... _VariantArgsT>
-    static inline void BuildCallback(ST::string parentCall, PyObject* callable,
-                                     std::variant<_VariantArgsT...>& cb)
+    inline void BuildCallback(ST::string parentCall, PyObject* callable,
+                              std::variant<_VariantArgsT...>& cb)
     {
         std::variant_alternative_t<_AlternativeN, std::decay_t<decltype(cb)>> cbFunc;
         BuildCallback(std::move(parentCall), callable, cbFunc);

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -352,7 +352,8 @@ T* plPythonFileMod::IScriptWantsMsg(func_num methodId, plMessage* msg) const
 
 namespace plPythonCallable
 {
-    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, ControlEventCode value)
+    template<>
+    inline void IBuildTupleArg(PyObject* tuple, size_t idx, ControlEventCode value)
     {
         PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong((long)value));
     }

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -54,6 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGeometry3.h"
 #include "pyKey.h"
 #include "pyObjectRef.h"
+#include "plPythonCallable.h"
 #include "hsResMgr.h"
 #include "hsStream.h"
 
@@ -349,98 +350,13 @@ T* plPythonFileMod::IScriptWantsMsg(func_num methodId, plMessage* msg) const
 //  PURPOSE    : Builds Python argument tuple for method calling.
 //
 
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, bool value)
+namespace plPythonCallable
 {
-    PyTuple_SET_ITEM(tuple, idx, PyBool_FromLong(value ? 1 : 0));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, char value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromFormat("%c", (int)value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, ControlEventCode value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong((long)value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, const char* value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromString(value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, double value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyFloat_FromDouble(value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, float value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyFloat_FromDouble(value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, int8_t value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong(value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, int16_t value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong(value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, int32_t value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong(value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, PyObject* value)
-{
-    PyTuple_SET_ITEM(tuple, idx, value);
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, pyObjectRef& value)
-{
-    PyTuple_SET_ITEM(tuple, idx, value.Release());
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, const ST::string& value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromSTString(value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint8_t value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyLong_FromSize_t(value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint16_t value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyLong_FromSize_t(value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, uint32_t value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyLong_FromSize_t(value));
-}
-
-static inline void IBuildTupleArg(PyObject* tuple, size_t idx, wchar_t value)
-{
-    PyTuple_SET_ITEM(tuple, idx, PyUnicode_FromFormat("%c", (int)value));
-}
-
-template<size_t Size, typename Arg>
-static inline void IBuildTupleArgs(PyObject* tuple, Arg&& arg)
-{
-    IBuildTupleArg(tuple, (Size - 1), std::forward<Arg>(arg));
-}
-
-template<size_t Size, typename Arg0, typename... Args>
-static inline void IBuildTupleArgs(PyObject* tuple, Arg0&& arg0, Args&&... args)
-{
-    IBuildTupleArg(tuple, (Size - (sizeof...(args) + 1)), std::forward<Arg0>(arg0));
-    IBuildTupleArgs<Size>(tuple, std::forward<Args>(args)...);
-}
+    static inline void IBuildTupleArg(PyObject* tuple, size_t idx, ControlEventCode value)
+    {
+        PyTuple_SET_ITEM(tuple, idx, PyLong_FromLong((long)value));
+    }
+};
 
 template<typename... Args>
 void plPythonFileMod::ICallScriptMethod(func_num methodId, Args&&... args)
@@ -450,7 +366,7 @@ void plPythonFileMod::ICallScriptMethod(func_num methodId, Args&&... args)
         return;
 
     pyObjectRef tuple = PyTuple_New(sizeof...(args));
-    IBuildTupleArgs<sizeof...(args)>(tuple.Get(), std::forward<Args>(args)...);
+    plPythonCallable::BuildTupleArgs<sizeof...(args)>(tuple.Get(), std::forward<Args>(args)...);
 
     plProfile_BeginTiming(PythonUpdate);
     pyObjectRef retVal = PyObject_CallObject(callable, tuple.Get());

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -614,7 +614,7 @@ static PyObject *methodName(PyObject *self) /* and now for the actual function *
 #define PYTHON_ENUM_START(enumName) std::vector<std::tuple<ST::string, Py_ssize_t>> enumName##_enumValues{
 
 // for each element of the enum
-#define PYTHON_ENUM_ELEMENT(enumName, elementName, elementValue) std::make_tuple(ST_LITERAL(#elementName), elementValue),
+#define PYTHON_ENUM_ELEMENT(enumName, elementName, elementValue) std::make_tuple(ST_LITERAL(#elementName), (Py_ssize_t)elementValue),
 
 // to finish off and define the enum
 #define PYTHON_ENUM_END(m, enumName) }; pyEnum::MakeEnum(m, #enumName, enumName##_enumValues);

--- a/Sources/Plasma/FeatureLib/pfPython/pyObjectRef.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyObjectRef.h
@@ -46,6 +46,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <Python.h>
 #include "HeadSpin.h"
 
+struct pyObjectNewRef_Type{};
+constexpr pyObjectNewRef_Type pyObjectNewRef;
+
 /** RAII reference count helper for Python objects. */
 class pyObjectRef
 {
@@ -56,6 +59,15 @@ public:
 
     /** Steals ownership of this object reference. */
     pyObjectRef(PyObject* object) : fPyObject(object) { }
+
+    /** Increments the reference count of this object. */
+    pyObjectRef(PyObject* object, pyObjectNewRef_Type)
+        : fPyObject(object)
+    {
+        Py_INCREF(object);
+    }
+
+    pyObjectRef(std::nullptr_t, pyObjectNewRef_Type) = delete;
 
     pyObjectRef(const pyObjectRef& copy)
         : fPyObject(copy.fPyObject)

--- a/Sources/Plasma/NucleusLib/inc/plCreatableIndex.h
+++ b/Sources/Plasma/NucleusLib/inc/plCreatableIndex.h
@@ -368,6 +368,7 @@ CLASS_INDEX_LIST_START
     CLASS_INDEX(plRidingAnimatedPhysicalDetector),
     CLASS_INDEX(plVolumeSensorConditionalObjectNoArbitration),
     CLASS_INDEX(plPXSubWorld),
+    CLASS_INDEX(pfConfirmationMgr),
 //---------------------------------------------------------
 // Keyed objects above this line, unkeyed (such as messages) below..
 //---------------------------------------------------------
@@ -956,6 +957,8 @@ CLASS_INDEX_LIST_START
     CLASS_INDEX(pl3DPipeline),
     CLASS_INDEX(plGLPipeline),
     CLASS_INDEX(plSDLModifierStateMsg),
+    CLASS_INDEX(plConfirmationMsg),
+    CLASS_INDEX(plLocalizedConfirmationMsg),
 CLASS_INDEX_LIST_END
 
 #endif // plCreatableIndex_inc

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plFixedKey.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plFixedKey.cpp
@@ -113,6 +113,7 @@ static constexpr plKeySeed SeedList[] = {
     { kJournalBookMgr_KEY,              CLASS_INDEX_SCOPED( pfJournalBook ),            "kJournalBookMgr_KEY",          },
     { kAgeLoader_KEY,                   CLASS_INDEX_SCOPED( plAgeLoader),               "kAgeLoader_KEY",               },
     { kBuiltIn3rdPersonCamera_KEY,      CLASS_INDEX_SCOPED( plCameraModifier1 ),        "kBuiltIn3rdPersonCamera_KEY",  },
+    { kConfirmationMgr_KEY,             CLASS_INDEX_SCOPED( pfConfirmationMgr ),        "kConfirmationMgr_KEY",         },
 
     { kLast_Fixed_KEY,                  CLASS_INDEX_SCOPED( plSceneObject ),            "kLast_Fixed_KEY",              }
 };

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plFixedKey.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plFixedKey.h
@@ -85,6 +85,7 @@ enum plFixedKeyId
     kJournalBookMgr_KEY,
     kAgeLoader_KEY,
     kBuiltIn3rdPersonCamera_KEY,
+    kConfirmationMgr_KEY,
 
     kLast_Fixed_KEY
 };

--- a/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
@@ -67,6 +67,7 @@ set(plMessage_HEADERS
     plClimbMsg.h
     plCollideMsg.h
     plCondRefMsg.h
+    plConfirmationMsg.h
     plConnectedToVaultMsg.h
     plConsoleMsg.h
     plDeviceRecreateMsg.h

--- a/Sources/Plasma/PubUtilLib/plMessage/plConfirmationMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plConfirmationMsg.h
@@ -1,0 +1,149 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef plConfirmationMsg_inc
+#define plConfirmationMsg_inc
+
+// I hope you like big STL headers...
+#include <functional>
+#include <variant>
+#include <vector>
+
+#include <string_theory/string>
+
+#include "pnMessage/plMessage.h"
+
+/** Show an in-game confirmation GUI dialog. */
+class plConfirmationMsg : public plMessage
+{
+public:
+    enum class Result : int32_t
+    {
+        OK = 1,
+        Cancel = 0,
+        Yes = 1,
+        No = 0,
+        Quit = 1,
+        Logout = 62,
+    };
+
+    using Callback = std::variant<std::monostate, std::function<void(Result)>, plKey>;
+
+    enum class Type : uint32_t
+    {
+        /** Informational item for the user with only the possibility to OK it. */
+        OK,
+
+        /**
+         * The quit dialog. Do not use for an error.
+         * If the user requests a quit or logout, then any optional callback will be
+         * dispatched, then the client will quit or logout on the next main thread
+         * evaluation.
+         */
+        ConfirmQuit,
+
+        /** Notify user about an exception case, then force quit the client. */
+        ForceQuit,
+
+        /** Requests the user to answer Yes or No to a question. */
+        YesNo,
+    };
+
+protected:
+    ST::string fMessage;
+    Type fDialogType;
+    Callback fCallback;
+
+public:
+    plConfirmationMsg()
+    {
+        SetBCastFlag(plMessage::kBCastByType);
+    }
+
+    plConfirmationMsg(ST::string msg, Type type = Type::OK, Callback cb = {})
+        : fMessage(std::move(msg)),
+          fDialogType(type),
+          fCallback(std::move(cb))
+    {
+        SetBCastFlag(plMessage::kBCastByType);
+    }
+
+    CLASSNAME_REGISTER(plConfirmationMsg);
+    GETINTERFACE_ANY(plConfirmationMsg, plMessage);
+
+    void Read(hsStream*, hsResMgr*) override { FATAL("no"); }
+    void Write(hsStream*, hsResMgr*) override { FATAL("no"); }
+
+    ST::string GetText() const { return fMessage; }
+    Type GetType() const { return fDialogType; }
+    Callback GetCallback() const { return fCallback; }
+
+    void SetText(ST::string msg) { fMessage = std::move(msg); }
+    void SetType(Type type) { fDialogType = type; }
+    void SetCallback(Callback cb) { fCallback = std::move(cb); }
+};
+
+
+/** Show a localized in-game confirmation GUI dialog. */
+class plLocalizedConfirmationMsg : public plConfirmationMsg
+{
+protected:
+    std::vector<ST::string> fArgs;
+
+public:
+    plLocalizedConfirmationMsg() = default;
+    plLocalizedConfirmationMsg(ST::string path, std::vector<ST::string> args = {},
+                               Type type = Type::OK, Callback cb = {})
+        : plConfirmationMsg(std::move(path), type, std::move(cb)),
+          fArgs(std::move(args))
+    { }
+
+    CLASSNAME_REGISTER(plLocalizedConfirmationMsg);
+    GETINTERFACE_ANY(plLocalizedConfirmationMsg, plConfirmationMsg);
+
+    const std::vector<ST::string>& GetArgs() const { return fArgs; }
+    std::vector<ST::string>& GetArgs() { return fArgs; }
+
+    void SetArgs(std::vector<ST::string> args) { fArgs = std::move(args); }
+};
+
+#endif

--- a/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
@@ -107,6 +107,10 @@ REGISTER_CREATABLE(plCollideMsg);
 #include "plCondRefMsg.h"
 REGISTER_CREATABLE(plCondRefMsg);
 
+#include "plConfirmationMsg.h"
+REGISTER_NONCREATABLE(plConfirmationMsg);
+REGISTER_NONCREATABLE(plLocalizedConfirmationMsg);
+
 #include "plConnectedToVaultMsg.h"
 REGISTER_CREATABLE(plConnectedToVaultMsg);
 


### PR DESCRIPTION
While working on the [clickable links in KI Chat](https://www.youtube.com/watch?v=qvsb0mhxUig) concept, it became apparent that I needed to issue a confirmation or Yes/No dialog from a Python script that did not have its own `plKey`. Currently, Yes/No dialogs are handled by the xKI python scripts over many hundreds of lines in an especially ad-hoc way and can only be responded to using a `plNotifyMsg`. This implements a singleton whose job is to receive confirmation requests from anyone who links against plMessage and respond to them via either a (potentially stateful) lambda or using a legacy `plNotifyMsg`.

This new functionality will allow us to be very flexible with where we issue and how we respond to confirmation requests. Some examples floating around in my mind:
- `PtYesNoDialog()` can accept a Python callable to call back in addition to a key to notify.
- If linking to an Age fails, we can ask if we want to quit or return to the previous Age... instead of popping up an OS dialog that says "Link to Age failed"
- Localized dialogs can be issued from code in C++ that does not link against pfLocalizationMgr.