### PR TITLE
Add margins to KI chat display to fix shadow clipping.

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -5451,6 +5451,7 @@ class xKI(ptModifier):
             chatArea.lock()         # Make the chat display immutable.
             chatArea.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
             chatArea.disableScrollControl()
+            chatArea.setMargins(left=2, right=2)
             btnUp = ptGUIControlButton(KIMicro.dialog.getControlFromTag(kGUI.miniChatScrollUp))
             btnUp.show()
             btnUp.hide()
@@ -5516,6 +5517,7 @@ class xKI(ptModifier):
             chatArea.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
             # Hide the chat scroll buttons (should be nothing in chat area yet anyhow).
             chatArea.disableScrollControl()
+            chatArea.setMargins(left=2, right=2)
             btnUp = ptGUIControlButton(KIMini.dialog.getControlFromTag(kGUI.miniChatScrollUp))
             btnUp.show()
             privateChbox = ptGUIControlCheckBox(KIMini.dialog.getControlFromTag(kGUI.miniPrivateToggle))

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -42,7 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
  *==LICENSE==* """
 
 from __future__ import annotations
-from typing import Callable, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 def PtAcceptInviteInGame(friendName,inviteKey):
     """Sends a VaultTask to the server to perform the invite"""
@@ -4271,6 +4271,10 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """Returns the ptKey for this GUI control"""
         pass
 
+    def getMargins(self) -> Tuple[int, int, int, int]:
+        """Returns a tuple of (top, left, right, bottom) margins"""
+        pass
+
     def getObjectCenter(self):
         """Returns ptPoint3 of the center of the GUI control object"""
         pass
@@ -4402,6 +4406,10 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 
     def setForeColor(self,r,g,b,a):
         """Sets the foreground color"""
+        pass
+
+    def setMargins(self, top: Optional[int] = None, left: Optional[int] = None, bottom: Optional[int] = None, right: Optional[int] = None) -> None:
+        """Sets the control's margins"""
         pass
 
     def setNotifyOnInteresting(self,state):

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -4272,7 +4272,7 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         pass
 
     def getMargins(self) -> Tuple[int, int, int, int]:
-        """Returns a tuple of (top, left, right, bottom) margins"""
+        """Returns a tuple of (top, left, bottom, right) margins"""
         pass
 
     def getObjectCenter(self):

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -51,6 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsBounds.h"
 
 #include <string_theory/string>
+#include <tuple>
 #include <vector>
 
 #include "pfGUIControlMod.h"
@@ -290,6 +291,15 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         void    SetCursorToLoc(int32_t loc) {ISetCursor(loc);}
 
         void    SetMargins(int top, int left, int bottom, int right);
+
+        /**
+         * Returns the margins of the GUIMultiLineEdit control
+         * \return A tuple of [top, left, bottom, right] margin.
+         */
+        std::tuple<int, int, int, int> GetMargins() const
+        {
+            return std::make_tuple(fTopMargin, fLeftMargin, fBottomMargin, fRightMargin);
+        }
 
         uint8_t   GetFontSize() {return fFontSize;} // because we're too cool to use the color scheme crap
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
@@ -661,3 +661,23 @@ bool pyGUIControlMultiLineEdit::IsUpdating() const
 
     return false;
 }
+
+std::tuple<int, int, int, int> pyGUIControlMultiLineEdit::GetMargins() const
+{
+    if (fGCkey) {
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if (pbmod)
+            return pbmod->GetMargins();
+    }
+
+    return std::make_tuple(0, 0, 0, 0);
+}
+
+void pyGUIControlMultiLineEdit::SetMargins(int top, int left, int bottom, int right)
+{
+    if (fGCkey) {
+        pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
+        if (pbmod)
+            pbmod->SetMargins(top, left, bottom, right);
+    }
+}

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
@@ -52,6 +52,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGUIControl.h"
 #include "pyGlueHelpers.h"
 
+#include <tuple>
+
 class pyColor;
 
 class pyGUIControlMultiLineEdit : public pyGUIControl
@@ -121,6 +123,9 @@ public:
     void BeginUpdate();
     void EndUpdate(bool redraw);
     bool IsUpdating() const;
+
+    std::tuple<int, int, int, int> GetMargins() const;
+    void SetMargins(int top, int left, int bottom, int right);
 };
 
 #endif // _pyGUIControlMultiLineEdit_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
