### PR TITLE
Fix potentially catastrophic Age init errors related to being alone.

### DIFF
--- a/Scripts/Python/ahnyPressurePlates.py
+++ b/Scripts/Python/ahnyPressurePlates.py
@@ -105,7 +105,7 @@ class ahnyPressurePlates(ptModifier):
         ageSDL.sendToClients(SDLOccupied.value)
         ageSDL.setNotify(self.key,SDLOccupied.value,0.0)
 
-        if not len(PtGetPlayerList()):
+        if PtIsSolo():
             ageSDL[SDLOccupied.value] = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
 
 

--- a/Scripts/Python/ercaHrvstr.py
+++ b/Scripts/Python/ercaHrvstr.py
@@ -268,7 +268,7 @@ class ercaHrvstr(ptResponder):
         
         
         ## if other players are already in the age, don't pre-set the Harvester
-        if len(PtGetPlayerList()):
+        if not PtIsSolo():
             if boolDrvLev:
                 RespDrvLevDwnOnInit.run(self.key,fastforward=1)
             if boolCarLev:

--- a/Scripts/Python/ercaOvenScope.py
+++ b/Scripts/Python/ercaOvenScope.py
@@ -207,7 +207,7 @@ class ercaOvenScope(ptModifier):
     def Load(self):
         global boolScopeOperated
 
-        solo = not PtGetPlayerList()
+        solo = PtIsSolo()
 
         boolOperated = self.SDL["boolOperated"][0]
         if boolOperated:

--- a/Scripts/Python/ercaPelletRoom.py
+++ b/Scripts/Python/ercaPelletRoom.py
@@ -282,14 +282,14 @@ class ercaPelletRoom(ptResponder):
             if boolMachine:
                 PtDebugPrint("We shouldn't get here.  Just in case some states got hosed.")
                 RespMachineMode.run(self.key,state="Close",fastforward=1)
-                if not len(PtGetPlayerList()):
+                if PtIsSolo():
                     ageSDL[SDLMachine.value] = (0,)
                     ageSDL[SDLChamber.value] = (0,)
                 boolMachine = 0
                 byteChamber = 0
             else:
                 RespMachineMode.run(self.key,state="Close",fastforward=1)
-                if not len(PtGetPlayerList()):
+                if PtIsSolo():
                     ageSDL[SDLChamber.value] = (0,)
                 byteChamber = 0
 
@@ -581,7 +581,7 @@ class ercaPelletRoom(ptResponder):
             elif byteChamber == 5:
                 ageSDL[SDLPellet5.value] = (0,)
                 RespHidePellet.run(self.key,state="pellet5")
-                if LastPellet or not len(PtGetPlayerList()):
+                if LastPellet or PtIsSolo():
                     ageSDL[SDLMachine.value] = (0,)
                     LastPellet = 0
         

--- a/Scripts/Python/grsnNexusBookMachine.py
+++ b/Scripts/Python/grsnNexusBookMachine.py
@@ -106,7 +106,7 @@ class grsnNexusBookMachine(ptResponder):
 
     def OnServerInitComplete(self):
         bookPillarSpinning.run(self.key,netPropagate=False)
-        if PtGetPlayerList():
+        if not PtIsSolo():
             return
         resetResponder.run(self.key,avatar=PtGetLocalAvatar())
 

--- a/Scripts/Python/grsnTrnCtrDoors.py
+++ b/Scripts/Python/grsnTrnCtrDoors.py
@@ -87,8 +87,7 @@ class grsnTrnCtrDoors(ptResponder):
         PtDebugPrint("grsnTrnCtrDoors: self.SDL = %d" % self.grsnDoorState)
         PtDebugPrint("grsnTrnCtrDoors: Player List = %d" % len(PtGetPlayerList()))
 
-        if len(PtGetPlayerList()) > 0:
-            
+        if not PtIsSolo():
             PtDebugPrint("grsnTrnCtrDoors: Somebody is already in the age. Attempting to sync states.")
 
             if self.grsnDoorState == doorSDLstates['open'] or self.grsnDoorState == doorSDLstates['opening']:
@@ -104,7 +103,7 @@ class grsnTrnCtrDoors(ptResponder):
             else:
                 PtDebugPrint("grsnTrnCtrDoors: Exception. Door State = %d" % self.grsnDoorState)
 
