### PR TITLE
Allow players to move or delete inbox items (besides global inbox items)

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -3699,9 +3699,7 @@ class xKI(ptModifier):
 
         # Get its parent folder.
         if isinstance(nodeRef, ptVaultNodeRef):
-            folder = self.BKCurrentContent.getParent()
-            item = self.BKCurrentContent.getChild()
-            if folder and item:
+            if (folder := self.BKCurrentContent.getParent()) and (item := self.BKCurrentContent.getChild()):
                 # Observed: sometimes, the creator ID is zero. This can mean either a DRC item or
                 # a poorly initialized node. Better check against the saver ID as well, which is
                 # used to display the From field.
@@ -3721,13 +3719,10 @@ class xKI(ptModifier):
 
         # Get its parent folder.
         if isinstance(nodeRef, ptVaultNodeRef):
-            folder = self.BKCurrentContent.getParent()
-            item = self.BKCurrentContent.getChild()
-            if folder and item:
+            if (folder := self.BKCurrentContent.getParent()) and (item := self.BKCurrentContent.getChild()):
                 if folder := folder.upcastToFolderNode():
-                    # Saver ID of zero should mean a DRC item. These inbox items are the only kind
-                    # of content that should *not* be able to be deleted or moved
-                    if folder.folderGetType() == PtVaultStandardNodes.kGlobalInboxFolder and self.BKCurrentContent.getSaverID() == 0:
+                    # Global inbox items should *not* be able to be deleted or moved
+                    if folder.folderGetType() == PtVaultStandardNodes.kGlobalInboxFolder:
                         return False
         return True
 

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -3437,17 +3437,11 @@ class xKI(ptModifier):
                 self.BKGettingPlayerID = False
             elif self.BKRightSideMode == kGUI.BKJournalExpanded:
                 KIJournalExpanded.dialog.show()
-                if self.IsContentMutable(self.BKCurrentContent):
-                    self.BigKIInvertToFolderButtons()
-                else:
-                    self.BigKIOnlySelectedToButtons()
+                self.BigKIInvertToFolderButtons()
                 self.BKGettingPlayerID = False
             elif self.BKRightSideMode == kGUI.BKPictureExpanded:
                 KIPictureExpanded.dialog.show()
-                if self.IsContentMutable(self.BKCurrentContent):
-                    self.BigKIInvertToFolderButtons()
-                else:
-                    self.BigKIOnlySelectedToButtons()
+                self.BigKIInvertToFolderButtons()
                 self.BKGettingPlayerID = False
             elif self.BKRightSideMode == kGUI.BKPlayerExpanded:
                 KIPlayerExpanded.dialog.show()
@@ -3484,10 +3478,7 @@ class xKI(ptModifier):
                 self.BKGettingPlayerID = False
             elif self.BKRightSideMode == kGUI.BKMarkerListExpanded:
                 KIMarkerFolderExpanded.dialog.show()
-                if self.IsContentMutable(self.BKCurrentContent):
-                    self.BigKIInvertToFolderButtons()
-                else:
-                    self.BigKIOnlySelectedToButtons()
+                self.BigKIInvertToFolderButtons()
                 self.BKGettingPlayerID = False
 
     ## Hide an open mode in the BigKI.
@@ -3532,15 +3523,9 @@ class xKI(ptModifier):
         if self.BKRightSideMode == kGUI.BKListMode:
             self.BigKIOnlySelectedToButtons()
         elif self.BKRightSideMode == kGUI.BKJournalExpanded:
-            if self.IsContentMutable(self.BKCurrentContent):
-                self.BigKIInvertToFolderButtons()
-            else:
-                self.BigKIOnlySelectedToButtons()
+            self.BigKIInvertToFolderButtons()
         elif self.BKRightSideMode == kGUI.BKPictureExpanded:
-            if self.IsContentMutable(self.BKCurrentContent):
-                self.BigKIInvertToFolderButtons()
-            else:
-                self.BigKIOnlySelectedToButtons()
+            self.BigKIInvertToFolderButtons()
         elif self.BKRightSideMode == kGUI.BKPlayerExpanded:
             localPlayer = PtGetLocalPlayer()
             if self.BKCurrentContent is not None:
@@ -3564,7 +3549,7 @@ class xKI(ptModifier):
         elif self.BKRightSideMode == kGUI.BKAgeOwnerExpanded:
             self.BigKIOnlySelectedToButtons()
         elif self.BKRightSideMode == kGUI.BKMarkerListExpanded:
-            if self.MFdialogMode not in (kGames.MFEditing, kGames.MFEditingMarker) and self.IsContentMutable(self.BKCurrentContent):
+            if self.MFdialogMode not in (kGames.MFEditing, kGames.MFEditingMarker):
                 self.BigKIInvertToFolderButtons()
             else:
                 self.BigKIOnlySelectedToButtons()
@@ -4518,8 +4503,8 @@ class xKI(ptModifier):
         if self.BKCurrentContent is None:
             PtDebugPrint("xKI.BigKIDisplayJournalEntry(): self.BKCurrentContent is None.", level=kErrorLevel)
             return
