### PR TITLE
Add mitigation for triangle mesh regions.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
@@ -188,6 +188,11 @@ void plPXPhysical::DirtyRecipe()
                                        "supported in PhysX 4... forcing to convex hull, sorry.",
                                        GetKeyName());
             fBounds = plSimDefs::kHullBounds;
+        } else if (IsTrigger()) {
+            plSimulationMgr::LogYellow("WARNING: '{}' is a detector region triangle mesh; this is not "
+                                       "supported in PhysX 4... forcing to convex hull, sorry.",
+                                       GetKeyName());
+            fBounds = plSimDefs::kHullBounds;
         }
         break;
 


### PR DESCRIPTION
This was discovered when testing Fahets Highgarden.

PhysX 4.1 doesn't support trigger shapes that are triangle regions. Instead of dropping them on the floor, however, PhysX seems to think that making them a normal, solid simulation shape is the way to go. Therefore, we force them to convex hull.

A better fix will be to refuse to export these obviously flawed regions in Korman.