-        elif len(PtGetPlayerList()) < 1:
+        else:
             # the door is really shut, someone left it open
             self.SDL['grsnDoorState'] = (doorSDLstates['closed'],)
             self.grsnDoorState = self.SDL['grsnDoorState'][0]

--- a/Scripts/Python/grsnWallImagerDisplayN.py
+++ b/Scripts/Python/grsnWallImagerDisplayN.py
@@ -68,7 +68,7 @@ class grsnWallImagerDisplayN(ptResponder):
         
         ageSDL.setNotify(self.key, "nState", 0.0)
         
-        if PtGetPlayerList() and ageSDL["nState"] >= kWait:
+        if not PtIsSolo() and ageSDL["nState"] >= kWait:
             for blocker in ageSDL["northWall"]:
                 if(blocker == -1):
                     return

--- a/Scripts/Python/grsnWallImagerDisplayS.py
+++ b/Scripts/Python/grsnWallImagerDisplayS.py
@@ -68,7 +68,7 @@ class grsnWallImagerDisplayS(ptResponder):
         
         ageSDL.setNotify(self.key, "sState", 0.0)
         
-        if PtGetPlayerList() and ageSDL["sState"] >= kWait:
+        if not PtIsSolo() and ageSDL["sState"] >= kWait:
             for blocker in ageSDL["southWall"]:
                 if(blocker == -1):
                     return

--- a/Scripts/Python/grsnWallPython.py
+++ b/Scripts/Python/grsnWallPython.py
@@ -290,7 +290,7 @@ class grsnWallPython(ptResponder):
 
     def OnServerInitComplete(self):
         PtDebugPrint("grsnWallPython::OnServerInitComplete")
-        solo = not PtGetPlayerList()
+        solo = PtIsSolo()
         ageSDL = PtGetAgeSDL()
 
         #Prepare SDLs (n-North, s-South)
@@ -390,7 +390,7 @@ class grsnWallPython(ptResponder):
                 else:
                     self.ChangeGameState(kNorth, kWait)
                     NorthPanelSound.run(self.key, state='gameStart')
-                    if not PtGetPlayerList():
+                    if PtIsSolo():
                         self.ChangeGameState(kSouth, kWait)
             return
         if (id == goButtonSouth.id and not state):
@@ -407,7 +407,7 @@ class grsnWallPython(ptResponder):
                 else:
                     self.ChangeGameState(kSouth, kWait)
                     SouthPanelSound.run(self.key, state='gameStart')
-                    if not PtGetPlayerList():
+                    if PtIsSolo():
                         self.ChangeGameState(kNorth, kWait)
             return
         ### Tube open Animation Finished ###
@@ -475,13 +475,13 @@ class grsnWallPython(ptResponder):
         if (id == readyButtonNorth.id and not state and ageSDL["nState"][0] == kSelectCount):
             self.ChangeGameState(kNorth, kSetBlocker)
             NorthPanelSound.run(self.key, state='up')
-            if not PtGetPlayerList():
+            if PtIsSolo():
                 self.ChangeGameState(kSouth, kSetBlocker)
             return
         if (id == readyButtonSouth.id and not state and ageSDL["sState"][0] == kSelectCount):
             self.ChangeGameState(kSouth, kSetBlocker)
             SouthPanelSound.run(self.key, state='up')
-            if not PtGetPlayerList():
+            if PtIsSolo():
                 self.ChangeGameState(kNorth, kSetBlocker)
             return
         ### Tube Entry trigger ###
@@ -576,7 +576,7 @@ class grsnWallPython(ptResponder):
         if (id == NorthTeamWin.id):
             if (PtFindAvatar(events) == PtGetLocalAvatar()):
                 PtAtTimeCallback(self.key, 3.0, kLinkToNorthNexus)
-                if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["nState"][0] != kEnd and PtGetPlayerList()):
+                if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["nState"][0] != kEnd and not PtIsSolo()):
                     avatar = PtGetLocalAvatar()
                     currentgender = avatar.avatar.getAvatarClothingGroup()
                     if currentgender == kFemaleClothingGroup:
@@ -601,7 +601,7 @@ class grsnWallPython(ptResponder):
         if (id == SouthTeamWin.id):
             if (PtFindAvatar(events) == PtGetLocalAvatar()):
                 PtAtTimeCallback(self.key, 3.0, kLinkToSouthNexus)
-                if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["sState"][0] != kEnd and PtGetPlayerList()):
+                if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["sState"][0] != kEnd and not PtIsSolo()):
                     avatar = PtGetLocalAvatar()
                     currentgender = avatar.avatar.getAvatarClothingGroup()
                     if currentgender == kFemaleClothingGroup:
