### PR TITLE
Add object library support.

### DIFF
--- a/Sources/Plasma/FeatureLib/inc/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/inc/CMakeLists.txt
@@ -1,9 +1,9 @@
-# Because there are no CPP sources, this needs to be an interface library. Change to
-# a static library if you ever add any real C++ code.
-add_library(pfFeatureInc INTERFACE)
-set_property(
-    TARGET pfFeatureInc
-    PROPERTY INTERFACE_LINK_LIBRARIES
+set(pfFeatureInc_HEADERS
+    pfAllCreatables.h
+)
+plasma_library(pfFeatureInc OBJECT SOURCES ${pfFeatureInc_HEADERS})
+target_link_libraries(pfFeatureInc
+    PUBLIC
         pfAnimation
         pfAudio
         pfCamera
@@ -17,7 +17,4 @@ set_property(
         pfPython
         pfSurface
 )
-set_property(
-    TARGET pfFeatureInc
-    PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}"
-)
+target_include_directories(pfFeatureInc INTERFACE "${CMAKE_CURRENT_LIST_DIR}")

--- a/Sources/Plasma/PubUtilLib/inc/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/inc/CMakeLists.txt
@@ -1,9 +1,10 @@
-# Because there are no CPP sources, this needs to be an interface library. Change to
-# a static library if you ever add any real C++ code.
-add_library(plPubUtilInc INTERFACE)
-set_property(
-    TARGET plPubUtilInc
-    PROPERTY INTERFACE_LINK_LIBRARIES
+set(plPubUtilInc_HEADERS
+    plAllCreatables.h
+)
+
+plasma_library(plPubUtilInc OBJECT SOURCES ${plPubUtilInc_HEADERS})
+target_link_libraries(plPubUtilInc
+    PUBLIC
         plAgeLoader
         plAnimation
         plAudible
@@ -33,7 +34,4 @@ set_property(
         plSurface
         plVault
 )
-set_property(
-    TARGET plPubUtilInc
-    PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}"
-)
+target_include_directories(plPubUtilInc INTERFACE "${CMAKE_CURRENT_LIST_DIR}")

--- a/cmake/PlasmaTargets.cmake
+++ b/cmake/PlasmaTargets.cmake
@@ -89,13 +89,19 @@ endfunction()
 
 function(plasma_library TARGET)
     cmake_parse_arguments(PARSE_ARGV 1 _plib
-        "UNITY_BUILD;SHARED;NO_SANITIZE"
+        "UNITY_BUILD;OBJECT;SHARED;NO_SANITIZE"
         ""
         "PRECOMPILED_HEADERS;SOURCES"
     )
 
+    if(_plib_SHARED AND _plib_OBJECT)
+        message(AUTHOR_WARNING "Library ${TARGET} is both an OBJECT and SHARED library. These options are mutually exclusive.")
+    endif()
+
     if(_plib_SHARED)
         set(libtype SHARED)
+    elseif(_plib_OBJECT)
+        set(libtype OBJECT)
     else()
         set(libtype STATIC)
     endif()


### PR DESCRIPTION
The benefit to this change is that for IDE-based generators (eg Visual Studio), you can now see the headers in a dedicated project instead of either having ghost headers that appear only as includes (or, worse, the headers duplicated into all consuming projects).

Required by #1217.