### PR TITLE
Remove bug-prone local data helper.

### DIFF
--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plUoid.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plUoid.cpp
@@ -239,9 +239,10 @@ bool plUoid::operator==(const plUoid& u) const
 // THIS SHOULD BE FOR DEBUGGING ONLY <hint hint>
 ST::string plUoid::StringIze() const // Format to displayable string
 {
-    return ST::format("({#x}:{#x}:{}:C:[{},{}])",
+    return ST::format("(S:{#x} F:{#x} I:{} N:{} C:[{},{}])",
         fLocation.GetSequenceNumber(),
         fLocation.GetFlags(),
+        GetObjectID(),
         fObjectName,
         GetClonePlayerID(),
         GetCloneID());


### PR DESCRIPTION
While this may make some amount of sense if you are working on the game in solely 3ds Max, what ends up happening is that it hides all the ObjID mismatches you have created. They will only be seen when using the external client. Generally, this results in whacky texture goof ups where the wrong textures are applied to the wrong objects. However, in more serious cases, such as pages that have been processed by plPageOptimizer, a round-trip through a bugged process can cause very wrong objects to be returned, crashing the game.