### PR TITLE
Fix plWaveSet7 UB.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
@@ -1304,18 +1304,6 @@ void plWaveSet7::IInitState()
 
 void plWaveSet7::IInitWaveConsts()
 {
-    // See header for what fS, fK and fD actually mean.
-    WaveK   waveKs[] = {
-        // fS       fK      fD
-        { 1.f,      5.f,    0.f },
-        { 1.f,      10.f,   2.f },
-        { -1.f,     20.f,   -9.f }, 
-        { 1.f,      30.f,   16.f }
-    };
-    int i;
-    for( i = 0; i < kNumTexWaves; i++ )
-        fWaveKs[i] = waveKs[i];
-
     TexWaveWindDep windDeps[] = {
         // WindSpeed, Height, Specular
         { 0.f,      0.01f,      1.f },
@@ -1326,7 +1314,7 @@ void plWaveSet7::IInitWaveConsts()
         { 25.f,     0.1f,       0.3f }
     };
 
-    for( i = 0; i < kNumWindDep; i++ )
+    for (size_t i = 0; i < kNumWindDep; i++)
         fWindDeps[i] = windDeps[i];
 
     ISetupTextureWaves();

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.h
@@ -304,22 +304,6 @@ protected:
 
     GraphState                      fGraphState[kGraphShorePasses];
 
-    class WaveK
-    {
-    public:
-        // fK is the number of times the sine wave repeats across the texture. Must be an integer
-        // fS/fK is the base X component of the direction of the wave, with Y = 1.f - X. Note that X^2 + Y^2 != 1.
-        // fD allows the wave to get more off the Y direction 
-        // So the X component will be Int(fS + fD*dispersion) / fK, because it must be an integer ratio to
-        // preserve tiling. Also, (fS + fD) must be <= fK (for the Y normalization).
-        // See the notes.
-        float   fS;
-        float   fK;
-        float   fD;
-    };
-
-    WaveK           fWaveKs[kNumTexWaves];
-
     class TexWaveDesc
     {
     public:


### PR DESCRIPTION
Copying too many elements from a stack array. This whole thing is unused, so just toss it.