### PR TITLE
Fix (and simplify) vcpkg NuGet binary caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,6 @@ jobs:
               -username "${{ github.repository_owner }}" `
               -password "${{ secrets.GITHUB_TOKEN }}"
 
-          nuget sources add `
-              -source "https://nuget.pkg.github.com/H-uru/index.json" `
-              -storepasswordincleartext `
-              -name "H-uru" `
-              -username "${{ github.repository_owner }}" `
-              -password "${{ secrets.GITHUB_TOKEN }}"
-
           nuget setapikey `
               "${{ secrets.GITHUB_TOKEN }}" `
               -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
@@ -88,7 +81,7 @@ jobs:
             -D3dsm_PATH="${{ github.workspace }}/maxsdk/${{ matrix.platform.max-version }}" `
             -S . -B build
         env:
-          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite;nuget,H-uru,read"
+          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
 
       - name: Build
         run: |
@@ -148,13 +141,6 @@ jobs:
               -username "${{ github.repository_owner }}" `
               -password "${{ secrets.GITHUB_TOKEN }}"
 
-          nuget sources add `
-              -source "https://nuget.pkg.github.com/H-uru/index.json" `
-              -storepasswordincleartext `
-              -name "H-uru" `
-              -username "${{ github.repository_owner }}" `
-              -password "${{ secrets.GITHUB_TOKEN }}"
-
           nuget setapikey `
               "${{ secrets.GITHUB_TOKEN }}" `
               -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
@@ -171,7 +157,7 @@ jobs:
             -D3dsm_PATH="${{ github.workspace }}/maxsdk/${{ matrix.cfg.sdk-version }}" `
             -S . -B build
         env:
-          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite;nuget,H-uru,read"
+          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
 
       - name: Build
         run: |
@@ -223,13 +209,6 @@ jobs:
               -username "${{ github.repository_owner }}" \
               -password "${{ secrets.GITHUB_TOKEN }}"
 
-          nuget sources add \
-              -source "https://nuget.pkg.github.com/H-uru/index.json" \
-              -storepasswordincleartext \
-              -name "H-uru" \
-              -username "${{ github.repository_owner }}" \
-              -password "${{ secrets.GITHUB_TOKEN }}"
-
           nuget setapikey \
               "${{ secrets.GITHUB_TOKEN }}" \
               -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
@@ -245,7 +224,7 @@ jobs:
             -DPLASMA_EXTERNAL_RELEASE=${{ matrix.cfg.external }} \
             -S . -B build
         env:
-          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite;nuget,H-uru,read"
+          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,26 @@ jobs:
           arch: ${{ matrix.platform.qt-arch }}
           dir: ${{ github.workspace }}/qt
 
+      - name: Setup NuGet
+        run: |
+          nuget sources add `
+              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
+              -storepasswordincleartext `
+              -name "GitHub" `
+              -username "${{ github.repository_owner }}" `
+              -password "${{ secrets.GITHUB_TOKEN }}"
+
+          nuget sources add `
+              -source "https://nuget.pkg.github.com/H-uru/index.json" `
+              -storepasswordincleartext `
+              -name "H-uru" `
+              -username "${{ github.repository_owner }}" `
+              -password "${{ secrets.GITHUB_TOKEN }}"
+
+          nuget setapikey `
+              "${{ secrets.GITHUB_TOKEN }}" `
+              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
       - name: Configure
         run: |
           cmake `
