### PR TITLE
Clickable URLs in KI Chat and KI Mail.

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -5195,7 +5195,7 @@ class xKI(ptModifier):
                                 edElement.save()
                         else:
                             if self.BKEditField == kGUI.BKEditFieldJRNNote:
-                                buf = textBox.getEncodedBufferW()
+                                buf = textBox.getStringW()
                                 if buf[:len(PtGetLocalizedString("KI.Journal.InitialMessage"))] == PtGetLocalizedString("KI.Journal.InitialMessage"):
                                     buf = buf[len(PtGetLocalizedString("KI.Journal.InitialMessage")):]
                                 edElement = edElement.upcastToTextNoteNode()

--- a/Scripts/Python/ki/xKIConstants.py
+++ b/Scripts/Python/ki/xKIConstants.py
@@ -211,6 +211,7 @@ class kColors:
     DniRed      = ptColor(1.0, 0.216, 0.380, 1.0)
     DniGreen    = ptColor(0.698, 0.878, 0.761, 1.0)
     DniGreenDk  = ptColor(0.0, 0.596, 0.211, 1.0)
+    DniLilac    = ptColor(0.6, 0.6, 1.0, 1.0)
     DniPurple   = ptColor(0.878, 0.698, 0.819, 1.0)
     DniWhite    = ptColor().white()
 
@@ -219,10 +220,13 @@ class kColors:
     
     DniShowBtn     = DniShowRed
     DniGhostBtn    = DniHideBlue
-    
+
+    TextNoteURL = DniLilac
+
     # Chat colors (messages and headers).
     ChatMessage             = DniWhite
     ChatMessageMention      = DniYellowLt
+    ChatMessageURL          = DniLilac
     ChatHeaderBroadcast     = DniBlue
     ChatHeaderPrivate       = DniYellow
     ChatHeaderAdmin         = DniCyan

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -4187,6 +4187,10 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """Clears all text from the multi-line edit control."""
         pass
 
+    def clearLink(self) -> None:
+        """Ends the hyperlink hotspot, if any, at the current cursor position."""
+        ...
+
     def clickable(self):
         """Sets this listbox to be clickable by the user."""
         pass
@@ -4241,6 +4245,10 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 
     def getCursor(self) -> int:
         """Get the current position of the cursor in the encoded buffer."""
+        ...
+
+    def getCurrentLink(self) -> int:
+        """Returns the link the mouse is currently over."""
         ...
 
     def getEncodedBuffer(self):
@@ -4307,6 +4315,10 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """Inserts an encoded color object at the current cursor position.
 'color' is a ptColor object."""
         pass
+
+    def insertLink(self, linkId: int) -> None:
+        """Inserts a link hotspot at the current cursor position."""
+        ...
 
     def insertString(self,string):
         """Inserts a string at the current cursor position."""

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -4239,6 +4239,10 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """Returns the size of the buffer"""
         pass
 
+    def getCursor(self) -> int:
+        """Get the current position of the cursor in the encoded buffer."""
+        ...
+
     def getEncodedBuffer(self):
         """Returns the encoded buffer in a python buffer object. Do NOT use result with setEncodedBufferW."""
         pass
@@ -4335,6 +4339,10 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
     def isLocked(self):
         """Is the multi-line edit control locked? Returns 1 if true otherwise returns 0"""
         pass
+
+    def isUpdating(self) -> bool:
+        """Is someone else already suppressing redraws of the control?"""
+        ...
 
     def isVisible(self):
         """Returns whether this GUI control is visible"""

--- a/Scripts/Python/plasma/PlasmaTypes.py
+++ b/Scripts/Python/plasma/PlasmaTypes.py
@@ -46,6 +46,7 @@ interfacing with the Plasma 2.0 engine.
 """
 from Plasma import *
 from PlasmaConstants import *
+from contextlib import contextmanager
 
 ####################################
 # Utility functions
@@ -275,6 +276,17 @@ If seed is None, the system time is used."""
         avatar.avatar.setMorph("MFace",0,morph)
     else:
         avatar.avatar.setMorph("FFace",0,morph)
+
+@contextmanager
+def PtBeginGUIUpdate(control, redraw=True):
+    if not control.isUpdating():
+        control.beginUpdate()
+        try:
+            yield
+        finally:
+            control.endUpdate(redraw)
+    else:
+        yield
 
 ####################################
 # Exceptions

--- a/Scripts/Python/plasma/PlasmaTypes.py
+++ b/Scripts/Python/plasma/PlasmaTypes.py
@@ -109,7 +109,7 @@ kFontShadowed=4
 
 # OnGUINotify Event Types
 kShowHide=1             # show or hide change (only on kDialog)
-kAction=2               # kButton clicked, kListBox item clicked on, kEditBox hit enter
+kAction=2               # kButton clicked, kListBox item clicked on, kEditBox hit enter, kMultiLineEdit hit link
 kValueChanged=3         # value changed in control (could be from kUpDownPair,kKnob,kCheckBox,kRadioGroup
 kDialogLoaded=4         # the dialog has just been loaded
 kFocusChange=5          # the focus changed from one control to another, or none, within the dialog

