### PR TITLE
Fix DX Pipeline externed global variables

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -1089,7 +1089,7 @@ PF_CONSOLE_CMD( Graphics, BumpW, "", "Set bump mapping method to cheapest availa
     pfConsole::GetPipeline()->SetDebugFlag(plPipeDbg::kFlagBumpW, true);
 }
 
-
+#ifdef PLASMA_PIPELINE_DX
 PF_CONSOLE_CMD( Graphics, AllowWBuffering, "", "Enables the use of w-buffering\n(w-buffering is disabled by default)." )
 {
     PF_SANITY_CHECK(pfConsole::GetPipeline() == nullptr, "This command MUST be used in an .ini file (before pipeline initialization)");
@@ -1111,6 +1111,7 @@ PF_CONSOLE_CMD( Graphics, ForceGeForce2Quality, "", "Forces higher-level hardwar
     fDbgSetupInitFlags |= 0x00000004;
     PrintString( "Hardware caps forced down to GeForce 2 level." );
 }
+#endif // PLASMA_PIPELINE_DX
 
 #endif // LIMIT_CONSOLE_COMMANDS
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -1240,10 +1240,12 @@ PF_CONSOLE_CMD( Graphics_Shadow,
                "...", 
                "Max shadowmap blur size." )
 {
-    extern float blurScale;
-    if( numParams > 0 )
-    {
-        blurScale = (float)atof( params[ 0 ] );
+    float blurScale;
+    if (numParams > 0) {
+        blurScale = strtof(params[0], nullptr);
+        plShadowMaster::SetGlobalMaxBlur(blurScale);
+    } else {
+        blurScale = plShadowMaster::GetGlobalMaxBlur();
     }
     pfConsolePrintF(PrintString, "Max shadowmap Blur {f}", blurScale);
 }

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
@@ -110,6 +110,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plGImage/plMipmap.h"
 #include "plGLight/plLightInfo.h"
 #include "plGLight/plShadowCaster.h"
+#include "plGLight/plShadowMaster.h"
 #include "plGLight/plShadowSlave.h"
 #include "plMessage/plDeviceRecreateMsg.h"
 #include "plResMgr/plLocalization.h"
@@ -10133,7 +10134,6 @@ const char  *plDXPipeline::IGetDXFormatName( D3DFORMAT format )
 
 
 
-float blurScale = -1.f;
 static  const int kL2NumSamples = 3; // Log2(4)
 
 // IBlurShadowMap //////////////////////////////////////////////////////////////////
@@ -11402,7 +11402,8 @@ bool plDXPipeline::IRenderShadowCaster(plShadowSlave* slave)
     }
 
     // Debug only.
-    if( blurScale >= 0.f )
+    float blurScale = plShadowMaster::GetGlobalMaxBlur();
+    if (blurScale >= 0.f)
         slave->fBlurScale = blurScale;
 
     // If this shadow requests being blurred, do it.

--- a/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.cpp
@@ -66,6 +66,7 @@ uint32_t plShadowMaster::fGlobalMaxSize = 512;
 float plShadowMaster::fGlobalMaxDist = 160.f; // PERSPTEST
 // float plShadowMaster::fGlobalMaxDist = 100000.f; // PERSPTEST
 float plShadowMaster::fGlobalVisParm = 1.f;
+float plShadowMaster::fGlobalMaxBlur = -1.f;
 
 void plShadowMaster::SetGlobalShadowQuality(float s) 
 { 

--- a/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.h
+++ b/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.h
@@ -74,19 +74,20 @@ public:
 
 protected:
     // Global clamp on shadow map size and stuff
-    static uint32_t                   fGlobalMaxSize;
-    static float                 fGlobalMaxDist;
-    static float                 fGlobalVisParm;
+    static uint32_t             fGlobalMaxSize;
+    static float                fGlobalMaxDist;
+    static float                fGlobalVisParm;
+    static float                fGlobalMaxBlur;
 
     // Constant parameter(s) for this master.
-    float                        fAttenDist;
-    float                        fMaxDist;
-    float                        fMinDist;
+    float                       fAttenDist;
+    float                       fMaxDist;
+    float                       fMinDist;
 
-    uint32_t                          fMaxSize;
-    uint32_t                          fMinSize;
+    uint32_t                    fMaxSize;
+    uint32_t                    fMinSize;
 
-    float                        fPower;
+    float                       fPower;
 
     // Temp data used for one frame and recycled.
     hsPoolVector<std::unique_ptr<plShadowSlave>> fSlavePool;
@@ -166,6 +167,9 @@ public:
 
     static void SetGlobalShadowQuality(float s);
     static float GetGlobalShadowQuality() { return fGlobalVisParm; }
+
+    static void SetGlobalMaxBlur(float s) { fGlobalMaxBlur = s; }
+    static float GetGlobalMaxBlur() { return fGlobalMaxBlur; }
 };
 
 


### PR DESCRIPTION
There are two global variables defined in plDXPipeline that are used by the Console.

* One is the maximum blur scale for shadows. There are already several configurable values in plShadowMaster, so I've just added this as another value there so it has a proper home instead of being referenced via extern.

* The other is a debug flag that restricts the rendering capabilities of the DirectX pipeline to that of a GeForce 2 card. This seems pretty DirectX-specific, so I opted to just wrap the console commands in `#ifdef` so that they are only enabled when the DX pipeline is enabled (and thus the externed variable is defined).

These were showing up as linker when I tried to compile a Linux build with plGLPipeline, because they were referenced from the console commands.

/cc @colincornaby because I saw you had to declare these in plMetalPipeline too, even though they serve no purpose there.