### PR TITLE
Ensure providing current folder name for delete player localized message

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -6073,7 +6073,7 @@ class xKI(ptModifier):
             plID = control.getTagID()
             # Is it one of the buttons?
             if plID == kGUI.BKIPLYDeleteButton:
-                PtLocalizedYesNoDialog(self.HandleBigKIDeleteConfirmation, "KI.Messages.DeletePlayer", self.BKCurrentContentTitle)
+                PtLocalizedYesNoDialog(self.HandleBigKIDeleteConfirmation, "KI.Messages.DeletePlayer", self.BKCurrentContentTitle, self.BKFolderListOrder[self.BKFolderSelected])
             elif plID == kGUI.BKIPLYPlayerIDEditBox:
                 self.BigKICheckSavePlayer()
         elif event == kFocusChange:


### PR DESCRIPTION
Previously, when trying to delete a player from Recent, Buddies, or Ignore List folders (or whatever folders in the Big KI that allow deleting players), the folder name was never populated.
![image](https://user-images.githubusercontent.com/94947971/168944292-ab74d190-416c-4af9-9272-59306e1a16f4.png)

Now, it is. 🎉 
![image](https://user-images.githubusercontent.com/94947971/168944513-15d50af2-d43a-47b7-8344-1c05b2229ff6.png)
