### PR TITLE
Fix platform-dependent path problems in the patcher.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -550,11 +550,11 @@ void pfPatcherWorker::Run()
 void pfPatcherWorker::IHashFile(pfPatcherQueuedFile& file)
 {
     // Check to see if ours matches
-    plFileInfo mine(file.fClientPath);
+    plFileInfo mine(file.fClientPath.Normalize());
     if (mine.FileSize() == file.fFileSize) {
-        plMD5Checksum cliMD5(file.fClientPath);
+        plMD5Checksum cliMD5(file.fClientPath.Normalize());
         if (cliMD5 == file.fChecksum) {
-            WhitelistFile(file.fClientPath, false);
+            WhitelistFile(file.fClientPath.Normalize(), false);
             return;
         }
     }
@@ -569,12 +569,12 @@ void pfPatcherWorker::IHashFile(pfPatcherQueuedFile& file)
 
     // If you got here, they're different and we want it.
     PatcherLogYellow("\tEnqueuing '{}'", file.fServerPath);
-    plFileSystem::CreateDir(file.fClientPath.StripFileName());
+    plFileSystem::CreateDir(file.fClientPath.Normalize().StripFileName());
 
     // If someone registered for SelfPatch notifications, then we should probably
     // let them handle the gruntwork... Otherwise, go nuts!
     if (fSelfPatch) {
-        if (file.fClientPath == plFileSystem::GetCurrentAppPath().GetFileName()) {
+        if (file.fClientPath.Normalize() == plFileSystem::GetCurrentAppPath().GetFileName()) {
             file.fClientPath += ".tmp"; // don't overwrite myself!
             file.fFlags |= kSelfPatch;
         }

--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbConst.h
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbConst.h
@@ -49,15 +49,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *
 ***/
 
-// FIXME: Remove all Windows assumptions in the net code
-#ifndef MAX_PATH
-#   define MAX_PATH 260
-#endif
-
 //============================================================================
 // Network constants
 //============================================================================
 const unsigned kMaxTcpPacketSize                = 1460;
+const unsigned kCli2File_FilenameSize           = 260;
 
 //============================================================================
 // Crypto constants

--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbConst.h
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbConst.h
@@ -53,7 +53,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // Network constants
 //============================================================================
 const unsigned kMaxTcpPacketSize                = 1460;
-const unsigned kCli2File_FilenameSize           = 260;
+const unsigned kNetDefaultStringSize            = 260;
 
 //============================================================================
 // Crypto constants

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
@@ -106,8 +106,8 @@ static const NetMsgField kAcctCreateFromKeyRequestFields[] = {
 static const NetMsgField kPlayerCreateRequestFields[] = {
     kNetMsgFieldTransId,                            // transId
     NET_MSG_FIELD_STRING(kMaxPlayerNameLength),     // playerName
-    NET_MSG_FIELD_STRING(MAX_PATH),                 // avatarShape
-    NET_MSG_FIELD_STRING(MAX_PATH),                 // friendInvite
+    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // avatarShape
+    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // friendInvite
 };
 
 static const NetMsgField kPlayerDeleteRequestFields[] = {
@@ -149,9 +149,9 @@ static const NetMsgField kAcctActivateRequestFields[] = {
 };
 
 static const NetMsgField kFileListRequestFields[] = {
-    kNetMsgFieldTransId,                // transId
-    NET_MSG_FIELD_STRING(MAX_PATH),     // directory
-    NET_MSG_FIELD_STRING(MAX_EXT),      // ext
+    kNetMsgFieldTransId,                                // transId
+    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),       // directory
+    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),       // ext
 };
 
 static const NetMsgField kFileDownloadRequestFields[] = {
@@ -201,15 +201,15 @@ static const NetMsgField kVaultNodeFetchFields[] = {
 };
 
 static const NetMsgField kVaultInitAgeRequestFields[] = {
-    kNetMsgFieldTransId,                        // transId
-    kNetMsgFieldUuid,                           // ageInstId
-    kNetMsgFieldUuid,                           // parentAgeInstId
-    NET_MSG_FIELD_STRING(MAX_PATH),             // ageFilename
-    NET_MSG_FIELD_STRING(MAX_PATH),             // ageInstName
-    NET_MSG_FIELD_STRING(MAX_PATH),             // ageUserName
-    NET_MSG_FIELD_STRING(1024),                 // ageDesc
-    NET_MSG_FIELD_DWORD(),                      // ageSequenceNumber
-    NET_MSG_FIELD_DWORD(),                      // ageLanguage
+    kNetMsgFieldTransId,                            // transId
+    kNetMsgFieldUuid,                               // ageInstId
+    kNetMsgFieldUuid,                               // parentAgeInstId
+    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // ageFilename
+    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // ageInstName
+    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // ageUserName
+    NET_MSG_FIELD_STRING(1024),                     // ageDesc
+    NET_MSG_FIELD_DWORD(),                          // ageSequenceNumber
+    NET_MSG_FIELD_DWORD(),                          // ageLanguage
 };
 
 static const NetMsgField kVaultNodeFindFields[] = {

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
@@ -106,8 +106,8 @@ static const NetMsgField kAcctCreateFromKeyRequestFields[] = {
 static const NetMsgField kPlayerCreateRequestFields[] = {
     kNetMsgFieldTransId,                            // transId
     NET_MSG_FIELD_STRING(kMaxPlayerNameLength),     // playerName
-    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // avatarShape
-    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // friendInvite
+    NET_MSG_FIELD_STRING(kNetDefaultStringSize),    // avatarShape
+    NET_MSG_FIELD_STRING(kNetDefaultStringSize),    // friendInvite
 };
 
 static const NetMsgField kPlayerDeleteRequestFields[] = {
@@ -150,13 +150,13 @@ static const NetMsgField kAcctActivateRequestFields[] = {
 
 static const NetMsgField kFileListRequestFields[] = {
     kNetMsgFieldTransId,                                // transId
-    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),       // directory
+    NET_MSG_FIELD_STRING(kNetDefaultStringSize),       // directory
     NET_MSG_FIELD_STRING(MAX_EXT),                      // ext
 };
 
 static const NetMsgField kFileDownloadRequestFields[] = {
     kNetMsgFieldTransId,                            // transId
-    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // filename
+    NET_MSG_FIELD_STRING(kNetDefaultStringSize),    // filename
 };
 
 static const NetMsgField kFileDownloadChunkAckFields[] = {
@@ -204,9 +204,9 @@ static const NetMsgField kVaultInitAgeRequestFields[] = {
     kNetMsgFieldTransId,                            // transId
     kNetMsgFieldUuid,                               // ageInstId
     kNetMsgFieldUuid,                               // parentAgeInstId
-    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // ageFilename
-    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // ageInstName
-    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // ageUserName
+    NET_MSG_FIELD_STRING(kNetDefaultStringSize),    // ageFilename
+    NET_MSG_FIELD_STRING(kNetDefaultStringSize),    // ageInstName
+    NET_MSG_FIELD_STRING(kNetDefaultStringSize),    // ageUserName
     NET_MSG_FIELD_STRING(1024),                     // ageDesc
     NET_MSG_FIELD_DWORD(),                          // ageSequenceNumber
     NET_MSG_FIELD_DWORD(),                          // ageLanguage

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
@@ -151,12 +151,12 @@ static const NetMsgField kAcctActivateRequestFields[] = {
 static const NetMsgField kFileListRequestFields[] = {
     kNetMsgFieldTransId,                                // transId
     NET_MSG_FIELD_STRING(kCli2File_FilenameSize),       // directory
-    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),       // ext
+    NET_MSG_FIELD_STRING(MAX_EXT),                      // ext
 };
 
 static const NetMsgField kFileDownloadRequestFields[] = {
-    kNetMsgFieldTransId,                // transId
-    NET_MSG_FIELD_STRING(MAX_PATH),     // filename
+    kNetMsgFieldTransId,                            // transId
+    NET_MSG_FIELD_STRING(kCli2File_FilenameSize),   // filename
 };
 
 static const NetMsgField kFileDownloadChunkAckFields[] = {

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.h
@@ -326,8 +326,8 @@ struct Cli2Auth_PlayerCreateRequest {
     uint32_t       messageId;
     uint32_t       transId;
     char16_t       playerName[kMaxPlayerNameLength];
-    char16_t       avatarShape[kCli2File_FilenameSize];
-    char16_t       friendInvite[kCli2File_FilenameSize];
+    char16_t       avatarShape[kNetDefaultStringSize];
+    char16_t       friendInvite[kNetDefaultStringSize];
 };
 
 extern const NetMsg kNetMsg_Cli2Auth_PlayerDeleteRequest;
@@ -392,7 +392,7 @@ extern const NetMsg kNetMsg_Cli2Auth_FileListRequest;
 struct Cli2Auth_FileListRequest {
     uint32_t       messageId;
     uint32_t       transId;
-    char16_t       directory[kCli2File_FilenameSize];
+    char16_t       directory[kNetDefaultStringSize];
     char16_t       ext[MAX_EXT];
 };
 
@@ -401,7 +401,7 @@ extern const NetMsg kNetMsg_Cli2Auth_FileDownloadRequest;
 struct Cli2Auth_FileDownloadRequest {
     uint32_t       messageId;
     uint32_t       transId;
-    char16_t       filename[kCli2File_FilenameSize];
+    char16_t       filename[kNetDefaultStringSize];
 };
 
 // FileDownloadChunkAck
@@ -473,9 +473,9 @@ struct Cli2Auth_VaultInitAgeRequest {
     uint32_t       transId;
     plUUID      ageInstId;
     plUUID      parentAgeInstId;
-    char16_t       ageFilename[kCli2File_FilenameSize];
-    char16_t       ageInstName[kCli2File_FilenameSize];
-    char16_t       ageUserName[kCli2File_FilenameSize];
+    char16_t       ageFilename[kNetDefaultStringSize];
+    char16_t       ageInstName[kNetDefaultStringSize];
+    char16_t       ageUserName[kNetDefaultStringSize];
     char16_t       ageDesc[1024];
     uint32_t       ageSequenceNumber;
     uint32_t       ageLanguage;

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.h
@@ -326,8 +326,8 @@ struct Cli2Auth_PlayerCreateRequest {
     uint32_t       messageId;
     uint32_t       transId;
     char16_t       playerName[kMaxPlayerNameLength];
-    char16_t       avatarShape[MAX_PATH];
-    char16_t       friendInvite[MAX_PATH];
+    char16_t       avatarShape[kCli2File_FilenameSize];
+    char16_t       friendInvite[kCli2File_FilenameSize];
 };
 
 extern const NetMsg kNetMsg_Cli2Auth_PlayerDeleteRequest;
@@ -392,7 +392,7 @@ extern const NetMsg kNetMsg_Cli2Auth_FileListRequest;
 struct Cli2Auth_FileListRequest {
     uint32_t       messageId;
     uint32_t       transId;
-    char16_t       directory[MAX_PATH];
+    char16_t       directory[kCli2File_FilenameSize];
     char16_t       ext[MAX_EXT];
 };
 
@@ -401,7 +401,7 @@ extern const NetMsg kNetMsg_Cli2Auth_FileDownloadRequest;
 struct Cli2Auth_FileDownloadRequest {
     uint32_t       messageId;
     uint32_t       transId;
-    char16_t       filename[MAX_PATH];
+    char16_t       filename[kCli2File_FilenameSize];
 };
 
 // FileDownloadChunkAck
@@ -473,9 +473,9 @@ struct Cli2Auth_VaultInitAgeRequest {
     uint32_t       transId;
     plUUID      ageInstId;
     plUUID      parentAgeInstId;
-    char16_t       ageFilename[MAX_PATH];
-    char16_t       ageInstName[MAX_PATH];
-    char16_t       ageUserName[MAX_PATH];
+    char16_t       ageFilename[kCli2File_FilenameSize];
+    char16_t       ageInstName[kCli2File_FilenameSize];
+    char16_t       ageUserName[kCli2File_FilenameSize];
     char16_t       ageDesc[1024];
     uint32_t       ageSequenceNumber;
     uint32_t       ageLanguage;

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2File/pnNpCli2File.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2File/pnNpCli2File.h
@@ -141,7 +141,7 @@ struct Cli2File_BuildIdRequest : Cli2File_MsgHeader {
 // ManifestRequest
 struct Cli2File_ManifestRequest : Cli2File_MsgHeader {
     uint32_t       transId;
-    char16_t       group[MAX_PATH];
+    char16_t       group[kCli2File_FilenameSize];
     unsigned    buildId; // 0 = newest
 };
 struct Cli2File_ManifestEntryAck : Cli2File_MsgHeader {
@@ -152,7 +152,7 @@ struct Cli2File_ManifestEntryAck : Cli2File_MsgHeader {
 // FileDownloadRequest
 struct Cli2File_FileDownloadRequest : Cli2File_MsgHeader {
     uint32_t    transId;
-    char16_t    filename[MAX_PATH];
+    char16_t    filename[kCli2File_FilenameSize];
     unsigned    buildId; // 0 = newest
 };
 struct Cli2File_FileDownloadChunkAck : Cli2File_MsgHeader {

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2File/pnNpCli2File.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2File/pnNpCli2File.h
@@ -141,7 +141,7 @@ struct Cli2File_BuildIdRequest : Cli2File_MsgHeader {
 // ManifestRequest
 struct Cli2File_ManifestRequest : Cli2File_MsgHeader {
     uint32_t       transId;
-    char16_t       group[kCli2File_FilenameSize];
+    char16_t       group[kNetDefaultStringSize];
     unsigned    buildId; // 0 = newest
 };
 struct Cli2File_ManifestEntryAck : Cli2File_MsgHeader {
@@ -152,7 +152,7 @@ struct Cli2File_ManifestEntryAck : Cli2File_MsgHeader {
 // FileDownloadRequest
 struct Cli2File_FileDownloadRequest : Cli2File_MsgHeader {
     uint32_t    transId;
-    char16_t    filename[kCli2File_FilenameSize];
+    char16_t    filename[kNetDefaultStringSize];
     unsigned    buildId; // 0 = newest
 };
 struct Cli2File_FileDownloadChunkAck : Cli2File_MsgHeader {

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -530,7 +530,7 @@ struct FileListRequestTrans : NetAuthTrans {
     FNetCliAuthFileListRequestCallback  m_callback;
     void *                              m_param;
 
-    char16_t                            m_directory[MAX_PATH];
+    char16_t                            m_directory[kCli2File_FilenameSize];
     char16_t                            m_ext[MAX_EXT];
 
     std::vector<NetCliAuthFileInfo>       m_fileInfoArray;
@@ -3040,7 +3040,7 @@ bool FileListRequestTrans::Recv (
             }
 
             // read in the filename
-            char16_t filename[MAX_PATH];
+            char16_t filename[kCli2File_FilenameSize];
             StrCopy(filename, curChar, std::size(filename));
             filename[std::size(filename) - 1] = L'\0'; // make sure it's terminated
 
@@ -3114,7 +3114,7 @@ bool FileDownloadRequestTrans::Send () {
     if (!AcquireConn())
         return false;
 
-    char16_t filename[MAX_PATH] {};
+    char16_t filename[kCli2File_FilenameSize] {};
     const ST::utf16_buffer buffer = m_filename.AsString().to_utf16();
     memcpy(filename, buffer.data(), std::min(sizeof(filename), buffer.size() * sizeof(char16_t)));
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -530,7 +530,7 @@ struct FileListRequestTrans : NetAuthTrans {
     FNetCliAuthFileListRequestCallback  m_callback;
     void *                              m_param;
 
-    char16_t                            m_directory[kCli2File_FilenameSize];
+    char16_t                            m_directory[kNetDefaultStringSize];
     char16_t                            m_ext[MAX_EXT];
 
     std::vector<NetCliAuthFileInfo>       m_fileInfoArray;
@@ -3040,7 +3040,7 @@ bool FileListRequestTrans::Recv (
             }
 
             // read in the filename
-            char16_t filename[kCli2File_FilenameSize];
+            char16_t filename[kNetDefaultStringSize];
             StrCopy(filename, curChar, std::size(filename));
             filename[std::size(filename) - 1] = L'\0'; // make sure it's terminated
 
@@ -3114,7 +3114,7 @@ bool FileDownloadRequestTrans::Send () {
     if (!AcquireConn())
         return false;
 
-    char16_t filename[kCli2File_FilenameSize] {};
+    char16_t filename[kNetDefaultStringSize] {};
     const ST::utf16_buffer buffer = m_filename.AsString().to_utf16();
     memcpy(filename, buffer.data(), std::min(sizeof(filename), buffer.size() * sizeof(char16_t)));
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
@@ -355,7 +355,7 @@ void NetCliAuthGetEncryptionKey (
 // File List
 //============================================================================
 struct NetCliAuthFileInfo {
-    char16_t    filename[kCli2File_FilenameSize];
+    char16_t    filename[kNetDefaultStringSize];
     unsigned    filesize;
 };
 typedef void (*FNetCliAuthFileListRequestCallback)(

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
@@ -355,7 +355,7 @@ void NetCliAuthGetEncryptionKey (
 // File List
 //============================================================================
 struct NetCliAuthFileInfo {
-    char16_t    filename[MAX_PATH];
+    char16_t    filename[kCli2File_FilenameSize];
     unsigned    filesize;
 };
 typedef void (*FNetCliAuthFileListRequestCallback)(

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -144,7 +144,7 @@ struct BuildIdRequestTrans : NetFileTrans {
 struct ManifestRequestTrans : NetFileTrans {
     FNetCliFileManifestRequestCallback  m_callback;
     void *                              m_param;
-    char16_t                            m_group[MAX_PATH];
+    char16_t                            m_group[kCli2File_FilenameSize];
     unsigned                            m_buildId;
 
     std::vector<NetCliFileManifestEntry>  m_manifest;
@@ -909,7 +909,7 @@ inline size_t FIXME_u16snlen(const char16_t* str, size_t maxlen)
 //============================================================================
 void ReadStringFromMsg(const char16_t* curMsgPtr, char16_t* destPtr, unsigned* length) {
     if (!(*length)) {
-        size_t maxlen = FIXME_u16snlen(curMsgPtr, MAX_PATH - 1);   // Hacky sack
+        size_t maxlen = FIXME_u16snlen(curMsgPtr, kCli2File_FilenameSize - 1);   // Hacky sack
         (*length) = maxlen;
         destPtr[maxlen] = 0;    // Don't do this on fixed length, because there's no room for it
     }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -144,7 +144,7 @@ struct BuildIdRequestTrans : NetFileTrans {
 struct ManifestRequestTrans : NetFileTrans {
     FNetCliFileManifestRequestCallback  m_callback;
     void *                              m_param;
-    char16_t                            m_group[kCli2File_FilenameSize];
+    char16_t                            m_group[kNetDefaultStringSize];
     unsigned                            m_buildId;
 
     std::vector<NetCliFileManifestEntry>  m_manifest;
@@ -909,7 +909,7 @@ inline size_t FIXME_u16snlen(const char16_t* str, size_t maxlen)
 //============================================================================
 void ReadStringFromMsg(const char16_t* curMsgPtr, char16_t* destPtr, unsigned* length) {
     if (!(*length)) {
-        size_t maxlen = FIXME_u16snlen(curMsgPtr, kCli2File_FilenameSize - 1);   // Hacky sack
+        size_t maxlen = FIXME_u16snlen(curMsgPtr, kNetDefaultStringSize - 1);   // Hacky sack
         (*length) = maxlen;
         destPtr[maxlen] = 0;    // Don't do this on fixed length, because there's no room for it
     }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
@@ -91,8 +91,8 @@ void NetCliFileRegisterBuildIdUpdate (FNetCliFileBuildIdUpdateCallback callback)
 // Manifest
 //============================================================================
 struct NetCliFileManifestEntry {
-    char16_t    clientName[MAX_PATH]; // path and file on client side (for comparison)
-    char16_t    downloadName[MAX_PATH]; // path and file on server side (for download)
+    char16_t    clientName[kCli2File_FilenameSize]; // path and file on client side (for comparison)
+    char16_t    downloadName[kCli2File_FilenameSize]; // path and file on server side (for download)
     char16_t    md5[32];
     char16_t    md5compressed[32]; // md5 for the compressed file
     unsigned    fileSize;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
@@ -91,8 +91,8 @@ void NetCliFileRegisterBuildIdUpdate (FNetCliFileBuildIdUpdateCallback callback)
 // Manifest
 //============================================================================
 struct NetCliFileManifestEntry {
-    char16_t    clientName[kCli2File_FilenameSize]; // path and file on client side (for comparison)
-    char16_t    downloadName[kCli2File_FilenameSize]; // path and file on server side (for download)
+    char16_t    clientName[kNetDefaultStringSize]; // path and file on client side (for comparison)
+    char16_t    downloadName[kNetDefaultStringSize]; // path and file on server side (for download)
     char16_t    md5[32];
     char16_t    md5compressed[32]; // md5 for the compressed file
     unsigned    fileSize;


### PR DESCRIPTION
Fixes for the patcher running on macOS (and likely Linux). The netcode linked some string lengths to MAX_PATH, but this is variable for each platform and can cause problems in network transactions.