### PR TITLE
Fix more char*/TCHAR* confusion in Max.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITagDefs.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITagDefs.cpp
@@ -49,6 +49,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfGUITagDefs.h"
 #include "pfGameGUIMgr.h"
 
+using namespace ST::literals;
 
 //// Tag List ////////////////////////////////////////////////////////////////
 //  Here's the actual list of tags. It's basically a list of konstants, but
@@ -64,36 +65,36 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // Step 2: Add the string here
 
 pfGUITag    gGUITags[] = {
-    { kKIMainDialog, "KI Main Dialog" },
-    { kKITestEditBox, "KI Test Control" },
-    { kKIEntryDlg, "KI Entry Dlg" },
-    { kKICloseButton, "KI Close Dlg Button" },
-    { kKITestControl2, "KI Test Control 2" },
-    { kKIAddButton, "KI Add Button" },
-    { kKIEditButton, "KI Edit Button" },
-    { kKIRemoveButton, "KI Remove Button" },
-    { kKIYesNoDlg, "KI Yes/No Dialog" },
-    { kKIYesBtn, "KI Yes Button" },
-    { kKINoBtn, "KI No Button" },
-    { kKIStaticText, "KI Static Text" },
-    { kKITestControl3, "KI Test Control 3" },
-    { kKIMiniDialog, "KI Mini Dialog" },
-    { kPlayerBook, "PB Dialog" },
-    { kPBLinkToBtn, "PB Link To Button" },
-    { kPBSaveLinkBtn, "PB Save Link Button" },
-    { kPBSaveSlotRadio, "PB Save Slot Radio" },
-    { kPBSaveSlotPrev1, "PB Save Slot Preview 1" },
-    { kPBSaveSlotPrev2, "PB Save Slot Preview 2" },
-    { kPBSaveSlotPrev3, "PB Save Slot Preview 3" },
-    { kPBSaveSlotPrev4, "PB Save Slot Preview 4" },
-    { kPBSaveSlotPrev5, "PB Save Slot Preview 5" },
-    { kPBSaveSlotPrev6, "PB Save Slot Preview 6" },
-    { kKICurrPlayerText, "KI Current Player Label" },
-    { kKIPlayerList,    "KI Mini Friends List" },
-    { kKIChatModeBtn,   "KI Toggle Chat Mode Btn" },
-    { kBlackBarDlg,     "Black Bar Dialog" },
-    { kBlackBarKIButtons, "Black Bar KI Radio Group" },
-    { kKILogoutButton, "KI Logout Button" },
+    { kKIMainDialog, "KI Main Dialog"_st },
+    { kKITestEditBox, "KI Test Control"_st },
+    { kKIEntryDlg, "KI Entry Dlg"_st },
+    { kKICloseButton, "KI Close Dlg Button"_st },
+    { kKITestControl2, "KI Test Control 2"_st },
+    { kKIAddButton, "KI Add Button"_st },
+    { kKIEditButton, "KI Edit Button"_st },
+    { kKIRemoveButton, "KI Remove Button"_st },
+    { kKIYesNoDlg, "KI Yes/No Dialog"_st },
+    { kKIYesBtn, "KI Yes Button"_st },
+    { kKINoBtn, "KI No Button"_st },
+    { kKIStaticText, "KI Static Text"_st },
+    { kKITestControl3, "KI Test Control 3"_st },
+    { kKIMiniDialog, "KI Mini Dialog"_st },
+    { kPlayerBook, "PB Dialog"_st },
+    { kPBLinkToBtn, "PB Link To Button"_st },
+    { kPBSaveLinkBtn, "PB Save Link Button"_st },
+    { kPBSaveSlotRadio, "PB Save Slot Radio"_st },
+    { kPBSaveSlotPrev1, "PB Save Slot Preview 1"_st },
+    { kPBSaveSlotPrev2, "PB Save Slot Preview 2"_st },
+    { kPBSaveSlotPrev3, "PB Save Slot Preview 3"_st },
+    { kPBSaveSlotPrev4, "PB Save Slot Preview 4"_st },
+    { kPBSaveSlotPrev5, "PB Save Slot Preview 5"_st },
+    { kPBSaveSlotPrev6, "PB Save Slot Preview 6"_st },
+    { kKICurrPlayerText, "KI Current Player Label"_st },
+    { kKIPlayerList,    "KI Mini Friends List"_st },
+    { kKIChatModeBtn,   "KI Toggle Chat Mode Btn"_st },
+    { kBlackBarDlg,     "Black Bar Dialog"_st },
+    { kBlackBarKIButtons, "Black Bar KI Radio Group"_st },
+    { kKILogoutButton, "KI Logout Button"_st },
 
-    { 0, "" }       // Ending tag, MUST ALWAYS BE HERE
+    { 0, ""_st }       // Ending tag, MUST ALWAYS BE HERE
 };

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.h
@@ -82,8 +82,8 @@ class plPostEffectMod;
 class pfGUITag
 {
     public:
-        uint32_t  fID;
-        char    fName[ 128 ];
+        uint32_t   fID;
+        ST::string fName;
 };
 
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -617,7 +617,15 @@ void plArmatureModBase::IEnableBones(int lod, bool enable)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-const char *plArmatureMod::BoneStrings[] = {"Male", "Female", "Critter", "Actor"};
+using namespace ST::literals;
+
+const ST::string plArmatureMod::BoneStrings[] =
+{
+    "Male"_st,
+    "Female"_st,
+    "Critter"_st,
+    "Actor"_st
+};
 
 float plArmatureMod::fMouseTurnSensitivity = 1.f;
 bool plArmatureMod::fClickToTurn = true;
@@ -631,8 +639,8 @@ plArmatureMod::plArmatureMod()
       fMouseFrameTurnStrength(), fSuspendInputCount(), fIsLinkedIn(), fMidLink(),
       fAlreadyPanicLinking(), fReverseFBOnIdle(), fFollowerParticleSystemSO(),
       fPendingSynch(), fOpaque(true), fPhysHeight(), fPhysWidth(), fUpdateMsg(),
