### PR TITLE
Pull Win32-specific client code into its own cpp file

### DIFF
--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -66,8 +66,18 @@ set(plClient_SOURCES
     plClient.cpp
     plClientLoader.cpp
     pnAllCreatables.cpp
-    winmain.cpp
 )
+
+if(WIN32)
+    list(APPEND plClient_SOURCES
+        plClient_Win.cpp
+        winmain.cpp
+    )
+else()
+    list(APPEND plClient_SOURCES
+        main.cpp
+    )
+endif()
 
 set(plClient_TEXT
     ${Plasma_SOURCE_DIR}/Docs/ReleaseNotes/ReleaseNotes.txt
@@ -137,7 +147,7 @@ target_link_libraries(
         pfCharacter
         pfConsole
         pfConsoleCore
-        pfCrashHandler
+        $<$<PLATFORM_ID:Windows>:pfCrashHandler>
         pfGameGUIMgr
         pfJournalBook
         pfLocalizationMgr

--- a/Sources/Plasma/Apps/plClient/main.cpp
+++ b/Sources/Plasma/Apps/plClient/main.cpp
@@ -1,0 +1,63 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "plClient.h"
+#include "plClientLoader.h"
+
+#include "plProgressMgr/plProgressMgr.h"
+
+// Stub all of these on non-Windows for now
+void plClient::IResizeNativeDisplayDevice(int width, int height, bool windowed) {}
+void plClient::IChangeResolution(int width, int height) {}
+void plClient::IUpdateProgressIndicator(plOperationProgress* progress) {}
+void plClient::InitDLLs() {}
+void plClient::ShutdownDLLs() {}
+void plClient::ShowClientWindow() {}
+void plClient::FlashWindow() {}
+
+static plClientLoader gClient;
+
+// Stub main function so it compiles on non-Windows
+int main(int argc, const char** argv)
+{
+    return 0;
+}

--- a/Sources/Plasma/Apps/plClient/plClient.h
+++ b/Sources/Plasma/Apps/plClient/plClient.h
@@ -58,38 +58,44 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plPipeline/hsG3DDeviceSelector.h"
 #include "plScene/plRenderRequest.h"
 
-class plSceneNode;
-class plPipeline;
-class plInputManager;
-class plInputController;
-class plSceneObject;
-class pfConsoleEngine;
-class pfConsole;
-class plAudioSystem;
-class plVirtualCam1;
-class plKey;
-class plPageTreeMgr;
-class plTransitionMgr;
-class plLinkEffectsMgr;
-class plOperationProgress;
-class pfGameGUIMgr;
-class pfKI;
+class plAgeLoaded2Msg;
 struct plAnimDebugList;
-class plFontCache;
+class plAudioSystem;
 class plClientMsg;
+class pfConsole;
+class pfConsoleEngine;
+class plFactory;
+class plFontCache;
+class pfGameGUIMgr;
+class plInputController;
+class plInputManager;
+class plKey;
+class pfKI;
+class plLinkEffectsMgr;
 class plLocation;
 class plMovieMsg;
 class plMoviePlayer;
-class plPreloaderMsg;
+class plNetClientApp;
 class plNetCommAuthMsg;
-class plAgeLoaded2Msg;
+class plOperationProgress;
+class plPageTreeMgr;
+class plPipeline;
+class plPreloaderMsg;
+class hsResMgr;
 class plResPatcherMsg;
+class plSceneNode;
+class plSceneObject;
+class plTimerCallbackManager;
+class plTimerShare;
+class plTransitionMgr;
+class plVirtualCam1;
 
 typedef void (*plMessagePumpProc)();
 
 class plClient : public hsKeyedObject
 {
 protected:
+    typedef void (*pInitGlobalsFunc)(hsResMgr*, plFactory*, plTimerCallbackManager*, plTimerShare*, plNetClientApp*);
 
     class plRoomRec
     {
@@ -209,8 +215,14 @@ protected:
     void IRoomLoaded(plSceneNode* node, bool hold);
     void IRoomUnloaded(plSceneNode* node);
     void ISetGraphicsDefaults();
+    void IDetectAudioVideoSettings();
+    void IWriteDefaultAudioSettings(const plFileName& destFile);
+    void IWriteDefaultGraphicsSettings(const plFileName& destFile);
 
+    // These have platform-dependent implementations
+    void IResizeNativeDisplayDevice(int width, int height, bool windowed);
     void IChangeResolution(int width, int height);
+    void IUpdateProgressIndicator(plOperationProgress* progress);
 
 public:
 
@@ -291,12 +303,13 @@ public:
 
     bool BeginGame();
 
+    // These have platform-dependent implementations
+    void ShowClientWindow();
     void FlashWindow();
-    void    SetMessagePumpProc( plMessagePumpProc proc ) { fMessagePumpProc = proc; }
+
+    void SetMessagePumpProc(plMessagePumpProc proc) { fMessagePumpProc = proc; }
     void ResetDisplayDevice(int Width, int Height, int ColorDepth, bool Windowed, int NumAASamples, int MaxAnisotropicSamples, bool VSync = false);
     void ResizeDisplayDevice(int Width, int Height, bool Windowed);
-    void IDetectAudioVideoSettings();
-    void IWriteDefaultGraphicsSettings(const plFileName& destFile);
 
     plAnimDebugList *fAnimDebugList;
 };

--- a/Sources/Plasma/Apps/plClient/plClientLoader.cpp
+++ b/Sources/Plasma/Apps/plClient/plClientLoader.cpp
@@ -45,11 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plFileSystem.h"
 #include "plPipeline.h"
 
-#ifdef HS_BUILD_FOR_WIN32
-#   include "hsWindows.h"
-#   include <shellapi.h>
-#endif
-
 #include "plClientResMgr/plClientResMgr.h"
 #include "plNetClient/plNetClientMgr.h"
 #include "plPhysX/plSimulationMgr.h"
@@ -86,12 +81,7 @@ void plClientLoader::Run()
 void plClientLoader::Start()
 {
     fClient->ResizeDisplayDevice(fClient->GetPipeline()->Width(), fClient->GetPipeline()->Height(), !fClient->GetPipeline()->IsFullScreen());
-
-#ifdef HS_BUILD_FOR_WIN32
-    // Show the client window
-    ShowWindow(fWindow, SW_SHOW);
-    BringWindowToTop(fWindow);
-#endif
+    fClient->ShowClientWindow();
 
     // Now, show the intro video, patch the global ages, etc...
     fClient->BeginGame();

--- a/Sources/Plasma/Apps/plClient/plClient_Win.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient_Win.cpp
@@ -1,0 +1,185 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "hsWindows.h"
+#include "hsResMgr.h"
+#include "hsTimer.h"
+#include "plTimerCallbackManager.h"
+
+#include <Shlobj.h>
+#include <shellapi.h>
+
+#include "plClient.h"
+
+#include "pnFactory/plFactory.h"
+#include "pnNetCommon/plNetApp.h"
+#include "plProgressMgr/plProgressMgr.h"
+
+extern ITaskbarList3* gTaskbarList;
+static std::vector<HMODULE> fLoadedDLLs;
+
+void plClient::IResizeNativeDisplayDevice(int width, int height, bool windowed)
+{
+    uint32_t winStyle, winExStyle;
+    if (windowed) {
+        // WS_VISIBLE appears necessary to avoid leaving behind framebuffer junk when going from windowed to a smaller window
+        winStyle = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_VISIBLE;
+        winExStyle = WS_EX_APPWINDOW | WS_EX_WINDOWEDGE;
+    } else {
+        winStyle = WS_VISIBLE;
+        winExStyle = WS_EX_APPWINDOW;
+    }
+    SetWindowLongPtr(fWindowHndl, GWL_STYLE, winStyle);
+    SetWindowLongPtr(fWindowHndl, GWL_EXSTYLE, winExStyle);
+
+    uint32_t flags = SWP_NOCOPYBITS | SWP_SHOWWINDOW | SWP_FRAMECHANGED;
+    uint32_t outsideWidth, outsideHeight;
+    if (windowed) {
+        RECT winRect = { 0, 0, width, height };
+        AdjustWindowRectEx(&winRect, winStyle, false, winExStyle);
+        outsideWidth = winRect.right - winRect.left;
+        outsideHeight = winRect.bottom - winRect.top;
+    } else {
+        outsideWidth = width;
+        outsideHeight = height;
+    }
+    SetWindowPos(fWindowHndl, HWND_NOTOPMOST, 0, 0, outsideWidth, outsideHeight, flags);
+}
+
+void plClient::IChangeResolution(int width, int height)
+{
+    // First, we need to be mindful that we may not be operating on the primary display device
+    // I unfortunately cannot test this works as expected, but it will likely save us some cursing
+    HMONITOR monitor = MonitorFromWindow(fWindowHndl, MONITOR_DEFAULTTONULL);
+    if (!monitor)
+        return;
+    MONITORINFOEXW moninfo;
+    memset(&moninfo, 0, sizeof(moninfo));
+    moninfo.cbSize = sizeof(moninfo);
+    GetMonitorInfoW(monitor, &moninfo);
+
+    // Fetch a base display settings
+    DEVMODEW devmode;
+    memset(&devmode, 0, sizeof(devmode));
+    devmode.dmSize = sizeof(devmode);
+    EnumDisplaySettingsW(moninfo.szDevice, ENUM_REGISTRY_SETTINGS, &devmode);
+
+    // Actually update the resolution
+    if (width != 0 && height != 0) {
+        devmode.dmPelsWidth = width;
+        devmode.dmPelsHeight = height;
+    }
+    ChangeDisplaySettingsExW(moninfo.szDevice, &devmode, nullptr, CDS_FULLSCREEN, nullptr);
+}
+
+// Increments the taskbar progress [Windows 7+]
+void plClient::IUpdateProgressIndicator(plOperationProgress* progress)
+{
+    if (gTaskbarList && fInstance->GetWindowHandle())
+    {
+        static TBPFLAG lastState = TBPF_NOPROGRESS;
+        TBPFLAG myState;
+
+        // So, calling making these kernel calls is kind of SLOW. So, let's
+        // hide that behind a userland check--this helps linking go faster!
+        if (progress->IsAborting())
+            myState = TBPF_ERROR;
+        else if (progress->IsLastUpdate())
+            myState = TBPF_NOPROGRESS;
+        else if (progress->GetMax() == 0.f)
+            myState = TBPF_INDETERMINATE;
+        else
+            myState = TBPF_NORMAL;
+
+        if (myState == TBPF_NORMAL)
+            // This sets us to TBPF_NORMAL
+            gTaskbarList->SetProgressValue(fInstance->GetWindowHandle(), (ULONGLONG)progress->GetProgress(), (ULONGLONG)progress->GetMax());
+        else if (myState != lastState)
+            gTaskbarList->SetProgressState(fInstance->GetWindowHandle(), myState);
+        lastState = myState;
+    }
+}
+
+void plClient::InitDLLs()
+{
+    hsStatusMessage("Init dlls client\n");
+    std::vector<plFileName> dlls = plFileSystem::ListDir("ModDLL", "*.dll");
+    for (auto iter = dlls.begin(); iter != dlls.end(); ++iter)
+    {
+        HMODULE hMod = LoadLibraryW(iter->WideString().data());
+        if (hMod)
+        {
+            pInitGlobalsFunc initGlobals = (pInitGlobalsFunc)GetProcAddress(hMod, "InitGlobals");
+            (*initGlobals)(hsgResMgr::ResMgr(), plFactory::GetTheFactory(), plgTimerCallbackMgr::Mgr(),
+                hsTimer::GetTheTimer(), plNetClientApp::GetInstance());
+            fLoadedDLLs.emplace_back(hMod);
+        }
+    }
+}
+
+void plClient::ShutdownDLLs()
+{
+    for (HMODULE dll : fLoadedDLLs)
+    {
+        BOOL ret = FreeLibrary(dll);
+        if (!ret)
+            hsStatusMessage("Failed to free lib\n");
+    }
+    fLoadedDLLs.clear();
+}
+
+// Show the client window
+void plClient::ShowClientWindow()
+{
+    ShowWindow(fWindowHndl, SW_SHOW);
+    BringWindowToTop(fWindowHndl);
+}
+
+void plClient::FlashWindow()
+{
+    FLASHWINFO info;
+    info.cbSize = sizeof(info);
+    info.dwFlags = FLASHW_TIMERNOFG | FLASHW_ALL;
+    info.hwnd = fWindowHndl;
+    info.uCount = -1;
+    FlashWindowEx(&info);
+}

--- a/Sources/Plasma/NucleusLib/pnTimer/plTimedValue.h
+++ b/Sources/Plasma/NucleusLib/pnTimer/plTimedValue.h
@@ -137,14 +137,14 @@ T plTimedValue<T>::Value() const
 
 
 template <>
-void plTimedSimple<float>::Read(hsStream* s)
+inline void plTimedSimple<float>::Read(hsStream* s)
 {
     float val = s->ReadLEFloat();
     Set(val, 0.f);
 }
 
 template <>
-void plTimedSimple<float>::Write(hsStream* s) const
+inline void plTimedSimple<float>::Write(hsStream* s) const
 {
     float val = this->Value();
     s->WriteLEFloat(val);


### PR DESCRIPTION
This lays the groundwork for having cross-platform X11 and Cocoa implementations of plClient.

winmain.cpp is still a problem, so we're going to ignore that for the moment and just provide a main.cpp with an empty stub so the compiler is happy.

Note: I have not enabled building plClient on non-Windows here because it fails to link due to pnAsyncCoreExe. It should work (for _very_ loose definitions of "work" with the changes from #1032 and #1042)