### PR TITLE
Improve text resolution of BaronCityOffice Marie note

### DIFF
--- a/Scripts/Python/xDynTextDefs.py
+++ b/Scripts/Python/xDynTextDefs.py
@@ -53,7 +53,7 @@ xTextObjects = {\
     "nb01GrsnBook":     ( "Sharper",    22, (0,0,0,1),  (0,0,0,0), 5,  "Neighborhood.TextObjects.GahreesenBook",    PtJustify.kCenter ),
     "grsnRetrieveKI":   ( "Sharper",    24, (0,0,0,1),  (0,0,0,0), 10, "Gahreesen.TextObjects.RetrieveKI",          PtJustify.kCenter ),
     "nb01EaselWelcome": ( "Sharper",    28, (0,0,0,1),  (0,0,0,0), 5,  "Neighborhood.TextObjects.EaselWelcome",     PtJustify.kCenter ),
-    "bcoWrinkledNote":  ( "Michelle",   10, (0,0,0,1),  (0,0,0,0), 5,  "BaronCityOffice.TextObjects.WrinkledNote",  PtJustify.kLeftJustify ),
+    "bcoWrinkledNote":  ( "Michelle",   24, (0,0,0,1),  (0,0,0,0), 10, "BaronCityOffice.TextObjects.WrinkledNote",  PtJustify.kLeftJustify ),
     "WatsonLetter":     ( "Courier",    10, (0,0,0,1),  (0,0,0,0), 0,  "City.TextObjects.WatsonLetter",             PtJustify.kLeftJustify ),
     "JCNote":           ( "Nick",       16, (0,0,0,1),  (0,0,0,0), 5,  "City.TextObjects.JCNote",                   PtJustify.kLeftJustify ),
     "clftAtrusNote":    ( "Atrus",      16, (0,0,0,1),  (0,0,0,0), 0,  "Cleft.TextObjects.AtrusNote",               PtJustify.kLeftJustify ),


### PR DESCRIPTION
Companion change of H-uru/moul-assets#86. This doubles the font size and line spacing of the note, to match the doubled resolution of the dynamic text map.

The original code sets the font size to 10, but the game actually uses size 12 instead, because that's the lowest available size of the Michelle font. So really I am just changing the font size from 12 to 24, even though the original code says 10.