### PR TITLE
Climb Brain crash fix

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainClimb.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainClimb.cpp
@@ -333,7 +333,7 @@ bool plAvBrainClimb::IProcessExitStage(double time, float elapsed)
 
     float curBlend = ai->GetBlend();
     
-    if(curBlend > .99)      // reached peak strength
+    if(fCurStage && curBlend > .99)      // reached peak strength
     {
         fCurStage->Detach(fAvMod);  // remove the (now completely masked) underlying anim
         fCurStage = nullptr;


### PR DESCRIPTION
Possible fix for crashing when the climb brain attempts to call a nulled fCurStage.