### PR TITLE
Moving Keychain integration off deprecated APIs

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
@@ -61,13 +61,13 @@ ST::string pfApplePasswordStore::GetPassword(const ST::string& username)
     CFAutorelease(accountName);
     CFAutorelease(serviceName);
     
-    const void *keys[] = { kSecClass, kSecAttrAccount, kSecAttrService, kSecReturnData };
-    const void *values[] = { kSecClassGenericPassword, accountName, serviceName, kCFBooleanTrue };
+    const void* keys[] = { kSecClass, kSecAttrAccount, kSecAttrService, kSecReturnData };
+    const void* values[] = { kSecClassGenericPassword, accountName, serviceName, kCFBooleanTrue };
     
     CFDictionaryRef query = CFDictionaryCreate(nullptr, keys, values, 4, nullptr, nullptr);
     CFDataRef result;
 
-    if (SecItemCopyMatching(query, (CFTypeRef *) &result) != errSecSuccess)
+    if (SecItemCopyMatching(query, (CFTypeRef*)&result) != errSecSuccess)
     {
         return ST::string();
     }
@@ -89,8 +89,8 @@ bool pfApplePasswordStore::SetPassword(const ST::string& username, const ST::str
     CFAutorelease(accountName);
     CFAutorelease(serviceName);
     
-    const void *keys[] = { kSecClass, kSecAttrService, kSecReturnData };
-    const void *values[] = { kSecClassGenericPassword, serviceName, kCFBooleanTrue };
+    const void* keys[] = { kSecClass, kSecAttrService, kSecReturnData };
+    const void* values[] = { kSecClassGenericPassword, serviceName, kCFBooleanTrue };
     
     CFDictionaryRef query = CFDictionaryCreate(nullptr, keys, values, 3, nullptr, nullptr);
     SecItemAdd(query, nullptr);

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
@@ -54,26 +54,25 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 ST::string pfApplePasswordStore::GetPassword(const ST::string& username)
 {
     ST::string service = GetServerDisplayName();
+    
+    CFStringRef accountName = CFStringCreateWithCString(nullptr, username.c_str(), kCFStringEncodingUTF8);
+    CFStringRef serviceName = CFStringCreateWithCString(nullptr, service.c_str(), kCFStringEncodingUTF8);
+    
+    const void *keys[] = { kSecClass, kSecAttrAccount, kSecAttrService, kSecReturnData };
+    const void *values[] = { kSecClassGenericPassword, accountName, serviceName, kCFBooleanTrue };
+    
+    CFDictionaryRef query = CFDictionaryCreate(nullptr, keys, values, 4, nullptr, nullptr);
+    CFDataRef result;
 
-    void* passwd = nullptr;
-    uint32_t passwd_len = 0;
-
-    if (SecKeychainFindGenericPassword(nullptr,
-                                       service.size(),
-                                       service.c_str(),
-                                       username.size(),
-                                       username.c_str(),
-                                       &passwd_len,
-                                       &passwd,
-                                       nullptr) != errSecSuccess)
+    if (SecItemCopyMatching(query, (CFTypeRef *) &result) != errSecSuccess)
     {
         return ST::string();
     }
-
-    ST::string ret(reinterpret_cast<const char*>(passwd), size_t(passwd_len));
-
-    SecKeychainItemFreeContent(nullptr, passwd);
-
+    
+    ST::string ret(reinterpret_cast<const char*>(CFDataGetBytePtr(result)), size_t(CFDataGetLength(result)));
+    
+    CFRelease(result);
+    
     return ret;
 }
 
@@ -81,14 +80,15 @@ bool pfApplePasswordStore::SetPassword(const ST::string& username, const ST::str
 {
     ST::string service = GetServerDisplayName();
     
-    OSStatus err = SecKeychainAddGenericPassword(nullptr,
-                                                service.size(),
-                                                service.c_str(),
-                                                username.size(),
-                                                username.c_str(),
-                                                password.size(),
-                                                password.c_str(),
-                                                nullptr);
+    CFStringRef accountName = CFStringCreateWithCString(nullptr, username.c_str(), kCFStringEncodingUTF8);
+    CFStringRef serviceName = CFStringCreateWithCString(nullptr, service.c_str(), kCFStringEncodingUTF8);
+    
+    const void *keys[] = { kSecClass, kSecAttrService, kSecReturnData };
+    const void *values[] = { kSecClassGenericPassword, serviceName, kCFBooleanTrue };
+    
+    CFDictionaryRef query = CFDictionaryCreate(nullptr, keys, values, 3, nullptr, nullptr);
+    SecItemAdd(query, nullptr);
+    OSStatus err = SecItemAdd(query, nullptr);
     if (err == errSecDuplicateItem) {
         // the keychain item already exists, update it
         CFStringRef cfUsername = CFStringCreateWithCString(nullptr, username.c_str(), kCFStringEncodingUTF8);

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
@@ -55,8 +55,11 @@ ST::string pfApplePasswordStore::GetPassword(const ST::string& username)
 {
     ST::string service = GetServerDisplayName();
     
-    CFStringRef accountName = CFStringCreateWithCString(nullptr, username.c_str(), kCFStringEncodingUTF8);
-    CFStringRef serviceName = CFStringCreateWithCString(nullptr, service.c_str(), kCFStringEncodingUTF8);
+    CFStringRef accountName = CFStringCreateWithCStringNoCopy(nullptr, username.c_str(), kCFStringEncodingUTF8, nullptr);
+    CFStringRef serviceName = CFStringCreateWithCStringNoCopy(nullptr, service.c_str(), kCFStringEncodingUTF8, nullptr);
+    
+    CFAutorelease(accountName);
+    CFAutorelease(serviceName);
     
     const void *keys[] = { kSecClass, kSecAttrAccount, kSecAttrService, kSecReturnData };
     const void *values[] = { kSecClassGenericPassword, accountName, serviceName, kCFBooleanTrue };
@@ -80,8 +83,11 @@ bool pfApplePasswordStore::SetPassword(const ST::string& username, const ST::str
 {
     ST::string service = GetServerDisplayName();
     
-    CFStringRef accountName = CFStringCreateWithCString(nullptr, username.c_str(), kCFStringEncodingUTF8);
-    CFStringRef serviceName = CFStringCreateWithCString(nullptr, service.c_str(), kCFStringEncodingUTF8);
+    CFStringRef accountName = CFStringCreateWithCStringNoCopy(nullptr, username.c_str(), kCFStringEncodingUTF8, nullptr);
+    CFStringRef serviceName = CFStringCreateWithCStringNoCopy(nullptr, service.c_str(), kCFStringEncodingUTF8, nullptr);
+    
+    CFAutorelease(accountName);
+    CFAutorelease(serviceName);
     
     const void *keys[] = { kSecClass, kSecAttrService, kSecReturnData };
     const void *values[] = { kSecClassGenericPassword, serviceName, kCFBooleanTrue };

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
@@ -65,6 +65,8 @@ ST::string pfApplePasswordStore::GetPassword(const ST::string& username)
     const void* values[] = { kSecClassGenericPassword, accountName, serviceName, kCFBooleanTrue };
     
     CFDictionaryRef query = CFDictionaryCreate(nullptr, keys, values, 4, nullptr, nullptr);
+    CFAutorelease(query);
+    
     CFDataRef result;
 
     if (SecItemCopyMatching(query, (CFTypeRef*)&result) != errSecSuccess)
@@ -93,8 +95,10 @@ bool pfApplePasswordStore::SetPassword(const ST::string& username, const ST::str
     const void* values[] = { kSecClassGenericPassword, serviceName, kCFBooleanTrue };
     
     CFDictionaryRef query = CFDictionaryCreate(nullptr, keys, values, 3, nullptr, nullptr);
-    SecItemAdd(query, nullptr);
+    CFAutorelease(query);
+    
     OSStatus err = SecItemAdd(query, nullptr);
+    
     if (err == errSecDuplicateItem) {
         // the keychain item already exists, update it
         CFStringRef cfUsername = CFStringCreateWithCString(nullptr, username.c_str(), kCFStringEncodingUTF8);
@@ -115,7 +119,6 @@ bool pfApplePasswordStore::SetPassword(const ST::string& username, const ST::str
         err = SecItemUpdate(query, attributes);
         
         CFRelease(attributes);
-        CFRelease(query);
     }
 
     return err == errSecSuccess;


### PR DESCRIPTION
This moves the Apple Keychain integration onto the supported APIs and off the deprecated ones. The APIs we use were deprecated in 10.10, and the replacement APIs were added in 10.6. The SecItem class APIs replace the SecKeychain class APIs. Note that we were already using one SecItem API - so this code already required 10.6.

The deprecated API was producing warnings so this will clean those up.