### PR TITLE
Fix OpenSSL 3 deprecation warnings from plBigNum

### DIFF
--- a/Sources/Plasma/NucleusLib/pnEncryption/plBigNum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plBigNum.h
@@ -113,14 +113,6 @@ public:
         *remainder = (uint32_t)BN_div_word(m_number, b);
     }
 
-    void Div(const plBigNum& a, const plBigNum& b, plBigNum* remainder)
-    {
-        // this = a / b, remainder = a % b
-        // either this or remainder may be nullptr
-        BN_div(this ? m_number : nullptr, remainder ? remainder->m_number : nullptr,
-               a.m_number, b.m_number, GetContext());
-    }
-
     void FromData_BE(uint32_t bytess, const void* data)
     {
         BN_bin2bn((const uint8_t*)data, bytess, m_number);
@@ -133,9 +125,13 @@ public:
 
     bool IsPrime() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
         // Cyan's code uses 3 checks, so we'll follow suit.
         // This provides an accurate answer to p < 0.015625
         return BN_is_prime_fasttest_ex(m_number, 3, GetContext(), 1, nullptr) > 0;
+#else
+        return BN_check_prime(m_number, GetContext(), nullptr) > 0;
+#endif
     }
 
     void Mod(const plBigNum& a, const plBigNum& b)


### PR DESCRIPTION
The "fast" BigNum prime check function is deprecated in OpenSSL 3 because it apparently doesn't do a sufficient job of testing prime-ness. This newer method does it properly, which probably means it's slower, but probably not to a degree that it noticeably impacts performance (if this method is called at all, which it doesn't seem to be?).

Also, the `Div` method was complaining about a ternary that tested whether `this` was null, which isn't possible in well-defined C++ code. I tried to look at where this was being used to see how that could happen and it turns out the function wasn't being used at all, so I just removed it entirely.