### PR TITLE
Clean up autogenerated Xcode schemes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
       - name: Configure
         run: |
           cmake \
+            -G Xcode \
             -DCMAKE_BUILD_TYPE=${{ matrix.cfg.type }} \
             -DCMAKE_FIND_FRAMEWORK=LAST \
             -DPLASMA_BUILD_TESTS=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,11 @@ if(APPLE)
 
     if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
         add_definitions(-DHS_BUILD_FOR_MACOS)
+
+        option(PLASMA_MAC_UNIVERSAL "Build macOS multi-architecture universal builds?" OFF)
+        if (PLASMA_MAC_UNIVERSAL)
+            set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
+        endif()
     endif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 endif(APPLE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ endif(UNIX)
 
 if(APPLE)
     add_definitions(-DHS_BUILD_FOR_APPLE)
+    set(CMAKE_XCODE_GENERATE_SCHEME FALSE)
 
     if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
         add_definitions(-DHS_BUILD_FOR_MACOS)

--- a/cmake/PlasmaTargets.cmake
+++ b/cmake/PlasmaTargets.cmake
@@ -34,6 +34,7 @@ function(plasma_executable TARGET)
         list(APPEND addexe_args EXCLUDE_FROM_ALL)
     endif()
     add_executable(${TARGET} ${addexe_args} ${_pex_SOURCES})
+    set_target_properties(${TARGET} PROPERTIES XCODE_GENERATE_SCHEME TRUE)
 
     if(_pex_CLIENT)
         set(install_destination client)


### PR DESCRIPTION
Instead of cluttering up Xcode with a scheme for every library, let's tell it to only include schemes for the executable targets.

Also add a macOS-specific option to tell it to do universal multi-architecture builds (disabled by default).