### PR TITLE
Prevent unicode decode errors when hovering BigKI menu items

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -5907,7 +5907,7 @@ class xKI(ptModifier):
                 if shortTB.getStringJustify() == kRightJustify and control.isInteresting():
                     # Switch to long versions.
                     longTB.setForeColor(shortTB.getForeColor())
-                    longTB.setString(shortTB.getString())
+                    longTB.setStringW(shortTB.getStringW())
                     shortTB.hide()
                     longTB.show()
                 else:


### PR DESCRIPTION
When playing in non-English language, hovering over menu/folder items in the Big KI (showing long text rather than short text) could throw errors like this one when the text contained non-ASCII characters:
```
KIHandler - Traceback (most recent call last):
  File "ki.__init__.py", line 626, in OnGUINotify
  File "ki.__init__.py", line 5912, in ProcessNotifyBigKI
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xee in position 2: invalid continuation byte
```
To reproduce, start the client in French, open the Big KI and hover over the **Boîte de réception** (Incoming/Inbox) menu item. A non-fatal (to the KI usability) Python error occurs. It no longer occurs when this fix is in place. 🎉 