@@ -676,9 +676,9 @@ class grsnWallPython(ptResponder):
                     except:
                         PtDebugPrint("grsnWallPython::OnNotify: Blocker not found on either panel")
                         return
-                if ((team == kNorth or not PtGetPlayerList()) and ageSDL["nState"][0] == kSetBlocker):
+                if ((team == kNorth or PtIsSolo()) and ageSDL["nState"][0] == kSetBlocker):
                     self.SetPanelBlocker(kNorth, index, not self.FindBlocker(kNorth, index), eventAvatar=PtFindAvatar(events))
-                if ((team == kSouth or not PtGetPlayerList()) and ageSDL["sState"][0] == kSetBlocker):
+                if ((team == kSouth or PtIsSolo()) and ageSDL["sState"][0] == kSetBlocker):
                     self.SetPanelBlocker(kSouth, index, not self.FindBlocker(kSouth, index), eventAvatar=PtFindAvatar(events))
 
 
@@ -778,12 +778,12 @@ class grsnWallPython(ptResponder):
                 #South player is ready - transmit blockers to the wall
                 for blocker in ageSDL["southWall"]:
                     SouthWall.value[blocker].physics.enable()
-                if (ageSDL["nState"][0] >= kWait and eventHandler and PtGetPlayerList()):
+                if (ageSDL["nState"][0] >= kWait and eventHandler and not PtIsSolo()):
                     eventHandler.Handle(kEventEntry)
                 SouthTubeOpen.run(self.key)
 
         if (VARname == "nWallPlayer" and ageSDL["nWallPlayer"] != (-1,)):
-            if (ageSDL["sState"][0] == kEntry or not PtGetPlayerList()):
+            if (ageSDL["sState"][0] == kEntry or PtIsSolo()):
                 if (eventHandler):
                     eventHandler.Handle(kEventStart)
                 #both players are in the Tube - flush them down
@@ -796,7 +796,7 @@ class grsnWallPython(ptResponder):
                 PtGetLocalAvatar().avatar.runBehaviorSetNotify(NorthTubeMulti.value, self.key, NorthTubeMulti.netForce)
 
         if (VARname == "sWallPlayer" and ageSDL["sWallPlayer"] != (-1,)):
-            if (ageSDL["nState"][0] == kEntry or not PtGetPlayerList()):
+            if (ageSDL["nState"][0] == kEntry or PtIsSolo()):
                 if (eventHandler):
                     eventHandler.Handle(kEventStart)
                 #both players are in the Tube - flush them down

--- a/Scripts/Python/grtzAccessDoors.py
+++ b/Scripts/Python/grtzAccessDoors.py
@@ -87,8 +87,7 @@ class grtzAccessDoors(ptResponder):
         PtDebugPrint("grtzAccessDoors: self.SDL = %d" % self.grtzDoorState)
         PtDebugPrint("grtzAccessDoors: Player List = %d" % len(PtGetPlayerList()))
 
-        if len(PtGetPlayerList()) > 0:
-            
+        if not PtIsSolo():
             PtDebugPrint("grtzAccessDoors: Somebody is already in the age. Attempting to sync states.")
 
             if self.grtzDoorState == doorSDLstates['open'] or self.grtzDoorState == doorSDLstates['opening']:
@@ -123,7 +122,7 @@ class grtzAccessDoors(ptResponder):
                 doorResponder.run(self.key,state='OpenTheDoor',fastforward=1,netPropagate=0)
 
 
-        elif len(PtGetPlayerList()) < 1:
+        else:
             # the door is really shut, someone left it open
             self.SDL['DoorOpen'] = (doorSDLstates['closed'],)
             self.grtzDoorState = self.SDL['DoorOpen'][0]

--- a/Scripts/Python/grtzMarkerScopes.py
+++ b/Scripts/Python/grtzMarkerScopes.py
@@ -86,7 +86,7 @@ class grtzMarkerScopes(ptResponder):
     def Load(self):
         global boolScopeOperated
 
-        solo = not PtGetPlayerList()
+        solo = PtIsSolo()
 
         boolOperated = self.SDL["boolOperated"][0]
         if boolOperated:

