### PR TITLE
Fix potential null defreference.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.cpp
@@ -63,7 +63,7 @@ plRegistryKeyList::~plRegistryKeyList()
 plKeyImp* plRegistryKeyList::FindKey(const ST::string& keyName) const
 {
     auto it = std::find_if(fKeys.begin(), fKeys.end(),
-        [&] (plKeyImp* key) { return key->GetName().compare_i(keyName) == 0; }
+        [&] (plKeyImp* key) { return key && key->GetName().compare_i(keyName) == 0; }
     );
     if (it != fKeys.end())
         return *it;


### PR DESCRIPTION
This occurs when using a GlobalClothing_District_Female.prp exported by our Max plugin builds. All other uses of fKeys condiser null keyimps, and the reader is not required to fill every slot.