### PR TITLE
Fix for plFileSystem not finding self on Mac

### DIFF
--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -56,8 +56,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   include <fnmatch.h>
 #   include <dirent.h>
 #   include <limits.h>
-#   include <sys/types.h>
 #   include <sys/param.h>
+#   include <sys/types.h>
 #   include <unistd.h>
 #endif
 
@@ -68,9 +68,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #     endif
 #   endif
 #
-#   include <NSSystemDirectories.h>
 #   include <CoreFoundation/CoreFoundation.h>
 #   include <mach-o/dyld.h>
+#   include <NSSystemDirectories.h>
 #endif
 
 #include <sys/stat.h>
@@ -572,11 +572,11 @@ plFileName plFileSystem::GetCurrentAppPath()
     return appPath;
 #elif HS_BUILD_FOR_MACOS
     CFBundleRef myBundle = CFBundleGetMainBundle();
-    if(!myBundle) {
+    if (!myBundle) {
         char path[MAXPATHLEN];
         uint32_t pathLen = MAXPATHLEN;
         _NSGetExecutablePath(path, &pathLen);
-        appPath = ST::string::from_utf8(path);
+        appPath = ST::string::from_utf8(path, pathLen);
     } else {
         CFURLRef url = CFBundleCopyBundleURL(myBundle);
         CFStringRef path = CFURLCopyPath(url);

--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -68,6 +68,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   endif
 #
 #   include <NSSystemDirectories.h>
+#   include <CoreFoundation/CoreFoundation.h>
 #endif
 
 #include <sys/stat.h>
@@ -566,6 +567,18 @@ plFileName plFileSystem::GetCurrentAppPath()
         appPath = ST::string::from_wchar(path);
     }
 
+    return appPath;
+#elif HS_BUILD_FOR_MACOS
+    //Not sure how we'd ever patch the executable on iOS,
+    //this is really Mac specific
+    //This will only work if this is an app bundle
+    CFBundleRef myBundle = CFBundleGetMainBundle();
+    hsAssert(myBundle != nullptr, "Plasma is not in a bundle on Mac - did not plan for that.");
+    CFURLRef url = CFBundleCopyBundleURL(myBundle);
+    CFStringRef path = CFURLCopyPath(url);
+    appPath = ST::string::from_utf8(CFStringGetCStringPtr(path, kCFStringEncodingUTF8));
+    CFRelease(path);
+    CFRelease(url);
     return appPath;
 #else
     // Look for /proc/self/exe (Linux), /proc/curproc/file (FreeBSD / Mac),

--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -571,9 +571,6 @@ plFileName plFileSystem::GetCurrentAppPath()
 
     return appPath;
 #elif HS_BUILD_FOR_MACOS
-    //Not sure how we'd ever patch the executable on iOS,
-    //this is really Mac specific
-    //This will only work if this is an app bundle
     CFBundleRef myBundle = CFBundleGetMainBundle();
     if(!myBundle) {
         char path[MAXPATHLEN];


### PR DESCRIPTION
The code as written should have worked - but Apple seems to have changed the way they do things. There are other reports of /proc/curproc/file disappearing from macOS. I'm not sure when that happened.

This code gets called as part of the patching process - which is why I wrote this change. Patching did not work without this change.

I defined a new implementation - but I realized this will only work if the current process is an app bundle. For a flat executable (like your command line patcher @dpogue), this probably isn't going to work. I'm open to other suggestions - this take is very AppKit centric.