### PR TITLE
Port plNetObjectDebugger to ST::string

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -438,16 +438,6 @@ char* hsStrcpy(char* dst, const char* src)
     return dst;
 }
 
-void hsStrLower(char *s)
-{
-    if (s)
-    {
-        size_t len = strlen(s);
-        for (size_t i = 0; i < len; i++)
-            s[i] = tolower(s[i]);
-    }
-}
-
 //// IStringToWString /////////////////////////////////////////////////////////
 // Converts a char * string to a wchar_t * string
 

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -276,7 +276,6 @@ template <> inline double hsToLE(double value) { return hsToLEDouble(value); }
 #endif // PLASMA_EXTERNAL_RELEASE
 
 char*   hsStrcpy(char* dstOrNil, const char* src);
-void    hsStrLower(char *s);
 
 inline char* hsStrcpy(const char* src)
 {

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
@@ -599,8 +599,9 @@ PF_CONSOLE_CMD( Net_DebugObject,        // groupName
                "string objName, ...", // paramList
                "Create a debug log about the specified object. AddObject objName [pageName], wildcards allowed" )   // helpString
 {
-    char* objName = params[0];  
-    char* pageName = numParams>1 ? (char*)params[1] : nullptr;
+    ST::string objName = ST::string::from_utf8(params[0], ST_AUTO_SIZE, ST::substitute_invalid);
+    ST::string pageName = (numParams > 1) ? ST::string::from_utf8(params[1], ST_AUTO_SIZE, ST::substitute_invalid)
+                                          : ST::string();
     if (plNetObjectDebugger::GetInstance())
         plNetObjectDebugger::GetInstance()->AddDebugObject(objName, pageName);
 }
@@ -610,8 +611,9 @@ PF_CONSOLE_CMD( Net_DebugObject,        // groupName
                "string objName, ...", // paramList
                "Stop focused debugging about the specified object. RemoveObject objName [pageName], wildcards allowed" )    // helpString
 {
-    char* objName = params[0];  
-    char* pageName = numParams>1 ? (char*)params[1] : nullptr;
+    ST::string objName = ST::string::from_utf8(params[0], ST_AUTO_SIZE, ST::substitute_invalid);
+    ST::string pageName = (numParams > 1) ? ST::string::from_utf8(params[1], ST_AUTO_SIZE, ST::substitute_invalid)
+                                          : ST::string();
     if (plNetObjectDebugger::GetInstance())
         plNetObjectDebugger::GetInstance()->RemoveDebugObject(objName, pageName);
 }

--- a/Sources/Plasma/NucleusLib/pnDispatch/plDispatch.cpp
+++ b/Sources/Plasma/NucleusLib/pnDispatch/plDispatch.cpp
@@ -335,7 +335,7 @@ void plDispatch::IMsgDispatch()
                             hsLogEntry(plNetObjectDebuggerBase::GetInstance()->LogMsg(
                                 ST::format("<RCV> object:{}, GameMessage {} st={.3f} rt={.3f}",
                                 ko->GetKeyName(), msg->ClassName(), hsTimer::GetSysSeconds(),
-                                hsTimer::GetSeconds()).c_str()));
+                                hsTimer::GetSeconds())));
                         }
                     }
                 }

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetApp.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetApp.h
@@ -292,7 +292,7 @@ public:
     static void SetInstance(plNetObjectDebuggerBase* i) { fInstance=i;  }
     virtual bool IsDebugObject(const hsKeyedObject* obj) const = 0;
     virtual void LogMsgIfMatch(const ST::string& msg) const = 0;      // write to status log if there's a string match
-    virtual void LogMsg(const char* msg) const = 0;
+    virtual void LogMsg(const ST::string& msg) const = 0;
     
     virtual bool GetDebugging() const = 0;
     virtual void SetDebugging(bool b) = 0;

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetApp.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetApp.h
@@ -291,7 +291,7 @@ public:
     static plNetObjectDebuggerBase* GetInstance() { return fInstance;   }
     static void SetInstance(plNetObjectDebuggerBase* i) { fInstance=i;  }
     virtual bool IsDebugObject(const hsKeyedObject* obj) const = 0;
