### PR TITLE
Fix for ENetError size on Clang/64 bit

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbError.h
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbError.h
@@ -114,7 +114,7 @@ enum ENetError: int32_t {
     kNumNetErrors,
 };
 
-//COMPILER_ASSERT_HEADER(pnNbError, sizeof(ENetError) == sizeof(uint32_t));
+static_assert(sizeof(ENetError) == sizeof(int32_t), "ENetError must be sizeof int32_t");
 
 #define IS_NET_ERROR(a)     (((int)(a)) > kNetSuccess)
 #define IS_NET_SUCCESS(a)   (((int)(a)) == kNetSuccess)

--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbError.h
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbError.h
@@ -54,7 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 // These codes may not be changed unless ALL servers, clients and databases
 // are simultaneously updated; so basically forget it =)
-enum ENetError {
+enum ENetError: int32_t {
     // codes <= 0 are not errors
     kNetPending                     = -1,
     kNetSuccess                     = 0,
@@ -112,9 +112,6 @@ enum ENetError {
     // Be sure to add strings for additional error codes in pnNbError.cpp
     // (don't worry, the compiler will tell you if one is missing ;)
     kNumNetErrors,
-
-    // Net messages require ENetError to be sizeof(uint32_t)
-    kNetErrorForceDword             = (uint32_t)(-1)
 };
 
 //COMPILER_ASSERT_HEADER(pnNbError, sizeof(ENetError) == sizeof(uint32_t));


### PR DESCRIPTION
ENetError was a 64 bit type when building with Clang on 64 bit systems. The kNetErrorForceDword value did not seem to be having any effect. My guess is MSVC might have been automatically compressing this type, and kNetErrorForceDword forced the type to be aligned with 32 bits?

This pull request is meant to be a starting point. I know this change fixed things on Clang/macOS. And kNetErrorForceDword doesn't seem needed anymore. I used int32_t instead of uint32_t. Happy to talk over any style or changes relevant to MSVC that I missed.