### PR TITLE
Run macOS builds with vcpkg again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,8 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { str: macos-x64 }
+          #- { str: macos-arm64, arch: arm64, triplet: arm64 }
+          - { str: macos-x64, arch: x86_64, triplet: x64 }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -259,25 +260,45 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew bundle
+          brew install \
+              autoconf \
+              automake \
+              cairo \
+              libtool \
+              nasm \
+              qt@5
+
+      - name: Setup NuGet
+        run: |
+          nuget sources add \
+              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+              -storepasswordincleartext \
+              -name "GitHub" \
+              -username "${{ github.repository_owner }}" \
+              -password "${{ secrets.GITHUB_TOKEN }}"
+
+          nuget setapikey \
+              "${{ secrets.GITHUB_TOKEN }}" \
+              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
 
       - name: Configure
         run: |
           cmake \
             -G Xcode \
+            -DUSE_VCPKG=ON \
+            -DVCPKG_TARGET_TRIPLET="${{ matrix.platform.triplet}}-osx" \
+            -DVCPKG_OSX_ARCHITECTURES=${{ matrix.platform.arch }} \
+            -DVCPKG_OSX_DEPLOYMENT_TARGET=10.14 \
+            -DCMAKE_OSX_ARCHITECTURES=${{ matrix.platform.arch }} \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
             -DCMAKE_FIND_FRAMEWORK=LAST \
             -DPLASMA_BUILD_TESTS=ON \
             -DPLASMA_BUILD_TOOLS=ON \
             -DPLASMA_EXTERNAL_RELEASE=${{ matrix.cfg.external }} \
-            -DCURL_ROOT=$(brew --prefix curl) \
-            -Dexpat_ROOT=$(brew --prefix expat) \
-            -DJPEG_ROOT=$(brew --prefix jpeg-turbo) \
-            -DOpenAL_ROOT=$(brew --prefix openal-soft) \
-            -DOpenSSL_ROOT=$(brew --prefix openssl@1.1) \
-            -DPython3_ROOT=$(brew --prefix python@3.10) \
-            -DQt5_ROOT=$(brew --prefix qt@5) \
-            -DZLIB_ROOT=$(brew --prefix zlib) \
+            ${{ (matrix.platform.triplet == 'x64' && '-DQt5_ROOT=$(brew --prefix qt@5)') || '' }} \
             -S . -B build
+        env:
+          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
 
       - name: Build
         run: |


### PR DESCRIPTION
This sets up the workflow to do arm64 builds in the future, but they're disabled now because of issues getting python3 to build with vcpkg for arm64.

We originally moved from vcpkg to homebrew for macOS dependencies because of issues with vcpkg caching and slow build times when macOS had to recompile several large dependencies (PhysX, OpenSSL, Python, etc.) on every single build. With the caching fixed, these builds should run much more quickly now (after the first run), comparable to the runtime with homebrew dependencies.