### PR TITLE
Add support for stripped PDBs.

### DIFF
--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -82,7 +82,7 @@ set(plClient_RESOURCES
     res/headspin.ico
 )
 
-plasma_executable(plClient WIN32 CLIENT
+plasma_executable(plClient WIN32 CLIENT INSTALL_PDB
     SOURCES
         ${plClient_SOURCES} ${plClient_HEADERS}
         ${plClient_TEXT} ${plClient_RESOURCES}
@@ -153,12 +153,6 @@ target_link_libraries(
 if(PLASMA_EXTERNAL_RELEASE)
     set_target_properties(plClient PROPERTIES OUTPUT_NAME "UruExplorer")
 endif(PLASMA_EXTERNAL_RELEASE)
-
-install(
-    FILES $<TARGET_PDB_FILE:plClient>
-    DESTINATION client
-    OPTIONAL
-)
 
 if(PLASMA_BUILD_RESOURCE_DAT)
     source_group("Client Resource Scripts" FILES ${external_SCRIPTS})


### PR DESCRIPTION
This is for the upcoming redesigned crash dialog. It doesn't really make sense outside that context, I know.

The new crash dialog needs plClient.pdb to show stack traces, however, this file generally weighs in at 100 MiB, which is a bit excessive to distribute just for showing some crash information. This generates another pdb file with the extension `.stripped.pdb` that has all of the file+line information removed, causing a massive reduction to around ~16 MiB. This compresses down to ~3 MiB. This would be a great file to distribute as plClient.pdb to end users so you get function names in the crash dialog. The crash.dmp file can still be used to gather the exact file and line numbers from the full-fat pdb.

Outside the context of the new crash dialog, the stripped pdb is still useful for debugging crash.dmp by other users.