### PR TITLE
Add Video Selector buttons for Video Options Menu GUI

### DIFF
--- a/Scripts/Python/xOptionsMenu.py
+++ b/Scripts/Python/xOptionsMenu.py
@@ -1002,7 +1002,7 @@ class xOptionsMenu(ptModifier):
                             gCurrentMovieName = gLiveMovieList[len(gLiveMovieList)-1]
                         else:
                             gCurrentMovieName = gLiveMovieList[tempIndex]
-                        gLiveMovie = ptMoviePlayer(f'{kLiveMovieDir}\{gCurrentMovieName}',self.key)
+                        gLiveMovie = ptMoviePlayer(os.path.join(kLiveMovieDir, gCurrentMovieName),self.key)
                         gLiveMovie.play()
                 elif tpID == kTrailerNextButton:
                     if gLiveMovie:
@@ -1012,7 +1012,7 @@ class xOptionsMenu(ptModifier):
                             gCurrentMovieName = gLiveMovieList[0]
                         else:
                             gCurrentMovieName = gLiveMovieList[tempIndex]
-                        gLiveMovie = ptMoviePlayer(f'{kLiveMovieDir}\{gCurrentMovieName}',self.key)
+                        gLiveMovie = ptMoviePlayer(os.path.join(kLiveMovieDir, gCurrentMovieName),self.key)
                         gLiveMovie.play()
                 elif tpID == kClickOnMeBtn:
                     if gLiveMovie:
@@ -1405,7 +1405,8 @@ class xOptionsMenu(ptModifier):
                 else:
                     gLiveMovieList = []
                     for file in os.listdir(kLiveMovieDir):
-                        if os.stat(f'{kLiveMovieDir}\{file}').st_size > 1000 and os.path.splitext(f'{kLiveMovieDir}\{file}')[1] == ".webm":
+                        tempfile = os.path.join(kLiveMovieDir, file)
+                        if os.stat(tempfile).st_size > 1000 and os.path.splitext(tempfile)[1] == ".webm":
                             gLiveMovieList.append(file)
                     else:
                         if gLiveMovieList == []:
@@ -1440,7 +1441,7 @@ class xOptionsMenu(ptModifier):
                 gLiveMovie = ptMoviePlayer(kDemoMovieName,self.key)
             else:
                 gCurrentMovieName = gLiveMovieList[0]
-                gLiveMovie = ptMoviePlayer(f'{kLiveMovieDir}\{gCurrentMovieName}',self.key)
+                gLiveMovie = ptMoviePlayer(os.path.join(kLiveMovieDir, gCurrentMovieName),self.key)
             gLiveMovie.playPaused()
         elif id == kTrailerFadeInID:
             PtDebugPrint("xLiveTrailer - roll the movie",level=kDebugDumpLevel)
@@ -1473,7 +1474,7 @@ class xOptionsMenu(ptModifier):
 
     def OnMovieEvent(self,movieName,reason):
         PtDebugPrint("xLiveTrailer: got movie done event on %s, reason=%d" % (movieName,reason),level=kDebugDumpLevel)
-        if gLiveMovie and movieName == f'{kLiveMovieDir}\{gCurrentMovieName}':
+        if gLiveMovie and movieName == os.path.join(kLiveMovieDir, gCurrentMovieName):
             PtFadeOut(kTrailerFadeOutSeconds,1)
             PtAtTimeCallback(self.key, kTrailerFadeOutSeconds, kTrailerFadeOutID)
 

--- a/Scripts/Python/xOptionsMenu.py
+++ b/Scripts/Python/xOptionsMenu.py
@@ -1406,7 +1406,7 @@ class xOptionsMenu(ptModifier):
                     gLiveMovieList = []
                     for file in os.listdir(kLiveMovieDir):
                         tempfile = os.path.join(kLiveMovieDir, file)
-                        if os.stat(tempfile).st_size > 1000 and os.path.splitext(tempfile)[1] == ".webm":
+                        if os.stat(tempfile).st_size > 1000 and tempfile.endswith(".webm"):
                             gLiveMovieList.append(file)
                     else:
                         if gLiveMovieList == []:

--- a/Scripts/Python/xOptionsMenu.py
+++ b/Scripts/Python/xOptionsMenu.py
@@ -1403,7 +1403,13 @@ class xOptionsMenu(ptModifier):
                 if PtIsDemoMode():
                     os.stat(kDemoMovieName)
                 else:
-                    os.listdir(kLiveMovieDir)[0]
+                    gLiveMovieList = []
+                    for file in os.listdir(kLiveMovieDir):
+                        if os.stat(f'{kLiveMovieDir}\{file}').st_size > 1000 and os.path.splitext(f'{kLiveMovieDir}\{file}')[1] == ".webm":
+                            gLiveMovieList.append(file)
+                    else:
+                        if gLiveMovieList == []:
+                            raise TypeError('No webm found')
                 # its there! show the background, which will start the movie
                 # just continue processing
             except:
@@ -1433,10 +1439,6 @@ class xOptionsMenu(ptModifier):
             if PtIsDemoMode():
                 gLiveMovie = ptMoviePlayer(kDemoMovieName,self.key)
             else:
-                gLiveMovieList = []
-                for file in os.listdir(kLiveMovieDir):
-                    if os.stat(f'{kLiveMovieDir}\{file}').st_size > 1000:
-                        gLiveMovieList.append(file)
                 gCurrentMovieName = gLiveMovieList[0]
                 gLiveMovie = ptMoviePlayer(f'{kLiveMovieDir}\{gCurrentMovieName}',self.key)
             gLiveMovie.playPaused()


### PR DESCRIPTION
PRP and other required files - https://github.com/H-uru/moul-assets/pull/206

Adds code for two new buttons in Trailer GUI
First video in AVI directory is now first video played
Ignores any videos smaller than 1000 bytes
Videos will loop if you keep clicking buttons
GUI will exit when video is over (retains previous behaviour)