--- a/Scripts/Python/xGUILinkHandler.py
+++ b/Scripts/Python/xGUILinkHandler.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+""" *==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+ *==LICENSE==* """
+
+from __future__ import annotations
+from dataclasses import dataclass
+import re
+from typing import Union
+import webbrowser
+
+from Plasma import *
+from PlasmaConstants import *
+from PlasmaTypes import *
+
+from xCensor import xCensor
+
+_HOST_REGEX = re.compile(R"https?:\/\/(?:www\.)?([^\/]+).*", re.IGNORECASE)
+_URL_REGEX = re.compile(R"https?:\/\/[\S]+", re.IGNORECASE)
+
+@dataclass
+class _Link:
+    url: str
+    pos: int = 0
+
+
+class xGUILinkHandler:
+    def __init__(self, control: ptGUIControlMultiLineEdit):
+        self._control = control
+        self._lastColor = control.getForeColor()
+        self._linkColor = ptColor().blue()
+        self._nextLink = 0
+        self._links = {}
+
+        # Cheap inheritance
+        for i in dir(control):
+            if not hasattr(self, i):
+                setattr(self, i, getattr(control, i))
+
+    def __getitem__(self, index: int) -> str:
+        if index in self._links:
+            return self._links[index].url
+        else:
+            raise KeyError(index)
+
+    def getCurrentURL(self) -> Union[None, str]:
+        linkId = self._control.getCurrentLink()
+        if linkId is None:
+            PtDebugPrint("xGUILinkHandler.getCurrentURL():\tNo active link", level=kWarningLevel)
+            return None
+        try:
+            link = self._links[linkId]
+        except LookupError:
+            PtDebugPrint(f"xGUILinkHandler.getCurrentURL():\tUnknown linkId {linkId}")
+            return None
+        else:
+            return link.url
+
+    @property
+    def linkColor(self) -> ptColor:
+        return self._linkColor
+
+    @linkColor.setter
+    def linkColor(self, value: ptColor):
+        self._linkColor = value
+
+    def openLink(self, prompt: bool = True) -> None:
+        url = self.getCurrentURL()
+        if url is None:
+            PtDebugPrint("xGUILinkHandler.openLink():\tNo active link to open!")
+            return
+
+        if prompt:
+            # Unparse the current URL as a hostname for prompting.
+            hostname = _HOST_REGEX.sub(R"\1", url)
+
+            def boom(result: int):
+                if result == PtConfirmationResult.Yes:
+                    PtDebugPrint(f"xGUILinkHandler.openLink():\tLink OK to open: {url}", level=kWarningLevel)
+                    webbrowser.open_new_tab(url)
+            PtLocalizedYesNoDialog(boom, "KI.Messages.OpenHyperlink", hostname)
+        else:
+            PtDebugPrint(f"xGUILinkHandler.openLink():\tUnconditional URL open: {url}")
+            webbrowser.open_new_tab(url)
+
+    # ======================================
+    # ptGUIControlMultiLineEdit "overrides"
+    # ======================================
+
+    def clearBuffer(self) -> None:
+        self._lastColor = self._control.getForeColor()
+        self._nextLink = 0
+        self._links.clear()
+        self._control.clearBuffer()
+
+    def deleteLinesFromTop(self, lines: int) -> None:
+        oldBufferLen = self._control.getBufferSize()
+        self._control.deleteLinesFromTop(lines)
+        diff = self._control.getBufferSize() - oldBufferLen
+        for linkId in list(self._links):
+            self._links[linkId].pos -= diff
+            if self._links[linkId].pos < 0:
+                del self._links[linkId]
+
+    def insertColor(self, color: ptColor) -> None:
+        self._lastColor = color
+        self._control.insertColor(color)
+
+    def insertString(self, text: str, /, *, censorLevel: Union[int, None] = None, urlDetection: bool = True) -> None:
+        lastInsert = 0
+        control, linkColor, normalColor = self._control, self._linkColor, self._lastColor
+
+        if censorLevel is None:
+            censor = lambda x: x
+        else:
+            censor = lambda x: xCensor(x, censorLevel)
+
+        if urlDetection:
+            with PtBeginGUIUpdate(control):
+                urls = ((i.span(), i[0]) for i in _URL_REGEX.finditer(text))
+                for (start, end), url in urls:
+                    if start > lastInsert:
+                        control.insertStringW(censor(text[lastInsert:start]))
+                    lastInsert = end
+                    control.insertColor(linkColor)
+
+                    self._links[self._nextLink] = _Link(url, control.getCursor())
+                    control.insertLink(self._nextLink)
+                    PtDebugPrint(f"xGUILinkHandler.insertString():\tInserting URL {url} as linkId {self._nextLink}", level=kDebugDumpLevel)
+                    self._nextLink += 1
+
+                    control.insertStringW(censor(url))
+                    control.clearLink()
+                    control.insertColor(normalColor)
+                if lastInsert != len(text):
+                    control.insertStringW(censor(text[lastInsert:]))
+        else:
+            control.insertStringW(censor(text))
+
+    def insertStringW(self, text: str, /, *, censorLevel: Union[int, None] = None, urlDetection: bool = True) -> None:
+        self.insertString(text, censorLevel=censorLevel, urlDetection=urlDetection)
+
+    def setString(self, text: str, /, *, censorLevel: Union[int, None] = None, urlDetection: bool = True) -> None:
+        with PtBeginGUIUpdate(self._control):
+            self.clearBuffer()
+            self.insertString(text, censorLevel=censorLevel, urlDetection=urlDetection)
+            # Emulate the real behavior of setString() - this to ensure we don't get duplicate
+            # cursors if the string is reset while the control is being focused (eg text notes).
+            self._control.moveCursor(PtGUIMultiLineDirection.kBufferStart)
+
+    def setStringW(self, text: str, /, *, censorLevel: Union[int, None] = None, urlDetection: bool = True) -> None:
+        self.setString(text, censorLevel=censorLevel, urlDetection=urlDetection)

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.h
@@ -215,6 +215,9 @@ class pfGUIControlMod : public plSingleModifier
         // Return false if you actually DON'T want the mouse clicked at this point (should only be used for non-rectangular region rejection)
         virtual bool    FilterMousePosition( hsPoint3 &mousePt ) { return true; }
 
