### PR TITLE
Save and load the user's /textcolor setting to persist it between game sessions

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1339,6 +1339,7 @@ class xKI(ptModifier):
         self.DetermineKILevel()
         self.DetermineKIFlags()
         self.DetermineGZ()
+        self.DetermineTextColor()
 
         # Hide all dialogs first.
         KIMicroBlackbar.dialog.hide()
@@ -1638,6 +1639,22 @@ class xKI(ptModifier):
                 control.setStringW(self.chatMgr.MessageCurrentLine)
                 control.end()
                 control.refresh()
+
+    #~~~~~~~~~~~~~~~~~#
+    #  KI Text Color  #
+    #~~~~~~~~~~~~~~~~~#
+
+    ## Sets the KI Text Color from the Chronicle.
+    def DetermineTextColor(self):
+
+        vault = ptVault()
+        entry = vault.findChronicleEntry(kChronicleKITextColor)
+        if entry is not None:
+            colorStr = entry.chronicleGetValue()
+            PtDebugPrint(f"xKI.DetermineTextColor(): KI Text Color is: \"{colorStr}\".", level=kWarningLevel)
+            args = colorStr.split(",")
+            if len(args) == 3:
+                self.chatMgr.commandsProcessor.SetTextColor(args[0], args[1], args[2])
 
     #~~~~~~~~~~#
     # GZ Games #

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1653,8 +1653,14 @@ class xKI(ptModifier):
             colorStr = entry.chronicleGetValue()
             PtDebugPrint(f"xKI.DetermineTextColor(): KI Text Color is: \"{colorStr}\".", level=kWarningLevel)
             args = colorStr.split(",")
-            if len(args) == 3:
-                self.chatMgr.commandsProcessor.SetTextColor(args[0], args[1], args[2])
+            try:
+                self.chatMgr.chatTextColor = ptColor(float(args[0]), float(args[1]), float(args[2]))
+            except (IndexError, ValueError):
+                # format is incorrect -- didn't have 3 values, or values weren't floats -- so log an error and destroy all evidence
+                PtDebugPrint(f"xKI.DetermineTextColor(): KI Text Color was not in the expected triplet format", level=kWarningLevel)
+                vault.addChronicleEntry(kChronicleKITextColor, kChronicleKITextColorType, "")
+
+
 
     #~~~~~~~~~~#
     # GZ Games #

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1217,6 +1217,23 @@ class CommandsProcessor:
             return
         PtChangePassword(newPassword)
 
+    ## Update the Chronicle's KI Text Color values.
+    # This uses an RGB triplet with parts separated by "," or an empty string for the default chat color.
+    def UpdateTextColorChronicle(self):
+
+        vault = ptVault()
+        entry = vault.findChronicleEntry(kChronicleKITextColor)
+        newVal = ""
+        if isinstance(self.chatMgr.chatTextColor, ptColor):
+            newVal = f"{self.chatMgr.chatTextColor.getRed()},{self.chatMgr.chatTextColor.getGreen()},{self.chatMgr.chatTextColor.getBlue()}"
+
+        PtDebugPrint(f"xKIChat.UpdateTextColorChronicle(): Setting KI Text Color chronicle to: \"{newVal}\".", level=kWarningLevel)
+        if entry is not None:
+            entry.chronicleSetValue(newVal)
+            entry.save()
+        else:
+            vault.addChronicleEntry(kChronicleKITextColor, kChronicleKITextColorType, newVal)
+
     ## Overrides the chat area text colors to be a single user-selected color
     def SetTextColor(self, arg1, arg2=None, arg3=None):
 
@@ -1239,6 +1256,7 @@ class CommandsProcessor:
             colorBlue = clamp(colorBlue, 0, 255)
             colorGreen = clamp(colorGreen, 0, 255)
             self.chatMgr.chatTextColor = ptColor(colorRed / 255.0, colorBlue / 255.0, colorGreen / 255.0)
+            self.UpdateTextColorChronicle()
             self.chatMgr.DisplayStatusMessage(PtGetLocalizedString("KI.Chat.TextColorSetValue", [f"({colorRed}, {colorBlue}, {colorGreen})"]))
             return
 