--- a/Scripts/Python/jlakField.py
+++ b/Scripts/Python/jlakField.py
@@ -189,7 +189,7 @@ class jlakField(ptResponder):
         
         #If the last person links out while a bulk move is being performed the SDL gets stuck!
         #So we'll reset it only if we're the first person entering the age....
-        if len(PtGetPlayerList()) == 0:
+        if PtIsSolo():
             PtDebugPrint("jlakField.OnServerInitComplete():\tResetting GUI lock as we're the only ones here!")
             ageSDL[sdlGUILock] = (0,)
             boolGUILock = 0
@@ -234,7 +234,7 @@ class jlakField(ptResponder):
             listWarpPlayers.append(pt)
         #PtDebugPrint("listWarpPlayers = ",listWarpPlayers)
 
-        if not len(PtGetPlayerList()):
+        if PtIsSolo():
             PtDebugPrint("jlakField.OnServerInitComplete(): on link-in, am only player here.  Will reset player start point")
             newPoint = byteStartPt
             while newPoint == byteStartPt:

--- a/Scripts/Python/kdshGlowInTheDark.py
+++ b/Scripts/Python/kdshGlowInTheDark.py
@@ -161,7 +161,7 @@ class kdshGlowInTheDark(ptResponder):
         if solved:
             PtDebugPrint("\tThe puzzle was solved.")
             PtDebugPrint("\tThere are", len(PtGetPlayerList()), " other players in this Kadish instance.")
-            if len(PtGetPlayerList()) == 0:
+            if PtIsSolo():
                 PtDebugPrint("\t I'm alone, so I'm starting the elevator.")
                 respElevDown.run(self.key)
                 PtAtTimeCallback(self.key,4,2) # clear xRgn at top

--- a/Scripts/Python/kdshPillarRoom.py
+++ b/Scripts/Python/kdshPillarRoom.py
@@ -405,7 +405,7 @@ class kdshPillarRoom(ptResponder):
     def CleanUpLaddersIfImAlone(self):
         ageSDL = PtGetAgeSDL()    
         
-        if len(PtGetPlayerList()) == 0:
+        if PtIsSolo():
             ageSDL["PillarsOccupied"] = (0,)
             ageSDL["PillarsResetting"] = (0,)
         else:

--- a/Scripts/Python/kdshTreeRings.py
+++ b/Scripts/Python/kdshTreeRings.py
@@ -163,7 +163,7 @@ class kdshTreeRings(ptModifier):
         PtDebugPrint("/tMiddleRing: ", MiddleRing)
         PtDebugPrint("/tInnerRing: ", InnerRing)
 
-        solo = not PtGetPlayerList()
+        solo = PtIsSolo()
 
         boolOperated = ageSDL["boolOperatedScope0" + str(ScopeNumber.value)][0]
         if boolOperated:

--- a/Scripts/Python/kdshVault.py
+++ b/Scripts/Python/kdshVault.py
@@ -176,7 +176,7 @@ class kdshVault(ptResponder):
         global ButtonsPushed
         ageSDL = PtGetAgeSDL()     
         
-        solo = not PtGetPlayerList()
+        solo = PtIsSolo()
 
         VCPboolOperated = ageSDL["VCPboolOperated"][0]
         if VCPboolOperated:

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1669,7 +1669,7 @@ class CommandsProcessor:
         if not file:
             self.chatMgr.AddChatLine(None, "Usage: /loadclothing <name>", kChat.SystemMessage)
             return
-        if PtGetPlayerList() and not PtIsInternalRelease():
+        if not PtIsSolo() and not PtIsInternalRelease():
             self.chatMgr.AddChatLine(None, "You have to be alone to change your clothes!", kChat.SystemMessage)
             return
         file = file + ".clo"

--- a/Scripts/Python/minkDayClicks.py
+++ b/Scripts/Python/minkDayClicks.py
@@ -99,7 +99,7 @@ class minkDayClicks(ptResponder):
     def OnFirstUpdate(self):
         ageSDL = PtGetAgeSDL()
 
-        if not len(PtGetPlayerList()) and ageSDL["minkIsDayTime"][0]:
+        if PtIsSolo() and ageSDL["minkIsDayTime"][0]:
             PtDebugPrint("minkDayClicks.OnFirstUpdate(): Resetting Show and Touch vars.")
             ageSDL["minkSymbolShow01"] = (0,)
             ageSDL["minkSymbolShow02"] = (0,)

