### PR TITLE
Fixing possible deadlock in plPythonCallable

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
@@ -93,6 +93,9 @@ namespace plPython
     };
 
     template<typename... Args>
+    inline pyObjectRef CallObject(PyObject* callable, Args&&... args);
+
+    template<typename... Args>
     inline pyObjectRef CallObject(const pyObjectRef& callable, Args&&... args)
     {
         return CallObject(callable.Get(), std::forward<Args>(args)...);

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
@@ -93,15 +93,6 @@ namespace plPython
     };
 
     template<typename... Args>
-    inline pyObjectRef CallObject(PyObject* callable, Args&&... args);
-
-    template<typename... Args>
-    inline pyObjectRef CallObject(const pyObjectRef& callable, Args&&... args)
-    {
-        return CallObject(callable.Get(), std::forward<Args>(args)...);
-    }
-
-    template<typename... Args>
     inline pyObjectRef CallObject(PyObject* callable, Args&&... args)
     {
         hsAssert(PyCallable_Check(callable), "Trying to call a non-callable, eh?");
@@ -142,6 +133,12 @@ namespace plPython
             auto argsObjs = std::make_unique<PyObject* []>(nargs);
             return _detail::VectorcallObject<nargs>(callable, argsObjs.get(), std::forward<Args>(args)...);
         }
+    }
+    
+    template<typename... Args>
+    inline pyObjectRef CallObject(const pyObjectRef& callable, Args&&... args)
+    {
+        return CallObject(callable.Get(), std::forward<Args>(args)...);
     }
 
     template<typename... _CBArgsT>


### PR DESCRIPTION
PyObject varient of CallObject is not declared before pyObjectRef CallObject varient. This could lead to pyObjectRef CallObject calling itself repeatedly in since the desired PyObject varient is not technically in scope.

I took the approach of declaring the function instead of moving the order - as it might be a bit safer and more clear for future developers. I'm assuming there may be some discussion on the approach (or style of where that declaration should go.)