### PR TITLE
Add Elonin, Eder Naybree and Highgarden definitions

### DIFF
--- a/Scripts/Python/xLinkingBookDefs.py
+++ b/Scripts/Python/xLinkingBookDefs.py
@@ -270,6 +270,9 @@ else:
         "ChisoPrenivNote":      ( 0, 1.0, 1.0, FanAgeStamp, BookStart1 + DRCStampHolder + NoShare + LinkStart + 'xlinkpanelchisopreniv' + LinkEnd ),
         "Serene":               ( 0, 1.0, 1.0, NoDRCStamp, BookStart1 + DRCStampHolder + NoShare + LinkStart + 'xlinkpanelserene' + LinkEnd ),
         "Tiam":                 ( 1, 1.0, 1.0, NoDRCStamp, BookStart1 + DRCStampHolder + ShareHolder + LinkStart + 'xlinkpaneltiam' + LinkEnd ),
+        "Elonin":               ( 1, 1.0, 1.0, NoDRCStamp, BookStart1 + DRCStampHolder + ShareHolder + LinkStart + 'xlinkpanelelonin' + LinkEnd ),
+        "EderNaybree":          ( 0, 1.0, 1.0, NoDRCStamp, BookStart1 + DRCStampHolder + NoShare + LinkStart + 'xlinkpaneledernaybree' + LinkEnd ),
+        "FahetsHighgarden":     ( 0, 1.0, 1.0, NoDRCStamp, BookStart1 + DRCStampHolder + NoShare + LinkStart + 'xlinkpanelhighgarden' + LinkEnd ),
 }
 
 # cross-references the book name with the age and spawn point it links to
@@ -346,6 +349,9 @@ xLinkDestinations = {\
     "ChisoPreniv":            ( "ChisoPreniv", "LinkInPointDefault" ),
     "Serene":                 ( "Serene", "LinkInPointDefault" ),
     "Tiam":                   ( "Tiam", "LinkInPointDefault" ),
+    "Elonin":                 ( "Elonin", "LinkInPointDefault" ),
+    "EderNaybree":            ( "EderNaybree", "LinkInPointDefault" ),
+    "FahetsHighgarden":       ( "FahetsHighgarden", "LinkInPointDefault" ),
 }
 
 #


### PR DESCRIPTION
* Adds Book and Linkpoint definitions for Elonin, Eder Naybree, and Highgarden to `xLinkingBookDefs.py` to match MOULa.