### PR TITLE
Fix issue with TPOTS code and Relto start

### DIFF
--- a/Scripts/Python/clftImager.py
+++ b/Scripts/Python/clftImager.py
@@ -441,7 +441,7 @@ class clftImager(ptResponder):
                 PlayFull = 1
                 PlayFinal = 0
                 PtDebugPrint("play full opening speech")
-            elif (IsCleftSolved() and self.TPOTSolved()):
+            elif (StartInRelto() and self.TPOTSolved()):
                 PlayFull = 0
                 PlayFinal = 0
                 PlayTPOT = 1


### PR DESCRIPTION
If you did the relto start, you would be prevented from entering the TPOTS imager code until you solved the cleft age.

Before the cleft start, you could do both Ahnonay and Er'cana, acquire the TPOTS imager code to solve that puzzle before you ever solved the cleft.

This fixes that issue.

It also now prevents you from brute-force solving the first journey code.