### PR TITLE
Sort clothing in closet and fix clothing resetting when clicking on arrows

### DIFF
--- a/Scripts/Python/xAvatarCustomization.py
+++ b/Scripts/Python/xAvatarCustomization.py
@@ -1247,7 +1247,7 @@ class xAvatarCustomization(ptModifier):
                 avatar.avatar.tintClothingItem(matchingItem[0], lastcolor1, 0)
                 avatar.avatar.tintClothingItemLayer(matchingItem[0], lastcolor2, 2, 0)
 
-        PtAtTimeCallback(self.key, 1, 666)
+        PtAtTimeCallback(self.key, 0.1, 666)
 
     def IRemoveWornSet(self):
         setToRemove = ''
@@ -1301,7 +1301,7 @@ class xAvatarCustomization(ptModifier):
             for clothingType in typesNeedingDefault:
                 PtWearDefaultClothingType(avatar.getKey(), clothingType)
 
-        PtAtTimeCallback(self.key, 1, 666)
+        PtAtTimeCallback(self.key, 0.1, 666)
 
 
     def ISaveSeasonalToCloset(self):
@@ -1415,8 +1415,10 @@ class xAvatarCustomization(ptModifier):
             # We need to update our current selection (probably because we just reset the avatar)
             self.IUpdateAllControls()
         elif id == 666:
+            PtClearTimerCallbacks(self.key)
             GetClothingWorn()
             avatar = PtGetLocalAvatar()
+            self.ISetStandardControls()
             self.ISetWhatWearing(avatar)
 
         if id == 999:

--- a/Scripts/Python/xAvatarCustomization.py
+++ b/Scripts/Python/xAvatarCustomization.py
@@ -2539,12 +2539,8 @@ class ScrollingListBox:
             rightArrow = ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(self.listboxID+kIDBtnRightOptOffset))
         if self.IShowLeftArrow():
             leftArrow.show()
-        else:
-            leftArrow.hide()
         if self.IShowRightArrow():
             rightArrow.show()
-        else:
-            rightArrow.hide()
         pass
 
     def UpdateListbox(self):
@@ -2561,6 +2557,8 @@ class ScrollingListBox:
         listbox.show()
         listbox.enable()
         displayItems = []
+        # sort clothing alphabetically
+        self.clothingList = sorted(self.clothingList, key=lambda x: getattr(x, 'name').lower().replace("*",""))
         # check to see if we can just copy it over
         if self.rows == 1 and len(self.clothingList) <= 4:
             displayItems = self.clothingList

--- a/Scripts/Python/xAvatarCustomization.py
+++ b/Scripts/Python/xAvatarCustomization.py
@@ -2558,7 +2558,7 @@ class ScrollingListBox:
         listbox.enable()
         displayItems = []
         # sort clothing alphabetically
-        self.clothingList = sorted(self.clothingList, key=lambda x: getattr(x, 'name').lower().replace("*",""))
+        self.clothingList = sorted(self.clothingList, key=lambda x: x.name.lower())
         # check to see if we can just copy it over
         if self.rows == 1 and len(self.clothingList) <= 4:
             displayItems = self.clothingList


### PR DESCRIPTION
Clothing and Clothing Categories are sorted alphabetically by the name (not the description)
This mostly sorts everything in a semi-correct order.
I tried sorting by description and the item that clothing category represented was not usually the first thing shown.

Fixed a bug that would cause the clothing to reset when you were clicking the right/left arrows and it would disappear.
This fix avoids the issue by always showing the arrows, and never hiding them.
The bug can still happen if you click on anything inside the "Additional Options" that is not a piece of clothing.
The code currently tells the section to refresh itself whenever you click on it and when you click on something that isn't a piece of clothing it just resets everything in that section.