--- a/Scripts/Python/minkDayNight.py
+++ b/Scripts/Python/minkDayNight.py
@@ -83,7 +83,7 @@ class minkDayNight(ptResponder):
         ageSDL.sendToClients("minkIsDayTime")
         ageSDL.setNotify(self.key, "minkIsDayTime", 0.0)
 
-        if not len(PtGetPlayerList()):
+        if PtIsSolo():
             ageSDL["minkIsDayTime"] = (1,)
 
         if ageSDL["minkIsDayTime"][0]:

--- a/Scripts/Python/nb01RPSGame.py
+++ b/Scripts/Python/nb01RPSGame.py
@@ -320,7 +320,7 @@ class nb01RPSGame(ptResponder, object):
         self.SDL.setFlags(SDL_WINNING_SELECTION, True, True)
 
         # Make sure we start out sane
-        if not PtGetPlayerList():
+        if PtIsSolo():
             self._KillEverything()
             self.SDL[SDL_PLAYERS] = tuple([0] * NUM_SEATS)
             self.game_state = GAME_ATTRACT_PLAYERS

--- a/Scripts/Python/nglnTreeMonkey.py
+++ b/Scripts/Python/nglnTreeMonkey.py
@@ -109,7 +109,7 @@ class nglnTreeMonkey(ptResponder):
             PtDebugPrint("nglnTreeMonkey: It's been less than a day since the last update, doing nothing")
             self.SetMonkeyTimers()
 
-        if not len(PtGetPlayerList()):
+        if PtIsSolo():
             respMonkeyOff.run(self.key, fastforward=1)
 
     ###########################

--- a/Scripts/Python/nglnUrwinBrain.py
+++ b/Scripts/Python/nglnUrwinBrain.py
@@ -123,7 +123,7 @@ class nglnUrwinBrain(ptResponder):
             PtDebugPrint("nglnUrwinBrain: It's been less than a day since the last update, doing nothing")
             self.SetUrwinTimers()
 
-        if not len(PtGetPlayerList()):
+        if PtIsSolo():
             UrwinMasterAnim.animation.skipToBegin()
  
     ###########################

--- a/Scripts/Python/payiUrwinBrain.py
+++ b/Scripts/Python/payiUrwinBrain.py
@@ -142,7 +142,7 @@ class payiUrwinBrain(ptResponder):
             PtDebugPrint("payiUrwinBrain: It's been less than a day since the last update, doing nothing")
             self.SetUrwinTimers()
 
-        if not len(PtGetPlayerList()):
+        if PtIsSolo():
             UrwinMasterAnim.animation.skipToBegin()
  
     ###########################

--- a/Scripts/Python/psnlBookshelf.py
+++ b/Scripts/Python/psnlBookshelf.py
@@ -198,7 +198,7 @@ class psnlBookshelf(ptModifier):
             actLock.disable()
             actTray.disable()
 
-        solo = not PtGetPlayerList()
+        solo = PtIsSolo()
 
         self.IUpdateLinks()
 

--- a/Scripts/Python/psnlBugs.py
+++ b/Scripts/Python/psnlBugs.py
@@ -110,7 +110,7 @@ class psnlBugs(ptResponder):
         # check for all the cases where it would be raining, and if its not then turn on bugs
         sdl = PtGetAgeSDL()
         bugState = sdl["psnlBugsVis"]
-        if rainState == 1 or (rainState == 4 and len(PtGetPlayerList()) == 0) or (rainState == 3 and len(PtGetPlayerList()) > 0):
+        if rainState == 1 or (rainState == 4 and PtIsSolo() or (rainState == 3 and not PtIsSolo())):
             PtDebugPrint("turning off bugs")
             if bugState != 0:
                 sdl["psnlBugsVis"] = (0,)

--- a/Scripts/Python/psnlBugs.py
+++ b/Scripts/Python/psnlBugs.py
@@ -110,7 +110,7 @@ class psnlBugs(ptResponder):
         # check for all the cases where it would be raining, and if its not then turn on bugs
         sdl = PtGetAgeSDL()
         bugState = sdl["psnlBugsVis"]
-        if rainState == 1 or (rainState == 4 and PtIsSolo() or (rainState == 3 and not PtIsSolo())):
+        if rainState == 1 or (rainState == 4 and PtIsSolo()) or (rainState == 3 and not PtIsSolo()):
             PtDebugPrint("turning off bugs")
             if bugState != 0:
                 sdl["psnlBugsVis"] = (0,)

