### PR TITLE
Fix error prone "rounding" used by ACA list box GUI.

### DIFF
--- a/Scripts/Python/xAvatarCustomization.py
+++ b/Scripts/Python/xAvatarCustomization.py
@@ -57,6 +57,7 @@ from colorsys import *
 import PlasmaControlKeys
 import time
 import os   #used for saving pictures locally
+import math
 
 import xACAItems
 
@@ -2286,7 +2287,7 @@ class ScrollingListBox:
         if self.rows == 1:
             self.columns = len(self.clothingList)
         else:
-            self.columns = int(round(float(len(self.clothingList))/2.0)) # half of the number of items, rounded up
+            self.columns = math.ceil(len(self.clothingList) / 2)
         self.offset = 0
         self.selection = 0
     


### PR DESCRIPTION
This interesting logic did not do what it said. Instead, it would work sometimes. When attempting to add the new "Gay Zero" shirt courtesy of Paradox, it unconditionally broke, leaving the Gay Zero shirt off the list unless another shirt was either added or removed.