### PR TITLE
Update vcpkg submodule.

### DIFF
--- a/Scripts/Ports/python3-cairosvg/portfile.cmake
+++ b/Scripts/Ports/python3-cairosvg/portfile.cmake
@@ -24,13 +24,13 @@ endif()
 # this should be the tools/python3 directory. In other cases, it should be CURRENT_INSTALLED_DIR.
 vcpkg_execute_in_download_mode(
     COMMAND "${PYTHON_EXECUTABLE}" -c "import sys;sys.stdout.write(sys.exec_prefix)"
+    WORKING_DIRECTORY "${INSTALLED_PYTHON_PREFIX}"
     OUTPUT_VARIABLE INSTALLED_PYTHON_PREFIX
-    LOGNAME query-prefix
 )
 vcpkg_execute_in_download_mode(
     COMMAND "${PYTHON_EXECUTABLE}" -c "import sys,distutils.sysconfig;sys.stdout.write(distutils.sysconfig.get_python_lib(plat_specific=False,standard_lib=False))"
+    WORKING_DIRECTORY "${INSTALLED_PYTHON_PREFIX}"
     OUTPUT_VARIABLE INSTALLED_SITE_PACKAGES_DIR
-    LOGNAME query-site-packages
 )
 
 # The returned values from above are absolute paths into the installed tree. However, we cannot
@@ -116,6 +116,8 @@ message(STATUS "Installing cairosvg from pip")
 file(TO_NATIVE_PATH "${CURRENT_PYTHON_PREFIX}" _PIP_PREFIX)
 vcpkg_execute_required_process(
     COMMAND "${PYTHON_EXECUTABLE}" -m pip install --prefix "${_PIP_PREFIX}" "cairosvg==${CAIROSVG_VERSION}"
+    ALLOW_IN_DOWNLOAD_MODE
+    WORKING_DIRECTORY "${CURRENT_PYTHON_PREFIX}"
     LOGNAME install
 )
 # Perform a sample import of cairosvg to ensure all this weird hacking actually works.
@@ -123,6 +125,7 @@ message(STATUS "Testing cairosvg")
 set(ENV{PYTHONPATH} "${CURRENT_SITE_PACKAGES_DIR}")
 vcpkg_execute_required_process(
     COMMAND "${PYTHON_EXECUTABLE}" -c "import cairosvg"
+    ALLOW_IN_DOWNLOAD_MODE
     WORKING_DIRECTORY "${CURRENT_PYTHON_PREFIX}"
     LOGNAME test
 )

--- a/Scripts/Ports/python3-cairosvg/portfile.cmake
+++ b/Scripts/Ports/python3-cairosvg/portfile.cmake
@@ -5,7 +5,7 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Install cairo on Ubuntu with `sudo apt install libcairo2` and on macOS with `brew install cairo`.")
 endif()
 
-set(CAIROSVG_VERSION "2.5.1")
+set(CAIROSVG_VERSION "2.5.2")
 set(INSTALLED_PYTHON_PREFIX "${CURRENT_INSTALLED_DIR}/tools/python3")
 
 # We are running in script mode, so no toolchains are available. Sad.

--- a/Scripts/Ports/python3-cairosvg/vcpkg.json
+++ b/Scripts/Ports/python3-cairosvg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "python3-cairosvg",
-  "version-semver": "2.5.1",
-  "port-version": 1,
+  "version-semver": "2.5.2",
   "description": "CairoSVG is an SVG converter based on Cairo. It can export SVG files to PDF, EPS, PS, and PNG files.",
   "homepage": "https://cairosvg.org/",
   "dependencies": [

--- a/Scripts/Ports/python3-cairosvg/vcpkg.json
+++ b/Scripts/Ports/python3-cairosvg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "python3-cairosvg",
-  "version-string": "2.5.1",
+  "version-semver": "2.5.1",
+  "port-version": 1,
   "description": "CairoSVG is an SVG converter based on Cairo. It can export SVG files to PDF, EPS, PS, and PNG files.",
   "homepage": "https://cairosvg.org/",
   "dependencies": [


### PR DESCRIPTION
Fixes CMake regression [#22444](https://gitlab.kitware.com/cmake/cmake/-/issues/22444) via microsoft/vcpkg-tool#107.

Other updates:
- asio 1.18.2
- cairo 1.17.4#2
- expat 2.4.1
- libcurl 7.74.0#8
- libogg 1.3.5
- libpng 1.6.37#15
- libvpx 1.10.0
- openssl 1.1.1k#7
- python3 3.9.6
- sqlite 3.35.5