### PR TITLE
Fix errors when HAVE_CPUID is false

### DIFF
--- a/Sources/Plasma/CoreLib/hsSystemInfo.cpp
+++ b/Sources/Plasma/CoreLib/hsSystemInfo.cpp
@@ -89,6 +89,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #    else
 #        define cpuid_t int
 #    endif
+#else
+#    define cpuid_t int
 #endif
 
 ST::string hsSystemInfo::AsString()


### PR DESCRIPTION
If `HAVE_CPUID` was not defined or falsey, then we would not define a value for `cpuid_t` but we would also not guard any of the code that used `cpuid_t`, leading to compilation errors from the undefined type.