### PR TITLE
Try to automatically init submodules with CMake

### DIFF
--- a/Sources/Tests/CMakeLists.txt
+++ b/Sources/Tests/CMakeLists.txt
@@ -1,3 +1,9 @@
+include(SubmoduleUtils)
+plasma_init_git_submodule("Sources/Tests/gtest" RESULT has_gtest_module)
+if(NOT has_gtest_module)
+    return()
+endif()
+
 # Why is this OFF by default?  It doesn't work with CMake's defaults, and
 # should really only be off if the project has specifically been set up to
 # use the static MSVC CRT

--- a/cmake/SubmoduleUtils.cmake
+++ b/cmake/SubmoduleUtils.cmake
@@ -1,0 +1,34 @@
+# Some optional dependencies are included as git submodule, and there's a
+# chance the repo wasn't cloned with submodules recursively. In that case, we
+# want to try to automatically initialize them.
+function(plasma_init_git_submodule MODULE)
+    cmake_parse_arguments(PARSE_ARGV 1 _pigs "" "RESULT" "")
+
+    if(EXISTS "${CMAKE_SOURCE_DIR}/${MODULE}/.git")
+        set(return_value TRUE)
+    else()
+        # First, we need to see if we have git available...
+        find_package(Git QUIET)
+
+        if(Git_FOUND)
+            execute_process(
+                COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${MODULE}
+                WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                RESULT_VARIABLE RETURNCODE
+            )
+
+            if(RETURNCODE)
+                set(return_value FALSE)
+            else()
+                set(return_value TRUE)
+            endif()
+        else()
+            message("Could not automatically initialize git submodule at ${MODULE}")
+            set(return_value FALSE)
+        endif()
+    endif()
+
+    if(_pigs_RESULT)
+        set(${_pigs_RESULT} ${return_value} PARENT_SCOPE)
+    endif()
+endfunction()

--- a/cmake/VcpkgToolchain.cmake
+++ b/cmake/VcpkgToolchain.cmake
@@ -22,6 +22,12 @@ if(NOT USE_VCPKG)
     return()
 endif()
 
+include(SubmoduleUtils)
+plasma_init_git_submodule("vcpkg" RESULT has_vcpkg_module)
+if(NOT has_vcpkg_module)
+    return()
+endif()
+
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake" CACHE STRING "" FORCE)
 
 # Binarycache can only be used on Windows or if mono is available.


### PR DESCRIPTION
This will hopefully allow people to just use Visual Studio to clone the main Plasma repo, and have it deal with git submodule initialization as part of the build process, rather than needing people to manually run a git command which clones submodules recursively.