### PR TITLE
Simplify KI inbox sorting... hopefully

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -4302,7 +4302,8 @@ class xKI(ptModifier):
             gInbox = vault.getGlobalInbox()
             if gInbox is not None:
                 self.BKContentList = gInbox.getChildNodeRefList() + self.BKContentList
-                self.BKContentList.sort(key=functools.cmp_to_key(CMPNodeDate))
+                # sort the inbox contents by descending modified date/time
+                self.BKContentList.sort(key=xKIHelpers.GetChildNodeModifyTime, reverse=True)
 
         removeList = []
         for contentidx in range(len(self.BKContentList)):

--- a/Scripts/Python/ki/xKIHelpers.py
+++ b/Scripts/Python/ki/xKIHelpers.py
@@ -42,7 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
  *==LICENSE==* """
 
 import re
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 # Plasma engine.
 from Plasma import *
@@ -214,17 +214,9 @@ def CMPplayerOnline(playerA, playerB):
             return -1 if online[0] else 1
     return 0
 
-
-## Helper function to sort nodes according to modification date.
-def CMPNodeDate(nodeA, nodeB):
-
-    elNodeA = nodeA.getChild()
-    elNodeB = nodeB.getChild()
-    if elNodeA is not None and elNodeB is not None:
-        if elNodeA.getModifyTime() > elNodeB.getModifyTime():
-            return -1
-        else:
-            return 1
+def GetChildNodeModifyTime(ref: Optional[ptVaultNodeRef]) -> int:
+    if ref and (node := ref.getChild()):
+        return node.getModifyTime()
     return 0
 
 ## Replace the Age's name as is appropriate.


### PR DESCRIPTION
Developed while trying to diagnose a problem Mirphak reported in the OU discord (the PR for the real issue is still to come). The node comparison method returning a -1/0/1 result seems much more complicated and potentially worse performance than the new streamlined version. I don't have evidence for any performance changes; not sure how to run a fair comparison. But I find it easier to read now, at least.