### PR TITLE
Use XML CDATA for journals in LOC files.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.cpp
@@ -211,7 +211,7 @@ void pfLocalizedString::IUpdateXML()
     bool wantCData = std::any_of(
         fText.cbegin(), fText.cend(),
         [](const textBlock& block) {
-            std::regex regex("<.+>");
+            static const std::regex regex("<.+>");
             return std::regex_search(block.fText.cbegin(), block.fText.cend(), regex);
         }
     );

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.cpp
@@ -180,7 +180,7 @@ void pfLocalizedString::IUpdatePlainText()
         if (curTextBlock.fIsParam)
         {
             // Fill in parameter value.
-            ss << "%%" << curTextBlock.fParamIndex + 1 << "s";
+            ss << "%" << curTextBlock.fParamIndex + 1 << "s";
         }
         else
         {
@@ -223,7 +223,7 @@ void pfLocalizedString::IUpdateXML()
     for (const auto& curTextBlock : fText) {
         if (curTextBlock.fIsParam) {
             // Fill in parameter value.
-            ss << "%%" << curTextBlock.fParamIndex + 1 << "s";
+            ss << "%" << curTextBlock.fParamIndex + 1 << "s";
         } else if (!wantCData) {
             // Encode XML entities.
             ss << curTextBlock.fText.replace("%", "\\%").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");


### PR DESCRIPTION
This adds some very basic heuristics for detecting journals contained in the localization files and exports their data enclosed in XML's `<![CDATA[thingy]]>` to prevent having to review localization changes with XML-encoded Plasma esHTML.

Bonus: a spurious copy was eliminated.