+        /** Return false if you actually DON'T want a mouse click to focus the control. */
+        virtual bool    FocusOnMouseDown(const hsPoint3& mousePt, uint8_t modifiers) const { return true; }
+
         virtual void    HandleMouseDown( hsPoint3 &mousePt, uint8_t modifiers ) { }
         virtual void    HandleMouseUp( hsPoint3 &mousePt, uint8_t modifiers ) { }
         virtual void    HandleMouseDrag( hsPoint3 &mousePt, uint8_t modifiers ) { }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
@@ -497,7 +497,7 @@ static bool     showBounds = false;
 
             // Clicking on a control (mouse down) also sets focus to that control. Unlike
             // control-of-interest, this does NOT get reset until a new control is clicked on
-            if( fFocusCtrl != fMousedCtrl )
+            if (fFocusCtrl != fMousedCtrl && fMousedCtrl->FocusOnMouseDown(mousePoint, modifiers))
             {
                 if (fHandler != nullptr)
                     fHandler->OnCtrlFocusChange( fFocusCtrl, fMousedCtrl );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogNotifyProc.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogNotifyProc.cpp
@@ -60,6 +60,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfGUIEditBoxMod.h"
 #include "pfGUIListBoxMod.h"
 #include "pfGUIListElement.h"
+#include "pfGUIMultiLineEditCtrl.h"
 
 #include "pfMessage/pfGUINotifyMsg.h"
 
@@ -89,19 +90,20 @@ void pfGUIDialogNotifyProc::DoSomething( pfGUIControlMod *ctrl )
 
 void pfGUIDialogNotifyProc::HandleExtendedEvent( pfGUIControlMod *ctrl, uint32_t event )
 {
-    pfGUIEditBoxMod *edit = pfGUIEditBoxMod::ConvertNoRef( ctrl );
-    if (edit != nullptr && event == pfGUIEditBoxMod::kWantAutocomplete)
-    {
-        //send notify, somebody will do something with that (like python script)
-        ISendNotify( ctrl->GetKey(), pfGUINotifyMsg::kSpecialAction );
+    pfGUIEditBoxMod* edit = pfGUIEditBoxMod::ConvertNoRef(ctrl);
+    if (edit) {
+        if (event == pfGUIEditBoxMod::kWantAutocomplete)
+            ISendNotify(ctrl->GetKey(), pfGUINotifyMsg::kSpecialAction);
+        else if (event == pfGUIEditBoxMod::kWantMessageHistoryUp)
+            ISendNotify(ctrl->GetKey(), pfGUINotifyMsg::kMessageHistoryUp);
+        else if (event == pfGUIEditBoxMod::kWantMessageHistoryDown)
+            ISendNotify(ctrl->GetKey(), pfGUINotifyMsg::kMessageHistoryDown);
     }
-    else if(edit && event == pfGUIEditBoxMod::kWantMessageHistoryUp)
-    {
-        ISendNotify( ctrl->GetKey(), pfGUINotifyMsg::kMessageHistoryUp );
-    }
-    else if(edit && event == pfGUIEditBoxMod::kWantMessageHistoryDown)
-    {
-        ISendNotify( ctrl->GetKey(), pfGUINotifyMsg::kMessageHistoryDown );
+
+    pfGUIMultiLineEditCtrl* mlEdit = pfGUIMultiLineEditCtrl::ConvertNoRef(ctrl);
+    if (mlEdit) {
+        if (event == pfGUIMultiLineEditCtrl::kLinkClicked)
+            ISendNotify(ctrl->GetKey(), pfGUINotifyMsg::kAction);
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -1569,11 +1569,6 @@ wchar_t *pfGUIMultiLineEditCtrl::GetCodedBufferW(size_t &length) const
     }
 }
 
-uint32_t  pfGUIMultiLineEditCtrl::GetBufferSize()
-{
-    return fBuffer.size() - 1;
-}
-
 //// ICharPosToBufferPos /////////////////////////////////////////////////////
 //  Given a character position (i.e. a buffer position if we didn't have
 //  control codes), returns the actual buffer pos.

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -63,6 +63,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plAnimation/plAGModifier.h"
 #include "plClipboard/plClipboard.h"
+#include "plInputCore/plInputInterface.h"
 #include "plMessage/plAnimCmdMsg.h"
 #include "plGImage/plDynamicTextMap.h"
 
@@ -135,15 +136,18 @@ class pfMLScrollProc : public pfGUICtrlProcObject
 
 constexpr wchar_t kColorCodeChar = (wchar_t)1;
 constexpr wchar_t kStyleCodeChar = (wchar_t)2;
+constexpr wchar_t kLinkCodeChar = (wchar_t)3;
 constexpr size_t kColorCodeSize = 5;
 constexpr size_t kStyleCodeSize = 3;
+constexpr size_t kLinkCodeSize = 3;
 
 //// Constructor/Destructor //////////////////////////////////////////////////
 
 pfGUIMultiLineEditCtrl::pfGUIMultiLineEditCtrl()
-    : fBuffer({L'\0'}), fCursorPos(), fLastCursorLine(), fBufferLimit(-1),
-      fScrollControl(), fScrollProc(), fScrollPos(), fReadyToRender(),
-      fLastKeyModifiers(), fLastKeyPressed(), fLockCount(),
+    : fBuffer({L'\0'}), fCursorPos(), fLastCursorLine(),
+      fClickedLinkId(-1), fCurrLinkId(-1),
+      fBufferLimit(-1), fScrollControl(), fScrollProc(), fScrollPos(),
+      fReadyToRender(), fLastKeyModifiers(), fLastKeyPressed(), fLockCount(),
       fNextCtrl(), fPrevCtrl(), fEventProc(),
       fTopMargin(), fLeftMargin(), fBottomMargin(), fRightMargin(),
       fFontSize(), fFontStyle(), fFontFlagsSet(), fCanUpdate(true),
@@ -412,7 +416,7 @@ void    pfGUIMultiLineEditCtrl::IUpdate( int32_t startLine, int32_t endLine )
         IRenderLine(fLeftMargin, y, start, end);
 
         // Render the cursor
-        if( fCursorPos >= start && fCursorPos < end && IsFocused() )
+        if( fCursorPos >= start && fCursorPos < end && IsFocused() && !IsLocked() )
         {
             uint16_t x = (fCursorPos > start)
                          ? (uint16_t)IRenderLine(fLeftMargin, y, start, fCursorPos, true)
@@ -475,7 +479,7 @@ inline bool pfGUIMultiLineEditCtrl::IIsRenderable( const wchar_t c )
 
 inline bool pfGUIMultiLineEditCtrl::IIsCodeChar( const wchar_t c )
 {
-    return (c == kColorCodeChar || c == kStyleCodeChar);
+    return (c == kColorCodeChar || c == kStyleCodeChar || c == kLinkCodeChar);
 }
 
 //// IFindLastCode Functions /////////////////////////////////////////////////
@@ -571,6 +575,11 @@ uint32_t  pfGUIMultiLineEditCtrl::IRenderLine( uint16_t x, uint16_t y, int32_t s
                 if( !dontRender )
                     fDynTextMap->SetFont( fFontFace, fFontSize  , GetColorScheme()->fFontFlags | currStyle,
                                             HasFlag( kXparentBgnd ) ? false : true );
+            }
+            else if (buffer[pos] == kLinkCodeChar)
+            {
+                // Advance beyond the link code
+                pos += kLinkCodeSize;
             }
             else if( buffer[ pos ] == L'\n' )
             {
@@ -696,6 +705,8 @@ inline  int32_t   pfGUIMultiLineEditCtrl::IOffsetToNextChar( wchar_t stringChar 
         return kColorCodeSize;
     else if (stringChar == kStyleCodeChar)
         return kStyleCodeSize;
+    else if (stringChar == kLinkCodeChar)
+        return kLinkCodeSize;
     else
         return 1;
 }
@@ -938,46 +949,115 @@ void    pfGUIMultiLineEditCtrl::IOffsetLineStarts( uint32_t position, int32_t of
         fNextCtrl->ISetLineStarts(fLineStarts);
 }
 
+//// IFindLink ///////////////////////////////////////////////////////////////
+
+int16_t pfGUIMultiLineEditCtrl::IFindLink(int32_t cursorPos, uint8_t modifiers) const
+{
+    // If we can edit, then require a Ctrl-Click
+    if (fFocused && !hsCheckBits(modifiers, pfGameGUIMgr::kCtrlDown))
+        return -1;
+
+    if (cursorPos >= 0) {
+        for (hsSsize_t i = cursorPos; i > 0; --i) {
+            if (fBuffer[i] == kLinkCodeChar)
+                return static_cast<int16_t>(fBuffer[i - 1]);
+        }
+    }
+    return -1;
+}
+
+//// HandleMouse /////////////////////////////////////////////////////////////
+
+bool pfGUIMultiLineEditCtrl::IHandleMouse(hsPoint3& mousePt)
+{
+    if (fDynTextMap == nullptr || !fBounds.IsInside(&mousePt))
+        return false;
+
+    IScreenToLocalPt(mousePt);
+    mousePt.fX *= fDynTextMap->GetVisibleWidth();
+    mousePt.fY *= fDynTextMap->GetVisibleHeight();
+    return true;
+}
+
+//// FocusOnMouseDown ////////////////////////////////////////////////////////
+
+bool pfGUIMultiLineEditCtrl::FocusOnMouseDown(const hsPoint3& mousePt, uint8_t modifiers) const
+{
+    // Don't focus the control if we've clicked on a link inside of it.
+    return fClickedLinkId == -1;
+}
+
 //// HandleMouseDown /////////////////////////////////////////////////////////
 
 void    pfGUIMultiLineEditCtrl::HandleMouseDown( hsPoint3 &mousePt, uint8_t modifiers )
 {
-    if (fDynTextMap == nullptr || !fBounds.IsInside(&mousePt))
-        return;
-
-    IScreenToLocalPt( mousePt );
-    mousePt.fX *= fDynTextMap->GetVisibleWidth();
-    mousePt.fY *= fDynTextMap->GetVisibleHeight();
-
-    IMoveCursorTo( IPointToPosition( (int16_t)(mousePt.fX), (int16_t)(mousePt.fY) ) );
+    if (IHandleMouse(mousePt)) {
+        int32_t cursorPos = IPointToPosition((int16_t)(mousePt.fX), (int16_t)(mousePt.fY));
+        fClickedLinkId = fCurrLinkId = IFindLink(cursorPos, modifiers);
+        if (fCurrLinkId == -1)
+            IMoveCursorTo(cursorPos);
+    } else {
+        fClickedLinkId = fCurrLinkId = -1;
+    }
 }
 
 //// HandleMouseUp ///////////////////////////////////////////////////////////
 
 void    pfGUIMultiLineEditCtrl::HandleMouseUp( hsPoint3 &mousePt, uint8_t modifiers )
 {
-    if (fDynTextMap == nullptr || !fBounds.IsInside(&mousePt))
-        return;
+    if (IHandleMouse(mousePt)) {
+        int32_t cursorPos = IPointToPosition((int16_t)(mousePt.fX), (int16_t)(mousePt.fY));
 
-    IScreenToLocalPt( mousePt );
-    mousePt.fX *= fDynTextMap->GetVisibleWidth();
-    mousePt.fY *= fDynTextMap->GetVisibleHeight();
-
-    IMoveCursorTo( IPointToPosition( (int16_t)(mousePt.fX), (int16_t)(mousePt.fY) ) );
+        fCurrLinkId = IFindLink(cursorPos, modifiers);
+        if (fClickedLinkId == fCurrLinkId && fCurrLinkId != -1) {
+            HandleExtendedEvent(kLinkClicked);
+            fClickedLinkId = -1;
+        } else {
+            IMoveCursorTo(cursorPos);
+        }
+    } else {
+        fClickedLinkId = fCurrLinkId = -1;
+    }
 }
 
 //// HandleMouseDrag /////////////////////////////////////////////////////////
 
 void    pfGUIMultiLineEditCtrl::HandleMouseDrag( hsPoint3 &mousePt, uint8_t modifiers )
 {
-    if (fDynTextMap == nullptr || !fBounds.IsInside(&mousePt))
-        return;
+    if (IHandleMouse(mousePt)) {
+        int32_t cursorPos = IPointToPosition((int16_t)(mousePt.fX), (int16_t)(mousePt.fY));
+        fCurrLinkId = IFindLink(cursorPos, modifiers);
+        if (fCurrLinkId == -1)
+            IMoveCursorTo(cursorPos);
+    } else {
+        fCurrLinkId = -1;
+    }
+}
 
-    IScreenToLocalPt( mousePt );
-    mousePt.fX *= fDynTextMap->GetVisibleWidth();
-    mousePt.fY *= fDynTextMap->GetVisibleHeight();
+//// HandleMouseHover /////////////////////////////////////////////////////////
 
-    IMoveCursorTo( IPointToPosition( (int16_t)(mousePt.fX), (int16_t)(mousePt.fY) ) );
+void    pfGUIMultiLineEditCtrl::HandleMouseHover(hsPoint3& mousePt, uint8_t modifiers)
+{
+    if (IHandleMouse(mousePt)) {
+        int32_t cursorPos = IPointToPosition((int16_t)(mousePt.fX), (int16_t)(mousePt.fY));
+        fCurrLinkId = IFindLink(cursorPos, modifiers);
+    } else {
+        fCurrLinkId = -1;
+    }
+}
+
+//// IGetDesiredCursor /////////////////////////////////////////////////////////
+
+uint32_t    pfGUIMultiLineEditCtrl::IGetDesiredCursor() const
+{
+    // Return a poised cursor if we're over any link, unless we're editing
+    // the control (FIXME this last part...)
+    if (fCurrLinkId == -1)
+        return plInputInterface::kNullCursor;
+    else if (fCurrLinkId == fClickedLinkId)
+        return plInputInterface::kCursorClicked;
+    else
+        return plInputInterface::kCursorPoised;
 }
 
 bool    pfGUIMultiLineEditCtrl::HandleKeyPress( wchar_t key, uint8_t modifiers )
@@ -1170,7 +1250,7 @@ void    pfGUIMultiLineEditCtrl::IMoveCursor( pfGUIMultiLineEditCtrl::Direction d
             if( cursor > 0 )
             {
                 cursor--;
-                while (cursor > 0 && (fBuffer[cursor] == kColorCodeChar || fBuffer[cursor] == kStyleCodeChar))
+                while (cursor > 0 && IIsCodeChar(fBuffer[cursor]))
                     cursor -= IOffsetToNextChar( fBuffer[ cursor ] );
             }
             break;
@@ -1179,7 +1259,7 @@ void    pfGUIMultiLineEditCtrl::IMoveCursor( pfGUIMultiLineEditCtrl::Direction d
             if (cursor < (int32_t)fBuffer.size() - 1)
             {
                 cursor++;
-                while (cursor < (int32_t)fBuffer.size() - 1 && (fBuffer[cursor] == kColorCodeChar || fBuffer[cursor] == kStyleCodeChar))
+                while (cursor < (int32_t)fBuffer.size() - 1 && IIsCodeChar(fBuffer[cursor]))
                     cursor += IOffsetToNextChar( fBuffer[ cursor ] );
             }
             break;
@@ -1373,6 +1453,26 @@ void    pfGUIMultiLineEditCtrl::IActuallyInsertStyle( int32_t pos, uint8_t style
             kStyleCodeChar,
             (wchar_t)style,
             kStyleCodeChar
+        });
+    }
+}
+
+void    pfGUIMultiLineEditCtrl::InsertLink(int16_t linkId)
+{
+    IActuallyInsertLink(fCursorPos, linkId);
+
+    IOffsetLineStarts(fCursorPos, kLinkCodeSize);
+    fCursorPos += kLinkCodeSize;
+    IRecalcFromCursor();
+}
+
+void     pfGUIMultiLineEditCtrl::IActuallyInsertLink(int32_t pos, int16_t linkId)
+{
+    if (fBufferLimit == -1 || (int32_t)fBuffer.size() + kLinkCodeSize < fBufferLimit - 1) {
+        fBuffer.insert(fBuffer.begin() + pos, {
+            kLinkCodeChar,
+            (wchar_t)linkId,
+            kLinkCodeChar
         });
     }
 }
@@ -1822,8 +1922,8 @@ void pfGUIMultiLineEditCtrl::DeleteLinesFromTop(int numLines)
         bool hitEnd = true; // did we hit the end of the buffer before we hit a newline?
 
         // search for the first newline and nuke it and everything before it
-        bool skippingColor = false, skippingStyle = false;
-        int curColorPos = 0, curStylePos = 0;
+        bool skippingColor = false, skippingStyle = false, skippingLink = false;
+        int curColorPos = 0, curStylePos = 0, curLinkPos = 0;
         for (uint32_t curChar = 0; curChar < bufferLen - 1; ++curChar)
         {
             // we need to skip the crappy color and style "tags" so non-character values inside them
@@ -1842,6 +1942,12 @@ void pfGUIMultiLineEditCtrl::DeleteLinesFromTop(int numLines)
                     skippingStyle = true;
                     continue;
                 }
+                else if (buffer[curChar] == kLinkCodeChar)
+                {
+                    curLinkPos = 0;
+                    skippingLink = true;
+                    continue;
+                }
             }
 
             if (skippingColor)
@@ -1858,6 +1964,15 @@ void pfGUIMultiLineEditCtrl::DeleteLinesFromTop(int numLines)
                 ++curStylePos;
                 if (curStylePos == kStyleCodeSize)
                     skippingStyle = false;
+                else
+                    continue;
+            }
+
+            if (skippingLink)
+            {
+                ++curLinkPos;
+                if (curLinkPos == kLinkCodeSize)
+                    skippingLink = false;
                 else
                     continue;
             }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -645,9 +645,9 @@ int32_t   pfGUIMultiLineEditCtrl::IPointToPosition( int16_t ptX, int16_t ptY, bo
     if (fPrevCtrl)
         fScrollPos = GetFirstVisibleLine(); // update the scroll position if we are linked
 
-    int32_t lastVisibleLine = (int32_t)fLineStarts.size() - 1;
+    int32_t lastVisibleLine = (int32_t)fLineStarts.size();
     if (!searchOutsideBounds)
-        lastVisibleLine = std::min(fScrollPos + ICalcNumVisibleLines() - 1, lastVisibleLine);
+        lastVisibleLine = std::min(fScrollPos + ICalcNumVisibleLines(), lastVisibleLine);
 
     int32_t line = searchOutsideBounds ? 0 : fScrollPos;
     int16_t y = (int16_t)(-(fScrollPos - line) * fLineHeight) + fTopMargin;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -97,11 +97,11 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         };
 
     protected:
-
         std::vector<wchar_t> fBuffer;
         std::vector<int32_t> fLineStarts;
         uint16_t        fLineHeight, fCurrCursorX, fCurrCursorY;
         int32_t         fCursorPos, fLastCursorLine;
+        int16_t         fClickedLinkId, fCurrLinkId;
         bool            fReadyToRender;
         hsBounds3Ext    fLastP2PArea;
         int8_t          fLockCount;
@@ -169,6 +169,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
 
         void    IActuallyInsertColor( int32_t pos, hsColorRGBA &color );
         void    IActuallyInsertStyle( int32_t pos, uint8_t style );
+        void    IActuallyInsertLink(int32_t pos, int16_t linkId);
 
         void    IUpdateScrollRange();
 
@@ -183,6 +184,10 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
 
         void    IHitEndOfControlList(int32_t cursorPos);
         void    IHitBeginningOfControlList(int32_t cursorPos);
+
+        bool    IHandleMouse(hsPoint3& mousePt);
+        int16_t IFindLink(int32_t cursorPos, uint8_t modifiers) const;
+        uint32_t IGetDesiredCursor() const override;
 
     public:
 
@@ -202,9 +207,11 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         void Read(hsStream* s, hsResMgr* mgr) override;
         void Write(hsStream* s, hsResMgr* mgr) override;
 
+        bool    FocusOnMouseDown(const hsPoint3& mousePt, uint8_t modifiers) const override;
         void    HandleMouseDown(hsPoint3 &mousePt, uint8_t modifiers) override;
         void    HandleMouseUp(hsPoint3 &mousePt, uint8_t modifiers) override;
         void    HandleMouseDrag(hsPoint3 &mousePt, uint8_t modifiers) override;
+        void    HandleMouseHover(hsPoint3& mousePt, uint8_t modifiers) override;
 
         bool    HandleKeyPress(wchar_t key, uint8_t modifiers) override;
         bool    HandleKeyEvent(pfGameGUIMgr::EventType event, plKeyDef key, uint8_t modifiers) override;
@@ -218,7 +225,8 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         {
             kValueChanging,
             kScrollPosChanged,
-            kKeyPressedEvent
+            kKeyPressedEvent,
+            kLinkClicked,
         };
 
         void    SetScrollPosition( int32_t topLine );
@@ -230,8 +238,16 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         void    InsertChar( wchar_t c);
         void    InsertString( const char *string );
         void    InsertString( const wchar_t *string );
+
         void    InsertColor( hsColorRGBA &color );
         void    InsertStyle( uint8_t fontStyle );
+
+        /** Inserts a clickable hyperlink at the current cursor position. */
+        void    InsertLink(int16_t linkId);
+
+        /** Clears any active hyperlink at the current cursor position. */
+        void    ClearLink() { InsertLink(-1); }
+
         void    DeleteChar();
         void    ClearBuffer();
         void    SetBuffer( const char *asciiText );
@@ -246,6 +262,9 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
 
         void    SetBufferLimit(int32_t limit) { fBufferLimit = limit; }
         int32_t   GetBufferLimit() { return fBufferLimit; }
+
+        /** Get the link the mouse is currently over. */
+        int16_t GetCurrentLink() const { return fCurrLinkId; }
 
         void    GetThisKeyPressed( char &key, uint8_t &modifiers ) const { key = (char)fLastKeyPressed; modifiers = fLastKeyModifiers; }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -224,6 +224,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         void    SetScrollPosition( int32_t topLine );
         int32_t GetScrollPosition();
         void    MoveCursor( Direction dir );
+        int32_t GetCursor() const { return fCursorPos; }
 
         void    InsertChar( char c );
         void    InsertChar( wchar_t c);
@@ -241,7 +242,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         wchar_t *GetNonCodedBufferW() const;
         char    *GetCodedBuffer(size_t &length) const;
         wchar_t *GetCodedBufferW(size_t &length) const;
-        uint32_t  GetBufferSize();
+        size_t  GetBufferSize() const { return fBuffer.size() - 1; }
 
         void    SetBufferLimit(int32_t limit) { fBufferLimit = limit; }
         int32_t   GetBufferLimit() { return fBufferLimit; }
@@ -293,6 +294,8 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
             if (redraw)
                 IUpdate();
         }
+
+        bool IsUpdating() const { return !fCanUpdate; }
 };
 
 #endif // _pfGUIMultiLineEditCtrl_h

