### PR TITLE
Use PEP 590 Vectorcall

### DIFF
--- a/Sources/Plasma/Apps/plPythonPack/main.cpp
+++ b/Sources/Plasma/Apps/plPythonPack/main.cpp
@@ -145,7 +145,7 @@ void WritePythonFile(const plFileName &fileName, const plFileName &path, hsStrea
             bool foundID = false;
             if (getID != nullptr && PyCallable_Check(getID))
             {
-                PyObject* id = PyObject_CallFunction(getID, nullptr);
+                PyObject* id = _PyObject_Vectorcall(getID, nullptr, 0, nullptr);
                 if ( id && PyLong_Check(id) )
                     foundID = true;
             }

--- a/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
@@ -96,6 +96,7 @@ set(pfPython_HEADERS
     cyPhysics.h
     cyPythonInterface.h
     plPythonCallable.h
+    plPythonConvert.h
     pfPythonCreatable.h
     plPythonFileMod.h
     plPythonHelpers.h

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
@@ -52,18 +52,19 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyKey.h"
 #include "pyPlayer.h"
 #include "plPythonCallable.h"
+#include "plPythonConvert.h"
 
 #include "plMessage/plConfirmationMsg.h"
 #include "plNetCommon/plNetCommon.h"
 #include "plResMgr/plLocalization.h"
 #include "plMessage/plLOSRequestMsg.h"
 
-namespace plPythonCallable
+namespace plPython
 {
     template<>
-    inline void IBuildTupleArg(PyObject* tuple, size_t idx, plConfirmationMsg::Result value)
+    inline PyObject* ConvertFrom(plConfirmationMsg::Result&& value)
     {
-        PyTuple_SET_ITEM(tuple, idx, PyLong_FromSsize_t((Py_ssize_t)value));
+        return PyLong_FromSsize_t((Py_ssize_t)value);
     }
 };
 
@@ -93,7 +94,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION_WKEY(PtYesNoDialog, args, kwargs,
     if (pyKey::Check(cbObj)) {
         cb = pyKey::ConvertFrom(cbObj)->getKey();
     } else if (PyCallable_Check(cbObj)) {
-        plPythonCallable::BuildCallback<1>("PtYesNoDialog", cbObj, cb);
+        plPython::BuildCallback<1>("PtYesNoDialog", cbObj, cb);
     } else if (cbObj != Py_None) {
         PyErr_SetString(PyExc_TypeError, kErrorMsg.data());
         PYTHON_RETURN_ERROR;
@@ -129,7 +130,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION_WKEY(PtLocalizedYesNoDialog, args, kwargs,
     if (pyKey::Check(cbObj)) {
         cb = pyKey::ConvertFrom(cbObj)->getKey();
     } else if (PyCallable_Check(cbObj)) {
-        plPythonCallable::BuildCallback<1>("PtLocalizedYesNoDialog", cbObj, cb);
+        plPython::BuildCallback<1>("PtLocalizedYesNoDialog", cbObj, cb);
     } else if (cbObj != Py_None) {
         PyErr_SetString(PyExc_TypeError, kErrorMsg.data());
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -60,6 +60,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <cpython/initconfig.h>
 #include <pylifecycle.h>
 
+#include "plPythonCallable.h"
 #include "cyPythonInterface.h"
 #include "plPythonPack.h"
 
@@ -1248,16 +1249,14 @@ void PythonInterface::debugTimeSlice()
     if (dbgSlice != nullptr)
     {
         // then send it the new text
-        PyObject* retVal = PyObject_CallFunction(dbgSlice, nullptr);
-        if (retVal == nullptr)
-        {
+        pyObjectRef retVal = plPython::CallObject(dbgSlice);
+        if (!retVal) {
             // for some reason this function didn't, remember that and not call it again
             dbgSlice = nullptr;
             // if there was an error make sure that the stderr gets flushed so it can be seen
             PyErr_Print();      // make sure the error is printed
             PyErr_Clear();      // clear the error
         }
-        Py_XDECREF(retVal);
     }
 }
 
@@ -1306,16 +1305,14 @@ int PythonInterface::getOutputAndReset(std::string *output)
         if (dbgOut != nullptr)
         {
             // then send it the new text
-            PyObject* retVal = PyObject_CallFunction(dbgOut, _pycs("s"), strVal.c_str());
-            if (retVal == nullptr)
-            {
+            pyObjectRef retVal = plPython::CallObject(dbgOut, PyUnicode_FromStdString(strVal));
+            if (!retVal) {
                 // for some reason this function didn't, remember that and not call it again
                 dbgOut = nullptr;
                 // if there was an error make sure that the stderr gets flushed so it can be seen
                 PyErr_Print();      // make sure the error is printed
                 PyErr_Clear();      // clear the error
             }
-            Py_XDECREF(retVal);
         }
 
         if (output)

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonConvert.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonConvert.h
@@ -168,7 +168,7 @@ namespace plPython
     constexpr ToTuple_Type ToTuple;
 
     template<typename... _TupleArgsT>
-    inline PyObject* ConvertFrom(ToTuple_Type, _TupleArgsT... args)
+    inline PyObject* ConvertFrom(ToTuple_Type, _TupleArgsT&&... args)
     {
         PyObject* tuple = PyTuple_New(sizeof...(args));
         Py_ssize_t i = 0;

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonConvert.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonConvert.h
@@ -83,19 +83,29 @@ namespace plPython
         return PyFloat_FromDouble(value);
     }
 
-    inline PyObject* ConvertFrom(int8_t value)
+    inline PyObject* ConvertFrom(signed char value)
     {
         return PyLong_FromLong(value);
     }
 
-    inline PyObject* ConvertFrom(int16_t value)
+    inline PyObject* ConvertFrom(signed short value)
     {
         return PyLong_FromLong(value);
     }
 
-    inline PyObject* ConvertFrom(int32_t value)
+    inline PyObject* ConvertFrom(signed int value)
     {
         return PyLong_FromLong(value);
+    }
+
+    inline PyObject* ConvertFrom(signed long value)
+    {
+        return PyLong_FromLong(value);
+    }
+
+    inline PyObject* ConvertFrom(signed long long value)
+    {
+        return PyLong_FromLongLong(value);
     }
 
     inline PyObject* ConvertFrom(ST::string&& value)
@@ -103,19 +113,29 @@ namespace plPython
         return PyUnicode_FromSTString(value);
     }
 
-    inline PyObject* ConvertFrom(uint8_t value)
+    inline PyObject* ConvertFrom(unsigned char value)
     {
         return PyLong_FromUnsignedLong(value);
     }
 
-    inline PyObject* ConvertFrom(uint16_t value)
+    inline PyObject* ConvertFrom(unsigned short value)
     {
         return PyLong_FromUnsignedLong(value);
     }
 
-    inline PyObject* ConvertFrom(uint32_t value)
+    inline PyObject* ConvertFrom(unsigned int value)
     {
         return PyLong_FromUnsignedLong(value);
+    }
+
+    inline PyObject* ConvertFrom(unsigned long value)
+    {
+        return PyLong_FromUnsignedLong(value);
+    }
+
+    inline PyObject* ConvertFrom(unsigned long long value)
+    {
+        return PyLong_FromUnsignedLongLong(value);
     }
 
     inline PyObject* ConvertFrom(wchar_t value)
@@ -125,8 +145,7 @@ namespace plPython
 
     inline PyObject* ConvertFrom(std::nullptr_t)
     {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
 
     /**

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonConvert.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonConvert.h
@@ -1,0 +1,186 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef _plPythonConvert_h_
+#define _plPythonConvert_h_
+
+#include <Python.h>
+#include <string_theory/string>
+#include <type_traits>
+#include <tuple>
+
+#include "pyGlueHelpers.h"
+#include "pyObjectRef.h"
+
+namespace plPython
+{
+    template<typename ArgT>
+    inline PyObject* ConvertFrom(ArgT&& value) = delete;
+
+    inline PyObject* ConvertFrom(bool value)
+    {
+        PyObject* result = value ? Py_True : Py_False;
+        Py_INCREF(result);
+        return result;
+    }
+
+    inline PyObject* ConvertFrom(char value)
+    {
+        return PyUnicode_FromFormat("%c", (int)value);
+    }
+
+    inline PyObject* ConvertFrom(const char* value)
+    {
+        return PyUnicode_FromString(value);
+    }
+
+    inline PyObject* ConvertFrom(double value)
+    {
+        return PyFloat_FromDouble(value);
+    }
+
+    inline PyObject* ConvertFrom(float value)
+    {
+        return PyFloat_FromDouble(value);
+    }
+
+    inline PyObject* ConvertFrom(int8_t value)
+    {
+        return PyLong_FromLong(value);
+    }
+
+    inline PyObject* ConvertFrom(int16_t value)
+    {
+        return PyLong_FromLong(value);
+    }
+
+    inline PyObject* ConvertFrom(int32_t value)
+    {
+        return PyLong_FromLong(value);
+    }
+
+    inline PyObject* ConvertFrom(ST::string&& value)
+    {
+        return PyUnicode_FromSTString(value);
+    }
+
+    inline PyObject* ConvertFrom(uint8_t value)
+    {
+        return PyLong_FromUnsignedLong(value);
+    }
+
+    inline PyObject* ConvertFrom(uint16_t value)
+    {
+        return PyLong_FromUnsignedLong(value);
+    }
+
+    inline PyObject* ConvertFrom(uint32_t value)
+    {
+        return PyLong_FromUnsignedLong(value);
+    }
+
+    inline PyObject* ConvertFrom(wchar_t value)
+    {
+        return PyUnicode_FromFormat("%c", (int)value);
+    }
+
+    inline PyObject* ConvertFrom(std::nullptr_t)
+    {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+
+    /**
+     * Returns a stolen reference to match the other overloads.
+     */
+    inline PyObject* ConvertFrom(PyObject* value)
+    {
+        return value;
+    }
+
+    /**
+     * Returns a stolen reference to match the other overloads.
+     */
+    inline PyObject* ConvertFrom(pyObjectRef&& value)
+    {
+        return value.Release();
+    }
+
+    namespace _detail
+    {
+        template<size_t _IdxT, typename... _TupleArgsT>
+        inline void ConvertToTuple(PyObject* result, std::tuple<_TupleArgsT...>&& tuple)
+        {
+            using _TupleT = std::decay_t<decltype(tuple)>;
+
+            if constexpr (_IdxT < std::tuple_size_v<_TupleT>) {
+                using _ElementT = std::tuple_element_t<_IdxT, _TupleT>;
+                PyTuple_SET_ITEM(
+                    result,
+                    _IdxT,
+                    plPython::ConvertFrom(
+                        std::forward<_ElementT>(
+                            std::get<_IdxT>(tuple)
+                        )
+                    )
+                );
+                ConvertToTuple<_IdxT + 1, _TupleArgsT...>(result, std::forward<_TupleT>(tuple));
+            }
+        }
+    };
+
+    struct ToTuple_Type {};
+    constexpr ToTuple_Type ToTuple;
+
+    template<typename... _TupleArgsT>
+    inline PyObject* ConvertFrom(ToTuple_Type, _TupleArgsT... args)
+    {
+        PyObject* tuple = PyTuple_New(sizeof...(args));
+        _detail::ConvertToTuple<0>(
+            tuple,
+            std::make_tuple<_TupleArgsT...>(std::forward<_TupleArgsT>(args)...)
+        );
+        return tuple;
+    }
+};
+
+#endif

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -302,7 +302,7 @@ plPythonFileMod::~plPythonFileMod()
             //  then have the glue delete the instance of class
             PyObject* delInst = PythonInterface::GetModuleItem("glue_delInst", fModule);
             if (delInst && PyCallable_Check(delInst)) {
-                pyObjectRef retVal = PyObject_CallFunction(delInst, nullptr);
+                pyObjectRef retVal = plPython::CallObject(delInst);
                 if (!retVal)
                     ReportError();
                 DisplayPythonOutput();
@@ -369,25 +369,7 @@ void plPythonFileMod::ICallScriptMethod(func_num methodId, Args&&... args)
     if (!callable)
         return;
 
-    pyObjectRef tuple = plPython::ConvertFrom(plPython::ToTuple, std::forward<Args>(args)...);
-
-    plProfile_BeginTiming(PythonUpdate);
-    pyObjectRef retVal = PyObject_CallObject(callable, tuple.Get());
-    plProfile_EndTiming(PythonUpdate);
-    if (!retVal)
-        ReportError();
-    DisplayPythonOutput();
-}
-
-void plPythonFileMod::ICallScriptMethod(func_num methodId)
-{
-    PyObject* callable = fPyFunctionInstances[methodId];
-    if (!callable)
-        return;
-
-    plProfile_BeginTiming(PythonUpdate);
-    pyObjectRef retVal = PyObject_CallObject(callable, nullptr);
-    plProfile_EndTiming(PythonUpdate);
+    pyObjectRef retVal = plPython::CallObject(callable, std::forward<Args>(args)...);
     if (!retVal)
         ReportError();
     DisplayPythonOutput();
@@ -477,7 +459,7 @@ void plPythonFileMod::AddTarget(plSceneObject* sobj)
             PyObject* getInst = PythonInterface::GetModuleItem("glue_getInst",fModule);
             fInstance = nullptr;
             if (getInst && PyCallable_Check(getInst)) {
-                fInstance = PyObject_CallFunction(getInst, nullptr);
+                fInstance = plPython::CallObject(getInst).Release();
                 if (!fInstance)
                     ReportError();
             }
@@ -545,7 +527,7 @@ void plPythonFileMod::AddTarget(plSceneObject* sobj)
                         case plPythonParameter::kAnimationName:
                             isNamedAttr = 0;
                             if (check_isNamed && PyCallable_Check(check_isNamed)) {
-                                retvalue = PyObject_CallFunction(check_isNamed, _pycs("l"), parameter.fID);
+                                retvalue = plPython::CallObject(check_isNamed, parameter.fID);
                                 if (!retvalue ) {
                                     ReportError();
                                     DisplayPythonOutput();
@@ -597,8 +579,11 @@ void plPythonFileMod::AddTarget(plSceneObject* sobj)
                     }
                     // if there is a value that was converted then tell the Python code
                     if (value) {
-                        pyObjectRef retVal = PyObject_CallFunction(setParams, _pycs("lO"),
-                                                                   parameter.fID, value.Get());
+                        pyObjectRef retVal = plPython::CallObject(
+                            setParams,
+                            parameter.fID,
+                            std::move(value)
+                        );
                         if (!retVal)
                             ReportError();
                     }
@@ -792,7 +777,11 @@ void plPythonFileMod::ISetKeyValue(const plKey& key, int32_t id)
             pyObjectRef value = pyKey::New(key);
 
             if (value) {
-                pyObjectRef retVal = PyObject_CallFunction(setParams, _pycs("lO"), id, value.Get());
+                pyObjectRef retVal = plPython::CallObject(
+                    setParams,
+                    id,
+                    std::move(value)
+                );
                 if (!retVal)
                     ReportError();
             }
@@ -1259,7 +1248,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
             pyControl.SetPyNone();
 
         // call their OnGUINotify method
-        ICallScriptMethod(kfunc_GUINotify, id, pyControl, pGUIMsg->GetEvent());
+        ICallScriptMethod(kfunc_GUINotify, id, std::move(pyControl), pGUIMsg->GetEvent());
         return true;
     }
 
@@ -1338,7 +1327,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
                 break;
         }
 
-        ICallScriptMethod(kfunc_KIMsg, pkimsg->GetCommand(), value);
+        ICallScriptMethod(kfunc_KIMsg, pkimsg->GetCommand(), std::move(value));
         return true;
     }
 
@@ -1352,7 +1341,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
     // are they looking for a RemoteAvatar Info message?
     auto pramsg = IScriptWantsMsg<plRemoteAvatarInfoMsg>(kfunc_RemoteAvatarInfo, msg);
     if (pramsg) {
-        PyObject* player = nullptr;
+        pyObjectRef player;
         if (pramsg->GetAvatarKey()) {
             // try to create the pyPlayer for where this message came from
             plNetTransportMember *mbr = plNetClientMgr::GetInstance()->TransportMgr().GetMemberByKey(pramsg->GetAvatarKey());
@@ -1361,7 +1350,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
         }
         if (!player)
             player = PyLong_FromLong(0);
-        ICallScriptMethod(kfunc_RemoteAvatarInfo, player);
+        ICallScriptMethod(kfunc_RemoteAvatarInfo, std::move(player));
         return true;
     }
 
@@ -1410,7 +1399,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
                     break;
             }
 
-            ICallScriptMethod(kfunc_OnVaultNotify, vaultNotifyMsg->GetType(), ptuple);
+            ICallScriptMethod(kfunc_OnVaultNotify, vaultNotifyMsg->GetType(), std::move(ptuple));
         }
         return true;
     }
@@ -1437,17 +1426,17 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
 
     auto ppMsg = IScriptWantsMsg<plPlayerPageMsg>(kfunc_AvatarPage, msg);
     if (ppMsg) {
-        PyObject* pSobj = pySceneObject::New(ppMsg->fPlayer, fSelfKey);
+        pyObjectRef pSobj = pySceneObject::New(ppMsg->fPlayer, fSelfKey);
         plSynchEnabler ps(true);    // enable dirty state tracking during shutdown
-        ICallScriptMethod(kfunc_AvatarPage, pSobj, !ppMsg->fUnload, ppMsg->fLastOut);
+        ICallScriptMethod(kfunc_AvatarPage, std::move(pSobj), !ppMsg->fUnload, ppMsg->fLastOut);
         return true;
     }
 
     auto pABLMsg = IScriptWantsMsg<plAgeBeginLoadingMsg>(kfunc_OnBeginAgeLoad, msg);
     if (pABLMsg) {
-        PyObject* pSobj = pySceneObject::New(plNetClientMgr::GetInstance()->GetLocalPlayerKey(), fSelfKey);
+        pyObjectRef pSobj = pySceneObject::New(plNetClientMgr::GetInstance()->GetLocalPlayerKey(), fSelfKey);
         plSynchEnabler ps(true);    // enable dirty state tracking during shutdowny
-        ICallScriptMethod(kfunc_OnBeginAgeLoad, pSobj);
+        ICallScriptMethod(kfunc_OnBeginAgeLoad, std::move(pSobj));
         return true;
     }
 
@@ -1493,7 +1482,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
                 break;
         }
 
-        ICallScriptMethod(kfunc_OnMarkerMsg, (int)markermsg->fType, ptuple);
+        ICallScriptMethod(kfunc_OnMarkerMsg, (int)markermsg->fType, std::move(ptuple));
         return true;
     }
 
