### PR TITLE
Short-circuit setting KI font size when new size is same as current size

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -2421,11 +2421,6 @@ class xKI(ptModifier):
 
         PtDebugPrint("xKI.SetFontSize(): Setting font size to {} from old size of {}.".format(fontSize, currentSize), level=kWarningLevel)
 
-        if self.KILevel < kNormalKI:
-            mKIdialog = KIMicro.dialog
-        else:
-            mKIdialog = KIMini.dialog
-
         for i in (self.chatMgr.miniChatArea, self.chatMgr.microChatArea):
             i.setFontSize(fontSize)
             i.refresh()

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -2414,7 +2414,13 @@ class xKI(ptModifier):
     ## Applies the specified font size.
     def SetFontSize(self, fontSize):
 
-        PtDebugPrint("xKI.SetFontSize(): Setting font size to {}.".format(fontSize), level=kWarningLevel)
+        currentSize = self.GetFontSize()
+        # do nothing if the requested size is our current size
+        if fontSize == currentSize:
+            return
+
+        PtDebugPrint("xKI.SetFontSize(): Setting font size to {} from old size of {}.".format(fontSize, currentSize), level=kWarningLevel)
+
         if self.KILevel < kNormalKI:
             mKIdialog = KIMicro.dialog
         else:


### PR DESCRIPTION
The Big KI's fontsize control is a weird continuous slider with only 5 distinct values. When sliding the slider, the SetFontSize method is constantly firing and presumably doing all the work and refreshing and whatnot that it does, even when the font size is exactly the same as before. At least for me, this can make the slider usage quite chunky and jerky, especially when there is a lot of text in the KI chat areas (e.g., subtitles from speeches). So... let's make it only do all the work when the new fontsize from the slider is actually different from the old value, yeah? It seems much smoother to me now, but I don't have timings or evidence to back up my claim or anything. 🤷 