-      fRootName(), fDontPanicLink(), fBodyAgeName("GlobalAvatars"),
-      fBodyFootstepSoundPage("Audio"), fAnimationPrefix("Male"), fUserStr(),
+      fRootName(), fDontPanicLink(), fBodyAgeName("GlobalAvatars"_st),
+      fBodyFootstepSoundPage("Audio"_st), fAnimationPrefix("Male"_st), fUserStr(),
       fUnconsumedJump(), fLastSynch()
 {
     fWaitFlags |= kNeedAudio | kNeedCamera | kNeedSpawn;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
@@ -361,7 +361,7 @@ public:
 
     static const float kAvatarInputSynchThreshold;
     static bool fClickToTurn;
-    static const char *BoneStrings[];
+    static const ST::string BoneStrings[];
     
     void SetPhysicalDims(float height, float width) { fPhysHeight = height; fPhysWidth = width; }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
@@ -1517,24 +1517,26 @@ bool plClothingOutfit::IReadFromFile(const plFileName &filename)
 
 /////////////////////////////////////////////////////////////////////////////
 
-const char *plClothingMgr::GroupStrings[] = 
+using namespace ST::literals;
+
+const ST::string plClothingMgr::GroupStrings[] = 
 {
-    "Male Clothing",
-    "Female Clothing",
-    "(No Clothing Options)"
+    "Male Clothing"_st,
+    "Female Clothing"_st,
+    "(No Clothing Options)"_st
 };
 
-const char *plClothingMgr::TypeStrings[] =
+const ST::string plClothingMgr::TypeStrings[] =
 {
-    "Pants",
-    "Shirt",
-    "LeftHand",
-    "RightHand",
-    "Face",
-    "Hair",
-    "LeftFoot",
-    "RightFoot",
-    "Accessory"
+    "Pants"_st,
+    "Shirt"_st,
+    "LeftHand"_st,
+    "RightHand"_st,
+    "Face"_st,
+    "Hair"_st,
+    "LeftFoot"_st,
+    "RightFoot"_st,
+    "Accessory"_st
 };
 
 plClothingMgr *plClothingMgr::fInstance = nullptr;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.h
@@ -347,8 +347,8 @@ public:
         kMaxType,
     };
 
-    static const char *GroupStrings[];
-    static const char *TypeStrings[];
+    static const ST::string GroupStrings[];
+    static const ST::string TypeStrings[];
 };
 
 

--- a/Sources/Tools/MaxComponent/pfGUISkinComp.cpp
+++ b/Sources/Tools/MaxComponent/pfGUISkinComp.cpp
@@ -396,21 +396,21 @@ INT_PTR CALLBACK    pfGUISkinEditProc::DialogProc( HWND hDlg, UINT msg, WPARAM w
     static struct plElemPair
     {
         pfGUISkin::Elements el;
-        const char          *name;
-    } sElemPairs[] = { { pfGUISkin::kUpLeftCorner,          "Upper-left Corner" },
-                       { pfGUISkin::kTopSpan,               "Top Span" },
-                       { pfGUISkin::kUpRightCorner,         "Upper-right Corner" },
-                       { pfGUISkin::kRightSpan,             "Right Span" },
-                       { pfGUISkin::kLowerRightCorner,      "Lower-right Corner" },
-                       { pfGUISkin::kBottomSpan,            "Bottom Span" },
-                       { pfGUISkin::kLowerLeftCorner,       "Lower-left Corner" },
-                       { pfGUISkin::kLeftSpan,              "Left Span" },
-                       { pfGUISkin::kMiddleFill,            "Middle Fill" },
-                       { pfGUISkin::kSelectedFill,          "Selected Middle Fill" },
-                       { pfGUISkin::kSubMenuArrow,          "Sub-Menu Arrow" },
-                       { pfGUISkin::kSelectedSubMenuArrow,  "Selected Sub-Menu Arrow" },
-                       { pfGUISkin::kTreeButtonClosed,      "Tree-view Button, Closed" },
-                       { pfGUISkin::kTreeButtonOpen,        "Tree-view Button, Open" },
+        const TCHAR          *name;
+    } sElemPairs[] = { { pfGUISkin::kUpLeftCorner,          _T("Upper-left Corner") },
+                       { pfGUISkin::kTopSpan,               _T("Top Span") },
+                       { pfGUISkin::kUpRightCorner,         _T("Upper-right Corner") },
+                       { pfGUISkin::kRightSpan,             _T("Right Span") },
+                       { pfGUISkin::kLowerRightCorner,      _T("Lower-right Corner") },
+                       { pfGUISkin::kBottomSpan,            _T("Bottom Span") },
+                       { pfGUISkin::kLowerLeftCorner,       _T("Lower-left Corner") },
+                       { pfGUISkin::kLeftSpan,              _T("Left Span") },
+                       { pfGUISkin::kMiddleFill,            _T("Middle Fill") },
+                       { pfGUISkin::kSelectedFill,          _T("Selected Middle Fill") },
+                       { pfGUISkin::kSubMenuArrow,          _T("Sub-Menu Arrow") },
+                       { pfGUISkin::kSelectedSubMenuArrow,  _T("Selected Sub-Menu Arrow") },
+                       { pfGUISkin::kTreeButtonClosed,      _T("Tree-view Button, Closed") },
+                       { pfGUISkin::kTreeButtonOpen,        _T("Tree-view Button, Open") },
                        { pfGUISkin::kNumElements, nullptr } };
 
 

--- a/Sources/Tools/MaxComponent/plAudioComponents.cpp
+++ b/Sources/Tools/MaxComponent/plAudioComponents.cpp
@@ -3650,27 +3650,27 @@ protected:
         int     i, toSet = -1;
         struct plSndGrp
         {
-            char name[ 64 ];
+            const TCHAR name[ 64 ];
             int group;
-        } groups[] = {  { "Metal",  plPhysicalSndGroup::kMetal },
-                        { "Grass",  plPhysicalSndGroup::kGrass },
-                        { "Wood",   plPhysicalSndGroup::kWood },
-                        { "Stone",  plPhysicalSndGroup::kWood + 1 },
-                        { "Water",  plPhysicalSndGroup::kWood + 2 },
-                        { "Bone",   plPhysicalSndGroup::kWood + 3 },
-                        { "Dirt",   plPhysicalSndGroup::kWood + 4 },
-                        { "Rug",    plPhysicalSndGroup::kWood + 5 },
-                        { "Cone",   plPhysicalSndGroup::kWood + 6 },
-                        { "User 1", plPhysicalSndGroup::kWood + 7 },
-                        { "User 2", plPhysicalSndGroup::kWood + 8 },
-                        { "User 3", plPhysicalSndGroup::kWood + 9 },
-                        { "", plPhysicalSndGroup::kNone } };
+        } groups[] = {  { _T("Metal"),  plPhysicalSndGroup::kMetal },
+                        { _T("Grass"),  plPhysicalSndGroup::kGrass },
+                        { _T("Wood"),   plPhysicalSndGroup::kWood },
+                        { _T("Stone"),  plPhysicalSndGroup::kWood + 1 },
+                        { _T("Water"),  plPhysicalSndGroup::kWood + 2 },
+                        { _T("Bone"),   plPhysicalSndGroup::kWood + 3 },
+                        { _T("Dirt"),   plPhysicalSndGroup::kWood + 4 },
+                        { _T("Rug"),    plPhysicalSndGroup::kWood + 5 },
+                        { _T("Cone"),   plPhysicalSndGroup::kWood + 6 },
+                        { _T("User 1"), plPhysicalSndGroup::kWood + 7 },
+                        { _T("User 2"), plPhysicalSndGroup::kWood + 8 },
+                        { _T("User 3"), plPhysicalSndGroup::kWood + 9 },
+                        { _T(""), plPhysicalSndGroup::kNone } };
 
         SendMessage( hList, CB_RESETCONTENT, 0, 0 );
         
         if( allowAll )
         {
-            int idx = (int)SendMessage(hList, CB_ADDSTRING, 0, (LPARAM)"* All *");
+            int idx = (int)SendMessage(hList, CB_ADDSTRING, 0, (LPARAM)_T("* All *"));
             SendMessage( hList, CB_SETITEMDATA, idx, (LPARAM)-1 );
             if( currSel == -1 )
                 toSet = idx;

--- a/Sources/Tools/MaxComponent/plAvatarComponent.cpp
+++ b/Sources/Tools/MaxComponent/plAvatarComponent.cpp
@@ -607,7 +607,6 @@ public:
 
         IParamBlock2 *pb = map->GetParamBlock();
         HWND cbox = nullptr;
-        char* buffer = nullptr;
 
         int selection;
         switch (msg)
@@ -617,7 +616,7 @@ public:
             for (j = 0; j < plClothingMgr::kMaxGroup; j++)
             {
                 cbox = GetDlgItem(hWnd, IDC_COMP_AVATAR_CLOTHING_GROUP);
-                SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)plClothingMgr::GroupStrings[j]);
+                SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)ST2T(plClothingMgr::GroupStrings[j]));
             }
             selection = pb->GetInt(ParamID(plAvatarComponent::kClothingGroup));
             SendMessage(cbox, CB_SETCURSEL, selection, 0);
