### PR TITLE
Replace NetVaultNode::Blob with a std::vector

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
@@ -201,30 +201,7 @@ protected:
                         kIString64_2 | kText_1 | kText_2 | kBlob_1 | kBlob_2)
     };
 
-public:
-    /**
-     * This is public only so that it may be referenced by anonymous functions.
-     * Should not be used outside NetVaultNode.
-     */
-    struct Blob
-    {
-        size_t size;
-        uint8_t* buffer;
-
-        Blob() : size(0), buffer(nullptr) { }
-        Blob(const Blob &rhs);
-        Blob(Blob &&rhs);
-        ~Blob() { delete[] buffer; }
-
-        void operator =(const Blob& rhs);
-        void operator =(Blob&& rhs);
-
-        bool operator ==(const Blob& rhs) const;
-        bool operator !=(const Blob& rhs) const { return !operator==(rhs); }
-    };
-
 private:
-
     uint64_t fUsedFields;
     uint64_t fDirtyFields;
     plUUID fRevision;
@@ -259,8 +236,8 @@ private:
     ST::string fIString64_2;
     ST::string fText_1;
     ST::string fText_2;
-    Blob     fBlob_1;
-    Blob     fBlob_2;
+    std::vector<uint8_t> fBlob_1;
+    std::vector<uint8_t> fBlob_2;
 
     template<typename T>
     inline void ISetVaultField(uint64_t bits, T& field, T value)
@@ -277,7 +254,8 @@ private:
         fUsedFields |= bits;
     }
 
-    void ISetVaultBlob(uint64_t bits, Blob& blob, const uint8_t* buf, size_t size);
+    void ISetVaultBlob(uint64_t bits, std::vector<uint8_t>& blob,
+                       const uint8_t* buf, size_t size);
 
 public:
     enum IOFlags
@@ -354,11 +332,11 @@ public:
     ST::string GetText_1() const { return fText_1; }
     ST::string GetText_2() const { return fText_2; }
 
-    const uint8_t* GetBlob_1() const { return fBlob_1.buffer; }
-    size_t GetBlob_1Length() const { return fBlob_1.size; }
+    const uint8_t* GetBlob_1() const { return fBlob_1.data(); }
+    size_t GetBlob_1Length() const { return fBlob_1.size(); }
 
-    const uint8_t* GetBlob_2() const { return fBlob_2.buffer; }
-    size_t GetBlob_2Length() const { return fBlob_2.size; }
+    const uint8_t* GetBlob_2() const { return fBlob_2.data(); }
+    size_t GetBlob_2Length() const { return fBlob_2.size(); }
 
 public:
     void SetNodeId(uint32_t value) { ISetVaultField(kNodeId, fNodeId, value); }

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
@@ -331,12 +331,8 @@ public:
     ST::string GetIString64_2() const { return fIString64_2; }
     ST::string GetText_1() const { return fText_1; }
     ST::string GetText_2() const { return fText_2; }
-
-    const uint8_t* GetBlob_1() const { return fBlob_1.data(); }
-    size_t GetBlob_1Length() const { return fBlob_1.size(); }
-
-    const uint8_t* GetBlob_2() const { return fBlob_2.data(); }
-    size_t GetBlob_2Length() const { return fBlob_2.size(); }
+    const std::vector<uint8_t>& GetBlob_1() const { return fBlob_1; }
+    const std::vector<uint8_t>& GetBlob_2() const { return fBlob_2; }
 
 public:
     void SetNodeId(uint32_t value) { ISetVaultField(kNodeId, fNodeId, value); }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