@@ -1519,8 +1508,14 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
             hitpoint.SetPyNone();
         }
 
-        ICallScriptMethod(kfunc_OnLOSNotify, pLOSMsg->fRequestID, pLOSMsg->fNoHit, scobj,
-                          hitpoint, pLOSMsg->fDistance);
+        ICallScriptMethod(
+            kfunc_OnLOSNotify,
+            pLOSMsg->fRequestID,
+            pLOSMsg->fNoHit,
+            std::move(scobj),
+            std::move(hitpoint),
+            pLOSMsg->fDistance
+        );
         return true;
     }
 
@@ -1536,7 +1531,12 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
         else
             pSobj.SetPyNone();
 
-        ICallScriptMethod(kfunc_OnBehaviorNotify, behNotifymsg->fType, pSobj, behNotifymsg->state);
+        ICallScriptMethod(
+            kfunc_OnBehaviorNotify,
+            behNotifymsg->fType,
+            std::move(pSobj),
+            behNotifymsg->state
+        );
         return true;
     }
 
@@ -1556,14 +1556,14 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
             pSobj = pyImage::New(capturemsg->GetMipmap());
         else
             pSobj.SetPyNone();
-        ICallScriptMethod(kfunc_OnScreenCaptureDone, pSobj);
+        ICallScriptMethod(kfunc_OnScreenCaptureDone, std::move(pSobj));
         return true;
     }
 
     auto pEvent = IScriptWantsMsg<plClimbEventMsg>(kfunc_OnClimbBlockerEvent, msg);
     if (pEvent) {
-        PyObject* pSobj = pySceneObject::New(pEvent->GetSender(), fSelfKey);
-        ICallScriptMethod(kfunc_OnClimbBlockerEvent, pSobj);
+        pyObjectRef pSobj = pySceneObject::New(pEvent->GetSender(), fSelfKey);
+        ICallScriptMethod(kfunc_OnClimbBlockerEvent, std::move(pSobj));
         return true;
     }
 
