### PR TITLE
Prevent sending blank/space KI messages in variety of contexts; Fix /invite so it doesn't silently crash

### DIFF
--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -866,27 +866,38 @@ class CommandsProcessor:
                 else:
                     statusMsg = PtGetLocalizedString(emote[1], [PtGetLocalPlayer().getPlayerName()])
                 self.chatMgr.DisplayStatusMessage(statusMsg, 1)
+
+                # Get remaining message string after emote command
                 message = message[len(words[0]):]
-                if message == "":
+                if message == "" or message.isspace():
                     return None
                 return message[1:]
             except LookupError:
                 try:
                     command = xKIExtChatCommands.xChatExtendedChat[str(words[0][1:].casefold())]
                     if isinstance(command, str):
+                        # Retrieved command is just a plain string
                         args = message[len(words[0]):]
                         PtConsole(command + args)
                     else:
+                        # Retrieved command is not a string (it's a function)
                         try:
+                            # Get remaining message string after chat command
                             args = message[len(words[0]) + 1:]
                             if args:
                                 try:
                                     retDisp = command(args)
                                 except TypeError:
                                     retDisp = command()
+
+                                    # Command took no args, so return args as new message
+                                    if args == "" or args.isspace():
+                                        return None
                                     return args
                             else:
                                 retDisp = command()
+
+                            # Check type of return value from command and display appropriately
                             if isinstance(retDisp, str):
                                 self.chatMgr.DisplayStatusMessage(retDisp)
                             elif isinstance(retDisp, tuple):
@@ -898,11 +909,19 @@ class CommandsProcessor:
                             PtDebugPrint("xKIChat.commandsProcessor(): Chat command function did not run.", command, level=kErrorLevel)
                 except LookupError:
                     if str(words[0].casefold()) in xKIExtChatCommands.xChatSpecialHandledCommands:
+                        # Get remaining message string after special chat command
+                        remainingMsg = message[len(words[0]):]
+                        if remainingMsg == "" or remainingMsg.isspace():
+                            return None
+                        # Return full message with special command still prefixed
                         return message
                     else:
                         self.chatMgr.AddChatLine(None, PtGetLocalizedString("KI.Errors.CommandError", [message]), kChat.SystemMessage)
                 return None
 
+        # Prevent sending blank/whitespace message
+        if message == "" or message.isspace():
+            return None
         return message
 
     ## Extract the player ID from a chat's params.

--- a/Scripts/Python/xCheat.py
+++ b/Scripts/Python/xCheat.py
@@ -678,6 +678,7 @@ def ImportMarkers(args):
                     if jnode.folderGetName() == mg[1]:
                         # yes, add the markers to this game
                         for marker in mg[0][4]:
+                            # TODO: PlasmaVaultConstants.PtVaultNodePermissionFlags does not exist
                             nMarker = Plasma.ptVaultMarkerNode(PlasmaVaultConstants.PtVaultNodePermissionFlags.kDefaultPermissions)
                             nMarker.markerSetText(marker[0])
                             pos = Plasma.ptPoint3(marker[1],marker[2],marker[3])

--- a/Scripts/Python/xCheat.py
+++ b/Scripts/Python/xCheat.py
@@ -678,7 +678,6 @@ def ImportMarkers(args):
                     if jnode.folderGetName() == mg[1]:
                         # yes, add the markers to this game
                         for marker in mg[0][4]:
-                            # TODO: PlasmaVaultConstants.PtVaultNodePermissionFlags does not exist
                             nMarker = Plasma.ptVaultMarkerNode(PlasmaVaultConstants.PtVaultNodePermissionFlags.kDefaultPermissions)
                             nMarker.markerSetText(marker[0])
                             pos = Plasma.ptPoint3(marker[1],marker[2],marker[3])

--- a/Scripts/Python/xInvite.py
+++ b/Scripts/Python/xInvite.py
@@ -95,7 +95,7 @@ def CreateInvitation(params=None):
         if invites is not None:
             if invites.getChildNodeCount() <= gMaxInviteCount:
                 # create the note
-                note = ptVaultTextNoteNode(PtVaultNodePermissionFlags.kDefaultPermissions)
+                note = ptVaultTextNoteNode()
                 note.noteSetTitle(passkey)
                 invites.addNode(note)
                 return PtGetLocalizedString("KI.Invitation.InviteKeyAdded", [str(passkey)])
@@ -172,7 +172,7 @@ def DeleteInvitation(params=None):
     return PtGetLocalizedString("KI.Invitation.DeletedInvitation") + str(passkey)
 
 def MeChat(params=None):
-    if (params == None):
+    if (params == None or params == "" or params.isspace()):
         PtDebugPrint('xChatExtend:MeCmd: If you have nothing to say, why say anything at all?')
         return 
     PtSendKIMessage(kKIChatStatusMsg, ('%s %s' % (PtGetLocalPlayer().getPlayerName(), params)))

--- a/Scripts/Python/xInvite.py
+++ b/Scripts/Python/xInvite.py
@@ -172,7 +172,7 @@ def DeleteInvitation(params=None):
     return PtGetLocalizedString("KI.Invitation.DeletedInvitation") + str(passkey)
 
 def MeChat(params=None):
-    if (params == None or params == "" or params.isspace()):
+    if (not params or params.isspace()):
         PtDebugPrint('xChatExtend:MeCmd: If you have nothing to say, why say anything at all?')
         return 
     PtSendKIMessage(kKIChatStatusMsg, ('%s %s' % (PtGetLocalPlayer().getPlayerName(), params)))


### PR DESCRIPTION
- Update KI chat command processor to discard blank/whitespace messages, including messages used with /me and /buddies, among other commands
- Remove usage of nonexistent constant so /invite command doesn't silently crash and instead actually creates an invite with passkey