### PR TITLE
Fix #941.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListElement.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListElement.cpp
@@ -180,8 +180,9 @@ pfGUIListPicture::pfGUIListPicture(plKey mipKey, bool respectAlpha)
         plMipmap *uncompBuffer = hsCodecManager::Instance().CreateUncompressedMipmap( mip, hsCodecManager::k32BitDepth );
         ST::string str = ST::format("{}_uncomp", mip->GetKeyName());
         fMipmapKey = hsgResMgr::ResMgr()->NewKey( str, uncompBuffer, fMipmapKey->GetUoid().GetLocation() );
-        fMipmapKey->RefObject();
     }
+
+    fMipmapKey->RefObject();
 }
 
 pfGUIListPicture::~pfGUIListPicture()


### PR DESCRIPTION
Fixes #941.

Unfortunately, my initial impression was wrong. This is really a ref counting issue. If an uncompressed mipmap is supplied to the list box, the object's reference count is never incremented. Once the GUI image is destroyed, the reference count is unconditionally decremented, so bye bye image.