### PR TITLE
WaveSet Buoys

### DIFF
--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -9667,6 +9667,10 @@ class ptWaveSet:
         """None"""
         pass
 
+    def addBuoy(self, soKey: ptKey) -> None:
+        """Adds the specified object as a buoy"""
+        pass
+
     def getDepthFalloff(self):
         """Returns the attribute's value"""
         pass
@@ -9793,6 +9797,10 @@ class ptWaveSet:
 
     def getWindDir(self):
         """Returns the attribute's value"""
+        pass
+
+    def removeBuoy(self, soKey: ptKey) -> None:
+        """Removes the specified object as a buoy"""
         pass
 
     def setDepthFalloff(self,s, secs = 0):
@@ -9922,4 +9930,3 @@ class ptWaveSet:
     def setWindDir(self,s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
-

--- a/Sources/Plasma/CoreLib/hsFastMath.h
+++ b/Sources/Plasma/CoreLib/hsFastMath.h
@@ -98,16 +98,16 @@ public:
 #define SET_EXP(a)      ((a) << EXP_POS)
 #define GET_EMANT(a)    (((a) >> LOOKUP_POS) & LOOKUP_MASK)
 
-#define SET_MANTSEED(a) (((unsigned long) (a)) << SEED_POS)
+#define SET_MANTSEED(a) (((uint32_t) (a)) << SEED_POS)
 
 inline float hsFastMath::InvSqrtAppr(float x)
 {
-    unsigned long a = *(long*)&x;
+    uint32_t a = *(int32_t*)&x;
 #if NUM_ITER > 0
     float arg = x;
 #endif
     union {
-        long    i;
+        int32_t i;
         float   f;
     } seed;
     float r;
@@ -131,10 +131,10 @@ inline float hsFastMath::InvSqrtAppr(float x)
 
 inline float hsFastMath::InvSqrt(float x)
 {
-    unsigned long a = *(long*)&x;
+    uint32_t a = *(int32_t*)&x;
     float arg = x;
     union {
-        long    i;
+        int32_t i;
         float   f;
     } seed;
     float r;

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -115,6 +115,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plMessage/plAvatarMsg.h"
 #include "plMessage/plBulletMsg.h"
 #include "plMessage/plConsoleMsg.h"
+#include "plMessage/plImpulseMsg.h"
 #include "plMessage/plInputEventMsg.h"
 #include "plMessage/plLinkToAgeMsg.h"
 #include "plMessage/plMovieMsg.h"
@@ -4914,10 +4915,11 @@ PF_CONSOLE_CMD( Physics, ApplyTorque, "string Object, float axisX, float axisY, 
         plgDispatch::MsgSend(m);
     }
 }
+*/
 
 PF_CONSOLE_CMD( Physics, ApplyImpulse, "string Object, float x, float y, float z", "Apply an impulse to a scene object.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
     if(key)
     {
@@ -4927,6 +4929,7 @@ PF_CONSOLE_CMD( Physics, ApplyImpulse, "string Object, float x, float y, float z
     }
 }
 
+/*
 PF_CONSOLE_CMD( Physics, ApplyImpulseAtPoint, "string Object, float impulseX, float impulseY, float impulseZ, float pointX, float pointY, float pointZ", "Apply an impulse to a scene object at a particular point in world space.")
 {
     plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -4621,6 +4621,42 @@ PF_CONSOLE_CMD( Wave_Set, Opacity,  // Group name, Function name
     ISendWaveCmd1f(PrintString, params, numParams, plWaveCmd::kWaterOpacity);
 }
 
+PF_CONSOLE_CMD( Wave_Set, AddBuoy,  // Group name, Function name
+                "string waveSet, string buoyObj", // Params
+                "Add the object as a buoy to the waveset") // Help string
+{
+    const char *status = "";
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[1]), "", &status);
+    PrintString(status);
+    if (!key)
+        return;
+
+    ST::string name = ST::string::from_utf8(params[0]);
+    plWaveSet7* waveSet = IGetWaveSet(PrintString, name);
+
+    if (waveSet) {
+        waveSet->AddBuoy(key);
+    }
+}
+
+PF_CONSOLE_CMD( Wave_Set, RemoveBuoy,  // Group name, Function name
+                "string waveSet, string buoyObj", // Params
+                "Remove the object as a buoy to the waveset") // Help string
+{
+    const char *status = "";
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[1]), "", &status);
+    PrintString(status);
+    if (!key)
+        return;
+
+    ST::string name = ST::string::from_utf8(params[0]);
+    plWaveSet7* waveSet = IGetWaveSet(PrintString, name);
+
+    if (waveSet) {
+        waveSet->RemoveBuoy(key);
+    }
+}
+
 #endif // LIMIT_CONSOLE_COMMANDS
 
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -115,6 +115,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plMessage/plAvatarMsg.h"
 #include "plMessage/plBulletMsg.h"
 #include "plMessage/plConsoleMsg.h"
+#include "plMessage/plDampMsg.h"
 #include "plMessage/plImpulseMsg.h"
 #include "plMessage/plInputEventMsg.h"
 #include "plMessage/plLinkToAgeMsg.h"
@@ -4881,7 +4882,7 @@ PF_CONSOLE_CMD( Physics, ShowExternal, "", "Display a snapshot of the world as H
 
 PF_CONSOLE_CMD( Physics, ApplyForce, "string Object, float x, float y, float z", "Apply a force to a scene object at its center of mass.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
     if(key) 
     {
@@ -4893,7 +4894,7 @@ PF_CONSOLE_CMD( Physics, ApplyForce, "string Object, float x, float y, float z",
 
 PF_CONSOLE_CMD( Physics, ApplyForceAtPoint, "string Object, float forceX, float forceY, float forceZ, float pointX, float pointY, float pointZ", "Apply a force to a scene object at a particular point in world space.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
     if(key) 
     {
@@ -4906,7 +4907,7 @@ PF_CONSOLE_CMD( Physics, ApplyForceAtPoint, "string Object, float forceX, float 
 
 PF_CONSOLE_CMD( Physics, ApplyTorque, "string Object, float axisX, float axisY, float axisZ", "Apply a torque to a scene object about given axis. Magnitude is size of force.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
     if(key)
     {
@@ -4921,7 +4922,7 @@ PF_CONSOLE_CMD( Physics, ApplyImpulse, "string Object, float x, float y, float z
 {
     plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
-    if(key)
+    if (key)
     {
         hsVector3 impulse(params[1], params[2], params[3]);
         plImpulseMsg *m = new plImpulseMsg(nullptr, key, impulse);
@@ -4932,7 +4933,7 @@ PF_CONSOLE_CMD( Physics, ApplyImpulse, "string Object, float x, float y, float z
 /*
 PF_CONSOLE_CMD( Physics, ApplyImpulseAtPoint, "string Object, float impulseX, float impulseY, float impulseZ, float pointX, float pointY, float pointZ", "Apply an impulse to a scene object at a particular point in world space.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
     if(key)
     {
@@ -4945,7 +4946,7 @@ PF_CONSOLE_CMD( Physics, ApplyImpulseAtPoint, "string Object, float impulseX, fl
 
 PF_CONSOLE_CMD( Physics, ApplyAngularImpulse, "string Object, float x, float y, float z", "Apply a rotational impulse about the given axis a scene object. Magnitude is strength.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
     if(key)
     {
@@ -4954,12 +4955,13 @@ PF_CONSOLE_CMD( Physics, ApplyAngularImpulse, "string Object, float x, float y, 
         plgDispatch::MsgSend(m);
     }
 }
+*/
 
 PF_CONSOLE_CMD( Physics, ApplyDamping, "string Object, float dampFactor", "Reduce the velocity and spin of the object to the given percentage.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
-    if(key)
+    if (key)
     {
         float dampFactor = params[1];
         plDampMsg *m = new plDampMsg(nullptr, key, dampFactor);
@@ -4967,9 +4969,10 @@ PF_CONSOLE_CMD( Physics, ApplyDamping, "string Object, float dampFactor", "Reduc
     }
 }
 
+/*
 PF_CONSOLE_CMD( Physics, ShiftMass, "string Object, float x, float y, float z", "Shift the object's center of mass.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
     if(key)
     {
@@ -4981,7 +4984,7 @@ PF_CONSOLE_CMD( Physics, ShiftMass, "string Object, float x, float y, float z", 
 
 PF_CONSOLE_CMD( Physics, Suppress, "string Object, int doSuppress", "Remove(true) or re-add the named physical from/to the simulation.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
     if(key)
     {
         int iDoSuppress = params[1];
@@ -4994,7 +4997,7 @@ PF_CONSOLE_CMD( Physics, Suppress, "string Object, int doSuppress", "Remove(true
 
 PF_CONSOLE_CMD( Physics, SetEventGroup, "string Object, int group, int status, int clearOthers", "Add to or remove from physics event group.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
     if(key)
     {
@@ -5006,7 +5009,7 @@ PF_CONSOLE_CMD( Physics, SetEventGroup, "string Object, int group, int status, i
 
 PF_CONSOLE_CMD( Physics, Freeze, "string Object, int status", "Immobilize the given simulated object.")
 {
-    plKey key = FindSceneObjectByName(params[0], nullptr, nullptr);
+    plKey key = FindSceneObjectByName(static_cast<const char *>(params[0]), "", nullptr);
 
     if(key)
     {

--- a/Sources/Plasma/FeatureLib/pfPython/cyPhysics.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPhysics.cpp
@@ -52,6 +52,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnMessage/plEnableMsg.h"
 #include "pnMessage/plWarpMsg.h"
+#include "plMessage/plImpulseMsg.h"
 #include "plMessage/plSimStateMsg.h"
 #include "plMessage/plLinearVelocityMsg.h"
 #include "plMessage/plAngularVelocityMsg.h"
@@ -509,20 +510,18 @@ void cyPhysics::Torque(pyVector3& torque)
 //
 void cyPhysics::Impulse(pyVector3& impulse)
 {
-    hsAssert(0, "Who uses this?");
-    // must have a receiver!
-/*  if (!fRecvr.empty())
+    if (!fRecvr.empty())
     {
         // create message
         plImpulseMsg* pMsg = new plImpulseMsg;
         // check if this needs to be network forced to all clients
-        if (fNetForce )
+        if (fNetForce)
         {
             // set the network propagate flag to make sure it gets to the other clients
             pMsg->SetBCastFlag(plMessage::kNetPropagate);
             pMsg->SetBCastFlag(plMessage::kNetForce);
         }
-        if ( fSender )
+        if (fSender)
             pMsg->SetSender(fSender);
 
         // add all our receivers to the message receiver list
@@ -530,9 +529,8 @@ void cyPhysics::Impulse(pyVector3& impulse)
             pMsg->AddReceiver(rcKey);
 
         pMsg->SetImpulse(impulse.fVector);
-        plgDispatch::MsgSend( pMsg );   // whoosh... off it goes
+        plgDispatch::MsgSend(pMsg);   // whoosh... off it goes
     }
-*/
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/cyPhysics.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPhysics.cpp
@@ -50,12 +50,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "cyPhysics.h"
 
-#include "pnMessage/plEnableMsg.h"
-#include "pnMessage/plWarpMsg.h"
-#include "plMessage/plImpulseMsg.h"
-#include "plMessage/plSimStateMsg.h"
-#include "plMessage/plLinearVelocityMsg.h"
 #include "plMessage/plAngularVelocityMsg.h"
+#include "plMessage/plDampMsg.h"
+#include "pnMessage/plEnableMsg.h"
+#include "plMessage/plImpulseMsg.h"
+#include "plMessage/plLinearVelocityMsg.h"
+#include "plMessage/plSimStateMsg.h"
+#include "pnMessage/plWarpMsg.h"
 
 #include "pnSceneObject/plSceneObject.h"
 #include "pnSceneObject/plCoordinateInterface.h"
@@ -619,20 +620,18 @@ void cyPhysics::AngularImpulse(pyVector3& impulse)
 //
 void cyPhysics::Damp(float damp)
 {
-    hsAssert(0, "Who uses this?");
-    // must have a receiver!
-/*  if (!fRecvr.empty())
+    if (!fRecvr.empty())
     {
         // create message
-        plDampMsg* pMsg = new plDampMsg;
+        plDampMsg* pMsg = new plDampMsg();
         // check if this needs to be network forced to all clients
-        if (fNetForce )
+        if (fNetForce)
         {
             // set the network propagate flag to make sure it gets to the other clients
             pMsg->SetBCastFlag(plMessage::kNetPropagate);
             pMsg->SetBCastFlag(plMessage::kNetForce);
         }
-        if ( fSender )
+        if (fSender)
             pMsg->SetSender(fSender);
 
         // add all our receivers to the message receiver list
@@ -640,9 +639,8 @@ void cyPhysics::Damp(float damp)
             pMsg->AddReceiver(rcKey);
 
         pMsg->SetDamp(damp);
-        plgDispatch::MsgSend( pMsg );   // whoosh... off it goes
+        plgDispatch::MsgSend(pMsg);   // whoosh... off it goes
     }
-*/
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/pyWaveSet.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyWaveSet.cpp
@@ -951,3 +951,27 @@ float pyWaveSet::GetEnvRadius() const
 }
 
 // --------------------------------------------------------------------------------
+
+void pyWaveSet::AddBuoy(const pyKey& soKey) const
+{
+    if (fWaterKey)
+    {
+        plWaveSet7* waveset = plWaveSet7::ConvertNoRef(fWaterKey->ObjectIsLoaded());
+        if (waveset)
+        {
+            return waveset->AddBuoy(soKey.getKey());
+        }
+    }
+}
+
+void pyWaveSet::RemoveBuoy(const pyKey& soKey) const
+{
+    if (fWaterKey)
+    {
+        plWaveSet7* waveset = plWaveSet7::ConvertNoRef(fWaterKey->ObjectIsLoaded());
+        if (waveset)
+        {
+            return waveset->RemoveBuoy(soKey.getKey());
+        }
+    }
+}

--- a/Sources/Plasma/FeatureLib/pfPython/pyWaveSet.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyWaveSet.h
@@ -185,6 +185,13 @@ public:
 
     PyObject* GetEnvCenter() const; // returns pyPoint3
     float GetEnvRadius() const;
+
+    // ==============================================================================
+    // Buoy functions
+    // ==============================================================================
+
+    void AddBuoy(const pyKey& soKey) const;
+    void RemoveBuoy(const pyKey& soKey) const;
 };
 
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyWaveSetGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyWaveSetGlue.cpp
@@ -168,6 +168,42 @@ WAVESET_FLOAT_DEF(SpecularMute)
 WAVESET_OBJ_DEF(EnvCenter, ptPoint3, pyPoint3)
 WAVESET_FLOAT_DEF(EnvRadius)
 
+PYTHON_METHOD_DEFINITION(ptWaveSet, addBuoy, args)
+{
+    PyObject *soKeyObject = nullptr;
+    if (!PyArg_ParseTuple(args, "O", &soKeyObject))
+    {
+        PyErr_SetString(PyExc_TypeError, "addBuoy expects a ptKey");
+        PYTHON_RETURN_ERROR;
+    }
+    if (!pyKey::Check(soKeyObject))
+    {
+        PyErr_SetString(PyExc_TypeError, "addBuoy expects a ptKey");
+        PYTHON_RETURN_ERROR;
+    }
+    pyKey *soKey = pyKey::ConvertFrom(soKeyObject);
+    self->fThis->AddBuoy(*soKey);
+    PYTHON_RETURN_NONE;
+}
+
+PYTHON_METHOD_DEFINITION(ptWaveSet, removeBuoy, args)
+{
+    PyObject *soKeyObject = nullptr;
+    if (!PyArg_ParseTuple(args, "O", &soKeyObject))
+    {
+        PyErr_SetString(PyExc_TypeError, "removeBuoy expects a ptKey");
+        PYTHON_RETURN_ERROR;
+    }
+    if (!pyKey::Check(soKeyObject))
+    {
+        PyErr_SetString(PyExc_TypeError, "removeBuoy expects a ptKey");
+        PYTHON_RETURN_ERROR;
+    }
+    pyKey *soKey = pyKey::ConvertFrom(soKeyObject);
+    self->fThis->RemoveBuoy(*soKey);
+    PYTHON_RETURN_NONE;
+}
+
 PYTHON_START_METHODS_TABLE(ptWaveSet)
     WAVESET_FLOAT(GeoMaxLength),
     WAVESET_FLOAT(GeoMinLength),
@@ -210,6 +246,9 @@ PYTHON_START_METHODS_TABLE(ptWaveSet)
 
     WAVESET_OBJ(EnvCenter),
     WAVESET_FLOAT(EnvRadius),
+
+    PYTHON_METHOD(ptWaveSet, addBuoy, "Params: soKey\nAdds the specified object as a buoy"),
+    PYTHON_METHOD(ptWaveSet, removeBuoy, "Params: soKey\nRemoves the specified object as a buoy"),
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
@@ -351,9 +351,18 @@ void plWaveSet7::Read(hsStream* stream, hsResMgr* mgr)
     }
     mgr->ReadKeyNotifyMe(stream, new plGenRefMsg(GetKey(), plRefMsg::kOnCreate, -1, kRefEnvMap), plRefFlags::kActiveRef);
 
-    if( HasFlag(kHasRefObject) )
+    if (HasFlag(kHasRefObject))
     {
         mgr->ReadKeyNotifyMe(stream, new plGenRefMsg(GetKey(), plRefMsg::kOnCreate, -1, kRefRefObj), plRefFlags::kPassiveRef);
+    }
+
+    if (HasFlag(kHasBuoys))
+    {
+        n = stream->ReadLE32();
+        for (i = 0; i < n; i++)
+        {
+            mgr->ReadKeyNotifyMe(stream, new plGenRefMsg(GetKey(), plRefMsg::kOnCreate, -1, kRefBuoy), plRefFlags::kPassiveRef);
+        }
     }
 
     ISetupTextureWaves();
@@ -388,9 +397,16 @@ void plWaveSet7::Write(hsStream* stream, hsResMgr* mgr)
 
     mgr->WriteKey(stream, fEnvMap);
 
-    if( HasFlag(kHasRefObject) )
+    if (HasFlag(kHasRefObject))
     {
         mgr->WriteKey(stream, fRefObj);
+    }
+
+    if (HasFlag(kHasBuoys))
+    {
+        stream->WriteLE32((uint32_t)fBuoys.size());
+        for (plSceneObject* buoy : fBuoys)
+            mgr->WriteKey(stream, buoy);
     }
 }
 
@@ -732,7 +748,6 @@ void plWaveSet7::IUpdateWaves(float dt)
     ITransition(dt);
     ITransTex(dt);
     ICalcScale();
-    fScrunchLen = 1.e33f;
 
     if( fTrialUpdate & kReInitWaves )
     {

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
@@ -96,6 +96,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plMessage/plMatRefMsg.h"
 #include "plMessage/plAgeLoadedMsg.h"
+#include "plMessage/plDampMsg.h"
 #include "plMessage/plImpulseMsg.h"
 
 #include "plTweak.h"
@@ -1057,8 +1058,8 @@ void plWaveSet7::IFloatBuoy(float dt, plSceneObject* so)
         damp *= kDampener;
         damp += kBaseDamp;
 
-//      plDampMsg* dMsg = new plDampMsg(GetKey(), physKey, damp);
-//      dMsg->Send();
+        plDampMsg* dMsg = new plDampMsg(GetKey(), physKey, damp);
+        dMsg->Send();
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
@@ -96,6 +96,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plMessage/plMatRefMsg.h"
 #include "plMessage/plAgeLoadedMsg.h"
+#include "plMessage/plImpulseMsg.h"
 
 #include "plTweak.h"
 
@@ -1033,10 +1034,10 @@ void plWaveSet7::IFloatBuoy(float dt, plSceneObject* so)
     // Don't currently have anything informative from the physical to use.
     // So, let's fake something for the moment.
 
-//  plKey physKey = so->GetSimulationInterface()->GetPhysical()->GetKey();
+    plKey physKey = so->GetSimulationInterface()->GetPhysical()->GetKey();
 
-//  plImpulseMsg* iMsg = new plImpulseMsg(GetKey(), physKey, hsVector3(0.f, 0.f, 1.f) * forceMag * dt);
-//  iMsg->Send();
+    plImpulseMsg* iMsg = new plImpulseMsg(GetKey(), physKey, hsVector3(0.f, 0.f, 1.f) * forceMag * dt);
+    iMsg->Send();
 
 #if 0
     plCONST(float) kRotScale(1.f);

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.h
@@ -108,7 +108,8 @@ public:
     };
     // Flags, also in a bitvector, so far unused in the multimodifier
     enum {
-        kHasRefObject           = 16
+        kHasRefObject           = 16,
+        kHasBuoys               = 17
     };
     enum {
         kNumWaves       = 4

--- a/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
@@ -74,6 +74,7 @@ set(plMessage_HEADERS
     plDynamicEnvMapMsg.h
     plDynamicTextMsg.h
     plExcludeRegionMsg.h
+    plImpulseMsg.h
     plInputEventMsg.h
     plInputIfaceMgrMsg.h
     plInterestingPing.h

--- a/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
@@ -69,6 +69,7 @@ set(plMessage_HEADERS
     plCondRefMsg.h
     plConnectedToVaultMsg.h
     plConsoleMsg.h
+    plDampMsg.h
     plDeviceRecreateMsg.h
     plDynaDecalEnableMsg.h
     plDynamicEnvMapMsg.h

--- a/Sources/Plasma/PubUtilLib/plMessage/plDampMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plDampMsg.h
@@ -1,0 +1,66 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef plDampMsg_h
+#define plDampMsg_h
+
+#include "pnMessage/plSimulationMsg.h"
+#include "hsGeometry3.h"
+
+class plDampMsg :  public plSimulationMsg
+{
+public:
+    plDampMsg() = default;
+    plDampMsg(const plKey& sender, const plKey& receiver, float damp)
+        : plSimulationMsg(sender, receiver, nullptr), fDampFactor(damp) { }
+
+    CLASSNAME_REGISTER(plDampMsg);
+    GETINTERFACE_ANY(plDampMsg, plSimulationMsg);
+
+    void SetDamp(float d) { fDampFactor = d; }
+    float Damp() const { return fDampFactor; }
+
+protected:
+    float fDampFactor;
+};
+
+#endif

--- a/Sources/Plasma/PubUtilLib/plMessage/plImpulseMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plImpulseMsg.h
@@ -1,0 +1,66 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef plImpulseMsg_h
+#define plImpulseMsg_h
+
+#include "pnMessage/plSimulationMsg.h"
+#include "hsGeometry3.h"
+
+class plImpulseMsg :  public plSimulationMsg
+{
+public:
+    plImpulseMsg() = default;
+    plImpulseMsg(const plKey& sender, const plKey& receiver, const hsVector3& impulse)
+        : plSimulationMsg(sender, receiver, nullptr), fImpulse(impulse) {};
+
+    CLASSNAME_REGISTER(plImpulseMsg);
+    GETINTERFACE_ANY(plImpulseMsg, plSimulationMsg);
+
+    void SetImpulse(const hsVector3& i) { fImpulse = i; }
+    const hsVector3& Impulse() const { return fImpulse; }
+
+protected:
+    hsVector3 fImpulse;
+};
+
+#endif

--- a/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
@@ -128,6 +128,9 @@ REGISTER_CREATABLE(plDynamicTextMsg);
 #include "plExcludeRegionMsg.h"
 REGISTER_CREATABLE(plExcludeRegionMsg);
 
+#include "plImpulseMsg.h"
+REGISTER_CREATABLE(plImpulseMsg);
+
 #include "plInputEventMsg.h"
 REGISTER_CREATABLE(plAvatarInputStateMsg);
 REGISTER_CREATABLE(plControlEventMsg);

--- a/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
@@ -113,6 +113,9 @@ REGISTER_CREATABLE(plConnectedToVaultMsg);
 #include "plConsoleMsg.h"
 REGISTER_CREATABLE(plConsoleMsg);
 
+#include "plDampMsg.h"
+REGISTER_CREATABLE(plDampMsg);
+
 #include "plDeviceRecreateMsg.h"
 REGISTER_CREATABLE(plDeviceRecreateMsg);
 

--- a/Sources/Plasma/PubUtilLib/plPhysX/plGenericPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plGenericPhysical.cpp
@@ -59,6 +59,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnSceneObject/plSimulationInterface.h"
 
 #include "plMessage/plAngularVelocityMsg.h"
+#include "plMessage/plDampMsg.h"
 #include "plMessage/plImpulseMsg.h"
 #include "plMessage/plLinearVelocityMsg.h"
 #include "plMessage/plSimStateMsg.h"
@@ -143,6 +144,15 @@ bool plPXPhysical::MsgReceive( plMessage* msg )
         plImpulseMsg* impMsg = plImpulseMsg::ConvertNoRef(msg);
         if (impMsg) {
             SetImpulseSim(impMsg->Impulse());
+            return true;
+        }
+
+        plDampMsg* dampMsg = plDampMsg::ConvertNoRef(msg);
+        if (dampMsg) {
+            // plDampMsg stores a percentage of how much to dampen the
+            // velocity, but PhysX wants a coefficient representing how strong
+            // the dampening is
+            SetDampingSim(1.0f - dampMsg->Damp());
             return true;
         }
         return false;

--- a/Sources/Plasma/PubUtilLib/plPhysX/plGenericPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plGenericPhysical.cpp
@@ -59,6 +59,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnSceneObject/plSimulationInterface.h"
 
 #include "plMessage/plAngularVelocityMsg.h"
+#include "plMessage/plImpulseMsg.h"
 #include "plMessage/plLinearVelocityMsg.h"
 #include "plMessage/plSimStateMsg.h"
 #include "plPhysical/plPhysicalSDLModifier.h"
@@ -136,6 +137,12 @@ bool plPXPhysical::MsgReceive( plMessage* msg )
         plAngularVelocityMsg* angvelMsg = plAngularVelocityMsg::ConvertNoRef(msg);
         if (angvelMsg) {
             SetAngularVelocitySim(angvelMsg->AngularVelocity());
+            return true;
+        }
+
+        plImpulseMsg* impMsg = plImpulseMsg::ConvertNoRef(msg);
+        if (impMsg) {
+            SetImpulseSim(impMsg->Impulse());
             return true;
         }
         return false;

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
@@ -500,6 +500,15 @@ void plPXPhysical::SetImpulseSim(const hsVector3& imp, bool wakeup)
     }
 }
 
+void plPXPhysical::SetDampingSim(float factor)
+{
+    if (auto dynamic = fActor->is<physx::PxRigidDynamic>()) {
+        plPXActorSimulationLock lock(fActor);
+        dynamic->setLinearDamping(factor * 10);
+        dynamic->setAngularDamping(factor * 10);
+    }
+}
+
 // ==========================================================================
 
 physx::PxConvexMesh* plPXPhysical::ICookHull(hsStream* s)

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
@@ -492,6 +492,14 @@ void plPXPhysical::SetAngularVelocitySim(const hsVector3& vel, bool wakeup)
     }
 }
 