@@ -625,7 +624,7 @@ public:
             for (j = 0; j < plArmatureMod::kMaxBoneBase; j++)
             {
                 cbox = GetDlgItem(hWnd, IDC_COMP_AVATAR_SKELETON);
-                SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)plArmatureMod::BoneStrings[j]);
+                SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)ST2T(plArmatureMod::BoneStrings[j]));
             }
             selection = pb->GetInt(ParamID(plAvatarComponent::kSkeleton));
             SendMessage(cbox, CB_SETCURSEL, selection, 0);
@@ -757,7 +756,6 @@ public:
                 fPB = map->GetParamBlock();
                 fComp = (plLODAvatarComponent*) fPB->GetOwner();
 
-                VCharArray Nilptr;
                 ILoadComboBox(LODCombo, fComp->fLODLevels);
                 SendMessage(LODCombo, CB_SETCURSEL, LodBeginState,  0); // select the right one
 
@@ -765,7 +763,7 @@ public:
                 for (i = 0; i < plClothingMgr::kMaxGroup; i++)
                 {
                     cbox = GetDlgItem(hWnd, IDC_COMP_AVATAR_CLOTHING_GROUP);
-                    SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)plClothingMgr::GroupStrings[i]);
+                    SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)ST2T(plClothingMgr::GroupStrings[i]));
                 }
                 selection = fPB->GetInt(ParamID(plLODAvatarComponent::kClothingGroup));
                 SendMessage(cbox, CB_SETCURSEL, selection, 0);
@@ -773,7 +771,7 @@ public:
                 for (i = 0; i < plArmatureMod::kMaxBoneBase; i++)
                 {
                     cbox = GetDlgItem(hWnd, IDC_COMP_AVATAR_SKELETON);
-                    SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)plArmatureMod::BoneStrings[i]);
+                    SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)ST2T(plArmatureMod::BoneStrings[i]));
                 }
                 selection = fPB->GetInt(ParamID(plLODAvatarComponent::kSkeleton));
                 SendMessage(cbox, CB_SETCURSEL, selection, 0);
@@ -1045,9 +1043,9 @@ plLODAvatarComponent::plLODAvatarComponent() : fMaterial()
     fClassDesc = &gLODAvatarCompDesc;
     fClassDesc->MakeAutoParamBlocks(this);
 
-    fLODLevels.push_back("High");
-    fLODLevels.push_back("Medium");
-    fLODLevels.push_back("Low");
+    fLODLevels.emplace_back(_M("High"));
+    fLODLevels.emplace_back(_M("Medium"));
+    fLODLevels.emplace_back(_M("Low"));
 
 }
 

--- a/Sources/Tools/MaxComponent/plAvatarComponent.cpp
+++ b/Sources/Tools/MaxComponent/plAvatarComponent.cpp
@@ -1043,9 +1043,11 @@ plLODAvatarComponent::plLODAvatarComponent() : fMaterial()
     fClassDesc = &gLODAvatarCompDesc;
     fClassDesc->MakeAutoParamBlocks(this);
 
-    fLODLevels.emplace_back(_M("High"));
-    fLODLevels.emplace_back(_M("Medium"));
-    fLODLevels.emplace_back(_M("Low"));
+    fLODLevels = {
+        _M("High"),
+        _M("Medium"),
+        _M("Low),
+    };
 
 }
 