@@ -1631,13 +1631,23 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
         if (!args)
             args.SetPyNone();
 
-        ICallScriptMethod(kfunc_OnAIMsg, brainObj, msgType, aiMsg->BrainUserString().c_str(), args);
+        ICallScriptMethod(
+            kfunc_OnAIMsg,
+            std::move(brainObj),
+            msgType,
+            aiMsg->BrainUserString().c_str(),
+            std::move(args)
+        );
         return true;
     }
 
     auto pScoreMsg = IScriptWantsMsg<pfGameScoreMsg>(kfunc_OnGameScoreMsg, msg);
     if (pScoreMsg) {
-        ICallScriptMethod(kfunc_OnGameScoreMsg, pyGameScoreMsg::CreateFinal(pScoreMsg));
+        pyObjectRef score = pyGameScoreMsg::CreateFinal(pScoreMsg);
+        ICallScriptMethod(
+            kfunc_OnGameScoreMsg,
+            std::move(score)
+        );
         return true;
     }
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.h
@@ -126,17 +126,6 @@ private:
     template<typename... Args>
     void ICallScriptMethod(func_num methodId, Args&&... args);
 
-    /**
-     * \brief Calls a bound method in this Python script.
-     * \detail Calls the bound method in this Python script specified by methodId. This overload
-     *         is used when there are no arguments to pass to the method.
-     * \note Calling a method that is not a member of the script instance is a no-op.
-     * \remarks Instance methods are resolved at initialization; therefore, Python metaprogramming
-     *          hacks such as `OnNotify = new_callable` will not actually override the OnNotify
-     *          method called when the plPythonFileMod receives a plNotifyMsg.
-     */
-    void ICallScriptMethod(func_num methodId);
-
 protected:
     friend class plPythonSDLModifier;
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyAlarm.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAlarm.h
@@ -47,16 +47,30 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 struct pyAlarm;
 typedef struct _object PyObject;
