### PR TITLE
Fix improper ground filter logic.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
@@ -393,12 +393,10 @@ std::optional<plControllerHitRecord> plWalkingStrategy::IFindGroundCandidate() c
 
     std::optional<plControllerHitRecord> result = std::nullopt;
     for (const auto& i : fContacts) {
-        if (result) {
-            if (!IFilterGround(i, zMax))
-                continue;
-            if (result->Normal.fZ > i.Normal.fZ)
-                continue;
-        }
+        if (!IFilterGround(i, zMax))
+            continue;
+        if (result && result->Normal.fZ > i.Normal.fZ)
+            continue;
         result = i;
     }
     return result;


### PR DESCRIPTION
The previous logic could result in a 90-degree contact being returned as the ground. At best, this caused the player to be "flung" backwards after jumping into a wall. At worst, this caused the player to start falling in place against sheer walls.