### PR TITLE
Change chat mentions to only highlight player's name instead of entire message

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1342,6 +1342,9 @@ class xKI(ptModifier):
             chatArea.moveCursor(PtGUIMultiLineDirection.kBufferStart)
             chatArea.getOwnerDialog().refreshAllControls()
 
+        # Setup the chat mention regex.
+        self.chatMgr.playerName = PtGetClientName()
+
         # Remove unneeded kFontShadowed flags (as long as we can't do that directly in the PRPs)
         for dialogAttr in (BigKI, KIListModeDialog, KIJournalExpanded, KIPictureExpanded, KIPlayerExpanded, KIAgeOwnerExpanded, KISettings, KIMarkerFolderExpanded, KICreateMarkerGameGUI):
             for i in range(dialogAttr.dialog.getNumControls()):
@@ -2481,6 +2484,11 @@ class xKI(ptModifier):
 
         if not self.chatMgr.fadeEnableFlag:
             return
+
+        # Never start the fade timer if the user is currently in chat edit mode
+        if self.chatMgr.isChatting:
+            return
+
         if not BigKI.dialog.isEnabled():
             if self.chatMgr.fadeMode in (kChat.FadeNotActive, kChat.FadeDone):
                 PtAtTimeCallback(self.key, kChat.FullTickTime, kTimers.Fade)

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -408,13 +408,13 @@ class xKIChat(object):
         playerNameMentionRegex = None
 
         # Compose the regex differently depending on if player name starts and ends with a word or with special characters
-        if _STARTS_WITH_WORD_REGEX.search(playerName) != None:
-            if _ENDS_WITH_WORD_REGEX.search(playerName) != None:
+        if _STARTS_WITH_WORD_REGEX.search(playerName) is not None:
+            if _ENDS_WITH_WORD_REGEX.search(playerName) is not None:
                 playerNameMentionRegex = re.compile(fr"\b({re.escape(playerName)})\b", re.IGNORECASE)
             else:
                 playerNameMentionRegex = re.compile(fr"\b({re.escape(playerName)})(?=$|\W)", re.IGNORECASE)
         else:
-            if _ENDS_WITH_WORD_REGEX.search(playerName) != None:
+            if _ENDS_WITH_WORD_REGEX.search(playerName) is not None:
                 playerNameMentionRegex = re.compile(fr"(?=^|\W)({re.escape(playerName)})\b", re.IGNORECASE)
             else:
                 playerNameMentionRegex = re.compile(fr"(?=^|\W)({re.escape(playerName)})(?=$|\W)", re.IGNORECASE)
@@ -491,7 +491,7 @@ class xKIChat(object):
                         self.lastPrivatePlayerID = (player.getPlayerName(), player.getPlayerID(), 1)
                         PtFlashWindow()
                     # Are we mentioned in the message?
-                    elif playerNameMentionRegex.search(message) != None:
+                    elif playerNameMentionRegex.search(message) is not None:
                         specialColor = kColors.ChatMessageMention
                         specialMatchPattern = playerNameMentionRegex
                         PtFlashWindow()
@@ -535,7 +535,7 @@ class xKIChat(object):
                     self.AddPlayerToRecents(player.getPlayerID())
 
                     # Are we mentioned in the message?
-                    if playerNameMentionRegex.search(message) != None:
+                    if playerNameMentionRegex.search(message) is not None:
                         specialColor = kColors.ChatMessageMention
                         specialMatchPattern = playerNameMentionRegex
                         forceKI = True
@@ -594,7 +594,7 @@ class xKIChat(object):
                 chatArea.insertColor(bodyColor)
 
                 # We have some special processing to do to change text colors mid-message
-                if specialMatchPattern != None and specialColor != None:
+                if specialMatchPattern is not None and specialColor is not None:
                     lastInsert = 0
                     urlMatches = list((match.span() for match in _URL_REGEX.finditer(chatMessageFormatted)))
                     specialMatches = ((match.span(1), match.groups(1)[0]) for match in specialMatchPattern.finditer(chatMessageFormatted))

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -402,7 +402,7 @@ class xKIChat(object):
     ## Adds a line to the RT chat.
     def AddChatLine(self, player, message, cFlags, forceKI=True):
 
-        playernameMentionRegex = re.compile(fr"({re.escape(PtGetClientName())})", re.IGNORECASE)
+        playernameMentionRegex = re.compile(fr"(?=^|\W)({re.escape(PtGetClientName())})(?=$|\W)", re.IGNORECASE)
 
         try:
             PtDebugPrint("xKIChat.AddChatLine(): Message = \"{}\".".format(message), player, cFlags, level=kDebugDumpLevel)

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -402,7 +402,7 @@ class xKIChat(object):
     ## Adds a line to the RT chat.
     def AddChatLine(self, player, message, cFlags, forceKI=True):
 
-        playernameMentionRegex = re.compile(fr"(?=^|\W)({re.escape(PtGetClientName())})(?=$|\W)", re.IGNORECASE)
+        playernameMentionRegex = re.compile(fr"({re.escape(PtGetClientName())})", re.IGNORECASE)
 
         try:
             PtDebugPrint("xKIChat.AddChatLine(): Message = \"{}\".".format(message), player, cFlags, level=kDebugDumpLevel)

--- a/Scripts/Python/ki/xKIConstants.py
+++ b/Scripts/Python/ki/xKIConstants.py
@@ -208,6 +208,7 @@ class kColors:
     DniYellowLt = ptColor(1.0, 1.0, 0.6, 1.0)
     DniCyan     = ptColor(0.576, 0.867, 0.851, 1.0)
     DniBlue     = ptColor(0.780, 0.706, 0.870, 1.0)
+    DniBlueDk   = ptColor(0.388, 0.577, 0.676, 1.0)
     DniRed      = ptColor(1.0, 0.216, 0.380, 1.0)
     DniGreen    = ptColor(0.698, 0.878, 0.761, 1.0)
     DniGreenDk  = ptColor(0.0, 0.596, 0.211, 1.0)


### PR DESCRIPTION
- Chat mentions will now only highlight the player's name in the message instead of the entire message. Intended to avoid confusion for players who mistake mentions for private/whisper messages
- When player's name is contained within a URL, the URL handling will take precedence and the name will not be highlighted
- Add DniBlueDk (medium dusky blue) color that matches KI lights for potential use later