--- a/Sources/Plasma/FeatureLib/pfMessage/pfGUINotifyMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfGUINotifyMsg.h
@@ -73,7 +73,7 @@ public:
     enum GUIEventType
     {
         kShowHide = 1,      // show or hide change
-        kAction,            // button clicked, ListBox click on item, EditBox hit enter
+        kAction,            // button clicked, ListBox click on item, EditBox hit enter, MultiLineEdit hit link
         kValueChanged,      // value changed in control
         kDialogLoaded,      // the dialog is now loaded and ready for action
         kFocusChange,       // when one of its controls loses focus to another
@@ -99,6 +99,9 @@ public:
 //    kSpecialAction    - tab key hit (for autocompletion on Python side)
 //    kMessageHistoryUp - up key hit
 //    kMessageHistoryDown - down key hit
+// kMultiLineEdit
+//    kAction           - clicked a link
+//    kValueChanged     - the content or position of the control changed
 // kUpDownPair
 //    kValueChanged     - the value of the pair has been changed
 // kKnob

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
@@ -446,6 +446,32 @@ void pyGUIControlMultiLineEdit::InsertStyle( uint8_t fontStyle )
     }
 }
 
+void pyGUIControlMultiLineEdit::InsertLink(int16_t linkId)
+{
+    if (fGCkey)
+    {
+        // get the pointer to the modifier
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if (pbmod)
+        {
+            pbmod->InsertLink(linkId);
+        }
+    }
+}
+
+void pyGUIControlMultiLineEdit::ClearLink()
+{
+    if (fGCkey)
+    {
+        // get the pointer to the modifier
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if (pbmod)
+        {
+            pbmod->ClearLink();
+        }
+    }
+}
+
 void pyGUIControlMultiLineEdit::DeleteChar()
 {
     if ( fGCkey )
@@ -537,6 +563,18 @@ int32_t pyGUIControlMultiLineEdit::GetBufferLimit()
             return pbmod->GetBufferLimit();
     }
     return 0;
