### PR TITLE
Fix for divide by zero breaking Mac/Vee Tsah

### DIFF
--- a/Sources/Plasma/PubUtilLib/plSurface/plShader.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plShader.cpp
@@ -139,17 +139,17 @@ void plShader::SetColor(size_t i, const hsColorRGBA& col)
 void plShader::SetVector(size_t i, const hsScalarTriple& vec)
 {
     /* Doesn't touch .fW */
-    fConsts[i].fX = vec.fX;
-    fConsts[i].fY = vec.fY;
-    fConsts[i].fZ = vec.fZ;
+    fConsts[i].fX = std::clamp(vec.fX, -FLT_MAX, FLT_MAX);
+    fConsts[i].fY = std::clamp(vec.fY, -FLT_MAX, FLT_MAX);
+    fConsts[i].fZ = std::clamp(vec.fZ, -FLT_MAX, FLT_MAX);
 }
 
 void plShader::SetVector(size_t i, float x, float y, float z, float w)
 {
-    fConsts[i].x = x;
-    fConsts[i].y = y;
-    fConsts[i].z = z;
-    fConsts[i].w = w;
+    fConsts[i].x = std::clamp(x, -FLT_MAX, FLT_MAX);
+    fConsts[i].y = std::clamp(y, -FLT_MAX, FLT_MAX);
+    fConsts[i].z = std::clamp(z, -FLT_MAX, FLT_MAX);
+    fConsts[i].w = std::clamp(w, -FLT_MAX, FLT_MAX);
 }
 
 void plShader::SetFloat(size_t i, int chan, float v)
@@ -159,10 +159,10 @@ void plShader::SetFloat(size_t i, int chan, float v)
 
 void plShader::SetFloat4(size_t i, const float* const f)
 {
-    fConsts[i].fX = f[0];
-    fConsts[i].fY = f[1];
-    fConsts[i].fZ = f[2];
-    fConsts[i].fW = f[3];
+    fConsts[i].fX = std::clamp(f[0], -FLT_MAX, FLT_MAX);
+    fConsts[i].fY = std::clamp(f[1], -FLT_MAX, FLT_MAX);
+    fConsts[i].fZ = std::clamp(f[2], -FLT_MAX, FLT_MAX);
+    fConsts[i].fW = std::clamp(f[3], -FLT_MAX, FLT_MAX);
 }
 
 plFloat44 plShader::GetMatrix(size_t i) const


### PR DESCRIPTION
This divide by zero was resolving to a INF value, which was causing the shader to generate garbage. Changing the divide by zero to non IEEE behavior which aligns with what HLSL 1.1 seems to expect. Metal inherits the IEEE behavior which causes problems.

More background - 

I've been trying to figure out why this hasn't caused problems in HLSL. My best guess is that HLSL treats divide by zero as a FLT_MAX result. The documentation for the rcp instruction in HLSL seems to make this explicit:
https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/rcp---vs

This also differs a bit from IEEE behavior where the sign of the denominator should be carried to the result. I'm mostly guessing at how DX Classic would interpret an IEEE float when loading into a shader that doesn't support IEEE. Following the HLSL 1.1 rules, I'm setting the value to FLT_MAX when the denominator is zero. If anyone has insights, that would be appreciated.

I haven't tested this change on Windows, but it fixes the water on Mac/Metal.

This likely is not the only divide by zero/shader issue lurking. But this one was breaking Vee Tsah on Mac. Vee Tsah also won't run under VMWare with a Windows guest, and I'm guessing this might have something to do with that. This would be tricky nuance for a translation layer to deal with.