### PR TITLE
Prevent empty command '/' or '/  ' from creating a blank message line

### DIFF
--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -893,8 +893,8 @@ class CommandsProcessor:
         if message.startswith("/"):
             words = message.split()
             # get the command word, trimming the / off the front
-            commandWord = str(words[0][1:].casefold())
-            if commandWord == "" or commandWord.isspace():
+            commandWord = words[0][1:].casefold()
+            if not commandWord or commandWord.isspace():
                 # no command after the /, so short-circuit trying to do or send anything
                 return None
 

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -892,8 +892,14 @@ class CommandsProcessor:
         # Is it an emote, a "/me" or invalid command?
         if message.startswith("/"):
             words = message.split()
+            # get the command word, trimming the / off the front
+            commandWord = str(words[0][1:].casefold())
+            if commandWord == "" or commandWord.isspace():
+                # no command after the /, so short-circuit trying to do or send anything
+                return None
+
             try:
-                emote = xKIExtChatCommands.xChatEmoteXlate[str(words[0][1:].casefold())]
+                emote = xKIExtChatCommands.xChatEmoteXlate[commandWord]
                 if emote[0] in xKIExtChatCommands.xChatEmoteLoop:
                     PtAvatarEnterAnimMode(emote[0])
                 else:
@@ -918,7 +924,7 @@ class CommandsProcessor:
                 return message[1:]
             except LookupError:
                 try:
-                    command = xKIExtChatCommands.xChatExtendedChat[str(words[0][1:].casefold())]
+                    command = xKIExtChatCommands.xChatExtendedChat[commandWord]
                     if isinstance(command, str):
                         # Retrieved command is just a plain string
                         args = message[len(words[0]):]


### PR DESCRIPTION
Calum reported on the OpenUru discord that just sending a chat line with "/" or "/   " would create a prefix-less and message-less line in the KI chat. This PR prevents this bizarre chat line from being added and short-circuits trying to find any emote or other command matches because having an empty command seems clearly invalid and should never match anything.