+
 class pyAlarmMgr
 {
-    typedef std::list<pyAlarm*> Alarms;
-    Alarms  fAlarms;
+    struct Alarm
+    {
+        double  fStart;
+        float   fSecs;
+        PyObject* fCb;
+        uint32_t  fCbContext;
+
+        Alarm(double start, float secs, PyObject* cb, uint32_t cbContext);
+        ~Alarm();
+        bool MaybeFire(double secs);
+        void Fire();
+    };
+
+    std::list<Alarm>  fAlarms;
+
 public:
     ~pyAlarmMgr();
     static pyAlarmMgr * GetInstance();
-    void    Update( double secs );
-    void    SetAlarm( float secs, PyObject * cb, uint32_t cbContext );
-    void    Clear();
+    void    Update(double secs);
+    void    SetAlarm(float secs, PyObject* cb, uint32_t cbContext);
+    void    Clear() { fAlarms.clear(); }
 };
 
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -103,7 +103,7 @@ void pyVaultNode::pyVaultNodeOperationCallback::VaultOperationStarted( uint32_t 
         if (PyObject_HasAttrString(fCbObject.Get(), "vaultOperationStarted")) {
             pyObjectRef func = PyObject_GetAttrString(fCbObject.Get(), "vaultOperationStarted");
             if (func && PyCallable_Check(func.Get()))
-                plPythonCallable::CallObject(func, context);
+                plPython::CallObject(func, context);
         }
     }
 }
