### PR TITLE
[Do Not Merge] Temp stub pnAceSocket impl for Linux

### DIFF
--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/CMakeLists.txt
@@ -27,6 +27,10 @@ if(WIN32)
     target_sources(pnAsyncCoreExe PRIVATE
         ${pnAsyncCoreExe_PRIVATE_NT}
     )
+else()
+    target_sources(pnAsyncCoreExe PRIVATE
+        Private/Stub/pnAceStubSocket.cpp
+    )
 endif()
 
 # Yeah, this looks strange, but this library has no public headers. It's

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Stub/pnAceStubSocket.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/Private/Stub/pnAceStubSocket.cpp
@@ -1,0 +1,64 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "../../Pch.h"
+
+void AsyncSocketConnect(
+    AsyncCancelId *         cancelId,
+    const plNetAddress&     netAddr,
+    FAsyncNotifySocketProc  notifyProc,
+    void *                  param,
+    const void *            sendData,
+    unsigned                sendBytes
+) { }
+
+void AsyncSocketConnectCancel(AsyncCancelId cancelId) { }
+
+void AsyncSocketDelete(AsyncSocket conn) { }
+
+void AsyncSocketDisconnect(AsyncSocket conn, bool hardClose) { }
+
+bool AsyncSocketSend(AsyncSocket conn, const void* data, unsigned bytes) {
+    return false;
+}
+
+void AsyncSocketEnableNagling(AsyncSocket conn, bool enable) { }

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceCore.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceCore.cpp
@@ -112,8 +112,6 @@ void AsyncCoreInitialize()
     s_initialized = true;
 #ifdef HS_BUILD_FOR_WIN32
     Nt::NtInitialize();
-#else
-    ErrorAssert(__LINE__, __FILE__, "Async API not yet supported for this platform");
 #endif
 }
 
@@ -122,8 +120,6 @@ void AsyncCoreDestroy(unsigned waitMs)
 {
 #ifdef HS_BUILD_FOR_WIN32
     Nt::NtDestroy(waitMs);
-#else
-    ErrorAssert(__LINE__, __FILE__, "Async API not yet supported for this platform");
 #endif
 
     DnsDestroy(waitMs);


### PR DESCRIPTION
I'm guessing this is not useful, except as a local patch for people wanting to _compile_ the full engine on Linux without wanting to _run_ it.

This allows pnAsyncCoreExe and all the net code to compile on Linux/macOS. However, trying to run a client/tool with this will almost definitely result in weird and broken behaviour as soon as it tries to do anything useful with a socket.