### PR TITLE
Small improvements for /look command and xKIConstants formatting updates

### DIFF
--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1245,33 +1245,44 @@ class CommandsProcessor:
     ## Look around for exits and informational text.
     def LookAround(self, params):
 
-        # Find the nearby people.
-        playerList = self.chatMgr.GetPlayersInChatDistance(minPlayers=-1)
-        people = "nobody in particular"
-        if len(playerList) > 0:
-            people = ""
-            for player in playerList:
-                people += player.getPlayerName() + ", "
-            people = people[:-2]
-
         # Load the Age-specific text.
         ageInfo = PtGetAgeInfo()
         if ageInfo is None:
             return
+
         currentAge = ageInfo.getAgeFilename()
         see = ""
         exits = " North and West."
+        people = ""
+        peopleVerb = "is"
         if currentAge in kEasterEggs:
             see = kEasterEggs[currentAge]["see"]
+
             if not kEasterEggs[currentAge]["exits"]:
                 exits = "... well, there are no exits."
             else:
-                exits = " " + kEasterEggs[currentAge]["exits"]
+                exits = kEasterEggs[currentAge]["exits"]
+
             if "people" in kEasterEggs[currentAge]:
                 people = kEasterEggs[currentAge]["people"]
 
+        # Find the nearby people if kEasterEggs didn't define people text override for the Age.
+        if not people:
+            playerList = self.chatMgr.GetPlayersInChatDistance(minPlayers=-1)
+            playerListLen = len(playerList)
+            people = " nobody in particular."
+            peopleVerb = "are" if playerListLen > 1 else "is"
+
+            if playerListLen > 0:
+                people = " "
+                for idx, player in enumerate(playerList):
+                    # concatenate player names together with commas (using "and" before the last name)
+                    people += player.getPlayerName() + (", " if idx != playerListLen - 2 else ", and ")
+                people = people[:-2]
+                people += "."
+
         ## Display the info.
-        self.chatMgr.AddChatLine(None, "{}: {} Standing near you is {}. There are exits to the{}".format(GetAgeName(), see, people, exits), 0)
+        self.chatMgr.AddChatLine(None, "{}: {} Standing near you {}{} There are exits to the{}".format(GetAgeName(), see, peopleVerb, people, exits), 0)
 
     ## Get a feather in the current Age.
     def GetFeather(self, params):

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1277,8 +1277,8 @@ class CommandsProcessor:
             else:
                 # concatenate player names together with commas (using "and" before the last name)
                 people = ", ".join((
-                    f"{' ' if idx == 0 else ''}{'and ' if playerListLen > 1 and idx + 1 == playerListLen else ''}"
-                    f"{player.getPlayerName()}{'.' if idx + 1 == playerListLen else ''}"
+                    f"{' ' if idx == 0 else ''}{'and ' if playerListLen > 1 and playerListLen == idx + 1 else ''}"
+                    f"{player.getPlayerName()}{'.' if playerListLen == idx + 1 else ''}"
                     for idx, player in enumerate(playerList)
                 ))
 

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1270,19 +1270,20 @@ class CommandsProcessor:
         if not people:
             playerList = self.chatMgr.GetPlayersInChatDistance(minPlayers=-1)
             playerListLen = len(playerList)
-            people = " nobody in particular."
             peopleVerb = "are" if playerListLen > 1 else "is"
 
-            if playerListLen > 0:
-                people = " "
-                for idx, player in enumerate(playerList):
-                    # concatenate player names together with commas (using "and" before the last name)
-                    people += player.getPlayerName() + (", " if idx != playerListLen - 2 else ", and ")
-                people = people[:-2]
-                people += "."
+            if playerListLen == 0:
+                people = " nobody in particular."
+            else:
+                # concatenate player names together with commas (using "and" before the last name)
+                people = ", ".join((
+                    f"{' ' if idx == 0 else ''}{'and ' if playerListLen > 1 and idx + 1 == playerListLen else ''}"
+                    f"{player.getPlayerName()}{'.' if idx + 1 == playerListLen else ''}"
+                    for idx, player in enumerate(playerList)
+                ))
 
         ## Display the info.
