### PR TITLE
Prevent python errors on startup dialog with empty explorer list

### DIFF
--- a/Scripts/Python/xDialogStartUp.py
+++ b/Scripts/Python/xDialogStartUp.py
@@ -269,7 +269,7 @@ class xDialogStartUp(ptResponder):
         elif id == GUIDiag4b.id:
             if event == kAction or event == kValueChanged:
                 if  tagID == k4bExploreID: ## Explore Uru ##
-                    if gSelectedSlot:
+                    if gSelectedSlot and gPlayerList[gSelectedSlot-gMinusExplorer]:
                         PtShowDialog("GUIDialog06a")
                         PtDebugPrint("Player selected.")
 
@@ -284,7 +284,7 @@ class xDialogStartUp(ptResponder):
                     PtLocalizedYesNoDialog(None, "KI.Messages.LeaveGame", dialogType=PtConfirmationType.ConfirmQuit)
 
                 elif  tagID == k4bDeleteID: ## Delete Explorer ##
-                    if gSelectedSlot:
+                    if gSelectedSlot and gPlayerList[gSelectedSlot-gMinusExplorer]:
                         deleteString = "Would you like to delete the EXPLORER " + str(gPlayerList[gSelectedSlot-gMinusExplorer][0]) + "?"
                         ptGUIControlTextBox(GUIDiag4c.dialog.getControlFromTag(k4cStaticID)).setStringW(deleteString)
                         self.PlayerListNotify(GUIDiag4b, gExp_HotSpot, 0)
@@ -306,7 +306,7 @@ class xDialogStartUp(ptResponder):
         #################################
         elif id == GUIDiag4c.id:
             if event == kAction or event == kValueChanged:
-                if  tagID == k4cYesID: ## Confirm Delete ##
+                if  tagID == k4cYesID and gPlayerList[gSelectedSlot-gMinusExplorer]: ## Confirm Delete ##
                     playerID = 0
                     playerID = gPlayerList[gSelectedSlot-gMinusExplorer][1]
                     PtDeletePlayer(playerID)
@@ -339,6 +339,9 @@ class xDialogStartUp(ptResponder):
                 elif  tagID == k6BackID: ## Back To Player Select ##
                     PtHideDialog("GUIDialog06")
                     PtShowDialog("GUIDialog04b")
+                    # if no explorers, unselect all slots so any of them can be clicked again
+                    if not gPlayerList or not gPlayerList[1]:
+                        self.SelectSlot(GUIDiag4b, 0)
 
                 elif  tagID == k6PlayID: ## Play ##
                     playerName = ptGUIControlEditBox(GUIDiag6.dialog.getControlFromTag(k6NameID)).getString()  #                 <---
@@ -511,8 +514,9 @@ class xDialogStartUp(ptResponder):
             PtSetActivePlayer(playerInt)
 
         elif opType == PtAccountUpdateType.kDeletePlayer:
-            self.SelectSlot(GUIDiag4b, 0)
             self.InitPlayerList(GUIDiag4b, gExp_HotSpot, gExp_TxtBox, gExp_HiLite)
+            # unselect all slots so any of them can be clicked again
+            self.SelectSlot(GUIDiag4b, 0)
             self.ToggleColor(GUIDiag4b, k4bPlayer03)
 
             PtHideDialog("GUIDialog04c")


### PR DESCRIPTION
- Prevent python errors when clicking Explore/Delete buttons with empty explorer list
- Adjustment so clicking the first Create Explorer slot on an empty list after a Create->Back path or after deleting the only explorer will properly go to the Create dialog again (instead of doing nothing when clicked)

Should close #1169.