### PR TITLE
Fixing chat crash on macOS (and likely Linux)

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
@@ -232,10 +232,10 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtSendRTChat, args, "Params: fromPlayer,toPlayer
     PyObject* fromPlayerObj = nullptr;
     PyObject* toPlayerListObj = nullptr;
     ST::string message;
-    long msgFlags = 0;
+    unsigned int msgFlags = 0;
     const char* err = "PtSendRTChat expects a ptPlayer, a sequence of ptPlayers, a string, and an optional long";
 
-    if (!PyArg_ParseTuple(args, "OOO&|l", &fromPlayerObj, &toPlayerListObj,
+    if (!PyArg_ParseTuple(args, "OOO&|I", &fromPlayerObj, &toPlayerListObj,
                           PyUnicode_STStringConverter, &message, &msgFlags))
     {
         PyErr_SetString(PyExc_TypeError, err);

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
@@ -232,7 +232,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtSendRTChat, args, "Params: fromPlayer,toPlayer
     PyObject* fromPlayerObj = nullptr;
     PyObject* toPlayerListObj = nullptr;
     ST::string message;
-    uint32_t msgFlags = 0;
+    long msgFlags = 0;
     const char* err = "PtSendRTChat expects a ptPlayer, a sequence of ptPlayers, a string, and an optional long";
 
     if (!PyArg_ParseTuple(args, "OOO&|l", &fromPlayerObj, &toPlayerListObj,


### PR DESCRIPTION
Long is 8 byte outside of Windows, not 4. Hardcoded uint32_t is causing pointer corruption on the stack because Python expects an 8 byte type.

I did a quick check and didn't see any other issues that looked like this in cyMiscGlue - doesn't mean they aren't lurking.

Intel has a guide for long size here:
https://www.intel.com/content/www/us/en/developer/articles/technical/size-of-long-integer-type-on-different-architecture-and-os.html