### PR TITLE
Improvements to plMoviePlayer

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.cpp
@@ -471,6 +471,7 @@ bool plMoviePlayer::Stop()
         fPlate->SetVisible(false);
     if (fLastImg) {
         vpx_img_free(fLastImg);
+        fLastImg = nullptr;
     }
 
     for (auto cb : fCallbacks)

--- a/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.cpp
@@ -335,7 +335,7 @@ void plMoviePlayer::IProcessVideoFrame(const std::vector<blkbuf_t>& frames)
     }
     
     // We need to refill the buffer if there is a new image or a new buffer
-    if (img || !fTexture->GetDeviceRef()) {
+    if (img || (!fTexture->GetDeviceRef() && fLastImg)) {
         // According to VideoLAN[1], I420 is the most common image format in videos. I am inclined to believe this as our
         // attemps to convert the common Uru videos use I420 image data. So, as a shortcut, we will only implement that format.
         // If for some reason we need other formats, please, be my guest!

--- a/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.h
+++ b/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.h
@@ -55,6 +55,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plMessage;
 
+#ifdef USE_WEBM
+#   include <vpx/vpx_decoder.h>
+#endif
+
 namespace mkvparser
 {
     class BlockEntry;
@@ -74,6 +78,7 @@ protected:
 #ifdef USE_WEBM
     mkvparser::MkvReader* fReader;
     std::unique_ptr<mkvparser::Segment> fSegment;
+    vpx_image_t* fLastImg;
 #endif
     std::unique_ptr<class TrackMgr> fAudioTrack, fVideoTrack; // TODO: vector of tracks?
     std::unique_ptr<class plWin32VideoSound> fAudioSound;

--- a/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.h
+++ b/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.h
@@ -55,10 +55,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plMessage;
 
-#ifdef USE_WEBM
-#   include <vpx/vpx_decoder.h>
-#endif
-
 namespace mkvparser
 {
     class BlockEntry;
@@ -68,6 +64,7 @@ namespace mkvparser
 }
 
 typedef std::tuple<std::unique_ptr<uint8_t>, int32_t> blkbuf_t;
+typedef struct vpx_image vpx_image_t;
 
 class plMoviePlayer
 {


### PR DESCRIPTION
- Freeing frames after we’re done with them to keep memory use flatter
- Caching the last frame so if the surface needs to be recreated we can populate it with image data

The first change frees frames after we don't need them. I don't think there is a leak here as everything was freed at the end of the movie. But memory use previously climbed during playback.

The second change is a little more nitpicky. On Mac, if the client changed resolutions during playback (or swapped between windowed/fullscreen) display would be blank momentarily. This is because the movie player only draws when it has a new frame. By retaining the last frame, the movie player can also immediately draw when a new surface is created in response to a reconfiguration.

I'm guessing Windows theoretically has similar issues but has tighter control over when a user can change modes. Haven't decided what to do with the Mac client yet, but trying to keep at least full screen/windowed transitions working nicely and at all times.