### PR TITLE
Fix crash when `plClipboard::SetClipboardText()` is called twice.

### DIFF
--- a/Sources/Plasma/CoreLib/hsWindows.h
+++ b/Sources/Plasma/CoreLib/hsWindows.h
@@ -107,7 +107,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
         HRESULT fResult;
 
         hsCOMError() : fResult() { }
-        hsCOMError(hsLastWin32Error_Type) : fResult(HRESULT_FROM_WIN32(GetLastError())) { }
+        hsCOMError(hsLastWin32Error_Type, DWORD error) : fResult(HRESULT_FROM_WIN32(error)) { }
         hsCOMError(HRESULT r) : fResult(r) { }
         hsCOMError& operator =(const hsCOMError&) = delete;
         hsCOMError& operator =(HRESULT r) { fResult = r; return *this; }

--- a/Sources/Plasma/CoreLib/hsWindows.h
+++ b/Sources/Plasma/CoreLib/hsWindows.h
@@ -97,12 +97,17 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     // Initializes COM exactly once the first time it's called.
     void hsRequireCOM();
 
+    /** Represents the last Win32 error. */
+    struct hsLastWin32Error_Type {};
+    constexpr hsLastWin32Error_Type hsLastWin32Error;
+
     /** COM Result holder used for formatting to log. */
     struct hsCOMError
     {
         HRESULT fResult;
 
         hsCOMError() : fResult() { }
+        hsCOMError(hsLastWin32Error_Type) : fResult(HRESULT_FROM_WIN32(GetLastError())) { }
         hsCOMError(HRESULT r) : fResult(r) { }
         hsCOMError& operator =(const hsCOMError&) = delete;
         hsCOMError& operator =(HRESULT r) { fResult = r; return *this; }

--- a/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
+++ b/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
@@ -109,10 +109,10 @@ void plClipboard::SetClipboardText(const ST::string& text)
 
     wchar_t* target = reinterpret_cast<wchar_t*>(GlobalLock(copy.get()));
     if (target == nullptr) {
-        hsAssert(0, ST::format("GlobalLock() failed:\n{}", hsCOMError(hsLastWin32Error)).c_str());
+        hsAssert(0, ST::format("GlobalLock() failed:\n{}", hsCOMError(hsLastWin32Error, GetLastError())).c_str());
         return;
     }
-    memcpy(target, buf.data(), (len + 1) * sizeof(wchar_t));
+    memcpy(target, buf.data(), len * sizeof(wchar_t));
     target[len] = L'\0';
     GlobalUnlock(copy.get());
 

--- a/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
+++ b/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
@@ -41,10 +41,12 @@ Mead, WA   99021
 *==LICENSE==*/
 
 #include "plClipboard.h"
+
+#include "HeadSpin.h"
 #include "hsWindows.h"
-#include <string_theory/string>
 
 #include <memory>
+#include <string_theory/string>
 
 plClipboard& plClipboard::GetInstance()
 {
@@ -89,29 +91,38 @@ void plClipboard::SetClipboardText(const ST::string& text)
 {
     if (text.empty())
         return;
+
 #ifdef HS_BUILD_FOR_WIN32
     ST::wchar_buffer buf = text.to_wchar();
     size_t len = buf.size();
 
-    if (len == 0) 
+    if (len == 0)
         return;
 
-    std::unique_ptr<void, HGLOBAL(WINAPI*)(HGLOBAL)> copy(::GlobalAlloc(GMEM_MOVEABLE, (len + 1) * sizeof(wchar_t)), ::GlobalFree);
+    std::unique_ptr<void, HGLOBAL(WINAPI*)(HGLOBAL)> copy(GlobalAlloc(GMEM_MOVEABLE, (len + 1) * sizeof(wchar_t)), GlobalFree);
     if (!copy)
         return;
 
-    if (!::OpenClipboard(nullptr))
+    HWND hWnd = GetActiveWindow();
+    if (!OpenClipboard(hWnd))
         return;
 
-    ::EmptyClipboard();
-
-    wchar_t* target = (wchar_t*)::GlobalLock(copy.get());
+    wchar_t* target = reinterpret_cast<wchar_t*>(GlobalLock(copy.get()));
+    if (target == nullptr) {
+        hsAssert(0, ST::format("GlobalLock() failed:\n{}", hsCOMError(hsLastWin32Error)).c_str());
+        return;
+    }
     memcpy(target, buf.data(), (len + 1) * sizeof(wchar_t));
-    target[len] = '\0';
-    ::GlobalUnlock(copy.get());
+    target[len] = L'\0';
+    GlobalUnlock(copy.get());
 
-    ::SetClipboardData(CF_UNICODETEXT, copy.get());
-    ::CloseClipboard();
+    if (SetClipboardData(CF_UNICODETEXT, copy.get()) != nullptr) {
+        // copy is now owned by the clipboard, do not destroy it.
+        // if we don't release it, then subsequent copies will crash.
+        copy.release();
+    }
+
+    CloseClipboard();
 #endif
 }
 


### PR DESCRIPTION
Found when experimenting with #1024.

Windows does not like it when you delete the HGLOBAL that you hand off to the clipboard. Subsequent calls to `GlobalLock()` will return nullptr and give the error "Invalid handle." - as in - you deleted my handle! As a bonus, cleanup some of the more C-ish aspects of this fxn.