### PR TITLE
Fix journal GUI variable access before declaration error for some cases

### DIFF
--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -162,6 +162,7 @@ class xJournalBookGUIPopup(ptModifier):
             JournalIdent = LocPath.value
 
         # compile journal text
+        journalContents = ""
         if Dynamic.value:
             inbox = ptVault().getGlobalInbox()
             inboxChildList = inbox.getChildNodeRefList()


### PR DESCRIPTION
The `journalContents` variable was not being declared and set in all branches of the if/else block, so trying to retrieve a Dynamic text block from the vault where the vault didn't have the item caused a somewhat unhelpful python error rather than a blank journal and a warning message in the python log.

Initialize it to empty string to make sure it always has been declared before it is used.