@@ -65,12 +85,10 @@ jobs:
             -DPLASMA_BUILD_TESTS=ON `
             -DPLASMA_BUILD_TOOLS=ON `
             -DPLASMA_EXTERNAL_RELEASE=${{ matrix.cfg.external }} `
-            -DPLASMA_VCPKG_NUGET_SOURCE="https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
-            -DPLASMA_VCPKG_NUGET_OWNER="${{ github.repository_owner }}" `
-            -DPLASMA_VCPKG_NUGET_TOKEN="${{ secrets.GITHUB_TOKEN }}" `
-            -DPLASMA_VCPKG_NUGET_RW=TRUE `
             -D3dsm_PATH="${{ github.workspace }}/maxsdk/${{ matrix.platform.max-version }}" `
             -S . -B build
+        env:
+          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite;nuget,H-uru,read"
 
       - name: Build
         run: |
@@ -121,6 +139,26 @@ jobs:
           token: ${{ secrets.MACHINE_USER_REPO_READ }}
           path: maxsdk
 
+      - name: Setup NuGet
+        run: |
+          nuget sources add `
+              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
+              -storepasswordincleartext `
+              -name "GitHub" `
+              -username "${{ github.repository_owner }}" `
+              -password "${{ secrets.GITHUB_TOKEN }}"
+
+          nuget sources add `
+              -source "https://nuget.pkg.github.com/H-uru/index.json" `
+              -storepasswordincleartext `
+              -name "H-uru" `
+              -username "${{ github.repository_owner }}" `
+              -password "${{ secrets.GITHUB_TOKEN }}"
+
+          nuget setapikey `
+              "${{ secrets.GITHUB_TOKEN }}" `
+              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
       - name: Configure
         run: |
           cmake `
@@ -130,12 +168,10 @@ jobs:
             -DPLASMA_BUILD_LAUNCHER=OFF `
             -DPLASMA_BUILD_TESTS=OFF `
             -DPLASMA_BUILD_TOOLS=OFF `
-            -DPLASMA_VCPKG_NUGET_SOURCE="https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
-            -DPLASMA_VCPKG_NUGET_OWNER="${{ github.repository_owner }}" `
-            -DPLASMA_VCPKG_NUGET_TOKEN="${{ secrets.GITHUB_TOKEN }}" `
-            -DPLASMA_VCPKG_NUGET_RW=TRUE `
             -D3dsm_PATH="${{ github.workspace }}/maxsdk/${{ matrix.cfg.sdk-version }}" `
             -S . -B build
+        env:
+          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite;nuget,H-uru,read"
 
       - name: Build
         run: |
@@ -178,6 +214,26 @@ jobs:
               ninja-build \
               qtbase5-dev
 
+      - name: Setup NuGet
+        run: |
+          nuget sources add \
+              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+              -storepasswordincleartext \
+              -name "GitHub" \
+              -username "${{ github.repository_owner }}" \
+              -password "${{ secrets.GITHUB_TOKEN }}"
+
+          nuget sources add \
+              -source "https://nuget.pkg.github.com/H-uru/index.json" \
+              -storepasswordincleartext \
+              -name "H-uru" \
+              -username "${{ github.repository_owner }}" \
+              -password "${{ secrets.GITHUB_TOKEN }}"
+
+          nuget setapikey \
+              "${{ secrets.GITHUB_TOKEN }}" \
+              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
       - name: Configure
         run: |
           cmake \
@@ -187,11 +243,9 @@ jobs:
             -DPLASMA_BUILD_TESTS=ON \
             -DPLASMA_BUILD_TOOLS=ON \
             -DPLASMA_EXTERNAL_RELEASE=${{ matrix.cfg.external }} \
-            -DPLASMA_VCPKG_NUGET_SOURCE="https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
-            -DPLASMA_VCPKG_NUGET_OWNER="${{ github.repository_owner }}" \
-            -DPLASMA_VCPKG_NUGET_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-            -DPLASMA_VCPKG_NUGET_RW=TRUE \
             -S . -B build
+        env:
+          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite;nuget,H-uru,read"
 
       - name: Build
         run: |

--- a/NuGet.Config.in
+++ b/NuGet.Config.in
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <config>
-        <add key="defaultPushSource" value="@_pvgnc_NUGET_SOURCE@" />
+        <add key="defaultPushSource" value="@PLASMA_NUGET_SOURCE@" />
     </config>
     <activePackageSource>
