### PR TITLE
Replace last uses of MSVC-specific `_DEBUG` with `HS_DEBUGGING`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ option(PRODUCT_EMBED_BUILD_INFO "Embed build revision information into plProduct
 cmake_dependent_option(PRODUCT_EMBED_BUILD_TIME "Embed build time into plProduct" ON [[PRODUCT_EMBED_BUILD_INFO]] OFF)
 
 # HeadSpin Configuration
+
+# Define HS_DEBUGGING for debug builds
+add_compile_definitions($<$<CONFIG:Debug>:HS_DEBUGGING>)
+
 if(WIN32 AND NOT CYGWIN)
     add_definitions(-DHS_BUILD_FOR_WIN32)
 endif(WIN32 AND NOT CYGWIN)

--- a/Sources/Plasma/Apps/plPageOptimizer/main.cpp
+++ b/Sources/Plasma/Apps/plPageOptimizer/main.cpp
@@ -60,12 +60,12 @@ int main(int argc, char* argv[])
     plFileName filename = argv[1];
     ST::printf("Optimizing {}...", filename);
 
-#ifndef _DEBUG
+#ifndef HS_DEBUGGING
     try {
 #endif
         plResManager* resMgr = new plResManager;
         hsgResMgr::Init(resMgr);
-#ifndef _DEBUG
+#ifndef HS_DEBUGGING
     } catch (std::exception &e) {
         printf(" ***crashed on init: %s\n", e.what());
         return 2;
@@ -75,14 +75,14 @@ int main(int argc, char* argv[])
     }
 #endif
 
-#ifndef _DEBUG
+#ifndef HS_DEBUGGING
     try
 #endif
     {
         plPageOptimizer optimizer(argv[1]);
         optimizer.Optimize();
     }
-#ifndef _DEBUG
+#ifndef HS_DEBUGGING
     catch (std::exception &e) {
         printf(" ***crashed on optimizing: %s\n", e.what());
         return 2;
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
     }
 #endif
 
-#ifndef _DEBUG
+#ifndef HS_DEBUGGING
     try {
 #endif
         // Reading in objects may have generated dirty state which we're obviously
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
         plSynchedObject::ClearDirtyState(carryOvers);
 
         hsgResMgr::Shutdown();
-#ifndef _DEBUG
+#ifndef HS_DEBUGGING
     } catch (std::exception &e) {
         printf(" ***crashed on shutdown: %s\n", e.what());
         return 2;

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -45,10 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // Ensure these get set consistently regardless of what module includes it
 #include "hsConfig.h"
 
-#if defined(_DEBUG)
-#   define HS_DEBUGGING
-#endif
-
 //======================================
 // Some standard includes
 //======================================

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.h
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.h
@@ -253,7 +253,7 @@ protected:
 
 };
 
-//#ifdef _DEBUG
+//#ifdef HS_DEBUGGING
 //#define TRACK_AG_ALLOCS       // for now, automatically track AG allocations in debug
 //#endif
 #ifdef TRACK_AG_ALLOCS

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
@@ -145,7 +145,7 @@ plAvBrainHuman::plAvBrainHuman(bool isActor /* = false */) :
 
 bool plAvBrainHuman::Apply(double timeNow, float elapsed)
 {
-#ifndef _DEBUG
+#ifndef HS_DEBUGGING
     try
     {
 #endif
@@ -156,7 +156,7 @@ bool plAvBrainHuman::Apply(double timeNow, float elapsed)
         fWalkingStrategy->RecalcVelocity(timeNow, elapsed, (fPreconditions & plHBehavior::kBehaviorTypeNeedsRecalcMask));
 
         plArmatureBrain::Apply(timeNow, elapsed);
-#ifndef _DEBUG
+#ifndef HS_DEBUGGING
     } catch (std::exception &e) {
         plStatusLog *log = plAvatarMgr::GetInstance()->GetLog();
         log->AddLineF("plAvBrainHuman::Apply - exception caught: {}", e.what());

--- a/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
@@ -154,7 +154,7 @@ public:
 
     bool  EatPage(plRegistryPageNode *pageNode) override
     {
-#ifndef _DEBUG
+#ifndef HS_DEBUGGING
         try
         {
 #endif
@@ -170,7 +170,7 @@ public:
                 if( !pageNode->IterateKeys( this ) )
                     return false;
             }
-#ifndef _DEBUG
+#ifndef HS_DEBUGGING
         } catch (...)
         {
         }

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -1,15 +1,3 @@
-# Detect Clang compiler
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
-    set(CMAKE_COMPILER_IS_CLANGXX 1)
-endif()
-
-# MSVC automatically defines -D_DEBUG when /MTd or /MDd is set, so we
-# need to make sure it gets added for other compilers too
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
-endif()
-
 # Use LTCG if available.
 cmake_policy(SET CMP0069 NEW)   # gtest projects use old cmake compatibility...
 if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)

--- a/cmake/FindPhysX.cmake
+++ b/cmake/FindPhysX.cmake
@@ -225,6 +225,16 @@ macro(_find_physx_library SUFFIX)
                 INTERFACE_LINK_LIBRARIES ${_fpl_INTERFACE_LIBS}
             )
         endif()
+
+        # The PhysX headers require that either _DEBUG or NDEBUG is always
+        # defined (but not both at once), otherwise they produce an error.
+        # For release builds, NDEBUG is always automatically defined
+        # (either by CMake and/or the compilers).
+        # For debug builds, _DEBUG is automatically defined by MSVC,
+        # but for other compilers we need to define it ourselves.
+        target_compile_definitions(${TARGET} INTERFACE
+            $<$<AND:$<CONFIG:Debug>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:_DEBUG>
+        )
     endif()
 
     unset(TARGET)


### PR DESCRIPTION
This allows removing some compiler-specific CMake code.