### PR TITLE
Allow `ptVaultNode.findNode()` to search deeper than one level.

### DIFF
--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -6639,7 +6639,7 @@ class ptVaultNode:
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -6822,7 +6822,7 @@ class ptVaultFolderNode(ptVaultNode):
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -7053,7 +7053,7 @@ class ptVaultAgeInfoListNode(ptVaultFolderNode):
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -7292,7 +7292,7 @@ class ptVaultAgeInfoNode(ptVaultNode):
         """Returns this ptVaultAgeInfoNode as a ptAgeInfoStruct"""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -7583,7 +7583,7 @@ class ptVaultAgeLinkNode(ptVaultNode):
         """Returns this ptVaultAgeLinkNode as a ptAgeLinkStruct"""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -7822,7 +7822,7 @@ class ptVaultChronicleNode(ptVaultNode):
         """LEGACY: Sets the chronicle to a value that is a string"""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -8029,7 +8029,7 @@ class ptVaultImageNode(ptVaultNode):
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -8264,7 +8264,7 @@ class ptVaultMarkerGameNode(ptVaultNode):
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -8513,7 +8513,7 @@ class ptVaultPlayerInfoListNode(ptVaultFolderNode):
         """Adds playerID player to this player info list node."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -8772,7 +8772,7 @@ class ptVaultPlayerInfoNode(ptVaultNode):
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -8999,7 +8999,7 @@ class ptVaultSDLNode(ptVaultNode):
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -9202,7 +9202,7 @@ class ptVaultSystemNode(ptVaultNode):
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -9385,7 +9385,7 @@ class ptVaultTextNoteNode(ptVaultNode):
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
@@ -181,6 +181,10 @@ ST::string pyVaultAgeInfoNode::GetAgeFilename() const
 
 void pyVaultAgeInfoNode::SetAgeFilename(const ST::string& v)
 {
+    if (fNode) {
+        VaultAgeInfoNode access(fNode);
+        access.SetAgeFilename(v);
+    }
 }
 
 ST::string pyVaultAgeInfoNode::GetAgeInstanceName() const
@@ -194,6 +198,10 @@ ST::string pyVaultAgeInfoNode::GetAgeInstanceName() const
 
 void pyVaultAgeInfoNode::SetAgeInstanceName(const ST::string& v)
 {
+    if (fNode) {
+        VaultAgeInfoNode access(fNode);
+        access.SetAgeInstanceName(v);
+    }
 }
 
 ST::string pyVaultAgeInfoNode::GetAgeUserDefinedName() const
@@ -207,6 +215,10 @@ ST::string pyVaultAgeInfoNode::GetAgeUserDefinedName() const
 
 void pyVaultAgeInfoNode::SetAgeUserDefinedName(const ST::string& v)
 {
+    if (fNode) {
+        VaultAgeInfoNode access(fNode);
+        access.SetAgeUserDefinedName(v);
+    }
 }
 
 plUUID pyVaultAgeInfoNode::GetAgeInstanceGuid() const
@@ -221,6 +233,12 @@ plUUID pyVaultAgeInfoNode::GetAgeInstanceGuid() const
 
 void pyVaultAgeInfoNode::SetAgeInstanceGuid( const char * sguid )
 {
+    if (fNode) {
+        VaultAgeInfoNode access(fNode);
+        plUUID uuid;
+        uuid.FromString(sguid);
+        access.SetAgeInstanceGuid(uuid);
+    }
 }
 
 ST::string pyVaultAgeInfoNode::GetAgeDescription() const
@@ -234,6 +252,10 @@ ST::string pyVaultAgeInfoNode::GetAgeDescription() const
 
 void pyVaultAgeInfoNode::SetAgeDescription(const ST::string& v)
 {
+    if (fNode) {
+        VaultAgeInfoNode access(fNode);
+        access.SetAgeDescription(v);
+    }
 }
 
 int32_t pyVaultAgeInfoNode::GetSequenceNumber() const
@@ -247,6 +269,10 @@ int32_t pyVaultAgeInfoNode::GetSequenceNumber() const
 
 void pyVaultAgeInfoNode::SetSequenceNumber( int32_t v )
 {
+    if (fNode) {
+        VaultAgeInfoNode access(fNode);
+        access.SetAgeSequenceNumber(v);
+    }
 }
 
 int32_t pyVaultAgeInfoNode::GetAgeLanguage() const
@@ -260,6 +286,10 @@ int32_t pyVaultAgeInfoNode::GetAgeLanguage() const
 
 void pyVaultAgeInfoNode::SetAgeLanguage( int32_t v )
 {
+    if (fNode) {
+        VaultAgeInfoNode access(fNode);
+        access.SetAgeLanguage(v);
+    }
 }
 
 uint32_t pyVaultAgeInfoNode::GetAgeID() const

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -580,13 +580,13 @@ PyObject * pyVaultNode::GetNode2( uint32_t nodeID ) const
     PYTHON_RETURN_NONE;
 }
 
-PyObject* pyVaultNode::FindNode( pyVaultNode * templateNode )
+PyObject* pyVaultNode::FindNode( pyVaultNode * templateNode, unsigned int maxDepth )
 {
     PyObject * result = nullptr;
     if ( fNode && templateNode->fNode )
     {
         hsWeakRef<NetVaultNode> node(templateNode->fNode);
-        if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(node, 1))
+        if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(node, maxDepth))
             result = pyVaultNode::New(rvn);
     }
     

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
@@ -181,7 +181,7 @@ public:
     //  Returns a ptVaultNodeRef or nullptr
     PyObject* GetNode2( uint32_t nodeID ) const;          // returns pyVaultNodeRef, for legacy compatibility
     // Get child node matching template node
-    PyObject* FindNode( pyVaultNode * templateNode );   // returns pyVaultNode
+    PyObject* FindNode( pyVaultNode * templateNode, unsigned int maxDepth = 1 );   // returns pyVaultNode
 
     // Get all child nodes.
     virtual PyObject* GetChildNodeRefList(); // for legacy compatibility

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeGlue.cpp
@@ -270,21 +270,23 @@ PYTHON_METHOD_DEFINITION(ptVaultNode, getNode, args)
 }
 
 
-PYTHON_METHOD_DEFINITION(ptVaultNode, findNode, args)
+PYTHON_METHOD_DEFINITION_WKEY(ptVaultNode, findNode, args, kw)
 {
+    const char* kwdlist[] = { "", "maxDepth", nullptr };
     PyObject* nodeObj = nullptr;
-    if (!PyArg_ParseTuple(args, "O", &nodeObj))
+    unsigned int depth = 1;
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "O|I", const_cast<char**>(kwdlist), &nodeObj, &depth))
     {
-        PyErr_SetString(PyExc_TypeError, "findNode expects a ptVaultNode");
+        PyErr_SetString(PyExc_TypeError, "findNode expects a ptVaultNode and an optional unsigned integer");
         PYTHON_RETURN_ERROR;
     }
     if (!pyVaultNode::Check(nodeObj))
     {
-        PyErr_SetString(PyExc_TypeError, "findNode expects a ptVaultNode");
+        PyErr_SetString(PyExc_TypeError, "findNode expects a ptVaultNode and an optional unsigned integer");
         PYTHON_RETURN_ERROR;
     }
     pyVaultNode* node = pyVaultNode::ConvertFrom(nodeObj);
-    return self->fThis->FindNode(node);
+    return self->fThis->FindNode(node, depth);
 }
 
 PYTHON_METHOD_DEFINITION(ptVaultNode, addNode, args)
@@ -483,7 +485,7 @@ PYTHON_START_METHODS_TABLE(ptVaultNode)
     PYTHON_BASIC_METHOD(ptVaultNode, removeAllNodes, "Removes all the child nodes on this node."),
     PYTHON_METHOD(ptVaultNode, hasNode, "Params: id\nReturns true if node if a child node"),
     PYTHON_METHOD(ptVaultNode, getNode, "Params: id\nReturns ptVaultNodeRef if is a child node, or None"),
-    PYTHON_METHOD(ptVaultNode, findNode, "Params: templateNode\nReturns ptVaultNode if child node found matching template, or None"),
+    PYTHON_METHOD_WKEY(ptVaultNode, findNode, "Params: templateNode, maxDepth=1\nReturns ptVaultNode if child node found matching template, or None"),
 
     PYTHON_METHOD(ptVaultNode, addNode, "Params: node,cb=None,cbContext=0\nAdds 'node'(ptVaultNode) as a child to this node."),
     PYTHON_METHOD(ptVaultNode, linkToNode, "Params: nodeID,cb=None,cbContext=0\nAdds a link to the node designated by nodeID"),


### PR DESCRIPTION
#1142 revealed inferior AgeInfo node finding code is required due to `ptVaultNode.findNode()` not allowing searches deeper than one level. This allows them.