@@ -1255,6 +1273,7 @@ class CommandsProcessor:
             colorBlue = clamp(colorBlue, 0.0, 1.0)
             colorGreen = clamp(colorGreen, 0.0, 1.0)
             self.chatMgr.chatTextColor = ptColor(colorRed, colorBlue, colorGreen)
+            self.UpdateTextColorChronicle()
             self.chatMgr.DisplayStatusMessage(PtGetLocalizedString("KI.Chat.TextColorSetValue", [f"({colorRed}, {colorBlue}, {colorGreen})"]))
             return
 
@@ -1263,10 +1282,12 @@ class CommandsProcessor:
             # newColor is a valid localized color name with a corresponding function on the ptColor class
             colorFn = getattr(ptColor(), kColorNames[newColor])
             self.chatMgr.chatTextColor = colorFn()
+            self.UpdateTextColorChronicle()
             self.chatMgr.DisplayStatusMessage(PtGetLocalizedString("KI.Chat.TextColorSetValue", [newColor]))
         elif newColor == PtGetLocalizedString("KI.Commands.ChatSetTextColorDefaultArg"):
             # user requested resetting text colors to defaults
             self.chatMgr.chatTextColor = None
+            self.UpdateTextColorChronicle()
             self.chatMgr.DisplayStatusMessage(PtGetLocalizedString("KI.Chat.TextColorSetDefault"))
         else:
             hexColor = newColor.lstrip("#")
@@ -1285,6 +1306,7 @@ class CommandsProcessor:
                     return
                 else:
                     self.chatMgr.chatTextColor = ptColor(colorRed, colorBlue, colorGreen)
+                    self.UpdateTextColorChronicle()
                     self.chatMgr.DisplayStatusMessage(PtGetLocalizedString("KI.Chat.TextColorSetValue", [f"#{hexColor}"]))
             else: 
                 # argument was not 3 or 6 characters long, so it cannot be a valid hexadecimal color

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1222,7 +1222,6 @@ class CommandsProcessor:
     def UpdateTextColorChronicle(self):
 
         vault = ptVault()
-        entry = vault.findChronicleEntry(kChronicleKITextColor)
         newVal = ""
         if isinstance(self.chatMgr.chatTextColor, ptColor):
             newVal = f"{self.chatMgr.chatTextColor.getRed()},{self.chatMgr.chatTextColor.getGreen()},{self.chatMgr.chatTextColor.getBlue()}"

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1228,11 +1228,7 @@ class CommandsProcessor:
             newVal = f"{self.chatMgr.chatTextColor.getRed()},{self.chatMgr.chatTextColor.getGreen()},{self.chatMgr.chatTextColor.getBlue()}"
 
         PtDebugPrint(f"xKIChat.UpdateTextColorChronicle(): Setting KI Text Color chronicle to: \"{newVal}\".", level=kWarningLevel)
-        if entry is not None:
-            entry.chronicleSetValue(newVal)
-            entry.save()
-        else:
-            vault.addChronicleEntry(kChronicleKITextColor, kChronicleKITextColorType, newVal)
+        vault.addChronicleEntry(kChronicleKITextColor, kChronicleKITextColorType, newVal)
 
     ## Overrides the chat area text colors to be a single user-selected color
     def SetTextColor(self, arg1, arg2=None, arg3=None):

--- a/Scripts/Python/plasma/PlasmaKITypes.py
+++ b/Scripts/Python/plasma/PlasmaKITypes.py
@@ -155,6 +155,8 @@ kChronicleGZMarkersAquired = "GZMarkersAquired"
 kChronicleGZMarkersAquiredType = 1
 kChronicleCalGZMarkersAquired = "CalGZMarkers"
 kChronicleCalGZMarkersAquiredType = 1
+kChronicleKITextColor = "KITextColor"
+kChronicleKITextColorType = 1
 
 
 def PtDetermineKILevel():


### PR DESCRIPTION
Add a new chronicle entry to store the RGB value of the user's current `/textcolor` setting.