### PR TITLE
Fix Kveer was registering itself as a city link

### DIFF
--- a/Scripts/Python/islmRegisterNexusLink.py
+++ b/Scripts/Python/islmRegisterNexusLink.py
@@ -109,7 +109,7 @@ class islmRegisterNexusLink(ptModifier):
                     PtDebugPrint("islmRegisterNexusLink.OnNotify(): Chronicle entry 'GotLinkToKveerPublic' not present, adding entry and setting to 'yes'")
                     PtSendKIMessage(kKILocalChatStatusMsg,PtGetLocalizedString("KI.Messages.NexusLinkAdded"))
             # Hacking away for GoMe Pub
-            if stationName.value == "GoMePubNew":
+            elif stationName.value == "GoMePubNew":
                 entryName = "GotLinkToGoMePublic"
                 entry = vault.findChronicleEntry(entryName)
                 if entry is not None:


### PR DESCRIPTION
Missing elif caused Kveer to register as a city link in nexus
Minor issue.
Your able to delete the link no issues, when you use it you end up on the city docks instead of in kveer.
The correct kveer link is lower in the nexus listing as usual as well.
