### PR TITLE
Fixes wrong Ahnonay instance bug

### DIFF
--- a/Scripts/Python/Ahnonay.py
+++ b/Scripts/Python/Ahnonay.py
@@ -71,6 +71,7 @@ class Ahnonay(ptResponder):
         pass
 
     def OnServerInitComplete(self):
+        vault = ptVault()
         agevault = ptAgeVault()
         ageinfo = agevault.getAgeInfo()
         guid = ageinfo.getAgeInstanceGuid()
@@ -82,9 +83,25 @@ class Ahnonay(ptResponder):
         myID = str(PtGetClientIDFromAvatarKey(PtGetLocalAvatar().getKey()))
 
         ageStruct = ptAgeInfoStruct()
+        ageStruct.setAgeFilename("AhnonayCathedral")
+        ageLinkNode = agevault.getSubAgeLink(ageStruct)
+        if ageLinkNode:
+            localCathedralGuid = ageLinkNode.getAgeInfo().getAgeInstanceGuid()
+
+        folder = vault.getAgesIOwnFolder()
+        contents = folder.getChildNodeRefList()
+        for content in contents:
+            link = content.getChild()
+            link = link.upcastToAgeLinkNode()
+            if link:
+                info = link.getAgeInfo()
+                if info.getAgeFilename() == "AhnonayCathedral":
+                    personalCathedralGuid = info.getAgeInstanceGuid()
+                    break
+
+        ageStruct = ptAgeInfoStruct()
         ageStruct.setAgeFilename("Personal")
 
-        vault = ptVault()
         ageLinkNode = vault.getOwnedAgeLink(ageStruct)
         if ageLinkNode:
             ageInfoNode = ageLinkNode.getAgeInfo()
@@ -110,12 +127,12 @@ class Ahnonay(ptResponder):
                         elif chron and chron.getName() == "AhnonaySpawnPoints":
                             spawn = chron
                             PtDebugPrint("Ahnonay.OnServerInitComplete(): Spawn Chron already exists: %s" % (spawn.getValue()))
-                        elif chron and chron.getName() == "AhnonayOwner":
+                        elif chron and chron.getName() == "AhnonayOwner" and personalCathedralGuid and personalCathedralGuid == localCathedralGuid:
                             owner = chron
                     break
 
         if owner == None:
-            PtDebugPrint("I am not the age owner, and I don't have my own Ahnonay")
+            PtDebugPrint("I am not the age owner")
         elif owner.getValue() == myID:
             if linkid == None:
                 PtDebugPrint("Ahnonay.OnServerInitComplete(): Link Chron not found, creating")
@@ -152,9 +169,6 @@ class Ahnonay(ptResponder):
                     locked.setValue("1")
                     volatile.setValue("0")
                     spawn.setValue("Default,LinkInPointDefault")
-        else:
-            PtDebugPrint("I am not the age owner, but I do have my own Ahnonay")
-
 
         ageSDL = PtGetAgeSDL()
         sphere = ageSDL["ahnyCurrentSphere"][0]

--- a/Scripts/Python/Ahnonay.py
+++ b/Scripts/Python/Ahnonay.py
@@ -71,7 +71,6 @@ class Ahnonay(ptResponder):
         pass
 
     def OnServerInitComplete(self):
-        vault = ptVault()
         agevault = ptAgeVault()
         ageinfo = agevault.getAgeInfo()
         guid = ageinfo.getAgeInstanceGuid()
@@ -88,20 +87,17 @@ class Ahnonay(ptResponder):
         if ageLinkNode:
             localCathedralGuid = ageLinkNode.getAgeInfo().getAgeInstanceGuid()
 
-        folder = vault.getAgesIOwnFolder()
-        contents = folder.getChildNodeRefList()
-        for content in contents:
-            link = content.getChild()
-            link = link.upcastToAgeLinkNode()
-            if link:
-                info = link.getAgeInfo()
-                if info.getAgeFilename() == "AhnonayCathedral":
-                    personalCathedralGuid = info.getAgeInstanceGuid()
-                    break
+        cathedralInfoTemplate = ptVaultAgeInfoNode(0)
+        cathedralInfoTemplate.setAgeFilename("AhnonayCathedral")
+        if cathedralInfo := folder.findNode(cathedralInfoTemplate, 2):
+            personalCathedralGuid = cathedralInfo.upcastToAgeInfoNode().getAgeInstanceGuid()
+        else:
+            personalCathedralGuid = None
 
         ageStruct = ptAgeInfoStruct()
         ageStruct.setAgeFilename("Personal")
 
+        vault = ptVault()
         ageLinkNode = vault.getOwnedAgeLink(ageStruct)
         if ageLinkNode:
             ageInfoNode = ageLinkNode.getAgeInfo()


### PR DESCRIPTION
Steps to trigger bug:
Visit your personal Ahnonay Cathedral, leave without going to your Ahnonay instance
Visit someone else's Ahnonay
Your Ahnonay book on the Relto Bookshelf is now tied to the Ahnonay you visited instead of your personal Ahnonay

Basically the previous code had no way of checking that you were in the correct Ahnonay sub age.
If you had visited your Ahnonay Cathedral, the next Ahnonay you visited became the one your Relto bookshelf book was tied to.

So added a check in Ahnonay to verify the Cathedral subage was your personal Cathedral and not someone elses.
This check allows the owner variable to be correctly set.

Also added a check in Ahnonay Cathedral that the GUID that is set for your AhnonayLink is the correct GUID.
If it isn't the correct one, it sets it to the correct one.