### PR TITLE
Add volume threshold for subtitled audio before sending subtitles

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
@@ -110,7 +110,7 @@ void plWin32Sound::Update()
             if (currentTimeMs <= srtReader->GetLastEntryEndTime()) {
                 while (plSrtEntry* nextEntry = srtReader->GetNextEntryStartingBeforeTime(currentTimeMs)) {
                     float currVol = plSound::QueryCurrVolume();
-                    if (plgAudioSys::AreSubtitlesEnabled() && currVol > 0.05f) {
+                    if (plgAudioSys::AreSubtitlesEnabled() && currVol > 0.01f) {
                         // add a plSubtitleMsg to go... to whoever is listening (probably the KI)
                         plSubtitleMsg* msg = new plSubtitleMsg(nextEntry->GetSubtitleText(), nextEntry->GetSpeakerName());
                         msg->Send();

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
@@ -109,7 +109,7 @@ void plWin32Sound::Update()
             uint32_t currentTimeMs = (uint32_t)(GetActualTimeSec() * 1000.0f);
             if (currentTimeMs <= srtReader->GetLastEntryEndTime()) {
                 while (plSrtEntry* nextEntry = srtReader->GetNextEntryStartingBeforeTime(currentTimeMs)) {
-                    float currVol = plSound::QueryCurrVolume();
+                    float currVol = QueryCurrVolume();
                     if (plgAudioSys::AreSubtitlesEnabled() && currVol > 0.01f) {
                         // add a plSubtitleMsg to go... to whoever is listening (probably the KI)
                         plSubtitleMsg* msg = new plSubtitleMsg(nextEntry->GetSubtitleText(), nextEntry->GetSpeakerName());

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
@@ -109,7 +109,8 @@ void plWin32Sound::Update()
             uint32_t currentTimeMs = (uint32_t)(GetActualTimeSec() * 1000.0f);
             if (currentTimeMs <= srtReader->GetLastEntryEndTime()) {
                 while (plSrtEntry* nextEntry = srtReader->GetNextEntryStartingBeforeTime(currentTimeMs)) {
-                    if (plgAudioSys::AreSubtitlesEnabled()) {
+                    float currVol = plSound::QueryCurrVolume();
+                    if (plgAudioSys::AreSubtitlesEnabled() && currVol > 0.05f) {
                         // add a plSubtitleMsg to go... to whoever is listening (probably the KI)
                         plSubtitleMsg* msg = new plSubtitleMsg(nextEntry->GetSubtitleText(), nextEntry->GetSpeakerName());
                         msg->Send();


### PR DESCRIPTION
This should prevent subtitles from being sent to the KI when audio is muted or the source is so far away that it is not audible.