### PR TITLE
Make `plWin32StreamingSound::GetActualTimeSec()` return correct values

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAudio/plDSoundBuffer.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plDSoundBuffer.cpp
@@ -695,9 +695,9 @@ bool    plDSoundBuffer::IsEAXAccelerated() const
 
 //// bytePosToMSecs //////////////////////////////////////////////////////////
 
-uint32_t  plDSoundBuffer::bytePosToMSecs( uint32_t bytePos ) const
+uint32_t  plDSoundBuffer::bytePosToMSecs(uint32_t bytePos) const
 {
-    return (uint32_t)(bytePos * 1000 / (float)fBufferDesc->fAvgBytesPerSec);
+    return (uint32_t)(bytePos / ((float)fBufferDesc->fAvgBytesPerSec / 1000.0f));
 }
 
 //// GetBufferBytePos ////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.cpp
@@ -440,21 +440,24 @@ void plWin32StreamingSound::IActuallyStop()
 
 unsigned plWin32StreamingSound::GetByteOffset()
 {
-    if(fDataStream && fDSoundBuffer)
-    {   
+    if (fDataStream && fDSoundBuffer)
+    {
+        uint32_t totalSize = fDataStream->GetDataSize();
+        uint32_t bytesRemaining = fDataStream->NumBytesLeft();
         unsigned bytesQueued = fDSoundBuffer->BuffersQueued() * STREAM_BUFFER_SIZE;
         unsigned offset = fDSoundBuffer->GetByteOffset();
-        long byteoffset = ((fDataStream->GetDataSize() - fDataStream->NumBytesLeft()) - bytesQueued) + offset;
-        
-        return byteoffset < 0 ? fDataStream->GetDataSize() - std::abs(byteoffset) : byteoffset;
+        long byteoffset = ((totalSize - bytesRemaining) - bytesQueued) + offset;
+
+        return byteoffset < 0 ? totalSize - std::abs(byteoffset) : byteoffset;
     }
+
     return 0;
 }
 
 float plWin32StreamingSound::GetActualTimeSec()
 {
-    if(fDataStream && fDSoundBuffer)
-        return fDSoundBuffer->bytePosToMSecs(fDataStream->NumBytesLeft()) / 1000.0f;
+    if (fDataStream && fDSoundBuffer)
+        return fDSoundBuffer->bytePosToMSecs(this->GetByteOffset()) / 1000.0f;
     return 0.0f;
 }
 


### PR DESCRIPTION
Arithmetic overflow and usage of an incorrect method were causing the `GetActualTimeSec()` method to return absurdly large values sometimes, usually for medium to long streaming audio.