### PR TITLE
Fixing timer not deallocating after reconnect

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -284,6 +284,7 @@ static void CheckedReconnect (CliGkConn * conn, ENetError error) {
         // Cancel all transactions in progress on this connection.
         NetTransCancelByConnId(conn->seq, kNetErrTimeout);
         // conn is dead.
+        conn->StopAutoReconnect();
         conn->UnRef("Lifetime");
         ReportNetError(kNetProtocolCli2GateKeeper, error);
     }


### PR DESCRIPTION
The reconnect timer prevents deallocation if a reconnect actually occurs. The reconnect timer removes the Gatekeeper connection from the connection list, preventing the timer for being stopped later.

When a reconnect event occurs, the refcount logging looks like:
Inc 0x600003b00000 Lifetime: 1
Inc 0x600003b00000 ReconnectTimer: 2
Inc 0x600003b00000 Connecting: 3
Dec 0x600003b00000 Connecting: 2
Inc 0x600003b00000 Connecting: 3
Dec 0x600003b00000 Connecting: 2
Inc 0x600003b00000 Connecting: 3
Dec 0x600003b00000 Connecting: 2
Inc 0x600003b00000 Connecting: 3
Dec 0x600003b00000 Connecting: 2
Inc 0x600003b00000 Connecting: 3
Dec 0x600003b00000 Lifetime: 2
Dec 0x600003b00000 Connecting: 1

(Where 0x600003b00000 is a plNGLGatekeeper instance.)

This logging is from plFilePatcher which is attempting to terminate, and waits for the connection counter to reach zero. plNGLGatekeeper never deallocates, so it never decrements the count.

ReconnectTimer is the function that is never releasing its hold on the object. This is because normally when plNGLGatekeeper shuts down, it iterates through the connection array and stops the timer on all of the connections. But when a connection fails, the connection is removed from the connection array until a connection can be re-established. If a connection is never re-established, the code will deadlock because the plNGLGatekeeper timer can never be stopped.

The solution is to manually end the reconnect timer if the timer function gives up.

I was reproducing this by invoking plFilePatcher in a directory that did not have a server.ini. This caused an instant connection failure.