### PR TITLE
Fix mis-encoded text when starting chat with a non-ASCII character

### DIFF
--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -174,7 +174,7 @@ class xKIChat(object):
             if not KIMini.dialog.isEnabled():
                 self.ClearBBMini(0)
             if firstChar:
-                chatEdit.setString(firstChar)
+                chatEdit.setStringW(firstChar)
                 chatEdit.end()
             else:
                 chatEdit.clearString()


### PR DESCRIPTION
To reproduce:

1. Use a keyboard layout with non-ASCII keys
2. Have "Start Chat" not mapped to anything in the Key Map
3. Be in-game without chat open
4. Start chatting by pressing a non-ASCII key

Without this fix, the first character was incorrectly re-encoded from UTF-8 to Latin 1 (e. g. "ä" became "Ã¤").