@@ -1231,5 +1233,4 @@ void plLODAvatarComponent::RemoveBone(int index)
     fCompPB->Delete(ParamID(kBoneList), boneIdx, 1);
     fCompPB->SetValue(ParamID(kGroupTotals), 0, fCompPB->GetInt(ParamID(kGroupTotals), 0, group) - 1, group);
 }
-
 

--- a/Sources/Tools/MaxComponent/plAvatarComponent.h
+++ b/Sources/Tools/MaxComponent/plAvatarComponent.h
@@ -175,7 +175,7 @@ protected:
     hsGMaterial *fMaterial;
     
 public:
-        VCharArray fLODLevels;  //Initialized in the CTR.
+        VStringArray fLODLevels;  //Initialized in the CTR.
 
 
         // Do not change any of the entries in this list. Only add at the end.

--- a/Sources/Tools/MaxComponent/plClothingComponent.cpp
+++ b/Sources/Tools/MaxComponent/plClothingComponent.cpp
@@ -276,16 +276,16 @@ INT_PTR plClothingComponentProc::DlgProc(TimeValue t, IParamMap2 *pm, HWND hWnd,
             ListBox_SetCurSel(hList, -1);
 
             for (i = 0; i < plClothingMgr::kMaxGroup; i++)
-                ComboBox_AddString(hGroup, plClothingMgr::GroupStrings[i]);
+                ComboBox_AddString(hGroup, ST2T(plClothingMgr::GroupStrings[i]));
             ComboBox_SetCurSel(hGroup, pb->GetInt(plClothingComponent::kGroup));
 
             for (i = 0; i < plClothingMgr::kMaxType; i++)
-                ComboBox_AddString(hType, plClothingMgr::TypeStrings[i]);
+                ComboBox_AddString(hType, ST2T(plClothingMgr::TypeStrings[i]));
             ComboBox_SetCurSel(hType, pb->GetInt(plClothingComponent::kType));
 
-            ComboBox_AddString(hLOD, "High");
-            ComboBox_AddString(hLOD, "Medium");
-            ComboBox_AddString(hLOD, "Low");
+            ComboBox_AddString(hLOD, _T("High"));
+            ComboBox_AddString(hLOD, _T("Medium"));
+            ComboBox_AddString(hLOD, _T("Low"));
             ComboBox_SetCurSel(hLOD, pb->GetInt(plClothingComponent::kLODState));
         }
         return TRUE;

--- a/Sources/Tools/MaxComponent/plComponentProcBase.h
+++ b/Sources/Tools/MaxComponent/plComponentProcBase.h
@@ -81,7 +81,7 @@ protected:
 //
 
 
