### PR TITLE
Fix /clearchat command regression.

### DIFF
--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -946,8 +946,8 @@ class CommandsProcessor:
 
     ## Clear the chat.
     def ClearChat(self, params):
-        self.miniChatArea.clearBuffer()
-        self.microChatArea.clearBuffer()
+        self.chatMgr.miniChatArea.clearBuffer()
+        self.chatMgr.microChatArea.clearBuffer()
 
     ## Ignores a player.
     def IgnorePlayer(self, player):


### PR DESCRIPTION
```
(07/06 17:50:50) KIHandler - Traceback (most recent call last):
(07/06 17:50:50)   File "ki.__init__.py", line 623, in OnGUINotify
(07/06 17:50:50)   File "ki.__init__.py", line 5559, in ProcessNotifyMini
(07/06 17:50:50)   File "ki.xKIChat.py", line 200, in SendMessage
(07/06 17:50:50)   File "ki.xKIChat.py", line 821, in __call__
(07/06 17:50:50)   File "ki.xKIChat.py", line 949, in ClearChat
(07/06 17:50:50) AttributeError: 'CommandsProcessor' object has no attribute 'miniChatArea'
```