### PR TITLE
Fix #985.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
@@ -267,7 +267,7 @@ void    plMouseDevice::CreateCursor( const char* cursor )
     fCursor->SetPosition( 0, 0, 0 );
     IUpdateCursorSize();
 
-    fCursor->SetVisible( true );
+    fCursor->SetVisible(!bCursorHidden);
     fCursor->SetOpacity( fOpacity );
 }
 
@@ -371,9 +371,6 @@ void plMouseDevice::NewCursor(const char* cursor)
     fInstance->CreateCursor(cursor);
     fInstance->SetCursorX(fInstance->GetCursorX());
     fInstance->SetCursorY(fInstance->GetCursorY());
-    
-    if (!plMouseDevice::bCursorHidden)
-        fInstance->fCursor->SetVisible( true );
 }
 
 void    plMouseDevice::SetCursorOpacity( float opacity )

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -247,15 +247,12 @@ void    plInputInterfaceMgr::IUpdateCursor( int32_t newCursor )
     const char*     mouseCursorResID;
 
 
-    fCurrentCursor = newCursor;
-    if( fCurrentCursor == plInputInterface::kCursorHidden )
+    if (newCursor == plInputInterface::kCursorHidden) {
         plMouseDevice::HideCursor();
-    else
-    {
-        plMouseDevice::ShowCursor();
-            
-        switch( fCurrentCursor )
-        {
+    } else {
+        if (fCurrentCursor == plInputInterface::kCursorHidden)
+            plMouseDevice::ShowCursor();
+        switch (newCursor) {
             case plInputInterface::kCursorUp:                   mouseCursorResID = CURSOR_UP;                   break;
             case plInputInterface::kCursorLeft:                 mouseCursorResID = CURSOR_LEFT;                 break;
             case plInputInterface::kCursorRight:                mouseCursorResID = CURSOR_RIGHT;                break;
@@ -279,12 +276,12 @@ void    plInputInterfaceMgr::IUpdateCursor( int32_t newCursor )
             case plInputInterface::kCursorHand:                 mouseCursorResID = CURSOR_HAND;                 break;
             case plInputInterface::kCursorUpward:               mouseCursorResID = CURSOR_UPWARD;               break;
             default:                                            mouseCursorResID = CURSOR_OPEN;                 break;
-                
         }
 
-        
-        plMouseDevice::NewCursor( mouseCursorResID );
+        plMouseDevice::NewCursor(mouseCursorResID);
     }
+
+    fCurrentCursor = newCursor;
 }
 
 //// IEval ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The problem here is that when the mouse moves quickly, the movement delta is so large that the mouse enters the "left", "right", or "down" arrow regions briefly before the re-center logic is able to reposition the mouse. This triggers the input code to change the cursor to one of those appropriate images. The problem happened in that both the mouse cursor update routine and the cursor creation routine had logic problems that would show the cursor when it changes. The latter would even override forced cursor hides done by `plMouseDevice::HideCursor(true)`.

I elected to NOT make panning the camera a forced hide (see `plCameraBrain1::MsgReceive()`'s `S_SET_FREELOOK` handler) because that seems like more of a gameplay oriented feature. It would be a shame if the cursor got stuck force hidden because we accidentally missed a mouse release, mouse-escaping the window, or something like that.