### PR TITLE
Allow disabling panic linking.

### DIFF
--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -1590,6 +1590,10 @@ Such as a game master, only running on the client that owns a particular object"
         """Save avatar clothing to a file"""
         pass
 
+    def setDontPanicLink(self, value: bool) -> None:
+        """Disables panic linking to Personal Age (warps the avatar back to the start instead)"""
+        pass
+
     def setMorph(self,clothing_name,layer,value):
         """Set the morph value (clipped between -1 and 1)"""
         pass

--- a/Sources/Plasma/FeatureLib/pfCamera/plVirtualCamNeu.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plVirtualCamNeu.cpp
@@ -448,6 +448,22 @@ void plVirtualCam1::SetCutNextTrans()
 #endif
 }
 
+void plVirtualCam1::SetCutNext()
+{
+    plCameraModifier1* cam = GetCurrentCamera();
+    if (cam && cam->GetBrain()) {
+        cam->GetBrain()->SetFlags(plCameraBrain1::kCutPosOnce);
+        cam->GetBrain()->SetFlags(plCameraBrain1::kCutPOAOnce);
+    }
+
+    SetFlags(kCutNextTrans);
+    SetRender(true);
+
+#ifdef STATUS_LOG
+    camLog->AddLine("Set Camera to cut on next frame");
+#endif
+}
+
 void plVirtualCam1::SetRender(bool render)
 {
     fFlags.SetBit(kRender,render);

--- a/Sources/Plasma/FeatureLib/pfCamera/plVirtualCamNeu.h
+++ b/Sources/Plasma/FeatureLib/pfCamera/plVirtualCamNeu.h
@@ -90,6 +90,7 @@ public:
     enum flags
     {
         kSetFOV,
+        /** Forces the next camera transition to be cut. */
         kCutNextTrans,
         kRender,
         kRegionIgnore,
@@ -150,6 +151,7 @@ public:
     hsPoint3 GetCameraPOA() const { return fOutputPOA; }
     hsVector3 GetCameraUp() const { return fOutputUp; }
     void    SetCutNextTrans(); // used when player warps into a new camera region
+    void    SetCutNext();
 
     const hsMatrix44 GetCurrentMatrix() { return fMatrix; }
     static plVirtualCam1* Instance() { return fInstance; }

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatar.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatar.cpp
@@ -2003,3 +2003,12 @@ bool cyAvatar::IsCurrentBrainHuman()
     }
     return false;
 }
+
+void cyAvatar::SetDontPanicLink(bool value)
+{
+    if (!fRecvr.empty()) {
+        plArmatureMod* mod = plAvatarMgr::FindAvatar(fRecvr[0]);
+        if (mod)
+            mod->SetDontPanicLinkFlag(value);
+    }
+}

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatar.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatar.h
@@ -577,6 +577,14 @@ public:
 
     static bool IsCurrentBrainHuman();
 
+    /////////////////////////////////////////////////////////////////////////////
+    //
+    //  Function   : SetDontPanicLink
+    //  PARAMETERS : value
+    //
+    //  PURPOSE    : Disables panic linking to Personal Age (warps the avatar back to the start instead)
+    //
+    void SetDontPanicLink(bool value);
 };
 
 #endif  // cyAvatar_h

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatarGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatarGlue.cpp
@@ -639,6 +639,18 @@ PYTHON_METHOD_DEFINITION(ptAvatar, loadClothingFromFile, args)
     PYTHON_RETURN_BOOL(self->fThis->LoadClothingFromFile(filename));
 }
 
+PYTHON_METHOD_DEFINITION(ptAvatar, setDontPanicLink, args)
+{
+    bool value;
+    if (!PyArg_ParseTuple(args, "b", &value)) {
+        PyErr_SetString(PyExc_TypeError, "setDontPanicLink expects a boolean");
+        PYTHON_RETURN_ERROR;
+    }
+
+    self->fThis->SetDontPanicLink(value);
+    PYTHON_RETURN_NONE;
+}
+
 PYTHON_START_METHODS_TABLE(ptAvatar)
     PYTHON_METHOD(ptAvatar, netForce, "Params: forceFlag\nSpecify whether this object needs to use messages that are forced to the network\n"
                 "- This is to be used if your Python program is running on only one client\n"
@@ -697,6 +709,8 @@ PYTHON_START_METHODS_TABLE(ptAvatar)
 
     PYTHON_METHOD(ptAvatar, saveClothingToFile, "Params: filename\nSave avatar clothing to a file"),
     PYTHON_METHOD(ptAvatar, loadClothingFromFile, "Params: filename\nLoad avatar clothing from a file"),
+
+    PYTHON_METHOD(ptAvatar, setDontPanicLink, "Params: value\nDisables panic linking to Personal Age (warps the avatar back to the start instead)"),
 PYTHON_END_METHODS_TABLE;
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtSetBehaviorLoopCount, args, "Params: behaviorKey,stage,loopCount,netForce\nThis will set the loop count for a particular stage in a multistage behavior")

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -826,10 +826,10 @@ void plArmatureMod::SpawnAt(int spawnNum, double time)
     w2l.RemoveScale();
     ci->SetTransform(l2w, w2l);
     ci->FlushTransform();
-    
-    if (plVirtualCam1::Instance())
-        plVirtualCam1::Instance()->SetCutNextTrans();
-    
+
+    if (IsLocalAvatar() && plVirtualCam1::Instance())
+        plVirtualCam1::Instance()->SetCutNext();
+
     if (GetFollowerParticleSystemSO())
     {
         // Since particles are in world space, if we've got some surrounding us, we've got to translate them to compensate for our warp.

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
@@ -233,7 +233,9 @@ public:
     virtual void PanicLink(bool playLinkOutAnim = true);
     virtual void PersonalLink();
 
-    virtual bool ToggleDontPanicLinkFlag() { fDontPanicLink = fDontPanicLink ? false : true; return fDontPanicLink; }
+    bool ToggleDontPanicLinkFlag() { fDontPanicLink = fDontPanicLink ? false : true; return fDontPanicLink; }
+
+    void SetDontPanicLinkFlag(bool value) { fDontPanicLink = value; }
 
     size_t GetBrainCount() const { return fBrains.size(); }
     plArmatureBrain *GetNextBrain(plArmatureBrain *brain);


### PR DESCRIPTION
Exposes `Avatar.Spawn.DontPanic` to Python. If enabled, instead of using the personal book, the player simply spawns back at the start of the Age. This also fixes some (but not all) longstanding problems related to spawning where the camera would zoom from across the Age when spawning.

Fixes #1056 