### PR TITLE
Support create player with unicode name and fix a bunch of string-murdering

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1180,7 +1180,7 @@ class xKI(ptModifier):
             avatarSet = 1
             self.BKPlayerSelected = player
             sendToField = ptGUIControlTextBox(BigKI.dialog.getControlFromTag(kGUI.BKIPlayerLine))
-            sendToField.setString(player.getPlayerName())
+            sendToField.setStringW(player.getPlayerName())
             self.SetBigKIToButtons()
             # Find the player in the list and select them.
             for pidx in range(len(self.BKPlayerList)):
@@ -1917,7 +1917,7 @@ class xKI(ptModifier):
 
         gameName = xLocTools.CreatePossessiveString(PtGetLocalPlayer().getPlayerName(), PtGetLocalizedString("KI.MarkerGame.DefaultGameTitle"))
 
-        ptGUIControlEditBox(KICreateMarkerGameGUI.dialog.getControlFromTag(kGUI.CreateMarkerGameNameEB)).setString(gameName)
+        ptGUIControlEditBox(KICreateMarkerGameGUI.dialog.getControlFromTag(kGUI.CreateMarkerGameNameEB)).setStringW(gameName)
 
     ## Begin the creation of a new Marker Game.
     def CreateMarkerGame(self):
@@ -3649,7 +3649,7 @@ class xKI(ptModifier):
                 curSendTo = sendToField.getString().strip()
                 if not curSendTo:
                     self.BKPlayerSelected = sender
-                    sendToField.setString(sender.playerGetName())
+                    sendToField.setStringW(sender.playerGetName())
 
     #~~~~~~~~~~~~~~~#
     # BigKI Content #
@@ -3749,7 +3749,7 @@ class xKI(ptModifier):
         playerText = ptGUIControlTextBox(BigKI.dialog.getControlFromTag(kGUI.BKPlayerName))
         IDText = ptGUIControlTextBox(BigKI.dialog.getControlFromTag(kGUI.BKPlayerID))
         localPlayer = PtGetLocalPlayer()
-        playerText.setString(localPlayer.getPlayerName())
+        playerText.setStringW(localPlayer.getPlayerName())
         IDText.setString("[ID:{:08d}]".format(localPlayer.getPlayerID()))
         self.UpdatePelletScore()
         self.BigKIRefreshHoodStatics()
@@ -4356,7 +4356,7 @@ class xKI(ptModifier):
                             contentIconJ.hide()
                             contentIconP.hide()
                             contentTitle.setForeColor(kColors.DniSelectable)
-                            contentTitle.setString(xCensor.xCensor(content.getPlayerName(), self.censorLevel))
+                            contentTitle.setStringW(xCensor.xCensor(content.getPlayerName(), self.censorLevel))
                             contentTitle.show()
                             contentDate.hide()
                             contentFrom.setForeColor(kColors.DniSelectable)
@@ -4409,7 +4409,7 @@ class xKI(ptModifier):
                                 if isinstance(element, ptVaultPlayerInfoNode):
                                     # If it's a player, use the title for the player name.
                                     contentTitle.setForeColor(kColors.DniSelectable)
-                                    contentTitle.setString(xCensor.xCensor(element.playerGetName(), self.censorLevel))
+                                    contentTitle.setStringW(xCensor.xCensor(element.playerGetName(), self.censorLevel))
                                     contentTitle.show()
                                     contentDate.hide()
                                     contentFrom.setForeColor(kColors.DniSelectable)
@@ -4430,11 +4430,11 @@ class xKI(ptModifier):
                                         contentDate.setForeColor(kColors.DniSelectable)
 
                                     if isinstance(element, ptVaultImageNode):
-                                        contentTitle.setString(xCensor.xCensor(element.imageGetTitle(), self.censorLevel))
+                                        contentTitle.setStringW(xCensor.xCensor(element.imageGetTitle(), self.censorLevel))
                                     elif isinstance(element, ptVaultTextNoteNode):
-                                        contentTitle.setString(xCensor.xCensor(element.noteGetTitle(), self.censorLevel))
+                                        contentTitle.setStringW(xCensor.xCensor(element.noteGetTitle(), self.censorLevel))
                                     elif isinstance(element, ptVaultMarkerGameNode):
-                                        contentTitle.setString(xCensor.xCensor(element.getGameName(), self.censorLevel))
+                                        contentTitle.setStringW(xCensor.xCensor(element.getGameName(), self.censorLevel))
                                     else:
                                         # Probably still downloading because of lag.
                                         contentTitle.setString("--[Downloading]--")
@@ -4460,7 +4460,7 @@ class xKI(ptModifier):
                                         else:
                                             contentFrom.setForeColor(kColors.DniSelectable)
                                             contentFrom.setFontSize(10)
-                                            contentFrom.setString(sender.playerGetName())
+                                            contentFrom.setStringW(sender.playerGetName())
                                         contentFrom.show()
                                     else:
                                         if content.getSaverID() == 0:
@@ -4635,7 +4635,7 @@ class xKI(ptModifier):
         picDate.setString(curTime)
         picDate.show()
         if not self.BKInEditMode or self.BKEditField != kGUI.BKEditFieldPICTitle:
-            picTitle.setString(xCensor.xCensor(element.imageGetTitle(), self.censorLevel))
+            picTitle.setStringW(xCensor.xCensor(element.imageGetTitle(), self.censorLevel))
             picTitle.show()
         if picImage.getNumMaps() > 0:
             dynMap = picImage.getMap(0)
@@ -4706,7 +4706,7 @@ class xKI(ptModifier):
             return
         if isinstance(self.BKCurrentContent, ptPlayer):
             # Display the content on the screen.
-            plyName.setString(xCensor.xCensor(self.BKCurrentContent.getPlayerName(), self.censorLevel))
+            plyName.setStringW(xCensor.xCensor(self.BKCurrentContent.getPlayerName(), self.censorLevel))
             plyName.show()
             IDText = "{:08d}".format(self.BKCurrentContent.getPlayerID())
             plyID.setString(IDText)
@@ -4715,7 +4715,7 @@ class xKI(ptModifier):
             plyDetail.show()
             sendToField = ptGUIControlTextBox(BigKI.dialog.getControlFromTag(kGUI.BKIPlayerLine))
             self.BKPlayerSelected = self.BKCurrentContent
-            sendToField.setString(self.BKCurrentContent.getPlayerName())
+            sendToField.setStringW(self.BKCurrentContent.getPlayerName())
             return
         element = self.BKCurrentContent.getChild()
         if element is None:
@@ -4727,7 +4727,7 @@ class xKI(ptModifier):
             return
         element = element.upcastToPlayerInfoNode()
         # Display the content on the screen.
-        plyName.setString(xCensor.xCensor(element.playerGetName(), self.censorLevel))
+        plyName.setStringW(xCensor.xCensor(element.playerGetName(), self.censorLevel))
         plyName.show()
         IDText = "{:08d}".format(element.playerGetID())
         plyID.setString(IDText)
@@ -4750,7 +4750,7 @@ class xKI(ptModifier):
             plyDeleteBtn.show()
         sendToField = ptGUIControlTextBox(BigKI.dialog.getControlFromTag(kGUI.BKIPlayerLine))
         self.BKPlayerSelected = self.BKCurrentContent
-        sendToField.setString(element.playerGetName())
+        sendToField.setStringW(element.playerGetName())
 
     ## Save after a player was edited.
     def BigKICheckSavePlayer(self):
@@ -5353,11 +5353,11 @@ class xKI(ptModifier):
                 if dataType == PtVaultNodeTypes.kMarkerGameNode:
                     element = element.upcastToMarkerGameNode()
                     if element is not None:
-                        if not control.wasEscaped() and control.getString() != "":
+                        if not control.wasEscaped() and (controlText := control.getStringW()):
                             # Set the new title.
-                            newText = xCensor.xCensor(control.getStringW(), self.censorLevel)
-                            element.setGameName(control.getStringW())
-                            title.setString(control.getStringW())
+                            newText = xCensor.xCensor(controlText, self.censorLevel)
+                            element.setGameName(controlText)
+                            title.setStringW(controlText)
                             element.save()
                             PtDebugPrint("xKI.SaveMarkerGameNameFromEdit(): Updating title to \"{}\".".format(newText), level=kDebugDumpLevel)
                             self.RefreshPlayerList()
