### PR TITLE
Guard all Win32 code in plClient

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClientLoader.cpp
+++ b/Sources/Plasma/Apps/plClient/plClientLoader.cpp
@@ -45,8 +45,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plFileSystem.h"
 #include "plPipeline.h"
 
-#include "hsWindows.h"
-#include <shellapi.h>
+#ifdef HS_BUILD_FOR_WIN32
+#   include "hsWindows.h"
+#   include <shellapi.h>
+#endif
 
 #include "plClientResMgr/plClientResMgr.h"
 #include "plNetClient/plNetClientMgr.h"
@@ -85,9 +87,11 @@ void plClientLoader::Start()
 {
     fClient->ResizeDisplayDevice(fClient->GetPipeline()->Width(), fClient->GetPipeline()->Height(), !fClient->GetPipeline()->IsFullScreen());
 
+#ifdef HS_BUILD_FOR_WIN32
     // Show the client window
     ShowWindow(fWindow, SW_SHOW);
     BringWindowToTop(fWindow);
+#endif
 
     // Now, show the intro video, patch the global ages, etc...
     fClient->BeginGame();

--- a/cmake/PlasmaTargets.cmake
+++ b/cmake/PlasmaTargets.cmake
@@ -66,7 +66,7 @@ function(plasma_executable TARGET)
 
     if(DEFINED install_destination)
         install(TARGETS ${TARGET} DESTINATION ${install_destination})
-        if(_pex_INSTALL_PDB)
+        if(_pex_INSTALL_PDB AND WIN32)
             if(MSVC)
                 set(stripped_pdb_path "$<TARGET_PDB_FILE_DIR:${TARGET}>/${TARGET}.stripped.pdb")
                 target_link_options(${TARGET} PRIVATE "/PDBSTRIPPED:${stripped_pdb_path}")


### PR DESCRIPTION
This allows plClient.cpp and plClientLoader.cpp to compile (but not link or do anything useful) on Linux.