### PR TITLE
Fix non-cursor resource output scaling.

### DIFF
--- a/Sources/Plasma/Apps/plClient/external/render_svg.py
+++ b/Sources/Plasma/Apps/plClient/external/render_svg.py
@@ -203,7 +203,7 @@ def render_loading_books(inpath, outpath):
 
 			cairosvg.svg2png(bytestring=bookSVG.toxml().encode('utf-8'),
 				write_to=os.path.join(outpath, "xLoading_Linking.{0:02}.png".format(angle)), 
-				parent_width=resSize["width"], parent_height=resSize["height"])
+				output_width=resSize["width"], output_height=resSize["height"])
 
 def render_loading_text(inpath, outpath):
 	resSize = {"width":192, "height":41}
@@ -215,7 +215,7 @@ def render_loading_text(inpath, outpath):
 			enable_only_layers(textList[textEntry], layers)
 			cairosvg.svg2png(bytestring=textSVG.toxml().encode('utf-8'),
 				write_to=os.path.join(outpath, textEntry + ".png"), 
-				parent_width=resSize["width"], parent_height=resSize["height"])
+				output_width=resSize["width"], output_height=resSize["height"])
 
 def render_voice_icons(inpath, outpath):
 	resSize = {"width":32, "height":32}
@@ -228,7 +228,7 @@ def render_voice_icons(inpath, outpath):
 
 			cairosvg.svg2png(bytestring=uiSVG.toxml().encode('utf-8'),
 				write_to=os.path.join(outpath, voiceUI + ".png"), 
-				parent_width=resSize["width"], parent_height=resSize["height"])
+				output_width=resSize["width"], output_height=resSize["height"])
 
 if __name__ == '__main__':
 	parser = OptionParser(usage="usage: %prog [options]")


### PR DESCRIPTION
Explicitly sets the output resolution for non-cursor resources during rasterization.