@@ -792,9 +792,9 @@ bool plClothingOutfit::IReadFromVault()
 
     for (const hsRef<RelVaultNode> &node : nodes) {
         VaultSDLNode sdl(node);
-        if (sdl.GetSDLDataLength()) {
+        if (!sdl.GetSDLData().empty()) {
             hsRAMStream ram;
-            ram.Write(sdl.GetSDLDataLength(), sdl.GetSDLData());
+            ram.Write(sdl.GetSDLData().size(), sdl.GetSDLData().data());
             ram.Rewind();
 
             ST::string sdlRecName;
@@ -1463,9 +1463,9 @@ bool plClothingOutfit::WriteToFile(const plFileName &filename)
     S.WriteLE32((uint32_t)nodes.size());
     for (const hsRef<RelVaultNode> &node : nodes) {
         VaultSDLNode sdl(node);
-        S.WriteLE32((uint32_t)sdl.GetSDLDataLength());
-        if (sdl.GetSDLDataLength())
-            S.Write(sdl.GetSDLDataLength(), sdl.GetSDLData());
+        S.WriteLE32((uint32_t)sdl.GetSDLData().size());
+        if (!sdl.GetSDLData().empty())
+            S.Write(sdl.GetSDLData().size(), sdl.GetSDLData().data());
     }
 
     S.Close();

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -429,7 +429,7 @@ static void InitFetchedNode(hsWeakRef<RelVaultNode> rvn) {
     switch (rvn->GetNodeType()) {
         case plVault::kNodeType_SDL: {
             VaultSDLNode access(rvn);
-            if (!access.GetSDLData() || !access.GetSDLDataLength())
+            if (access.GetSDLData().empty())
                 access.InitStateDataRecord(access.GetSDLName());
         }
         break;

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.cpp
@@ -137,11 +137,11 @@ bool VaultTextNoteNode::GetVisitInfo (plAgeInfoStruct * info) {
 
 //============================================================================
 bool VaultSDLNode::GetStateDataRecord (plStateDataRecord * rec, unsigned readOptions) {
-    if (!GetSDLDataLength() || !GetSDLData())
+    if (GetSDLData().empty())
         return false;
 
     hsRAMStream ram;
-    ram.Write(GetSDLDataLength(), GetSDLData());
+    ram.Write(GetSDLData().size(), GetSDLData().data());
     ram.Rewind();
 
     ST::string sdlRecName;
@@ -239,7 +239,7 @@ void VaultImageNode::StuffImage (plMipmap * src, int dstType) {
 //============================================================================
 bool VaultImageNode::ExtractImage (plMipmap ** dst) {
     hsRAMStream ramStream;
-    ramStream.Write(GetImageDataLength(), GetImageData());
+    ramStream.Write(GetImageData().size(), GetImageData().data());
     ramStream.Rewind();
 
     switch (GetImageType()) {
@@ -340,7 +340,8 @@ bool VaultAgeLinkNode::HasSpawnPoint (const plSpawnPointInfo & point) const {
 //============================================================================
 void VaultAgeLinkNode::GetSpawnPoints (plSpawnPointVec * out) const {
 
-    ST::string str = ST::string::from_utf8(reinterpret_cast<const char*>(GetSpawnPoints()), GetSpawnPointsLength());
+    ST::string str = ST::string::from_utf8(reinterpret_cast<const char*>(GetSpawnPoints().data()),
+                                           GetSpawnPoints().size());
     std::vector<ST::string> izer = str.tokenize(";");
     for (auto token1 = izer.begin(); token1 != izer.end(); ++token1)
     {
@@ -435,10 +436,10 @@ void VaultAgeInfoNode::CopyTo (plAgeInfoStruct * info) const {
 //============================================================================
 void VaultMarkerGameNode::GetMarkerData(std::vector<VaultMarker>& data) const
 {
-    if (base->GetBlob_1Length() < sizeof(uint32_t))
+    if (base->GetBlob_1().size() < sizeof(uint32_t))
         return;
 
-    hsReadOnlyStream stream(base->GetBlob_1Length(), base->GetBlob_1());
+    hsReadOnlyStream stream(base->GetBlob_1().size(), base->GetBlob_1().data());
     uint32_t size = stream.ReadLE32();
     data.reserve(size);
 

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultNodeAccess.h
@@ -87,8 +87,7 @@ private:
     void Set##name (type v) { base->Set##basename(v); }
 
 #define VNODE_BLOB(name, basename) \
-    const uint8_t * Get##name () const { return base->Get##basename(); } \
-    size_t Get##name##Length () const { return base->Get##basename##Length(); } \
+    const std::vector<uint8_t>& Get##name() const { return base->Get##basename(); } \
     void Set##name (const uint8_t data[], size_t length) { base->Set##basename(data, length); }
 
 #define VNODE_STRING(name, basename) \


### PR DESCRIPTION
This also cleans up a hack where a private type needed to be exposed publically for helper functions in pnNpCommon.cpp.