-typedef std::vector<std::string> VStringArray;
+typedef std::vector<M_STD_STRING> VStringArray;
 
 class plVSBaseComponentProc : public ParamMap2UserDlgProc
 {
@@ -100,7 +100,7 @@ protected:
         if(nNames)
             for (int i = 0; i < nNames ; i++)
             {
-                const char * name = names[i].c_str();
+                const auto* name = names[i].c_str();
                 SendMessage(hComboBox, CB_INSERTSTRING, i, (LPARAM)name);
                 
             }
@@ -116,7 +116,7 @@ protected:
         SendMessage(hListBox, LB_RESETCONTENT, 0, 0);
         for (int i = 0; i < names.size(); i++)
         {
-            const char* c_name = names[i].c_str();
+            const auto* c_name = names[i].c_str();
             LRESULT idxptr = SendMessage(hListBox, LB_ADDSTRING, 0, (LPARAM)c_name);
             
             SendMessage(hListBox, LB_SETITEMDATA, (WPARAM) idxptr, (LPARAM) GetItemVals[i]);

--- a/Sources/Tools/MaxComponent/plDistribComponent.cpp
+++ b/Sources/Tools/MaxComponent/plDistribComponent.cpp
@@ -71,55 +71,55 @@ void DummyCodeIncludeFuncDistrib()
 struct plIsoTypeStringValPair
 {
     plDistributor::IsoType          fValue;
-    const char*                     fString;
+    const TCHAR*                     fString;
 };
 
 static const int kNumSeparations = 4;
 static plIsoTypeStringValPair kSeparationStrings[kNumSeparations] =
 {
-    { plDistributor::kIsoNone, "None" },
-    { plDistributor::kIsoLow, "Low" },
-    { plDistributor::kIsoMedium, "Medium" },
-    { plDistributor::kIsoHigh, "High" }
+    { plDistributor::kIsoNone, _T("None") },
+    { plDistributor::kIsoLow, _T("Low") },
+    { plDistributor::kIsoMedium, _T("Medium") },
+    { plDistributor::kIsoHigh, _T("High") }
 };
 
 struct plConformTypeStringValPair
 {
     plDistributor::ConformType      fValue;
-    const char*                     fString;
+    const TCHAR*                     fString;
 };
 
 static const int kNumConforms = 5;
 static plConformTypeStringValPair kConformStrings[kNumConforms] =
 {
-    { plDistributor::kConformNone, "None" },
-    { plDistributor::kConformCheck, "Check" },
-    { plDistributor::kConformAll, "All Verts" },
-    { plDistributor::kConformHeight, "Bottom" },
-    { plDistributor::kConformBase, "Base" }
+    { plDistributor::kConformNone, _T("None") },
+    { plDistributor::kConformCheck, _T("Check") },
+    { plDistributor::kConformAll, _T("All Verts") },
+    { plDistributor::kConformHeight, _T("Bottom") },
+    { plDistributor::kConformBase, _T("Base") }
 };
 
 struct plColorChanStringValPair
 {
     plDistributor::ColorChan        fValue;
-    const char*                     fString;
+    const TCHAR*                     fString;
 };
 
 static plColorChanStringValPair kColorChanStrings[] =
 {
-    { plDistributor::kRed, "Red" },
-    { plDistributor::kGreen, "Green" },
-    { plDistributor::kBlue, "Blue" },
-    { plDistributor::kAlpha, "Alpha" },
-    { plDistributor::kAverageRedGreen, "Avg(R,G)" },
-    { plDistributor::kAverageRedGreenTimesAlpha, "Avg(R,G)xA" },
-    { plDistributor::kAverage, "Avg(R,G,B)" },
-    { plDistributor::kAverageTimesAlpha, "Avg(R,G,B)xA" },
-    { plDistributor::kMax, "Max(R,G,B)" },
-    { plDistributor::kMaxColor, "Max(R,G,B)" },
-    { plDistributor::kMaxColorTimesAlpha, "Max(R,G,B)xA" },
-    { plDistributor::kMaxRedGreen, "Max(R,G)" },
-    { plDistributor::kMaxRedGreenTimesAlpha, "Max(R,G)xA" }
+    { plDistributor::kRed, _T("Red") },
+    { plDistributor::kGreen, _T("Green") },
+    { plDistributor::kBlue, _T("Blue") },
+    { plDistributor::kAlpha, _T("Alpha") },
+    { plDistributor::kAverageRedGreen, _T("Avg(R,G)") },
+    { plDistributor::kAverageRedGreenTimesAlpha, _T("Avg(R,G)xA") },
+    { plDistributor::kAverage, _T("Avg(R,G,B)") },
+    { plDistributor::kAverageTimesAlpha, _T("Avg(R,G,B)xA") },
+    { plDistributor::kMax, _T("Max(R,G,B)") },
+    { plDistributor::kMaxColor, _T("Max(R,G,B)") },
+    { plDistributor::kMaxColorTimesAlpha, _T("Max(R,G,B)xA") },
+    { plDistributor::kMaxRedGreen, _T("Max(R,G)") },
+    { plDistributor::kMaxRedGreenTimesAlpha, _T("Max(R,G)xA") }
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Sources/Tools/MaxComponent/plDistribComponent_old.cpp
+++ b/Sources/Tools/MaxComponent/plDistribComponent_old.cpp
@@ -64,24 +64,24 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 struct plProbChanStringValPair
 {
     plDistributor::ColorChan        fValue;
-    const char*                     fString;
+    const TCHAR*                     fString;
 };
 
 static plProbChanStringValPair kProbColorChanStrings[] =
 {
-    { plDistributor::kRed, "Red" },
-    { plDistributor::kGreen, "Green" },
-    { plDistributor::kBlue, "Blue" },
-    { plDistributor::kAlpha, "Alpha" },
-    { plDistributor::kAverageRedGreen, "Avg(R,G)" },
-    { plDistributor::kAverageRedGreenTimesAlpha, "Avg(R,G)xA" },
-    { plDistributor::kAverage, "Avg(R,G,B)" },
-    { plDistributor::kAverageTimesAlpha, "Avg(R,G,B)xA" },
-    { plDistributor::kMax, "Max(R,G,B)" },
-    { plDistributor::kMaxColor, "Max(R,G,B)" },
-    { plDistributor::kMaxColorTimesAlpha, "Max(R,G,B)xA" },
-    { plDistributor::kMaxRedGreen, "Max(R,G)" },
-    { plDistributor::kMaxRedGreenTimesAlpha, "Max(R,G)xA" }
+    { plDistributor::kRed, _T("Red") },
+    { plDistributor::kGreen, _T("Green") },
+    { plDistributor::kBlue, _T("Blue") },
+    { plDistributor::kAlpha, _T("Alpha") },
+    { plDistributor::kAverageRedGreen, _T("Avg(R,G)") },
+    { plDistributor::kAverageRedGreenTimesAlpha, _T("Avg(R,G)xA") },
+    { plDistributor::kAverage, _T("Avg(R,G,B)") },
+    { plDistributor::kAverageTimesAlpha, _T("Avg(R,G,B)xA") },
+    { plDistributor::kMax, _T("Max(R,G,B)") },
+    { plDistributor::kMaxColor, _T("Max(R,G,B)") },
+    { plDistributor::kMaxColorTimesAlpha, _T("Max(R,G,B)xA") },
+    { plDistributor::kMaxRedGreen, _T("Max(R,G)") },
+    { plDistributor::kMaxRedGreenTimesAlpha, _T("Max(R,G)xA") }
 };
 
 void DummyCodeIncludeFuncDistrib_old()

--- a/Sources/Tools/MaxComponent/plGUIComponents.cpp
+++ b/Sources/Tools/MaxComponent/plGUIComponents.cpp
@@ -432,7 +432,7 @@ void    plGUITagProc::ILoadTags( HWND hWnd, IParamBlock2 *pb )
     for( uint32_t i = 0; i < pfGameGUIMgr::GetNumTags(); i++ )
     {
         pfGUITag *tag = pfGameGUIMgr::GetTag( i );
-        idx = (int)SendMessage(hWnd, CB_ADDSTRING, 0, (LPARAM)tag->fName);
+        idx = (int)SendMessage(hWnd, CB_ADDSTRING, 0, (LPARAM)ST2T(tag->fName));
         SendMessage( hWnd, CB_SETITEMDATA, (WPARAM)idx, (LPARAM)tag->fID );
 
         if( tag->fID == pb->GetInt( plGUITagComponent::kRefCurrIDSel ) )
@@ -1942,9 +1942,9 @@ INT_PTR plGUIButtonProc::DlgProc(TimeValue t, IParamMap2 *pmap, HWND hWnd, UINT 
     {
         case WM_INITDIALOG:
             SendMessage( GetDlgItem( hWnd, IDC_COMBO_BUTTON_NOTIFYTYPE ), CB_RESETCONTENT, 0, 0 );
-            SendMessage( GetDlgItem( hWnd, IDC_COMBO_BUTTON_NOTIFYTYPE ), CB_ADDSTRING, 0, (LPARAM)"Button Up" );
-            SendMessage( GetDlgItem( hWnd, IDC_COMBO_BUTTON_NOTIFYTYPE ), CB_ADDSTRING, 0, (LPARAM)"Button Down" );
-            SendMessage( GetDlgItem( hWnd, IDC_COMBO_BUTTON_NOTIFYTYPE ), CB_ADDSTRING, 0, (LPARAM)"Button Down and Up" );
+            SendMessage( GetDlgItem( hWnd, IDC_COMBO_BUTTON_NOTIFYTYPE ), CB_ADDSTRING, 0, (LPARAM)_T("Button Up") );
+            SendMessage( GetDlgItem( hWnd, IDC_COMBO_BUTTON_NOTIFYTYPE ), CB_ADDSTRING, 0, (LPARAM)_T("Button Down") );
+            SendMessage( GetDlgItem( hWnd, IDC_COMBO_BUTTON_NOTIFYTYPE ), CB_ADDSTRING, 0, (LPARAM)_T("Button Down and Up") );
             SendMessage( GetDlgItem( hWnd, IDC_COMBO_BUTTON_NOTIFYTYPE ), CB_SETCURSEL, pmap->GetParamBlock()->GetInt( plGUIButtonComponent::kRefNotifyType ), 0 );
             return TRUE;
 
@@ -3087,7 +3087,7 @@ public:
                     SetDlgItemText( hWnd, IDC_GUI_INITTEXT, pmap->GetParamBlock()->GetStr( plGUITextBoxComponent::kRefInitText ) );
                 SendMessage( GetDlgItem( hWnd, IDC_GUI_LANGUAGE ), CB_RESETCONTENT, 0, 0 );
                 for (i=0; i<plLocalization::kNumLanguages; i++)
-                    SendMessage( GetDlgItem( hWnd, IDC_GUI_LANGUAGE ), CB_ADDSTRING, 0, (LPARAM)plLocalization::GetLanguageName((plLocalization::Language)i) );
+                    SendMessageA( GetDlgItem( hWnd, IDC_GUI_LANGUAGE ), CB_ADDSTRING, 0, (LPARAM)plLocalization::GetLanguageName((plLocalization::Language)i) );
                 SendMessage( GetDlgItem( hWnd, IDC_GUI_LANGUAGE ), CB_SETCURSEL, 0, 0 );
                 fCurLanguage = 0;
 

--- a/Sources/Tools/MaxComponent/plGrassComponent.cpp
+++ b/Sources/Tools/MaxComponent/plGrassComponent.cpp
@@ -102,10 +102,10 @@ public:
         {
         case WM_INITDIALOG:
             cbox = GetDlgItem(hWnd, IDC_GRASS_WAVE);
-            SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)"1");
-            SendMessage(cbox, CB_ADDSTRING, 1, (LPARAM)"2");
-            SendMessage(cbox, CB_ADDSTRING, 2, (LPARAM)"3");
-            SendMessage(cbox, CB_ADDSTRING, 3, (LPARAM)"4");
+            SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)_T("1"));
+            SendMessage(cbox, CB_ADDSTRING, 1, (LPARAM)_T("2"));
+            SendMessage(cbox, CB_ADDSTRING, 2, (LPARAM)_T("3"));
+            SendMessage(cbox, CB_ADDSTRING, 3, (LPARAM)_T("4"));
 
             selection = pb->GetInt(plGrassComponent::kWave);
             ISetToWave(selection, hWnd, pb, map);

--- a/Sources/Tools/MaxComponent/plParticleComponents.cpp
+++ b/Sources/Tools/MaxComponent/plParticleComponents.cpp
@@ -107,11 +107,11 @@ void DummyCodeIncludeFuncParticles()
 //
 // stuff for plParticleComponent
 
-const char *plParticleCoreComponent::GenStrings[] = // line these up with the generation types enum.
+const TCHAR* plParticleCoreComponent::GenStrings[] = // line these up with the generation types enum.
 {
-    "Point Source",
-    "Mesh",
-    "One Per Vertex"
+    _T("Point Source"),
+    _T("Mesh"),
+    _T("One Per Vertex")
 };
 
 bool plParticleCoreComponent::IsParticleSystemComponent(plComponentBase *comp)

--- a/Sources/Tools/MaxComponent/plParticleComponents.h
+++ b/Sources/Tools/MaxComponent/plParticleComponents.h
@@ -98,7 +98,7 @@ public:
         kGenOnePerVertex,
         kGenNumOptions
     };
-    static const char *GenStrings[];
+    static const TCHAR* GenStrings[];
 
     enum
     {

--- a/Sources/Tools/MaxComponent/plRepComponent.cpp
+++ b/Sources/Tools/MaxComponent/plRepComponent.cpp
@@ -66,11 +66,11 @@ const Class_ID REPCOMP_CID(0x157c29f3, 0x18fa54cd);
 const Class_ID REPGROUP_CID(0x20ce74a2, 0x471b2386);
 
 static const int kNumQualities = 4;
-static const char* kQualityStrings[kNumQualities] = {
-    "Low",
-    "Medium",
-    "High",
-    "Ultra"
+static const TCHAR* kQualityStrings[kNumQualities] = {
+    _T("Low"),
+    _T("Medium"),
+    _T("High"),
+    _T("Ultra")
 };
 
 class plRepresentComp : public plComponent

--- a/Sources/Tools/MaxComponent/plShadowComponents.cpp
+++ b/Sources/Tools/MaxComponent/plShadowComponents.cpp
@@ -70,11 +70,11 @@ static uint8_t QualityBitToMask(int q) { return ~((1 << q) - 1); }
 
 #define WM_ROLLOUT_OPEN WM_USER+1
 static const int kNumQualities = 4;
-static const char* kQualityStrings[kNumQualities] = {
-    "Low",
-    "Medium",
-    "High",
-    "Ultra"
+static const TCHAR* kQualityStrings[kNumQualities] = {
+    _T("Low"),
+    _T("Medium"),
+    _T("High"),
+    _T("Ultra")
 };
 
 template <class T> class plQualityProc : public ParamMap2UserDlgProc

--- a/Sources/Tools/MaxMain/plAgeDescInterface.cpp
+++ b/Sources/Tools/MaxMain/plAgeDescInterface.cpp
@@ -727,7 +727,7 @@ void plAgeDescInterface::IInitControls()
         int i, curr = 0;
         for (i = 0; i < branches.Size(); i++)
         {
-            int idx = SendDlgItemMessage(fhDlg, IDC_BRANCHCOMBO, CB_ADDSTRING, 0, (LPARAM)(const char*)(branches[i].Name));
+            int idx = SendDlgItemMessage(fhDlg, IDC_BRANCHCOMBO, CB_ADDSTRING, 0, (LPARAM)(const TCHAR*)(branches[i].Name));
             SendDlgItemMessage(fhDlg, IDC_BRANCHCOMBO, CB_SETITEMDATA, idx, (LPARAM)branches[i].Id);
 
             if (branches[i].Id == fAssetManIface->GetCurrBranch())

--- a/Sources/Tools/MaxPlasmaLights/plRealTimeLightBase.cpp
+++ b/Sources/Tools/MaxPlasmaLights/plRealTimeLightBase.cpp
@@ -69,7 +69,7 @@ static int GetTargetPoint(TimeValue t, INode *inode, Point3& p)
 //  This class provides the base functionality for all the dialog procs for
 //  the ParamBlock rollouts for each light
 
-void    plBaseLightProc::ILoadComboBox( HWND hComboBox, const char *names[] )
+void    plBaseLightProc::ILoadComboBox( HWND hComboBox, const TCHAR* names[] )
 {
     SendMessage(hComboBox, CB_RESETCONTENT, 0, 0);
     for (int i = 0; names[i]; i++)

--- a/Sources/Tools/MaxPlasmaLights/plRealTimeLightBase.h
+++ b/Sources/Tools/MaxPlasmaLights/plRealTimeLightBase.h
@@ -95,7 +95,7 @@ class plRTLightBase;
 class plBaseLightProc : public ParamMap2UserDlgProc
 {
     protected:
-        void            ILoadComboBox( HWND hComboBox, const char *names[] );
+        void            ILoadComboBox( HWND hComboBox, const TCHAR* names[] );
         void            IBuildLightMesh( plRTLightBase *base, float coneSize );
 
     public:

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.cpp
@@ -707,7 +707,7 @@ void plStealthDlgProc::ILoadLoops(IParamBlock2 *pb)
     SendMessage( hLoops, CB_RESETCONTENT, 0, 0 );
 
     // Add the default option
-    int defIdx = (int)SendMessage(hLoops, CB_ADDSTRING, 0, (LPARAM)ENTIRE_ANIMATION_NAME);
+    int defIdx = (int)SendMessage(hLoops, CB_ADDSTRING, 0, (LPARAM)_T(ENTIRE_ANIMATION_NAME));
     SendMessage( hLoops, CB_SETITEMDATA, defIdx, kDefault );
 
     ST::string segName = M2ST( pb->GetStr( (ParamID)plAnimStealthNode::kPBName ) );
@@ -733,7 +733,7 @@ void plStealthDlgProc::ILoadLoops(IParamBlock2 *pb)
                     (spec->fEnd   == -1 || spec->fEnd   <= animSpec->fEnd) )
                 {
                     // Add the name
-                    int idx = (int)SendMessage(hLoops, CB_ADDSTRING, 0, (LPARAM)spec->fName.c_str());
+                    int idx = (int)SendMessage(hLoops, CB_ADDSTRING, 0, (LPARAM)ST2T(spec->fName));
                     SendMessage( hLoops, CB_SETITEMDATA, idx, kName );
                 }       
             }
@@ -837,12 +837,12 @@ protected:
     {
         int type = fPB->GetInt(fTypeID);
 
-        int idx = ListBox_AddString( hList, kUseParamBlockNodeString );
+        int idx = ListBox_AddString( hList, _T(kUseParamBlockNodeString) );
         if (type == plAnimObjInterface::kUseParamBlockNode && !fPB->GetINode(fNodeParamID))
             ListBox_SetCurSel(hList, idx);
 
 
-        idx = ListBox_AddString( hList, kUseOwnerNodeString );
+        idx = ListBox_AddString( hList, _T(kUseOwnerNodeString) );
         if (type == plAnimObjInterface::kUseOwnerNode)
             ListBox_SetCurSel(hList, idx);
     }

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plClothingMtl.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plClothingMtl.cpp
@@ -97,18 +97,18 @@ const UINT32 plClothingMtl::TextConstants[] =
     IDC_CLOTHING_TILE4_SIZE
 };
 
-const char *plClothingMtl::LayerStrings[] = 
+const TCHAR* plClothingMtl::LayerStrings[] =
 {
-    "Base",
-    "Skin",
-    "Skin Blend (1)",
-    "Skin Blend (2)",
-    "Skin Blend (3)",
-    "Skin Blend (4)",
-    "Skin Blend (5)",
-    "Skin Blend (6)",
-    "Tint 1",
-    "Tint 2"
+    _T("Base"),
+    _T("Skin"),
+    _T("Skin Blend (1)"),
+    _T("Skin Blend (2)"),
+    _T("Skin Blend (3)"),
+    _T("Skin Blend (4)"),
+    _T("Skin Blend (5)"),
+    _T("Skin Blend (6)"),
+    _T("Tint 1"),
+    _T("Tint 2")
 };
 
 const uint8_t plClothingMtl::LayerToPBIdx[] =
@@ -703,25 +703,3 @@ void plClothingMtl::ReleaseTilesets()
         fTilesets.pop_back();
     }
 }
-
-/////////////////////////////////////////////////////////////////////////////////
-
-plClothingTileset::plClothingTileset() : fName()
-{
-}
-
-plClothingTileset::~plClothingTileset()
-{
-    delete [] fName;
-}
-
-void plClothingTileset::AddElement(plClothingElement *element)
-{
-    fElements.emplace_back(element);
-}
-
-void plClothingTileset::SetName(char *name)
-{
-    delete fName; fName = hsStrcpy(name);
-}
-

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plClothingMtl.h
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plClothingMtl.h
@@ -44,12 +44,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <vector>
 
+#include <string_theory/string>
+
 class Bitmap;
 class plClothingItem;
 class plMaxNode;
 class plClothingElement;
 class Texmap;
-namespace ST { class string; }
 
 #define CLOTHING_MTL_CLASS_ID Class_ID(0x792c6de4, 0x1f952b65)
 
@@ -58,14 +59,11 @@ extern TCHAR *GetString(int id);
 class plClothingTileset
 {
 public:
-    char *fName;
+    ST::string fName;
     std::vector<plClothingElement *> fElements;
 
-    plClothingTileset();
-    ~plClothingTileset();
-
-    void SetName(char *name);
-    void AddElement(plClothingElement *element);
+    void SetName(ST::string name) { fName = std::move(name); }
+    void AddElement(plClothingElement* element) { fElements.emplace_back(element); }
 };
 
 class plClothingMtl : public Mtl
@@ -77,7 +75,7 @@ protected:
 public:
     IMtlParams *fIMtlParams;
 
-    static const char *LayerStrings[];
+    static const TCHAR* LayerStrings[];
     static const uint8_t LayerToPBIdx[];
 
     enum

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plClothingMtlPBDec.h
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plClothingMtlPBDec.h
@@ -44,7 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "../../AssetMan/PublicInterface/AssManBaseTypes.h"
 #endif
 
-#include "MaxMain/MaxCompat.h"
+#include "MaxMain/MaxAPI.h"
 
 
 class plClothingEditBox
@@ -197,7 +197,7 @@ public:
         {
             plClothingElement *element = tileset->fElements[i];
             SendMessage(GetDlgItem(hWnd, plClothingMtl::TextConstants[2 * i]), 
-                        WM_SETTEXT, 0, (LPARAM)element->fName.c_str());
+                        WM_SETTEXT, 0, (LPARAM)ST2T(element->fName));
             _sntprintf(buff, std::size(buff), _T("(%d, %d)"), element->fWidth, element->fHeight);
             SendMessage(GetDlgItem(hWnd, plClothingMtl::TextConstants[2 * i + 1]), 
                         WM_SETTEXT, 0, (LPARAM)buff);
@@ -242,7 +242,7 @@ public:
             mtl->InitTilesets();
             cbox = GetDlgItem(hWnd, IDC_CLOTHING_TILESET);
             for (plClothingTileset* set : mtl->fTilesets)
-                SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)set->fName);
+                SendMessage(cbox, CB_ADDSTRING, 0, (LPARAM)ST2T(set->fName));
 
             mtl->ReleaseTilesets();
 

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plCompositeMtl.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plCompositeMtl.cpp
@@ -66,16 +66,16 @@ ClassDesc2* GetCompMtlDesc() { return &plCompositeMtlDesc; }
 
 #include "plCompositeMtlPBDec.h"
 
-const char *plCompositeMtl::BlendStrings[] = // Make sure these match up in order with the Blend enum (in the header)
+const TCHAR* plCompositeMtl::BlendStrings[] = // Make sure these match up in order with the Blend enum (in the header)
 {
-    "Vertex Alpha",
-    "Inverse Vtx Alpha",
-    "Vertex Illum Red",
-    "Inv. Vtx Illum Red",
-    "Vertex Illum Green",
-    "Inv. Vtx Illum Green",
-    "Vertex Illum Blue",
-    "Inv. Vtx Illum Blue"
+    _T("Vertex Alpha"),
+    _T("Inverse Vtx Alpha"),
+    _T("Vertex Illum Red"),
+    _T("Inv. Vtx Illum Red"),
+    _T("Vertex Illum Green"),
+    _T("Inv. Vtx Illum Green"),
+    _T("Vertex Illum Blue"),
+    _T("Inv. Vtx Illum Blue")
 };
 
 plCompositeMtl::plCompositeMtl(BOOL loading) : fPassesPB()

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plCompositeMtl.h
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plCompositeMtl.h
@@ -86,7 +86,7 @@ public:
         kCompNumBlendMethods
     };  
 
