### PR TITLE
Improve detection of pthread_timedjoin_np

### DIFF
--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceThread.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceThread.cpp
@@ -47,7 +47,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "Pch.h"
 
-#if defined(HS_BUILD_FOR_LINUX)
+#if defined(HAVE_PTHREAD_TIMEDJOIN_NP)
+#include <pthread.h>
 #include <time.h>
 #endif
 
@@ -74,7 +75,7 @@ void AsyncThreadTimedJoin(std::thread& thread, unsigned timeoutMs)
     if (rc == WAIT_TIMEOUT)
         LogMsg(kLogDebug, "Thread did not terminate after {} ms", timeoutMs);
     thread.detach();
-#elif defined(HS_BUILD_FOR_LINUX)
+#elif defined(HAVE_PTHREAD_TIMEDJOIN_NP)
     struct timespec deadline;
     if (clock_gettime(CLOCK_REALTIME, &deadline) < 0)
         hsAssert(false, "Could not get the realtime clock");

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -23,6 +23,10 @@ if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
     endif()
 endif()
 
+try_compile(HAVE_PTHREAD_TIMEDJOIN_NP ${PROJECT_BINARY_DIR}
+            ${PROJECT_SOURCE_DIR}/cmake/check_pthread_timedjoin_np.cpp
+            LINK_LIBRARIES Threads::Threads)
+
 # Check for CPUID headers
 try_compile(HAVE_CPUID ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_cpuid.cpp)

--- a/cmake/check_pthread_timedjoin_np.cpp
+++ b/cmake/check_pthread_timedjoin_np.cpp
@@ -1,0 +1,9 @@
+#include <pthread.h>
+#include <time.h>
+
+int main()
+{
+    pthread_t thread;
+    struct timespec ts{};
+    return pthread_timedjoin_np(thread, nullptr, &ts);
+}

--- a/cmake/hsConfig.h.cmake
+++ b/cmake/hsConfig.h.cmake
@@ -61,4 +61,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #cmakedefine USE_VPX
 #cmakedefine USE_WEBM
 
+#cmakedefine HAVE_PTHREAD_TIMEDJOIN_NP
+
 #endif


### PR DESCRIPTION
This will now use `pthread_timedjoin_np()` on any platform which provides it with a compatible API, rather than restricting its use to Linux.