### PR TITLE
Fix macOS compiler errors when sysdir.h is not available

### DIFF
--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -60,12 +60,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   include <unistd.h>
 #endif
 
-#if HS_BUILD_FOR_APPLE
-#   if defined(__has_include)
-#     if __has_include(<sysdir.h>)
+#ifdef HS_BUILD_FOR_APPLE
+#   ifdef HAVE_SYSDIR
 #       include <sysdir.h>
-#       define HAS_SYSDIR
-#     endif
 #   endif
 #
 #   include <NSSystemDirectories.h>
@@ -473,7 +470,7 @@ plFileName plFileSystem::GetUserDataPath()
         _userData = plFileName::Join(ST::string::from_wchar(path), plProduct::LongName());
 #elif HS_BUILD_FOR_APPLE
         char path[PATH_MAX] {};
-#ifdef HAS_SYSDIR
+#if defined(HAVE_BUILTIN_AVAILABLE) && defined(HAVE_SYSDIR)
         if (__builtin_available(macOS 10.12, *)) {
             sysdir_search_path_enumeration_state state;
             state = sysdir_start_search_path_enumeration(SYSDIR_DIRECTORY_APPLICATION_SUPPORT, SYSDIR_DOMAIN_MASK_USER);

--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -64,6 +64,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #   if defined(__has_include)
 #     if __has_include(<sysdir.h>)
 #       include <sysdir.h>
+#       define HAS_SYSDIR
 #     endif
 #   endif
 #
@@ -472,11 +473,15 @@ plFileName plFileSystem::GetUserDataPath()
         _userData = plFileName::Join(ST::string::from_wchar(path), plProduct::LongName());
 #elif HS_BUILD_FOR_APPLE
         char path[PATH_MAX] {};
+#ifdef HAS_SYSDIR
         if (__builtin_available(macOS 10.12, *)) {
             sysdir_search_path_enumeration_state state;
             state = sysdir_start_search_path_enumeration(SYSDIR_DIRECTORY_APPLICATION_SUPPORT, SYSDIR_DOMAIN_MASK_USER);
             state = sysdir_get_next_search_path_enumeration(state, path);
-        } else {
+        }
+        else
+#endif
+        {
             IGNORE_WARNINGS_BEGIN("deprecated-declarations")
 
             NSSearchPathEnumerationState state;

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -35,6 +35,13 @@ check_cxx_symbol_exists("sysinfo" "sys/sysinfo.h" HAVE_SYSINFO)
 try_compile(HAVE_SYSCTL ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_sysctl.cpp)
 
+# Check for Apple sysdir header.
+CHECK_INCLUDE_FILE("sysdir.h" HAVE_SYSDIR)
+
+# Check for `__builtin_available()` Apple extension
+try_compile(HAVE_BUILTIN_AVAILABLE ${PROJECT_BINARY_DIR}
+            ${PROJECT_SOURCE_DIR}/cmake/check_builtin_available.cpp)
+
 # Check for CPUID headers
 try_compile(HAVE_CPUID ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_cpuid.cpp)

--- a/cmake/check_builtin_available.cpp
+++ b/cmake/check_builtin_available.cpp
@@ -1,0 +1,5 @@
+int main()
+{
+    (void)__builtin_available(macOS 10.12, *);
+    return 0;
+}

--- a/cmake/hsConfig.h.cmake
+++ b/cmake/hsConfig.h.cmake
@@ -44,6 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define HeadSpinConfigHDefined
 
 /* Compiler settings */
+#cmakedefine HAVE_BUILTIN_AVAILABLE
 #cmakedefine HAVE_CPUID
 #cmakedefine HAVE_AVX2
 #cmakedefine HAVE_AVX
@@ -64,6 +65,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #cmakedefine HAVE_PTHREAD_TIMEDJOIN_NP
 #cmakedefine HAVE_SYSCTL
+#cmakedefine HAVE_SYSDIR
 #cmakedefine HAVE_SYSINFO
 
 #endif


### PR DESCRIPTION
Technically, the issue here is the `__builtin_available` on compilers that don't support it (such as gcc), but we can effectively mask it by only running the `__builtin_available` check if we actually need to (when sysdir.h is found).