### PR TITLE
`ST::string`-ize `pfGUIControlTextBox`.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfCharacter/pfConfirmationMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfCharacter/pfConfirmationMgr.cpp
@@ -85,11 +85,11 @@ class pfConfirmationDialogProc : public pfGUIDialogProc
     friend class pfConfirmationMgr;
     pfConfirmationMgr* fMgr;
 
-    inline void ISetText(const ST::string& text, uint32_t tagID)
+    inline void ISetText(ST::string text, uint32_t tagID)
     {
         pfGUITextBoxMod* mod = pfGUITextBoxMod::ConvertNoRef(fDialog->GetControlFromTag(tagID));
         hsAssert(mod != nullptr, "You sure about this, boss?");
-        mod->SetText(text.to_wchar().data());
+        mod->SetText(std::move(text));
     }
 
     inline void ISetLocalizedText(const ST::string& path, uint32_t tagID)
@@ -97,7 +97,7 @@ class pfConfirmationDialogProc : public pfGUIDialogProc
         ISetText(pfLocalizationMgr::Instance().GetString(path), tagID);
     }
 
-    void ILayoutYesNo(const ST::string& text)
+    void ILayoutYesNo(ST::string text)
     {
         fDialog->GetControlFromTag(kLogoutTextTag)->SetVisible(false);
         fDialog->GetControlFromTag(kLogoutButtonTag)->SetVisible(false);
@@ -107,10 +107,10 @@ class pfConfirmationDialogProc : public pfGUIDialogProc
         fDialog->GetControlFromTag(kNoButtonTag)->SetVisible(true);
         ISetLocalizedText("KI.YesNoDialog.YESButton"_st, kYesTextTag);
         ISetLocalizedText("KI.YesNoDialog.NoButton"_st, kNoTextTag);
-        ISetText(text, kMessageTextTag);
+        ISetText(std::move(text), kMessageTextTag);
     }
 
-    void ILayoutSingle(const ST::string& message, const ST::string& button)
+    void ILayoutSingle(ST::string message, const ST::string& button)
     {
         fDialog->GetControlFromTag(kLogoutTextTag)->SetVisible(false);
         fDialog->GetControlFromTag(kLogoutButtonTag)->SetVisible(false);
@@ -119,10 +119,10 @@ class pfConfirmationDialogProc : public pfGUIDialogProc
         fDialog->GetControlFromTag(kNoTextTag)->SetVisible(true);
         fDialog->GetControlFromTag(kNoButtonTag)->SetVisible(true);
         ISetLocalizedText(button, kNoTextTag);
-        ISetText(message, kMessageTextTag);
+        ISetText(std::move(message), kMessageTextTag);
     }
 
-    void ILayoutQuit(const ST::string& text)
+    void ILayoutQuit(ST::string text)
     {
         bool canLogout = plNetClientApp::GetInstance()->GetPlayerID() != 0;
         fDialog->GetControlFromTag(kLogoutTextTag)->SetVisible(canLogout);
@@ -135,7 +135,7 @@ class pfConfirmationDialogProc : public pfGUIDialogProc
             ISetText("Logout"_st, kLogoutTextTag); // FIXME: This is missing from the LOC files.
         ISetLocalizedText("KI.YesNoDialog.QuitButton"_st, kYesTextTag);
         ISetLocalizedText("KI.YesNoDialog.NoButton"_st, kNoTextTag);
-        ISetText(text, kMessageTextTag);
+        ISetText(std::move(text), kMessageTextTag);
     }
 
 public:

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.h
@@ -60,7 +60,7 @@ class pfGUITextBoxMod : public pfGUIControlMod
 {
     protected:
 
-        wchar_t         *fText;
+        ST::string      fText;
         ST::string      fLocalizationPath;
         bool            fUseLocalizationPath;
 
@@ -73,7 +73,6 @@ class pfGUITextBoxMod : public pfGUIControlMod
     public:
 
         pfGUITextBoxMod();
-        virtual ~pfGUITextBoxMod();
 
         CLASSNAME_REGISTER( pfGUITextBoxMod );
         GETINTERFACE_ANY( pfGUITextBoxMod, pfGUIControlMod );
@@ -95,13 +94,16 @@ class pfGUITextBoxMod : public pfGUIControlMod
 
         void    PurgeDynaTextMapImage() override;
 
-        virtual const wchar_t*  GetText() { return fText; }
+        ST::string  GetText() const { return fText; }
 
         // Export only
-        void    SetText( const char *text );
-        void    SetText( const wchar_t *text );
+        void    SetText(ST::string text)
+        {
+            fText = std::move(text);
+            IUpdate();
+        }
 
-        void    SetLocalizationPath(const ST::string& path);
+        void    SetLocalizationPath(ST::string path);
         void    SetUseLocalizationPath(bool use);
 };
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.cpp
@@ -68,48 +68,25 @@ bool pyGUIControlTextBox::IsGUIControlTextBox(pyKey& gckey)
 }
 
 