-    virtual void LogMsgIfMatch(const char* msg) const = 0;      // write to status log if there's a string match    
+    virtual void LogMsgIfMatch(const ST::string& msg) const = 0;      // write to status log if there's a string match
     virtual void LogMsg(const char* msg) const = 0;
     
     virtual bool GetDebugging() const = 0;

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
@@ -460,7 +460,7 @@ bool plNCAgeJoiner::MsgReceive (plMessage * msg) {
     //========================================================================
     plInitialAgeStateLoadedMsg * stateMsg = plInitialAgeStateLoadedMsg::ConvertNoRef(msg);
     if(stateMsg) {
-        plNetObjectDebugger::GetInstance()->LogMsg("OnServerInitComplete");
+        plNetObjectDebugger::GetInstance()->LogMsg(ST_LITERAL("OnServerInitComplete"));
         nc->SetFlagsBit(plNetClientApp::kLoadingInitialAgeState, false);
 
         const plArmatureMod *avMod = plAvatarMgr::GetInstance()->GetLocalAvatar();

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -970,8 +970,8 @@ bool plNetClientMgr::MsgReceive( plMessage* msg )
         // add 1 debug object for age sdl
         if (plNetObjectDebugger::GetInstance())
         {
-            plNetObjectDebugger::GetInstance()->RemoveDebugObject("AgeSDLHook");    
-            plNetObjectDebugger::GetInstance()->AddDebugObject("AgeSDLHook");
+            plNetObjectDebugger::GetInstance()->RemoveDebugObject(ST_LITERAL("AgeSDLHook"));
+            plNetObjectDebugger::GetInstance()->AddDebugObject(ST_LITERAL("AgeSDLHook"));
         }
 
         // if we're linking to startup we don't need (or want) a player set

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -265,7 +265,7 @@ bool plNetClientMgr::Log(const ST::string& str) const
 
     GetLog();
 
-    plNetObjectDebugger::GetInstance()->LogMsgIfMatch(buf2.c_str());
+    plNetObjectDebugger::GetInstance()->LogMsgIfMatch(buf2);
 
     if (fStatusLog) {
         return fStatusLog->AddLine(buf2);

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrSend.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrSend.cpp
@@ -394,7 +394,7 @@ int plNetClientMgr::ISendGameMessage(plMessage* msg)
             ST::format("<SND> object:{}, rcvr {} {}",
             msg->GetSender().GetKeyName(),
             msg->GetNumReceivers() ? msg->GetReceiver(0)->GetName() : "?",
-            netMsgWrap->AsStdString()).c_str()));
+            netMsgWrap->AsStdString())));
     #endif
     }
 

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.cpp
@@ -52,11 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plResMgr/plKeyFinder.h"
 #include "plStatusLog/plStatusLog.h"
 
-plNetObjectDebugger::DebugObject::DebugObject(const ST::string& objName, plLocation& loc, uint32_t flags)
-    : fObjName(objName.to_lower()), fLoc(loc), fFlags(flags)
-{
-}
-
 //
 // return true if string matches objName according to flags
 //
@@ -201,7 +196,7 @@ bool plNetObjectDebugger::AddDebugObject(ST::string objName, const ST::string& p
         flags |= kPageMatch;
     }
 
-    fDebugObjects.push_back(new DebugObject(objName, loc, flags));
+    fDebugObjects.push_back(new DebugObject(std::move(objName), loc, flags));
 
     ICreateStatusLog();
 

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.cpp
@@ -277,11 +277,11 @@ void plNetObjectDebugger::LogMsgIfMatch(const ST::string& msg) const
     }
 }
 
-void plNetObjectDebugger::LogMsg(const char* msg) const
+void plNetObjectDebugger::LogMsg(const ST::string& msg) const
 {
-    DEBUG_MSG(msg);
+    DEBUG_MSG(msg.c_str());
 }
