### PR TITLE
Fixing Mac builds with CMake 3.24

### DIFF
--- a/cmake/FindOpenAL.cmake
+++ b/cmake/FindOpenAL.cmake
@@ -9,12 +9,21 @@ if(NOT TARGET OpenAL::OpenAL)
 
     if(OPENAL_FOUND)
         if(NOT TARGET OpenAL::OpenAL)
-            add_library(OpenAL::OpenAL UNKNOWN IMPORTED)
-            set_target_properties(
-                OpenAL::OpenAL PROPERTIES
-                INTERFACE_INCLUDE_DIRECTORIES ${OPENAL_INCLUDE_DIR}
-                IMPORTED_LOCATION ${OPENAL_LIBRARY}
-            )
+            if(OPENAL_LIBRARY MATCHES "/([^/]+)\\.framework$")
+                add_library(OpenAL::OpenAL INTERFACE IMPORTED)
+                set_target_properties(
+                    OpenAL::OpenAL PROPERTIES
+                    INTERFACE_INCLUDE_DIRECTORIES ${OPENAL_INCLUDE_DIR}
+                    INTERFACE_LINK_LIBRARIES ${OPENAL_LIBRARY}
+                )
+            else()
+                add_library(OpenAL::OpenAL UNKNOWN IMPORTED)
+                set_target_properties(
+                    OpenAL::OpenAL PROPERTIES
+                    INTERFACE_INCLUDE_DIRECTORIES ${OPENAL_INCLUDE_DIR}
+                    IMPORTED_LOCATION ${OPENAL_LIBRARY}
+                )
+            endif()
         endif()
     elseif(OpenAL_FIND_REQUIRED)
         message(FATAL_ERROR "Could NOT find OpenAL")

--- a/cmake/FindSecurity.cmake
+++ b/cmake/FindSecurity.cmake
@@ -8,9 +8,9 @@ find_library(
 find_package_handle_standard_args(Security REQUIRED_VARS Security_LIBRARY)
 
 if(Security_FOUND AND NOT TARGET Security::Security)
-    add_library(Security::Security UNKNOWN IMPORTED)
+    add_library(Security::Security INTERFACE IMPORTED)
     set_target_properties(
         Security::Security PROPERTIES
-        IMPORTED_LOCATION ${Security_LIBRARY}
+        INTERFACE_LINK_LIBRARIES ${Security_LIBRARY}
     )
 endif()


### PR DESCRIPTION
It looks like CMake changed the expected of interface libraries when the end library is a framework. Frameworks were failing to link properly previously - this seems to fix them. Dylibs were unaffected.

This is lifted from CMake's FindOpenCL.cmake:
https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/FindOpenCL.cmake