### PR TITLE
PhysX Behavior Rollup

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
@@ -457,7 +457,12 @@ void plWalkingStrategy::Apply(float delSecs)
                 velocity.fY += groundVel.fY;
             }
             if (std::fabs(velocity.fZ) < 0.001f) {
-                velocity.fZ = std::max(achievedVelocity.fZ + (kGravity * delSecs), groundVel.fZ);
+                if (std::fabs(groundVel.fZ) < 0.001f) {
+                    float zcomp = 1.f - std::max(0.f, ground->Normal.fZ);
+                    velocity.fZ = achievedVelocity.fZ + (kGravity * zcomp * delSecs);
+                } else {
+                    velocity.fZ = groundVel.fZ;
+                }
             }
         } else if (std::fabs(velocity.fZ) < 0.001f) {
             float zcomp = 1.f - std::max(0.f, ground->Normal.fZ);
@@ -471,7 +476,8 @@ void plWalkingStrategy::Apply(float delSecs)
 
     // Limit final requested downward velocity to the magnitude of the acceleration of gravity.
     // It's not the way R/L works, but it yields a better visual result.
-    velocity.fZ = std::max(velocity.fZ, kGravity);
+    if (!(fFlags & kGroundContact))
+        velocity.fZ = std::max(velocity.fZ, kGravity);
 
     // Reset vars and move the controller
     fController->SetPushingPhysical(nullptr);

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
@@ -319,7 +319,7 @@ static physx::PxFilterFlags ISimulationFilterShader(physx::PxFilterObjectAttribu
         FILTER(plSimDefs::kGroupAvatar, plSimDefs::kGroupAvatarBlocker, defFlags, defResult);
         FILTER(plSimDefs::kGroupAvatar, plSimDefs::kGroupStatic, defFlags, defResult);
         FILTER(plSimDefs::kGroupAvatar, plSimDefs::kGroupDynamic, defFlags, defResult);
-        FILTER(plSimDefs::kGroupAvatar, plSimDefs::kGroupExcludeRegion, defFlags, cbResult);
+        FILTER(plSimDefs::kGroupAvatar, plSimDefs::kGroupExcludeRegion, defFlags, defResult);
     }
 
 #undef FILTER

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
@@ -538,8 +538,12 @@ physx::PxRigidActor* plPXSimulation::CreateRigidActor(const physx::PxGeometry& g
         actor = fPxPhysics->createRigidStatic(globalPose);
         break;
     case plPXActorType::kDynamicActor:
-        actor = fPxPhysics->createRigidDynamic(globalPose);
-        break;
+        {
+            physx::PxRigidDynamic* dynamic = fPxPhysics->createRigidDynamic(globalPose);
+            dynamic->setMaxDepenetrationVelocity(10.f);
+            actor = dynamic;
+            break;
+        }
     case plPXActorType::kKinematicActor:
         {
             physx::PxRigidDynamic* dynamic = fPxPhysics->createRigidDynamic(globalPose);


### PR DESCRIPTION
Some corrections to physical behaviors resulting from the PhysX 4.1 upgrade. See each commit description for details. This unfortunately does not include #784, which needs more investigation.