### PR TITLE
Fix #680

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -118,7 +118,10 @@ void ErrorEnableGui(bool enabled)
     s_GuiAsserts = enabled;
 }
 
-NORETURN void ErrorAssert(int line, const char* file, const char* fmt, ...)
+#if !defined(HS_DEBUGGING)
+[[noreturn]]
+#endif // defined(HS_DEBUGGING)
+void ErrorAssert(int line, const char* file, const char* fmt, ...)
 {
 #if defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
     char msg[1024];
@@ -131,6 +134,9 @@ NORETURN void ErrorAssert(int line, const char* file, const char* fmt, ...)
     {
         if (_CrtDbgReport(_CRT_ASSERT, file, line, nullptr, msg))
             DebugBreakAlways();
+
+        // All handling was done by the GUI, so bail.
+        return;
     } else
 #endif // _MSC_VER
     {
@@ -146,7 +152,9 @@ NORETURN void ErrorAssert(int line, const char* file, const char* fmt, ...)
 #endif // defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
 
     // If no debugger break occurred, just crash.
+#if !defined(HS_DEBUGGING)
     std::abort();
+#endif // defined(HS_DEBUGGING)
 }
 
 bool DebugIsDebuggerPresent()

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -376,10 +376,8 @@ constexpr float hsInvert(float a) { return 1.f / a; }
 
 #ifdef _MSC_VER
 #   define ALIGN(n) __declspec(align(n))
-#   define NORETURN __declspec(noreturn)
 #else
 #   define ALIGN(n) __attribute__((aligned(n)))
-#   define NORETURN __attribute__((noreturn))
 #endif
 
 /************************ Debug/Error Macros **************************/
@@ -393,7 +391,11 @@ extern hsDebugMessageProc gHSStatusProc;
 hsDebugMessageProc hsSetStatusMessageProc(hsDebugMessageProc newProc);
 
 void ErrorEnableGui (bool enabled);
-NORETURN void ErrorAssert (int line, const char* file, const char* fmt, ...);
+
+#ifndef HS_DEBUGGING
+[[noreturn]]
+#endif
+void ErrorAssert (int line, const char* file, const char* fmt, ...);
 
 bool DebugIsDebuggerPresent();
 void DebugBreakIfDebuggerPresent();


### PR DESCRIPTION
Imagine you are working on a Python change, such as #1058. You make a minor syntax error and the traceback is longer than 1024. With the current code, `std::abort()` is unconditionally called in debug mode, forcing everything to be murdered immediately. Potentially before you can even get the traceback logged to disk. This fixes things so you can press the "IGNORE" button on the assertion GUI and keep going.