+        jrnDeleteBtn.show()
         if self.IsContentMutable(self.BKCurrentContent):
-            jrnDeleteBtn.show()
             jrnNote.unlock()
             if not self.BKInEditMode or self.BKEditField != kGUI.BKEditFieldJRNTitle:
                 jrnTitleBtn.show()
@@ -4596,10 +4581,9 @@ class xKI(ptModifier):
         if self.BKCurrentContent is None:
             PtDebugPrint("xKI.BigKIDisplayPicture(): self.BKCurrentContent is None.", level=kErrorLevel)
             return
-        if self.IsContentMutable(self.BKCurrentContent):
-            picDeleteBtn.show()
-            if not self.BKInEditMode or self.BKEditField != kGUI.BKEditFieldPICTitle:
-                picTitleBtn.show()
+        picDeleteBtn.show()
+        if self.IsContentMutable(self.BKCurrentContent) and (not self.BKInEditMode or self.BKEditField != kGUI.BKEditFieldPICTitle):
+            picTitleBtn.show()
         else:
             picTitleBtn.hide()
         element = self.BKCurrentContent.getChild()
@@ -4778,14 +4762,16 @@ class xKI(ptModifier):
     ## Prepares the display of a marker game, as it may be loading.
     def BigKIDisplayMarkerGame(self):
 
-        # Make sure that the player can view this game.
-        if self.gKIMarkerLevel < kKIMarkerNormalLevel:
-            self.BigKIDisplayMarkerGameMessage(PtGetLocalizedString("KI.MarkerGame.pendingActionUpgradeKI"))
-            return
-
         # Save some typing.
         mgr = self.markerGameManager
         getControl = KIMarkerFolderExpanded.dialog.getControlFromTag
+        mbtnDelete = ptGUIControlButton(getControl(kGUI.MarkerFolderDeleteBtn))
+
+        # Make sure that the player can view this game.
+        if self.gKIMarkerLevel < kKIMarkerNormalLevel:
+            self.BigKIDisplayMarkerGameMessage(PtGetLocalizedString("KI.MarkerGame.pendingActionUpgradeKI"))
+            mbtnDelete.show()
+            return
 
         # Initialize the markerGameDisplay to the currently selected game.
         # But first, ensure that the player meets all the necessary criteria.
@@ -4840,7 +4826,6 @@ class xKI(ptModifier):
         mrkfldStatus = ptGUIControlTextBox(getControl(kGUI.MarkerFolderStatus))
         mrkfldTitle = ptGUIControlTextBox(getControl(kGUI.MarkerFolderTitleText))
         mrkfldTitleBtn = ptGUIControlButton(getControl(kGUI.MarkerFolderTitleBtn))
-        mbtnDelete = ptGUIControlButton(getControl(kGUI.MarkerFolderDeleteBtn))
         mbtnGameTimePullD = ptGUIControlButton(getControl(kGUI.MarkerFolderTimePullDownBtn))
         mtbGameType = ptGUIControlTextBox(getControl(kGUI.MarkerFolderGameTypeTB))
         mbtnGameTypePullD = ptGUIControlButton(getControl(kGUI.MarkerFolderTypePullDownBtn))
@@ -4874,10 +4859,7 @@ class xKI(ptModifier):
         # Is the player merely looking at a Marker Game?
         if self.MFdialogMode == kGames.MFOverview:
             mrkfldTitleBtn.disable()
-            if self.IsContentMutable(self.BKCurrentContent):
-                mbtnDelete.show()
-            else:
-                mbtnDelete.hide()
+            mbtnDelete.show()
             mbtnGameTimePullD.hide()
             mbtnGameTimeArrow.hide()
             if element.getCreatorNodeID() == PtGetLocalClientID():

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -3437,11 +3437,17 @@ class xKI(ptModifier):
                 self.BKGettingPlayerID = False
             elif self.BKRightSideMode == kGUI.BKJournalExpanded:
                 KIJournalExpanded.dialog.show()
-                self.BigKIInvertToFolderButtons()
+                if self.IsContentDeletableAndMovable(self.BKCurrentContent):
+                    self.BigKIInvertToFolderButtons()
+                else:
+                    self.BigKIOnlySelectedToButtons()
                 self.BKGettingPlayerID = False
             elif self.BKRightSideMode == kGUI.BKPictureExpanded:
                 KIPictureExpanded.dialog.show()
-                self.BigKIInvertToFolderButtons()
+                if self.IsContentDeletableAndMovable(self.BKCurrentContent):
+                    self.BigKIInvertToFolderButtons()
+                else:
+                    self.BigKIOnlySelectedToButtons()
                 self.BKGettingPlayerID = False
             elif self.BKRightSideMode == kGUI.BKPlayerExpanded:
                 KIPlayerExpanded.dialog.show()
@@ -3478,7 +3484,10 @@ class xKI(ptModifier):
                 self.BKGettingPlayerID = False
             elif self.BKRightSideMode == kGUI.BKMarkerListExpanded:
                 KIMarkerFolderExpanded.dialog.show()
