### PR TITLE
Fix some truncation warnings.

### DIFF
--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -80,7 +80,7 @@ public:
     virtual void      CopyToMem(void* mem);
     virtual bool      IsCompressed() { return false; }
 
-    uint32_t        WriteString(const ST::string & string) { return Write(string.size(), string.c_str()); }
+    uint32_t        WriteString(const ST::string & string) { return Write((uint32_t)string.size(), string.c_str()); }
 
     template        <typename... _Args>
     uint32_t        WriteFmt(const char * fmt, _Args&&... args) { return WriteString(ST::format(fmt, std::forward<_Args>(args)...)); }

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
@@ -273,7 +273,7 @@ struct NetCliQueue;
 *
 ***/
 
-#define NET_MSG(msgId, msgFields)               { #msgId, msgId, msgFields, std::size(msgFields) }
+#define NET_MSG(msgId, msgFields)               { #msgId, msgId, msgFields, (unsigned)std::size(msgFields) }
 
 #define NET_MSG_FIELD(type, count, size)        { type, count, size }
 

--- a/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
@@ -330,7 +330,7 @@ uint32_t plEncryptedStream::Read(uint32_t bytes, void* buffer)
     if (numMidChunks != 0)
     {
         uint32_t* bufferPos = (uint32_t*)(((char*)buffer)+startAmt);
-        for (int i = 0; i < numMidChunks; i++)
+        for (uint32_t i = 0; i < numMidChunks; i++)
         {
             // Decrypt chunk
             IDecipher(bufferPos);

--- a/Sources/Plasma/PubUtilLib/plPipeline/plPlates.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plPlates.cpp
@@ -401,7 +401,7 @@ void    plGraphPlate::AddData( std::vector<int32_t> values )
     uint32_t  *bits = (uint32_t *)fMipmap->GetImage(), *ptr;
     uint32_t  *minDPos = fMipmap->GetAddr32( 3, fMipmap->GetHeight() - 3 - 10 );
     uint32_t  *maxDPos = fMipmap->GetAddr32( 3, 2 );
-    int     i, j;
+    size_t    i, j;
     std::vector<int> lows, his;
     float   lineCtr, lineInc;
     int     lastLineInt, lineInt, bumpCtr;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plPlates.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plPlates.h
@@ -185,8 +185,8 @@ class plGraphPlate : public plPlate
 
         const char      *GetLabelText( int i ) { return fLabelText[ i ].c_str(); }
         uint32_t        GetDataColor( int i ) { return fDataHexColors[ i ]; }
-        uint32_t        GetNumLabels() { return fLabelText.size(); }
-        uint32_t        GetNumColors() { return fDataHexColors.size(); }
+        uint32_t        GetNumLabels() { return (uint32_t)fLabelText.size(); }
+        uint32_t        GetNumColors() { return (uint32_t)fDataHexColors.size(); }
 };
 
 //// plPlateManager Class Definition /////////////////////////////////////////


### PR DESCRIPTION
Most of these are fairly noisy because they're in header files.