### PR TITLE
Add new menorah flame SDL state

### DIFF
--- a/Scripts/SDL/GoMePubNew.sdl
+++ b/Scripts/SDL/GoMePubNew.sdl
@@ -185,11 +185,34 @@ STATEDESC GoMePubNew
 STATEDESC GoMePubNew
 {
     VERSION 11
-
+ 
     VAR BOOL    BarDoorStat[1]                   DEFAULT=1
     VAR BOOL    islmGZBeamVis[1]                 DEFAULT=0    DEFAULTOPTION=VAULT
     VAR BOOL    SinkStat[1]                      DEFAULT=0
     VAR BOOL    ChisoBookVis[1]                  DEFAULT=0    DEFAULTOPTION=VAULT
+# Christmas/Hanukkah Decor
+    VAR BOOL    XMasVis[1]                       DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+    VAR BOOL    gmpnMenorahFlame01[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+    VAR BOOL    gmpnMenorahFlame02[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+    VAR BOOL    gmpnMenorahFlame03[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+    VAR BOOL    gmpnMenorahFlame04[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+    VAR BOOL    gmpnMenorahFlame05[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+    VAR BOOL    gmpnMenorahFlame06[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+    VAR BOOL    gmpnMenorahFlame07[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+    VAR BOOL    gmpnMenorahFlame08[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+    VAR BOOL    gmpnMenorahFlameShammash[1]      DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+# Pride Decor
+    VAR BOOL    gmpnPrideDecoVis[1]              DEFAULT=0    DEFAULTOPTION=VAULT
+# Halloween Deco (depreciated)
+    VAR BOOL    gmpnHalloweenVis[1]              DEFAULT=0    DEFAULTOPTION=VAULT
+# Fall/Thanksgiving (depreciated)
+    VAR BOOL    gmpnFallThanksVis[1]             DEFAULT=0    DEFAULTOPTION=VAULT
+# New Year Deco (depreciated)
+    VAR BOOL    gmpnNewYearVis[1]                DEFAULT=0    DEFAULTOPTION=VAULT
+# St Patricks Day Deco (depreciated)
+    VAR BOOL    gmpnStPatsDayVis[1]              DEFAULT=0    DEFAULTOPTION=VAULT
+# Tiki Deco for GreyDragon (depreciated)
+    VAR BOOL    gmpnTikiDecoVis[1]               DEFAULT=0    DEFAULTOPTION=VAULT
 # New Holiday Deco SDL (USE THIS FOR ALL HOLIDAY DECO!)
     VAR BYTE    gmpnHolidayVis[1]                   DEFAULT=0    DEFAULTOPTION=VAULT
 #       List of Integers/holidays:
@@ -201,17 +224,16 @@ STATEDESC GoMePubNew
 #       5 - Fall/Thanksgiving
 #       6 - Christmas/Hannukah
 #       7 - Tiki (not implemented yet)
-
+ 
 # New Menorah Flame State
     VAR INT gmpnMenFlameStat[1]                  DEFAULT=0    DEFAULTOPTION=VAULT
-#    0 - Default (no flames)
-#    1 - Shammash and Flame01 on (Day 1)
-#    2 - Flame02 on (Day 2)
-#    3 - Flame03 on (Day 3)
-#    4 - Flame04 on (Day 4)
-#    5 - Flame05 on (Day 5)
-#    6 - Flame06 on (Day 6)
-#    7 - Flame07 on (Day 7)
-#    8 - Flame08 on (Day 8)
+#       0 - Default (no flames)
+#       1 - Shammash and Flame01 on (Day 1)
+#       2 - Flame02 on (Day 2)
+#       3 - Flame03 on (Day 3)
+#       4 - Flame04 on (Day 4)
+#       5 - Flame05 on (Day 5)
+#       6 - Flame06 on (Day 6)
+#       7 - Flame07 on (Day 7)
+#       8 - Flame08 on (Day 8)
 }
-

--- a/Scripts/SDL/GoMePubNew.sdl
+++ b/Scripts/SDL/GoMePubNew.sdl
@@ -190,29 +190,6 @@ STATEDESC GoMePubNew
     VAR BOOL    islmGZBeamVis[1]                 DEFAULT=0    DEFAULTOPTION=VAULT
     VAR BOOL    SinkStat[1]                      DEFAULT=0
     VAR BOOL    ChisoBookVis[1]                  DEFAULT=0    DEFAULTOPTION=VAULT
-# Christmas/Hanukkah Decor
-    VAR BOOL    XMasVis[1]                       DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
-    VAR BOOL    gmpnMenorahFlame01[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
-    VAR BOOL    gmpnMenorahFlame02[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
-    VAR BOOL    gmpnMenorahFlame03[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
-    VAR BOOL    gmpnMenorahFlame04[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
-    VAR BOOL    gmpnMenorahFlame05[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
-    VAR BOOL    gmpnMenorahFlame06[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
-    VAR BOOL    gmpnMenorahFlame07[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
-    VAR BOOL    gmpnMenorahFlame08[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
-    VAR BOOL    gmpnMenorahFlameShammash[1]      DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
-# Pride Decor
-    VAR BOOL    gmpnPrideDecoVis[1]              DEFAULT=0    DEFAULTOPTION=VAULT
-# Halloween Deco (depreciated)
-    VAR BOOL    gmpnHalloweenVis[1]              DEFAULT=0    DEFAULTOPTION=VAULT
-# Fall/Thanksgiving (depreciated)
-    VAR BOOL    gmpnFallThanksVis[1]             DEFAULT=0    DEFAULTOPTION=VAULT
-# New Year Deco (depreciated)
-    VAR BOOL    gmpnNewYearVis[1]                DEFAULT=0    DEFAULTOPTION=VAULT
-# St Patricks Day Deco (depreciated)
-    VAR BOOL    gmpnStPatsDayVis[1]              DEFAULT=0    DEFAULTOPTION=VAULT
-# Tiki Deco for GreyDragon (depreciated)
-    VAR BOOL    gmpnTikiDecoVis[1]               DEFAULT=0    DEFAULTOPTION=VAULT
 # New Holiday Deco SDL (USE THIS FOR ALL HOLIDAY DECO!)
     VAR BYTE    gmpnHolidayVis[1]                   DEFAULT=0    DEFAULTOPTION=VAULT
 #       List of Integers/holidays:

--- a/Scripts/SDL/GoMePubNew.sdl
+++ b/Scripts/SDL/GoMePubNew.sdl
@@ -181,3 +181,60 @@ STATEDESC GoMePubNew
 #       6 - Christmas/Hannukah
 #       7 - Tiki (not implemented yet)
 }
+
+STATEDESC GoMePubNew
+{
+    VERSION 11
+
+    VAR BOOL    BarDoorStat[1]                   DEFAULT=1
+    VAR BOOL    islmGZBeamVis[1]                 DEFAULT=0    DEFAULTOPTION=VAULT
+    VAR BOOL    SinkStat[1]                      DEFAULT=0
+    VAR BOOL    ChisoBookVis[1]                  DEFAULT=0    DEFAULTOPTION=VAULT
+# Christmas/Hanukkah Decor
+    VAR BOOL    XMasVis[1]                       DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated
+    VAR BOOL    gmpnMenorahFlame01[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
+    VAR BOOL    gmpnMenorahFlame02[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
+    VAR BOOL    gmpnMenorahFlame03[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
+    VAR BOOL    gmpnMenorahFlame04[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
+    VAR BOOL    gmpnMenorahFlame05[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
+    VAR BOOL    gmpnMenorahFlame06[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
+    VAR BOOL    gmpnMenorahFlame07[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
+    VAR BOOL    gmpnMenorahFlame08[1]            DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
+    VAR BOOL    gmpnMenorahFlameShammash[1]      DEFAULT=0    DEFAULTOPTION=VAULT # Depreciated (see gmpnMenFlameStat below)
+# Pride Decor
+    VAR BOOL    gmpnPrideDecoVis[1]              DEFAULT=0    DEFAULTOPTION=VAULT
+# Halloween Deco (depreciated)
+    VAR BOOL    gmpnHalloweenVis[1]              DEFAULT=0    DEFAULTOPTION=VAULT
+# Fall/Thanksgiving (depreciated)
+    VAR BOOL    gmpnFallThanksVis[1]             DEFAULT=0    DEFAULTOPTION=VAULT
+# New Year Deco (depreciated)
+    VAR BOOL    gmpnNewYearVis[1]                DEFAULT=0    DEFAULTOPTION=VAULT
+# St Patricks Day Deco (depreciated)
+    VAR BOOL    gmpnStPatsDayVis[1]              DEFAULT=0    DEFAULTOPTION=VAULT
+# Tiki Deco for GreyDragon (depreciated)
+    VAR BOOL    gmpnTikiDecoVis[1]               DEFAULT=0    DEFAULTOPTION=VAULT
+# New Holiday Deco SDL (USE THIS FOR ALL HOLIDAY DECO!)
+    VAR BYTE    gmpnHolidayVis[1]                   DEFAULT=0    DEFAULTOPTION=VAULT
+#       List of Integers/holidays:
+#       0 - Default (no holiday decor)
+#       1 - New Years
+#       2 - St Pat's Day
+#       3 - Unused For Now
+#       4 - Halloween
+#       5 - Fall/Thanksgiving
+#       6 - Christmas/Hannukah
+#       7 - Tiki (not implemented yet)
+
+# New Menorah Flame State
+    VAR INT gmpnMenFlameStat[1]                  DEFAULT=0    DEFAULTOPTION=VAULT
+#    0 - Default (no flames)
+#    1 - Shammash and Flame01 on (Day 1)
+#    2 - Flame02 on (Day 2)
+#    3 - Flame03 on (Day 3)
+#    4 - Flame04 on (Day 4)
+#    5 - Flame05 on (Day 5)
+#    6 - Flame06 on (Day 6)
+#    7 - Flame07 on (Day 7)
+#    8 - Flame08 on (Day 8)
+}
+


### PR DESCRIPTION
Once again condenses a bunch of SDL states into one, this time for the menorah candle flames.

Instead of each flame being a separate bool SDL, everything is now controlled by an integer "gmpnMenFlameStat". The menorah itself is still controlled by the gmpnHolidayVis state.

0 - Default (no flames)
1 - Shammash and Flame01 on Day 1
2 - Flame02 on Day 2
3 - Flame03 on Day 3
4 - Flame04 on Day 4
5 - Flame05 on Day 5
6 - Flame06 on Day 6
7 - Flame07 on Day 7
8 - Flame08 on Day 8

New PRPs to go along with this will be PRed later after I do a few more adjustments to collision to keep the cones and Eddie out of weird spots.