-    static const char *BlendStrings[];
+    static const TCHAR* BlendStrings[];
 
     enum { kRefPasses };
     enum { kBlkPasses };

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plCompositeMtlPB.h
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plCompositeMtlPB.h
@@ -42,6 +42,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef PL_COMPOSITE_MTL_PB_H
 #define PL_COMPOSITE_MTL_PB_H
 
+#include <tchar.h>
+
 enum
 {
     kCompPasses,
@@ -66,16 +68,16 @@ enum BlendMethod // These should match up in order with the blend strings
     kCompNumBlendMethods
 };  
 
-static char *BlendStrings[] = // Make sure these match up in order with the Blend enum
+static TCHAR* BlendStrings[] = // Make sure these match up in order with the Blend enum
 {
-    "Vertex Alpha",
-    "Inverse Vtx Alpha",
-    "Vertex Illum Red",
-    "Inv. Vtx Illum Red",
-    "Vertex Illum Green",
-    "Inv. Vtx Illum Green",
-    "Vertex Illum Blue",
-    "Inv. Vtx Illum Blue"
+    _T("Vertex Alpha"),
+    _T("Inverse Vtx Alpha"),
+    _T("Vertex Illum Red"),
+    _T("Inv. Vtx Illum Red"),
+    _T("Vertex Illum Green"),
+    _T("Inv. Vtx Illum Green"),
+    _T("Vertex Illum Blue"),
+    _T("Inv. Vtx Illum Blue")
 };
 
 #endif //PL_COMPOSITE_MTL_PB_H

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plPassAnimDlgProc.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plPassAnimDlgProc.cpp
@@ -292,7 +292,7 @@ void plPassAnimDlgProc::ILoadNames(IParamBlock2 *pb )
         plAnimStealthNode *stealth = mtl->IGetStealth( i, false );
         if (stealth != nullptr)
         {
-            int idx = (int)SendMessage(hAnims, CB_ADDSTRING, 0, (LPARAM)stealth->GetSegmentName().c_str());
+            int idx = (int)SendMessage(hAnims, CB_ADDSTRING, 0, (LPARAM)ST2T(stealth->GetSegmentName()));
             SendMessage( hAnims, CB_SETITEMDATA, idx, (LPARAM)stealth );
         }
     }

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plPassMtlBase.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plPassMtlBase.cpp
@@ -512,10 +512,10 @@ void    plPassMtlBase::PostLoadAnimPBFixup()
         }
 
         // Step 3...
-        const char *oldSel = (const char *)fAnimPB->GetStr( (ParamID)kPBAnimName );
+        const MCHAR* oldSel = fAnimPB->GetStr( (ParamID)kPBAnimName );
         if (oldSel == nullptr)
-            oldSel = ENTIRE_ANIMATION_NAME;
-        plAnimStealthNode *myNew = IFindStealth( ST::string::from_utf8( oldSel ) );
+            oldSel = _M(ENTIRE_ANIMATION_NAME);
+        plAnimStealthNode *myNew = IFindStealth( M2ST( oldSel ) );
         if (myNew != nullptr)
         {
             myNew->SetAutoStart( (bool)fAnimPB->GetInt( (ParamID)kPBAnimAutoStart ) );


### PR DESCRIPTION
This fixes a number of property pages in Max being junked due to foolishness such as casting `char*` to `LPARAM` when Windows is expecting a `wchar_t*`. I audited every cast matching `(LPARAM)foo`, so hopefully this should be all of them.