### PR TITLE
Don't feed remaining subtitles when audio skips to past the end of last subtitle

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
@@ -106,11 +106,14 @@ void plWin32Sound::Update()
     if (buf != nullptr) {
         plSrtFileReader* srtReader = buf->GetSrtReader();
         if (srtReader != nullptr) {
-            while (plSrtEntry* nextEntry = srtReader->GetNextEntryStartingBeforeTime((uint32_t)(GetActualTimeSec() * 1000.0f))) {
-                if (plgAudioSys::AreSubtitlesEnabled()) {
-                    // add a plSubtitleMsg to go... to whoever is listening (probably the KI)
-                    plSubtitleMsg* msg = new plSubtitleMsg(nextEntry->GetSubtitleText(), nextEntry->GetSpeakerName());
-                    msg->Send();
+            uint32_t currentTimeMs = (uint32_t)(GetActualTimeSec() * 1000.0f);
+            if (currentTimeMs <= srtReader->GetLastEntryEndTime()) {
+                while (plSrtEntry* nextEntry = srtReader->GetNextEntryStartingBeforeTime((uint32_t)(GetActualTimeSec() * 1000.0f))) {
+                    if (plgAudioSys::AreSubtitlesEnabled()) {
+                        // add a plSubtitleMsg to go... to whoever is listening (probably the KI)
+                        plSubtitleMsg* msg = new plSubtitleMsg(nextEntry->GetSubtitleText(), nextEntry->GetSpeakerName());
+                        msg->Send();
+                    }
                 }
             }
         }

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
@@ -108,7 +108,7 @@ void plWin32Sound::Update()
         if (srtReader != nullptr) {
             uint32_t currentTimeMs = (uint32_t)(GetActualTimeSec() * 1000.0f);
             if (currentTimeMs <= srtReader->GetLastEntryEndTime()) {
-                while (plSrtEntry* nextEntry = srtReader->GetNextEntryStartingBeforeTime((uint32_t)(GetActualTimeSec() * 1000.0f))) {
+                while (plSrtEntry* nextEntry = srtReader->GetNextEntryStartingBeforeTime(currentTimeMs)) {
                     if (plgAudioSys::AreSubtitlesEnabled()) {
                         // add a plSubtitleMsg to go... to whoever is listening (probably the KI)
                         plSubtitleMsg* msg = new plSubtitleMsg(nextEntry->GetSubtitleText(), nextEntry->GetSpeakerName());

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plSrtFileReader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plSrtFileReader.cpp
@@ -181,3 +181,12 @@ plSrtEntry* plSrtFileReader::GetNextEntryEndingBeforeTime(uint32_t timeMs)
 
     return nullptr;
 }
+
+uint32_t plSrtFileReader::GetLastEntryEndTime()
+{
+    if (!fEntries.empty()) {
+        return fEntries.back().GetEndTimeMs();
+    }
+
+    return 0;
+}

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plSrtFileReader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plSrtFileReader.cpp
@@ -182,7 +182,7 @@ plSrtEntry* plSrtFileReader::GetNextEntryEndingBeforeTime(uint32_t timeMs)
     return nullptr;
 }
 
-uint32_t plSrtFileReader::GetLastEntryEndTime()
+uint32_t plSrtFileReader::GetLastEntryEndTime() const
 {
     if (!fEntries.empty()) {
         return fEntries.back().GetEndTimeMs();

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plSrtFileReader.h
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plSrtFileReader.h
@@ -92,6 +92,7 @@ public:
     void            AdvanceToTime(uint32_t timeMs);
     plSrtEntry*     GetNextEntryStartingBeforeTime(uint32_t timeMs);
     plSrtEntry*     GetNextEntryEndingBeforeTime(uint32_t timeMs);
+    uint32_t        GetLastEntryEndTime();
 
 protected:
 

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plSrtFileReader.h
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plSrtFileReader.h
@@ -92,7 +92,7 @@ public:
     void            AdvanceToTime(uint32_t timeMs);
     plSrtEntry*     GetNextEntryStartingBeforeTime(uint32_t timeMs);
     plSrtEntry*     GetNextEntryEndingBeforeTime(uint32_t timeMs);
-    uint32_t        GetLastEntryEndTime();
+    uint32_t        GetLastEntryEndTime() const;
 
 protected:
 


### PR DESCRIPTION
In the Yeesha Cleft speech, it appears that when you press the imager button to stop the hologram in the middle of her speech, the audio skips close to the ending position and stays there for several `Update` cycles before actually ending, which was causing the updater to feed all the remaining subtitles up to that point. This doesn't seem to be the case when Kirel podium audio is stopped, so I don't exactly know why the Yeesha audio does this. Added a check to make sure the current position/time isn't past the end of the last subtitle before requesting to display entries up to that time.

This will collide with #1096 , so please let me rebase and merge/fix before merging this one.