### PR TITLE
Add chronicle helper scripts.

### DIFF
--- a/Scripts/Python/xPlayerChronicleRespond.py
+++ b/Scripts/Python/xPlayerChronicleRespond.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+""" *==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+ *==LICENSE==* """
+
+from Plasma import *
+from PlasmaTypes import *
+from PlasmaVaultConstants import *
+
+chronName = ptAttribString(1, "Chronicle Name")
+respTrue = ptAttribResponder(2, "Run if TRUE")
+respFalse = ptAttribResponder(3, "Run if FALSE")
+initFastFwd = ptAttribBoolean(4, "F-Forward on Init", default=True)
+defaultValue = ptAttribBoolean(5, "Default setting", default=False)
+
+class xPlayerChronicleRespond(ptResponder):
+    def __init__(self):
+        ptResponder.__init__(self)
+        self.id = -1
+        self.version = 1
+
+    def OnServerInitComplete(self):
+        if chron := ptVault().findChronicleEntry(chronName.value):
+            self._Eval(chron, ff=initFastFwd.value)
+        else:
+            self._Eval(defaultValue.value, ff=initFastFwd.value)
+
+    def OnVaultEvent(self, event, tupData):
+        if event == PtVaultCallbackTypes.kVaultNodeSaved:
+            if chron := tupData[0].upcastToChronicleNode():
+                if chron.getName() == chronName.value:
+                    self._Eval(chron)
+
+    def OnBackdoorMsg(self, target, param):
+        if target == chronName:
+            self._Eval(param)
+
+    def _Eval(self, value, ff=False):
+        if isinstance(value, ptVaultChronicleNode):
+            value = value.getValue().strip().lower()
+        if isinstance(value, str):
+            if value in {"1", "true", "on", "show", "yes"}:
+                value = True
+            elif value in {"0", "false", "off", "hide", "no", ""}:
+                value = False
+            else:
+                PtDebugPrint(f"xPlayerChronicleRespond._Eval():\tUnhandled value string '{value}', doing nothing")
+                return
+        assert isinstance(value, bool), "value should be a boolean"
+
+        if value:
+            PtDebugPrint(f"xPlayerChronicleRespond._Eval():\tRunning TRUE responder on '{self.sceneobject.getName()}' {ff=}", level=kDebugDumpLevel)
+            respTrue.run(self.key, fastforward=ff)
+        else:
+            PtDebugPrint(f"xPlayerChronicleRespond._Eval():\tRunning FALSE responder on '{self.sceneobject.getName()}' {ff=}", level=kDebugDumpLevel)
+            respFalse.run(self.key, fastforward=ff)

--- a/Scripts/Python/xPlayerChronicleSet.py
+++ b/Scripts/Python/xPlayerChronicleSet.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+""" *==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+ *==LICENSE==* """
+
+from Plasma import *
+from PlasmaTypes import *
+
+actTrigger = ptAttribActivator(1,"Activator")
+chronName = ptAttribString(2, "Chronicle Name")
+chronValue = ptAttribString(3, "Chronicle Value")
+preInit = ptAttribBoolean(4, "Initialize the chronicle on link-in", default=True)
+defaultValue = ptAttribString(5, "Chronicle's default value")
+
+class xPlayerChronicleSet(ptResponder):
+    def __init__(self):
+        ptResponder.__init__(self)
+        self.id = -1
+        self.version = 1
+
+    def OnServerInitComplete(self):
+        # When a chronicle is created, the main draw thread is blocked. We would ideally not want
+        # for that to happen while the game is being played, so here you go.
+        if preInit.value:
+            vault = ptVault()
+            if not vault.findChronicleEntry(chronName.value):
+                vault.addChronicleEntry(chronName.value, 0, defaultValue.value)
+
+    def OnNotify(self, state, id, events):
+        if id == actTrigger.id:
+            # This fxn checks for an already existing chronicle before creating a new one.
+            ptVault().addChronicleEntry(chronName.value, 0, chronValue.value)

--- a/Scripts/Python/xPlayerChronicleShowHide.py
+++ b/Scripts/Python/xPlayerChronicleShowHide.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+""" *==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+ *==LICENSE==* """
+
+from Plasma import *
+from PlasmaTypes import *
+from PlasmaVaultConstants import *
+
+chronName = ptAttribString(1, "Chronicle Name")
+showOnTrue = ptAttribBoolean(2, "Show on true", default=True)
+defaultValue = ptAttribBoolean(3, "Default value", default=False)
+
+class xPlayerChronicleShowHide(ptMultiModifier):
+    def __init__(self):
+        ptMultiModifier.__init__(self)
+        self.id = -1
+        self.version = 1
+
+    def OnServerInitComplete(self):
+        if chron := ptVault().findChronicleEntry(chronName.value):
+            self._Eval(chron)
+        else:
+            self._Eval(defaultValue.value)
+
+    def OnVaultEvent(self, event, tupData):
+        if event == PtVaultCallbackTypes.kVaultNodeSaved:
+            if chron := tupData[0].upcastToChronicleNode():
+                if chron.getName() == chronName.value:
+                    self._Eval(chron)
+
+    def OnBackdoorMsg(self, target, param):
+        if target == chronName:
+            self._Eval(param)
+
+    def _Eval(self, value):
+        if isinstance(value, ptVaultChronicleNode):
+            value = value.getValue().strip().lower()
+        if isinstance(value, str):
+            if value in {"1", "true", "on", "show", "yes"}:
+                value = True
+            elif value in {"0", "false", "off", "hide", "no", ""}:
+                value = False
+            else:
+                PtDebugPrint(f"xPlayerChronicleShowHide._Eval():\tUnhandled value string '{value}', doing nothing")
+                return
+        assert isinstance(value, bool), "value should be a boolean"
+
+        if value:
+            PtDebugPrint(f"xPlayerChronicleShowHide._Eval():\tEnabling drawing and collision on '{self.sceneobject.getName()}'", level=kDebugDumpLevel)
+            self.sceneobject.draw.enable()
+            self.sceneobject.physics.suppress(False)
+        else:
+            PtDebugPrint(f"xPlayerChronicleShowHide._Eval():\tDisabling drawing and collision on '{self.sceneobject.getName()}'", level=kDebugDumpLevel)
+            self.sceneobject.draw.disable()
+            self.sceneobject.physics.suppress(True)


### PR DESCRIPTION
Closes #906.

xPlayerChronicleRespond: runs a responder based off the boolean conversion of a chronicle's value. **WARNING**: NEVER USE THIS TO CONTROL AN AVATAR. Use SDL for that.
xPlayerChronicleSet: sets a chronicle's value when an action happens
xPlayerChronicleShowHide: shows or hides objects based off the boolean conversion of a chronicle's value.

Reminder... Chronicles are stored in the player's vault. They should be used only when you explicitly do not want something to be synchronized among players, rather, specific to the local player.

Danger: completely untested