### PR TITLE
Fix 3dsMax python parameters.

### DIFF
--- a/Sources/Tools/MaxComponent/plAutoUIBase.cpp
+++ b/Sources/Tools/MaxComponent/plAutoUIBase.cpp
@@ -523,7 +523,17 @@ void plAutoUIBase::ICreateControls()
 
     RECT rect;
     GetWindowRect(fhDlg, &rect);
-    MoveWindow(fhDlg, rect.left, rect.top, rect.right - rect.left, yOffset+5, FALSE);
+
+    // This used to use MoveWindow() to resize the rollup, but in Max 2022,
+    // that does not seem to work anymore. So, we now do the same thing
+    // that WM_SIZE_PANEL does.
+    IRollupWindow* rollup = GetCOREInterface()->GetCommandPanelRollup();
+    int index = rollup->GetPanelIndex(fhDlg);
+
+    if (index >= 0)
+        rollup->SetPageDlgHeight(index, yOffset + 5);
+
+    InvalidateRect(fhDlg, nullptr, TRUE);
 }
 
 void plAutoUIBase::CreateAutoRollup(IParamBlock2 *pb)


### PR DESCRIPTION
Only the first parameter was visible in Max 2022 because `MoveWindow()` was no longer resizing the rollup for some reason. Copying and pasting the method from `WM_SIZE_PANEL` fixed it, so here you go.

Before:
![image](https://user-images.githubusercontent.com/714455/153662917-b8dd0097-f61c-4e38-b5ce-09a839b0b259.png)

After:
![image](https://user-images.githubusercontent.com/714455/153663768-f34730ba-73ef-49de-95fe-632538aa76e4.png)
