### PR TITLE
Adding cursor scale

### DIFF
--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
@@ -227,6 +227,7 @@ bool plMouseDevice::bCursorOverride = false;
 bool plMouseDevice::bInverted = false;
 float plMouseDevice::fWidth = BASE_WIDTH;
 float plMouseDevice::fHeight = BASE_HEIGHT;
+float plMouseDevice::fScale = 1.0f;
 plMouseDevice* plMouseDevice::fInstance = nullptr;
 
 plMouseDevice::plMouseDevice()
@@ -253,6 +254,12 @@ void plMouseDevice::SetDisplayResolution(float Width, float Height)
     IUpdateCursorSize();
 }
 
+void plMouseDevice::SetScale(float Scale)
+{
+    fScale = Scale;
+    IUpdateCursorSize();
+}
+
 void    plMouseDevice::CreateCursor( const char* cursor )
 {
     if (fCursor == nullptr)
@@ -276,7 +283,7 @@ void plMouseDevice::IUpdateCursorSize()
     if(fCursor)
     {
         // set the size of the cursor based on resolution.
-        fCursor->SetSize( 2*fCursor->GetMipmap()->GetWidth()/fWidth, 2*fCursor->GetMipmap()->GetHeight()/fHeight );
+        fCursor->SetSize( fScale * 2*fCursor->GetMipmap()->GetWidth()/fWidth, fScale * 2*fCursor->GetMipmap()->GetHeight()/fHeight );
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
@@ -254,7 +254,7 @@ void plMouseDevice::SetDisplayResolution(float Width, float Height)
     IUpdateCursorSize();
 }
 
-void plMouseDevice::SetScale(float Scale)
+void plMouseDevice::SetDisplayScale(float Scale)
 {
     fScale = Scale;
     IUpdateCursorSize();
@@ -292,7 +292,7 @@ void plMouseDevice::AddNameToCursor(const ST::string& name)
     if (fInstance && !name.empty())
     {
         plDebugText     &txt = plDebugText::Instance();
-        txt.DrawString(fInstance->fWXPos + 12 ,fInstance->fWYPos - 7,name);
+        txt.DrawString(fInstance->fWXPos + 12 * fScale, fInstance->fWYPos - txt.GetFontHeight() / 2,name);
     }
 }
 void plMouseDevice::AddCCRToCursor()
@@ -300,7 +300,7 @@ void plMouseDevice::AddCCRToCursor()
     if (fInstance)
     {
         plDebugText     &txt = plDebugText::Instance();
-        txt.DrawString(fInstance->fWXPos + 12, fInstance->fWYPos - 17, "CCR");
+        txt.DrawString(fInstance->fWXPos + 12 * fScale, fInstance->fWYPos - 17, "CCR");
     }
 }
 void plMouseDevice::AddIDNumToCursor(uint32_t idNum)
@@ -310,7 +310,7 @@ void plMouseDevice::AddIDNumToCursor(uint32_t idNum)
         plDebugText     &txt = plDebugText::Instance();
         char str[256];
         sprintf(str, "%d",idNum);
-        txt.DrawString(fInstance->fWXPos + 12 ,fInstance->fWYPos + 3,str);
+        txt.DrawString(fInstance->fWXPos + 12 * fScale,fInstance->fWYPos + 3,str);
     }
 }
         
@@ -490,7 +490,7 @@ bool plMouseDevice::MsgReceive(plMessage* msg)
             fXPos = pXMsg->fX;
 
         SetCursorX(fXPos);
-        fWXPos = pXMsg->fWx;
+        fWXPos = pXMsg->fWx * fScale;
         return true;
     }
 
@@ -527,7 +527,7 @@ bool plMouseDevice::MsgReceive(plMessage* msg)
         else
             fYPos = pYMsg->fY;
 
-        fWYPos = pYMsg->fWy;
+        fWYPos = pYMsg->fWy * fScale;
         SetCursorY(fYPos);
         
         return true;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
@@ -175,7 +175,7 @@ public:
     uint32_t  GetButtonState() { return fButtonState; }
     float GetCursorOpacity() { return fOpacity; }
     void SetDisplayResolution(float Width, float Height);
-    void SetScale(float Scale);
+    void SetDisplayScale(float Scale);
     
     bool MsgReceive(plMessage* msg) override;
     

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
@@ -175,6 +175,7 @@ public:
     uint32_t  GetButtonState() { return fButtonState; }
     float GetCursorOpacity() { return fOpacity; }
     void SetDisplayResolution(float Width, float Height);
+    void SetScale(float Scale);
     
     bool MsgReceive(plMessage* msg) override;
     
@@ -223,6 +224,7 @@ protected:
     static bool bCursorOverride;
     static bool bInverted;
     static float fWidth, fHeight;
+    static float fScale;
 };
 
 


### PR DESCRIPTION
Cursor scale corrects corrects the size of the cursor on Retina displays.

Proposing this change for supporting hi DPI displays. On Mac, this is tied to the Retina display scale. It corrects for the cursor being way too small as the resolution increases. On a Retina display, this will draw the cursor at 2x. While on a non Retina display the cursor will remain 1x.

Cursor scale is an independent property because a lot of things touch the cursor frame. This allows the scale to stay constant even if something else does a resolution change.

On Windows - this could be tied to display scale. Proposing this change for mainline, and am using it in the Mac branch.