### PR TITLE
Allow getting PID from name for online buddies or neighbors

### DIFF
--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1016,10 +1016,18 @@ class CommandsProcessor:
             return int(params)
         except ValueError:
             for player in self.chatMgr.BKPlayerList:
+                # Age Players
                 if isinstance(player, ptPlayer):
                     plyrName = player.getPlayerName().casefold()
                     if params.casefold() == plyrName:
                         return player.getPlayerID()
+                # Buddies or Neighbors
+                elif isinstance(player, ptVaultNodeRef):
+                    plyrInfoNode = player.getChild().upcastToPlayerInfoNode()
+                    if type(plyrInfoNode) != type(None) and plyrInfoNode.getType() == PtVaultNodeTypes.kPlayerInfoNode:
+                        plyrName = plyrInfoNode.playerGetName().casefold()
+                        if params.casefold() == plyrName:
+                            return plyrInfoNode.playerGetID()
             return 0
 
     #~~~~~~~~~~~~~~~~~~~#

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1024,7 +1024,7 @@ class CommandsProcessor:
                 # Buddies or Neighbors
                 elif isinstance(player, ptVaultNodeRef):
                     plyrInfoNode = player.getChild().upcastToPlayerInfoNode()
-                    if type(plyrInfoNode) != type(None) and plyrInfoNode.getType() == PtVaultNodeTypes.kPlayerInfoNode:
+                    if plyrInfoNode is not None:
                         plyrName = plyrInfoNode.playerGetName().casefold()
                         if params.casefold() == plyrName:
                             return plyrInfoNode.playerGetID()


### PR DESCRIPTION
Previously the name-to-ID conversion would only work for Age Players due to player nodes in Buddies and Neighbors folders not being of type ptPlayer. Primarily for easier /addbuddy usage with neighbor names. Requested by Hazado on OpenUru discord.