### PR TITLE
Deep Color/10 bit support for pipelines

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -1353,11 +1353,7 @@ PF_CONSOLE_CMD( Graphics_Renderer, Gamma2, "float g", "Set gamma value (alternat
             float t = float(i) / 1023.f;
             float sinT = std::sin(t * hsConstants::pi<float> / 2.f);
 
-            float remap = t + (sinT - t) * g;
-            if( remap < 0 )
-                remap = 0;
-            else if( remap > 1.f )
-                remap = 1.f;
+            float remap = std::clamp(t + (sinT - t) * g, 0.f, 1.f);
 
             ramp[i] = uint16_t(remap * float(uint16_t(-1)) + 0.5f);
         }
@@ -1371,11 +1367,7 @@ PF_CONSOLE_CMD( Graphics_Renderer, Gamma2, "float g", "Set gamma value (alternat
             float t = float(i) / 255.f;
             float sinT = std::sin(t * hsConstants::pi<float> / 2.f);
 
-            float remap = t + (sinT - t) * g;
-            if( remap < 0 )
-                remap = 0;
-            else if( remap > 1.f )
-                remap = 1.f;
+            float remap = std::clamp(t + (sinT - t) * g, 0.f, 1.f);
 
             ramp[i] = uint16_t(remap * float(uint16_t(-1)) + 0.5f);
         }

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -1342,25 +1342,46 @@ PF_CONSOLE_CMD( Graphics_Renderer, Gamma2, "float g", "Set gamma value (alternat
     hsAssert(pfConsole::GetPipeline() != nullptr, "Cannot use this command before pipeline initialization");
 
     std::vector<uint16_t> ramp;
-    ramp.resize(256);
 
     float g = params[0];
 
-    for (int i = 0; i < 256; i++)
-    {
-        float t = float(i) / 255.f;
-        float sinT = std::sin(t * hsConstants::pi<float> / 2.f);
+    if (pfConsole::GetPipeline()->Supports10BitGamma()) {
+        ramp.resize(1024);
+        
+        for (int i = 0; i < 1024; i++)
+        {
+            float t = float(i) / 1023.f;
+            float sinT = std::sin(t * hsConstants::pi<float> / 2.f);
 
-        float remap = t + (sinT - t) * g;
-        if( remap < 0 )
-            remap = 0;
-        else if( remap > 1.f )
-            remap = 1.f;
+            float remap = t + (sinT - t) * g;
+            if( remap < 0 )
+                remap = 0;
+            else if( remap > 1.f )
+                remap = 1.f;
 
-        ramp[i] = uint16_t(remap * float(uint16_t(-1)) + 0.5f);
+            ramp[i] = uint16_t(remap * float(uint16_t(-1)) + 0.5f);
+        }
+        
+        pfConsole::GetPipeline()->SetGamma10(ramp.data());
+    } else {
+        ramp.resize(256);
+        
+        for (int i = 0; i < 256; i++)
+        {
+            float t = float(i) / 255.f;
+            float sinT = std::sin(t * hsConstants::pi<float> / 2.f);
+
+            float remap = t + (sinT - t) * g;
+            if( remap < 0 )
+                remap = 0;
+            else if( remap > 1.f )
+                remap = 1.f;
+
+            ramp[i] = uint16_t(remap * float(uint16_t(-1)) + 0.5f);
+        }
+        
+        pfConsole::GetPipeline()->SetGamma(ramp.data());
     }
-
-    pfConsole::GetPipeline()->SetGamma(ramp.data());
 
 //  pfConsolePrintF(PrintString, "Gamma set to <alt> {}.", g);
 }

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -326,8 +326,8 @@ public:
     virtual bool                        SetGamma(float e) { return SetGamma(e, e, e); }
     virtual bool                        SetGamma(const uint16_t* const table) { return SetGamma(table, table, table); }
     virtual bool                        SetGamma10(const uint16_t* const table) { return SetGamma10(table, table, table); }
-    virtual bool                        SetGamma10(const uint16_t* const tabR, const uint16_t* const tabG, const uint16_t* const tabB) { return false; };
-    virtual bool                        Supports10BitGamma() { return false; };
+    virtual bool                        SetGamma10(const uint16_t* const tabR, const uint16_t* const tabG, const uint16_t* const tabB) { return false; }
+    virtual bool                        Supports10BitGamma() const { return false; }
 
     // flipVertical is for the AVI writer, which wants it's frames upside down
     virtual bool                        CaptureScreen( plMipmap *dest, bool flipVertical = false, uint16_t desiredWidth = 0, uint16_t desiredHeight = 0 ) = 0;

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -327,7 +327,7 @@ public:
     virtual bool                        SetGamma(const uint16_t* const table) { return SetGamma(table, table, table); }
     virtual bool                        SetGamma10(const uint16_t* const table) { return SetGamma10(table, table, table); }
     virtual bool                        SetGamma10(const uint16_t* const tabR, const uint16_t* const tabG, const uint16_t* const tabB) { return false; };
-    virtual bool                        Supports10BitGamma() { return 0; };
+    virtual bool                        Supports10BitGamma() { return false; };
 
     // flipVertical is for the AVI writer, which wants it's frames upside down
     virtual bool                        CaptureScreen( plMipmap *dest, bool flipVertical = false, uint16_t desiredWidth = 0, uint16_t desiredHeight = 0 ) = 0;

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -324,7 +324,10 @@ public:
     virtual bool                        SetGamma(float eR, float eG, float eB) = 0;
     virtual bool                        SetGamma(const uint16_t* const tabR, const uint16_t* const tabG, const uint16_t* const tabB) = 0; // len table = 256.
     virtual bool                        SetGamma(float e) { return SetGamma(e, e, e); }
-    virtual bool                        SetGamma(const uint16_t* const table) { return SetGamma(table, table, table); } 
+    virtual bool                        SetGamma(const uint16_t* const table) { return SetGamma(table, table, table); }
+    virtual bool                        SetGamma10(const uint16_t* const table) { return SetGamma10(table, table, table); }
+    virtual bool                        SetGamma10(const uint16_t* const tabR, const uint16_t* const tabG, const uint16_t* const tabB) { return false; };
+    virtual bool                        Supports10BitGamma() { return 0; };
 
     // flipVertical is for the AVI writer, which wants it's frames upside down
     virtual bool                        CaptureScreen( plMipmap *dest, bool flipVertical = false, uint16_t desiredWidth = 0, uint16_t desiredHeight = 0 ) = 0;


### PR DESCRIPTION
This PR adds some initial support for deep/10 bit color supports in the graphics pipelines. It's still up to the pipelines to implement - but this adds the option for 10 bit gamma tables.

Uru assets tend to be 8 bits or less per color channel - but color blending happens in a 16 bit color space. So does lighting, effects like water, and fog. These effects can suffer banding in an 8 bit color space. For example, the fog near Kerath's Arch can show banding. Allowing 10 bit output on compatible displays can reduce or eliminate banding, and allowing blending outside of 8 bit color resolution.

This commit doesn't attempt to enable wide color (either the P3 color space or HDR.) Metal can also render in these modes - but it would likely require assets specifically built for wide color. Allowing assets to blend outside of a 0.0-1.0 range could also cause unintentionally change content in the way authors didn't intend.

10 bit gamma is opt in. The way DX is doing gamma is specifically tied to a legacy Windows API that expects an 8 bit lookup table - so 8 bit compatibility has to be maintained. Additionally Cyan chose a peculiar custom Gamma ramp based on a sine wave which could be expensive to implement directly in a shader.

Assuming the DX pipeline continues to exist and is eventually updated, the latest Microsoft API makes a similar changeover to larger Gamma tables:
https://docs.microsoft.com/en-us/windows/win32/api/dxgi/nf-dxgi-idxgioutput-setgammacontrol