+}
+
+int16_t pyGUIControlMultiLineEdit::GetCurrentLink() const
+{
+    if (fGCkey)
+    {
+        // get the pointer to the modifier
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if (pbmod)
+            return pbmod->GetCurrentLink();
+    }
+    return -1;
 }
 
 void pyGUIControlMultiLineEdit::EnableScrollControl()

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
@@ -114,6 +114,18 @@ void pyGUIControlMultiLineEdit::MoveCursor( int32_t dir)
     }
 }
 
+int32_t pyGUIControlMultiLineEdit::GetCursor() const
+{
+    if (fGCkey)
+    {
+        // get the pointer to the modifier
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if (pbmod)
+            return pbmod->GetCursor();
+    }
+
+    return -1;
+}
 
 void pyGUIControlMultiLineEdit::ClearBuffer()
 {
@@ -339,7 +351,7 @@ const wchar_t* pyGUIControlMultiLineEdit::GetEncodedBufferW()
     return nullptr;
 }
 
-uint32_t  pyGUIControlMultiLineEdit::GetBufferSize()
+size_t pyGUIControlMultiLineEdit::GetBufferSize() const
 {
     if ( fGCkey )
     {
@@ -599,4 +611,15 @@ void pyGUIControlMultiLineEdit::EndUpdate(bool redraw)
         if (pbmod)
             pbmod->EndUpdate(redraw);
     }
+}
+
+bool pyGUIControlMultiLineEdit::IsUpdating() const
+{
+    if (fGCkey) {
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if (pbmod)
+            return pbmod->IsUpdating();
+    }
+
+    return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
@@ -80,6 +80,7 @@ public:
     virtual int32_t GetScrollPosition();
     virtual bool    IsAtEnd();
     virtual void    MoveCursor( int32_t dir );
+    int32_t GetCursor() const;
     virtual void    ClearBuffer();
     virtual void    SetText( const char *asciiText );
     virtual void    SetTextW( const wchar_t *asciiText );
@@ -89,8 +90,8 @@ public:
     virtual void    SetEncodedBufferW( PyObject* buffer_object );
     virtual const char* GetEncodedBuffer();
     virtual const wchar_t* GetEncodedBufferW();
-    virtual uint32_t  GetBufferSize();
-    
+    size_t  GetBufferSize() const;
+
     virtual void    SetBufferLimit(int32_t limit);
     virtual int32_t   GetBufferLimit();
 
@@ -116,6 +117,7 @@ public:
 
     void BeginUpdate();
     void EndUpdate(bool redraw);
+    bool IsUpdating() const;
 };
 
 #endif // _pyGUIControlMultiLineEdit_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
