### PR TITLE
Only allow marker game title editing during edit mode

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -4879,6 +4879,7 @@ class xKI(ptModifier):
             mbtnMarkerText.disable()
         # Is the player editing a Marker Game?
         elif self.MFdialogMode == kGames.MFEditing or self.MFdialogMode == kGames.MFEditingMarker:
+            mrkfldTitleBtn.show()
             mrkfldTitleBtn.enable()
             mbtnDelete.hide()
             mbtnGameTimePullD.hide()
@@ -5014,9 +5015,6 @@ class xKI(ptModifier):
         # Display the content on the screen.
         mrkfldTitle.setStringW(xCensor.xCensor(element.getGameName(), self.censorLevel))
         mrkfldTitle.show()
-        # Enable the editable Title.
-        mrkfldTitleBtn.show()
-        mrkfldTitleBtn.enable()
 
         count = mgr.marker_total
         if self.MFdialogMode == kGames.MFEditing or self.MFdialogMode == kGames.MFEditingMarker:


### PR DESCRIPTION
Previously editing a game title was allowed at any time. This makes it work like the OU client will now, where only the owner can edit the title and only during editing mode. I don't know if H'uru was previously allowing non-owners to edit the titles since I only had self-created games to test, but... now they can't, I guess.