### PR TITLE
Allow usage of /textcolor command to override chat area text colors

### DIFF
--- a/Scripts/Python/ki/xKIConstants.py
+++ b/Scripts/Python/ki/xKIConstants.py
@@ -69,6 +69,10 @@ kListLightResps = ["respKILightOff","respKILightOn" ]
 ## The name of the KI light scene object.
 kKILightObjectName = "RTOmniKILight"
 
+## The color names usable to set the KI text color override
+## TODO: Can/should these be localized somehow? Would need conversion back to English before used as the ptColor method names.
+kColorNames = set(["black", "blue", "brown", "cyan", "darkbrown", "darkgreen", "darkpurple", "gray", "green", "magenta", "maroon", "navyblue", "orange", "pink", "red", "slateblue", "steelblue", "tan", "white", "yellow"])
+
 ## The easter eggs chat command fill-ins.
 ## Dictionary key is Age filename
 ## "see": [Required] Write an entire sentence, and end it with punctuation.
@@ -286,29 +290,30 @@ class kColors:
 ## Constants for KI Chat commands.
 class kCommands:
     Localized = {PtGetLocalizedString("KI.Commands.ChatClearAll") : "ClearChat",
-                 PtGetLocalizedString("KI.Commands.ChatStartLog") : "StartLog",
-                 PtGetLocalizedString("KI.Commands.ChatStopLog") : "StopLog",
-                 PtGetLocalizedString("KI.Commands.AddBuddy") : "AddBuddy",
-                 PtGetLocalizedString("KI.Commands.RemoveBuddy") : "RemoveBuddy",
-                 PtGetLocalizedString("KI.Commands.Ignore") : "IgnorePlayer",
-                 PtGetLocalizedString("KI.Commands.Unignore") : "UnignorePlayer",
-                 PtGetLocalizedString("KI.Commands.DumpLogs") : "DumpLogs",
-                 PtGetLocalizedString("KI.Commands.DumpLog") : "DumpLogs",
-                 PtGetLocalizedString("KI.Commands.ChangePassword") : "ChangePassword"}
+        PtGetLocalizedString("KI.Commands.ChatSetTextColor") : "SetTextColor",
+        PtGetLocalizedString("KI.Commands.ChatStartLog") : "StartLog",
+        PtGetLocalizedString("KI.Commands.ChatStopLog") : "StopLog",
+        PtGetLocalizedString("KI.Commands.AddBuddy") : "AddBuddy",
+        PtGetLocalizedString("KI.Commands.RemoveBuddy") : "RemoveBuddy",
+        PtGetLocalizedString("KI.Commands.Ignore") : "IgnorePlayer",
+        PtGetLocalizedString("KI.Commands.Unignore") : "UnignorePlayer",
+        PtGetLocalizedString("KI.Commands.DumpLogs") : "DumpLogs",
+        PtGetLocalizedString("KI.Commands.DumpLog") : "DumpLogs",
+        PtGetLocalizedString("KI.Commands.ChangePassword") : "ChangePassword"}
     Jalak = {"/savecolumns" : "SaveColumns",
              "/loadcolumns" : "LoadColumns"}
     Internal = {"/revisitcleft" : "RevisitCleft",
-                "/restart" : "RestartGame",
+        "/restart" : "RestartGame",
                 "/gamereward" : "MarkerGameReward"}
     EasterEggs = {"/look" : "LookAround",
-                  "/get feather" : "GetFeather",
-                  "/look in pocket" : "LookForFeathers"}
+        "/get feather" : "GetFeather",
+        "/look in pocket" : "LookForFeathers"}
     Text = {"/go" : "Put one foot in front of the other and eventually you will get there.",
             "/fly" : "You close your eyes, you feel light headed and the ground slips away from your feet... Then you open your eyes and WAKE UP! (Ha, you can only dream about flying.)"}
     Other = {"/party" : "PartyTime",
-             "/saveclothing" : "SaveClothing",
-             "/loadclothing" : "LoadClothing",
-             "/threaten" : "CoopExample",
+        "/saveclothing" : "SaveClothing",
+        "/loadclothing" : "LoadClothing",
+        "/threaten" : "CoopExample",
              "/roll": "RollDice"}
 
 ## Numeric limits for the KI.


### PR DESCRIPTION
Needs to be merged with its paired assets (LOCs) PR: https://github.com/H-uru/moul-assets/pull/119

URL/Link color is not affected. Changing that will be a hairier deal than the overriding the other colors and I was rather doubtful that making the clickable links blend into the other text was The Right Thing To Do. Open to opinions.

Also need to decide whether to make the `kColorNames` constant a dictionary with localized keys for translated color names and dictionary values as the color names required to use with `ptColor`. Or something like that... to support non-English color naming.