### PR TITLE
Better user data paths on non-Windows

### DIFF
--- a/Sources/Plasma/CoreLib/hsThread_Unix.cpp
+++ b/Sources/Plasma/CoreLib/hsThread_Unix.cpp
@@ -51,7 +51,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #if NO_POSIX_CLOCK
 #include <sys/time.h>
 #include <unistd.h>
-#define CLOCK_REALTIME 0
+
+#ifndef CLOCK_REALTIME
+#   define CLOCK_REALTIME 0
+#endif
 
 //
 // A linux hack b/c we're not quite POSIX
@@ -86,11 +89,15 @@ hsGlobalSemaphore::hsGlobalSemaphore(int initialValue, const ST::string& name)
             throw hsOSException(errno);
         }
     } else {
+        IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+
         /* Anonymous semaphore shared between threads */
         int shared = 0; // 1 if sharing between processes
         fPSema = new sem_t;
         int status = sem_init(fPSema, shared, initialValue);
         hsThrowIfOSErr(status);
+
+        IGNORE_WARNINGS_END
     }
 #else
     int status = ::pthread_mutex_init(&fPMutex, nullptr);
@@ -110,8 +117,12 @@ hsGlobalSemaphore::~hsGlobalSemaphore()
     if (fNamed) {
         status = sem_close(fPSema);
     } else {
+        IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+
         status = sem_destroy(fPSema);
         delete fPSema;
+
+        IGNORE_WARNINGS_END
     }
     hsThrowIfOSErr(status);
 #else

--- a/Sources/Tools/plSystemInfo/main.cpp
+++ b/Sources/Tools/plSystemInfo/main.cpp
@@ -40,6 +40,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+#include "plFileSystem.h"
 #include "hsSystemInfo.h"
 
 #include <iostream>
@@ -47,6 +48,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 int main()
 {
-    std::cout << hsSystemInfo::AsString() << std::endl;
+    std::cout << hsSystemInfo::AsString() << std::endl << std::endl;
+
+    std::cout << "User Data Path: " << plFileSystem::GetUserDataPath().AsString() << std::endl;
     return 0;
 }


### PR DESCRIPTION
On macOS, this will use a more standard `~/Library/Application Support/Uru Live` path.
On Linux/Solaris/etc., this will be `~/.config/Uru Live` which matches the XDG spec.

~Uses the POSIX standard [`wordexp`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/wordexp.html) function to expand the user home path, rather than relying on the `$HOME` environment variable.~

/fyi @colincornaby