### PR TITLE
Allow the max plugin to auto-generate PlasmaMAX2.ini

### DIFF
--- a/Sources/Plasma/PubUtilLib/plFile/plBrowseFolder.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plBrowseFolder.h
@@ -45,7 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifdef HS_BUILD_FOR_WIN32
 
 #include "HeadSpin.h"
-#include "hsWindows.h"
 #include "plFileSystem.h"
 
 //
@@ -66,9 +65,6 @@ class plBrowseFolder
 public:
     static plFileName GetFolder(const plFileName &startPath = {},
                                 const ST::string &title = {}, HWND hwndOwner = nullptr);
-
-protected:
-    static int CALLBACK BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData);
 };
 
 #endif // HS_BUILD_FOR_WIN32

--- a/Sources/Tools/MaxMain/GlobalUtility.cpp
+++ b/Sources/Tools/MaxMain/GlobalUtility.cpp
@@ -209,9 +209,8 @@ DWORD PlasmaMax::Start()
 
     // Setup the localization mgr
     // Dirty hacks are because Cyan sucks...
-    plFileName pathTemp = plMaxConfig::GetClientPath(false, true);
-    if (!pathTemp.IsValid())
-    {
+    plFileName pathTemp = plMaxConfig::GetClientPath();
+    if (!pathTemp.IsValid()) {
         ST::string errmsg = ST::format(
             "PlasmaMAX2.ini is missing or invalid.\nPlasmaMAX will be unavailable until this file is added at\n{}",
             plMaxConfig::GetPluginIni()

--- a/Sources/Tools/MaxMain/plMaxCFGFile.cpp
+++ b/Sources/Tools/MaxMain/plMaxCFGFile.cpp
@@ -69,7 +69,7 @@ plFileName plMaxConfig::GetClientPath(bool getNew, bool quiet)
     if ((len == 0 || getNew) && !quiet)
     {
         // If the user selects one, save it
-        plasmaPath = plBrowseFolder::GetFolder(plasmaPath, "Specify your client folder");
+        plasmaPath = plBrowseFolder::GetFolder(plasmaPath, "Select your Plasma 2.0 client folder");
         if (plasmaPath.IsValid())
             WritePrivateProfileStringW(L"SceneViewer", L"Directory", plasmaPath.WideString().data(),
                                        plugDir.WideString().data());


### PR DESCRIPTION
Previously, if you launched Max without a PlasmaMAX2.ini file, you were SOL. The functionality to specify a client directory was already present, so this simply enables it. As a bonus, we now use the folder picker dialog from Vista (and above) instead of the old Windows 9x dialog, and windows.h becomes much less viral.