--- a/Scripts/Python/psnlYeeshaPageChanges.py
+++ b/Scripts/Python/psnlYeeshaPageChanges.py
@@ -144,7 +144,7 @@ class psnlYeeshaPageChanges(ptMultiModifier):
                     MAX_SIZE = 10
                     size, state = divmod(CurrentValue, 10)
 
-                    if len(PtGetPlayerList()) == 0 and state != 0:
+                    if PtIsSolo() and state != 0:
                         growSizes = self.TimeToGrow()
                         PtDebugPrint("Growsizes: %d" % growSizes)
                         if growSizes and size < MAX_SIZE:
@@ -189,7 +189,7 @@ class psnlYeeshaPageChanges(ptMultiModifier):
                             except:
                                 PtDebugPrint("ERROR: psnlYeeshaPageChanges.OnServerInitComplete():\tException occurred trying to access age SDL")
                         
-                    if len(PtGetPlayerList()) == 0:
+                    if PtIsSolo():
                         newstate = self.UpdateState(CurrentValue, 0, SDLVar, AgeVault, ageSDL, 0)
                     else:
                         newstate = CurrentValue

--- a/Scripts/Python/tldn3FloorElevator.py
+++ b/Scripts/Python/tldn3FloorElevator.py
@@ -138,7 +138,7 @@ class tldn3FloorElevator(ptResponder):
         PtDebugPrint("tldn3FloorElevator.OnServerInitComplete():\t%s=%d, %s=%d" % (kStringAgeSDLElvCurrFloor,elevCurrFloor,kStringAgeSDLElvIdle,elevIdle) )
 
         # correct state if necessary - workaround for elev subworld seeming to fastforward itself and break itself...hopefully removable in future
-        if len(PtGetPlayerList()) == 0: # I'm the only person here
+        if PtIsSolo():
             PtDebugPrint("tldn3FloorElevator.OnServerInitComplete():\tsolo player... initializing elevator state")
             if not elevIdle:
                 PtDebugPrint("\tmaking elevator idle")

--- a/Scripts/Python/tldnPwrTwrPeriscope.py
+++ b/Scripts/Python/tldnPwrTwrPeriscope.py
@@ -136,7 +136,7 @@ class tldnPwrTwrPeriscope(ptResponder):
 
 
     def Load(self):
-        solo = not PtGetPlayerList()
+        solo = PtIsSolo()
         boolOperated = self.SDL["boolOperated"][0]
         if boolOperated:
             if solo:

--- a/Scripts/Python/tldnSlavePrisonDoors.py
+++ b/Scripts/Python/tldnSlavePrisonDoors.py
@@ -151,9 +151,8 @@ class tldnSlavePrisonDoors(ptResponder):
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
             # look at the SDL for the plates if we are NOT the first person in the Age
-            players = PtGetPlayerList()
-            if len(players) > 0:
-                PtDebugPrint("   - and the number of players is %d, so get plate states from SDL"%(len(players)),level=kDebugDumpLevel)
+            if not PtIsSolo():
+                PtDebugPrint("   - and this isn't solo mode, so get plate states from SDL",level=kDebugDumpLevel)
                 for platesdl,actid in PlateSDLs:
                     boolCurrentValue = ageSDL[platesdl][0]
                     if boolCurrentValue:

--- a/Scripts/Python/tldnVaporScope.py
+++ b/Scripts/Python/tldnVaporScope.py
@@ -128,7 +128,7 @@ class tldnVaporScope(ptModifier):
 
     def Load(self):
         global boolScopeOperated
-        solo = not PtGetPlayerList()
+        solo = PtIsSolo()
         boolOperated = self.SDL["boolOperated"][0]
         if boolOperated:
             if solo:

--- a/Scripts/Python/tldnWRCCBrain.py
+++ b/Scripts/Python/tldnWRCCBrain.py
@@ -146,7 +146,7 @@ class tldnWRCCBrain(ptResponder):
     def Load(self):
         global boolWRCCOperated
         
-        solo = not PtGetPlayerList()
+        solo = PtIsSolo()
 
         boolOperated = self.SDL["boolOperated"][0]
         if boolOperated:

--- a/Scripts/Python/xAgeSDLBoolActivatorComboSet.py
+++ b/Scripts/Python/xAgeSDLBoolActivatorComboSet.py
@@ -85,7 +85,7 @@ class xAgeSDLBoolActivatorComboSet(ptResponder):
         self.SDL.sendToClients("attemptCombo")
         self.SDL.setFlags("attemptCombo", True, True)
 