@@ -5563,7 +5563,7 @@ class xKI(ptModifier):
             # Get the original position of the miniKI.
             dragbar = ptGUIControlDragBar(KIMini.dialog.getControlFromTag(kGUI.miniDragBar))
             self.originalminiKICenter = dragbar.getObjectCenter()
-            # Retreive the original alpha.
+            # Retrieve the original alpha.
             fore = control.getForeColor()
             self.originalForeAlpha = fore.getAlpha()
             sel = control.getSelectColor()
@@ -5649,13 +5649,13 @@ class xKI(ptModifier):
                         # Can't be sent to.
                         pass
                     elif isinstance(self.BKPlayerSelected, Device):
-                        sendToField.setString(self.BKPlayerSelected.name)
+                        sendToField.setStringW(self.BKPlayerSelected.name)
                     # Is it a specific player info node?
                     elif isinstance(self.BKPlayerSelected, ptVaultNodeRef):
                         plyrInfoNode = self.BKPlayerSelected.getChild()
                         plyrInfo = plyrInfoNode.upcastToPlayerInfoNode()
                         if plyrInfo is not None:
-                            sendToField.setString(plyrInfo.playerGetName())
+                            sendToField.setStringW(plyrInfo.playerGetName())
                             # Set private caret.
                             caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + str(plyrInfo.playerGetName()) + " >")
                             privateChbox.setChecked(1)
@@ -5663,7 +5663,7 @@ class xKI(ptModifier):
                             self.BKPlayerSelected = None
                     # Is it a specific player?
                     elif isinstance(self.BKPlayerSelected, ptPlayer):
-                        sendToField.setString(self.BKPlayerSelected.getPlayerName())
+                        sendToField.setStringW(self.BKPlayerSelected.getPlayerName())
                         caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + str(self.BKPlayerSelected.getPlayerName()) + " >")
                         privateChbox.setChecked(1)
                     # Is it a list of players?

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -2967,7 +2967,7 @@ class xKI(ptModifier):
                     if PLR.playerIsOnline():
                         playerlist.addStringWithColor(PLR.playerGetName(), kColors.DniSelectable, kSelectUseGUIColor)
                     else:
-                        playerlist.addStringWithColor(PLR.playerGetName(), kColors.AgenBlueDk,kSelectDetermined)
+                        playerlist.addStringWithColor(PLR.playerGetName(), kColors.AgenBlueDk, kSelectDetermined)
                 else:
                     PtDebugPrint("xKI.RefreshPlayerListDisplay(): Unknown player element type {}.".format(PLR.getType()), level=kErrorLevel)
             elif isinstance(plyr, ptPlayer):

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -3133,7 +3133,7 @@ class xKI(ptModifier):
                 myAge = None
             if myAge is not None:
                 title = ptGUIControlTextBox(KIAgeOwnerExpanded.dialog.getControlFromTag(kGUI.BKAgeOwnerTitleTB))
-                title.setString(GetAgeName(myAge))
+                title.setStringW(GetAgeName(myAge))
                 titlebtn = ptGUIControlButton(KIAgeOwnerExpanded.dialog.getControlFromTag(kGUI.BKAgeOwnerTitleBtn))
                 titlebtn.enable()
                 titleEdit = ptGUIControlEditBox(KIAgeOwnerExpanded.dialog.getControlFromTag(kGUI.BKAgeOwnerTitleEditbox))
@@ -4361,7 +4361,7 @@ class xKI(ptModifier):
                             contentDate.hide()
                             contentFrom.setForeColor(kColors.DniSelectable)
                             contentFrom.setFontSize(10)
