### PR TITLE
Decrease morph UV delta threshold.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plDrawable/plMorphDelta.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plMorphDelta.cpp
@@ -181,7 +181,7 @@ void plMorphDelta::ComputeDeltas(const std::vector<plGeometrySpan*>& base, const
             // These are actually min del SQUARED.
             plConst(float) kMinDelPos(1.e-4f); // From Budtpueller's Handbook of Constants
             plConst(float) kMinDelNorm(3.e-2f); // About 10 degrees
-            plConst(float) kMinDelUVW(1.e-4f); // From BHC
+            plConst(float) kMinDelUVW(1.e-5f); // Science'd from clothing UVW work
             hsPoint3 mPos = d2b * *movedIter.Position();
             hsVector3 delPos( &mPos, baseIter.Position());
             float delPosSq = delPos.MagnitudeSquared();


### PR DESCRIPTION
Actual work with clothing UVs demonstrates that the old threshold is too great. Only large changes such as mirroring the entire UV map will pass and therefore be available in the data. This seems to be enough to enable the kind of tweaking real UV work involves.

Video of previous behavior available on request.