### PR TITLE
Fix pfJournalBook parsing where wchar_t != 2 bytes

### DIFF
--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -2210,7 +2210,7 @@ bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wc
         return false;
 
     // Copy name
-    size_t len = ((uintptr_t)string - (uintptr_t)c)/sizeof(wchar_t);
+    size_t len = string - c;
     wcsncpy( name, c, len );
     name[len] = L'\0';
 
@@ -2230,7 +2230,7 @@ bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wc
         while( *string != L'>' && *string != L'\"' && *string != L'\0' )
             string++;
 
-        len = ((uintptr_t)string - (uintptr_t)c)/sizeof(wchar_t);
+        len = string - c;
         wcsncpy( option, c, len );
         option[len] = L'\0';
         
@@ -2245,7 +2245,7 @@ bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wc
     while( *string != L' ' && *string != L'>' && *string != L'\0' )
         string++;
 
-    len = ((uintptr_t)string - (uintptr_t)c)/sizeof(wchar_t);
+    len = string - c;
     wcsncpy( option, c, len );
     option[len] = L'\0';
     

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -2210,7 +2210,7 @@ bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wc
         return false;
 
     // Copy name
-    size_t len = ((uintptr_t)string - (uintptr_t)c)/2; // divide length by 2 because each character is two bytes
+    size_t len = ((uintptr_t)string - (uintptr_t)c)/sizeof(wchar_t);
     wcsncpy( name, c, len );
     name[len] = L'\0';
 
@@ -2230,7 +2230,7 @@ bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wc
         while( *string != L'>' && *string != L'\"' && *string != L'\0' )
             string++;
 
-        len = ((uintptr_t)string - (uintptr_t)c)/2; // divide length by 2 because each character is two bytes
+        len = ((uintptr_t)string - (uintptr_t)c)/sizeof(wchar_t);
         wcsncpy( option, c, len );
         option[len] = L'\0';
         
@@ -2245,7 +2245,7 @@ bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wc
     while( *string != L' ' && *string != L'>' && *string != L'\0' )
         string++;
 
-    len = ((uintptr_t)string - (uintptr_t)c)/2; // divide length by 2 because each character is two bytes
+    len = ((uintptr_t)string - (uintptr_t)c)/sizeof(wchar_t);
     wcsncpy( option, c, len );
     option[len] = L'\0';
     


### PR DESCRIPTION
wchar_t length can vary by compiler. On Clang/64 bit/macOS it's 4 bytes, not 2. This was causing parsing to fail.

With this change linking books are now rendering properly on Mac/Metal and are linkable. Other books that weren't rendering correctly (like the welcome book in Great Zero) are now rendering in the correct font. I haven't done a full comparison with the Windows version yet so I don't want to label those books as correctly rendering yet.

Also possible more wchar_t issues could be lurking. There is still some funny behavior in places like key mapping that may or may not be related. I haven't really investigated yet, but if the assumption was made wchar_t is always two bytes, that could show up elsewhere.