### PR TITLE
Disable "Need an account?" button if no Server.Signup URL is set

### DIFF
--- a/Sources/Plasma/Apps/plClient/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/winmain.cpp
@@ -795,6 +795,8 @@ INT_PTR CALLBACK UruLoginDialogProc( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
             }
             SendMessage(GetDlgItem(hwndDlg, IDC_LANGUAGE), CB_SETCURSEL, (WPARAM)plLocalization::GetLanguage(), 0);
 
+            EnableWindow(GetDlgItem(hwndDlg, IDC_URULOGIN_NEWACCTLINK), !GetServerSignupUrl().empty());
+
             SetTimer(hwndDlg, AUTH_LOGIN_TIMER, 10, nullptr);
             return FALSE;
         }


### PR DESCRIPTION
Previously, clicking the button with no Server.Signup URL set would send the login window to the background with no explanation.