### PR TITLE
Safety checking for avatars without clothing outfits

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -1317,7 +1317,8 @@ bool plArmatureMod::MsgReceive(plMessage* msg)
     {
         // We got a clothing file and are supposed to load our avatar from it.
         // Let's tell our outfit to do so!
-        fClothingOutfit->SetClothingFile(clothingMsg->GetClothingFile());
+        if (fClothingOutfit)
+            fClothingOutfit->SetClothingFile(clothingMsg->GetClothingFile());
         return true;
     }
 
@@ -1938,6 +1939,9 @@ void plArmatureMod::SynchIfLocal(double timeNow, int force)
 
 plLayerLinkAnimation *plArmatureMod::IFindLayerLinkAnim()
 {
+    if (!fClothingOutfit)
+        return nullptr;
+
     hsGMaterial *mat = fClothingOutfit->fMaterial;
     if (!mat)
         return nullptr;


### PR DESCRIPTION
Most of the code properly handles `fClothingOutfit` being null, but the LayerLinkAnimation check does not.

Currently all the avatars have clothing outfits (PlasmaMax always exports them) but it doesn't necessarily make sense for things like Quabs.