-                self.BigKIInvertToFolderButtons()
+                if self.IsContentDeletableAndMovable(self.BKCurrentContent):
+                    self.BigKIInvertToFolderButtons()
+                else:
+                    self.BigKIOnlySelectedToButtons()
                 self.BKGettingPlayerID = False
 
     ## Hide an open mode in the BigKI.
@@ -3523,9 +3532,15 @@ class xKI(ptModifier):
         if self.BKRightSideMode == kGUI.BKListMode:
             self.BigKIOnlySelectedToButtons()
         elif self.BKRightSideMode == kGUI.BKJournalExpanded:
-            self.BigKIInvertToFolderButtons()
+            if self.IsContentDeletableAndMovable(self.BKCurrentContent):
+                self.BigKIInvertToFolderButtons()
+            else:
+                self.BigKIOnlySelectedToButtons()
         elif self.BKRightSideMode == kGUI.BKPictureExpanded:
-            self.BigKIInvertToFolderButtons()
+            if self.IsContentDeletableAndMovable(self.BKCurrentContent):
+                self.BigKIInvertToFolderButtons()
+            else:
+                self.BigKIOnlySelectedToButtons()
         elif self.BKRightSideMode == kGUI.BKPlayerExpanded:
             localPlayer = PtGetLocalPlayer()
             if self.BKCurrentContent is not None:
@@ -3549,7 +3564,7 @@ class xKI(ptModifier):
         elif self.BKRightSideMode == kGUI.BKAgeOwnerExpanded:
             self.BigKIOnlySelectedToButtons()
         elif self.BKRightSideMode == kGUI.BKMarkerListExpanded:
-            if self.MFdialogMode not in (kGames.MFEditing, kGames.MFEditingMarker):
+            if self.MFdialogMode not in (kGames.MFEditing, kGames.MFEditingMarker) and self.IsContentDeletableAndMovable(self.BKCurrentContent):
                 self.BigKIInvertToFolderButtons()
             else:
                 self.BigKIOnlySelectedToButtons()
@@ -3679,7 +3694,7 @@ class xKI(ptModifier):
             return True
         return False
 
-    ## Determines whether the content Node Reference is mutable.
+    ## Determines whether the content Node Reference is mutable (editable).
     def IsContentMutable(self, nodeRef):
 
         # Get its parent folder.
@@ -3698,6 +3713,21 @@ class xKI(ptModifier):
                     return False
                 if folder := folder.upcastToFolderNode():
                     if folder.folderGetType() == PtVaultStandardNodes.kGlobalInboxFolder:
+                        return False
+        return True
+
+    ## Determines whether the content Node Reference is deletable (and by extension movable to other folders).
+    def IsContentDeletableAndMovable(self, nodeRef):
+
+        # Get its parent folder.
+        if isinstance(nodeRef, ptVaultNodeRef):
+            folder = self.BKCurrentContent.getParent()
+            item = self.BKCurrentContent.getChild()
+            if folder and item:
+                if folder := folder.upcastToFolderNode():
+                    # Saver ID of zero should mean a DRC item. These inbox items are the only kind
+                    # of content that should *not* be able to be deleted or moved
+                    if folder.folderGetType() == PtVaultStandardNodes.kGlobalInboxFolder and self.BKCurrentContent.getSaverID() == 0:
                         return False
         return True
 
@@ -4503,7 +4533,8 @@ class xKI(ptModifier):
         if self.BKCurrentContent is None:
             PtDebugPrint("xKI.BigKIDisplayJournalEntry(): self.BKCurrentContent is None.", level=kErrorLevel)
             return
-        jrnDeleteBtn.show()
+        if self.IsContentDeletableAndMovable(self.BKCurrentContent):
+            jrnDeleteBtn.show()
         if self.IsContentMutable(self.BKCurrentContent):
             jrnNote.unlock()
             if not self.BKInEditMode or self.BKEditField != kGUI.BKEditFieldJRNTitle:
@@ -4581,7 +4612,8 @@ class xKI(ptModifier):
         if self.BKCurrentContent is None:
             PtDebugPrint("xKI.BigKIDisplayPicture(): self.BKCurrentContent is None.", level=kErrorLevel)
             return
-        picDeleteBtn.show()
+        if self.IsContentDeletableAndMovable(self.BKCurrentContent):
+            picDeleteBtn.show()
         if self.IsContentMutable(self.BKCurrentContent) and (not self.BKInEditMode or self.BKEditField != kGUI.BKEditFieldPICTitle):
             picTitleBtn.show()
         else:


### PR DESCRIPTION
Reported by @DamnBriggsy on OU discord. The H'uru client was not allowing players to move or delete items sent by other players out of their inbox. Notes, pictures, and marker games could not be moved to other folders or deleted from the player's folders.

Fixed this by splitting out checks for mutability (e.g., editing journal notes or editing titles of journals/pictures) versus checks for deletability/movability (e.g., nearly any journal, picture, or game other than DRC mails) and using appropriately. Journals, pictures, and games sent by other people can be safely deleted by the recipient without affecting the original sender or creator's items.

Also allow users to delete a marker game from their folders when they are still pending a KI upgrade in order to be able to play it, otherwise they can have an inbox full of unplayable games and no way to clear it out if they want.