@@ -94,6 +94,7 @@ public:
 
     virtual void    SetBufferLimit(int32_t limit);
     virtual int32_t   GetBufferLimit();
+    int16_t GetCurrentLink() const;
 
     virtual void    InsertChar( char c );
     virtual void    InsertCharW( wchar_t c );
@@ -101,6 +102,8 @@ public:
     virtual void    InsertStringW( const wchar_t *string );
     virtual void    InsertColor( pyColor& color );
     virtual void    InsertStyle( uint8_t fontStyle );
+    void InsertLink(int16_t linkId);
+    void ClearLink();
     virtual void    DeleteChar();
 
     virtual void    Lock();

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
@@ -315,6 +315,19 @@ PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, insertStyle, args)
     PYTHON_RETURN_NONE;
 }
 
+PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, insertLink, args)
+{
+    int16_t linkId;
+    if (!PyArg_ParseTuple(args, "h", &linkId)) {
+        PyErr_SetString(PyExc_TypeError, "insertLink expects a 16-bit integer");
+        PYTHON_RETURN_ERROR;
+    }
+    self->fThis->InsertLink(linkId);
+    PYTHON_RETURN_NONE;
+}
+
+PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlMultiLineEdit, clearLink, ClearLink)
+
 PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlMultiLineEdit, deleteChar, DeleteChar)
 
 PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlMultiLineEdit, lock, Lock)
