### PR TITLE
Fix Linux deprecation warnings about `<sys/sysctl.h>`

### DIFF
--- a/Sources/Plasma/CoreLib/hsSystemInfo.cpp
+++ b/Sources/Plasma/CoreLib/hsSystemInfo.cpp
@@ -56,9 +56,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifdef HAVE_SYSINFO
 #    include <sys/sysinfo.h>
 #    include <sys/utsname.h>
-#endif
-
-#ifdef HAVE_SYSCTL
+#elif defined(HAVE_SYSCTL)
 #    include <sys/types.h>
 #    include <sys/sysctl.h>
 #endif


### PR DESCRIPTION
glibc 2.32 and later no longer have `<sys/sysctl.h>` on Linux. With glibc 2.30/2.31, the header still exists, but gives a deprecation warning when included.

The hsSystemInfo code already uses `<sys/sysinfo.h>` instead if possible, but it also included `<sys/sysctl.h>` if it exists (despite not using it), giving a spurious deprecation warning with those glibc versions.