-std::string pyGUIControlTextBox::GetText()
+ST::string pyGUIControlTextBox::GetText() const
 {
-    char *temp = hsWStringToString(GetTextW().c_str());
-    std::string retVal = temp;
-    delete [] temp;
-    return retVal;
-}
-
-std::wstring pyGUIControlTextBox::GetTextW()
-{
-    if (fGCkey)
-    {
+    if (fGCkey) {
         // get the pointer to the modifier
         pfGUITextBoxMod* ptbmod = pfGUITextBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
-        if ( ptbmod )
-        {
-            if ( ptbmod->GetText() )
-            {
-                std::wstring retVal = ptbmod->GetText();
-                return retVal;
-            }
-        }
+        if (ptbmod)
+            return ptbmod->GetText();
     }
     // else if there is no string... fake one
-    return L"";
+    return {};
 }
 
-void pyGUIControlTextBox::SetText( const char *text )
+void pyGUIControlTextBox::SetText(ST::string text)
 {
-    wchar_t *wText = hsStringToWString(text);
-    SetTextW(wText);
-    delete [] wText;
-}
-
-void pyGUIControlTextBox::SetTextW( const std::wstring& text )
-{
-    if ( fGCkey )
-    {
+    if (fGCkey) {
         // get the pointer to the modifier
         pfGUITextBoxMod* ptbmod = pfGUITextBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
-        if ( ptbmod )
-            ptbmod->SetText(text.c_str());
+        if (ptbmod)
+            ptbmod->SetText(std::move(text));
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.h
@@ -51,10 +51,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pyGUIControl.h"
 #include "pyGlueHelpers.h"
-#include <string>
 
 class pyColor;
 class pfGUIColorScheme;
+
+namespace ST { class string; }
 
 class pyGUIControlTextBox : public pyGUIControl
 {
@@ -78,10 +79,8 @@ public:
 
     static bool IsGUIControlTextBox(pyKey& gckey);
 
-    virtual void    SetText( const char *text );
-    virtual void    SetTextW( const std::wstring& text );
-    virtual std::string GetText();
-    virtual std::wstring GetTextW();
+    void SetText(ST::string text);
+    ST::string GetText() const;
     virtual void    SetFontSize( uint8_t size );
     virtual void    SetForeColor( pyColor& color );
     virtual void    SetBackColor( pyColor& color );

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBoxGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBoxGlue.cpp
@@ -74,47 +74,37 @@ PYTHON_INIT_DEFINITION(ptGUIControlTextBox, args, keywords)
 
 PYTHON_METHOD_DEFINITION(ptGUIControlTextBox, setString, args)
 {
-    char* text;
-    if (!PyArg_ParseTuple(args, "s", &text))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "setString expects a string");
         PYTHON_RETURN_ERROR;
     }
-    self->fThis->SetText(text);
+    self->fThis->SetText(std::move(text));
     PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlTextBox, setStringW, args)
 {
-    PyObject* textObj;
-    if (!PyArg_ParseTuple(args, "O", &textObj))
-    {
-        PyErr_SetString(PyExc_TypeError, "setStringW expects a unicode string");
+    // TODO: Remove this from the scripts.
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text)) {
+        PyErr_SetString(PyExc_TypeError, "setString expects a string");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* temp = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->SetTextW(temp);
-        PyMem_Free(temp);
-        PYTHON_RETURN_NONE;
-    }
-    else
-    {
-        PyErr_SetString(PyExc_TypeError, "setStringW expects a unicode string");
-        PYTHON_RETURN_ERROR;
-    }
+    self->fThis->SetText(std::move(text));
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlTextBox, getString)
 {
-    return PyUnicode_FromStdString(self->fThis->GetText());
+    return PyUnicode_FromSTString(self->fThis->GetText());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlTextBox, getStringW)
 {
-    std::wstring retVal = self->fThis->GetTextW();
-    return PyUnicode_FromWideChar(retVal.c_str(), retVal.length());
+    // TODO: Remove this from the scripts.
+    return PyUnicode_FromSTString(self->fThis->GetText());
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlTextBox, setFontSize, args)

--- a/Sources/Tools/MaxComponent/plGUIComponents.cpp
+++ b/Sources/Tools/MaxComponent/plGUIComponents.cpp
@@ -3289,7 +3289,7 @@ bool plGUITextBoxComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
 
     pfGUITextBoxMod *ctrl = (pfGUITextBoxMod *)fControl;
 
-    ctrl->SetText( fCompPB->GetStr( kRefInitText ) );
+    ctrl->SetText(M2ST(fCompPB->GetStr(kRefInitText)));
 
     if( fCompPB->GetInt( kRefXparentBgnd ) )
         ctrl->SetFlag( pfGUITextBoxMod::kXparentBgnd );
@@ -3304,7 +3304,7 @@ bool plGUITextBoxComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         ctrl->SetFlag( pfGUIControlMod::kScaleTextWithResolution );
 
     ctrl->SetUseLocalizationPath( fCompPB->GetInt( kRefUseLocalization ) != 0 );
-    ctrl->SetLocalizationPath( fCompPB->GetStr( kRefLocalizationPath ) );
+    ctrl->SetLocalizationPath(M2ST(fCompPB->GetStr(kRefLocalizationPath)));
 
     return true;
 }


### PR DESCRIPTION
Now with many less allocations. This fixes problems reported about the Python API nuking unicode characters when going through the non-W codepath.