### PR TITLE
Add clipboard support to the console.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfConsole/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(
         plAnimation
         plAudio
         plAvatar
+        plClipboard
         plDrawable
         plGImage
         plGLight

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -557,8 +557,6 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
     else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_V)
     {
         ST::string text = plClipboard::GetInstance().GetClipboardText();
-        if (text.empty())
-            return;
 
         // Chop off leading or trailing newlines, which are probably not intended.
         text = text.trim("\r\n");
@@ -630,9 +628,11 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
         {
             // FIXME: make the console unicode friendly.
             IHandleCharacter((char)key);
-            findAgain = false;
-            findCounter = 0;
-            IUpdateTooltip();
+            if (strnlen(fWorkingLine, std::size(fWorkingLine)) < kMaxCharsWide - 2 && key != 0) {
+                findAgain = false;
+                findCounter = 0;
+                IUpdateTooltip();
+            }
         }
     }
 }
@@ -650,7 +650,7 @@ void    pfConsole::IHandleCharacter(const char c)
     size_t i = strnlen(fWorkingLine, std::size(fWorkingLine));
 
     // The current working line is too long. Ignore this character.
-    if (!(i < kMaxCharsWide - 2 && c != '\0'))
+    if (i >= kMaxCharsWide - 2 || c == '\0')
         return;
 
     // Advance any trailing characters one space to make room for the new character.

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -540,6 +540,20 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
     {
         fWorkingCursor = 0;
     }
+    else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_C)
+    {
+        // FIXME: console unicode friendly
+        plClipboard::GetInstance().SetClipboardText(ST::string::from_latin_1(fWorkingLine));
+    }
+    else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_X)
+    {
+        // FIXME: console unicode friendly
+        plClipboard::GetInstance().SetClipboardText(ST::string::from_latin_1(fWorkingLine));
+        fWorkingLine[fWorkingCursor = 0] = 0;
+        findAgain = false;
+        findCounter = 0;
+        IUpdateTooltip();
+    }
     else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_V)
     {
         ST::string text = plClipboard::GetInstance().GetClipboardText();

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -560,6 +560,11 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
         if (text.empty())
             return;
 
+        // Chop off leading or trailing newlines, which are probably not intended.
+        text = text.trim("\r\n");
+        if (text.empty())
+            return;
+
         // FIXME: Unfortunately, the console is currently limited to single byte
         //        characters. Remove this when the console is unicode safe.
         ST::char_buffer buf = text.to_latin_1(ST::utf_validation_t::substitute_invalid);

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.h
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.h
@@ -113,6 +113,7 @@ class pfConsole : public hsKeyedObject
         pfConsoleEngine     *fEngine;
 
         void    IHandleKey( plKeyEventMsg *msg );
+        void    IHandleCharacter(const char c);
 
         static uint32_t       fConsoleTextColor;
         static pfConsole    *fTheConsole;
@@ -130,6 +131,7 @@ class pfConsole : public hsKeyedObject
 
         void    IPrintSomeHelp();
         void    IUpdateTooltip();
+        void    IExecuteWorkingLine();
 
     public:
 

--- a/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
+++ b/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
@@ -76,9 +76,12 @@ ST::string plClipboard::GetClipboardText()
     size_t size = ::GlobalSize(clipboardData) / sizeof(wchar_t);
     wchar_t* clipboardDataPtr = (wchar_t*)::GlobalLock(clipboardData);
 
-    ST::string result = ST::string::from_wchar(clipboardDataPtr, size);
+    // Per MSDN, with CF_UNICODETEXT: "A null character signals the end of the data."
+    // This null character is included in size. Be sure to NOT include it in the size
+    // we give to ST, or we will get a double null terminator.
+    ST::string result = ST::string::from_wchar(clipboardDataPtr, size - 1);
 
-    ::GlobalUnlock(clipboardData);	
+    ::GlobalUnlock(clipboardData);
     ::CloseClipboard();
 
     return result;


### PR DESCRIPTION
A lot of the changes are just churn to avoid duplicating console logic. Unfortunately, this does not attempt to make the console unicode friendly. The console still uses the ACP.

If you paste multi-line text into the console, you will get this prompt:
![image](https://user-images.githubusercontent.com/714455/162599451-c6cebdcd-2919-4c18-b015-e8c6e986702c.png)
and all intervening lines (ie all but the last) are executed.

Fixes #1113.