### PR TITLE
More pfLocalization `std::map` copying fixes.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
@@ -1004,42 +1004,33 @@ void pfLocalizationDataMgr::SetupData()
 
 pfLocalizedString pfLocalizationDataMgr::GetElement(const ST::string & name) const
 {
-    pfLocalizedString retVal; // if this returns before we initialize it, it will be empty, indicating failure
-
     if (!fLocalizedElements.exists(name)) // does the requested element exist?
-        return retVal; // nope, so return failure
+        return {}; // nope, so return failure
 
     auto currLangIt = fLocalizedElements[name].find(IGetCurrentLanguageName());
-    if (currLangIt != fLocalizedElements[name].cend()) {
-        retVal = currLangIt->second;
-        return retVal;
-    }
+    if (currLangIt != fLocalizedElements[name].cend())
+        return currLangIt->second;
 
     // Force to English
     auto englishIt = fLocalizedElements[name].find("English");
-    if (englishIt != fLocalizedElements[name].cend()) {
-        retVal = currLangIt->second;
-        return retVal;
-    }
+    if (englishIt != fLocalizedElements[name].cend())
+        return currLangIt->second;
 
-    return retVal;
+    return {};
 }
 
 //// GetSpecificElement //////////////////////////////////////////////
 
 pfLocalizedString pfLocalizationDataMgr::GetSpecificElement(const ST::string & name, const ST::string & language) const
 {
-    pfLocalizedString retVal; // if this returns before we initialize it, it will have an ID of 0, indicating failure
-
     if (!fLocalizedElements.exists(name)) // does the requested subtitle exist?
-        return retVal; // nope, so return failure
+        return {}; // nope, so return failure
 
     auto findIt = fLocalizedElements[name].find(language);
     if (findIt == fLocalizedElements[name].cend())
-        return retVal; // language doesn't exist
+        return {}; // language doesn't exist
 
-    retVal = findIt->second;
-    return retVal;
+    return findIt->second;
 }
 
 //// GetLanguages ////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
@@ -135,24 +135,6 @@ public:
     void AddError(const ST::string & errorText);
 };
 
-// A few small helper structs
-// I am setting these up so the header file can use this data without having to put
-// the LocalizationXMLFile class into the header file
-struct LocElementInfo
-{
-    LocalizationXMLFile::element fElement;
-};
-
-struct LocSetInfo
-{
-    LocalizationXMLFile::set fSet;
-};
-
-struct LocAgeInfo
-{
-    LocalizationXMLFile::age fAge;
-};
-
 //////////////////////////////////////////////////////////////////////
 // Memory functions
 //////////////////////////////////////////////////////////////////////
@@ -867,12 +849,12 @@ std::vector<ST::string> pfLocalizationDataMgr::IGetAllLanguageNames()
 
 //// IConvertSubtitle ////////////////////////////////////////////////
 
