### PR TITLE
Fixing plSplineEaseCurve asserts on Mac

### DIFF
--- a/Sources/Plasma/PubUtilLib/plInterp/plATCEaseCurves.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plATCEaseCurves.cpp
@@ -305,7 +305,7 @@ float plSplineEaseCurve::TimeGivenVelocity(float velocity) const
     if (D >= 0) 
     {   
         // 3 roots, find the one in the range [0, 1]
-        double theta = acos(R / sqrt(Q3));
+        double theta = (float)acos(double(R / sqrt(Q3)));
         double sqrtQ = sqrt(Q);
 
         root = (float)(-2 * sqrtQ * cos((theta + 4 * hsConstants::pi<float>) / 3) - c / 3); // Middle root, most likely to match


### PR DESCRIPTION
This one is gonna be a bit weird. macOS (and maybe Linux in the future) is tripping the assert on 331 repeatedly. There is a key difference between macOS and Windows on the line I changed.

M_PI as a float is 3.14159274. hsConstants::pi<float> is also 3.14159274.

acos(-1.0f) should be Pi. And on Windows acos(-1.0f) is:
3.14159274.

Makes sense. But on macOS, acos(-1.0f) is instead:
3.1415925

I don't know why. It's a big enough change it moves around this function and trips the assert.

Basically the best solution seems to be to force the acos to be done as a double, and then downcast that into a float. That's the same way hsConstants::pi<float> converts it's value down to float.

`(float)acos(double(R / sqrt(Q3)))` properly resolves to 3.14159274. Even though it's stored in a double, we need the actual values precision to be consistent for things to line up with the float values.

I kind of know roughly what this function is for - but I'm not familiar with the algorithm. I tried increasing the precision of more things to double and it only made the assert trip more. Perhaps with a more careful set of changes to this code everything could be made consistent and we wouldn't have to worry about weird float and double inconsistencies.

I also don't know why macOS is different. I looked at a whole bunch of compile flags, but I don't know why it's output is different.