-                            contentFrom.setString(GetAgeName())
+                            contentFrom.setStringW(GetAgeName())
                             contentFrom.show()
                             # Find the button to enable it.
                             lmButton = ptGUIControlButton(KIListModeDialog.dialog.getControlFromTag(((ID - 100) // 10) + kGUI.BKIListModeCreateBtn))
@@ -4415,7 +4415,7 @@ class xKI(ptModifier):
                                     contentFrom.setForeColor(kColors.DniSelectable)
                                     contentFrom.setFontSize(10)
                                     if element.playerIsOnline():
-                                        contentFrom.setString(FilterAgeName(element.playerGetAgeInstanceName()))
+                                        contentFrom.setStringW(FilterAgeName(element.playerGetAgeInstanceName()))
                                     else:
                                         contentFrom.setString("  ")
                                     contentFrom.show()
@@ -4552,7 +4552,7 @@ class xKI(ptModifier):
             return
         element = element.upcastToTextNoteNode()
         # Display the content on the screen.
-        jrnAgeName.setString(FilterAgeName(xCensor.xCensor(element.getCreateAgeName(), self.censorLevel)))
+        jrnAgeName.setStringW(FilterAgeName(xCensor.xCensor(element.getCreateAgeName(), self.censorLevel)))
         jrnAgeName.show()
         tupTime = time.gmtime(PtGMTtoDniTime(element.getModifyTime()))
         curTime = time.strftime(PtGetLocalizedString("Global.Formats.Date"), tupTime)
@@ -4628,7 +4628,7 @@ class xKI(ptModifier):
             return
         element = element.upcastToImageNode()
         # Display the content on the screen.
-        picAgeName.setString(FilterAgeName(xCensor.xCensor(element.getCreateAgeName(), self.censorLevel)))
+        picAgeName.setStringW(FilterAgeName(xCensor.xCensor(element.getCreateAgeName(), self.censorLevel)))
         picAgeName.show()
         tupTime = time.gmtime(PtGMTtoDniTime(element.getModifyTime()))
         curTime = time.strftime(PtGetLocalizedString("Global.Formats.Date"), tupTime)
@@ -6218,7 +6218,7 @@ class xKI(ptModifier):
                 try:
                     # Get the selected Age config setting.
                     myAge = self.BKConfigFolderDict[self.BKConfigListOrder[self.BKFolderSelected]]
-                    titleEdit.setString(myAge.getAgeUserDefinedName())
+                    titleEdit.setStringW(myAge.getAgeUserDefinedName())
                 except LookupError:
                     titleEdit.setString("")
                 titleEdit.show()
@@ -6245,7 +6245,7 @@ class xKI(ptModifier):
                         myAge = self.BKConfigFolderDict[self.BKConfigListOrder[self.BKFolderSelected]]
                         if myAge is not None:
                             PtDebugPrint("xKI.ProcessNotifyAgeOwnerExpanded(): Age description updated for {}.".format(myAge.getDisplayName()), level=kDebugDumpLevel)
-                            myAge.setAgeDescription(descript.getString())
+                            myAge.setAgeDescription(descript.getStringW())
                             myAge.save()
                         else:
                             PtDebugPrint("xKI.ProcessNotifyAgeOwnerExpanded(): Neighborhood is None while trying to update description.", level=kDebugDumpLevel)
@@ -6256,7 +6256,7 @@ class xKI(ptModifier):
                     myAge = self.BKConfigFolderDict[self.BKConfigListOrder[self.BKFolderSelected]]
                     if myAge is not None:
                         PtDebugPrint("xKI.ProcessNotifyAgeOwnerExpanded(): Age description updated for {}.".format(myAge.getDisplayName()), level=kDebugDumpLevel)
-                        buff = descript.getString()
+                        buff = descript.getStringW()
                         myAge.setAgeDescription(buff)
                         myAge.save()
                     else:

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -4460,7 +4460,7 @@ class xKI(ptModifier):
                                         else:
                                             contentFrom.setForeColor(kColors.DniSelectable)
                                             contentFrom.setFontSize(10)
-                                            contentFrom.setStringW(sender.playerGetName())
+                                            contentFrom.setString(sender.playerGetName())
                                         contentFrom.show()
                                     else:
                                         if content.getSaverID() == 0:
@@ -4727,7 +4727,7 @@ class xKI(ptModifier):
             return
         element = element.upcastToPlayerInfoNode()
         # Display the content on the screen.
-        plyName.setStringW(xCensor.xCensor(element.playerGetName(), self.censorLevel))
+        plyName.setString(xCensor.xCensor(element.playerGetName(), self.censorLevel))
         plyName.show()
         IDText = "{:08d}".format(element.playerGetID())
         plyID.setString(IDText)

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1180,7 +1180,7 @@ class xKI(ptModifier):
             avatarSet = 1
             self.BKPlayerSelected = player
             sendToField = ptGUIControlTextBox(BigKI.dialog.getControlFromTag(kGUI.BKIPlayerLine))
-            sendToField.setStringW(player.getPlayerName())
+            sendToField.setString(player.getPlayerName())
             self.SetBigKIToButtons()
             # Find the player in the list and select them.
             for pidx in range(len(self.BKPlayerList)):
@@ -3133,7 +3133,7 @@ class xKI(ptModifier):
                 myAge = None
             if myAge is not None:
                 title = ptGUIControlTextBox(KIAgeOwnerExpanded.dialog.getControlFromTag(kGUI.BKAgeOwnerTitleTB))
-                title.setStringW(GetAgeName(myAge))
+                title.setString(GetAgeName(myAge))
                 titlebtn = ptGUIControlButton(KIAgeOwnerExpanded.dialog.getControlFromTag(kGUI.BKAgeOwnerTitleBtn))
                 titlebtn.enable()
                 titleEdit = ptGUIControlEditBox(KIAgeOwnerExpanded.dialog.getControlFromTag(kGUI.BKAgeOwnerTitleEditbox))
@@ -3649,7 +3649,7 @@ class xKI(ptModifier):
                 curSendTo = sendToField.getString().strip()
                 if not curSendTo:
                     self.BKPlayerSelected = sender
-                    sendToField.setStringW(sender.playerGetName())
+                    sendToField.setString(sender.playerGetName())
 
     #~~~~~~~~~~~~~~~#
     # BigKI Content #
@@ -3749,7 +3749,7 @@ class xKI(ptModifier):
         playerText = ptGUIControlTextBox(BigKI.dialog.getControlFromTag(kGUI.BKPlayerName))
         IDText = ptGUIControlTextBox(BigKI.dialog.getControlFromTag(kGUI.BKPlayerID))
         localPlayer = PtGetLocalPlayer()
-        playerText.setStringW(localPlayer.getPlayerName())
+        playerText.setString(localPlayer.getPlayerName())
         IDText.setString("[ID:{:08d}]".format(localPlayer.getPlayerID()))
         self.UpdatePelletScore()
         self.BigKIRefreshHoodStatics()
@@ -4356,12 +4356,12 @@ class xKI(ptModifier):
                             contentIconJ.hide()
                             contentIconP.hide()
                             contentTitle.setForeColor(kColors.DniSelectable)
-                            contentTitle.setStringW(xCensor.xCensor(content.getPlayerName(), self.censorLevel))
+                            contentTitle.setString(xCensor.xCensor(content.getPlayerName(), self.censorLevel))
                             contentTitle.show()
                             contentDate.hide()
                             contentFrom.setForeColor(kColors.DniSelectable)
                             contentFrom.setFontSize(10)
-                            contentFrom.setStringW(GetAgeName())
+                            contentFrom.setString(GetAgeName())
                             contentFrom.show()
                             # Find the button to enable it.
                             lmButton = ptGUIControlButton(KIListModeDialog.dialog.getControlFromTag(((ID - 100) // 10) + kGUI.BKIListModeCreateBtn))
@@ -4409,13 +4409,13 @@ class xKI(ptModifier):
                                 if isinstance(element, ptVaultPlayerInfoNode):
                                     # If it's a player, use the title for the player name.
                                     contentTitle.setForeColor(kColors.DniSelectable)
-                                    contentTitle.setStringW(xCensor.xCensor(element.playerGetName(), self.censorLevel))
+                                    contentTitle.setString(xCensor.xCensor(element.playerGetName(), self.censorLevel))
                                     contentTitle.show()
                                     contentDate.hide()
                                     contentFrom.setForeColor(kColors.DniSelectable)
                                     contentFrom.setFontSize(10)
                                     if element.playerIsOnline():
-                                        contentFrom.setStringW(FilterAgeName(element.playerGetAgeInstanceName()))
+                                        contentFrom.setString(FilterAgeName(element.playerGetAgeInstanceName()))
                                     else:
                                         contentFrom.setString("  ")
                                     contentFrom.show()
@@ -4430,11 +4430,11 @@ class xKI(ptModifier):
                                         contentDate.setForeColor(kColors.DniSelectable)
 
                                     if isinstance(element, ptVaultImageNode):
-                                        contentTitle.setStringW(xCensor.xCensor(element.imageGetTitle(), self.censorLevel))
+                                        contentTitle.setString(xCensor.xCensor(element.imageGetTitle(), self.censorLevel))
                                     elif isinstance(element, ptVaultTextNoteNode):
-                                        contentTitle.setStringW(xCensor.xCensor(element.noteGetTitle(), self.censorLevel))
+                                        contentTitle.setString(xCensor.xCensor(element.noteGetTitle(), self.censorLevel))
                                     elif isinstance(element, ptVaultMarkerGameNode):
-                                        contentTitle.setStringW(xCensor.xCensor(element.getGameName(), self.censorLevel))
+                                        contentTitle.setString(xCensor.xCensor(element.getGameName(), self.censorLevel))
                                     else:
                                         # Probably still downloading because of lag.
                                         contentTitle.setString("--[Downloading]--")
@@ -4552,7 +4552,7 @@ class xKI(ptModifier):
             return
         element = element.upcastToTextNoteNode()
         # Display the content on the screen.
-        jrnAgeName.setStringW(FilterAgeName(xCensor.xCensor(element.getCreateAgeName(), self.censorLevel)))
+        jrnAgeName.setString(FilterAgeName(xCensor.xCensor(element.getCreateAgeName(), self.censorLevel)))
         jrnAgeName.show()
         tupTime = time.gmtime(PtGMTtoDniTime(element.getModifyTime()))
         curTime = time.strftime(PtGetLocalizedString("Global.Formats.Date"), tupTime)
@@ -4628,14 +4628,14 @@ class xKI(ptModifier):
             return
         element = element.upcastToImageNode()
         # Display the content on the screen.
-        picAgeName.setStringW(FilterAgeName(xCensor.xCensor(element.getCreateAgeName(), self.censorLevel)))
+        picAgeName.setString(FilterAgeName(xCensor.xCensor(element.getCreateAgeName(), self.censorLevel)))
         picAgeName.show()
         tupTime = time.gmtime(PtGMTtoDniTime(element.getModifyTime()))
         curTime = time.strftime(PtGetLocalizedString("Global.Formats.Date"), tupTime)
         picDate.setString(curTime)
         picDate.show()
         if not self.BKInEditMode or self.BKEditField != kGUI.BKEditFieldPICTitle:
-            picTitle.setStringW(xCensor.xCensor(element.imageGetTitle(), self.censorLevel))
+            picTitle.setString(xCensor.xCensor(element.imageGetTitle(), self.censorLevel))
             picTitle.show()
         if picImage.getNumMaps() > 0:
             dynMap = picImage.getMap(0)
@@ -4706,7 +4706,7 @@ class xKI(ptModifier):
             return
         if isinstance(self.BKCurrentContent, ptPlayer):
             # Display the content on the screen.
-            plyName.setStringW(xCensor.xCensor(self.BKCurrentContent.getPlayerName(), self.censorLevel))
+            plyName.setString(xCensor.xCensor(self.BKCurrentContent.getPlayerName(), self.censorLevel))
             plyName.show()
             IDText = "{:08d}".format(self.BKCurrentContent.getPlayerID())
             plyID.setString(IDText)
@@ -4715,7 +4715,7 @@ class xKI(ptModifier):
             plyDetail.show()
             sendToField = ptGUIControlTextBox(BigKI.dialog.getControlFromTag(kGUI.BKIPlayerLine))
             self.BKPlayerSelected = self.BKCurrentContent
-            sendToField.setStringW(self.BKCurrentContent.getPlayerName())
+            sendToField.setString(self.BKCurrentContent.getPlayerName())
             return
         element = self.BKCurrentContent.getChild()
         if element is None:
@@ -4750,7 +4750,7 @@ class xKI(ptModifier):
             plyDeleteBtn.show()
         sendToField = ptGUIControlTextBox(BigKI.dialog.getControlFromTag(kGUI.BKIPlayerLine))
         self.BKPlayerSelected = self.BKCurrentContent
-        sendToField.setStringW(element.playerGetName())
+        sendToField.setString(element.playerGetName())
 
     ## Save after a player was edited.
     def BigKICheckSavePlayer(self):
@@ -5357,7 +5357,7 @@ class xKI(ptModifier):
                             # Set the new title.
                             newText = xCensor.xCensor(controlText, self.censorLevel)
                             element.setGameName(controlText)
-                            title.setStringW(controlText)
+                            title.setString(controlText)
                             element.save()
                             PtDebugPrint("xKI.SaveMarkerGameNameFromEdit(): Updating title to \"{}\".".format(newText), level=kDebugDumpLevel)
                             self.RefreshPlayerList()
@@ -5649,13 +5649,13 @@ class xKI(ptModifier):
                         # Can't be sent to.
                         pass
                     elif isinstance(self.BKPlayerSelected, Device):
-                        sendToField.setStringW(self.BKPlayerSelected.name)
+                        sendToField.setString(self.BKPlayerSelected.name)
                     # Is it a specific player info node?
                     elif isinstance(self.BKPlayerSelected, ptVaultNodeRef):
                         plyrInfoNode = self.BKPlayerSelected.getChild()
                         plyrInfo = plyrInfoNode.upcastToPlayerInfoNode()
                         if plyrInfo is not None:
-                            sendToField.setStringW(plyrInfo.playerGetName())
+                            sendToField.setString(plyrInfo.playerGetName())
                             # Set private caret.
                             caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + str(plyrInfo.playerGetName()) + " >")
                             privateChbox.setChecked(1)
@@ -5663,7 +5663,7 @@ class xKI(ptModifier):
                             self.BKPlayerSelected = None
                     # Is it a specific player?
                     elif isinstance(self.BKPlayerSelected, ptPlayer):
-                        sendToField.setStringW(self.BKPlayerSelected.getPlayerName())
+                        sendToField.setString(self.BKPlayerSelected.getPlayerName())
                         caret.setStringW(PtGetLocalizedString("KI.Chat.TOPrompt") + str(self.BKPlayerSelected.getPlayerName()) + " >")
                         privateChbox.setChecked(1)
                     # Is it a list of players?

--- a/Scripts/Python/xAvatarCustomization.py
+++ b/Scripts/Python/xAvatarCustomization.py
@@ -1438,7 +1438,7 @@ class xAvatarCustomization(ptModifier):
         editbox = ptGUIControlEditBox(AvCustGUI.dialog.getControlFromTag(kNameEBID))
         editbox.hide() # don't want people changing their name
         localplayer = PtGetLocalPlayer()
-        namebox.setString(localplayer.getPlayerName())
+        namebox.setStringW(localplayer.getPlayerName())
         panelRG = ptGUIControlRadioGroup(AvCustGUI.dialog.getControlFromTag(kPanelsRGID))
         clothing_panel = panelRG.getValue()
         zoomBtn = ptGUIControlCheckBox(AvCustGUI.dialog.getControlFromTag(kZoomButton))

--- a/Scripts/Python/xAvatarCustomization.py
+++ b/Scripts/Python/xAvatarCustomization.py
@@ -1438,7 +1438,7 @@ class xAvatarCustomization(ptModifier):
         editbox = ptGUIControlEditBox(AvCustGUI.dialog.getControlFromTag(kNameEBID))
         editbox.hide() # don't want people changing their name
         localplayer = PtGetLocalPlayer()
-        namebox.setStringW(localplayer.getPlayerName())
+        namebox.setString(localplayer.getPlayerName())
         panelRG = ptGUIControlRadioGroup(AvCustGUI.dialog.getControlFromTag(kPanelsRGID))
         clothing_panel = panelRG.getValue()
         zoomBtn = ptGUIControlCheckBox(AvCustGUI.dialog.getControlFromTag(kZoomButton))

--- a/Scripts/Python/xDialogStartUp.py
+++ b/Scripts/Python/xDialogStartUp.py
@@ -341,20 +341,10 @@ class xDialogStartUp(ptResponder):
                     PtShowDialog("GUIDialog04b")
 
                 elif  tagID == k6PlayID: ## Play ##
-                    playerName = ptGUIControlEditBox(GUIDiag6.dialog.getControlFromTag(k6NameID)).getString()  #                 <---
-                    playerNameW = ptGUIControlEditBox(GUIDiag6.dialog.getControlFromTag(k6NameID)).getStringW()  #                 <---
-
-                    try:
-                        playerName == playerNameW
-                    except:
-                        errorString = PtGetLocalizedString("GUI.Dialog04d.InvalidName")
-                        ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setStringW(errorString)
-                        PtShowDialog("GUIDialog04d")
-                        self.ToggleColor(GUIDiag4b, k4bPlayer03)
-                        return
-
+                    playerName = ptGUIControlEditBox(GUIDiag6.dialog.getControlFromTag(k6NameID)).getStringW()
                     playerGender = ""
                     playerStart = ""
+
                     if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6MaleID)).isChecked():
                         playerGender = "male"
                     if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6FemaleID)).isChecked():

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.cpp
@@ -1140,14 +1140,14 @@ void    pfGUIListBoxMod::ClearAllElements()
     HandleExtendedEvent( pfGUIListBoxMod::kListCleared );
 }
 
