### PR TITLE
Update GitHub CI to VS 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { generator: Visual Studio 16 2019, max-version: 7, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2,  str: windows-x86 }
-          - { generator: Visual Studio 16 2019, max-version: 2022, arch: x64, qt-arch: win64_msvc2019_64, qt-version: 5.15.2,  str: windows-x64 }
+          - { generator: Visual Studio 17 2022, max-version: 7, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2,  str: windows-x86 }
+          - { generator: Visual Studio 17 2022, max-version: 2022, arch: x64, qt-arch: win64_msvc2019_64, qt-version: 5.15.2,  str: windows-x64 }
         cfg:
           - { external: OFF, type: RelWithPDB, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -97,12 +97,12 @@ jobs:
       matrix:
         cfg:
           # Max 7 and 2020 are tested in the x86 and x64 windows build jobs, respectively.
-          - { sdk-version: 2008, generator: Visual Studio 16 2019, arch: Win32, str: 2008-windows-x86 }
-          - { sdk-version: 2012, generator: Visual Studio 16 2019, arch: Win32, str: 2012-windows-x86 }
-          - { sdk-version: 2013, generator: Visual Studio 16 2019, arch: x64, str: 2013-windows-x64 }
-          - { sdk-version: 2017, generator: Visual Studio 16 2019, arch: x64, str: 2017-windows-x64 }
-          - { sdk-version: 2019, generator: Visual Studio 16 2019, arch: x64, str: 2019-windows-x64 }
-          - { sdk-version: 2020, generator: Visual Studio 16 2019, arch: x64, str: 2020-windows-x64 }
+          - { sdk-version: 2008, generator: Visual Studio 17 2022, arch: Win32, str: 2008-windows-x86 }
+          - { sdk-version: 2012, generator: Visual Studio 17 2022, arch: Win32, str: 2012-windows-x86 }
+          - { sdk-version: 2013, generator: Visual Studio 17 2022, arch: x64, str: 2013-windows-x64 }
+          - { sdk-version: 2017, generator: Visual Studio 17 2022, arch: x64, str: 2017-windows-x64 }
+          - { sdk-version: 2019, generator: Visual Studio 17 2022, arch: x64, str: 2019-windows-x64 }
+          - { sdk-version: 2020, generator: Visual Studio 17 2022, arch: x64, str: 2020-windows-x64 }
 
     steps:
       - name: Checkout Plasma


### PR DESCRIPTION
GitHub Actions is moving `windows-latest` to point to the `windows-2022` runner, which includes VS 2022 rather than VS 2019.

Alternatively, we could change our CI workflow to point specifically to the `windows-2019` runner.