### PR TITLE
Reformat HTML Console documentation output

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.cpp
@@ -570,9 +570,9 @@ const char  *pfConsoleCmd::GetSignature()
     for( i = 0; i < fSignature.GetCount(); i++ )
     {
         if (fSigLabels[i] == nullptr)
-            sprintf( pStr, "%s", fSigTypes[ fSignature[ i ] ] );
+            sprintf( pStr, "[%s]", fSigTypes[ fSignature[ i ] ] );
         else
-            sprintf( pStr, "%s %s", fSigTypes[ fSignature[ i ] ], fSigLabels[ i ] );
+            sprintf( pStr, "[%s %s]", fSigTypes[ fSignature[ i ] ], fSigLabels[ i ] );
 
         hsAssert( strlen( string ) + strlen( pStr ) + 2 < sizeof( string ), "Not enough room for signature string" );
         strcat( string, ( i > 0 ) ? ", " : " " );


### PR DESCRIPTION
This (IMO) significantly improves the formatting of the console documentation, and makes the command group sections collapsible.
Example output of these changes: https://bl.ocks.org/dpogue/raw/3156ee19b6a55d659e2ac92c96527d60/?raw=true

One side effect is that console command arguments will now always be wrapped in `[` `]` when printed anywhere (including in the console itself), but IMO this still ends up being more readable:
`Some.Group.Command [string name], [bool value]` vs `Some.Group.Command string name, bool value`