### PR TITLE
Customize the libepoxy vcpkg port

### DIFF
--- a/Scripts/Ports/libepoxy/portfile.cmake
+++ b/Scripts/Ports/libepoxy/portfile.cmake
@@ -1,0 +1,43 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+endif()
+
+if(VCPKG_TARGET_IS_LINUX AND NOT EXISTS "/usr/share/doc/libgles2/copyright")
+    message(STATUS "libgles2-mesa-dev must be installed before libepoxy can build. Install it with \"apt-get install libgles2-mesa-dev\".")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO anholt/libepoxy
+    REF 1.5.10
+    SHA512 6786f31c6e2865e68a90eb912900a86bf56fd3df4d78a477356886ac3b6ef52ac887b9c7a77aa027525f868ae9e88b12e5927ba56069c2e115acd631fca3abee
+    HEAD_REF master
+    PATCHES
+        threading.patch
+)
+
+# TODO: Enable EGL on Windows
+if (VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_OSX)
+    set(OPTIONS -Dglx=no -Degl=no -Dx11=false)
+else()
+    set(OPTIONS -Dglx=yes -Degl=yes -Dx11=true)
+endif()
+if(VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND OPTIONS -Dc_std=c99)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+        -Dtests=false
+)
+vcpkg_install_meson()
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/Scripts/Ports/libepoxy/threading.patch
+++ b/Scripts/Ports/libepoxy/threading.patch
@@ -1,0 +1,177 @@
+https://github.com/anholt/libepoxy/pull/265
+From: gjz010 <gjz010944@gmail.com>
+
+diff --git a/src/dispatch_common.h b/src/dispatch_common.h
+index a136943..3449b22 100644
+--- a/src/dispatch_common.h
++++ b/src/dispatch_common.h
+@@ -23,12 +23,18 @@
+ 
+ #include "config.h"
+ 
++#ifdef __GNUC__
++#define EPOXY_THREADLOCAL __thread
++#elif defined (_MSC_VER)
++#define EPOXY_THREADLOCAL __declspec(thread)
++#endif
++
+ #ifdef _WIN32
+ #define PLATFORM_HAS_EGL ENABLE_EGL
+ #define PLATFORM_HAS_GLX ENABLE_GLX
+ #define PLATFORM_HAS_WGL 1
+ #elif defined(__APPLE__)
+-#define PLATFORM_HAS_EGL 0 
++#define PLATFORM_HAS_EGL 0
+ #define PLATFORM_HAS_GLX ENABLE_GLX
+ #define PLATFORM_HAS_WGL 0
+ #elif defined(ANDROID)
+diff --git a/src/dispatch_wgl.c b/src/dispatch_wgl.c
+index 7baf130..dc1b0c4 100644
+--- a/src/dispatch_wgl.c
++++ b/src/dispatch_wgl.c
+@@ -27,9 +27,6 @@
+ 
+ #include "dispatch_common.h"
+ 
+-static bool first_context_current = false;
+-static bool already_switched_to_dispatch_table = false;
+-
+ /**
+  * If we can determine the WGL extension support from the current
+  * context, then return that, otherwise give the answer that will just
+@@ -75,71 +72,10 @@
+ void
+ epoxy_handle_external_wglMakeCurrent(void)
+ {
+-    if (!first_context_current) {
+-        first_context_current = true;
+-    } else {
+-        if (!already_switched_to_dispatch_table) {
+-            already_switched_to_dispatch_table = true;
+-            gl_switch_to_dispatch_table();
+-            wgl_switch_to_dispatch_table();
+-        }
+-
+-        gl_init_dispatch_table();
+-        wgl_init_dispatch_table();
+-    }
++    gl_init_dispatch_table();
++    wgl_init_dispatch_table();
+ }
+ 
+-/**
+- * This global symbol is apparently looked up by Windows when loading
+- * a DLL, but it doesn't declare the prototype.
+- */
+-BOOL WINAPI
+-DllMain(HINSTANCE dll, DWORD reason, LPVOID reserved);
+-
+-BOOL WINAPI
+-DllMain(HINSTANCE dll, DWORD reason, LPVOID reserved)
+-{
+-    void *data;
+-
+-    switch (reason) {
+-    case DLL_PROCESS_ATTACH:
+-        gl_tls_index = TlsAlloc();
+-        if (gl_tls_index == TLS_OUT_OF_INDEXES)
+-            return FALSE;
+-        wgl_tls_index = TlsAlloc();
+-        if (wgl_tls_index == TLS_OUT_OF_INDEXES)
+-            return FALSE;
+-
+-        first_context_current = false;
+-
+-        /* FALLTHROUGH */
+-
+-    case DLL_THREAD_ATTACH:
+-        data = LocalAlloc(LPTR, gl_tls_size);
+-        TlsSetValue(gl_tls_index, data);
+-
+-        data = LocalAlloc(LPTR, wgl_tls_size);
+-        TlsSetValue(wgl_tls_index, data);
+-
+-        break;
+-
+-    case DLL_THREAD_DETACH:
+-    case DLL_PROCESS_DETACH:
+-        data = TlsGetValue(gl_tls_index);
+-        LocalFree(data);
+-
+-        data = TlsGetValue(wgl_tls_index);
+-        LocalFree(data);
+-
+-        if (reason == DLL_PROCESS_DETACH) {
+-            TlsFree(gl_tls_index);
+-            TlsFree(wgl_tls_index);
+-        }
+-        break;
+-    }
+-
+-    return TRUE;
+-}
+ 
+ WRAPPER_VISIBILITY (BOOL)
+ WRAPPER(epoxy_wglMakeCurrent)(HDC hdc, HGLRC hglrc)
+diff --git a/src/gen_dispatch.py b/src/gen_dispatch.py
+index 3daad84..ed0fb95 100755
+--- a/src/gen_dispatch.py
++++ b/src/gen_dispatch.py
+@@ -639,7 +639,7 @@
+                                                                        func.args_list))
+ 
+     def write_function_pointer(self, func):
+-        self.outln('{0} epoxy_{1} = epoxy_{1}_global_rewrite_ptr;'.format(func.ptr_type, func.wrapped_name))
++        self.outln('{0} epoxy_{1} = EPOXY_DISPATCH_PTR(epoxy_{1});'.format(func.ptr_type, func.wrapped_name))
+         self.outln('')
+ 
+     def write_provider_enums(self):
+@@ -816,7 +816,11 @@
+             self.write_thunks(func)
+         self.outln('')
+ 
++        self.outln('#define EPOXY_DISPATCH_PTR(name) name##_global_rewrite_ptr')
++
+         self.outln('#if USING_DISPATCH_TABLE')
++        self.outln('#undef EPOXY_DISPATCH_PTR')
++        self.outln('#define EPOXY_DISPATCH_PTR(name) name##_dispatch_table_thunk')
+ 
+         self.outln('static struct dispatch_table resolver_table = {')
+         for func in self.sorted_functions:
+@@ -824,14 +828,15 @@
+         self.outln('};')
+         self.outln('')
+ 
+-        self.outln('uint32_t {0}_tls_index;'.format(self.target))
+-        self.outln('uint32_t {0}_tls_size = sizeof(struct dispatch_table);'.format(self.target))
+-        self.outln('')
++        self.outln('EPOXY_THREADLOCAL struct dispatch_table {0}_tls_data = {{'.format(self.target))
++        for func in self.sorted_functions:
++            self.outln('    epoxy_{0}_dispatch_table_rewrite_ptr, /* {0} */'.format(func.wrapped_name))
++        self.outln('};')
+ 
+         self.outln('static inline struct dispatch_table *')
+         self.outln('get_dispatch_table(void)')
+         self.outln('{')
+-        self.outln('	return TlsGetValue({0}_tls_index);'.format(self.target))
++        self.outln('	return &{0}_tls_data;'.format(self.target))
+         self.outln('}')
+         self.outln('')
+ 
+@@ -843,16 +848,6 @@
+         self.outln('}')
+         self.outln('')
+ 
+-        self.outln('void')
+-        self.outln('{0}_switch_to_dispatch_table(void)'.format(self.target))
+-        self.outln('{')
+-
+-        for func in self.sorted_functions:
+-            self.outln('    epoxy_{0} = epoxy_{0}_dispatch_table_thunk;'.format(func.wrapped_name))
+-
+-        self.outln('}')
+-        self.outln('')
+-
+         self.outln('#endif /* !USING_DISPATCH_TABLE */')
+ 
+         for func in self.sorted_functions:

--- a/Scripts/Ports/libepoxy/vcpkg.json
+++ b/Scripts/Ports/libepoxy/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "libepoxy",
+  "version-semver": "1.5.10",
+  "port-version": 1,
+  "description": "Epoxy is a library for handling OpenGL function pointer management for you",
+  "homepage": "https://github.com/anholt/libepoxy",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
- Resolve multithreading issues
- Enable building as a static library

Unfortunately, using it as a static library causes linking errors, so we're keeping the line that forces it to be a dynamic library on Windows.

Ref: https://github.com/anholt/libepoxy/pull/265