### PR TITLE
Add plFilePatcher command-line tool

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglCore.cpp
@@ -75,7 +75,7 @@ struct ReportNetErrorTrans : NetNotifyTrans {
 *
 ***/
 
-static FNetClientErrorProc  s_errorProc;
+static NetClientErrorFunc   s_errorFunc;
 static std::atomic<long>    s_initCount;
 
 
@@ -113,8 +113,8 @@ ReportNetErrorTrans::ReportNetErrorTrans (
 
 //============================================================================
 void ReportNetErrorTrans::Post () {
-    if (s_errorProc)
-        s_errorProc(m_errProtocol, m_errError);
+    if (s_errorFunc)
+        s_errorFunc(m_errProtocol, m_errError);
 }
 
 
@@ -160,7 +160,7 @@ void NetClientCancelAllTrans () {
 void NetClientDestroy (bool wait) {
 
     if (1 == s_initCount.fetch_sub(1)) {
-        s_errorProc = nullptr;
+        s_errorFunc = nullptr;
 
         GateKeeperDestroy(false);
         FileDestroy(false);
@@ -194,6 +194,6 @@ void NetClientPingEnable (bool enable) {
 }
 
 //============================================================================
-void NetClientSetErrorHandler (FNetClientErrorProc errorProc) {
-    s_errorProc = errorProc;
+void NetClientSetErrorHandler(NetClientErrorFunc errorFunc) {
+    s_errorFunc = std::move(errorFunc);
 }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglCore.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglCore.h
@@ -50,6 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #endif
 #define PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETGAMELIB_PRIVATE_PLNGLCORE_H
 
+#include <functional>
 
 
 /*****************************************************************************
@@ -67,8 +68,7 @@ void NetClientUpdate ();
 void NetClientSetTransTimeoutMs (unsigned ms);
 void NetClientPingEnable (bool enable);
 
-typedef void (*FNetClientErrorProc)(
-    ENetProtocol    protocol,
-    ENetError       error
-);
-void NetClientSetErrorHandler (FNetClientErrorProc errorProc);
+
+typedef std::function<void(ENetProtocol, ENetError)> NetClientErrorFunc;
+
+void NetClientSetErrorHandler(NetClientErrorFunc errorFunc);

--- a/Sources/Tools/CMakeLists.txt
+++ b/Sources/Tools/CMakeLists.txt
@@ -6,6 +6,9 @@ include_directories("${PLASMA_SOURCE_ROOT}/PubUtilLib")
 if(PLASMA_BUILD_TOOLS)
     add_subdirectory(SoundDecompress)
     add_subdirectory(plSystemInfo)
+    if(WIN32) # Until ASIO netcode is done
+        add_subdirectory(plFilePatcher)
+    endif()
 
     if(Qt_FOUND)
         add_subdirectory(plLocalizationEditor)

--- a/Sources/Tools/plFilePatcher/CMakeLists.txt
+++ b/Sources/Tools/plFilePatcher/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(plFilePatcher_SOURCES
+    plAllCreatables.cpp
+    plFilePatcher.cpp
+    main.cpp
+)
+
+set(plFilePatcher_HEADERS
+    plFilePatcher.h
+)
+
+plasma_executable(plFilePatcher TOOL
+    SOURCES ${plFilePatcher_SOURCES} ${plFilePatcher_HEADERS}
+)
+
+target_link_libraries(
+    plFilePatcher
+    PRIVATE
+        CoreLib
+        pnNucleusInc
+        plNetGameLib
+        pfConsoleCore
+        pfPatcher
+)
+
+source_group("Source Files" FILES ${plFilePatcher_SOURCES})
+source_group("Header Files" FILES ${plFilePatcher_HEADERS})

--- a/Sources/Tools/plFilePatcher/main.cpp
+++ b/Sources/Tools/plFilePatcher/main.cpp
@@ -1,0 +1,186 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "HeadSpin.h"
+#include "plCmdParser.h"
+#include "plFileSystem.h"
+#include "plProduct.h"
+
+#include "plFilePatcher.h"
+
+#include <cstdio>
+#include <vector>
+#include <string_theory/format>
+#include <string_theory/stdio>
+
+#if HS_BUILD_FOR_WIN32
+#   include "hsWindows.h"
+#   include <io.h>
+#   define isatty _isatty
+
+    void GetConsoleWidth(size_t& width)
+    {
+        CONSOLE_SCREEN_BUFFER_INFO csbi;
+        GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
+        width = size_t(csbi.srWindow.Right - csbi.srWindow.Left);
+    }
+#else
+#   include <sys/ioctl.h>
+#   include <unistd.h>
+
+    void GetConsoleWidth(size_t& width)
+    {
+        struct winsize w;
+        ioctl(fileno(stdout), TIOCGWINSZ, &w);
+        width = size_t(w.ws_col) - 1;
+    }
+#endif
+
+static void PrintUsage(const ST::string& exeName)
+{
+    ST::printf("Plasma File Patcher\n{}\n\n", plProduct::ProductString());
+
+    ST::printf("File patcher for the Plasma client and game data.\n\n");
+
+    ST::printf("Usage:\n");
+    ST::printf("\t{} [options]\n\n", exeName);
+
+    ST::printf("Available options:\n");
+    ST::printf("\t--ServerIni file.ini\tSpecify the server config file\n");
+    ST::printf("\t--DataOnly\t\tPatch only the game data files\n");
+    ST::printf("\t--ClientOnly\t\tPatch only the client executable files\n");
+    ST::printf("\t--help\t\t\tDisplay this help message\n");
+    ST::printf("\t--quiet\t\t\tDo not display download progress\n\n");
+
+    ST::printf("By default, updates to both game data and client executables will be\ndownloaded, and it will use \"server.ini\" for server connection details.\n");
+}
+
+static size_t consoleWidth = 0;
+static ST::string lastProgress;
+
+static void FileDownloadBegin(const plFileName& file)
+{
+    // To account for terminal resizing, we want to refresh this value
+    // periodically, but not every time we draw to the screen, so let's grab it
+    // whenever we start downloading a new file (which is probably still
+    // excessive tbh)
+    GetConsoleWidth(consoleWidth);
+
+    size_t fill = consoleWidth - file.GetSize();
+    ST::printf("\r{}{}\n{}", file, ST::string::fill(fill, ' '), lastProgress);
+}
+
+static void FileDownloadProgress(uint64_t bytesDown, uint64_t bytesTotal, const ST::string& stats)
+{
+    size_t availWidth = consoleWidth - stats.size() - 3;
+    size_t progWidth = size_t(double(bytesDown) / double(bytesTotal) * availWidth);
+
+    lastProgress = ST::format("|{}{}| {}", ST::string::fill(progWidth, '='), ST::string::fill(availWidth - progWidth, ' '), stats);
+    ST::printf("\r{}", lastProgress);
+}
+
+int main(int argc, char* argv[])
+{
+    enum { kArgServerIni, kArgDataOnly, kArgClientOnly, kArgQuiet, kArgHelp1, kArgHelp2 };
+    const plCmdArgDef cmdLineArgs[] = {
+        { kCmdArgFlagged | kCmdTypeString,  "ServerIni",    kArgServerIni },
+        { kCmdArgFlagged | kCmdTypeBool,    "DataOnly",     kArgDataOnly },
+        { kCmdArgFlagged | kCmdTypeBool,    "ClientOnly",   kArgClientOnly },
+        { kCmdArgFlagged | kCmdTypeBool,    "quiet",        kArgQuiet },
+        { kCmdArgFlagged | kCmdTypeBool,    "help",         kArgHelp1 },
+        { kCmdArgFlagged | kCmdTypeBool,    "?",            kArgHelp2 },
+    };
+
+    std::vector<ST::string> args;
+    args.reserve(argc);
+    for (size_t i = 0; i < argc; i++) {
+        args.emplace_back(ST::string::from_utf8(argv[i]));
+    }
+
+    plCmdParser cmdParser(cmdLineArgs, std::size(cmdLineArgs));
+    if (cmdParser.Parse(args)) {
+        if (cmdParser.GetBool(kArgHelp1) || cmdParser.GetBool(kArgHelp2)) {
+            plFileName exeName = plFileName(cmdParser.GetProgramName());
+            PrintUsage(exeName.GetFileName());
+            return 0;
+        }
+    } else {
+        ST::printf(stderr, "An error occurred while parsing the provided arguments.\n");
+        ST::printf(stderr, "Use the --help option to display usage information.\n");
+        return 1;
+    }
+
+    plFileName serverIni = ST_LITERAL("server.ini");
+    if (cmdParser.IsSpecified(kArgServerIni))
+        serverIni = cmdParser.GetString(kArgServerIni);
+
+    plFilePatcher patcher(serverIni);
+    uint32_t flags = 0;
+
+    if (cmdParser.GetBool(kArgDataOnly))
+        flags |= plFilePatcher::kPatchData;
+    if (cmdParser.GetBool(kArgClientOnly))
+        flags |= plFilePatcher::kPatchClient;
+
+    // The options aren't mutually exclusive, so if we've ended up telling it
+    // not to patch anything, we'll set it back to patching everything.
+    if (!flags)
+        flags = plFilePatcher::kPatchEverything;
+
+    patcher.SetPatcherFlags(flags);
+
+    if (!cmdParser.GetBool(kArgQuiet) && isatty(fileno(stdout))) {
+        patcher.SetDownloadBeginCallback(&FileDownloadBegin);
+        patcher.SetProgressCallback(&FileDownloadProgress);
+    }
+
+    bool result = patcher.Patch();
+    if (!result) {
+        ST::printf(stderr, "File Patching failed: {}\n", patcher.GetError());
+        return 1;
+    }
+
+    if (!cmdParser.GetBool(kArgQuiet) && isatty(fileno(stdout))) {
+        ST::printf("\r{}\r", ST::string::fill(consoleWidth, ' '));
+    }
+    return 0;
+}

--- a/Sources/Tools/plFilePatcher/plAllCreatables.cpp
+++ b/Sources/Tools/plFilePatcher/plAllCreatables.cpp
@@ -1,0 +1,48 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+#include "HeadSpin.h"
+
+#include "pnFactory/plCreator.h"
+
+#include "pnKeyedObject/pnKeyedObjectCreatable.h"
+#include "pnMessage/pnMessageCreatable.h"
+#include "pnNetCommon/pnNetCommonCreatable.h"

--- a/Sources/Tools/plFilePatcher/plFilePatcher.cpp
+++ b/Sources/Tools/plFilePatcher/plFilePatcher.cpp
@@ -1,0 +1,190 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "plFilePatcher.h"
+
+#include <string_theory/format>
+
+#include "pnAsyncCore/pnAsyncCore.h"
+#include "plNetGameLib/plNetGameLib.h"
+#include "pfConsoleCore/pfConsoleEngine.h"
+#include "pfPatcher/plManifests.h"
+
+constexpr int kNetTransTimeout = 5 * 60 * 1000;                     // 5m
+constexpr int kAsyncCoreShutdownTime = 2 * 1000;                    // 2s
+constexpr std::chrono::milliseconds kNetCoreUpdateSleepTime(10);    // 10ms
+
+plFilePatcher::plFilePatcher(plFileName serverIni)
+    : fFlags(kPatchEverything), fServerIni(std::move(serverIni)), fError(),
+      fNetCoreState(kNetCoreInactive), fProgressFunc(), fDownloadFunc()
+{
+}
+
+PF_CONSOLE_LINK_FILE(Core)
+bool plFilePatcher::ILoadServerIni()
+{
+    PF_CONSOLE_INITIALIZE(Core);
+
+    pfConsoleEngine console;
+    return console.ExecuteFile(fServerIni);
+}
+
+void plFilePatcher::IInitNetCore()
+{
+    AsyncCoreInitialize();
+
+    NetClientInitialize();
+    NetClientSetErrorHandler(std::bind(&plFilePatcher::IHandleNetError, this, std::placeholders::_1, std::placeholders::_2));
+    NetClientSetTransTimeoutMs(kNetTransTimeout);
+
+    fNetCoreState = kNetCoreActive;
+}
+
+bool plFilePatcher::IRunNetCore()
+{
+    if (fNetCoreState == kNetCoreActive) {
+        NetClientUpdate();
+    }
+
+    // don't nom all the CPU... kthx
+    std::this_thread::sleep_for(kNetCoreUpdateSleepTime);
+    return fNetCoreState != kNetCoreShutdown;
+}
+
+void plFilePatcher::IFiniNetCore()
+{
+    NetCliGateKeeperDisconnect();
+    NetCliFileDisconnect();
+    NetClientDestroy();
+
+    AsyncCoreDestroy(kAsyncCoreShutdownTime);
+}
+
+void plFilePatcher::IHandleNetError(ENetProtocol protocol, ENetError error)
+{
+    ISetNetError(ST::format("Patching failed: {} - {}", NetProtocolToString(protocol), NetErrorAsString(error)));
+    ISignalNetCoreShutdown();
+}
+
+void plFilePatcher::IRequestFileSrvInfo()
+{
+    // Gotta grab the filesrvs from the gate
+    const ST::string* addrs;
+    uint32_t num = GetGateKeeperSrvHostnames(addrs);
+    NetCliGateKeeperStartConnect(addrs, num);
+
+    NetCliGateKeeperFileSrvIpAddressRequest([](ENetError result, void* param, const ST::string& addr) {
+        static_cast<plFilePatcher*>(param)->IHandleFileSrvInfo(result, addr);
+    }, this, true);
+}
+
+void plFilePatcher::IHandleFileSrvInfo(ENetError result, const ST::string& addr)
+{
+    NetCliGateKeeperDisconnect();
+
+    if (IS_NET_SUCCESS(result)) {
+        ST::string ips[] = { addr };
+        NetCliFileStartConnect(ips, 1, true);
+
+        IRunPatcher();
+    } else {
+        ISetNetError(ST::format("Patching failed: {}", NetErrorAsString(result)));
+        ISignalNetCoreShutdown();
+    }
+}
+
+void plFilePatcher::IRunPatcher()
+{
+    pfPatcher* patcher = new pfPatcher();
+    patcher->OnFileDownloadDesired(std::bind(&plFilePatcher::IApproveDownload, this, std::placeholders::_1));
+    patcher->OnCompletion(std::bind(&plFilePatcher::IOnPatchComplete, this, std::placeholders::_1, std::placeholders::_2));
+
+    if (fDownloadFunc)
+        patcher->OnFileDownloadBegin(fDownloadFunc);
+
+    if (fProgressFunc)
+        patcher->OnProgressTick(fProgressFunc);
+
+    // Request everything, and then we'll filter the file list before we fetch
+    patcher->RequestManifest(plManifest::ClientImageManifest());
+    patcher->Start();
+}
+
+bool plFilePatcher::IApproveDownload(const plFileName& file)
+{
+    if (fFlags == kPatchEverything)
+        return true;
+
+    plFileName path = file.StripFileName();
+    bool isDataFile = path.IsValid();
+
+    return fFlags == kPatchData ? isDataFile : !isDataFile;
+}
+
+void plFilePatcher::IOnPatchComplete(ENetError result, const ST::string& msg)
+{
+    if (IS_NET_SUCCESS(result)) {
+        ISignalNetCoreShutdown();
+    } else {
+        ISetNetError(ST::format("Patching failed: {}", NetErrorAsString(result)));
+        ISignalNetCoreShutdown();
+    }
+}
+
+bool plFilePatcher::Patch()
+{
+    if (!ILoadServerIni()) {
+        return false;
+    }
+
+    IInitNetCore();
+    IRequestFileSrvInfo();
+
+    while (true) {
+        if (!IRunNetCore())
+            break;
+    }
+
+    IFiniNetCore();
+
+    return fError.empty();
+}

--- a/Sources/Tools/plFilePatcher/plFilePatcher.h
+++ b/Sources/Tools/plFilePatcher/plFilePatcher.h
@@ -1,0 +1,106 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+
+#ifndef _plFilePatcher_inc_
+#define _plFilePatcher_inc_
+
+#include <string_theory/string>
+
+#include "plFileSystem.h"
+#include "pnNetBase/pnNbProtocol.h"
+#include "pfPatcher/pfPatcher.h"
+
+class plFilePatcher
+{
+public:
+    enum
+    {
+        kPatchData          = 0x1,
+        kPatchClient        = 0x2,
+        kPatchEverything    = kPatchData | kPatchClient
+    };
+
+private:
+    enum NetCoreState
+    {
+        kNetCoreInactive,
+        kNetCoreActive,
+        kNetCoreShutdown,
+    };
+
+    uint32_t fFlags;
+    plFileName fServerIni;
+    ST::string fError;
+    NetCoreState fNetCoreState;
+
+    pfPatcher::ProgressTickFunc fProgressFunc;
+    pfPatcher::FileDownloadFunc fDownloadFunc;
+
+    bool ILoadServerIni();
+
+    void IInitNetCore();
+    bool IRunNetCore();
+    void ISignalNetCoreShutdown() { fNetCoreState = kNetCoreShutdown; }
+    void IFiniNetCore();
+    void ISetNetError(const ST::string& err) { fError = err; }
+
+    void IHandleNetError(ENetProtocol protocol, ENetError error);
+    void IRequestFileSrvInfo();
+    void IHandleFileSrvInfo(ENetError result, const ST::string& addr);
+    void IRunPatcher();
+    bool IApproveDownload(const plFileName& file);
+    void IOnPatchComplete(ENetError result, const ST::string& msg);
+
+public:
+    plFilePatcher(plFileName serverIni = ST_LITERAL("server.ini"));
+
+    bool Patch();
+    const ST::string& GetError() const { return fError; }
+
+    void SetPatcherFlags(uint32_t flags) { fFlags = flags; }
+
+    void SetProgressCallback(pfPatcher::ProgressTickFunc cb) { fProgressFunc = std::move(cb); }
+    void SetDownloadBeginCallback(pfPatcher::FileDownloadFunc cb) { fDownloadFunc = std::move(cb); }
+};
+
+#endif //_plFilePatcher_inc_


### PR DESCRIPTION
This provides a simple patcher that can be run on the command-line, intended for testing the ASIO cross-platform networking code, but also because it might be useful in general.

Windows-only for the moment, until the cross-platform sockets are merged.