### PR TITLE
Allow mouse-free and message-free KI commands to select KI folders: /age, /neighbors, and /buddies

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -5599,14 +5599,14 @@ class xKI(ptModifier):
                         if plyrInfo is not None:
                             sendToField.setString(plyrInfo.playerGetName())
                             # Set private caret.
-                            caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + str(plyrInfo.playerGetName()) + " >")
+                            caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + plyrInfo.playerGetName() + " >")
                             privateChbox.setChecked(1)
                         else:
                             self.BKPlayerSelected = None
                     # Is it a specific player?
                     elif isinstance(self.BKPlayerSelected, ptPlayer):
                         sendToField.setString(self.BKPlayerSelected.getPlayerName())
-                        caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + str(self.BKPlayerSelected.getPlayerName()) + " >")
+                        caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + self.BKPlayerSelected.getPlayerName() + " >")
                         privateChbox.setChecked(1)
                     # Is it a list of players?
                     elif isinstance(self.BKPlayerSelected, ptVaultPlayerInfoListNode):

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -5599,14 +5599,14 @@ class xKI(ptModifier):
                         if plyrInfo is not None:
                             sendToField.setString(plyrInfo.playerGetName())
                             # Set private caret.
-                            caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + plyrInfo.playerGetName() + " >")
+                            caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + str(plyrInfo.playerGetName()) + " >")
                             privateChbox.setChecked(1)
                         else:
                             self.BKPlayerSelected = None
                     # Is it a specific player?
                     elif isinstance(self.BKPlayerSelected, ptPlayer):
                         sendToField.setString(self.BKPlayerSelected.getPlayerName())
-                        caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + self.BKPlayerSelected.getPlayerName() + " >")
+                        caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + str(self.BKPlayerSelected.getPlayerName()) + " >")
                         privateChbox.setChecked(1)
                     # Is it a list of players?
                     elif isinstance(self.BKPlayerSelected, ptVaultPlayerInfoListNode):

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -952,11 +952,45 @@ class CommandsProcessor:
                         except:
                             PtDebugPrint("xKIChat.commandsProcessor(): Chat command function did not run.", command, level=kErrorLevel)
                 except LookupError:
-                    if str(words[0].casefold()) in xKIExtChatCommands.xChatSpecialHandledCommands:
+                    firstWordLower = str(words[0].casefold())
+                    if firstWordLower in xKIExtChatCommands.xChatSpecialHandledCommands:
                         # Get remaining message string after special chat command
                         remainingMsg = message[len(words[0]):]
+
+                        # If remaining message is empty, try to do mousefree KI folder selection instead
                         if remainingMsg == "" or remainingMsg.isspace():
+                            userListBox = ptGUIControlListBox(KIMini.dialog.getControlFromTag(kGUI.PlayerList))
+                            caret = ptGUIControlTextBox(KIMini.dialog.getControlFromTag(kGUI.ChatCaretID))
+                            privateChbox = ptGUIControlCheckBox(KIMini.dialog.getControlFromTag(kGUI.miniPrivateToggle))
+
+                            # Handling for selecting Age Players, Buddies, or Neighbors
+                            if firstWordLower == PtGetLocalizedString("KI.Commands.ChatAge"):
+                                folderName = xLocTools.FolderIDToFolderName(PtVaultStandardNodes.kAgeMembersFolder)
+                                caretValue = ">"
+                            elif firstWordLower == PtGetLocalizedString("KI.Commands.ChatBuddies"):
+                                folderName = xLocTools.FolderIDToFolderName(PtVaultStandardNodes.kBuddyListFolder)
+                                caretValue = PtGetLocalizedString("KI.Chat.TOPrompt") + folderName + " >"
+                            elif firstWordLower == PtGetLocalizedString("KI.Commands.ChatNeighbors"):
+                                folderName = xLocTools.FolderIDToFolderName(PtVaultStandardNodes.kHoodMembersFolder)
+                                caretValue = PtGetLocalizedString("KI.Chat.TOPrompt") + folderName + " >"
+
+                            # Only try to find in list if it was one of the 3 expected folders, not a reply command
+                            if folderName is not None:
+                                numElements = userListBox.getNumElements()
+                                folderIdx = 0
+                                while folderIdx < numElements:
+                                    if userListBox.getElement(folderIdx).casefold() == folderName.casefold():
+                                        break;
+                                    folderIdx += 1
+
+                                if folderIdx < numElements:
+                                    userListBox.setSelection(folderIdx)
+                                    caret.setStringW(caretValue)
+                                    privateChbox.setChecked(0)
+                                
+                            # Don't send an actual message because it was just a command with nothing after it
                             return None
+
                         # Return full message with special command still prefixed
                         return message
                     else:

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -986,7 +986,7 @@ class CommandsProcessor:
                                 if folderIdx < numElements:
                                     userListBox.setSelection(folderIdx)
                                     caret.setStringW(caretValue)
-                                    privateChbox.setChecked(0)
+                                    privateChbox.setChecked(False)
                                 
                             # Don't send an actual message because it was just a command with nothing after it
                             return None

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -976,14 +976,13 @@ class CommandsProcessor:
 
                             # Only try to find in list if it was one of the 3 expected folders, not a reply command
                             if folderName is not None:
-                                numElements = userListBox.getNumElements()
-                                folderIdx = 0
-                                while folderIdx < numElements:
-                                    if userListBox.getElement(folderIdx).casefold() == folderName.casefold():
-                                        break;
-                                    folderIdx += 1
-
-                                if folderIdx < numElements:
+                                try:
+                                    folderIdx = next((i for i in range(userListBox.getNumElements()) if userListBox.getElement(i).casefold() == folderName.casefold()))
+                                except StopIteration:
+                                    # Indicate an error to the user here because the KI folder was not found for some reason.
+                                    self.chatMgr.AddChatLine(None, PtGetLocalizedString("KI.Errors.CommandError", [message]), kChat.SystemMessage)
+                                    pass
+                                else:
                                     userListBox.setSelection(folderIdx)
                                     caret.setStringW(caretValue)
                                     privateChbox.setChecked(False)

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -952,7 +952,7 @@ class CommandsProcessor:
                         except:
                             PtDebugPrint("xKIChat.commandsProcessor(): Chat command function did not run.", command, level=kErrorLevel)
                 except LookupError:
-                    firstWordLower = str(words[0].casefold())
+                    firstWordLower = words[0].casefold()
                     if firstWordLower in xKIExtChatCommands.xChatSpecialHandledCommands:
                         # Get remaining message string after special chat command
                         remainingMsg = message[len(words[0]):]

--- a/Scripts/Python/ki/xKIExtChatCommands.py
+++ b/Scripts/Python/ki/xKIExtChatCommands.py
@@ -135,5 +135,6 @@ xChatSpecialHandledCommands = [
     Plasma.PtGetLocalizedString("KI.Commands.ChatPrivate"),
     Plasma.PtGetLocalizedString("KI.Commands.ChatNeighbors"),
     Plasma.PtGetLocalizedString("KI.Commands.ChatBuddies"),
+    Plasma.PtGetLocalizedString("KI.Commands.ChatAge"),
     "/r",
 ]


### PR DESCRIPTION
This allows users to change chat context for future messages without clicking on the KI folders. For example, if you are PMing/whispering to someone, then want to stop whispering and start sending future messages to all Age Players, you can switch context by using "/age\<Enter\>" and it behaves like you have clicked the AGE PLAYERS folder from your KI list.

Should be merged alongside [this moul-assets PR](https://github.com/H-uru/moul-assets/pull/95).