### PR TITLE
Allow clickable URLs to begin with "www."

### DIFF
--- a/Scripts/Python/xGUILinkHandler.py
+++ b/Scripts/Python/xGUILinkHandler.py
@@ -54,10 +54,10 @@ from PlasmaTypes import *
 from xCensor import xCensor
 
 # These regexes match URLs in the format of:
-# https://(anything not a space
+# https://(anything not a space)
 # http://(anything not a space)
 # www.(anything not a space or a dot).(anything not a space)
-_HOST_REGEX = re.compile(R"(?:https?:\/\/)?(?:www\.)?([^\/]+).*", re.IGNORECASE)
+_HOST_REGEX = re.compile(R"(?:https?:\/\/)?(?:www\.)?([^\/?#]+).*", re.IGNORECASE)
 _URL_REGEX = re.compile(R"\b(?:https?:\/\/[\S]+|www\.[^\s.]+\.[^\s]+)\b", re.IGNORECASE)
 
 @dataclass

--- a/Scripts/Python/xGUILinkHandler.py
+++ b/Scripts/Python/xGUILinkHandler.py
@@ -53,8 +53,12 @@ from PlasmaTypes import *
 
 from xCensor import xCensor
 
-_HOST_REGEX = re.compile(R"https?:\/\/(?:www\.)?([^\/]+).*", re.IGNORECASE)
-_URL_REGEX = re.compile(R"https?:\/\/[\S]+", re.IGNORECASE)
+# These regexes match URLs in the format of:
+# https://(anything not a space
+# http://(anything not a space)
+# www.(anything not a space or a dot).(anything not a space)
+_HOST_REGEX = re.compile(R"(?:https?:\/\/)?(?:www\.)?([^\/]+).*", re.IGNORECASE)
+_URL_REGEX = re.compile(R"\b(?:https?:\/\/[\S]+|www\.[^\s.]+\.[^\s]+)\b", re.IGNORECASE)
 
 @dataclass
 class _Link:


### PR DESCRIPTION
The Kirel 2022 Q1 audio has subtitles of URLs that begin with only www. as the prefix. This will enable that common URL anti-pattern to also be highlighted and opened directly from the KI.

See H-uru/moul-assets#113.