### PR TITLE
Attempt to fix compiling with Python 3.11

### DIFF
--- a/Sources/Plasma/Apps/plPythonPack/PythonInterface.cpp
+++ b/Sources/Plasma/Apps/plPythonPack/PythonInterface.cpp
@@ -41,8 +41,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 #include "PythonInterface.h"
 
-#include <compile.h>
-#include <eval.h>
 #include <cpython/initconfig.h>
 #include <marshal.h>
 #include <pylifecycle.h>

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
@@ -111,7 +111,7 @@ namespace plPython
             plProfile_BeginTiming(PythonUpdate);
 #if PY_VERSION_HEX >= 0x03090000
             // Use Python's built-in vectorcall optimization for no argument.
-            pyObjectRef result = _PyObject_CallNoArg(callable);
+            pyObjectRef result = PyObject_CallNoArgs(callable);
 #else
             // This is basically the same idea.
             pyObjectRef result = _PyObject_Vectorcall(


### PR DESCRIPTION
The macOS GitHub Actions runner on my fork has started defaulting to the system's Python 3.11 installation, and these changes were needed to stop the builds failing. This makes it compile, but no promises about whether there are other changes needed to make it actually work.
(Aside: We're using homebrew on macOS to install Python 3.10 and telling CMake to use that... and it's still grabbing the system Python 3.11 somehow...)

* eval.h has been removed in Python 3.11. That's not a problem though because it's been included in Python.h since at least Python 2.7, and we're already including Python.h so we don't need to include either eval.h or compile.h.

* `_PyObject_CallNoArg` static inline method has been made private. Use the public `PyObject_CallNoArgs` method (available since Python 3.9)
  There's a long bug report about making these methods private and the hypothetical performance implications and apparently none of the benchmarks showed any meaningful difference.