@@ -340,6 +353,14 @@ PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, setBufferLimit, args)
 PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, getBufferLimit)
 {
     return PyLong_FromLong(self->fThis->GetBufferLimit());
+}
+
+PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, getCurrentLink)
+{
+    int16_t linkId = self->fThis->GetCurrentLink();
+    if (linkId >= 0)
+        return PyLong_FromLong(linkId);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlMultiLineEdit, enableScrollControl, EnableScrollControl)
@@ -418,12 +439,15 @@ PYTHON_START_METHODS_TABLE(ptGUIControlMultiLineEdit)
     PYTHON_METHOD(ptGUIControlMultiLineEdit, insertColor, "Params: color\nInserts an encoded color object at the current cursor position.\n"
                 "'color' is a ptColor object."),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, insertStyle, "Params: style\nInserts an encoded font style at the current cursor position."),
+    PYTHON_METHOD(ptGUIControlMultiLineEdit, insertLink, "Params: linkId\nInserts a link hotspot at the current cursor position."),
+    PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, clearLink, "Ends the hyperlink hotspot, if any, at the current cursor position."),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, deleteChar, "Deletes a character at the current cursor position."),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, lock, "Locks the multi-line edit control so the user cannot make changes."),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, unlock, "Unlocks the multi-line edit control so that the user can make changes."),
     PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, isLocked, "Is the multi-line edit control locked? Returns 1 if true otherwise returns 0"),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, setBufferLimit, "Params: bufferLimit\nSets the buffer max for the editbox"),
     PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, getBufferLimit, "Returns the current buffer limit"),
