### PR TITLE
Fix clothing UVs not being updated by morphs.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp
@@ -170,6 +170,13 @@ static inline void inlCopy(uint8_t*& src, uint8_t*& dst)
     dst += sizeof(T);
 }
 
+static inline void inlCopy(const uint8_t*& src, uint8_t*& dst, size_t sz)
+{
+    memcpy(dst, src, sz);
+    src += sz;
+    dst += sz;
+}
+
 template<typename T>
 static inline const uint8_t* inlExtract(const uint8_t* src, T* val)
 {
@@ -8900,9 +8907,8 @@ static void IBlendVertBuffer(plSpan* span, hsMatrix44* matrixPalette, int numMat
         dest = inlStuff<hsPoint3>(dest, reinterpret_cast<hsPoint3*>(destPt_buf));
         dest = inlStuff<hsVector3>(dest, reinterpret_cast<hsVector3*>(destNorm_buf));
 
-        // Jump past colors and UVws
-        dest += sizeof(uint32_t) * 2 + uvChanSize;
-        src  += sizeof(uint32_t) * 2 + uvChanSize;
+        // memcpy the colors and UVs
+        inlCopy(src, dest, sizeof(uint32_t) * 2 + uvChanSize);
     }
 }
 


### PR DESCRIPTION
Generally skinned objects will not change their UVs - except in the case of avatar clothing. When the morph slider is adjusted in the ACA, new UVs may or may not be committed to the `plGBufferGroup`. If we simply skip over them in the skinning loop, then the newly morphed UVs will not be sent to DirectX.