### PR TITLE
Code for static imager image to show in imager slides

### DIFF
--- a/Scripts/Python/xSimpleImager.py
+++ b/Scripts/Python/xSimpleImager.py
@@ -339,11 +339,11 @@ class xSimpleImager(ptModifier):
                             self.IShowCurrentContent()
                     elif event[1][:9] == "Uploaded=":
                         newID = int(event[1][9:])
-                        if newID == CurrentDisplayedElementID:
-                            if self.clueHandler:
-                                # force the clue imager to turn off so the new upload is visible
-                                self.clueHandler.UpdateClueState(forceOff=True)
-                            self.IShowCurrentContent()
+                        if self.clueHandler:
+                            # force the clue imager to turn off so the new upload is visible
+                            self.clueHandler.UpdateClueState(forceOff=True)
+                        CurrentDisplayedElementID = newID
+                        self.IShowCurrentContent()
                     elif event[1][:7] == "Upload=":
                         deviceName = event[1][7:]
                         nodeId = int(event[3])

--- a/Scripts/Python/xSimpleImager.py
+++ b/Scripts/Python/xSimpleImager.py
@@ -75,6 +75,7 @@ ImagerInboxVariable = ptAttribString(9,"Inbox SDL variable (optional)")
 ImagerPelletUpload = ptAttribBoolean(10, "Pellet Score Imager?", 0)
 ImagerClueObject = ptAttribSceneobject(11, "Imager Object (for puzzle clue)")
 ImagerClueTime = ptAttribInt(12, "Number of seconds until clue image shows",default=870)
+ImagerRandomTime = ptAttribInt(13, "Random number added to make timer more variable",default=0)
 #----------
 # globals
 #----------
@@ -99,8 +100,8 @@ AgeStartedIn = None
 #----------
 kFlipImagesTimerStates = 5
 kFlipImagesTimerCurrent = 0
-kImagerClueStart = 1
-kImagerClueEnd = 2
+kImagerClueStart = 1 + ImagerMax.value
+kImagerClueEnd = 2 + ImagerMax.value
 
 #====================================
 
@@ -159,7 +160,8 @@ class xSimpleImager(ptModifier):
                 kFlipImagesTimerCurrent = (kFlipImagesTimerCurrent + 1) % kFlipImagesTimerStates
                 PtAtTimeCallback(Instance.key,ImagerTime.value,kFlipImagesTimerCurrent)
                 if ImagerClueObject.sceneobject is not None:
-                    PtAtTimeCallback(self.key,ImagerClueTime.value,kImagerClueStart)
+                    randomize = random.randint(0, ImagerRandomTime.value)
+                    PtAtTimeCallback(self.key,ImagerClueTime.value + randomize,kImagerClueStart)
                 # turn button animation off
                 ImagerButtonResp.run(Instance.key,state='buttonOff')
 
@@ -169,6 +171,7 @@ class xSimpleImager(ptModifier):
         #~ ImagerMembersOnly.value = 0
 ###==== Cheat
         global AgeStartedIn
+        random.seed()
         AgeStartedIn = PtGetAgeName()
         if ImagerClueObject.sceneobject is not None:
             ImagerClueObject.sceneobject.draw.disable()
@@ -246,8 +249,9 @@ class xSimpleImager(ptModifier):
             ImagerClueObject.sceneobject.physics.suppress(True)
             ImagerObject.sceneobject.draw.enable()
             ImagerObject.sceneobject.physics.suppress(False)
+            randomize = random.randint(0, ImagerRandomTime.value)
             PtAtTimeCallback(self.key,ImagerTime.value,kFlipImagesTimerCurrent)
-            PtAtTimeCallback(self.key,ImagerClueTime.value,kImagerClueStart)
+            PtAtTimeCallback(self.key,ImagerClueTime.value + randomize,kImagerClueStart)
 
     def OnVaultEvent(self,event,tupdata):
         "An AgeKI event received"

--- a/Scripts/Python/xSimpleImager.py
+++ b/Scripts/Python/xSimpleImager.py
@@ -250,7 +250,6 @@ class xSimpleImager(ptModifier):
             ImagerObject.sceneobject.draw.enable()
             ImagerObject.sceneobject.physics.suppress(False)
             randomize = random.randint(0, ImagerRandomTime.value)
-            PtAtTimeCallback(self.key,ImagerTime.value,kFlipImagesTimerCurrent)
             PtAtTimeCallback(self.key,ImagerClueTime.value + randomize,kImagerClueStart)
 
     def OnVaultEvent(self,event,tupdata):

--- a/Scripts/Python/xSimpleImagerClueHandler.py
+++ b/Scripts/Python/xSimpleImagerClueHandler.py
@@ -78,9 +78,13 @@ class xSimpleImagerClueHandler:
             if self.baseImager.isLocallyOwned():
                 # if clue currently being shown, turn it off and flip the regularly scheduled imager back on
                 PtDebugPrint("xSimpleImagerClueHandler.UpdateClueState: Turning the clue off now...", level=kWarningLevel)
