### PR TITLE
Add `-SkipIntroMovies`.

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -1819,6 +1819,9 @@ void plClient::IKillMovies()
 
 bool plClient::IPlayIntroMovie(const char* movieName, float endDelay, float posX, float posY, float scaleX, float scaleY, float volume /* = 1.0 */)
 {
+    if (HasFlag(kFlagSkipIntroMovies))
+        return true;
+
     SetQuitIntro(false);
     plMoviePlayer player;
     player.SetPosition(posX, posY);

--- a/Sources/Plasma/Apps/plClient/plClient.h
+++ b/Sources/Plasma/Apps/plClient/plClient.h
@@ -251,6 +251,7 @@ public:
         kFlagDBGDisableRRequests,
         kFlagAsyncInitComplete,
         kFlagGlobalDataLoaded,
+        kFlagSkipIntroMovies,
     };
 
     bool HasFlag(int f) const { return fFlags.IsBitSet(f); }

--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -104,6 +104,7 @@ enum
     kArgPlayerId,
     kArgStartUpAgeName,
     kArgPvdFile,
+    kArgSkipIntroMovies,
 };
 
 static const plCmdArgDef s_cmdLineArgs[] = {
@@ -114,6 +115,7 @@ static const plCmdArgDef s_cmdLineArgs[] = {
     { kCmdArgFlagged  | kCmdTypeInt,        "PlayerId",        kArgPlayerId },
     { kCmdArgFlagged  | kCmdTypeString,     "Age",             kArgStartUpAgeName },
     { kCmdArgFlagged  | kCmdTypeString,     "PvdFile",         kArgPvdFile },
+    { kCmdArgFlagged  | kCmdTypeBool,       "SkipIntroMovies", kArgSkipIntroMovies },
 };
 
 /// Made globals now, so we can set them to zero if we take the border and 
@@ -1211,6 +1213,10 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
 
     // Main loop
     if (gClient && !gClient->GetDone()) {
+        // Must be done here due to the plClient* dereference.
+        if (cmdParser.IsSpecified(kArgSkipIntroMovies))
+            gClient->SetFlag(plClient::kFlagSkipIntroMovies);
+
         if (gPendingActivate)
             gClient->WindowActivate(gPendingActivateFlag);
         gClient->SetMessagePumpProc(PumpMessageQueueProc);

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
@@ -234,6 +234,8 @@ ST::string plClientLauncher::GetAppArgs() const
         ss << " -PatchOnly";
     if (hsCheckBits(fFlags, kSkipLoginDialog))
         ss << " -SkipLoginDialog";
+    if (hsCheckBits(fFlags, kSkipIntroMovies))
+        ss << " -SkipIntroMovies";
 
     return ss.to_string();
 }
@@ -448,14 +450,15 @@ void plClientLauncher::ParseArguments()
         fFlags |= flag;
 
     enum { kArgServerIni, kArgNoSelfPatch, kArgImage, kArgRepairGame, kArgPatchOnly,
-           kArgSkipLoginDialog };
+           kArgSkipLoginDialog, kArgSkipIntroMovies };
     const plCmdArgDef cmdLineArgs[] = {
         { kCmdArgFlagged | kCmdTypeString, "ServerIni", kArgServerIni },
         { kCmdArgFlagged | kCmdTypeBool, "NoSelfPatch", kArgNoSelfPatch },
         { kCmdArgFlagged | kCmdTypeBool, "Image", kArgImage },
         { kCmdArgFlagged | kCmdTypeBool, "Repair", kArgRepairGame },
         { kCmdArgFlagged | kCmdTypeBool, "PatchOnly", kArgPatchOnly },
-        { kCmdArgFlagged | kCmdTypeBool, "SkipLoginDialog", kArgSkipLoginDialog }
+        { kCmdArgFlagged | kCmdTypeBool, "SkipLoginDialog", kArgSkipLoginDialog },
+        { kCmdArgFlagged | kCmdTypeBool, "SkipIntroMovies", kArgSkipIntroMovies }
     };
 
     std::vector<ST::string> args;
@@ -475,6 +478,7 @@ void plClientLauncher::ParseArguments()
     APPLY_FLAG(kArgRepairGame, kRepairGame);
     APPLY_FLAG(kArgPatchOnly, kPatchOnly);
     APPLY_FLAG(kArgSkipLoginDialog, kSkipLoginDialog);
+    APPLY_FLAG(kArgSkipIntroMovies, kSkipIntroMovies);
 
     // last chance setup
     if (hsCheckBits(fFlags, kPatchOnly))

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
@@ -66,6 +66,7 @@ private:
         kGameDataOnly = 1<<2,
         kPatchOnly = 1<<3,
         kSkipLoginDialog = 1<<4,
+        kSkipIntroMovies = 1<<5,
 
         kRepairGame = kHaveSelfPatched | kClientImage | kGameDataOnly,
     };


### PR DESCRIPTION
This adds the command line switch `-SkipIntroMovies` to allow skipping any and all intro movies when the game starts. This fixes #910 - but doesn't address the letter of the concern because `-Age` only works on internal clients (this switch works on all build types). This switch can be passed directly to plClient or to plUruLauncher.