### PR TITLE
Fix some uses of deprecated libc functions

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
@@ -61,7 +61,9 @@ ST::string GetTextAddr(uint32_t binAddr)
 {
     in_addr in;
     memcpy(&in, &binAddr, sizeof(binAddr));
-    return ST::string::from_utf8(inet_ntoa(in));
+
+    char text_addr[INET_ADDRSTRLEN];
+    return ST::string::from_utf8(inet_ntop(AF_INET, &in, text_addr, sizeof(text_addr)));
 }
 
 // NOTE: On Win32, WSAStartup() must be called before GetBinAddr() will work.
@@ -71,9 +73,12 @@ uint32_t GetBinAddr(const ST::string& textAddr)
     if (textAddr.empty())
         return addr;
 
-    addr = inet_addr(textAddr.c_str());
-    if(addr == INADDR_NONE)
-    {
+    in_addr in;
+    int result = inet_pton(AF_INET, textAddr.c_str(), &in);
+    hsAssert(result >= 0, "inet_pton failed");
+    if (result) {
+        memcpy(&addr, &in, sizeof(addr));
+    } else {
         struct addrinfo* ai = nullptr;
         struct addrinfo hints;
         memset(&hints, 0, sizeof(struct addrinfo));

--- a/Sources/Tools/MaxExport/plExportDlg.cpp
+++ b/Sources/Tools/MaxExport/plExportDlg.cpp
@@ -461,11 +461,12 @@ static void GetFileNameSection(const wchar_t* configFile, const wchar_t* keyName
     GetPrivateProfileStringW(L"Settings", keyName, L"", source, std::size(source), configFile);
 
     wchar_t* seps = L",";
-    wchar_t* token = wcstok(source, seps);
+    wchar_t* state = nullptr;
+    wchar_t* token = wcstok(source, seps, &state);
     while (token != nullptr)
     {
         strings.emplace_back(ST::string::from_wchar(token));
-        token = wcstok(nullptr, seps);
+        token = wcstok(nullptr, seps, &state);
     }
 }
 


### PR DESCRIPTION
* `inet_ntoa` and `inet_addr` are both considered deprecated due to flaws in their API.  This replaces them with the more flexible `inet_ntop` and `inet_pton`, respectively.
* Eliminate some unnecessary `memcpy`/`memset` in `in_addr` manipulation.
* Fix use of non-standard MSVC-backwards-compatible variant of `wcstok` by converting it to the standards-compliant version.