### PR TITLE
Fixing parser to not split tokens containing flags

### DIFF
--- a/Sources/Plasma/CoreLib/plCmdParser.cpp
+++ b/Sources/Plasma/CoreLib/plCmdParser.cpp
@@ -311,7 +311,7 @@ bool plCmdParserImpl::ProcessValue(plCmdTokenState* state, size_t index, const S
 bool plCmdParserImpl::TokenizeFlags(plCmdTokenState* state, const ST::string& str)
 {
     bool result = true;
-    std::vector<ST::string> tokens = str.tokenize(ALL);
+    std::vector<ST::string> tokens = str.tokenize(WHITESPACE SEPARATORS);
 
     for (auto it = tokens.begin(); result && it != tokens.end(); ++it) {
         size_t lastIndex = size_t(-1);
@@ -320,6 +320,8 @@ bool plCmdParserImpl::TokenizeFlags(plCmdTokenState* state, const ST::string& st
         if (buffer.empty()) {
             continue;
         }
+        
+        buffer = buffer.trim_left(FLAGS);
 
         while (result) {
             // Lookup the argument name

--- a/Sources/Tests/CoreTests/test_plCmdParser.cpp
+++ b/Sources/Tests/CoreTests/test_plCmdParser.cpp
@@ -548,7 +548,7 @@ TEST(plCmdParser, case_sensitive_match)
     EXPECT_EQ(specified, true);
 }
 
-TEST(plCmdParser, seperator_in_value)
+TEST(plCmdParser, separator_in_value)
 {
     const plCmdArgDef cmds[] = {
         { kCmdTypeString, "color", 0}

--- a/Sources/Tests/CoreTests/test_plCmdParser.cpp
+++ b/Sources/Tests/CoreTests/test_plCmdParser.cpp
@@ -548,7 +548,7 @@ TEST(plCmdParser, case_sensitive_match)
     EXPECT_EQ(specified, true);
 }
 
-TEST(plCmdParser, separator_in_value)
+TEST(plCmdParser, separator_in_value_nix)
 {
     const plCmdArgDef cmds[] = {
         { kCmdTypeString, "color", 0}
@@ -556,6 +556,20 @@ TEST(plCmdParser, separator_in_value)
 
     plCmdParser parser(cmds, std::size(cmds));
     parser.Parse("plCmdParser --color=reddish-blue");
+
+    ST::string value = parser.GetString("color");
+
+    EXPECT_EQ(value, "reddish-blue");
+}
+
+TEST(plCmdParser, separator_in_value_windows)
+{
+    const plCmdArgDef cmds[] = {
+        { kCmdTypeString, "color", 0}
+    };
+
+    plCmdParser parser(cmds, std::size(cmds));
+    parser.Parse("plCmdParser /color=reddish-blue");
 
     ST::string value = parser.GetString("color");
 

--- a/Sources/Tests/CoreTests/test_plCmdParser.cpp
+++ b/Sources/Tests/CoreTests/test_plCmdParser.cpp
@@ -547,3 +547,17 @@ TEST(plCmdParser, case_sensitive_match)
 
     EXPECT_EQ(specified, true);
 }
+
+TEST(plCmdParser, seperator_in_value)
+{
+    const plCmdArgDef cmds[] = {
+        { kCmdTypeString, "color", 0}
+    };
+
+    plCmdParser parser(cmds, std::size(cmds));
+    parser.Parse("plCmdParser --color=reddish-blue");
+
+    ST::string value = parser.GetString("color");
+
+    EXPECT_EQ(value, "reddish-blue");
+}


### PR DESCRIPTION
The tokenizer as it was written would split tokens midway if they contained a flag character. I made changes so that the initial tokenization is done by whitespace and separators, and then flags are removed from the front instead of a split being used.

My assumption is that all arguments have to be separated by whitespace and separators.

This should fix things like -Age=GuildPub-Writers