### PR TITLE
Fix custom avatar footsteps

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
@@ -369,6 +369,7 @@ public:
     void SetBodyFootstepSoundPage(const ST::string& pageName) { fBodyFootstepSoundPage = pageName; }
     void SetAnimationPrefix(const ST::string& prefix) { fAnimationPrefix = prefix; }
 
+    const ST::string& GetBodyFootstepSoundPage() const { return fBodyFootstepSoundPage; }
     ST::string GetUserStr() const { return fUserStr; }
 
 protected:
@@ -382,6 +383,7 @@ protected:
     void    IHandleInputStateMsg(plAvatarInputStateMsg *msg);
     void    ILinkToPersonalAge();
     int     IFindSpawnOverride();
+    void    ISetupFootstepSounds(const plKey& effectMgrKey, hsResMgr* mgr);
     void    ISetTransparentDrawOrder(bool val);
     plLayerLinkAnimation *IFindLayerLinkAnim();
 

--- a/Sources/Tools/MaxComponent/plAvatarComponent.cpp
+++ b/Sources/Tools/MaxComponent/plAvatarComponent.cpp
@@ -510,6 +510,11 @@ void AddClothingToMod(plMaxNode *node, plArmatureMod *mod, int group, hsGMateria
         return;
     }
 
+    if (group == plClothingMgr::kClothingBaseNoOptions) {
+        // We don't need a clothing outfit for avatars with no clothing options
+        return;
+    }
+
     plClothingBase *base = new plClothingBase();
     if (node->GetUserPropString(_M("layout"), sdata))
     {


### PR DESCRIPTION
The age and page names for footstep sounds are stored in the plArmatureMod data, but the effects were getting initialized before those values were read, so they were always using the defaults of "GlobalAvatars" and "Audio". This results in the custom footstep sounds for Quabs not taking effect in-game.

However, this will break footstep sounds for other custom avatars who *do* want to use the global sounds, because the age name is exported as "CustomAvatars" instead of "GlobalAvatars" in their plLODAvatarMod data.  
The custom avatar data can easily be fixed in the compiled data files in the moul-assets repo.

This change include an update to PlasmaMax so that if the avatar footstep page is set to "Audio" it will export with a hardcoded "GlobalAvatars" age, otherwise it will use the current age name. If the footstep page field is left blank, it will export an avatar with no plArmatureEffectsMgr (which is valid and supported by the engine).

This also includes a change to PlasmaMax to stop generating unneeded plClothingOutfit and plClothingBase objects for avatars with "(No Clothing Options)" selected. The engine is perfectly happy with avatars that have a null clothing outfit.