### PR TITLE
Mark kinematic actors as passive by default.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
@@ -285,6 +285,10 @@ bool plPXPhysical::InitActor()
     if (IsDynamic() && !GetProperty(plSimulationInterface::kNoSynchronize))
         InitSDL();
 
+    // Kinematics are driven by animations, so don't blow away the animated transform.
+    if (IsKinematic())
+        SetProperty(plSimulationInterface::kPassive, true);
+
     return true;
 }
 


### PR DESCRIPTION
This was previously done in PhysX 2.6 - I evidently forgot to include this when rewriting everything for PhysX 4.1. It fixes an issue where animated objects that are both visual and physical will jitter during the animation if re-exported from 3dsMax. See: https://www.youtube.com/watch?v=sC26AxS05PY

Equivalent to [this](https://github.com/H-uru/Plasma/blob/97b732a83c9e53961bb8220a38b4831cc555c4e4/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp#L260).