### PR TITLE
vcpkg upgrade

### DIFF
--- a/Scripts/Triplets/x64-windows-plasma.cmake
+++ b/Scripts/Triplets/x64-windows-plasma.cmake
@@ -1,6 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
-
+set(VCPKG_DISABLE_COMPILER_TRACKING TRUE)
 
 # Unfortunately, we cannot include() anything from here because CMAKE_CURRENT_LIST_DIR is "wrong."
 # If you update this list, remember to synchronize x86-windows-plasma.cmake.

--- a/Scripts/Triplets/x86-windows-plasma.cmake
+++ b/Scripts/Triplets/x86-windows-plasma.cmake
@@ -1,5 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE x86)
 set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_DISABLE_COMPILER_TRACKING TRUE)
 
 # Unfortunately, we cannot include() anything from here because CMAKE_CURRENT_LIST_DIR is "wrong."
 # If you update this list, remember to synchronize x64-windows-plasma.cmake.

--- a/cmake/VcpkgToolchain.cmake
+++ b/cmake/VcpkgToolchain.cmake
@@ -5,7 +5,7 @@
 set(_NUGET_SOURCE "https://nuget.pkg.github.com/H-uru/index.json")
 set(_NUGET_OWNER "H-uruMachineUser")
 # Python: print(*(ord(i) for i in token), sep=";")
-set(_NUGET_TOKEN_ASCII 99;48;53;54;49;55;52;54;102;48;52;101;101;50;55;102;56;52;57;102;100;97;52;100;100;100;54;50;55;102;101;50;100;101;102;57;100;57;97;57)
+set(_NUGET_TOKEN_ASCII 103;104;112;95;100;111;87;99;122;56;49;97;76;101;110;122;82;116;119;112;80;49;97;87;72;107;71;57;103;51;110;100;100;112;52;69;57;88;73;48)
 string(ASCII ${_NUGET_TOKEN_ASCII} _NUGET_TOKEN)
 
 # You're not crazy. This is so we can read from the main package source and write to another one.


### PR DESCRIPTION
Routine vcpkg upgrade with some not-so-routine fixes. This pulls down a patch I submitted to fix the python3 build on GHA windows-2019 runners due to what appears to be a bug in the Windows SDK. Also, we now use the newfangled `VCPKG_DISABLE_COMPILER_TRACKING` to avoid including the hash of cl.exe in the binarycache. So, hopefully, folks will actually download the libraries from GitHub Packages now, instead of rebuilding them from scratch because they have a slightly newer or older VS.

Before merging:
- [x] Check that python39.dll is present in the artifacts.
- [x] Ensure all 3ds Max builds succeed.

Updated Libraries:
- asio 1.19.2
- curl 7.79.1
- libjpeg-tubo 2.0.6#1
- libvpx 1.10.0#2
- openssl 1.1.1l#1
- Python 3.9.7#1
- sqlite3 3.36.0
- zlib 1.2.11#12