### PR TITLE
Add python/system/lib-dynload to module paths

### DIFF
--- a/Scripts/CMakeLists.txt
+++ b/Scripts/CMakeLists.txt
@@ -33,6 +33,7 @@ install(
 
     FILES_MATCHING
     PATTERN "*.py"
+    PATTERN "lib-dynload/*"
     PATTERN "*.pyc" EXCLUDE
 
     # These Python stdlib modules should be EXCLUDED from the copy due to either practical or

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -904,6 +904,7 @@ void PythonInterface::initPython()
     PyWideStringList_Append(&config.module_search_paths, L"./python");
     PyWideStringList_Append(&config.module_search_paths, L"./python/plasma");
     PyWideStringList_Append(&config.module_search_paths, L"./python/system");
+    PyWideStringList_Append(&config.module_search_paths, L"./python/system/lib-dynload");
     config.module_search_paths_set = 1;
 #endif
 


### PR DESCRIPTION
On non-Windows, some modules with C implementations are compiled as shared libraries under a lib-dynload path. These cannot be found by default, resulting in errors when scripts do things like `import math`.