### PR TITLE
Fixes Yeesha Page 8 issues

### DIFF
--- a/Scripts/Python/clftYeeshaPage08.py
+++ b/Scripts/Python/clftYeeshaPage08.py
@@ -123,9 +123,7 @@ class clftYeeshaPage08(ptModifier):
         global isOpen
         
         if id == actClickableBook.id and state and PtWasLocallyNotified(self.key):
-            #if not PtIsDialogLoaded(DialogName):
-            #    PtLoadDialog(DialogName,self.key)
-
+            PtLoadDialog(DialogName,self.key)
             self.SetStdGUIVisibility(0)
             PtShowDialog(DialogName)
             RespOpen.run(self.key)


### PR DESCRIPTION
This fixes the issues noted in #1274 

Relto Pages in the rainy cleft before would sometimes have the holographic page show instead of the correct solid background.
It could also show the previous symbol used in addition to the holographic page.

This code in my testing fixed the issues.