### PR TITLE
Fix moar Max plugin crashes.

### DIFF
--- a/Sources/Tools/MaxComponent/plAnimCompProc.cpp
+++ b/Sources/Tools/MaxComponent/plAnimCompProc.cpp
@@ -413,7 +413,7 @@ protected:
 
     void ISetUserType(plMaxNode* node, const TCHAR* userType) override
     {
-        if (_tcscmp(userType, kUserTypeAll) == 0)
+        if (userType && _tcscmp(userType, kUserTypeAll) == 0)
             ISetNodeValue(nullptr);
     }
 

--- a/Sources/Tools/MaxComponent/plAnimComponent.cpp
+++ b/Sources/Tools/MaxComponent/plAnimComponent.cpp
@@ -949,18 +949,15 @@ protected:
 
     void ISetUserType(plMaxNode* node, const TCHAR* userType) override
     {
-        if (_tcscmp(userType, _T(kUseParamBlockNodeString)) == 0)
-        {
+        if (userType && _tcscmp(userType, _T(kUseParamBlockNodeString)) == 0) {
             ISetNodeValue(nullptr);
             fPB->SetValue(fTypeID, 0, plAnimObjInterface::kUseParamBlockNode);
-        }
-        else if (_tcscmp(userType, _T(kUseOwnerNodeString)) == 0)
-        {
+        } else if (userType && _tcscmp(userType, _T(kUseOwnerNodeString)) == 0) {
             ISetNodeValue(nullptr);
             fPB->SetValue(fTypeID, 0, plAnimObjInterface::kUseOwnerNode);
-        }
-        else
+        } else {
             fPB->SetValue(fTypeID, 0, plAnimObjInterface::kUseParamBlockNode);
+        }
     }
 
 public:

--- a/Sources/Tools/MaxComponent/plGUIComponents.cpp
+++ b/Sources/Tools/MaxComponent/plGUIComponents.cpp
@@ -527,13 +527,14 @@ INT_PTR plGUITagProc::DlgProc(TimeValue t, IParamMap2 *pmap, HWND hWnd, UINT msg
 
             // Set the edit control of the combo box to only accept number characters
             edit = GetEditCtrlFromComboBox( GetDlgItem( hWnd, IDC_GUI_TAGCOMBO ) );
-            SetWindowLong( edit, GWL_STYLE, GetWindowLong( edit, GWL_STYLE ) | ES_WANTRETURN );
+            SetWindowLongPtr( edit, GWL_STYLE, GetWindowLongPtr( edit, GWL_STYLE ) | ES_WANTRETURN );
             sOriginalProc = (WNDPROC)SetWindowLongPtr(edit, GWLP_WNDPROC, (LONG_PTR)SubclassedEditProc);
             
             return TRUE;
 
         case WM_DESTROY:
-            SetWindowLongPtr(GetDlgItem(hWnd, IDC_GUI_TAGCOMBO), GWLP_WNDPROC, (LONG_PTR)sOriginalProc);
+            edit = GetEditCtrlFromComboBox(GetDlgItem(hWnd, IDC_GUI_TAGCOMBO));
+            SetWindowLongPtr(edit, GWLP_WNDPROC, (LONG_PTR)sOriginalProc);
             break;
 
         case WM_COMMAND:

--- a/Sources/Tools/MaxComponent/plNotetrackDlg.cpp
+++ b/Sources/Tools/MaxComponent/plNotetrackDlg.cpp
@@ -94,16 +94,16 @@ void plNoteTrackDlg::Load()
 
 void plNoteTrackDlg::AnimChanged()
 {
-    const char *animName = IGetSel(fhAnim);
-    fPB->SetValue(fAnimID, 0, (TCHAR*)animName);
+    ST::string animName = IGetSel(fhAnim);
+    fPB->SetValue(fAnimID, 0, ST2M(animName));
 
     ILoadLoops();
 }
 
 void plNoteTrackDlg::LoopChanged()
 {
-    const char *loopName = IGetSel(fhLoop);
-    fPB->SetValue(fLoopID, 0, (TCHAR*)loopName);
+    ST::string loopName = IGetSel(fhLoop);
+    fPB->SetValue(fLoopID, 0, ST2M(loopName));
 }
 
 void plNoteTrackDlg::ILoadAnims()
@@ -114,16 +114,14 @@ void plNoteTrackDlg::ILoadAnims()
     ComboBox_ResetContent(fhAnim);
 
     // Add the default option
-    int def = ComboBox_AddString(fhAnim, ENTIRE_ANIMATION_NAME);
+    int def = ComboBox_AddString(fhAnim, _T(ENTIRE_ANIMATION_NAME));
     ComboBox_SetItemData(fhAnim, def, kDefault);
     ComboBox_SetCurSel(fhAnim, def);
 
     if (!fSegMap)
         return;
 
-    const MCHAR* savedAnim = fPB->GetStr(fAnimID);
-    if (!savedAnim)
-        savedAnim = _M("");
+    ST::string savedAnim = M2ST(fPB->GetStr(fAnimID));
 
     // Add the names of the animations
     for (SegmentMap::iterator it = fSegMap->begin(); it != fSegMap->end(); it++)
@@ -131,11 +129,11 @@ void plNoteTrackDlg::ILoadAnims()
         SegmentSpec *spec = it->second;
         if (spec->fType == SegmentSpec::kAnim)
         {
-            int idx = ComboBox_AddString(fhAnim, spec->fName.c_str());
+            int idx = ComboBox_AddString(fhAnim, ST2T(spec->fName));
             ComboBox_SetItemData(fhAnim, idx, kName);
 
             // If this is the saved animation name, select it
-            if (!spec->fName.compare(savedAnim))
+            if (spec->fName == savedAnim)
                 ComboBox_SetCurSel(fhAnim, idx);
         }
     }