-        <add key="vcpkg" value="@_pvgnc_NUGET_SOURCE@" />
+        <add key="vcpkg" value="@PLASMA_NUGET_SOURCE@" />
     </activePackageSource>
     <packageSources>
-        <add key="vcpkg" value="@_pvgnc_NUGET_SOURCE@" />
+        <add key="vcpkg" value="@PLASMA_NUGET_SOURCE@" />
     </packageSources>
     <packageSourceCredentials>
         <vcpkg>
-            <add key="Username" value="@_pvgnc_NUGET_OWNER@" />
-            <add key="ClearTextPassword" value="@_pvgnc_NUGET_TOKEN@" />
+            <add key="Username" value="@PLASMA_NUGET_OWNER@" />
+            <add key="ClearTextPassword" value="@PLASMA_NUGET_TOKEN@" />
         </vcpkg>
     </packageSourceCredentials>
 </configuration>

--- a/cmake/VcpkgToolchain.cmake
+++ b/cmake/VcpkgToolchain.cmake
@@ -42,6 +42,11 @@ endfunction()
 function(_plasma_vcpkg_setup_binarycache)
     cmake_parse_arguments(_pvsb "" "NAME;PREFIX" "" ${ARGN})
 
+    # We don't want to use our own NuGet config when running in GitHub Actions
+    if(DEFINED ENV{CI})
+        return()
+    endif()
+
     if(NOT ${_pvsb_PREFIX}_SOURCE OR NOT ${_pvsb_PREFIX}_OWNER OR NOT ${_pvsb_PREFIX}_TOKEN)
         return()
     endif()

--- a/cmake/VcpkgToolchain.cmake
+++ b/cmake/VcpkgToolchain.cmake
@@ -2,17 +2,11 @@
 # unless you're doing something really special. Note that GitHub's package server requires an
 # access token with scope package:read for this to work... To make matters worse, if GitHub sees
 # the token in-repo, it will automatically revoke it... Grrr...
-set(_NUGET_SOURCE "https://nuget.pkg.github.com/H-uru/index.json")
-set(_NUGET_OWNER "H-uruMachineUser")
+set(PLASMA_NUGET_SOURCE "https://nuget.pkg.github.com/H-uru/index.json")
+set(PLASMA_NUGET_OWNER "H-uruMachineUser")
 # Python: print(*(ord(i) for i in token), sep=";")
-set(_NUGET_TOKEN_ASCII 103;104;112;95;100;111;87;99;122;56;49;97;76;101;110;122;82;116;119;112;80;49;97;87;72;107;71;57;103;51;110;100;100;112;52;69;57;88;73;48)
-string(ASCII ${_NUGET_TOKEN_ASCII} _NUGET_TOKEN)
-
-# You're not crazy. This is so we can read from the main package source and write to another one.
-set(PLASMA_VCPKG_NUGET_SOURCE "" CACHE INTERNAL "")
-set(PLASMA_VCPKG_NUGET_OWNER "" CACHE INTERNAL "")
-set(PLASMA_VCPKG_NUGET_TOKEN "" CACHE INTERNAL "")
-set(PLASMA_VCPKG_NUGET_RW FALSE CACHE INTERNAL "")
+set(_PLASMA_NUGET_TOKEN_ASCII 103;104;112;95;100;111;87;99;122;56;49;97;76;101;110;122;82;116;119;112;80;49;97;87;72;107;71;57;103;51;110;100;100;112;52;69;57;88;73;48)
+string(ASCII ${_PLASMA_NUGET_TOKEN_ASCII} PLASMA_NUGET_TOKEN)
 
 # Welcome to vcpkg-land. Population: Hoikas.
 # The goal here is that if cmake is being invoked with no arguments, we want to force usage of
@@ -30,47 +24,18 @@ endif()
 
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake" CACHE STRING "" FORCE)
 
