### PR TITLE
Fix KI chat not wrapping correctly after size change.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -1873,6 +1873,8 @@ void pfGUIMultiLineEditCtrl::SetFontFace(const ST::string &fontFace)
     fDynTextMap->SetFont( fFontFace, fFontSize, fFontStyle,
                             HasFlag( kXparentBgnd ) ? false : true );
     fDynTextMap->CalcStringWidth( "The quick brown fox jumped over the lazy dog.", &fLineHeight );
+    // The line length might have changed due to the new font face, so recalc the line wrapping.
+    IRecalcLineStarts(0, true);
 }
 
 void pfGUIMultiLineEditCtrl::SetFontSize(uint8_t fontSize)
@@ -1883,6 +1885,8 @@ void pfGUIMultiLineEditCtrl::SetFontSize(uint8_t fontSize)
     fDynTextMap->SetFont( fFontFace, fFontSize, fFontStyle,
                             HasFlag( kXparentBgnd ) ? false : true );
     fDynTextMap->CalcStringWidth( "The quick brown fox jumped over the lazy dog.", &fLineHeight );
+    // The line length might have changed due to the new font size, so recalc the line wrapping.
+    IRecalcLineStarts(0, true);
 }
 
 // are we showing the beginning of the buffer? (controls before us are too far up)


### PR DESCRIPTION
KI Chat lines were not re-wrapping after changing the font size. Now they will.

Bug:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/714455/157147073-772a322e-8d51-42f4-9f75-8ec74b224b91.gif)

Fixed:
![ezgif-4-7db112a8cf](https://user-images.githubusercontent.com/714455/157147085-8a5a5cf5-a250-427a-b7e9-25201868a1bf.gif)