@@ -149,7 +147,7 @@ void plNoteTrackDlg::ILoadLoops()
     ComboBox_ResetContent(fhLoop);
 
     // Add the default option
-    int def = ComboBox_AddString(fhLoop, ENTIRE_ANIMATION_NAME);
+    int def = ComboBox_AddString(fhLoop, _T(ENTIRE_ANIMATION_NAME));
     ComboBox_SetItemData(fhLoop, def, kDefault);
     ComboBox_SetCurSel(fhLoop, def);
 
@@ -157,14 +155,12 @@ void plNoteTrackDlg::ILoadLoops()
     {
         // Get the animation segment (or leave it nil if we're using the entire animation)
         SegmentSpec *animSpec = nullptr;
-        ST::string animName = ST::string(fPB->GetStr(fAnimID));
+        ST::string animName = M2ST(fPB->GetStr(fAnimID));
         if (!animName.empty() && fSegMap->find(animName) != fSegMap->end())
             animSpec = (*fSegMap)[animName];
 
         // Get the saved loop name
-        const MCHAR* loopName = fPB->GetStr(fLoopID);
-        if (!loopName)
-            loopName = _M("");
+        ST::string loopName = M2ST(fPB->GetStr(fLoopID));
 
         for (SegmentMap::iterator i = fSegMap->begin(); i != fSegMap->end(); i++)
         {
@@ -176,10 +172,10 @@ void plNoteTrackDlg::ILoadLoops()
                 if (!animSpec || animSpec->Contains(spec))
                 {
                     // Add the name
-                    int idx = ComboBox_AddString(fhLoop, spec->fName.c_str());
+                    int idx = ComboBox_AddString(fhLoop, ST2T(spec->fName));
                     ComboBox_SetItemData(fhLoop, idx, kName);
 
-                    if (!spec->fName.compare(loopName))
+                    if (spec->fName == loopName)
                         ComboBox_SetCurSel(fhLoop, idx);
                 }
             }
@@ -187,15 +183,15 @@ void plNoteTrackDlg::ILoadLoops()
     }
 }
 