@@ -119,7 +119,7 @@ void pyVaultNode::pyVaultNodeOperationCallback::VaultOperationComplete( uint32_t
                 pyObjectRef tup = PyTuple_New(2);
                 PyTuple_SET_ITEM(tup.Get(), 0, pyVaultNode::New(fNode));
                 PyTuple_SET_ITEM(tup.Get(), 1, fPyNodeRef.Release());
-                plPythonCallable::CallObject(func, context, tup, resultCode);
+                plPython::CallObject(func, context, tup, resultCode);
             }
         }
     }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -119,7 +119,7 @@ void pyVaultNode::pyVaultNodeOperationCallback::VaultOperationComplete( uint32_t
                 pyObjectRef tup = PyTuple_New(2);
                 PyTuple_SET_ITEM(tup.Get(), 0, pyVaultNode::New(fNode));
                 PyTuple_SET_ITEM(tup.Get(), 1, fPyNodeRef.Release());
-                plPython::CallObject(func, context, tup, resultCode);
+                plPython::CallObject(func, context, std::move(tup), resultCode);
             }
         }
     }

--- a/Sources/Tools/MaxMain/plPythonMgr.cpp
+++ b/Sources/Tools/MaxMain/plPythonMgr.cpp
@@ -53,7 +53,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "MaxComponent/plAutoUIBlock.h"
 #include "MaxComponent/plPythonFileComponent.h"
 #include "MaxComponent/plResponderComponent.h"
