### PR TITLE
Restore handling for GUIDialog4d OK button

### DIFF
--- a/Scripts/Python/xDialogStartUp.py
+++ b/Scripts/Python/xDialogStartUp.py
@@ -311,6 +311,17 @@ class xDialogStartUp(ptResponder):
                     self.PlayerListNotify(GUIDiag4b, gExp_HotSpot, 1)
 
         #################################
+        ##    Display Error Message    ##
+        #################################
+        elif id == GUIDiag4d.id:
+            if event == kAction or event == kValueChanged:
+                if tagID == k4dYesID: ## OK/Continue from Error ##
+                    self.ToggleColor(GUIDiag4b, k4bPlayer03)
+                    self.PlayerListNotify(GUIDiag4b, gExp_HotSpot, 1)
+                    PtHideDialog("GUIDialog04d")
+                    ptGUIControlButton(GUIDiag6.dialog.getControlFromTag(k6PlayID)).enable()
+
+        #################################
         ##        Create Player        ##
         #################################
         elif id == GUIDiag6.id:


### PR DESCRIPTION
Fixes #1031 by re-adding OnGUINotify handling for the error message display box's OK button. I took the missing elif code block from the current OU version of this python file and removed the antiquated gIsExplorer handling.