### PR TITLE
Don't build libuuid on macOS with vcpkg.

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -28,7 +28,7 @@
       "string-theory",
       {
         "name": "libuuid",
-        "platform": "linux | osx"
+        "platform": "linux"
       },
       "zlib"
     ],


### PR DESCRIPTION
The libuuid port and vcpkg are now stricter about enforcing that libuuid is a Linux only library. Attempting to build libuuid on macOS fails the build.