+
 #include "pfPython/cyPythonInterface.h"
+#include "pfPython/plPythonCallable.h"
 
 plPythonMgr::plPythonMgr()
 {
@@ -81,7 +83,7 @@ bool ICallVoidFunc(PyObject *dict, const char *funcName, PyObject*& val)
     {
         if (PyCallable_Check(func))
         {
-            val = PyObject_CallFunction(func, nullptr);
+            val = plPython::CallObject(func).Release();
             if (val)
             {
                 // there might have been some message printed, so get it out to the log file
@@ -330,18 +332,17 @@ bool plPythonMgr::IQueryPythonFile(const ST::string& fileName)
 
             for (int i = numParams-1; i >= 0; i--)
             {
-                PyObject *ret = PyObject_CallFunction(getParamFunc, "l", i);
+                PyObject* ret = plPython::CallObject(getParamFunc, i).Release();
                 
-                PyObject *visinfo = nullptr;
                 int ddlParamID = -1;
                 std::unordered_set<ST::string> vec;
 
                 if (PyCallable_Check(getVisInfoFunc))
                 {
-                    visinfo = PyObject_CallFunction(getVisInfoFunc, "l", i);
-                    if (visinfo && PyTuple_Check(visinfo))
+                    pyObjectRef visinfo = plPython::CallObject(getVisInfoFunc, i);
+                    if (visinfo && PyTuple_Check(visinfo.Get()))
                     {
-                        IExtractVisInfo(visinfo, &ddlParamID, vec);
+                        IExtractVisInfo(visinfo.Get(), &ddlParamID, vec);
                     }
                 }
 


### PR DESCRIPTION
As of Python 3.8, a new calling convention was added to CPython. The new convention is faster, per the the PSF, so we now use it. The major benefit to it on our end is that we don't have to construct intermediate Python tuples holding function call arguments anymore. Instead, we simply pass arrays of `PyObject*`. As part of this, I added scaffolding for more generic C++ -> PyObject* conversion.

There is still lots of room for improvement in the Python API in a large variety of topics, for example:
- There are many places in `plPythonFileMod` where an `ST::string` is being `c_str()`'d and the result being sent to Python.
- All of the glue should probably be updated to use [`METH_FASTCALL`](https://docs.python.org/3.8/c-api/structures.html#METH_FASTCALL) to remove the overhead of parsing argument tuples.

These items are outside the scope of this PR.