-        if not PtGetPlayerList():
+        if PtIsSolo():
             self._butsInUse = False
             if allowSlidingSolution.value:
                 self._attemptCombo = []

--- a/Scripts/Python/xBlueSpiral.py
+++ b/Scripts/Python/xBlueSpiral.py
@@ -207,7 +207,7 @@ class xBlueSpiral(ptResponder, object):
         # Nobody here? Close the door and reset everything.
         # Somebody here? Set everything to SDL state
         PtDebugPrint("xBlueSpiral.OnServerInitComplete():\tWhen I got here...", level=kDebugDumpLevel)
-        if len(PtGetPlayerList()):
+        if not PtIsSolo():
             if self.running:
                 PtDebugPrint("xBlueSpiral.OnServerInitComplete():\t... they were playing", level=kDebugDumpLevel)
                 clkBSDoor.disableActivator()

--- a/Scripts/Python/xHighLevelStarTrekDoor.py
+++ b/Scripts/Python/xHighLevelStarTrekDoor.py
@@ -102,9 +102,8 @@ class xHighLevelStarTrekDoor(ptModifier):
             self.DoorState = self.SDL['DoorState'][0]
          
         PtDebugPrint("xHighLevelStarTrekDoor: self.SDL = %d" % self.DoorState)
-        PtDebugPrint("xHighLevelStarTrekDoor: Player List = %d" % len(PtGetPlayerList()))
 
-        if len(PtGetPlayerList()) > 0:
+        if not PtIsSolo():
             
             PtDebugPrint("xHighLevelStarTrekDoor: Somebody is already in the age. Attempting to sync states.")
 
@@ -131,7 +130,7 @@ class xHighLevelStarTrekDoor(ptModifier):
                 respOpenDoor.run(self.key,fastforward=1)
                 
 
-        elif len(PtGetPlayerList()) < 1:
+        else:
             # the door is really shut, someone left it open
             self.SDL['DoorState'] = (doorSDLstates['closed'],)
             self.DoorState = self.SDL['DoorState'][0]

--- a/Scripts/Python/xPodBattery.py
+++ b/Scripts/Python/xPodBattery.py
@@ -202,7 +202,7 @@ class xPodBattery(ptResponder):
         PtDebugPrint("xPodBattery: The Pod Battery has %s of a possible %s units." % (BatteryCharge, BatteryCapacity))
         CurrentTime = PtGetDniTime()
         
-        if not PtGetPlayerList():
+        if PtIsSolo():
             if BatteryLastUpdated == 0:
                 ageSDL[SDLBatteryLastUpdated.value] = (CurrentTime,)
                 PtDebugPrint("xPodBattery: This is your first time here. The Battery has never been updated.")

--- a/Scripts/Python/xPodium.py
+++ b/Scripts/Python/xPodium.py
@@ -65,7 +65,7 @@ class xPodium(ptResponder):
 
     def OnServerInitComplete(self):
         ageSDL = PtGetAgeSDL()
-        if not PtGetPlayerList():
+        if PtIsSolo():
             ageSDL[stringVarName.value] = (0,)
         ageSDL.setNotify(self.key, stringVarName.value, 0.0)
         ageSDL.sendToClients(stringVarName.value)

--- a/Scripts/Python/xRandomBoolChange.py
+++ b/Scripts/Python/xRandomBoolChange.py
@@ -111,7 +111,7 @@ class xRandomBoolChange(ptModifier):
             nearby  = ageSDL[strProximityVar.value][0]
     
             # if I'm the only one in here then make sure the proximity setting is 0
-            if len(PtGetPlayerList()) == 0 and nearby:
+            if PtIsSolo() and nearby:
                 ageSDL[strProximityVar.value] = (0,)
                 nearby = 0
         except:

--- a/Scripts/Python/xStandardDoor.py
+++ b/Scripts/Python/xStandardDoor.py
@@ -146,7 +146,7 @@ class xStandardDoor(ptResponder):
                 PtDebugPrint("xStandardDoor.OnServerInitComplete():\tERROR: age sdl read failed, defaulting door enabled")
     
             # correct SDL state if necessary
-            if len(PtGetPlayerList()) == 0: # I'm the only person here
+            if PtIsSolo():  # I'm the only person here
                 if boolForceOpen.value and doorClosed:
                     doorClosed = 0
                     ageSDL.setTagString(stringSDLVarClosed.value,"ignore")

