### PR TITLE
Update vcpkg submodule to current

### DIFF
--- a/Scripts/Ports/python3-cairosvg/portfile.cmake
+++ b/Scripts/Ports/python3-cairosvg/portfile.cmake
@@ -111,6 +111,15 @@ if(VCPKG_TARGET_IS_WINDOWS)
     endforeach()
 endif()
 
+# vcpkg may or may not have pip available. Bootstrap it.
+message(STATUS "Bootstrapping pip")
+vcpkg_execute_required_process(
+    COMMAND "${PYTHON_EXECUTABLE}" -m ensurepip
+    ALLOW_IN_DOWNLOAD_MODE
+    WORKING_DIRECTORY "${CURRENT_PYTHON_PREFIX}"
+    LOGNAME ensurepip
+)
+
 # Use pip to install cairosvg into the staging dir.
 message(STATUS "Installing cairosvg from pip")
 file(TO_NATIVE_PATH "${CURRENT_PYTHON_PREFIX}" _PIP_PREFIX)

--- a/Scripts/Ports/python3-cairosvg/vcpkg.json
+++ b/Scripts/Ports/python3-cairosvg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "python3-cairosvg",
   "version-semver": "2.5.2",
+  "port-version": 1,
   "description": "CairoSVG is an SVG converter based on Cairo. It can export SVG files to PDF, EPS, PS, and PNG files.",
   "homepage": "https://cairosvg.org/",
   "dependencies": [


### PR DESCRIPTION
@Hoikas requested that I update vcpkg now that it includes the latest python 3.10 stuff. In theory this also includes the update to string_theory to fix the char buffer issue. I dunno what else changed. YOLO?