-        self.chatMgr.AddChatLine(None, "{}: {} Standing near you {}{} There are exits to the{}".format(GetAgeName(), see, peopleVerb, people, exits), 0)
+        self.chatMgr.AddChatLine(None, f"{GetAgeName()}: {see} Standing near you {peopleVerb}{people} There are exits to the{exits}", 0)
 
     ## Get a feather in the current Age.
     def GetFeather(self, params):

--- a/Scripts/Python/ki/xKIConstants.py
+++ b/Scripts/Python/ki/xKIConstants.py
@@ -69,86 +69,126 @@ kListLightResps = ["respKILightOff","respKILightOn" ]
 ## The name of the KI light scene object.
 kKILightObjectName = "RTOmniKILight"
 
-## The easter eggs chat commands.
+## The easter eggs chat command fill-ins.
+## Dictionary key is Age filename
+## "see": [Required] Write an entire sentence, and end it with punctuation.
+## "exits": [Required] Your text will be preceded by "There are exits to the", so
+##     prefix your text with a space if needed and end it with punctuation.
+##     Set value to None to use "... well, there are no exits."
+## "people": [Optional] Your text will be preceded by "Standing near you is", so
+##     prefix your text with a space if needed and end it with punctuation.
+##     Only define "people" for your location if you want to override default behavior
+##     of using nearby players' names or it's a private Age that has NPCs (e.g., Cleft).
+##     *Default Value*: Comma-separated list of player names from GetPlayersInChatDistance
+##         OR " nobody in particular." if there are no nearby players
 kEasterEggs = {
-               "city" : {"see" : "You see the remnants of a great civilization, ready to be rebuilt. Where are the flying monkeys?",
-                         "exits" : "NorthWest and South."},
-               "Personal" : {"see" : "You see a small hut... looks deserted.",
-                             "exits" : None},
-               "Teledahn" : {"see" : "You see 'shrooms everywhere! Big ones, small ones. Are they edible?",
-                             "exits" : "East."},
-               "Nexus" : {"see" : "You see a jukebox-like machine.",
-                          "exits" : None},
-               "Garden" : {"see" : "You see bugs. BUGS! I hate bugs.",
-                           "exits" : "North and South."},
-               "EderTsogal" : {"see" : "You see grass, water and things floating in the air (not feathers).",
-                               "exits" : "North. But you'll have to climb or fly to get there."},
-               "Dereno" : {"see" : "Ah, Dah-Ree-Toe. You see... Well, if someone would clean those stupid windows you could see a *lot*. Have I been here before? Maybe all pods just look the same.",
-                           "exits" : "SouthWest and East. But they are both blocked."},
-               "BahroCave" : {"see" : "You see a darkly lit cavern. Strange images on the wall next to you, flickering in the subdued light.Be afraid. Be very afraid!",
-                              "exits" : "North, West and East. But they are blocked by a large hole in the floor."},
-               "Minkata" : {"see" : "You see sand and dust in all directions. Above you there is a filtered sun or two... or more. Somewhere there is a horse with no name.",
-                            "exits" : "East. Nine days away."},
-               "Cleft" : {"see" : "You see sand for as far as the eye can see. Gonna need a vehicle of some sort.",
-                          "exits" : "... well, I don't know. Maybe you can ask the old man (if he ever stops listening to that music!).",
-                          "people" : "an old man. Ok, maybe he's not standing. BTW, wasn't he on M*A*S*H?"},
-               "GoMePubNew" : {"see" : "You are in a festively yet dimly lit Pub. The echoes of Messenger work and play echo along the walls of the massive main chamber.",
-                               "exits" : "... wait, where ARE the exits? Who built this place anyway?",
-                               "people" : "a large group of people...unless you are here by yourself...in which case, you don't."},
-               "ChisoPreniv" : {"see" : "All around you are bookshelves upon bookshelves but not a book to read. To the south is a large set of windows that reveal a vast landscape that you'll never be able to access.",
-                                "exits" : " ... I guess in this library, the only exit is through the window, but let's not do that"},
+    "city" : {
+        "see" : "You see the remnants of a great civilization, ready to be rebuilt. Where are the flying monkeys?",
+        "exits" : " NorthWest and South."
+    },
+    "Personal" : {
+        "see" : "You see a small hut... looks deserted.",
+        "exits" : None
+    },
+    "Teledahn" : {
+        "see" : "You see 'shrooms everywhere! Big ones, small ones. Are they edible?",
+        "exits" : " East."
+    },
+    "Nexus" : {
+        "see" : "You see a jukebox-like machine.",
+        "exits" : None
+    },
+    "Garden" : {
+        "see" : "You see bugs. BUGS! I hate bugs.",
+        "exits" : " North and South."
+    },
+    "EderTsogal" : {
+        "see" : "You see grass, water and things floating in the air (not feathers).",
+        "exits" : " North. But you'll have to climb or fly to get there."
+    },
+    "Dereno" : {
+        "see" : "Ah, Dah-Ree-Toe. You see... Well, if someone would clean those stupid windows you could see a *lot*. Have I been here before? Maybe all pods just look the same.",
+        "exits" : " SouthWest and East. But they are both blocked."
+    },
+    "BahroCave" : {
+        "see" : "You see a darkly lit cavern. Strange images on the wall next to you, flickering in the subdued light.Be afraid. Be very afraid!",
+        "exits" : " North, West and East. But they are blocked by a large hole in the floor."
+    },
+    "Minkata" : {
+        "see" : "You see sand and dust in all directions. Above you there is a filtered sun or two... or more. Somewhere there is a horse with no name.",
+        "exits" : " East. Nine days away."
+    },
+    "Cleft" : {
+        "see" : "You see sand for as far as the eye can see. Gonna need a vehicle of some sort.",
+        "exits" : "... well, I don't know. Maybe you can ask the old man (if he ever stops listening to that music!).",
+        "people" : " an old man. Ok, maybe he's not standing. BTW, wasn't he on M*A*S*H?"
+    },
+    "GoMePubNew" : {
+        "see" : "You are in a festively yet dimly lit Pub. The echoes of Messenger work and play echo along the walls of the massive main chamber.",
+        "exits" : "... wait, where ARE the exits? Who built this place anyway?",
+        "people" : " a large group of people... unless you are here by yourself... in which case, you don't."
+    },
+    "ChisoPreniv" : {
+        "see" : "All around you are bookshelves upon bookshelves but not a book to read. To the south is a large set of windows that reveal a vast landscape that you'll never be able to access.",
+        "exits" : "... I guess in this library, the only exit is through the window, but let's not do that."
+    }
 }
 
 ## Constants for Age display names.
 class kAges:
