### PR TITLE
Guard against invalid data when reading vault nodes

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -59,7 +59,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 # pragma message("Compiling pnNetCli with debugging on")
 # define NCCLI_LOG  LogMsg
 #else
-# define NCCLI_LOG  LogMsg
+# define NCCLI_LOG(...) ((void)0)
 #endif
 
 #if !defined(PLASMA_EXTERNAL_RELEASE) && defined(HS_BUILD_FOR_WIN32)

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -54,9 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <mutex>
 #include <string>
 
-//#define NCCLI_DEBUGGING
-#ifdef NCCLI_DEBUGGING
-# pragma message("Compiling pnNetCli with debugging on")
+#ifdef HS_DEBUGGING
 # define NCCLI_LOG  LogMsg
 #else
 # define NCCLI_LOG(...) ((void)0)

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
@@ -288,7 +288,7 @@ public:
 
     bool Matches(const NetVaultNode* rhs) const;
 
-    void Read(const uint8_t* buf, size_t size);
+    bool Read(const uint8_t* buf, size_t bufsz);
     void Write(std::vector<uint8_t>* buf, uint32_t ioFlags=0);
 
 protected:

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -3479,7 +3479,12 @@ bool VaultFetchNodeTrans::Recv (
     
     if (IS_NET_SUCCESS(reply.result)) {
         m_node.Steal(new NetVaultNode);
-        m_node->Read(reply.nodeBuffer, reply.nodeBytes);
+        if (!m_node->Read(reply.nodeBuffer, reply.nodeBytes)) {
+            LogMsg(kLogError, "VaultFetchNodeTrans::Recv: Invalid vault node data - most likely a length field is incorrect");
+            m_result = kNetErrBadServerData;
+            m_state = kTransStateComplete;
+            return true;
+        }
     }
 
     m_result = reply.result;


### PR DESCRIPTION
Previously the game crashed when reading truncated vault node data.

I implemented these checks in a similar way as in the other `IRead*` functions further up in pnNpCommon. Perhaps these two sets of functions should be merged... Or maybe all of these functions should be replaced with `hsReadOnlyStream`/`hsRAMStream`? (Most of the `hsStream::Read*` methods don't really handle truncated data either, but at least they don't crash right away.)