### PR TITLE
Fix Python deprecation warnings because of \s and \d escape characters in regex patterns

### DIFF
--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1452,7 +1452,7 @@ class CommandsProcessor:
             return
 
         # Parse common dice notation
-        dice_opt = re.match("^(\d+)d(\d+)$", dice_str)
+        dice_opt = re.match("^(\\d+)d(\\d+)$", dice_str)
         if not dice_opt:
             self.chatMgr.AddChatLine(None, "I'm sorry, I don't know how to roll {}.".format(dice_str), kChat.SystemMessage)
             return

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1452,7 +1452,7 @@ class CommandsProcessor:
             return
 
         # Parse common dice notation
-        dice_opt = re.match("^(\\d+)d(\\d+)$", dice_str)
+        dice_opt = re.match(r"^(\d+)d(\d+)$", dice_str)
         if not dice_opt:
             self.chatMgr.AddChatLine(None, "I'm sorry, I don't know how to roll {}.".format(dice_str), kChat.SystemMessage)
             return

--- a/Scripts/Python/ki/xKIHelpers.py
+++ b/Scripts/Python/ki/xKIHelpers.py
@@ -62,8 +62,8 @@ class AutocompleteState:
         self.prefix = ""
         self.candidates = list()
         self.lastCandidateId = None
-        self.space_match = re.compile("\\s+", re.UNICODE)
-        self.word_match = re.compile("\\S+", re.UNICODE)
+        self.space_match = re.compile(r"\s+", re.UNICODE)
+        self.word_match = re.compile(r"\S+", re.UNICODE)
 
     def pickFirst(self, text, nameList):
 

--- a/Scripts/Python/xDialogStartUp.py
+++ b/Scripts/Python/xDialogStartUp.py
@@ -341,7 +341,7 @@ class xDialogStartUp(ptResponder):
                     if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6FemaleID)).isChecked():
                         playerGender = "female"
 
-                    if playerName == "" or playerName == "":
+                    if playerName == "" or playerName.isspace():
                         errorString = "Error, you must enter a Name."
                         ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setString(errorString)
                         PtShowDialog("GUIDialog04d")
@@ -353,7 +353,7 @@ class xDialogStartUp(ptResponder):
                         self.ToggleColor(GUIDiag4b, k4bPlayer03)
                     else:
                         fixedPlayerName = playerName.strip()
-                        (fixedPlayerName, whitespacefixedcount) = re.subn("\s{2,}|[\t\n\r\f\v]", " ", fixedPlayerName)
+                        (fixedPlayerName, whitespacefixedcount) = re.subn("\\s{2,}|[\t\n\r\f\v]", " ", fixedPlayerName)
                         
                         (fixedPlayerName, RogueCount,) = re.subn('[\x00-\x1f]', '', fixedPlayerName)
                         if RogueCount > 0 or whitespacefixedcount > 0:

--- a/Scripts/Python/xDialogStartUp.py
+++ b/Scripts/Python/xDialogStartUp.py
@@ -353,7 +353,7 @@ class xDialogStartUp(ptResponder):
                         self.ToggleColor(GUIDiag4b, k4bPlayer03)
                     else:
                         fixedPlayerName = playerName.strip()
-                        (fixedPlayerName, whitespacefixedcount) = re.subn("\\s{2,}|[\t\n\r\f\v]", " ", fixedPlayerName)
+                        (fixedPlayerName, whitespacefixedcount) = re.subn(r"\s{2,}|[\t\n\r\f\v]", " ", fixedPlayerName)
                         
                         (fixedPlayerName, RogueCount,) = re.subn('[\x00-\x1f]', '', fixedPlayerName)
                         if RogueCount > 0 or whitespacefixedcount > 0:


### PR DESCRIPTION
- Change \s and \d escape characters in some python regex pattern strings to use \\s and \\d so they no longer throw deprecation warnings
- Update missing player name check on Create Player dialog so it doesn't repeat (playerName == "") twice