### PR TITLE
Move implementation of pyVaultNodeOperationCallback constructors to .cpp file

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -82,6 +82,19 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 ///////////////////////////////////////////////////////////////////////////
 
+pyVaultNode::pyVaultNodeOperationCallback::pyVaultNodeOperationCallback()
+    : fContext()
+{ }
+
+/** Constructs a new operation callback from a borrowed reference */
+pyVaultNode::pyVaultNodeOperationCallback::pyVaultNodeOperationCallback(PyObject* cbObject) noexcept
+    : fCbObject(cbObject, pyObjectNewRef), fContext()
+{ }
+
+pyVaultNode::pyVaultNodeOperationCallback::pyVaultNodeOperationCallback(pyObjectRef cbObject) noexcept
+    : fCbObject(std::move(cbObject)), fContext()
+{ }
+
 void pyVaultNode::pyVaultNodeOperationCallback::VaultOperationStarted( uint32_t context )
 {
     fContext = context;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
@@ -88,18 +88,12 @@ public:
         pyObjectRef         fPyNodeRef;
         uint32_t            fContext;
 
-        pyVaultNodeOperationCallback()
-            : fContext()
-        { }
+        pyVaultNodeOperationCallback();
 
         /** Constructs a new operation callback from a borrowed reference */
-        explicit pyVaultNodeOperationCallback(PyObject* cbObject) noexcept
-            : fCbObject(cbObject, pyObjectNewRef), fContext()
-        { }
+        explicit pyVaultNodeOperationCallback(PyObject* cbObject) noexcept;
 
-        explicit pyVaultNodeOperationCallback(pyObjectRef cbObject) noexcept
-            : fCbObject(std::move(cbObject)), fContext()
-        { }
+        explicit pyVaultNodeOperationCallback(pyObjectRef cbObject) noexcept;
 
         void VaultOperationStarted(uint32_t context);
         void VaultOperationComplete(uint32_t context, int resultCode);


### PR DESCRIPTION
This avoids an incomplete type error on GCC 11, since RelVaultNode is only forward-declared in pyVaultNode.h.