+void plPXPhysical::SetImpulseSim(const hsVector3& imp, bool wakeup)
+{
+    if (auto dynamic = fActor->is<physx::PxRigidDynamic>()) {
+        plPXActorSimulationLock lock(fActor);
+        dynamic->addForce(plPXConvert::Vector(imp), physx::PxForceMode::eIMPULSE, wakeup);
+    }
+}
+
 // ==========================================================================
 
 physx::PxConvexMesh* plPXPhysical::ICookHull(hsStream* s)

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.h
@@ -208,6 +208,8 @@ public:
     bool GetAngularVelocitySim(hsVector3& vel) const override;
     void SetAngularVelocitySim(const hsVector3& vel, bool wakeup=true) override;
 
+    void SetImpulseSim(const hsVector3& imp, bool wakeup=true);
+
     void SetTransform(const hsMatrix44& l2w, const hsMatrix44& w2l, bool force=false) override;
     void GetTransform(hsMatrix44& l2w, hsMatrix44& w2l) override;
 

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.h
@@ -209,6 +209,7 @@ public:
     void SetAngularVelocitySim(const hsVector3& vel, bool wakeup=true) override;
 
     void SetImpulseSim(const hsVector3& imp, bool wakeup=true);
+    void SetDampingSim(float factor);
 
     void SetTransform(const hsMatrix44& l2w, const hsMatrix44& w2l, bool force=false) override;
     void GetTransform(hsMatrix44& l2w, hsMatrix44& w2l) override;


### PR DESCRIPTION
These were mostly already implemented, but the physics messages had gone missing, and someone added a wildly incorrect multiplication factor.

* Fixes some 32-bit assumptions in hsFastMath, but I can drop this commit if it seems misplaced
* Adds back plImpulseMsg and plDampMsg and hooks them up in the physics simulation
  * I suspect the damping handling could be improved, but it gives a reasonably decent effect right now
* Adds console commands for testing
* Adds Python API for fun runtime shenanigans
* Adds a new flag to the existing plWaveSet7 bitvector, which causes it to read an extra array of buoys to attach automatically
  * I have code ready to go for libHSPlasma and korman
  * This should be compatible with all existing data, but not compatible with old clients (although maybe they just neglect to read the extra data and it's fine?)

[Demo video](https://www.youtube.com/watch?v=m_74DyDb0pY)

Wishlist: A way to specify that some dynamic physical objects should not interact with the avatar