--- a/Scripts/Python/xTelescope.py
+++ b/Scripts/Python/xTelescope.py
@@ -89,7 +89,7 @@ class xTelescope(ptModifier):
     def Load(self):
         global boolScopeOperated
 
-        solo = not PtGetPlayerList()
+        solo = PtIsSolo()
 
         boolOperated = self.SDL["boolOperated"][0]
         if boolOperated:

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -1022,7 +1022,7 @@ void cyMisc::PrintToScreen(const char* msg)
 //  Function   : IsSolo
 //  PARAMETERS : 
 //
-//  PURPOSE    : Return if we are the only player in the Age
+//  PURPOSE    : Return whether we are the only player in the Age
 //
 bool cyMisc::IsSolo()
 {

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -1019,6 +1019,21 @@ void cyMisc::PrintToScreen(const char* msg)
 
 /////////////////////////////////////////////////////////////////////////////
 //
+//  Function   : IsSolo
+//  PARAMETERS : 
+//
+//  PURPOSE    : Return if we are the only player in the Age
+//
+bool cyMisc::IsSolo()
+{
+    plNetClientMgr* nc = plNetClientMgr::GetInstance();
+    if (nc)
+        return nc->TransportMgr().GetMemberList().empty();
+    return true;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
 //  Function   : GetPlayerList
 //  Function   : GetPlayerListDistanceSorted
 //  PARAMETERS : 

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -429,7 +429,7 @@ public:
     //  Function   : IsSolo
     //  PARAMETERS : 
     //
-    //  PURPOSE    : Return if we are the only player in the Age
+    //  PURPOSE    : Return whether we are the only player in the Age
     //
     static bool IsSolo();
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -426,6 +426,15 @@ public:
 
     /////////////////////////////////////////////////////////////////////////////
     //
+    //  Function   : IsSolo
+    //  PARAMETERS : 
+    //
+    //  PURPOSE    : Return if we are the only player in the Age
+    //
+    static bool IsSolo();
+
+    /////////////////////////////////////////////////////////////////////////////
+    //
     //  Function   : GetPlayerList
     //  Function   : GetPlayerListDistanceSorted
     //  PARAMETERS : 

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
@@ -133,7 +133,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetLocalPlayer, "Returns a ptPlayer obj
     return cyMisc::GetLocalPlayer();
 }
 
-PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtIsSolo, "Returns if we are the only player in the Age")
+PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtIsSolo, "Returns whether we are the only player in the Age")
 {
     return plPython::ConvertFrom(cyMisc::IsSolo());
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue.cpp
@@ -40,12 +40,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#include <Python.h>
-#include "pyKey.h"
-
 #include "cyMisc.h"
+
+#include <Python.h>
+
 #include "pyGlueHelpers.h"
+#include "pyKey.h"
 #include "pyPlayer.h"
+#include "plPythonConvert.h"
 
 
 PYTHON_BASIC_GLOBAL_METHOD_DEFINITION(PtFlashWindow, cyMisc::FlashWindow, "Flashes the client window if it is not focused");
@@ -129,6 +131,11 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetLocalAvatar, "This will return a ptS
 PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetLocalPlayer, "Returns a ptPlayer object of the local player")
 {
     return cyMisc::GetLocalPlayer();
+}
+
+PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtIsSolo, "Returns if we are the only player in the Age")
+{
+    return plPython::ConvertFrom(cyMisc::IsSolo());
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetPlayerList, "Returns a list of ptPlayer objects of all the remote players")


### PR DESCRIPTION
A common anti-pattern for determining whether or not we are the only person in an Age is to check the player list returned by `PtGetPlayerList()`. Generally, if this list is empty, some initialization to a default state is done or some restoration work is done if it is not empty. What the gameplay programmers seem to have not realized, though, is that the list returned by `PtGetPlayerList()` [omits any players that are in your ignore list](https://github.com/H-uru/Plasma/blob/2136c25ed7b8bc16183ece2af62b446007a07ad2/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp#L1076). Therefore, the wrong initialization path may be executed if there are players in the Age, but all of them are in your ignore list. This could have consequences that range from odd but amusing to catastrophic, depending on the script in question.

Therefore, we fix this problem by introducing `PtIsSolo()`, which tells us whether or not we are the only player in the Age. This function is not vulnerable to ignore shennanigans, and we avoid creating lots of temporary `ptPlayer` objects that we don't actually care about.