-const char *plNoteTrackDlg::IGetSel(HWND hCombo)
+ST::string plNoteTrackDlg::IGetSel(HWND hCombo) const
 {
     int sel = ComboBox_GetCurSel(hCombo);
     if (sel != CB_ERR && ComboBox_GetItemData(hCombo, sel) == kName)
     {
         TCHAR buf[256];
         ComboBox_GetText(hCombo, buf, std::size(buf));
-        return (*fSegMap)[ST::string(buf)]->fName.c_str();
+        return (*fSegMap)[T2ST(buf)]->fName;
     }
 
-    return "";
+    return {};
 }

--- a/Sources/Tools/MaxComponent/plNotetrackDlg.h
+++ b/Sources/Tools/MaxComponent/plNotetrackDlg.h
@@ -86,7 +86,7 @@ protected:
     void ILoadAnims();
     void ILoadLoops();
 
-    const char *IGetSel(HWND hCombo);
+    ST::string IGetSel(HWND hCombo) const;
 };
 
 

--- a/Sources/Tools/MaxComponent/plResponderAnim.cpp
+++ b/Sources/Tools/MaxComponent/plResponderAnim.cpp
@@ -709,13 +709,12 @@ protected:
 
     void ISetUserType(plMaxNode* node, const TCHAR* userType)
     {
-        if (userType && _tcscmp(userType, kResponderNodeName) == 0)
-        {
+        if (userType && _tcscmp(userType, kResponderNodeName) == 0) {
             ISetNodeValue(nullptr);
             fPB->SetValue(fTypeID, 0, kNodeResponder);
-        }
-        else
+        } else {
             fPB->SetValue(fTypeID, 0, kNodePB);
+        }
     }
 
 public:

--- a/Sources/Tools/MaxComponent/plResponderMtl.cpp
+++ b/Sources/Tools/MaxComponent/plResponderMtl.cpp
@@ -603,18 +603,15 @@ protected:
 
     void ISetUserType(plMaxNode* node, const TCHAR* userType) override
     {
-        if (_tcscmp(userType, kUserTypeAll) == 0)
-        {
+        if (userType && _tcscmp(userType, kUserTypeAll) == 0) {
             ISetNodeValue(nullptr);
             fPB->SetValue(fTypeID, 0, kNodePB);
-        }
-        else if (_tcscmp(userType, kResponderNodeName) == 0)
-        {
+        } else if (userType && _tcscmp(userType, kResponderNodeName) == 0) {
             ISetNodeValue(nullptr);
             fPB->SetValue(fTypeID, 0, kNodeResponder);
-        }
-        else
+        } else {
             fPB->SetValue(fTypeID, 0, kNodePB);
+        }
     }
 
 public:

--- a/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.cpp
+++ b/Sources/Tools/MaxPlasmaMtls/Materials/plAnimStealthNode.cpp
@@ -849,18 +849,15 @@ protected:
 
     void ISetUserType(plMaxNode* node, const TCHAR* userType) override
     {
-        if( _tcscmp( userType, _T(kUseParamBlockNodeString) ) == 0 )
-        {
+        if (userType && _tcscmp(userType, _T(kUseParamBlockNodeString)) == 0) {
             ISetNodeValue(nullptr);
             fPB->SetValue(fTypeID, 0, plAnimObjInterface::kUseParamBlockNode);
-        }
-        else if( _tcscmp(userType, _T(kUseOwnerNodeString) ) == 0 )
-        {
+        } else if (userType && _tcscmp(userType, _T(kUseOwnerNodeString)) == 0) {
             ISetNodeValue(nullptr);
             fPB->SetValue(fTypeID, 0, plAnimObjInterface::kUseOwnerNode);
-        }
-        else
+        } else {
             fPB->SetValue(fTypeID, 0, plAnimObjInterface::kUseParamBlockNode);
+        }
     }
 
 public:


### PR DESCRIPTION
Fixes Max plugin crashes reported by @Hazado:
- Hardens the pick node dialog setters against null strings, which are passed in by design.
- Fixed a crash when destroying the GUI Konstant Tag rollout in the GUI Dialog component. Likely related to 64-bit.
- Fixed more UTF-8 being reinterpreted as UCS-2 in note track related UI items.