@@ -423,6 +423,11 @@ PYTHON_METHOD_DEFINITION_WKEY(ptGUIControlMultiLineEdit, setMargins, args, kw)
 {
     const char* kwlist[] = { "top", "left", "bottom", "right", nullptr };
     auto [top, left, bottom, right] = self->fThis->GetMargins();
+
+    // This means that any arguments not passed into the function retain their previous
+    // value. Further, there is no guarantee that any arguments have been passed in at
+    // all - the scripter might be unpacking an empty arguments dict. This case will
+    // simply be a no-op.
     if (!PyArg_ParseTupleAndKeywords(args, kw, "|iiii", const_cast<char**>(kwlist), &top, &left, &bottom, &right)) {
         PyErr_SetString(PyExc_TypeError, "setMargins expects four optional ints");
         PYTHON_RETURN_ERROR;
@@ -474,7 +479,7 @@ PYTHON_START_METHODS_TABLE(ptGUIControlMultiLineEdit)
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, beginUpdate, "Signifies that the control will be updated heavily starting now, so suppress all redraws"),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, endUpdate, "Signifies that the massive updates are over. We can now redraw."),
     PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, isUpdating, "Is someone else already suppressing redraws of the control?"),
-    PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, getMargins, "Returns a tuple of (top, left, right, bottom) margins"),
+    PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, getMargins, "Returns a tuple of (top, left, bottom, right) margins"),
     PYTHON_METHOD_WKEY(ptGUIControlMultiLineEdit, setMargins, "Sets the control's margins"),
 PYTHON_END_METHODS_TABLE;
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
@@ -413,6 +413,24 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, isUpdating)
     return PyBool_FromLong(self->fThis->IsUpdating());
 }
 
+PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, getMargins)
+{
+    auto [top, left, bottom, right] = self->fThis->GetMargins();
+    return Py_BuildValue("iiii", top, left, bottom, right);
+}
+
+PYTHON_METHOD_DEFINITION_WKEY(ptGUIControlMultiLineEdit, setMargins, args, kw)
+{
+    const char* kwlist[] = { "top", "left", "bottom", "right", nullptr };
+    auto [top, left, bottom, right] = self->fThis->GetMargins();
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "|iiii", const_cast<char**>(kwlist), &top, &left, &bottom, &right)) {
+        PyErr_SetString(PyExc_TypeError, "setMargins expects four optional ints");
+        PYTHON_RETURN_ERROR;
+    }
+    self->fThis->SetMargins(top, left, bottom, right);
+    PYTHON_RETURN_NONE;
+}
+
 PYTHON_START_METHODS_TABLE(ptGUIControlMultiLineEdit)
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, clickable, "Sets this listbox to be clickable by the user."),
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, unclickable, "Makes this listbox not clickable by the user.\n"
@@ -456,6 +474,8 @@ PYTHON_START_METHODS_TABLE(ptGUIControlMultiLineEdit)
     PYTHON_BASIC_METHOD(ptGUIControlMultiLineEdit, beginUpdate, "Signifies that the control will be updated heavily starting now, so suppress all redraws"),
     PYTHON_METHOD(ptGUIControlMultiLineEdit, endUpdate, "Signifies that the massive updates are over. We can now redraw."),
     PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, isUpdating, "Is someone else already suppressing redraws of the control?"),
+    PYTHON_METHOD_NOARGS(ptGUIControlMultiLineEdit, getMargins, "Returns a tuple of (top, left, right, bottom) margins"),
+    PYTHON_METHOD_WKEY(ptGUIControlMultiLineEdit, setMargins, "Sets the control's margins"),
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition


### PR DESCRIPTION
When chat lines did not have a leading space character, you could sometimes see that shadows were being clipped due to drawing 2 pixels out of bounds. While I generally think managing the shadow unclipping would be better in the text rendering code, Plasma's text rendering is not that smart and works on the idea that text is rendered exactly where you specify it. So, we're largely obligated to handle this kind of text positioning logic in higher level code.

This issue became very apparent when testing #1063 due to the subtitles being drawn at x=0. To illustrate...
Before:
![image](https://user-images.githubusercontent.com/714455/156687734-2908cd61-6e83-460d-b8a5-11752a6611dc.png)

After:
![image](https://user-images.githubusercontent.com/714455/156687822-9c87f56e-57d0-4d03-981a-34e3c3dcca8f.png)
