### PR TITLE
Fix so chat logs don't duplicate every line

### DIFF
--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -638,10 +638,6 @@ class xKIChat(object):
 
                 chatArea.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
 
-                # Write to the log file.
-                if self.chatLogFile is not None and self.chatLogFile.isOpen():
-                    self.chatLogFile.write(chatHeaderFormatted[0:] + chatMessageFormatted)
-
                 # If the chat is overflowing, erase the first line.
                 if chatArea.getBufferSize() > kChat.MaxChatSize:
                     while chatArea.getBufferSize() > kChat.MaxChatSize and chatArea.getBufferSize() > 0:
@@ -658,6 +654,10 @@ class xKIChat(object):
                     # flash the down arrow to indicate that new chat has come in
                     self.incomingChatFlashState = 3
                     PtAtTimeCallback(self.key, 0.0, kTimers.IncomingChatFlash)
+
+        # Write to the log file.
+        if self.chatLogFile is not None and self.chatLogFile.isOpen():
+            self.chatLogFile.write(chatHeaderFormatted[0:] + chatMessageFormatted)
 
         # Update the fading controls.
         self.ResetFadeState()


### PR DESCRIPTION
Due to the chat logging code being inside the for-loop over the miniKI and microKI chat areas, it was previously a sad time when using the chat log:
```
(05/11 21:46:28) Chat.log started...
(05/11 21:46:28) Chat.log started...
(05/11 21:46:32) [ERROR] Error: Don't know how to "/fake"
(05/11 21:46:33) [ERROR] Error: Don't know how to "/fake"
(05/11 21:46:50) AbelarTL does a dance
(05/11 21:46:50) AbelarTL does a dance
(05/11 21:47:07) Text reset to default color(s).
(05/11 21:47:07) Text reset to default color(s).
(05/11 21:47:12) ...Chat.log stopped.
(05/11 21:47:12) ...Chat.log stopped.
```

Now it is a less sad time.
```
(05/12 23:58:02) Chat.log started...
(05/12 23:58:07)  Zaroth TL: hello
(05/12 23:58:17) Text color now set to blue.
(05/12 23:58:25)  Zaroth TL: foo
(05/12 23:58:33) To Neighbors: bar
(05/12 23:58:42) Zaroth TL does a funky dance
(05/12 23:58:51) Text reset to default color(s).
(05/12 23:58:54) ...Chat.log stopped.
```