### PR TITLE
Update script review workflow to latest versions

### DIFF
--- a/.github/workflows/scripts_review.yml
+++ b/.github/workflows/scripts_review.yml
@@ -1,4 +1,5 @@
 name: Scripts Review
+
 on:
   pull_request:
     paths:
@@ -13,9 +14,10 @@ jobs:
       PLASMA_PATH: ${{ github.workspace }}
     steps:
       - name: Checkout Plasma
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 


### PR DESCRIPTION
This avoids warnings about deprecation of node12 in GHA workflows.