### PR TITLE
Fixes issue with using Great Zero Mission Scopes at the end

### DIFF
--- a/Scripts/Python/grtzMarkerScopeGUI.py
+++ b/Scripts/Python/grtzMarkerScopeGUI.py
@@ -229,8 +229,7 @@ class grtzMarkerScopeGUI(ptModifier):
         if id in self._scopes:
             if PtDetermineKIMarkerLevel() < kKIMarkerNormalLevel:
                 MarkerGameDlg.dialog.hide()
-            else:
-                MGMachineOffResp.run(self.key, netPropagate=False)
+            MGMachineOffResp.run(self.key, netPropagate=False)
         elif id == MGMachineOnResp.id:
             PtEnableControlKeyEvents(self.key)
         elif id == MGMachineOffResp.id:


### PR DESCRIPTION
If you have someone open the Great Zero Mission room for you and you have not done both red and green calibration, you will get stuck in the mission GUI.