-uint16_t  pfGUIListBoxMod::AddString( const ST::string &string )
+uint16_t  pfGUIListBoxMod::AddString( ST::string string )
 {
-    return AddElement( new pfGUIListText( string ) );
+    return AddElement( new pfGUIListText( std::move(string) ) );
 }
 
-int16_t   pfGUIListBoxMod::FindString( const ST::string &toCompareTo )
+int16_t   pfGUIListBoxMod::FindString( ST::string toCompareTo )
 {
-    pfGUIListText   text( toCompareTo );
+    pfGUIListText text( std::move(toCompareTo) );
     return FindElement( &text );
 }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.h
@@ -190,8 +190,8 @@ class pfGUIListBoxMod : public pfGUIControlMod
         uint16_t              GetNumElements();
         pfGUIListElement    *GetElement( uint16_t idx );
 
-        uint16_t  AddString( const ST::string &string );
-        int16_t   FindString( const ST::string &toCompareTo );
+        uint16_t  AddString( ST::string string );
+        int16_t   FindString( ST::string toCompareTo );
 
         // Export only
         void    SetScrollCtrl( pfGUIValueCtrl *ctrl ) { fScrollControl = ctrl; }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListElement.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListElement.cpp
@@ -83,8 +83,8 @@ pfGUIListText::pfGUIListText()
 {
 }
 
-pfGUIListText::pfGUIListText( const ST::string &text )
-    : pfGUIListElement(kText), fText(text), fJustify(kLeftJustify)
+pfGUIListText::pfGUIListText( ST::string text )
+    : pfGUIListElement(kText), fText(std::move(text)), fJustify(kLeftJustify)
 {
 }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListElement.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListElement.h
@@ -130,7 +130,7 @@ class pfGUIListText : public pfGUIListElement
     public:
 
         pfGUIListText();
-        pfGUIListText( const ST::string &text );
+        pfGUIListText( ST::string text );
         
         void    Read(hsStream *s, hsResMgr *mgr) override;
         void    Write(hsStream *s, hsResMgr *mgr) override;
@@ -144,7 +144,7 @@ class pfGUIListText : public pfGUIListElement
 
         // These two are virtual so we can derive and override them
         virtual ST::string  GetText() const { return fText; }
-        virtual void        SetText(const ST::string &text) { fText = text; }
+        virtual void        SetText(ST::string text) { fText = std::move(text); }
 };
 
 class pfGUIListPicture : public pfGUIListElement