-function(_plasma_vcpkg_generate_nuget_config)
-    cmake_parse_arguments(_pvgnc "" "OUT_FILE;NUGET_NAME;NUGET_SOURCE;NUGET_OWNER;NUGET_TOKEN" "" ${ARGN})
-    configure_file(
-        "${CMAKE_SOURCE_DIR}/NuGet.Config.in"
-        "${_pvgnc_OUT_FILE}"
-        @ONLY
-    )
-endfunction()
-
-function(_plasma_vcpkg_setup_binarycache)
-    cmake_parse_arguments(_pvsb "" "NAME;PREFIX" "" ${ARGN})
-
-    # We don't want to use our own NuGet config when running in GitHub Actions
-    if(DEFINED ENV{CI})
-        return()
-    endif()
-
-    if(NOT ${_pvsb_PREFIX}_SOURCE OR NOT ${_pvsb_PREFIX}_OWNER OR NOT ${_pvsb_PREFIX}_TOKEN)
-        return()
-    endif()
-
-    set(_CONFIG_PATH "${CMAKE_BINARY_DIR}/${_pvsb_NAME}-NuGet.Config")
-    _plasma_vcpkg_generate_nuget_config(
-        OUT_FILE ${_CONFIG_PATH}
-        NUGET_SOURCE ${${_pvsb_PREFIX}_SOURCE}
-        NUGET_OWNER ${${_pvsb_PREFIX}_OWNER}
-        NUGET_TOKEN ${${_pvsb_PREFIX}_TOKEN}
-    )
-
-    file(TO_NATIVE_PATH "${_CONFIG_PATH}" _CONFIG_PATH_NATIVE)
-    set(ENV{VCPKG_BINARY_SOURCES} "$ENV{VCPKG_BINARY_SOURCES};nugetconfig,${_CONFIG_PATH_NATIVE}")
-    if(${_pvsb_PREFIX}_RW)
-        set(ENV{VCPKG_BINARY_SOURCES} "$ENV{VCPKG_BINARY_SOURCES},readwrite")
-    endif()
-endfunction()
-
 # Binarycache can only be used on Windows or if mono is available.
 find_program(_VCPKG_MONO mono)
 if(_HOST_IS_WINDOWS OR EXISTS "${_VCPKG_MONO}")
-    _plasma_vcpkg_setup_binarycache(NAME mainline PREFIX _NUGET)
-    _plasma_vcpkg_setup_binarycache(NAME fork PREFIX PLASMA_VCPKG_NUGET)
+    set(_NUGET_CONFIG_PATH "${CMAKE_BINARY_DIR}/NuGet.Config")
+    configure_file(
+        "${CMAKE_SOURCE_DIR}/NuGet.Config.in"
+        "${_NUGET_CONFIG_PATH}"
+        @ONLY
+    )
+
+    file(TO_NATIVE_PATH "${_NUGET_CONFIG_PATH}" _NUGET_CONFIG_PATH_NATIVE)
+    set(ENV{VCPKG_BINARY_SOURCES} "$ENV{VCPKG_BINARY_SOURCES};nugetconfig,${_NUGET_CONFIG_PATH_NATIVE},read")
 endif()
 
 list(APPEND VCPKG_OVERLAY_PORTS "${CMAKE_SOURCE_DIR}/Scripts/Ports")


### PR DESCRIPTION
The NuGet.config file wasn't working reliably for uploading packages to GitHub's package registry during CI builds, in part because NuGet really wants you to use an API key instead (and those API keys are apparently encrypted in a machine-specific way). It also caused issues when building from forks because it would try to use the fork for all the packages instead of falling back to the H-uru repo.

So, now the NuGet.config file is only set up to read from the H-uru packages. This should (hypothetically) still allow anyone building on their own machine to grab the binaries from GPR automatically.

In CI, we manually configure NuGet credentials ahead of time, telling it to read/write from the current repository, but still allowing it to fall back to the NuGet.config file that allows reading from H-uru.