### PR TITLE
Fix some resource.dat bugs.

### DIFF
--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -86,8 +86,12 @@ plasma_executable(plClient WIN32 CLIENT
     SOURCES
         ${plClient_SOURCES} ${plClient_HEADERS}
         ${plClient_TEXT} ${plClient_RESOURCES}
-        ${external_SCRIPTS} ${external_SOURCES} ${external_DAT}
 )
+
+if(PLASMA_BUILD_RESOURCE_DAT)
+    target_sources(plClient PRIVATE ${external_SCRIPTS} ${external_SOURCES} ${external_DAT})
+endif()
+
 target_link_libraries(
     plClient
     PRIVATE

--- a/Sources/Plasma/Apps/plClient/external/render_svg.py
+++ b/Sources/Plasma/Apps/plClient/external/render_svg.py
@@ -50,6 +50,7 @@ import math
 import io
 from xml.dom.minidom import parse
 from optparse import OptionParser
+from glob import glob
 import scalergba
 
 try:
@@ -247,7 +248,12 @@ if __name__ == '__main__':
 	outpath = os.path.expanduser(options.outpath)
 	inpath = os.path.expanduser(options.inpath)
 
-	if not os.path.exists(outpath):
+	# Ensure that the render directory is empty, preventing old renders from junking the output
+	if os.path.exists(outpath):
+		print("Cleaning render directory...")
+		for i in glob(os.path.join(outpath, "*.png")):
+			os.unlink(os.path.join(outpath, i))
+	else:
 		os.makedirs(outpath)
 
 	## Do the work!


### PR DESCRIPTION
Fixes:
- resource.dat being junked if the number of frames in the spinning book changes or if the number of zeroes changes. Happens when switching to and from the Gehn Shard branch
- removes the listing for all resource files from plClient's target if `PLASMA_BUILD_RESOURCE_DAT` is `OFF`.