@@ -187,7 +187,7 @@ class pfGUIListTreeRoot : public pfGUIListElement
     public:
 
         pfGUIListTreeRoot() : pfGUIListElement(kTreeRoot), fShowChildren(true) { }
-        pfGUIListTreeRoot(const ST::string &text) : pfGUIListElement(kTreeRoot), fShowChildren(true), fText(text) { }
+        pfGUIListTreeRoot( ST::string text) : pfGUIListElement(kTreeRoot), fShowChildren(true), fText(std::move(text)) { }
         
         void    Read(hsStream *s, hsResMgr *mgr) override;
         void    Write(hsStream *s, hsResMgr *mgr) override;
@@ -198,8 +198,8 @@ class pfGUIListTreeRoot : public pfGUIListElement
 
         bool    MouseClicked(uint16_t localX, uint16_t localY) override;
 
-        const ST::string GetTitle() const { return fText; }
-        void        SetTitle(const ST::string &text) { fText = text; }
+        ST::string GetTitle() const { return fText; }
+        void SetTitle(ST::string text) { fText = std::move(text); }
 
         size_t              GetNumChildren() const { return fChildren.size(); }
         pfGUIListElement    *GetChild(size_t i) const { return fChildren[i]; }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
@@ -77,12 +77,12 @@ class pfColorListElement : public pfGUIListText
 
         pfColorListElement(ST::string string1, hsColorRGBA color1, ST::string string2, hsColorRGBA color2, uint32_t inheritalpha, int32_t fontsize = -1) 
             : pfGUIListText(), fTextColor1(color1), fTextColor2(color2), fString1(std::move(string1)), fString2(std::move(string2)),
-            fInheritAlpha(inheritalpha), fOverrideFontSize(fontsize)
+              fInheritAlpha(inheritalpha), fOverrideFontSize(fontsize)
         {}
 
         pfColorListElement(ST::string string1, hsColorRGBA color1, uint32_t inheritalpha, int32_t fontsize = -1)
             : pfGUIListText(), fTextColor1(color1), fTextColor2(), fString1(std::move(string1)), fInheritAlpha(inheritalpha),
-            fOverrideFontSize(fontsize)
+              fOverrideFontSize(fontsize)
         {}
 
         virtual void SetText(ST::string text)

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
@@ -75,31 +75,17 @@ class pfColorListElement : public pfGUIListText
             kSelectUseGUIColor,
         };
 
-        pfColorListElement( ST::string string1, hsColorRGBA color1, ST::string string2, hsColorRGBA color2, uint32_t inheritalpha, int32_t fontsize=-1 )
-        {
-            fText = ST::string();
-            fString1 = std::move(string1);
-            fTextColor1 = color1;
-            fString2 = std::move(string2);
-            fTextColor2 = color2;
-            fInheritAlpha = inheritalpha;
-            fJustify = kLeftJustify;
-            fOverrideFontSize = fontsize;
-        }
+        pfColorListElement(ST::string string1, hsColorRGBA color1, ST::string string2, hsColorRGBA color2, uint32_t inheritalpha, int32_t fontsize = -1) 
+            : pfGUIListText(), fTextColor1(color1), fTextColor2(color2), fString1(std::move(string1)), fString2(std::move(string2)),
+            fInheritAlpha(inheritalpha), fOverrideFontSize(fontsize)
+        {}
 
         pfColorListElement(ST::string string1, hsColorRGBA color1, uint32_t inheritalpha, int32_t fontsize = -1)
-        {
-            fText = ST::string();
-            fString1 = std::move(string1);
-            fTextColor1 = color1;
-            fString2 = ST::string();
-            fTextColor2 = hsColorRGBA();
-            fInheritAlpha = inheritalpha;
-            fJustify = kLeftJustify;
-            fOverrideFontSize = fontsize;
-        }
+            : pfGUIListText(), fTextColor1(color1), fTextColor2(), fString1(std::move(string1)), fInheritAlpha(inheritalpha),
+            fOverrideFontSize(fontsize)
+        {}
 
-        virtual void SetText(ST::string text )
+        virtual void SetText(ST::string text)
         {
             fString1 = std::move(text);
         }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
@@ -183,7 +183,14 @@ class pfColorListElement : public pfGUIListText
 
         void    GetSize(plDynamicTextMap *textGen, uint16_t *width, uint16_t *height) override
         {
-            ST::string thestring = ST::format("{} {}", fString1, fString2);            
+            ST::string_stream ss;
+            if (!fString1.empty())
+                ss << fString1;
+            if (!fString1.empty() && !fString2.empty())
+                ss << ' ';
+            if (!fString2.empty())
+                ss << fString2;
+            ST::string thestring = ss.to_string();
             *width = textGen->GetVisibleWidth() - 4;
 
             if ( fOverrideFontSize != -1 )

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
@@ -286,7 +286,7 @@ class pfListTextInBox : public pfGUIListText
         uint32_t              fMinHeight;
 
     public:
-        pfListTextInBox( const ST::string &text, uint32_t min_width=0, uint32_t min_height=0 ) : pfGUIListText( text )
+        pfListTextInBox( ST::string text, uint32_t min_width=0, uint32_t min_height=0 ) : pfGUIListText( std::move(text) )
         {
             fMinWidth = min_width;
             fMinHeight = min_height;
@@ -502,7 +502,7 @@ uint16_t pyGUIControlListBox::GetNumElements()
     return 0;
 }
 
-void pyGUIControlListBox::SetElement( uint16_t idx, const ST::string& text )
+void pyGUIControlListBox::SetElement( uint16_t idx, ST::string text )
 {
     if ( fGCkey )
     {
@@ -517,7 +517,7 @@ void pyGUIControlListBox::SetElement( uint16_t idx, const ST::string& text )
                 {
                     // if its a text element type then it should be safe to cast it to a pfGUIListText
                     pfGUIListText* letext = (pfGUIListText*)le;
-                    letext->SetText(text);
+                    letext->SetText(std::move(text));
                 }
             }
         }
@@ -575,7 +575,7 @@ ST::string pyGUIControlListBox::GetElement( uint16_t idx )
     return "";
 }
 