-    
+
 bool plNetObjectDebugger::IsDebugObject(const hsKeyedObject* obj) const
 {
     DebugObjectList::const_iterator it =fDebugObjects.begin();

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.cpp
@@ -42,7 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plNetObjectDebugger.h"
 
-#include <string>
+#include <string_theory/string_stream>
 
 #include "hsResMgr.h"
 
@@ -243,31 +243,27 @@ void plNetObjectDebugger::ClearAllDebugObjects()
 //
 // write to status log if there's a string match
 //
-void plNetObjectDebugger::LogMsgIfMatch(const char* msg) const
+void plNetObjectDebugger::LogMsgIfMatch(const ST::string& msg) const
 {
-    if (GetNumDebugObjects()==0 || !msg)
+    if (GetNumDebugObjects() == 0 || msg.empty())
         return;
 
     // extract object name from msg, expects '...object:foo,...'
-    std::string tmp = msg;
-    hsStrLower((char*)tmp.c_str());
-    std::string objTag="object";
-    const char* c=strstr(tmp.c_str(), objTag.c_str());
-    if (c && c != tmp.c_str())
+    const auto objTag = ST_LITERAL("object");
+    ST_ssize_t pos = msg.find(objTag, ST::case_insensitive);
+    if (pos > 0)
     {
-        c+=objTag.size();
+        const char* c = &msg[pos] + objTag.size();
 
         // move past spaces
         while ( *c || *c==' ' )
             c++;
 
-        char objName[128];
-        int i=0;
-
         // copy objName token
-        while(*c && *c != ',' && *c != ' ' && i<127)
-            objName[i++] = *c++;
-        objName[i]=0;
+        ST::string_stream buildName;
+        while (*c && *c != ',' && *c != ' ')
+            buildName.append_char(*c++);
+        ST::string objName = buildName.to_string(true, ST::substitute_invalid);
 
         DebugObjectList::const_iterator it = fDebugObjects.begin();
         for(; it != fDebugObjects.end(); it++)

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.h
@@ -94,7 +94,7 @@ public:
     int GetNumDebugObjects() const { return fDebugObjects.size(); }
     bool IsDebugObject(const hsKeyedObject* obj) const override;
 
-    void LogMsgIfMatch(const char* msg) const override;      // write to status log if there's a string match
+    void LogMsgIfMatch(const ST::string& msg) const override;      // write to status log if there's a string match
     void LogMsg(const char* msg) const override;
 };
 

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.h
@@ -70,7 +70,8 @@ private:
         bool StringMatches(const ST::string& str) const;  // return true if string matches objName according to flags
         bool ObjectMatches(const hsKeyedObject* obj);
         bool ObjectMatches(const ST::string& objName, const ST::string& pageName);
-        DebugObject(const ST::string& objName, plLocation& loc, uint32_t flags);
+        DebugObject(ST::string objName, plLocation& loc, uint32_t flags)
+            : fObjName(std::move(objName)), fLoc(loc), fFlags(flags) { }
     };
     typedef std::vector<DebugObject*> DebugObjectList;
     DebugObjectList fDebugObjects;

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.h
@@ -95,7 +95,7 @@ public:
     bool IsDebugObject(const hsKeyedObject* obj) const override;
 
     void LogMsgIfMatch(const ST::string& msg) const override;      // write to status log if there's a string match
-    void LogMsg(const char* msg) const override;
+    void LogMsg(const ST::string& msg) const override;
 };
 
 #endif      // plNetObjectDebugger_inc

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.h
@@ -46,7 +46,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnKeyedObject/plUoid.h"
 #include "pnNetCommon/plNetApp.h"
 
-#include <string>
 #include <vector>
 
 class hsKeyedObject;
@@ -65,13 +64,13 @@ public:
 private:
     struct DebugObject
     {
-        std::string fObjName;
+        ST::string fObjName;
         plLocation fLoc;
         uint32_t fFlags;
-        bool StringMatches(const char* str) const;  // return true if string matches objName according to flags
+        bool StringMatches(const ST::string& str) const;  // return true if string matches objName according to flags
         bool ObjectMatches(const hsKeyedObject* obj);
-        bool ObjectMatches(const char* objName, const char* pageName);
-        DebugObject(const char* objName, plLocation& loc, uint32_t flags);
+        bool ObjectMatches(const ST::string& objName, const ST::string& pageName);
+        DebugObject(const ST::string& objName, plLocation& loc, uint32_t flags);
     };
     typedef std::vector<DebugObject*> DebugObjectList;
     DebugObjectList fDebugObjects;