-    Display = {"Ae'gura" : "D'ni-Ae'gura",
-               "AhnonayCathedral" : "Ahnonay Cathedral",
-               "AvatarCustomization" : "Avatar Customization",
-               "BaronCityOffice" : "D'ni-Ae'gura",
-               "city" : "D'ni-Ae'gura",
-               "Cleft" : "D'ni-Riltagamin",
-               "Descent" : "D'ni-Tiwah",
-               "EderDelin" : "Eder Delin",
-               "EderTsogal" : "Eder Tsogal",
-               "Er'canaCitySilo" : "D'ni-Ashem'en",
-               "ErcanaCitySilo" : "D'ni-Ashem'en",
-               "GreatTreePub" : "D'ni-Watcher's Pub",
-               "Great Zero" : "D'ni-Rezeero",
-               "GreatZero" : "D'ni-Rezeero",
-               "GuildPub-Cartographers" : "D'ni-Cartographers' Pub",
-               "GuildPub-Greeters" : "D'ni-Greeters' Pub",
-               "GuildPub-Maintainers" : "D'ni-Maintainers' Pub",
-               "GuildPub-Messengers" : "D'ni-Messengers' Pub",
-               "GuildPub-Writers" : "D'ni-Writers' Pub",
-               "Kirel" : "D'ni-Kirel",
-               "K'veer" : "D'ni-K'veer",
-               "Kveer" : "D'ni-K'veer",
-               "Neighborhood02" : "D'ni-Kirel",
-               "Old Spy Room" : "D'ni-Ae'gura",
-               "philRelto" : "Phil's Relto",
-               "Shaft" : "D'ni-Tiwah",
-               "Spy Room" : "D'ni-Ae'gura",
-               "spyroom" : "D'ni-Ae'gura",
-##             Fan Ages
-               "Trebivdil" : "Tre'bivdil",
-               "trebivdil" : "Tre'bivdil",
-               "vothol" : "D'ni-Vothol Gallery",
-               "FehnirHouse" : "D'ni-Fehnir's House",
-               "GoMePubNew" : "D'ni-Messengers' Pub - Ae'gura",
-               "ChisoPreniv" : "Chiso Preniv",
-               "VeeTsah" : "Veelay Tsahvahn"}
+    Display = {
+        "Ae'gura" : "D'ni-Ae'gura",
+        "AhnonayCathedral" : "Ahnonay Cathedral",
+        "AvatarCustomization" : "Avatar Customization",
+        "BaronCityOffice" : "D'ni-Ae'gura",
+        "city" : "D'ni-Ae'gura",
+        "Cleft" : "D'ni-Riltagamin",
+        "Descent" : "D'ni-Tiwah",
+        "EderDelin" : "Eder Delin",
+        "EderTsogal" : "Eder Tsogal",
+        "Er'canaCitySilo" : "D'ni-Ashem'en",
+        "ErcanaCitySilo" : "D'ni-Ashem'en",
+        "GreatTreePub" : "D'ni-Watcher's Pub",
+        "Great Zero" : "D'ni-Rezeero",
+        "GreatZero" : "D'ni-Rezeero",
+        "GuildPub-Cartographers" : "D'ni-Cartographers' Pub",
+        "GuildPub-Greeters" : "D'ni-Greeters' Pub",
+        "GuildPub-Maintainers" : "D'ni-Maintainers' Pub",
+        "GuildPub-Messengers" : "D'ni-Messengers' Pub",
+        "GuildPub-Writers" : "D'ni-Writers' Pub",
+        "Kirel" : "D'ni-Kirel",
+        "K'veer" : "D'ni-K'veer",
+        "Kveer" : "D'ni-K'veer",
+        "Neighborhood02" : "D'ni-Kirel",
+        "Old Spy Room" : "D'ni-Ae'gura",
+        "philRelto" : "Phil's Relto",
+        "Shaft" : "D'ni-Tiwah",
+        "Spy Room" : "D'ni-Ae'gura",
+        "spyroom" : "D'ni-Ae'gura",
+##      Fan Ages
+        "Trebivdil" : "Tre'bivdil",
+        "trebivdil" : "Tre'bivdil",
+        "vothol" : "D'ni-Vothol Gallery",
+        "FehnirHouse" : "D'ni-Fehnir's House",
+        "GoMePubNew" : "D'ni-Messengers' Pub - Ae'gura",
+        "ChisoPreniv" : "Chiso Preniv",
+        "VeeTsah" : "Veelay Tsahvahn"
+    }
     Hide = {"BahroCave", "PelletBahroCave", "Pellet Cave", "LiveBahroCave", "LiveBahroCaves"}