-int16_t pyGUIControlListBox::AddString( const ST::string &string )
+int16_t pyGUIControlListBox::AddString( ST::string string )
 {
     if ( fGCkey )
     {
@@ -583,7 +583,7 @@ int16_t pyGUIControlListBox::AddString( const ST::string &string )
         pfGUIListBoxMod* plbmod = pfGUIListBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( plbmod )
         {
-            pfGUIListText *element = new pfGUIListText(string);
+            pfGUIListText *element = new pfGUIListText(std::move(string));
             if (!fBuildRoots.empty())
                 fBuildRoots.back()->AddChild(element);
             return plbmod->AddElement( element );
@@ -610,27 +610,25 @@ int16_t   pyGUIControlListBox::AddImage( pyImage& image, bool respectAlpha )
 }
 
 
-int16_t pyGUIControlListBox::FindString( const ST::string &toCompareTo )
+int16_t pyGUIControlListBox::FindString( ST::string toCompareTo )
 {
     if ( fGCkey )
     {
         // get the pointer to the modifier
         pfGUIListBoxMod* plbmod = pfGUIListBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( plbmod )
-            return plbmod->FindString(toCompareTo);
+            return plbmod->FindString(std::move(toCompareTo));
     }
     return -1;
 }
 
-int16_t pyGUIControlListBox::AddTextWColor( const char *str, pyColor& textcolor, uint32_t inheritalpha)
+int16_t pyGUIControlListBox::AddTextWColor( ST::string str, pyColor& textcolor, uint32_t inheritalpha)
 {
-    wchar_t *wStr = hsStringToWString(str);
-    int16_t retVal = AddTextWColorW(wStr,textcolor,inheritalpha);
-    delete [] wStr;
+    int16_t retVal = AddTextWColorW(std::move(str), textcolor, inheritalpha);
     return retVal;
 }
 
-int16_t pyGUIControlListBox::AddTextWColorW( const std::wstring& str, pyColor& textcolor, uint32_t inheritalpha)
+int16_t pyGUIControlListBox::AddTextWColorW( ST::string str, pyColor& textcolor, uint32_t inheritalpha)
 {
     if ( fGCkey )
     {
@@ -647,15 +645,13 @@ int16_t pyGUIControlListBox::AddTextWColorW( const std::wstring& str, pyColor& t
     return -1;
 }
 
-int16_t pyGUIControlListBox::AddTextWColorWSize( const char *str, pyColor& textcolor, uint32_t inheritalpha, int32_t fontsize)
+int16_t pyGUIControlListBox::AddTextWColorWSize( ST::string str, pyColor& textcolor, uint32_t inheritalpha, int32_t fontsize)
 {
-    wchar_t *wStr = hsStringToWString(str);
-    int16_t retVal = AddTextWColorWSizeW(wStr,textcolor,inheritalpha,fontsize);
-    delete [] wStr;
+    int16_t retVal = AddTextWColorWSizeW(str, textcolor, inheritalpha, fontsize);
     return retVal;
 }
 
-int16_t pyGUIControlListBox::AddTextWColorWSizeW( const std::wstring& str, pyColor& textcolor, uint32_t inheritalpha, int32_t fontsize)
+int16_t pyGUIControlListBox::AddTextWColorWSizeW( ST::string str, pyColor& textcolor, uint32_t inheritalpha, int32_t fontsize)
 {
     if ( fGCkey )
     {
@@ -672,16 +668,12 @@ int16_t pyGUIControlListBox::AddTextWColorWSizeW( const std::wstring& str, pyCol
     return -1;
 }
 
-void pyGUIControlListBox::Add2TextWColor( const char *str1, pyColor& textcolor1,const char *str2, pyColor& textcolor2, uint32_t inheritalpha)
+void pyGUIControlListBox::Add2TextWColor( ST::string str1, pyColor& textcolor1, ST::string str2, pyColor& textcolor2, uint32_t inheritalpha)
 {
-    wchar_t *wStr1 = hsStringToWString(str1);
-    wchar_t *wStr2 = hsStringToWString(str2);
-    Add2TextWColorW(wStr1,textcolor1,wStr2,textcolor2,inheritalpha);
-    delete [] wStr2;
-    delete [] wStr1;
+    Add2TextWColorW(std::move(str1), textcolor1, std::move(str2), textcolor2, inheritalpha);
 }
 
-void pyGUIControlListBox::Add2TextWColorW( const std::wstring& str1, pyColor& textcolor1, const std::wstring& str2, pyColor& textcolor2, uint32_t inheritalpha)
+void pyGUIControlListBox::Add2TextWColorW( ST::string str1, pyColor& textcolor1, ST::string str2, pyColor& textcolor2, uint32_t inheritalpha)
 {
     if ( fGCkey )
     {
@@ -689,7 +681,7 @@ void pyGUIControlListBox::Add2TextWColorW( const std::wstring& str1, pyColor& te
         pfGUIListBoxMod* plbmod = pfGUIListBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( plbmod )
         {
-            pfColorListElement *element = new pfColorListElement(str1.c_str(),textcolor1.getColor(),str2.c_str(),textcolor2.getColor(),inheritalpha );
+            pfColorListElement *element = new pfColorListElement(str1.c_str(), textcolor1.getColor(), str2.c_str(), textcolor2.getColor(), inheritalpha);
             if (!fBuildRoots.empty())
                 fBuildRoots.back()->AddChild(element);
             plbmod->AddElement( element );
@@ -697,7 +689,7 @@ void pyGUIControlListBox::Add2TextWColorW( const std::wstring& str1, pyColor& te
     }
 }
 
-int16_t pyGUIControlListBox::AddStringInBox( const ST::string &string, uint32_t min_width, uint32_t min_height )
+int16_t pyGUIControlListBox::AddStringInBox( ST::string string, uint32_t min_width, uint32_t min_height )
 {
     if ( fGCkey )
     {
@@ -705,7 +697,7 @@ int16_t pyGUIControlListBox::AddStringInBox( const ST::string &string, uint32_t 
         pfGUIListBoxMod* plbmod = pfGUIListBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( plbmod )
         {
-            pfListTextInBox *element = new pfListTextInBox( string, min_width, min_height );
+            pfListTextInBox *element = new pfListTextInBox( std::move(string), min_width, min_height );
             if (!fBuildRoots.empty())
                 fBuildRoots.back()->AddChild(element);
             return plbmod->AddElement( element );
@@ -870,7 +862,7 @@ void pyGUIControlListBox::Unclickable()
     }
 }
 
-void    pyGUIControlListBox::AddBranch( const ST::string &name, bool initiallyOpen )
+void    pyGUIControlListBox::AddBranch( ST::string name, bool initiallyOpen )
 {
     if ( fGCkey )
     {
@@ -878,7 +870,7 @@ void    pyGUIControlListBox::AddBranch( const ST::string &name, bool initiallyOp
         pfGUIListBoxMod* plbmod = pfGUIListBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( plbmod )
         {
-            pfGUIListTreeRoot *root = new pfGUIListTreeRoot(name);
+            pfGUIListTreeRoot *root = new pfGUIListTreeRoot(std::move(name));
             root->ShowChildren( initiallyOpen );
             
             if (!fBuildRoots.empty())

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
@@ -51,7 +51,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pyGUIControl.h"
 #include "pyGlueHelpers.h"
-#include <string>
 
 
 class pyColor;

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
@@ -101,11 +101,8 @@ public:
     virtual void    SetSwatchEdgeOffset( uint32_t size );
     virtual void    SetStringJustify( uint16_t idx, uint32_t justify);
     virtual int16_t   FindString( ST::string toCompareTo );
-    virtual int16_t   AddTextWColor( ST::string str, pyColor& textcolor, uint32_t inheritalpha);
     virtual int16_t   AddTextWColorW( ST::string str, pyColor& textcolor, uint32_t inheritalpha);
-    virtual int16_t   AddTextWColorWSize( ST::string str, pyColor& textcolor, uint32_t inheritalpha, int32_t fontsize);
     virtual int16_t   AddTextWColorWSizeW( ST::string str, pyColor& textcolor, uint32_t inheritalpha, int32_t fontsize);
-    virtual void    Add2TextWColor( ST::string str1, pyColor& textcolor1, ST::string str2, pyColor& textcolor2, uint32_t inheritalpha);
     virtual void    Add2TextWColorW( ST::string str1, pyColor& textcolor1, ST::string str2, pyColor& textcolor2, uint32_t inheritalpha);
     virtual int16_t   AddStringInBox( ST::string string, uint32_t min_width, uint32_t min_height );
     virtual void    ScrollToBegin();

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
@@ -87,12 +87,12 @@ public:
     virtual int32_t   GetSelection();
     virtual void    SetSelection( int32_t item );
     void            Refresh() override;
-    virtual void    SetElement( uint16_t idx, const ST::string& text );
+    virtual void    SetElement( uint16_t idx, ST::string text );
     virtual void    RemoveElement( uint16_t index );
     virtual void    ClearAllElements();
     virtual uint16_t  GetNumElements();
     virtual ST::string  GetElement( uint16_t idx );
-    virtual int16_t   AddString( const ST::string &string );
+    virtual int16_t   AddString( ST::string string );
     virtual int16_t   AddImage( pyImage& image, bool respectAlpha );
     virtual int16_t   AddImageInBox( pyImage& image, uint32_t x, uint32_t y, uint32_t width, uint32_t height, bool respectAlpha );
     virtual int16_t   AddImageAndSwatchesInBox( pyImage& image, uint32_t x, uint32_t y, uint32_t width, uint32_t height, bool respectAlpha,
@@ -100,14 +100,14 @@ public:
     virtual void    SetSwatchSize( uint32_t size );
     virtual void    SetSwatchEdgeOffset( uint32_t size );
     virtual void    SetStringJustify( uint16_t idx, uint32_t justify);
-    virtual int16_t   FindString( const ST::string &toCompareTo );
-    virtual int16_t   AddTextWColor( const char *str, pyColor& textcolor, uint32_t inheritalpha);
-    virtual int16_t   AddTextWColorW( const std::wstring& str, pyColor& textcolor, uint32_t inheritalpha);
-    virtual int16_t   AddTextWColorWSize( const char *str, pyColor& textcolor, uint32_t inheritalpha, int32_t fontsize);
-    virtual int16_t   AddTextWColorWSizeW( const std::wstring& str, pyColor& textcolor, uint32_t inheritalpha, int32_t fontsize);
-    virtual void    Add2TextWColor( const char *str1, pyColor& textcolor1,const char *str2, pyColor& textcolor2, uint32_t inheritalpha);
-    virtual void    Add2TextWColorW( const std::wstring& str1, pyColor& textcolor1, const std::wstring& str2, pyColor& textcolor2, uint32_t inheritalpha);
-    virtual int16_t   AddStringInBox( const ST::string &string, uint32_t min_width, uint32_t min_height );
+    virtual int16_t   FindString( ST::string toCompareTo );
+    virtual int16_t   AddTextWColor( ST::string str, pyColor& textcolor, uint32_t inheritalpha);
+    virtual int16_t   AddTextWColorW( ST::string str, pyColor& textcolor, uint32_t inheritalpha);
+    virtual int16_t   AddTextWColorWSize( ST::string str, pyColor& textcolor, uint32_t inheritalpha, int32_t fontsize);
+    virtual int16_t   AddTextWColorWSizeW( ST::string str, pyColor& textcolor, uint32_t inheritalpha, int32_t fontsize);
+    virtual void    Add2TextWColor( ST::string str1, pyColor& textcolor1, ST::string str2, pyColor& textcolor2, uint32_t inheritalpha);
+    virtual void    Add2TextWColorW( ST::string str1, pyColor& textcolor1, ST::string str2, pyColor& textcolor2, uint32_t inheritalpha);
+    virtual int16_t   AddStringInBox( ST::string string, uint32_t min_width, uint32_t min_height );
     virtual void    ScrollToBegin();
     virtual void    ScrollToEnd();
     virtual void    SetScrollPos( int32_t pos );
@@ -119,7 +119,7 @@ public:
 
     // To create tree branches, call AddBranch() with a name, then add elements as usual, including new sub-branches
     // via additional AddBranch() calls. Call CloseBranch() to stop writing elements to that branch.
-    void            AddBranch( const ST::string &name, bool initiallyOpen );
+    void            AddBranch( ST::string name, bool initiallyOpen );
     void            CloseBranch();
 
     void            RemoveSelection( int32_t item );

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBoxGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBoxGlue.cpp
@@ -313,7 +313,7 @@ PYTHON_METHOD_DEFINITION(ptGUIControlListBox, add2StringsWithColors, args)
     }
     pyColor* color1 = pyColor::ConvertFrom(color1Obj);
     pyColor* color2 = pyColor::ConvertFrom(color2Obj);
-    self->fThis->Add2TextWColor(std::move(text1), *color1, std::move(text2), *color2, inheritAlpha);
+    self->fThis->Add2TextWColorW(std::move(text1), *color1, std::move(text2), *color2, inheritAlpha);
     PYTHON_RETURN_NONE;
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBoxGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBoxGlue.cpp
@@ -116,26 +116,26 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlListBox, getNumElements)
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, setElement, args)
 {
     unsigned short index;
-    char* text;
-    if (!PyArg_ParseTuple(args, "hs", &index, &text))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "hO&", &index, PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "setElement expects an unsigned short and a string");
         PYTHON_RETURN_ERROR;
     }
-    self->fThis->SetElement(index, text);
+    self->fThis->SetElement(index, std::move(text));
     PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, setElementW, args)
 {
     unsigned short index;
-    wchar_t* text;
-    if (!PyArg_ParseTuple(args, "hu", &index, &text))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "hO&", &index, PyUnicode_STStringConverter, &text))
     {
-        PyErr_SetString(PyExc_TypeError, "setElementW expects an unsigned short and a unicode string");
+        PyErr_SetString(PyExc_TypeError, "setElementW expects an unsigned short and a string");
         PYTHON_RETURN_ERROR;
     }
-    self->fThis->SetElement(index, ST::string::from_wchar(text));
+    self->fThis->SetElement(index, std::move(text));
     PYTHON_RETURN_NONE;
 }
 
@@ -176,46 +176,46 @@ PYTHON_METHOD_DEFINITION(ptGUIControlListBox, setStringJustify, args)
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addString, args)
 {
-    char* text;
-    if (!PyArg_ParseTuple(args, "s", &text))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "addString expects a string");
         PYTHON_RETURN_ERROR;
     }
-    return PyLong_FromLong(self->fThis->AddString(text));
+    return PyLong_FromLong(self->fThis->AddString(std::move(text)));
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addStringW, args)
 {
-    wchar_t* text;
-    if (!PyArg_ParseTuple(args, "u", &text))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
-        PyErr_SetString(PyExc_TypeError, "addStringW expects a unicode string");
+        PyErr_SetString(PyExc_TypeError, "addStringW expects a string");
         PYTHON_RETURN_ERROR;
     }
-    return PyLong_FromLong(self->fThis->AddString(ST::string::from_wchar(text)));
+    return PyLong_FromLong(self->fThis->AddString(std::move(text)));
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, findString, args)
 {
-    char* text;
-    if (!PyArg_ParseTuple(args, "s", &text))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "findString expects a string");
         PYTHON_RETURN_ERROR;
     }
-    return PyLong_FromLong(self->fThis->FindString(text));
+    return PyLong_FromLong(self->fThis->FindString(std::move(text)));
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, findStringW, args)
 {
-    wchar_t* text;
-    if (!PyArg_ParseTuple(args, "u", &text))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
-        PyErr_SetString(PyExc_TypeError, "findStringW expects a unicode string");
+        PyErr_SetString(PyExc_TypeError, "findStringW expects a string");
         PYTHON_RETURN_ERROR;
     }
-    return PyLong_FromLong(self->fThis->FindString(ST::string::from_wchar(text)));
+    return PyLong_FromLong(self->fThis->FindString(std::move(text)));
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addImage, args)
@@ -257,51 +257,51 @@ PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addImageInBox, args)
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addStringWithColor, args)
 {
-    wchar_t* text;
+    ST::string text;
     PyObject* colorObj = nullptr;
     unsigned long inheritAlpha;
-    if (!PyArg_ParseTuple(args, "uOl", &text, &colorObj, &inheritAlpha))
+    if (!PyArg_ParseTuple(args, "O&Ol", PyUnicode_STStringConverter, &text, &colorObj, &inheritAlpha))
     {
-        PyErr_SetString(PyExc_TypeError, "addStringWithColor expects a unicode string, ptColor, and an unsigned long");
+        PyErr_SetString(PyExc_TypeError, "addStringWithColor expects a string, ptColor, and an unsigned long");
         PYTHON_RETURN_ERROR;
     }
     if (!pyColor::Check(colorObj))
     {
-        PyErr_SetString(PyExc_TypeError, "addStringWithColor expects a unicode string, ptColor, and an unsigned long");
+        PyErr_SetString(PyExc_TypeError, "addStringWithColor expects a string, ptColor, and an unsigned long");
         PYTHON_RETURN_ERROR;
     }
     pyColor* color = pyColor::ConvertFrom(colorObj);
-    return PyLong_FromLong(self->fThis->AddTextWColorW(text, *color, inheritAlpha));
+    return PyLong_FromLong(self->fThis->AddTextWColorW(std::move(text), *color, inheritAlpha));
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addStringWithColorWithSize, args)
 {
-    wchar_t* text;
+    ST::string text;
     PyObject* colorObj = nullptr;
     unsigned long inheritAlpha;
     long textSize;
-    if (!PyArg_ParseTuple(args, "uOll", &text, &colorObj, &inheritAlpha, &textSize))
+    if (!PyArg_ParseTuple(args, "O&Oll", PyUnicode_STStringConverter, &text, &colorObj, &inheritAlpha, &textSize))
     {
-        PyErr_SetString(PyExc_TypeError, "addStringWithColorWithSize expects a unicode string, ptColor, an unsigned long, and a long");
+        PyErr_SetString(PyExc_TypeError, "addStringWithColorWithSize expects a string, ptColor, an unsigned long, and a long");
         PYTHON_RETURN_ERROR;
     }
     if (!pyColor::Check(colorObj))
     {
-        PyErr_SetString(PyExc_TypeError, "addStringWithColorWithSize expects a unicode string, ptColor, an unsigned long, and a long");
+        PyErr_SetString(PyExc_TypeError, "addStringWithColorWithSize expects a string, ptColor, an unsigned long, and a long");
         PYTHON_RETURN_ERROR;
     }
     pyColor* color = pyColor::ConvertFrom(colorObj);
-    return PyLong_FromLong(self->fThis->AddTextWColorWSizeW(text, *color, inheritAlpha, textSize));
+    return PyLong_FromLong(self->fThis->AddTextWColorWSizeW(std::move(text), *color, inheritAlpha, textSize));
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, add2StringsWithColors, args)
 {
-    char* text1;
+    ST::string text1;
     PyObject* color1Obj = nullptr;
-    char* text2;
+    ST::string text2;
     PyObject* color2Obj = nullptr;
     unsigned long inheritAlpha;
-    if (!PyArg_ParseTuple(args, "sOsOl", &text1, &color1Obj, &text2, &color2Obj, &inheritAlpha))
+    if (!PyArg_ParseTuple(args, "O&OO&Ol", PyUnicode_STStringConverter, &text1, &color1Obj, PyUnicode_STStringConverter, &text2, &color2Obj, &inheritAlpha))
     {
         PyErr_SetString(PyExc_TypeError, "addStringWithColor expects a string, ptColor, string, ptColor, and an unsigned long");
         PYTHON_RETURN_ERROR;
@@ -313,20 +313,20 @@ PYTHON_METHOD_DEFINITION(ptGUIControlListBox, add2StringsWithColors, args)
     }
     pyColor* color1 = pyColor::ConvertFrom(color1Obj);
     pyColor* color2 = pyColor::ConvertFrom(color2Obj);
-    self->fThis->Add2TextWColor(text1, *color1, text2, *color2, inheritAlpha);
+    self->fThis->Add2TextWColor(std::move(text1), *color1, std::move(text2), *color2, inheritAlpha);
     PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addStringInBox, args)
 {
-    char* text;
+    ST::string text;
     unsigned long minWidth, minHeight;
-    if (!PyArg_ParseTuple(args, "sll", &text, &minWidth, &minHeight))
+    if (!PyArg_ParseTuple(args, "O&ll", PyUnicode_STStringConverter, &text, &minWidth, &minHeight))
     {
         PyErr_SetString(PyExc_TypeError, "addStringInBox expects a string and two unsigned longs");
         PYTHON_RETURN_ERROR;
     }
-    return PyLong_FromLong(self->fThis->AddStringInBox(text, minWidth, minHeight));
+    return PyLong_FromLong(self->fThis->AddStringInBox(std::move(text), minWidth, minHeight));
 }
 
 PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlListBox, scrollToBegin, ScrollToBegin)
