### PR TITLE
Oh look, more /textcolor fixes

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1655,13 +1655,18 @@ class xKI(ptModifier):
         if entry is not None:
             colorStr = entry.chronicleGetValue()
             PtDebugPrint(f"xKI.DetermineTextColor(): KI Text Color is: \"{colorStr}\".", level=kWarningLevel)
-            args = colorStr.split(",")
-            try:
-                self.chatMgr.chatTextColor = ptColor(float(args[0]), float(args[1]), float(args[2]))
-            except (IndexError, ValueError):
-                # format is incorrect -- didn't have 3 values, or values weren't floats -- so log an error and destroy all evidence
-                PtDebugPrint(f"xKI.DetermineTextColor(): KI Text Color was not in the expected triplet format", level=kWarningLevel)
-                vault.addChronicleEntry(kChronicleKITextColor, kChronicleKITextColorType, "")
+            if colorStr:
+                args = colorStr.split(",")
+                try:
+                    self.chatMgr.chatTextColor = ptColor(float(args[0]), float(args[1]), float(args[2]))
+                except (IndexError, ValueError):
+                    # format is incorrect -- didn't have 3 values, or values weren't floats -- so log an error and destroy all evidence
+                    PtDebugPrint(f"xKI.DetermineTextColor(): KI Text Color was not in the expected triplet format", level=kWarningLevel)
+                    vault.addChronicleEntry(kChronicleKITextColor, kChronicleKITextColorType, "")
+                return
+
+        # reset to None if there is no set value, otherwise could be carried over from user's previous character
+        self.chatMgr.chatTextColor = None
 
 
 


### PR DESCRIPTION
Yezzy screwed some more stuff up and is fixing it. Yezzy is also very tired right now.

Fix two problems:
1. When KITextColor chronicle had empty string for textcolor reset to default, it went through the `except` path. Not intended or ideal.
2. When switching from a character with a set /textcolor to one without a set /textcolor, the KI kept its outlandish color settings. Set chatTextColor explicitly to None when there is no chronicle or the chronicle is empty string.