### PR TITLE
More bug fixes for Apple password store

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore_Apple.cpp
@@ -91,6 +91,7 @@ bool pfApplePasswordStore::SetPassword(const ST::string& username, const ST::str
     
     CFAutorelease(accountName);
     CFAutorelease(serviceName);
+    CFAutorelease(passwordData);
     
     const void* keys[] = { kSecClass, kSecAttrService, kSecReturnData, kSecValueData };
     const void* values[] = { kSecClassGenericPassword, serviceName, kCFBooleanTrue, passwordData };


### PR DESCRIPTION
- Default arguments to CFStringCreateWithCStringNoCopy deallocate the source buffer on dealloc. kCFAllocatorNull prevents this.
- Creating only on set of CF ojbects in SetPassword.
- SetPassword wasn’t setting the password data on the initial store.