### PR TITLE
Cope with more goofy colliders.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvTaskSeek.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvTaskSeek.h
@@ -166,6 +166,8 @@ protected:
     bool fPosGoalHit;
     bool fRotGoalHit;
 
+    bool fSweepTestHit;
+
     bool fStillPositioning;               // haven't yet reached the final position
     bool fStillRotating;                  // haven't yet reached the final orientation
     

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
@@ -239,6 +239,7 @@ bool plPXPhysical::InitActor()
     case plSimDefs::kHullBounds:
     {
         physx::PxConvexMeshGeometry geometry(fRecipe.convexMesh);
+        geometry.meshFlags.set(physx::PxConvexMeshGeometryFlag::eTIGHT_BOUNDS);
         physx::PxTransform localPose(physx::PxIdentity);
         fActor = sim->CreateRigidActor(geometry, globalPose, localPose,
                                        fRecipe.friction, fRecipe.friction, fRecipe.restitution,

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
@@ -103,7 +103,7 @@ public:
 
 plPhysicalControllerCore* plPhysicalControllerCore::Create(plKey ownerSO, float height, float width)
 {
-    float radius = width / 2.0f;
+    float radius = width / 2.0f - .2f;
     float realHeight = height - width;
     return new plPXPhysicalControllerCore(ownerSO, realHeight, radius);
 }


### PR DESCRIPTION
This fixes the issue by which attempting to use any of the Teledahn power tower machinery would result in the avatar getting stuck while seeking. Also nukes the old PhysX 2.6-era skin width off the character capsule and tries to use tighter bounds for convex hulls.