-    NoInvite = {"Personal", "Nexus", "Cleft", "AvatarCustomization", "city",
-                "BahroCave", "LiveBahroCave", "LiveBahroCaves", 
-                "BaronCityOffice", "ErcanaCitySilo", "GreatZero", "Shaft",
-                "Descent", "Spyroom", "Myst"}
-    Replace = {"Ercana" : "Er'cana",
-               "Garden" : "Eder Kemo",
-               "Garrison" : "Gahreesen",
-               "Gira" : "Eder Gira",
-               "Personal" : "Relto",
-              }
-    
+    NoInvite = {
+        "Personal", "Nexus", "Cleft", "AvatarCustomization", "city",
+        "BahroCave", "LiveBahroCave", "LiveBahroCaves", 
+        "BaronCityOffice", "ErcanaCitySilo", "GreatZero", "Shaft",
+        "Descent", "Spyroom", "Myst"
+    }
+    Replace = {
+        "Ercana" : "Er'cana",
+        "Garden" : "Eder Kemo",
+        "Garrison" : "Gahreesen",
+        "Gira" : "Eder Gira",
+        "Personal" : "Relto"
+    }
+
 ## Constants used for the chat.
 class kChat:
     MaxChatSize = 2048


### PR DESCRIPTION
- Improve formatting and readability for dictionaries of constants in xKIConstants.py
- Add documentation comments for kEasterEggs dictionary in xKIConstants.py so Age creators can more easily know how to add new values without trial and error or trying to understand the python that uses it in xKIChat.py.
- Improve behavior of /look command so it does not try to get nearby player list when kEasterEggs already defined a value to display for "people".
- Improve formatting of nearby player names by conditionally using "is" or "are" depending on how many players are nearby and ending the concatenated list with ", and {lastPlayerName}" instead of ", {lastPlayerName}"