+                self.clueImager.draw.netForce(True)
                 self.clueImager.draw.disable()
+                self.clueImager.physics.netForce(True)
                 self.clueImager.physics.suppress(True)
+                self.baseImager.draw.netForce(True)
                 self.baseImager.draw.enable()
+                self.baseImager.physics.netForce(True)
                 self.baseImager.physics.suppress(False)
 
             # set alarm to show the clue again if it was on before we turned it off (versus forcing while already off)
@@ -95,9 +99,13 @@ class xSimpleImagerClueHandler:
             if self.baseImager.isLocallyOwned():
                 # it is time for the clue imager to shine!
                 PtDebugPrint("xSimpleImagerClueHandler.UpdateClueState: Turn the clue on now!", level=kWarningLevel)
+                self.clueImager.draw.netForce(True)
                 self.clueImager.draw.enable()
+                self.clueImager.physics.netForce(True)
                 self.clueImager.physics.suppress(False)
+                self.baseImager.draw.netForce(True)
                 self.baseImager.draw.disable()
+                self.baseImager.physics.netForce(True)
                 self.baseImager.physics.suppress(True)
 
             self.isShowing = True

--- a/Scripts/Python/xSimpleImagerClueHandler.py
+++ b/Scripts/Python/xSimpleImagerClueHandler.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+""" *==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+ *==LICENSE==* """
+
+from Plasma import *
+from PlasmaTypes import *
+
+import random
+
+class xSimpleImagerClueHandler:
+
+    def __init__(self, baseImager: ptSceneobject, imagerMaxSize: int, clueImager: ptSceneobject, clueTime: int, randomMaxTimeOffset: int):
+        PtDebugPrint(f"xSimpleImagerClueHandler: init for imager with max size {imagerMaxSize}, clue time of {clueTime} seconds, and {randomMaxTimeOffset} possible offset", level=kWarningLevel)
+
+        random.seed()
+        self.isShowing = False
+        self.shouldShow = False
+        self.baseImager = baseImager
+        self.imagerMaxSize = imagerMaxSize
+        self.clueImager = clueImager
+        self.clueTime = clueTime
+        self.randomMaxTimeOffset = randomMaxTimeOffset
+
+        # initialize hidden
+        self.clueImager.draw.disable()
+        self.clueImager.physics.suppress(True)
+
+        self.SetClueAlarm()
+
+    def SetClueAlarm(self):
+        randomizedClueTime = self.clueTime + random.randint(0, self.randomMaxTimeOffset)
+        PtDebugPrint(f"xSimpleImagerClueHandler.SetClueAlarm: Set for {randomizedClueTime} seconds", level=kWarningLevel)
+        PtSetAlarm(randomizedClueTime, self, 1)
+
+    def UpdateClueState(self, forceOff=False):
+
+        if self.isShowing or forceOff:
+            # only the owner of the imager changes the images
+            if self.baseImager.isLocallyOwned():
+                # if clue currently being shown, turn it off and flip the regularly scheduled imager back on
+                PtDebugPrint("xSimpleImagerClueHandler.UpdateClueState: Turning the clue off now...", level=kWarningLevel)
+                self.clueImager.draw.disable()
+                self.clueImager.physics.suppress(True)
+                self.baseImager.draw.enable()
+                self.baseImager.physics.suppress(False)
+
+            # set alarm to show the clue again if it was on before we turned it off (versus forcing while already off)
+            # otherwise multiple alarms will be active at the same time
+            if self.isShowing:
+                self.shouldShow = False
+                self.SetClueAlarm()
+
+            self.isShowing = False
+        elif self.shouldShow:
+            # only the owner of the imager changes the images
+            if self.baseImager.isLocallyOwned():
+                # it is time for the clue imager to shine!
+                PtDebugPrint("xSimpleImagerClueHandler.UpdateClueState: Turn the clue on now!", level=kWarningLevel)
+                self.clueImager.draw.enable()
+                self.clueImager.physics.suppress(False)
+                self.baseImager.draw.disable()
+                self.baseImager.physics.suppress(True)
+
+            self.isShowing = True
+            self.shouldShow = False
+
+    def onAlarm(self, context):
+
+        PtDebugPrint("xSimpleImagerClueHandler.onAlarm: Clue set to show on next flip", level=kWarningLevel)
+        self.shouldShow = True


### PR DESCRIPTION
This would be used for showing a puzzle image or any static image for imagers at a set interval.

It does require an additional imager object setup to function properly.
You create another imager object, and set the final texture to use the static image you want.
When the timer for the static image is up, it will hide the normal imager object and show the static imager object instead.
That imager goes for the standard image time, then resumes the standard imager images.