### PR TITLE
Suppress vault callbacks when loading or unloading VNodeMgrs.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
@@ -401,7 +401,7 @@ bool plNCAgeJoiner::MsgReceive (plMessage * msg) {
         }
         else if (unsigned ageVaultId = NetCommGetAge()->ageVaultId) {
             // Download the age vault
-            VaultDownload(
+            VaultDownloadNoCallbacks(
                 "AgeJoin",
                 ageVaultId,
                 AgeVaultDownloadCallback,

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -310,7 +310,7 @@ static void INetCliAuthSetPlayerRequestCallback (
     else {
         s_needAvatarLoad = true;
 
-        VaultDownload(
+        VaultDownloadNoCallbacks(
             "SetActivePlayer",
             s_player->playerInt,
             PlayerInitCallback,
@@ -366,7 +366,7 @@ static void INetCliAuthLoginSetPlayerRequestCallback (
         msg->Send();
     }
     else {
-        VaultDownload(
+        VaultDownloadNoCallbacks(
             "SetActivePlayer",
             s_player->playerInt,
             LoginPlayerInitCallback,

--- a/Sources/Plasma/PubUtilLib/plVault/Pch.h
+++ b/Sources/Plasma/PubUtilLib/plVault/Pch.h
@@ -56,6 +56,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plDniCoordinateInfo.h"
 
 #include <algorithm>
+#include <atomic>
 #include <memory>
 #include <sstream>
 #include <string_theory/string>

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -477,6 +477,14 @@ void VaultDownload (
     FVaultProgressCallback      progressCallback,
     void *                      cbProgressParam
 );
+void VaultDownloadNoCallbacks (
+    const ST::string&           tag,
+    unsigned                    vaultId,
+    FVaultDownloadCallback      callback,
+    void *                      cbParam,
+    FVaultProgressCallback      progressCallback,
+    void *                      cbProgressParam
+);
 void VaultDownloadAndWait (
     const ST::string&           tag,
     unsigned                    vaultId,

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -84,6 +84,17 @@ struct VaultCallback {
 void VaultRegisterCallback (VaultCallback * cb);
 void VaultUnregisterCallback (VaultCallback * cb);
 
+void VaultSuppressCallbacks();
+void VaultEnableCallbacks();
+
+class VaultCallbackSuppressor
+{
+public:
+    VaultCallbackSuppressor() { VaultSuppressCallbacks(); }
+    VaultCallbackSuppressor(const VaultCallbackSuppressor&) = delete;
+    VaultCallbackSuppressor(VaultCallbackSuppressor&&) = delete;
+    ~VaultCallbackSuppressor() { VaultEnableCallbacks(); }
+};
 
 /*****************************************************************************
 *


### PR DESCRIPTION
On MOULa, there have been complaints about linking to some Neighborhoods and activating some players taking a very long time. One of these Neighborhoods in particular is the "DRC(67) Bevin". When I attempted to link to this Age, I found the link took approximately 85 seconds each time. On profiling, I discovered that for every node downloaded during the initialization phase, we were calling into Python at least once. Suppressing vault callbacks during times when they are obviously going to storm and be useless decreases the link time to 7 seconds.

Initially, I suppressed just the Python side of the callbacks when an Age is being initialized, but it seems to me that a more reasonable solution is to not run callbacks during vault loads and unloads. Clearly, things are happening at this stage, so we don't need that level of granulatrity about what is happening to the vault(s) that we are subscribing to or unsubscribing from.