@@ -89,8 +88,8 @@ public:
     void SetDebugging(bool b) override { fDebugging = b; }
 
     // object fxns
-    bool AddDebugObject(const char* objName, const char* pageName=nullptr);
-    bool RemoveDebugObject(const char* objName, const char* pageName=nullptr);
+    bool AddDebugObject(ST::string objName, const ST::string& pageName={});
+    bool RemoveDebugObject(const ST::string& objName, const ST::string& pageName={});
     void ClearAllDebugObjects();
     int GetNumDebugObjects() const { return fDebugObjects.size(); }
     bool IsDebugObject(const hsKeyedObject* obj) const override;

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateDataRecord.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateDataRecord.cpp
@@ -754,12 +754,12 @@ void plStateDataRecord::DumpToObjectDebugger(const char* msg, bool dirtyOnly, in
     int numVars = dirtyOnly ? GetNumDirtyVars() : GetNumUsedVars();
     int numSDVars = dirtyOnly ? GetNumDirtySDVars() : GetNumUsedSDVars();
 
-    dbg->LogMsg(fAssocObject.IsValid() ? fAssocObject.GetObjectName().c_str() : " ");
+    dbg->LogMsg(fAssocObject.IsValid() ? fAssocObject.GetObjectName() : ST_LITERAL(" "));
     if (msg)
-        dbg->LogMsg(ST::format("{}{}", pad, msg).c_str());
+        dbg->LogMsg(ST::format("{}{}", pad, msg));
 
     dbg->LogMsg(ST::format("{}SDR({#x}), desc={}, showDirty={}, numVars={}, vol={}",
-        pad, (uintptr_t)this, fDescriptor->GetName(), dirtyOnly, numVars+numSDVars, fFlags&kVolatile).c_str());
+        pad, (uintptr_t)this, fDescriptor->GetName(), dirtyOnly, numVars+numSDVars, fFlags&kVolatile));
 
     // dump simple vars
     for (size_t i=0; i<fVarsList.size(); i++)

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
@@ -2170,7 +2170,7 @@ void plSimpleStateVariable::NotifyStateChange(const plSimpleStateVariable* other
     {
         plNetObjectDebuggerBase::GetInstance()->LogMsg(
             ST::format("Var {} did {} send notification difference. Has {} notifiers with {} recipients.",
-                       GetName(), !notify ? "NOT" : "", fChangeNotifiers.size(), numNotifiers).c_str());
+                       GetName(), !notify ? "NOT" : "", fChangeNotifiers.size(), numNotifiers));
     }
 
 }
@@ -2292,7 +2292,7 @@ void plSimpleStateVariable::DumpToObjectDebugger(bool dirtyOnly, int level) cons
 
     if (GetCount()>1)
     {
-        dbg->LogMsg(logMsg.to_string().c_str());    // it's going to be a long msg, so print it on its own line
+        dbg->LogMsg(logMsg.to_string());    // it's going to be a long msg, so print it on its own line
         logMsg.truncate();
     }
 
@@ -2321,7 +2321,7 @@ void plSimpleStateVariable::DumpToObjectDebugger(bool dirtyOnly, int level) cons
             logMsg << (IsDirty() ? 0 : 1);
         }
 
-        dbg->LogMsg(logMsg.to_string().c_str());
+        dbg->LogMsg(logMsg.to_string());
         logMsg.truncate();
     }
 }
@@ -2693,7 +2693,7 @@ void plSDStateVariable::DumpToObjectDebugger(bool dirtyOnly, int level) const
 
     int cnt = dirtyOnly ? GetDirtyCount() : GetUsedCount();
     dbg->LogMsg(ST::format("{}SDVar, name:{} dirtyOnly:{} count:{}",
-                           pad, GetName(), dirtyOnly, cnt).c_str());
+                           pad, GetName(), dirtyOnly, cnt));
 
     for (size_t i=0; i<GetCount(); i++)
     {


### PR DESCRIPTION
This allows us to get rid of the final user of `hsStrLower()`, which can now be removed from the code.  As a bonus, we also don't need to keep around copies of strings converted to lower-case any more, since ST already enables all the case-insensitive comparisons we need to perform.