### PR TITLE
macOS CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew update
           brew install \
               autoconf \
               cairo \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,8 @@ jobs:
             -DPLASMA_VCPKG_NUGET_OWNER="${{ github.repository_owner }}" \
             -DPLASMA_VCPKG_NUGET_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             -DPLASMA_VCPKG_NUGET_RW=TRUE \
+            -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5 \
             -S . -B build
-        env:
-          CMAKE_PREFIX_PATH: "/usr/local/opt/qt"
 
       - name: Build
         run: |


### PR DESCRIPTION
I removed the `brew update` step since it takes a bunch of time and was causing issues when trying to install packages that already had an older version installed. We install most of our dependencies from vcpkg, so I don't think we need to be picky about running the absolute latest version of things like autoconf and libtool and qt5.

Also (although I swear we tested this previously) the qt path for CMake wasn't getting picked up properly. Now we pass it in as a CMake directive and it works (as evidenced in build logs).