### PR TITLE
Update vcpkg submodule and fix libvpx debug.

### DIFF
--- a/cmake/FindVPX.cmake
+++ b/cmake/FindVPX.cmake
@@ -1,39 +1,49 @@
-include(FindPackageHandleStandardArgs)
-include(SelectLibraryConfigurations)
-
-find_path(VPX_INCLUDE_DIR vpx/vp8.h
-          /usr/local/include
-          /usr/include
-)
-
-find_library(VPX_LIBRARY_RELEASE NAMES vpxmt vpxmd vpx
-             PATHS /usr/local/lib /usr/lib
-)
-find_library(VPX_LIBRARY_DEBUG NAMES vpxmtd vpxmdd vpxd
-             PATHS /usr/local/lib /usr/lib
-)
-
-select_library_configurations(VPX)
-find_package_handle_standard_args(VPX REQUIRED_VARS VPX_INCLUDE_DIR VPX_LIBRARY)
-
-if(VPX_FOUND AND NOT TARGET VPX::VPX)
-    add_library(VPX::VPX UNKNOWN IMPORTED)
-    set_target_properties(
-        VPX::VPX PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES ${VPX_INCLUDE_DIR}
-    )
-    if(EXISTS "${VPX_LIBRARY_DEBUG}" AND EXISTS "${VPX_LIBRARY_RELEASE}")
-        set_target_properties(
-            VPX::VPX PROPERTIES
-            IMPORTED_LOCATION_DEBUG ${VPX_LIBRARY_DEBUG}
-            IMPORTED_LOCATION_RELEASE ${VPX_LIBRARY_RELEASE}
-            MAP_IMPORTED_CONFIG_MINSIZEREL Release
-            MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
-        )
+if(NOT TARGET VPX::VPX)
+    find_package(unofficial-libvpx CONFIG QUIET)
+    if(TARGET unofficial::libvpx::libvpx)
+        # vcpkg has erased the debug library suffix, so CMake can only detect the release library.
+        # So, we make an alias to vcpkg's exported target that has both imported libraries.
+        add_library(VPX::VPX ALIAS unofficial::libvpx::libvpx)
+        set(VPX_FOUND TRUE)
     else()
-        set_target_properties(
-            VPX::VPX PROPERTIES
-            IMPORTED_LOCATION ${VPX_LIBRARY}
+        include(FindPackageHandleStandardArgs)
+        include(SelectLibraryConfigurations)
+
+        find_path(VPX_INCLUDE_DIR vpx/vp8.h
+                /usr/local/include
+                /usr/include
         )
+
+        find_library(VPX_LIBRARY_RELEASE NAMES vpxmt vpxmd vpx
+                    PATHS /usr/local/lib /usr/lib
+        )
+        find_library(VPX_LIBRARY_DEBUG NAMES vpxmtd vpxmdd vpxd
+                    PATHS /usr/local/lib /usr/lib
+        )
+
+        select_library_configurations(VPX)
+        find_package_handle_standard_args(VPX REQUIRED_VARS VPX_INCLUDE_DIR VPX_LIBRARY)
+
+        if(VPX_FOUND)
+            add_library(VPX::VPX UNKNOWN IMPORTED)
+            set_target_properties(
+                VPX::VPX PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES ${VPX_INCLUDE_DIR}
+            )
+            if(EXISTS "${VPX_LIBRARY_DEBUG}" AND EXISTS "${VPX_LIBRARY_RELEASE}")
+                set_target_properties(
+                    VPX::VPX PROPERTIES
+                    IMPORTED_LOCATION_DEBUG ${VPX_LIBRARY_DEBUG}
+                    IMPORTED_LOCATION_RELEASE ${VPX_LIBRARY_RELEASE}
+                    MAP_IMPORTED_CONFIG_MINSIZEREL Release
+                    MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
+                )
+            else()
+                set_target_properties(
+                    VPX::VPX PROPERTIES
+                    IMPORTED_LOCATION ${VPX_LIBRARY}
+                )
+            endif()
+        endif()
     endif()
 endif()


### PR DESCRIPTION
The last vcpkg update removed the "d" suffix from the libvpx debug library, so we now alias to the vcpkg libvpx target, if available, to ensure proper library linkage.

Updates:
asio 1.18.1 -> 1.18.1#1
cairo 1.16.0#11 -> 1.17.4#1
curl 7.74.0#4 -> 7.74.0#6
OpenSSL 1.1.1j#2 -> 1.1.1k#2
PhysX 4.1.1#7 -> 4.1.2
Python 3.9.2#1 -> 3.9.5
sqlite 3.35.4 -> 3.35.4#1