### PR TITLE
Fix #990.

### DIFF
--- a/Scripts/Python/GardenBugs.py
+++ b/Scripts/Python/GardenBugs.py
@@ -80,7 +80,7 @@ class GardenBugs(ptResponder):
         self.version = 2
         self.bugCount = 0
     
-    def ISaveBugCount(self, count):
+    def ISaveBugCount(self, count: int):
         vault = ptVault()
         entry = vault.findChronicleEntry(chronicleEntryName)
         if entry is None:
@@ -186,7 +186,7 @@ class GardenBugs(ptResponder):
                     PtDebugPrint("GardenBugs.OnTimer():\tRunning, kill more bugs")
                     PtKillParticles(3.0,0.1,avatar.getKey())
                     PtAtTimeCallback(self.key, 0.4, PtBehaviorTypes.kBehaviorTypeRun)
-                    self.bugCount = self.bugCount * 0.1
+                    self.bugCount = self.bugCount // 10
                     self.ISaveBugCount(self.bugCount)
 
         elif (self.bugCount == 0):            
@@ -329,7 +329,7 @@ class GardenBugs(ptResponder):
                         self.bugCount = 0
                     else:
                         PtKillParticles(3.0,0.5,avatar.getKey())
-                        self.bugCount = self.bugCount / 2
+                        self.bugCount = self.bugCount // 2
                     self.ISaveBugCount(self.bugCount)
                 else:
                     PtKillParticles(3.0,1,avatar.getKey())
@@ -353,7 +353,7 @@ class GardenBugs(ptResponder):
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,0.1,avatar.getKey())
                 PtAtTimeCallback(self.key, 0.4, PtBehaviorTypes.kBehaviorTypeRun)
-                self.bugCount = self.bugCount * 0.1
+                self.bugCount = self.bugCount // 10
                 self.ISaveBugCount(self.bugCount)
                 return
 

--- a/Scripts/Python/GiraBugs.py
+++ b/Scripts/Python/GiraBugs.py
@@ -86,7 +86,7 @@ class GiraBugs(ptResponder):
         self.version = 2
         self.bugCount = 0
     
-    def ISaveBugCount(self, count):
+    def ISaveBugCount(self, count: int):
         vault = ptVault()
         entry = vault.findChronicleEntry(chronicleEntryName)
         if entry is None:
@@ -241,7 +241,7 @@ class GiraBugs(ptResponder):
                         self.bugCount = 0
                     else:
                         PtKillParticles(3.0,0.5,avatar.getKey())
-                        self.bugCount = self.bugCount / 2;
+                        self.bugCount = self.bugCount // 2
                     self.ISaveBugCount(self.bugCount)
                     
                 else:
@@ -266,7 +266,7 @@ class GiraBugs(ptResponder):
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,0.1,avatar.getKey())
                 PtAtTimeCallback(self.key, 0.25, PtBehaviorTypes.kBehaviorTypeRun)
-                self.bugCount = self.bugCount * 0.1
+                self.bugCount = self.bugCount // 10
                 self.ISaveBugCount(self.bugCount)
                 return
 


### PR DESCRIPTION
Another dangling issue from the Python 3 upgrade--use the new float division method to get ints for whole numbers of bugs on the avatar.

I believe the user visible impact of this is that if you run or jump with bugs on your avatar, they will not resume as expected when you link to another Age.