@@ -359,38 +359,28 @@ PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlListBox, unlock, UnlockList)
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addBranch, args)
 {
-    char* name;
+    ST::string name;
     char initiallyOpen;
-    if (!PyArg_ParseTuple(args, "sb", &name, &initiallyOpen))
+    if (!PyArg_ParseTuple(args, "O&b", PyUnicode_STStringConverter, &name, &initiallyOpen))
     {
         PyErr_SetString(PyExc_TypeError, "addBranch expects a string and a boolean");
         PYTHON_RETURN_ERROR;
     }
-    self->fThis->AddBranch(name, initiallyOpen != 0);
+    self->fThis->AddBranch(std::move(name), initiallyOpen != 0);
     PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addBranchW, args)
 {
-    PyObject* textObj;
+    ST::string name;
     char initiallyOpen;
-    if (!PyArg_ParseTuple(args, "Ob", &textObj, &initiallyOpen))
+    if (!PyArg_ParseTuple(args, "O&b", PyUnicode_STStringConverter, &name, &initiallyOpen))
     {
-        PyErr_SetString(PyExc_TypeError, "addBranchW expects a unicode string and a boolean");
+        PyErr_SetString(PyExc_TypeError, "addBranchW expects a string and a boolean");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* name = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->AddBranch(ST::string::from_wchar(name), initiallyOpen != 0);
-        PyMem_Free(name);
-        PYTHON_RETURN_NONE;
-    }
-    else
-    {
-        PyErr_SetString(PyExc_TypeError, "addBranchW expects a unicode string and a boolean");
-        PYTHON_RETURN_ERROR;
-    }
+    self->fThis->AddBranch(std::move(name), initiallyOpen != 0);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlListBox, closeBranch, CloseBranch)

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBoxGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBoxGlue.cpp
@@ -257,41 +257,41 @@ PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addImageInBox, args)
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addStringWithColor, args)
 {
-    char* text;
+    wchar_t* text;
     PyObject* colorObj = nullptr;
     unsigned long inheritAlpha;
-    if (!PyArg_ParseTuple(args, "sOl", &text, &colorObj, &inheritAlpha))
+    if (!PyArg_ParseTuple(args, "uOl", &text, &colorObj, &inheritAlpha))
     {
-        PyErr_SetString(PyExc_TypeError, "addStringWithColor expects a string, ptColor, and an unsigned long");
+        PyErr_SetString(PyExc_TypeError, "addStringWithColor expects a unicode string, ptColor, and an unsigned long");
         PYTHON_RETURN_ERROR;
     }
     if (!pyColor::Check(colorObj))
     {
-        PyErr_SetString(PyExc_TypeError, "addStringWithColor expects a string, ptColor, and an unsigned long");
+        PyErr_SetString(PyExc_TypeError, "addStringWithColor expects a unicode string, ptColor, and an unsigned long");
         PYTHON_RETURN_ERROR;
     }
     pyColor* color = pyColor::ConvertFrom(colorObj);
-    return PyLong_FromLong(self->fThis->AddTextWColor(text, *color, inheritAlpha));
+    return PyLong_FromLong(self->fThis->AddTextWColorW(text, *color, inheritAlpha));
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, addStringWithColorWithSize, args)
 {
-    char* text;
+    wchar_t* text;
     PyObject* colorObj = nullptr;
     unsigned long inheritAlpha;
     long textSize;
-    if (!PyArg_ParseTuple(args, "sOll", &text, &colorObj, &inheritAlpha, &textSize))
+    if (!PyArg_ParseTuple(args, "uOll", &text, &colorObj, &inheritAlpha, &textSize))
     {
-        PyErr_SetString(PyExc_TypeError, "addStringWithColorWithSize expects a string, ptColor, an unsigned long, and a long");
+        PyErr_SetString(PyExc_TypeError, "addStringWithColorWithSize expects a unicode string, ptColor, an unsigned long, and a long");
         PYTHON_RETURN_ERROR;
     }
     if (!pyColor::Check(colorObj))
     {
-        PyErr_SetString(PyExc_TypeError, "addStringWithColorWithSize expects a string, ptColor, an unsigned long, and a long");
+        PyErr_SetString(PyExc_TypeError, "addStringWithColorWithSize expects a unicode string, ptColor, an unsigned long, and a long");
         PYTHON_RETURN_ERROR;
     }
     pyColor* color = pyColor::ConvertFrom(colorObj);
-    return PyLong_FromLong(self->fThis->AddTextWColorWSize(text, *color, inheritAlpha, textSize));
+    return PyLong_FromLong(self->fThis->AddTextWColorWSizeW(text, *color, inheritAlpha, textSize));
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlListBox, add2StringsWithColors, args)


### PR DESCRIPTION
Now with less string-y death and sadness, including:
- Allow users to be created successfully from startup when names include unicode characters like ü and ó and ä and such
- Make unicode-including player names show up correctly in the avatar customization title bar
- A ton of stuff that displays player names in KI lists, Big KI footer, Big KI content titles, and the Send To Player field
- Some stuff around marker game title creation and editing
- Adjust the pyGUIControlListBoxGlue to treat its input string as unicode so KI folder player lists (left side collapsible lists) are displayed with unicode text properly