-void pfLocalizationDataMgr::IConvertElement(LocElementInfo *elementInfo, const ST::string & curPath)
+void pfLocalizationDataMgr::IConvertElement(const pfLocalizationDataMgr::element& elementInfo, const ST::string & curPath)
 {
     pfLocalizationDataMgr::localizedElement newElement;
     int16_t numArgs = -1;
 
-    for (const auto& curTranslation : elementInfo->fElement)
+    for (const auto& curTranslation : elementInfo)
     {
         newElement[curTranslation.first].FromXML(curTranslation.second);
         uint16_t argCount = newElement[curTranslation.first].GetArgumentCount();
@@ -887,26 +869,18 @@ void pfLocalizationDataMgr::IConvertElement(LocElementInfo *elementInfo, const S
 
 //// IConvertSet /////////////////////////////////////////////////////
 
-void pfLocalizationDataMgr::IConvertSet(LocSetInfo *setInfo, const ST::string & curPath)
+void pfLocalizationDataMgr::IConvertSet(const pfLocalizationDataMgr::set& setInfo, const ST::string & curPath)
 {
-    for (const auto& curElement : setInfo->fSet)
-    {
-        LocElementInfo elementInfo{ curElement.second };
-
-        IConvertElement(&elementInfo, ST::format("{}.{}", curPath, curElement.first));
-    }
+    for (const auto& curElement : setInfo)
+        IConvertElement(curElement.second, ST::format("{}.{}", curPath, curElement.first));
 }
 
 //// IConvertAge /////////////////////////////////////////////////////
 
-void pfLocalizationDataMgr::IConvertAge(LocAgeInfo *ageInfo, const ST::string & curPath)
+void pfLocalizationDataMgr::IConvertAge(const LocalizationXMLFile::age& ageInfo, const ST::string & curPath)
 {
-    for (const auto& curSet : ageInfo->fAge)
-    {
-        LocSetInfo setInfo{ curSet.second };
-
-        IConvertSet(&setInfo, ST::format("{}.{}", curPath, curSet.first));
-    }
+    for (const auto& curSet : ageInfo)
+        IConvertSet(curSet.second, ST::format("{}.{}", curPath, curSet.first));
 }
 
 //// IWriteText //////////////////////////////////////////////////////
@@ -1012,12 +986,7 @@ void pfLocalizationDataMgr::SetupData()
 
     // transfer localization data
     for (const auto& curAge : fDatabase->GetData())
-    {
-        LocAgeInfo ageInfo;
-        ageInfo.fAge = curAge.second;
-
-        IConvertAge(&ageInfo, curAge.first);
-    }
+        IConvertAge(curAge.second, curAge.first);
 
     OutputTreeToLog();
 }

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.h
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.h
@@ -72,6 +72,11 @@ private:
     static pfLocalizationDataMgr*   fInstance;
     static plStatusLog*             fLog;
 
+    // These need to match the typedefs in LocalizedXMLFile
+    using element = std::map<ST::string, ST::string>;
+    using set = std::map<ST::string, element>;
+    using age = std::map<ST::string, set>;
+
 protected:
     // This is a special case map class that will deconstruct the "Age.Set.Name" key into component parts
     // and store them so that a list of each part given it's parent part is easy to grab. I.e. I can grab
@@ -113,9 +118,9 @@ protected:
     ST::string IGetCurrentLanguageName(); // get the name of the current language
     std::vector<ST::string> IGetAllLanguageNames();
 
-    void IConvertElement(LocElementInfo *elementInfo, const ST::string & curPath);
-    void IConvertSet(LocSetInfo *setInfo, const ST::string & curPath);
-    void IConvertAge(LocAgeInfo *ageInfo, const ST::string & curPath);
+    void IConvertElement(const element& elementInfo, const ST::string & curPath);
+    void IConvertSet(const set& setInfo, const ST::string & curPath);
+    void IConvertAge(const age& ageInfo, const ST::string & curPath);
 
     void IWriteText(const plFileName & filename, const ST::string & ageName, const ST::string & languageName); // Write localization text to the specified file
 

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.h
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.h
@@ -90,18 +90,19 @@ protected:
         typedef std::map<ST::string, std::map<ST::string, std::map<ST::string, mapT> > > ThreePartMap;
         ThreePartMap fData;
 
-        void ISplitString(const ST::string& key, ST::string &age, ST::string &set, ST::string &name);
+        void ISplitString(const ST::string& key, ST::string &age, ST::string &set, ST::string &name) const;
     public:
         // We will just have very basic functionality
-        bool exists(const ST::string & key); // returns true if the key exists
-        bool setExists(const ST::string & key); // returns true if the age.set exists (ignores name if passed in)
+        bool exists(const ST::string & key) const; // returns true if the key exists
+        bool setExists(const ST::string & key) const; // returns true if the age.set exists (ignores name if passed in)
         void erase(const ST::string & key); // erases the key from the map
 
-        mapT &operator[](const ST::string &key); // returns the item referenced by the key (and creates if necessary)
+        const mapT& operator[](const ST::string& key) const; // returns the item referenced by the key
+        mapT& operator[](const ST::string& key); // returns the item referenced by the key (and creates if necessary)
 
-        std::vector<ST::string> getAgeList(); // returns a list of all ages in this map
-        std::vector<ST::string> getSetList(const ST::string & age); // returns a list of all sets in the specified age
-        std::vector<ST::string> getNameList(const ST::string & age, const ST::string & set);
+        std::vector<ST::string> getAgeList() const; // returns a list of all ages in this map
+        std::vector<ST::string> getSetList(const ST::string & age) const; // returns a list of all sets in the specified age
+        std::vector<ST::string> getNameList(const ST::string & age, const ST::string & set) const;
     };
 
     LocalizationDatabase *fDatabase;
@@ -115,14 +116,14 @@ protected:
 
     localizedElement ICreateLocalizedElement(); // ease of use function that creates a basic localized element object
 
-    ST::string IGetCurrentLanguageName(); // get the name of the current language
-    std::vector<ST::string> IGetAllLanguageNames();
+    ST::string IGetCurrentLanguageName() const; // get the name of the current language
+    std::vector<ST::string> IGetAllLanguageNames() const;
 
     void IConvertElement(const element& elementInfo, const ST::string & curPath);
     void IConvertSet(const set& setInfo, const ST::string & curPath);
     void IConvertAge(const age& ageInfo, const ST::string & curPath);
 
-    void IWriteText(const plFileName & filename, const ST::string & ageName, const ST::string & languageName); // Write localization text to the specified file
+    void IWriteText(const plFileName & filename, const ST::string & ageName, const ST::string & languageName) const; // Write localization text to the specified file
 
     pfLocalizationDataMgr(const plFileName & path);
 public:
@@ -136,25 +137,25 @@ public:
 
     void SetupData();
 
-    pfLocalizedString GetElement(const ST::string & name);
-    pfLocalizedString GetSpecificElement(const ST::string & name, const ST::string & languageName);
+    pfLocalizedString GetElement(const ST::string & name) const;
+    pfLocalizedString GetSpecificElement(const ST::string & name, const ST::string & languageName) const;
 
-    std::vector<ST::string> GetAgeList()
+    std::vector<ST::string> GetAgeList() const
     {
         return fLocalizedElements.getAgeList();
     }
-    std::vector<ST::string> GetSetList(const ST::string & ageName)
+    std::vector<ST::string> GetSetList(const ST::string & ageName) const
     {
         return fLocalizedElements.getSetList(ageName);
     }
-    std::vector<ST::string> GetElementList(const ST::string & ageName, const ST::string & setName)
+    std::vector<ST::string> GetElementList(const ST::string & ageName, const ST::string & setName) const
     {
         return fLocalizedElements.getNameList(ageName, setName);
     }
-    std::vector<ST::string> GetLanguages(const ST::string & ageName, const ST::string & setName, const ST::string & elementName);
+    std::vector<ST::string> GetLanguages(const ST::string & ageName, const ST::string & setName, const ST::string & elementName) const;
 
-    ST::string GetElementXMLData(const ST::string & name, const ST::string & languageName);
-    ST::string GetElementPlainTextData(const ST::string & name, const ST::string & languageName);
+    ST::string GetElementXMLData(const ST::string & name, const ST::string & languageName) const;
+    ST::string GetElementPlainTextData(const ST::string & name, const ST::string & languageName) const;
 
     // These convert the XML data to the actual subtitle and return true if successful (editor only)
     bool SetElementXMLData(const ST::string & name, const ST::string & languageName, const ST::string & xmlData);
@@ -167,9 +168,9 @@ public:
     bool DeleteElement(const ST::string & name);
 
     // Writes the current database to the disk (editor only). It will create all the files and put them into path
-    void WriteDatabaseToDisk(const plFileName & path);
+    void WriteDatabaseToDisk(const plFileName & path) const;
 
-    void OutputTreeToLog(); // prints the localization tree to the log file
+    void OutputTreeToLog() const; // prints the localization tree to the log file
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationMgr.cpp
@@ -95,12 +95,12 @@ void pfLocalizationMgr::Shutdown()
 
 //// GetString ///////////////////////////////////////////////////////
 
-ST::string pfLocalizationMgr::GetString(const ST::string & path, const std::vector<ST::string> & args)
+ST::string pfLocalizationMgr::GetString(const ST::string & path, const std::vector<ST::string> & args) const
 {
     return pfLocalizationDataMgr::Instance().GetElement(path) % args;
 }
 
-ST::string pfLocalizationMgr::GetString(const ST::string & path)
+ST::string pfLocalizationMgr::GetString(const ST::string & path) const
 {
     std::vector<ST::string> args; // blank args so that % signs are still handled correctly
     return pfLocalizationDataMgr::Instance().GetElement(path) % args;

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationMgr.h
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationMgr.h
@@ -73,8 +73,8 @@ public:
     // want the arguments in a different order (like you had to switch things around for a specific language)
     // then you use %1s, %2s, %3s and so on to specify arguments, these two cannot be mixed and you won't get
     // the results you expect if you do mix them. Path is specified by Age.Set.Name
-    ST::string GetString(const ST::string & path, const std::vector<ST::string> & args);
-    ST::string GetString(const ST::string & path);
+    ST::string GetString(const ST::string & path, const std::vector<ST::string> & args) const;
+    ST::string GetString(const ST::string & path) const;
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.cpp
@@ -246,32 +246,32 @@ void pfLocalizedString::FromXML(const ST::string & xml)
 
 //// Operators ///////////////////////////////////////////////////////
 
-bool pfLocalizedString::operator<(pfLocalizedString &obj)
+bool pfLocalizedString::operator<(pfLocalizedString &obj) const
 {
     return (fPlainTextRep.compare(obj.fPlainTextRep) < 0);
 }
 
-bool pfLocalizedString::operator>(pfLocalizedString &obj)
+bool pfLocalizedString::operator>(pfLocalizedString &obj) const
 {
     return (fPlainTextRep.compare(obj.fPlainTextRep) > 0);
 }
 
-bool pfLocalizedString::operator==(pfLocalizedString &obj)
+bool pfLocalizedString::operator==(pfLocalizedString &obj) const
 {
     return (fPlainTextRep.compare(obj.fPlainTextRep) == 0);
 }
 
-bool pfLocalizedString::operator<=(pfLocalizedString &obj)
+bool pfLocalizedString::operator<=(pfLocalizedString &obj) const
 {
     return (fPlainTextRep.compare(obj.fPlainTextRep) <= 0);
 }
 
-bool pfLocalizedString::operator>=(pfLocalizedString &obj)
+bool pfLocalizedString::operator>=(pfLocalizedString &obj) const
 {
     return (fPlainTextRep.compare(obj.fPlainTextRep) >= 0);
 }
 
-bool pfLocalizedString::operator!=(pfLocalizedString &obj)
+bool pfLocalizedString::operator!=(pfLocalizedString &obj) const
 {
     return (fPlainTextRep.compare(obj.fPlainTextRep) != 0);
 }
@@ -296,7 +296,7 @@ pfLocalizedString &pfLocalizedString::operator=(const ST::string & plainText)
     return *this;
 }
 
-ST::string pfLocalizedString::operator%(const std::vector<ST::string> & arguments)
+ST::string pfLocalizedString::operator%(const std::vector<ST::string> & arguments) const
 {
     ST::string_stream ss;
     for (std::vector<ST::string>::size_type curIndex = 0; curIndex < fText.size(); curIndex++)

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.h
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.h
@@ -89,27 +89,28 @@ public:
 
     // To translate to and from xml format (where <, > and other signs can't be used)
     void FromXML(const ST::string & xml);
-    ST::string ToXML() {return fXMLRep;}
+    ST::string ToXML() const { return fXMLRep; }
 
-    uint16_t GetArgumentCount() {return fNumArguments;}
+    uint16_t GetArgumentCount() const { return fNumArguments; }
 
     // Various operators, they all work pretty much the same as the standard string or wstring operators
     // but note that the all work on the plain text representation (not the XML representation)
-    bool operator<(pfLocalizedString &obj);
-    bool operator>(pfLocalizedString &obj);
-    bool operator==(pfLocalizedString &obj);
-    bool operator<=(pfLocalizedString &obj);
-    bool operator>=(pfLocalizedString &obj);
-    bool operator!=(pfLocalizedString &obj);
+    bool operator<(pfLocalizedString &obj) const;
+    bool operator>(pfLocalizedString &obj) const;
+    bool operator==(pfLocalizedString &obj) const;
+    bool operator<=(pfLocalizedString &obj) const;
+    bool operator>=(pfLocalizedString &obj) const;
+    bool operator!=(pfLocalizedString &obj) const;
 
-    operator ST::string() {return fPlainTextRep;}
+    operator ST::string() const { return fPlainTextRep; }
+    operator bool() const { return !fPlainTextRep.empty(); }
 
     pfLocalizedString operator+(pfLocalizedString &obj);
     pfLocalizedString &operator+=(pfLocalizedString &obj);
     pfLocalizedString &operator=(const ST::string & plainText);
 
     // Specialized operator for replacing text with arguments
-    ST::string operator%(const std::vector<ST::string> & arguments);
+    ST::string operator%(const std::vector<ST::string> & arguments) const;
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.h
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizedString.h
@@ -85,7 +85,6 @@ protected:
 public:
     pfLocalizedString() : fNumArguments(0) {}
     pfLocalizedString(const ST::string & plainText);
-    virtual ~pfLocalizedString() {}
 
     // To translate to and from xml format (where <, > and other signs can't be used)
     void FromXML(const ST::string & xml);


### PR DESCRIPTION
pfLocalization is the gift that keeps on giving in terms of pointless copying. The gains for these changes are very minor until you start to increase the localization database to ridiculous levels (eg the GULP hell data set).

MOULa:
```
Before (1,000 iterations):
Total: 90.4061 seconds (90406071 us)
Average: 0.0904 seconds (90406 us)


After (1,000 iterations):
Total: 86.0913 seconds (86091275 us)
Average: 0.0861 seconds (86091 us)
```

Hell:
```
HELL SET BEFORE (1,000 iterations):
Total: 206.5140 seconds (206514028 us)
Average: 0.2065 seconds (206514 us)

HELL SET AFTER (1,000 iterations):
Total: 199.5938 seconds (199593832 us)
Average: 0.1996 seconds (199593 us)
```

There are still more gains that could be achieved in pfLocalization, but these are mostly around actually fetching the translations.