### PR TITLE
Give GCC and Clang a hint that DEFAULT_FATAL() is unreachable

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -427,8 +427,10 @@ void DebugMsg(const char* fmt, ...);
 #endif  // HS_DEBUGGING
 
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #define  DEFAULT_FATAL(var)  default: FATAL("No valid case for switch variable '" #var "'"); __assume(0); break;
+#elif defined(__GNUC__)
+#define  DEFAULT_FATAL(var)  default: FATAL("No valid case for switch variable '" #var "'"); __builtin_unreachable(); break;
 #else
 #define  DEFAULT_FATAL(var)  default: FATAL("No valid case for switch variable '" #var "'"); break;
 #endif


### PR DESCRIPTION
…matching the MSVC behavior.

This silences some warnings about functions not returning a value when a switch statement with `DEFAULT_FATAL` is at the end of the function.