+    PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, getCurrentLink, "Returns the link the mouse is currently over"),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, enableScrollControl, "Enables the scroll control if there is one"),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, disableScrollControl, "Disables the scroll control if there is one"),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, deleteLinesFromTop, "Params: numLines\nDeletes the specified number of lines from the top of the text buffer"),

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
@@ -112,6 +112,11 @@ PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, moveCursor, args)
     PYTHON_RETURN_NONE;
 }
 
+PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, getCursor)
+{
+    return PyLong_FromLong(self->fThis->GetCursor());
+}
+
 PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlMultiLineEdit, clearBuffer, ClearBuffer)
 
 PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, setString, args)
@@ -201,7 +206,7 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, getEncodedBufferW)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, getBufferSize)
 {
-    return PyLong_FromUnsignedLong(self->fThis->GetBufferSize());
+    return PyLong_FromSize_t(self->fThis->GetBufferSize());
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, insertChar, args)
@@ -382,6 +387,11 @@ PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, endUpdate, args)
     PYTHON_RETURN_NONE;
 }
 
+PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, isUpdating)
+{
+    return PyBool_FromLong(self->fThis->IsUpdating());
+}
+
 PYTHON_START_METHODS_TABLE(ptGUIControlMultiLineEdit)
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, clickable, "Sets this listbox to be clickable by the user."),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, unclickable, "Makes this listbox not clickable by the user.\n"
@@ -390,6 +400,7 @@ PYTHON_START_METHODS_TABLE(ptGUIControlMultiLineEdit)
     PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, getScrollPosition, "Gets what line is the top line."),
     PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, isAtEnd, "Returns true if the end of the buffer has been reached."),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, moveCursor, "Params: direction\nMove the cursor in the specified direction (see PtGUIMultiLineDirection)"),
+    PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, getCursor, "Get the current position of the cursor in the encoded buffer."),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, clearBuffer, "Clears all text from the multi-line edit control."),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, setString, "Params: asciiText\nSets the multi-line edit control string."),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, setStringW, "Params: unicodeText\nUnicode version of setString."),
@@ -420,6 +431,7 @@ PYTHON_START_METHODS_TABLE(ptGUIControlMultiLineEdit)
     PYTHON_METHOD(ptGUIControlMultiLineEdit, setFontSize, "Params: fontSize\nSets the default font size for the edit control"),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, beginUpdate, "Signifies that the control will be updated heavily starting now, so suppress all redraws"),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, endUpdate, "Signifies that the massive updates are over. We can now redraw."),
+    PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, isUpdating, "Is someone else already suppressing redraws of the control?"),
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition


### PR DESCRIPTION
This implements clickable URLs in KI chat and KI mail. This is done by adding a new control code to the `pfGUIMultiLineEditCtrl` that indicates a "link". The actual detection and handling of these links is done in Python where the rest of the text handling is done. Note that due to technical limitations, there are some behavior changes in the KI. Specifically, KI mail is no longer censored in the vault. Rather, it is censored at display time to prevent the corruption of URLs containing censored words. Further, KI mail can only be edited by the sender, preventing a trivial opportunity to escape the naughty word censor... When edit mode is activated, all censored words become unmasked.

[Demonstration video here](https://www.youtube.com/watch?v=ewpgJrTKv1w)

Depends on:
- [ ] H-uru/moul-assets#26
- [x] #884 
- [ ] ~~#889~~

So merge those first.