### PR TITLE
Ensure emotes and afk message are shown in receiver's localization

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -997,21 +997,24 @@ class xKI(ptModifier):
             if cFlags.broadcast and cFlags.channel != self.chatMgr.privateChatChannel:
                 return
 
-            # Is the message from an ignored plaer?
+            # Is the message from an ignored player?
             vault = ptVault()
             ignores = vault.getIgnoreListFolder()
             if ignores is not None and ignores.playerlistHasPlayer(player.getPlayerID()):
                 return
+
+            if cFlags.lockey:
+                keys = message.split(":")
+                message = PtGetLocalizedString(keys[0], [player.getPlayerName(), PtGetLocalizedString(keys[1] if len(keys) > 1 else "KI.EmoteStrings.Their")])
 
             # Display the message if it passed all the above checks.
             self.chatMgr.AddChatLine(player, message, cFlags, forceKI=not self.sawTheKIAtLeastOnce)
 
             # If they are AFK and the message was directly to them, send back their state to sender.
             try:
-                if self.KIDisabled or PtGetLocalAvatar().avatar.getCurrentMode() == PtBrainModes.kAFK and cFlags.private and not cFlags.toSelf:
-                    myself = PtGetLocalPlayer()
-                    AFKSelf = ptPlayer(myself.getPlayerName() + PtGetLocalizedString("KI.Chat.AFK"), myself.getPlayerID())
-                    PtSendRTChat(AFKSelf, [player], " ", cFlags.flags)
+                if (self.KIDisabled or PtGetLocalAvatar().avatar.getCurrentMode() == PtBrainModes.kAFK) and cFlags.private and not cFlags.lockey:
+                    cFlags.lockey = True
+                    PtSendRTChat(PtGetLocalPlayer(), [player], "KI.Chat.AFK", cFlags.flags)
             except NameError:
                 pass
 

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1004,8 +1004,8 @@ class xKI(ptModifier):
                 return
 
             if cFlags.lockey:
-                keys = message.split(":")
-                message = PtGetLocalizedString(keys[0], [player.getPlayerName(), PtGetLocalizedString(keys[1] if len(keys) > 1 else "KI.EmoteStrings.Their")])
+                keys = LocKey(*message.split(":"))
+                message = PtGetLocalizedString(keys.message, [player.getPlayerName(), PtGetLocalizedString(keys.pronoun)])
 
             # Display the message if it passed all the above checks.
             self.chatMgr.AddChatLine(player, message, cFlags, forceKI=not self.sawTheKIAtLeastOnce)

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -43,7 +43,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 import re
 import time
-from typing import NamedTuple
 import random
 import inspect
 
@@ -62,10 +61,6 @@ import xLocTools
 from . import xKIExtChatCommands
 from .xKIConstants import *
 from .xKIHelpers import *
-
-class LocKey(NamedTuple):
-    message: str
-    pronoun: str = "KI.EmoteStrings.Their"
 
 ## A class to process all the RT Chat functions of the KI.
 class xKIChat(object):

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -967,7 +967,7 @@ class CommandsProcessor:
                     PtEmoteAvatar(emote[0])
 
                 pronounKey = xLocTools.GetLocalAvatarPossessivePronounLocKey()
-                self.chatMgr.DisplayStatusMessage(LocKey(emote[1], pronounKey), netPropagate=1)
+                self.chatMgr.DisplayStatusMessage(LocKey(emote[1], pronounKey), netPropagate=True)
 
                 # Get remaining message string after emote command
                 message = message[len(words[0]):]

--- a/Scripts/Python/ki/xKIHelpers.py
+++ b/Scripts/Python/ki/xKIHelpers.py
@@ -42,6 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
  *==LICENSE==* """
 
 import re
+from typing import NamedTuple
 
 # Plasma engine.
 from Plasma import *
@@ -53,6 +54,9 @@ from xPsnlVaultSDL import *
 # xKI sub-modules.
 from .xKIConstants import *
 
+class LocKey(NamedTuple):
+    message: str
+    pronoun: str = "KI.EmoteStrings.Their"
 
 ## Helper class for autocompletion in the KI.
 class AutocompleteState:

--- a/Scripts/Python/plasma/PlasmaKITypes.py
+++ b/Scripts/Python/plasma/PlasmaKITypes.py
@@ -305,6 +305,7 @@ kRTChatInterAge = 0x08
 kRTChatStatusMsg = 0x10
 kRTChatNeighborsMsg = 0x20
 kRTChatAudioSubtitleMsg = 0x40
+kRTChatLocKeyMsg = 0x80
 
 # flags channel mask
 kRTChatFlagMask = 65535

--- a/Scripts/Python/xLocTools.py
+++ b/Scripts/Python/xLocTools.py
@@ -42,6 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
  *==LICENSE==* """
 from Plasma import *
 from PlasmaVaultConstants import *
+from PlasmaTypes import *
 
 xFolderIDToFolderName = {
     PtVaultStandardNodes.kUserDefinedNode:          PtGetLocalizedString("Global.FolderNames.UserDefined"),
@@ -113,6 +114,17 @@ def CreatePossessiveString(possessorName, possessionName):
     else:
         # otherwise throw it through the localized possessive formatter
         return PtGetLocalizedString("Global.Formats.Possessive", [possessorName, possessionName])
+
+def GetLocalAvatarPossessivePronounLocKey():
+
+    avatar = PtGetLocalAvatar()
+    clothingGroup = avatar.avatar.getAvatarClothingGroup()
+
+    if clothingGroup == kFemaleClothingGroup:
+        return "KI.EmoteStrings.Her"
+    else:
+        return "KI.EmoteStrings.His"
+
 
 def LocalizeAgeName(displayName):
     "Returns a localized version of the age display name you give it"

--- a/Scripts/Python/xLocTools.py
+++ b/Scripts/Python/xLocTools.py
@@ -41,8 +41,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
  *==LICENSE==* """
 from Plasma import *
-from PlasmaVaultConstants import *
 from PlasmaTypes import *
+from PlasmaVaultConstants import *
 
 xFolderIDToFolderName = {
     PtVaultStandardNodes.kUserDefinedNode:          PtGetLocalizedString("Global.FolderNames.UserDefined"),

--- a/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
@@ -164,6 +164,8 @@ class pfKIMsg : public plMessage
             kInterAgeMsg    = 0x00000008,
             kStatusMsg      = 0x00000010,
             kNeighborMsg    = 0x00000020,   // sending to all the neighbors
+            kSubtitleMsg    = 0x00000040,
+            kLocKeyMsg      = 0x00000080,
             kChannelMask    = 0x0000ff00
         };
 


### PR DESCRIPTION
Previously, these messages were localized by the sender and sent via net propagation. By Adam's request for a return to UU capabilities, these messages now send one or more LOC key strings along with a flag indicating for the receiver to process the message localization themselves.

As a side effect of my digging and the use of the new chat flag, I have also fixed at least one cause of AFK response spam.

Needs https://github.com/H-uru/moul-assets/pull/131.