### PR TITLE
Fixing clipped char calc under Clang

### DIFF
--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -1206,8 +1206,7 @@ void    plFont::CalcStringExtents( const wchar_t *string, uint16_t &width, uint1
 
     // firstClippedChar is an index into the given string that points to the start of the part of the string
     // that got clipped (i.e. not rendered).
-    firstClippedChar = (uint32_t)((uintptr_t)fRenderInfo.fVolatileStringPtr - (uintptr_t)string);
-    firstClippedChar /= 2; // divide by 2 because a wchar_t is two bytes wide, instead of one (like a char)
+    firstClippedChar = fRenderInfo.fVolatileStringPtr - string;
 }
 
 //// IGetFreeCharData /////////////////////////////////////////////////////////


### PR DESCRIPTION
Clipped character calculation is being done with pointer math, but assumes that wchar_t is 2 bytes.

Windows and Mac are now rendering books identically (in the books I've seen so far.)