### PR TITLE
Update vcpkg submodule and manifest.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
         run: |
           brew install \
               autoconf \
+              automake \
               cairo \
               libtool \
               nasm \

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,11 +17,13 @@
       "openssl",
       "opus",
       "physx",
-      "python3",
       {
-        "name": "speex",
-        "platform": "!(linux | osx)"
+        "name": "python3",
+        "features": [
+          "deprecated-win7-support"
+        ]
       },
+      "speex",
       "string-theory",
       {
         "name": "libuuid",


### PR DESCRIPTION
Updates:
- asio 1.18.1
- brotli 1.0.9#1
- libffi 3.3#7
- libjpeg-turbo 2.0.6
- libwebm 1.0.0.27#6
- openal-soft 1.21.1
- physx 4.1.1#7 - Debug symbols are now embedded in the static library
- python3 3.9.2#1 - Gained Windows 7 backwards compatibility
- speex 1.2.0#8 - Gained Linux and macOS support
- sqlite3 3.35.2