### PR TITLE
Fix for infinite BK refresh due to addition to Recents with inbox item senders

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -4314,12 +4314,11 @@ class xKI(ptModifier):
             del self.BKContentList[removeidx]
 
         if self.BKFolderListOrder[self.BKFolderSelected] == xLocTools.FolderIDToFolderName(PtVaultStandardNodes.kInboxFolder):
-            PIKAFolder = ptVault().getPeopleIKnowAboutFolder()
-            if PIKAFolder and kLimits.MaxRecentPlayerListSize - len(PIKAFolder.getChildNodeRefList()) > 0:
-                PtDebugPrint(f"xKI.BigKIProcessContentList(): {kLimits.MaxRecentPlayerListSize - len(PIKAFolder.getChildNodeRefList())} remaining recents slots.", level=kWarningLevel)
+            recentsList = ptVault().getPeopleIKnowAboutFolder()
+            if recentsList and (remRecents := kLimits.MaxRecentPlayerListSize - len(recentsList.getChildNodeRefList())) > 0:
+                PtDebugPrint(f"xKI.BigKIProcessContentList(): {remRecents} remaining recents slots.", level=kWarningLevel)
                 # add Inbox senders (sorted by most recent) to Recents folder
                 # but don't overload Recents or refresh triggers infinitely due to Recents node additions/removals
-                recentsList = PIKAFolder.upcastToPlayerInfoListNode()
                 cannotAdd = lambda ref: not (s := xKIHelpers.GetSaverID(ref)) or recentsList.playerlistHasPlayer(s) or not self.chatMgr.AddPlayerToRecents(s)
                 # add only one then stop because addition triggers BK refresh again that will add next one, etc.
                 inboxRef = next(itertools.dropwhile(cannotAdd, self.BKContentList), None)

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -64,6 +64,7 @@ import os    # Used for saving pictures locally.
 import glob  # Used for saving pictures locally.
 import math
 import functools
+import itertools
 
 from xGUILinkHandler import xGUILinkHandler
 import xLocTools
@@ -4286,9 +4287,6 @@ class xKI(ptModifier):
                             # Remove from inbox (how will this work?).
                             element = ref.getChild()
                             inbox.removeNode(element)
-                    else:
-                        # add non-blocked senders to Recents folder so they can be added to buddies or ignore lists
-                        self.chatMgr.AddPlayerToRecents(ref.getSaverID())
 
         if removeList:
             PtDebugPrint("xKI.BigKIProcessContentList(): Removing {} contents from being displayed.".format(len(removeList)), level=kWarningLevel)
@@ -4314,6 +4312,18 @@ class xKI(ptModifier):
                         removeList.insert(0, contentidx)
         for removeidx in removeList:
             del self.BKContentList[removeidx]
+
+        if self.BKFolderListOrder[self.BKFolderSelected] == xLocTools.FolderIDToFolderName(PtVaultStandardNodes.kInboxFolder):
+            PIKAFolder = ptVault().getPeopleIKnowAboutFolder()
+            if PIKAFolder and kLimits.MaxRecentPlayerListSize - len(PIKAFolder.getChildNodeRefList()) > 0:
+                PtDebugPrint(f"xKI.BigKIProcessContentList(): {kLimits.MaxRecentPlayerListSize - len(PIKAFolder.getChildNodeRefList())} remaining recents slots.", level=kWarningLevel)
+                # add Inbox senders (sorted by most recent) to Recents folder
+                # but don't overload Recents or refresh triggers infinitely due to Recents node additions/removals
+                recentsList = PIKAFolder.upcastToPlayerInfoListNode()
+                cannotAdd = lambda ref: not (s := xKIHelpers.GetSaverID(ref)) or recentsList.playerlistHasPlayer(s) or not self.chatMgr.AddPlayerToRecents(s)
+                # add only one then stop because addition triggers BK refresh again that will add next one, etc.
+                inboxRef = next(itertools.dropwhile(cannotAdd, self.BKContentList), None)
+                PtDebugPrint(f"xKI.BigKIProcessContentList(): Added {xKIHelpers.GetSaverID(inboxRef)} ({inboxRef}) to recents.", level=kWarningLevel)
 
     ## Refresh the display of the selected content list.
     def BigKIRefreshContentListDisplay(self):

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -707,14 +707,12 @@ class xKIChat(object):
     ## Adds a player to the recent players folder.
     def AddPlayerToRecents(self, playerID):
 
