### PR TITLE
Fix for crash when a different player leaves

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
@@ -835,6 +835,8 @@ void plPXPhysicalControllerCore::IDeleteController()
 
     if (fController) {
         plPXActorData* actor = static_cast<plPXActorData*>(fController->getUserData());
+        fController->setUserData(nullptr);
+        fController->getActor()->userData = nullptr;
         plSimulationMgr::GetInstance()->GetPhysX()->RemoveFromWorld(fController);
         fController = nullptr;
         delete actor;


### PR DESCRIPTION
The controller was being removed from the scene - but user data wasn't being cleared. Mangled key was being processed during physics events causing crashes.

I was investigating this but @Hoikas wrote the fix.