### PR TITLE
Fix 3dsMax crash caused by Garrison Wall.

### DIFF
--- a/Scripts/Python/grsnWallEventHandler.py
+++ b/Scripts/Python/grsnWallEventHandler.py
@@ -73,12 +73,13 @@ class grsnWallEventHandler(ptResponder):
         self.id = 763327
         self.version = 1
         self.BlockersHit = 0
-        self.startTime = PtGetDniTime()
+        self.startTime = 0
         self.BlockerSfxBlock = True
         InitEventHandler(self)
 
     def OnServerInitComplete(self):
         PtDebugPrint("grsnWallEventHandler::OnServerInitComplete")
+        self.startTime = PtGetDniTime()
         ageSDL = PtGetAgeSDL()
         ageSDL.setNotify(self.key, "nState", 0.0)
         ageSDL.setNotify(self.key, "sState", 0.0)


### PR DESCRIPTION
Plasma functions should never be executed in the constructor. This is because you may not be executing in the client... for example, it might be a type checker or test tool. In this case, the network client is not initialized, so the call to `PtGetDniTime()` explodes.