-        isAdded = False
         PIKAFolder = ptVault().getPeopleIKnowAboutFolder()
         if PIKAFolder:
             PIKA = PIKAFolder.upcastToPlayerInfoListNode()
             if PIKA is not None:
                 if not PIKA.playerlistHasPlayer(playerID):
                     PIKA.playerlistAddPlayer(playerID)
-                    isAdded = True
                     childRefList = PIKAFolder.getChildNodeRefList()
                     numPeople = len(childRefList)
                     if numPeople > kLimits.MaxRecentPlayerListSize:
@@ -724,7 +722,8 @@ class xKIChat(object):
                             peopleToRemove.append(childRefList[i].getChild())
                         for person in peopleToRemove:
                             PIKAFolder.removeNode(person)
-        return isAdded
+                    return True
+        return False
 
     ## Returns a list of players within chat distance.
     def GetPlayersInChatDistance(self, minPlayers=8):

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -707,13 +707,14 @@ class xKIChat(object):
     ## Adds a player to the recent players folder.
     def AddPlayerToRecents(self, playerID):
 
-        vault = ptVault()
-        PIKAFolder = vault.getPeopleIKnowAboutFolder()
+        isAdded = False
+        PIKAFolder = ptVault().getPeopleIKnowAboutFolder()
         if PIKAFolder:
             PIKA = PIKAFolder.upcastToPlayerInfoListNode()
             if PIKA is not None:
                 if not PIKA.playerlistHasPlayer(playerID):
                     PIKA.playerlistAddPlayer(playerID)
+                    isAdded = True
                     childRefList = PIKAFolder.getChildNodeRefList()
                     numPeople = len(childRefList)
                     if numPeople > kLimits.MaxRecentPlayerListSize:
@@ -723,6 +724,7 @@ class xKIChat(object):
                             peopleToRemove.append(childRefList[i].getChild())
                         for person in peopleToRemove:
                             PIKAFolder.removeNode(person)
+        return isAdded
 
     ## Returns a list of players within chat distance.
     def GetPlayersInChatDistance(self, minPlayers=8):

--- a/Scripts/Python/ki/xKIHelpers.py
+++ b/Scripts/Python/ki/xKIHelpers.py
@@ -42,7 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
  *==LICENSE==* """
 
 import re
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 # Plasma engine.
 from Plasma import *
@@ -225,6 +225,11 @@ def CMPNodeDate(nodeA, nodeB):
             return -1
         else:
             return 1
+    return 0
+
+def GetSaverID(ref: Optional[ptVaultNodeRef]) -> int:
+    if ref and ref.getSaver():
+        return ref.getSaverID()
     return 0
 
 ## Replace the Age's name as is appropriate.

--- a/Scripts/Python/ki/xKIHelpers.py
+++ b/Scripts/Python/ki/xKIHelpers.py
@@ -228,9 +228,7 @@ def CMPNodeDate(nodeA, nodeB):
     return 0
 
 def GetSaverID(ref: Optional[ptVaultNodeRef]) -> int:
-    if ref and ref.getSaver():
-        return ref.getSaverID()
-    return 0
+    return ref.getSaverID() if ref else 0
 
 ## Replace the Age's name as is appropriate.
 # It accepts as a parameter a name, unlike GetAgeName.


### PR DESCRIPTION
Bug introduced in https://github.com/H-uru/Plasma/pull/1129 by me. Could infinitely recurse when opening the Big KI Incoming folder and it added a player to a full Recents list, triggering an addition and removal, which triggered the Big KI refresh again, which tried to add/remove another player to Recents, etc. With this fix, it will recurse to a maximum of 50 (max Recents list size) refreshes if the Recents folder was empty and never try to add more Recents from Inbox Savers if the Recents list is already full.