### PR TITLE
Add capability to use a sliding solution window for puzzle buttons

### DIFF
--- a/Scripts/Python/xAgeSDLBoolActivatorComboSet.py
+++ b/Scripts/Python/xAgeSDLBoolActivatorComboSet.py
@@ -215,12 +215,13 @@ class xAgeSDLBoolActivatorComboSet(ptResponder):
         if self._solved:
             PtDebugPrint("xAgeSDLBoolActComboSet._TriggerButton():\tYou just unsolved it, moron.", level=kWarningLevel)
             self._solved = False
-            self._numCorrect = 0
             self._attemptCombo = [actId]
             return
 
         if allowSlidingSolution.value:
             attempt = self._attemptCombo
+            # find the subset of the attempt array that matches the start of the combination, if it exists.
+            # the length of this matching attempt subset is the current number of correct values, otherwise 0 are correct.
             self._numCorrect = next((len(attempt) - i for i in range(len(attempt)) if self._IsAttemptCorrectAtIndex(i)), 0)
             PtDebugPrint(f"xAgeSDLBoolActComboSet._TriggerButton():\t Sliding attempt {attempt} has {self._numCorrect} correct.", level=kWarningLevel)
             self._CheckSolved()
@@ -258,11 +259,9 @@ class xAgeSDLBoolActivatorComboSet(ptResponder):
     def _AddToAttempt(self, actId):
         attempt = self._attemptCombo
         attempt.append(actId)
-        if len(attempt) > len(self._combination):
-            attempt = attempt[1:]
-        PtDebugPrint(f"xAgeSDLBoolActComboSet._AddToAttempt():\t New attempt value: {attempt}", level=kWarningLevel)
+        attempt = attempt[-len(self._combination):]
         self._attemptCombo = attempt
 
     def _IsAttemptCorrectAtIndex(self, i):
         attempt = self._attemptCombo
-        return attempt[i:] == self._combination[0:len(attempt)-i]
+        return attempt[i:] == self._combination[:len(attempt)-i]

--- a/Scripts/Python/xAgeSDLBoolActivatorComboSet.py
+++ b/Scripts/Python/xAgeSDLBoolActivatorComboSet.py
@@ -82,11 +82,13 @@ class xAgeSDLBoolActivatorComboSet(ptResponder):
         ageSDL.setNotify(self.key, butsInUseVariableName.value, 0.0)
         ageSDL.setFlags(numCorrectVariableName.value, True, True)
         ageSDL.sendToClients(numCorrectVariableName.value)
-        self.SDL.setDefault("attemptCombo", ())
         self.SDL.sendToClients("attemptCombo")
+        self.SDL.setFlags("attemptCombo", True, True)
 
         if not PtGetPlayerList():
             self._butsInUse = False
+            if allowSlidingSolution.value:
+                self._attemptCombo = []
             if resetOnEmpty.value:
                 self._solved = (False, "fastforward")
                 self._numCorrect = (0, "fastforward")

--- a/Scripts/SDL/xAgeSDLBoolActivatorComboSet.sdl
+++ b/Scripts/SDL/xAgeSDLBoolActivatorComboSet.sdl
@@ -1,0 +1,55 @@
+# /*==LICENSE==*
+# 
+# CyanWorlds.com Engine - MMOG client, server and tools
+# Copyright (C) 2011  Cyan Worlds, Inc.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU GPL version 3 section 7
+#
+# If you modify this Program, or any covered work, by linking or
+# combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+# NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+# JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+# (or a modified version of those libraries),
+# containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+# PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+# JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+# licensors of this Program grant you additional
+# permission to convey the resulting work. Corresponding Source for a
+# non-source form of such a combination shall include the source code for
+# the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+# work.
+# 
+# You can contact Cyan Worlds, Inc. by email legal@cyan.com
+#  or by snail mail at:
+#       Cyan Worlds, Inc.
+#       14617 N Newport Hwy
+#       Mead, WA   99021
+# 
+# *==LICENSE==*/
+#
+#==============================================================
+# READ:   When modifying an SDL record, do *not* modify the
+#   existing record. You must copy and paste a new version
+#   below the current one and make your changes there.
+#==============================================================
+#
+# State Description Language for a xAgeSDLBoolActivatorComboSet
+
+STATEDESC xAgeSDLBoolActivatorComboSet
+{
+	VERSION 1
+	VAR INT        attemptCombo[] DEFAULT=-1
+}

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -420,6 +420,12 @@ void plPythonSDLModifier::IPythonVarToSDL(plStateDataRecord* state, const ST::st
         Py_ssize_t count = PyTuple_Size(pyVar);
         plSimpleVarDescriptor::Type type = var->GetSimpleVarDescriptor()->GetType();
 
+        // Ensure that variable length arrays match.
+        if (var->GetSimpleVarDescriptor()->IsVariableLength()) {
+            if (var->GetCount() != count)
+                var->Alloc(count);
+        }
+
         for (Py_ssize_t i = 0; i < count; i++) {
             PyObject* pyVarItem = PyTuple_GetItem(pyVar, i);
             if (pyVarItem)


### PR DESCRIPTION
In response to a report by @EhrenCG on the OU discord and comment that @ametist365 would like to try the sliding window variation. When the puzzle button python file mod is used without providing feedback to the user that the combination is reset on a wrong click and prompting them to start over from the beginning of the sequence, it can seem that entering the right combination will not work correctly. With this new attribute added for puzzles, the script will check a sliding window of the last N entries so that, for example, entering 1,1,2,3 will match a combination of 1,2,3 rather than failing after 1,1 and expecting the user to start the sequence over.

**Original report by Ehren (re: flower button sequence in Elonin):**
Guys, I feel like I've found a major programming oversight and it can be understood pretty well just looking at the Python log, in the red and blue squares I show that push the same sequence of buttons in both, but the one in red registers as all wrong, and the one in blue as all right.

The problem lays in the fact that the first button in the sequence counts as wrong if you hit it a second time (rather then considering that you are starting the sequence over again from the start).

This could lead to confusing situations where someone messes with the buttons goes to check on something, comes back to try entering the code again, and having the code that SHOULD work end up not working...
![image](https://user-images.githubusercontent.com/94947971/173259838-0bd26341-f019-4120-afea-c79a96a4c057.png)

This issue affects simple puzzle in Tiam too, you know the three buttons you have to keep using each time  you visit?  Try pushing the first one two times, then the rest of the code, you now have a situation where you have entered the correct code, but the initial first press canceled it out.  This would not have happened if you had pressed it three times though, just even numbers where you keep canceling the first code button out.