### PR TITLE
Fix a pfMarkerMgr crashing problem.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfCharacter/pfMarkerInfo.h
+++ b/Sources/Plasma/FeatureLib/pfCharacter/pfMarkerInfo.h
@@ -74,7 +74,7 @@ protected:
 
 public:
     pfMarkerInfo(const hsPoint3& pos, bool isNew);
-    ~pfMarkerInfo() {}
+    ~pfMarkerInfo() { Remove(); }
 
     static void Init();
 

--- a/Sources/Plasma/FeatureLib/pfCharacter/pfMarkerMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfCharacter/pfMarkerMgr.cpp
@@ -321,7 +321,8 @@ bool pfMarkerMgr::MsgReceive(plMessage* msg)
         {
             uint32_t id;
             pfMarkerInfo* marker = IFindMarker(cloneKey, id);
-            marker->InitSpawned(cloneKey);
+            if (marker)
+                marker->InitSpawned(cloneKey);
         }
 
         return true;


### PR DESCRIPTION
If user code (ie Python) spawns a marker then quickly deletes it, the deletion may occur before the global marker object is cloned. This results in trying to call `InitSpawned()` on a null pointer. Fix that.

Drive-by: fix a potential memory leak.