### PR TITLE
Fix var reference before assignment exception in cases like empty /r and /p

### DIFF
--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -970,6 +970,7 @@ class CommandsProcessor:
                             privateChbox = ptGUIControlCheckBox(KIMini.dialog.getControlFromTag(kGUI.miniPrivateToggle))
 
                             # Handling for selecting Age Players, Buddies, or Neighbors
+                            folderName = None
                             if firstWordLower == PtGetLocalizedString("KI.Commands.ChatAge"):
                                 folderName = xLocTools.FolderIDToFolderName(PtVaultStandardNodes.kAgeMembersFolder)
                                 caretValue = ">"


### PR DESCRIPTION
Yeah, I caused a bug with #1040 where I referenced a Python var before it was assigned a value in some cases and caused the KI to crash. Sorry. So I made sure to initialize it to None now. Found by HenryMikel on OU discord.