### PR TITLE
Change or fix bindings that conflict with chatting.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainDrive.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainDrive.cpp
@@ -51,6 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 // other includes
 #include "pnMessage/plCameraMsg.h"
+#include "pnMessage/plCmdIfaceModMsg.h"
 #include "pnSceneObject/plSceneObject.h"
 
 #include "plMessage/plInputEventMsg.h"
@@ -75,6 +76,8 @@ void plAvBrainDrive::Activate(plArmatureModBase *avMod)
     plArmatureBrain::Activate(avMod);
 
     IEnablePhysics(false, avMod->GetTarget(0)->GetKey());
+    IToggleCtrlCodes(true);
+
     plCameraMsg* pMsg = new plCameraMsg;
     pMsg->SetCmd(plCameraMsg::kNonPhysOn);
     pMsg->SetBCastFlag(plMessage::kBCastByExactType);
@@ -87,10 +90,27 @@ void plAvBrainDrive::Deactivate()
     if (fAvMod)
     {   
         IEnablePhysics(true, fAvMod->GetTarget(0)->GetKey());
+        IToggleCtrlCodes(false);
+
         plCameraMsg* pMsg = new plCameraMsg;
         pMsg->SetCmd(plCameraMsg::kNonPhysOff);
         pMsg->SetBCastFlag(plMessage::kBCastByExactType);
-        pMsg->Send();               
+        pMsg->Send();
+    }
+}
+
+void plAvBrainDrive::IToggleCtrlCodes(bool on) const
+{
+    if (fAvMod->IsLocalAvatar()) {
+        plCmdIfaceModMsg* pUpMsg = new plCmdIfaceModMsg;
+        pUpMsg->fCmd.SetBit(on ? plCmdIfaceModMsg::kEnableControlCode : plCmdIfaceModMsg::kDisableControlCode);
+        pUpMsg->fControlCode = B_CONTROL_MOVE_UP;
+        pUpMsg->Send();
+
+        plCmdIfaceModMsg* pDownMsg = new plCmdIfaceModMsg;
+        pDownMsg->fCmd.SetBit(on ? plCmdIfaceModMsg::kEnableControlCode : plCmdIfaceModMsg::kDisableControlCode);
+        pDownMsg->fControlCode = B_CONTROL_MOVE_DOWN;
+        pDownMsg->Send();
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainDrive.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainDrive.h
@@ -93,7 +93,9 @@ public:
 
 protected:
     void IEnablePhysics(bool enable, plKey avKey);
-    
+
+    void IToggleCtrlCodes(bool on) const;
+
     float    fMaxVelocity;
     float    fTurnRate;
 };

--- a/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.cpp
@@ -157,6 +157,11 @@ plAvatarInputInterface::plAvatarInputInterface()
     fControlMap->AddCode( B_CONTROL_MOVE_UP,                kControlFlagNormal | kControlFlagNoRepeat );
     fControlMap->AddCode( B_CONTROL_MOVE_DOWN,              kControlFlagNormal | kControlFlagNoRepeat );
     fControlMap->AddCode( B_TOGGLE_DRIVE_MODE,              kControlFlagDownEvent | kControlFlagNoRepeat );
+
+    // These by default conflict with text characters, so we deactivate the bindings until they are needed.
+    IDisableControl(B_CONTROL_MOVE_UP);
+    IDisableControl(B_CONTROL_MOVE_DOWN);
+
     fControlMap->AddConsoleCommand( "NextStatusLog" );
 #endif
 
@@ -308,7 +313,7 @@ void    plAvatarInputInterface::RestoreDefaultKeyMappings()
     fControlMap->BindKey( KEY_NUMPAD_SUBTRACT,          B_CAMERA_ZOOM_OUT );
 
     fControlMap->BindKey( KEY_SHIFT,                    B_CONTROL_MODIFIER_FAST );
-    fControlMap->BindKey( KEY_Z,                        B_CONTROL_MODIFIER_STRAFE );
+    fControlMap->BindKey( KEY_ALT,                      B_CONTROL_MODIFIER_STRAFE );
     fControlMap->BindKey( KEY_UP,                       B_CONTROL_MOVE_FORWARD );
     fControlMap->BindKey( KEY_DOWN,                     B_CONTROL_MOVE_BACKWARD );
     fControlMap->BindKey( KEY_LEFT,                     B_CONTROL_ROTATE_LEFT );
@@ -351,12 +356,12 @@ void    plAvatarInputInterface::RestoreDefaultKeyMappings()
     fControlMap->BindKeyToConsoleCmd( KEY_F8,                                   "Game.KICreateMarkerFolder" );
 
 #ifndef PLASMA_EXTERNAL_RELEASE
-    fControlMap->BindKey( plShiftKeyCombo( KEY_P ),     B_CONTROL_TOGGLE_PHYSICAL );
+    fControlMap->BindKey( plCtrlKeyCombo( KEY_P ),      B_CONTROL_TOGGLE_PHYSICAL );
     fControlMap->BindKey( KEY_U,                        B_CONTROL_MOVE_UP );
     fControlMap->BindKey( KEY_H,                        B_CONTROL_MOVE_DOWN );
-    fControlMap->BindKey( plShiftKeyCombo( KEY_C ),     B_TOGGLE_DRIVE_MODE );
-    
-    fControlMap->BindKeyToConsoleCmd( KEY_L,            "NextStatusLog" );
+    fControlMap->BindKey( plCtrlKeyCombo( KEY_D ),      B_TOGGLE_DRIVE_MODE );
+
+    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_L ),                  "NextStatusLog" );
 #endif
 }
 


### PR DESCRIPTION
When working on the [clickable URLs in KI chat](https://www.youtube.com/watch?v=wgRlXdGxluA) functionality (see #890), it became apparent that the internal client could not start chatting by pressing the H key. This is problematic because, at this time, all URLs start with H. This fixes that problem and others.

Changed bindings:
- (Internal Client) Open Logs: Ctrl+L (was L)
- (Internal Client) Camera Drive: Ctrl+D (was Shift+C)
- (Internal Client) Flymode: Ctrl+P (was Shift+P)
- (All Clients) Strafe Modifier: Alt (was Z)

Unchanged:
- Flymode Up: U
- Flymode Down: H

The unchanged keys now bind only when they are needed.