### PR TITLE
Wall game code adjustments

### DIFF
--- a/Scripts/Python/grsnMainWallPython.py
+++ b/Scripts/Python/grsnMainWallPython.py
@@ -44,6 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 from Plasma import *
 from PlasmaTypes import *
 from grsnWallConstants import *
+from itertools import takewhile
 
 
 ##############################################################
@@ -66,8 +67,8 @@ class grsnMainWallPython(ptResponder):
         ptResponder.__init__(self)
         self.id = 52394
         self.version = 2
-        self.oldNorthWall = None
-        self.oldSouthWall = None
+        self.oldNorthWall = []
+        self.oldSouthWall = []
 
     def OnServerInitComplete(self):
         PtDebugPrint("grsnMainWallPython::OnServerInitComplete")
@@ -104,25 +105,15 @@ class grsnMainWallPython(ptResponder):
         if(nState == sState == kEnd):
             self.oldNorthWall = ageSDL["northWall"]
             self.oldSouthWall = ageSDL["southWall"]
-            for blocker in ageSDL["northWall"]:
-                if(blocker == -1):
-                    break
+            for blocker in takewhile(lambda x: x!= -1, ageSDL["northWall"]):
                 northWall.value[blocker].runAttachedResponder(kBlockerOn)
-            for blocker in ageSDL["southWall"]:
-                if(blocker == -1):
-                    break
+            for blocker in takewhile(lambda x: x!= -1, ageSDL["southWall"]):
                 southWall.value[blocker].runAttachedResponder(kBlockerOn)
         elif(nState == sState == kSelectCount and ageSDL["NumBlockers"][0] == 0):
-            if self.oldNorthWall:
-                for blocker in self.oldNorthWall:
-                    if(blocker == -1):
-                        break
-                    northWall.value[blocker].runAttachedResponder(kBlockerOff)
-            if self.oldSouthWall:
-                for blocker in self.oldSouthWall:
-                    if(blocker == -1):
-                        break
-                    southWall.value[blocker].runAttachedResponder(kBlockerOff)
+            for blocker in takewhile(lambda x: x!= -1, self.oldNorthWall):
+                northWall.value[blocker].runAttachedResponder(kBlockerOff)
+            for blocker in takewhile(lambda x: x!= -1, self.oldSouthWall):
+                southWall.value[blocker].runAttachedResponder(kBlockerOff)
 
     def IAmMaster(self):
         return (self.sceneobject.isLocallyOwned())

--- a/Scripts/Python/grsnWallEventHandler.py
+++ b/Scripts/Python/grsnWallEventHandler.py
@@ -105,22 +105,18 @@ class grsnWallEventHandler(ptResponder):
         if id == 1:
             self.BlockerSfxBlock = True
             PtClearTimerCallbacks(self.key)
-            
-    def IAmMaster(self):
-        return (self.sceneobject.isLocallyOwned())
 
     def Handle(self, event):
-        if(self.IAmMaster()):
-            if random.randint(0, 100) <= dniSndChance:
-                idx = 1
-            else:
-                idx = random.randint(2, 4)
-            (stage, sndResp) = getattr(self, event)(idx)
+        if random.randint(0, 100) <= dniSndChance:
+            idx = 1
+        else:
+            idx = random.randint(2, 4)
+        (stage, sndResp) = getattr(self, event)(idx)
 
-            sndResp.run(self.key, state=stage)
+        sndResp.run(self.key, state=stage)
 
     def HandleBlocker(self):
-        if(self.IAmMaster() and self.BlockerSfxBlock):
+        if(self.BlockerSfxBlock):
             self.BlockerSfxBlock = False
             self.BlockersHit += 1
 

--- a/Scripts/Python/grsnWallImagerDisplayN.py
+++ b/Scripts/Python/grsnWallImagerDisplayN.py
@@ -61,14 +61,16 @@ class grsnWallImagerDisplayN(ptResponder):
         ptResponder.__init__(self)
         self.id = 52398
         self.version = 2
+        self.oldNorthWall = None
 
     def OnServerInitComplete(self):
         PtDebugPrint("grsnWallImagerDisplayN::OnServerInitComplete")
         ageSDL = PtGetAgeSDL()
+        self.oldNorthWall = ageSDL["northWall"]
         
         ageSDL.setNotify(self.key, "nState", 0.0)
         
-        if not PtIsSolo() and ageSDL["nState"] >= kWait:
+        if not PtIsSolo() and ageSDL["nState"][0] >= kWait:
             for blocker in ageSDL["northWall"]:
                 if(blocker == -1):
                     return
@@ -78,16 +80,13 @@ class grsnWallImagerDisplayN(ptResponder):
         ageSDL = PtGetAgeSDL()
         #We only get a notify from nState
         value = ageSDL[VARname][0]
-        if(value == kWait):
+        if(value == kEnd):
+            self.oldNorthWall = ageSDL["northWall"]
+        elif(value == kWait):
             for blocker in ageSDL["northWall"]:
                 if(blocker == -1):
                     break
                 northImager.value[blocker].runAttachedResponder(kBlockerOn)
-        if(value == kSelectCount):
-            for i in range(0,171):
-                northImager.value[i].runAttachedResponder(kBlockerOff)
-
-
-
-
-
+        elif(value == kSelectCount):
+            for blocker in self.oldNorthWall:
+                northImager.value[blocker].runAttachedResponder(kBlockerOff)

--- a/Scripts/Python/grsnWallImagerDisplayN.py
+++ b/Scripts/Python/grsnWallImagerDisplayN.py
@@ -44,6 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 from Plasma import *
 from PlasmaTypes import *
 from grsnWallConstants import *
+from itertools import takewhile
 
 
 ##############################################################
@@ -61,7 +62,7 @@ class grsnWallImagerDisplayN(ptResponder):
         ptResponder.__init__(self)
         self.id = 52398
         self.version = 2
-        self.oldNorthWall = None
+        self.oldNorthWall = []
 
     def OnServerInitComplete(self):
         PtDebugPrint("grsnWallImagerDisplayN::OnServerInitComplete")
@@ -71,9 +72,7 @@ class grsnWallImagerDisplayN(ptResponder):
         ageSDL.setNotify(self.key, "nState", 0.0)
         
         if not PtIsSolo() and ageSDL["nState"][0] >= kWait:
-            for blocker in ageSDL["northWall"]:
-                if(blocker == -1):
-                    return
+            for blocker in takewhile(lambda x: x!= -1, ageSDL["northWall"]):
                 northImager.value[blocker].runAttachedResponder(kBlockerOn)
 
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
@@ -83,9 +82,7 @@ class grsnWallImagerDisplayN(ptResponder):
         if(value == kEnd):
             self.oldNorthWall = ageSDL["northWall"]
         elif(value == kWait):
-            for blocker in ageSDL["northWall"]:
-                if(blocker == -1):
-                    break
+            for blocker in takewhile(lambda x: x!= -1, ageSDL["northWall"]):
                 northImager.value[blocker].runAttachedResponder(kBlockerOn)
         elif(value == kSelectCount):
             for blocker in self.oldNorthWall:

--- a/Scripts/Python/grsnWallImagerDisplayS.py
+++ b/Scripts/Python/grsnWallImagerDisplayS.py
@@ -44,7 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 from Plasma import *
 from PlasmaTypes import *
 from grsnWallConstants import *
-
+from itertools import takewhile
 
 ##############################################################
 # define the attributes/parameters that we need from the 3dsMax scene
@@ -61,7 +61,7 @@ class grsnWallImagerDisplayS(ptResponder):
         ptResponder.__init__(self)
         self.id = 52397
         self.version = 2
-        self.oldSouthWall = None
+        self.oldSouthWall = []
 
     def OnServerInitComplete(self):
         PtDebugPrint("grsnWallImagerDisplayS::OnServerInitComplete")
@@ -71,9 +71,7 @@ class grsnWallImagerDisplayS(ptResponder):
         ageSDL.setNotify(self.key, "sState", 0.0)
         
         if not PtIsSolo() and ageSDL["sState"][0] >= kWait:
-            for blocker in ageSDL["southWall"]:
-                if(blocker == -1):
-                    return
+            for blocker in takewhile(lambda x: x!= -1, ageSDL["southWall"]):
                 southImager.value[blocker].runAttachedResponder(kBlockerOn)
 
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
@@ -83,9 +81,7 @@ class grsnWallImagerDisplayS(ptResponder):
         if(value == kEnd):
             self.oldSouthWall = ageSDL["southWall"]
         elif(value == kWait):
-            for blocker in ageSDL["southWall"]:
-                if(blocker == -1):
-                    break
+            for blocker in takewhile(lambda x: x!= -1, ageSDL["southWall"]):
                 southImager.value[blocker].runAttachedResponder(kBlockerOn)
         elif(value == kSelectCount):
             for blocker in self.oldSouthWall:

--- a/Scripts/Python/grsnWallImagerDisplayS.py
+++ b/Scripts/Python/grsnWallImagerDisplayS.py
@@ -61,14 +61,16 @@ class grsnWallImagerDisplayS(ptResponder):
         ptResponder.__init__(self)
         self.id = 52397
         self.version = 2
+        self.oldSouthWall = None
 
     def OnServerInitComplete(self):
         PtDebugPrint("grsnWallImagerDisplayS::OnServerInitComplete")
         ageSDL = PtGetAgeSDL()
+        self.oldSouthWall = ageSDL["southWall"]
         
         ageSDL.setNotify(self.key, "sState", 0.0)
         
-        if not PtIsSolo() and ageSDL["sState"] >= kWait:
+        if not PtIsSolo() and ageSDL["sState"][0] >= kWait:
             for blocker in ageSDL["southWall"]:
                 if(blocker == -1):
                     return
@@ -78,11 +80,13 @@ class grsnWallImagerDisplayS(ptResponder):
         ageSDL = PtGetAgeSDL()
         #We only get a notify from nState
         value = ageSDL[VARname][0]
-        if(value == kWait):
+        if(value == kEnd):
+            self.oldSouthWall = ageSDL["southWall"]
+        elif(value == kWait):
             for blocker in ageSDL["southWall"]:
                 if(blocker == -1):
                     break
                 southImager.value[blocker].runAttachedResponder(kBlockerOn)
-        if(value == kSelectCount):
-            for i in range(0,171):
-                southImager.value[i].runAttachedResponder(kBlockerOff)
+        elif(value == kSelectCount):
+            for blocker in self.oldSouthWall:
+                southImager.value[blocker].runAttachedResponder(kBlockerOff)

--- a/Scripts/Python/grsnWallPython.py
+++ b/Scripts/Python/grsnWallPython.py
@@ -392,7 +392,7 @@ class grsnWallPython(ptResponder):
                             DefaultColor1 = {item[1]: avatar.avatar.getTintClothingItem(item[0],1) for item in wornItem}
                             DefaultColor2 = {item[1]: avatar.avatar.getTintClothingItem(item[0],2) for item in wornItem}
                         for index, item in enumerate(clothing):
-                            if item == None:
+                            if item is None:
                                 continue
                             avatar.avatar.netForce(1)
                             avatar.avatar.wearClothingItem(item, 0)
@@ -425,7 +425,7 @@ class grsnWallPython(ptResponder):
                             DefaultColor1 = {item[1]: avatar.avatar.getTintClothingItem(item[0],1) for item in wornItem}
                             DefaultColor2 = {item[1]: avatar.avatar.getTintClothingItem(item[0],2) for item in wornItem}
                         for index, item in enumerate(clothing):
-                            if item == None:
+                            if item is None:
                                 continue
                             avatar.avatar.netForce(1)
                             avatar.avatar.wearClothingItem(item, 0)
@@ -454,17 +454,17 @@ class grsnWallPython(ptResponder):
             ### Blocker ###
             elif (id == NorthPanelClick.id or id == SouthPanelClick.id):
                 if (event[0] == kPickedEvent and event[1] == 1):
-                    pickedBlockerObj = event[3]
-                    team = kNorth
+                    if id == NorthPanelClick.id:
+                        team = kNorth
+                        blockerObjs = NorthPanel.value
+                    else:
+                        team = kSouth
+                        blockerObjs = SouthPanel.value
                     try:
-                        index = NorthPanel.value.index(pickedBlockerObj)
+                        index = blockerObjs.index(event[3])
                     except:
-                        try:
-                            index = SouthPanel.value.index(pickedBlockerObj)
-                            team = kSouth
-                        except:
-                            PtDebugPrint("grsnWallPython::OnNotify: Blocker not found on either panel")
-                            continue
+                        PtDebugPrint("grsnWallPython::OnNotify: Blocker not found on panel")
+                        continue
                     if ((team == kNorth or PtIsSolo()) and ageSDL["nState"][0] == kSetBlocker):
                         self.SetPanelBlocker(kNorth, index, not self.FindBlocker(kNorth, index), eventAvatar=PtFindAvatar(events))
                     if ((team == kSouth or PtIsSolo()) and ageSDL["sState"][0] == kSetBlocker):

--- a/Scripts/Python/grsnWallPython.py
+++ b/Scripts/Python/grsnWallPython.py
@@ -306,6 +306,8 @@ class grsnWallPython(ptResponder):
 
         ageSDL.setNotify(self.key,"nState",0.0)
         ageSDL.setNotify(self.key,"sState",0.0)
+        ageSDL.setNotify(self.key,"nChairOccupant",0.0)
+        ageSDL.setNotify(self.key,"sChairOccupant",0.0)
         ageSDL.setNotify(self.key,"NumBlockers",0.0)
         ageSDL.setNotify(self.key,"northWall",0.0)
         ageSDL.setNotify(self.key,"southWall",0.0)
@@ -329,53 +331,161 @@ class grsnWallPython(ptResponder):
             PtDebugPrint("grsnWallPython::OnServerInitComplete: There is already another Game Master - Request Game Update")
             self.RequestGameUpdate()
 
+    def AvatarPage(self, avObj, pageIn, lastOut):
+        if not pageIn:
+            ageSDL = PtGetAgeSDL()
+            avID = PtGetClientIDFromAvatarKey(avObj.getKey())
+            if avID == ageSDL["nChairOccupant"][0]:
+                ageSDL["nChairOccupant"] = (-1,)
+            elif avID == ageSDL["sChairOccupant"][0]:
+                ageSDL["sChairOccupant"] = (-1,)
+
     def OnNotify(self,state,id,events):
         global wornItem
         global DefaultColor1
         global DefaultColor2
-        cID = PtGetLocalClientID()
         ageSDL = PtGetAgeSDL()
+        cID = PtGetLocalClientID()
+        avatar = PtGetLocalAvatar()
 
+        ### Tube open Animation Finished ###
+        if (id == NorthTubeOpen.id):
+            NorthTubeExclude.release(self.key)
+            return
+        elif (id == SouthTubeOpen.id):
+            SouthTubeExclude.release(self.key)
+            return
+
+        for event in events:
+            ### Stand up ###
+            if (id == NorthChairSit.id):
+                if (event[0] == kContainedEvent and event[1] == 1 and not state):
+                    if (cID == ageSDL["nChairOccupant"][0]):
+                        ageSDL["nChairOccupant"] = (-1,)
+                        if (ageSDL["nState"][0] == kSit):
+                            self.ChangeGameState(kNorth, kStandby)
+                    return
+            elif (id == SouthChairSit.id):
+                if (event[0] == kContainedEvent and event[1] == 1 and not state):
+                    if (cID == ageSDL["sChairOccupant"][0]):
+                        ageSDL["sChairOccupant"] = (-1,)
+                        if (ageSDL["sState"][0] == kSit):
+                            self.ChangeGameState(kSouth, kStandby)
+                    return
+            ### Tube Multibehaviors ###
+            elif (id == NorthTubeMulti.id):
+                if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage):
+                    #Smart seek complete
+                    NorthTubeClose.run(self.key)
+                    if (PtFindAvatar(events) != avatar):
+                        NorthTubeExclude.clear(self.key)
+                elif (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage):
+                    #Multistage complete
+                    if (PtFindAvatar(events) == avatar):
+                        currentgender = avatar.avatar.getAvatarClothingGroup()
+                        if currentgender == kFemaleClothingGroup:
+                            clothing = FemaleSuit
+                        else:
+                            clothing = MaleSuit
+                        if not wornItem:
+                            wornItem = avatar.avatar.getAvatarClothingList()
+                            DefaultColor1 = {item[1]: avatar.avatar.getTintClothingItem(item[0],1) for item in wornItem}
+                            DefaultColor2 = {item[1]: avatar.avatar.getTintClothingItem(item[0],2) for item in wornItem}
+                        for index, item in enumerate(clothing):
+                            if item == None:
+                                continue
+                            avatar.avatar.netForce(1)
+                            avatar.avatar.wearClothingItem(item, 0)
+                            avatar.avatar.tintClothingItem(item, DefaultColor1[index], 0)
+                            avatar.avatar.tintClothingItemLayer(item, DefaultColor2[index], 2, 1)
+                        PtSendKIMessage(kDisableEntireYeeshaBook, 0)
+                        avatar.physics.warpObj(SouthTeamWarpPt.value.getKey())
+                        ageSDL["nWallPlayer"] = (-1,)
+                        if (ageSDL["nState"][0] == kEntry):
+                            self.ChangeGameState(kNorth, kGameInProgress)
+                            self.ChangeGameState(kSouth, kGameInProgress)
+                    NorthTubeOpen.run(self.key)
+                    return
+            elif (id == SouthTubeMulti.id):
+                if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage):
+                    #Smart seek complete
+                    SouthTubeClose.run(self.key)
+                    if (PtFindAvatar(events) != avatar):
+                        SouthTubeExclude.clear(self.key)
+                elif (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage):
+                    #Multistage complete
+                    if (PtFindAvatar(events) == avatar):
+                        currentgender = avatar.avatar.getAvatarClothingGroup()
+                        if currentgender == kFemaleClothingGroup:
+                            clothing = FemaleSuit
+                        else:
+                            clothing = MaleSuit
+                        if not wornItem:
+                            wornItem = avatar.avatar.getAvatarClothingList()
+                            DefaultColor1 = {item[1]: avatar.avatar.getTintClothingItem(item[0],1) for item in wornItem}
+                            DefaultColor2 = {item[1]: avatar.avatar.getTintClothingItem(item[0],2) for item in wornItem}
+                        for index, item in enumerate(clothing):
+                            if item == None:
+                                continue
+                            avatar.avatar.netForce(1)
+                            avatar.avatar.wearClothingItem(item, 0)
+                            avatar.avatar.tintClothingItem(item, DefaultColor1[index], 0)
+                            avatar.avatar.tintClothingItemLayer(item, DefaultColor2[index], 2, 1)
+                        PtSendKIMessage(kDisableEntireYeeshaBook, 0)
+                        avatar.physics.warpObj(NorthTeamWarpPt.value.getKey())
+                        ageSDL["sWallPlayer"] = (-1,)
+                        if (ageSDL["sState"][0] == kEntry):
+                            self.ChangeGameState(kNorth, kGameInProgress)
+                            self.ChangeGameState(kSouth, kGameInProgress)
+                    SouthTubeOpen.run(self.key)
+                    return
+            elif (id == NorthQuitBehavior.id):
+                if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage and PtFindAvatar(events) == avatar):
+                    #Touched the Crystal
+                    PtDebugPrint("Trigger North Crystal")
+                    PtAtTimeCallback(self.key, 3.0, kLinkToNorthNexus)
+                    return
+            elif (id == SouthQuitBehavior.id):
+                if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage and PtFindAvatar(events) == avatar):
+                    #Touched the Crystal
+                    PtDebugPrint("Trigger South Crystal")
+                    PtAtTimeCallback(self.key, 3.0, kLinkToSouthNexus)
+                    return
+            ### Blocker ###
+            elif (id == NorthPanelClick.id or id == SouthPanelClick.id):
+                if (event[0] == kPickedEvent and event[1] == 1):
+                    pickedBlockerObj = event[3]
+                    team = kNorth
+                    try:
+                        index = NorthPanel.value.index(pickedBlockerObj)
+                    except:
+                        try:
+                            index = SouthPanel.value.index(pickedBlockerObj)
+                            team = kSouth
+                        except:
+                            PtDebugPrint("grsnWallPython::OnNotify: Blocker not found on either panel")
+                            continue
+                    if ((team == kNorth or PtIsSolo()) and ageSDL["nState"][0] == kSetBlocker):
+                        self.SetPanelBlocker(kNorth, index, not self.FindBlocker(kNorth, index), eventAvatar=PtFindAvatar(events))
+                    if ((team == kSouth or PtIsSolo()) and ageSDL["sState"][0] == kSetBlocker):
+                        self.SetPanelBlocker(kSouth, index, not self.FindBlocker(kSouth, index), eventAvatar=PtFindAvatar(events))
+
+        if PtFindAvatar(events) != avatar:
+            return
+        
         ### Sit down ###
         if (id == NorthChair.id and state):
+            ageSDL["nChairOccupant"] = (cID,)
             if (ageSDL["nState"][0] == kStandby or ageSDL["nState"][0] == kEnd):
                 self.ChangeGameState(kNorth, kSit)
-            NorthChair.disable()
-            if (PtFindAvatar(events) == PtGetLocalAvatar()):
-                ageSDL["nChairOccupant"] = (cID,)
-                self.SetPanelMode(kNorth)
             return
-        if (id == SouthChair.id and state):
+        elif (id == SouthChair.id and state):
+            ageSDL["sChairOccupant"] = (cID,)
             if (ageSDL["sState"][0] == kStandby or ageSDL["sState"][0] == kEnd):
                 self.ChangeGameState(kSouth, kSit)
-            SouthChair.disable()
-            if (PtFindAvatar(events) == PtGetLocalAvatar()):
-                ageSDL["sChairOccupant"] = (cID,)
-                self.SetPanelMode(kSouth)
-            return
-        ### Stand up ###
-        if (id == NorthChairSit.id):
-            for event in events:
-                if (event[0] == kContainedEvent and event[1] == 1 and not state):
-                    NorthChair.enable()
-                    if (ageSDL["nState"][0] == kSit):
-                        self.ChangeGameState(kNorth, kStandby)
-                    self.SetPanelMode(kNorth, disableAll=True)
-                    if (self.IAmMaster()):
-                        ageSDL["nChairOccupant"] = (-1,)
-            return
-        if (id == SouthChairSit.id):
-            for event in events:
-                if (event[0] == kContainedEvent and event[1] == 1 and not state):
-                    SouthChair.enable()
-                    if (ageSDL["sState"][0] == kSit):
-                        self.ChangeGameState(kSouth, kStandby)
-                    self.SetPanelMode(kSouth, disableAll=True)
-                    if (self.IAmMaster()):
-                        ageSDL["sChairOccupant"] = (-1,)
             return
         ### Press Go Button ###
-        if (id == goButtonNorth.id and not state):
+        elif (id == goButtonNorth.id and not state):
             ### Start Game ###
             if (ageSDL["nState"][0] == kSit):
                 self.ResetWall(resetState=False)
@@ -393,7 +503,7 @@ class grsnWallPython(ptResponder):
                     if PtIsSolo():
                         self.ChangeGameState(kSouth, kWait)
             return
-        if (id == goButtonSouth.id and not state):
+        elif (id == goButtonSouth.id and not state):
             ### Start Game ###
             if (ageSDL["sState"][0] == kSit):
                 self.ResetWall(resetState=False)
@@ -410,34 +520,27 @@ class grsnWallPython(ptResponder):
                     if PtIsSolo():
                         self.ChangeGameState(kNorth, kWait)
             return
-        ### Tube open Animation Finished ###
-        if (id == NorthTubeOpen.id):
-            NorthTubeExclude.release(self.key)
-            return
-        if (id == SouthTubeOpen.id):
-            SouthTubeExclude.release(self.key)
-            return
         ### Blocker Count Buttons ###
-        if (id == fiveBtnNorth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
+        elif (id == fiveBtnNorth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
             NorthPanelSound.run(self.key, state='up')
             self.ChangeBlockerCount(5)
             return
-        if (id == tenBtnNorth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
+        elif (id == tenBtnNorth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
             NorthPanelSound.run(self.key, state='up')
             self.ChangeBlockerCount(10)
             return
-        if (id == fifteenBtnNorth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
+        elif (id == fifteenBtnNorth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
             NorthPanelSound.run(self.key, state='up')
             self.ChangeBlockerCount(15)
             return
-        if (id == upButtonNorth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
+        elif (id == upButtonNorth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
             if (ageSDL["NumBlockers"][0] >= 20):
                 NorthPanelSound.run(self.key, state='denied')
             else:
                 NorthPanelSound.run(self.key, state='up')
                 self.ChangeBlockerCount(ageSDL["NumBlockers"][0] + 1)
             return
-        if (id == dnButtonNorth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
+        elif (id == dnButtonNorth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
             if (ageSDL["NumBlockers"][0] <= 0):
                 NorthPanelSound.run(self.key, state='denied')
             else:
@@ -445,26 +548,26 @@ class grsnWallPython(ptResponder):
                 self.ChangeBlockerCount(ageSDL["NumBlockers"][0] - 1)
             return
         #South
-        if (id == fiveBtnSouth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
+        elif (id == fiveBtnSouth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
             SouthPanelSound.run(self.key, state='up')
             self.ChangeBlockerCount(5)
             return
-        if (id == tenBtnSouth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
+        elif (id == tenBtnSouth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
             SouthPanelSound.run(self.key, state='up')
             self.ChangeBlockerCount(10)
             return
-        if (id == fifteenBtnSouth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
+        elif (id == fifteenBtnSouth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
             SouthPanelSound.run(self.key, state='up')
             self.ChangeBlockerCount(15)
             return
-        if (id == upButtonSouth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
+        elif (id == upButtonSouth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
             if (ageSDL["NumBlockers"][0] >= 20):
                 SouthPanelSound.run(self.key, state='denied')
             else:
                 SouthPanelSound.run(self.key, state='up')
                 self.ChangeBlockerCount(ageSDL["NumBlockers"][0] + 1)
             return
-        if (id == dnButtonSouth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
+        elif (id == dnButtonSouth.id and state and (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount)):
             if (ageSDL["NumBlockers"][0] <= 0):
                 SouthPanelSound.run(self.key, state='denied')
             else:
@@ -472,151 +575,76 @@ class grsnWallPython(ptResponder):
                 self.ChangeBlockerCount(ageSDL["NumBlockers"][0] - 1)
             return
         ### Confirm count Button ###
-        if (id == readyButtonNorth.id and not state and ageSDL["nState"][0] == kSelectCount):
+        elif (id == readyButtonNorth.id and not state and ageSDL["nState"][0] == kSelectCount):
             self.ChangeGameState(kNorth, kSetBlocker)
             NorthPanelSound.run(self.key, state='up')
             if PtIsSolo():
                 self.ChangeGameState(kSouth, kSetBlocker)
             return
-        if (id == readyButtonSouth.id and not state and ageSDL["sState"][0] == kSelectCount):
+        elif (id == readyButtonSouth.id and not state and ageSDL["sState"][0] == kSelectCount):
             self.ChangeGameState(kSouth, kSetBlocker)
             SouthPanelSound.run(self.key, state='up')
             if PtIsSolo():
                 self.ChangeGameState(kNorth, kSetBlocker)
             return
         ### Tube Entry trigger ###
-        if (id == NorthTubeEntry.id and ageSDL["nState"][0] >= kWait and ageSDL["nState"][0] != kEnd):
+        elif (id == NorthTubeEntry.id and ageSDL["nState"][0] >= kWait and ageSDL["nState"][0] != kEnd):
             if ageSDL["nState"][0] == kWait:
                 self.ChangeGameState(kNorth, kEntry)
-            if (ageSDL["nWallPlayer"] == (-1,)):
+            if (ageSDL["nWallPlayer"][0] == -1):
                 self.ChangeChuteState(kNorth, PtGetClientIDFromAvatarKey(PtFindAvatar(events).getKey()))
-                if (PtFindAvatar(events) == PtGetLocalAvatar() and cID == ageSDL["sWallPlayer"][0]):
+                if (cID == ageSDL["sWallPlayer"][0]):
                     ageSDL["sWallPlayer"] = (-1,)
             return
-        if (id == SouthTubeEntry.id and ageSDL["sState"][0] >= kWait and ageSDL["sState"][0] != kEnd):
+        elif (id == SouthTubeEntry.id and ageSDL["sState"][0] >= kWait and ageSDL["sState"][0] != kEnd):
             if ageSDL["sState"][0] == kWait:
                 self.ChangeGameState(kSouth, kEntry)
-            if (ageSDL["sWallPlayer"] == (-1,)):
+            if (ageSDL["sWallPlayer"][0] == -1):
                 self.ChangeChuteState(kSouth, PtGetClientIDFromAvatarKey(PtFindAvatar(events).getKey()))
-                if (PtFindAvatar(events) == PtGetLocalAvatar() and cID == ageSDL["nWallPlayer"][0]):
+                if (cID == ageSDL["nWallPlayer"][0]):
                     ageSDL["nWallPlayer"] = (-1,)
             return
-        ### Tube Multibehaviors ###
-        if (id == NorthTubeMulti.id):
-            for event in events:
-                if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage):
-                    #Smart seek complete
-                    NorthTubeClose.run(self.key)
-                    if (PtFindAvatar(events) != PtGetLocalAvatar()):
-                        NorthTubeExclude.clear(self.key)
-                elif (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage):
-                    #Multistage complete
-                    if (PtFindAvatar(events) == PtGetLocalAvatar()):
-                        avatar = PtGetLocalAvatar()
-                        currentgender = avatar.avatar.getAvatarClothingGroup()
-                        if currentgender == kFemaleClothingGroup:
-                            clothing = FemaleSuit
-                        else:
-                            clothing = MaleSuit
-                        if not wornItem:
-                            wornItem = avatar.avatar.getAvatarClothingList()
-                            DefaultColor1 = {item[1]: avatar.avatar.getTintClothingItem(item[0],1) for item in wornItem}
-                            DefaultColor2 = {item[1]: avatar.avatar.getTintClothingItem(item[0],2) for item in wornItem}
-                        for index, item in enumerate(clothing):
-                            if item == None:
-                                continue
-                            avatar.avatar.netForce(1)
-                            avatar.avatar.wearClothingItem(item, 0)
-                            avatar.avatar.tintClothingItem(item, DefaultColor1[index], 0)
-                            avatar.avatar.tintClothingItemLayer(item, DefaultColor2[index], 2, 1)
-                        PtSendKIMessage(kDisableEntireYeeshaBook, 0)
-                        PtGetLocalAvatar().physics.warpObj(SouthTeamWarpPt.value.getKey())
-                        ageSDL["nWallPlayer"] = (-1,)
-                    if (ageSDL["nState"][0] == kEntry):
-                        self.ChangeGameState(kNorth, kGameInProgress)
-                        self.ChangeGameState(kSouth, kGameInProgress)
-                    NorthTubeOpen.run(self.key)
-            return
-        if (id == SouthTubeMulti.id):
-            for event in events:
-                if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage):
-                    #Smart seek complete
-                    SouthTubeClose.run(self.key)
-                    if (PtFindAvatar(events) != PtGetLocalAvatar()):
-                        SouthTubeExclude.clear(self.key)
-                elif (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage):
-                    #Multistage complete
-                    if (PtFindAvatar(events) == PtGetLocalAvatar()):
-                        avatar = PtGetLocalAvatar()
-                        currentgender = avatar.avatar.getAvatarClothingGroup()
-                        if currentgender == kFemaleClothingGroup:
-                            clothing = FemaleSuit
-                        else:
-                            clothing = MaleSuit
-                        if not wornItem:
-                            wornItem = avatar.avatar.getAvatarClothingList()
-                            DefaultColor1 = {item[1]: avatar.avatar.getTintClothingItem(item[0],1) for item in wornItem}
-                            DefaultColor2 = {item[1]: avatar.avatar.getTintClothingItem(item[0],2) for item in wornItem}
-                        for index, item in enumerate(clothing):
-                            if item == None:
-                                continue
-                            avatar.avatar.netForce(1)
-                            avatar.avatar.wearClothingItem(item, 0)
-                            avatar.avatar.tintClothingItem(item, DefaultColor1[index], 0)
-                            avatar.avatar.tintClothingItemLayer(item, DefaultColor2[index], 2, 1)
-                        PtSendKIMessage(kDisableEntireYeeshaBook, 0)
-                        PtGetLocalAvatar().physics.warpObj(NorthTeamWarpPt.value.getKey())
-                        ageSDL["sWallPlayer"] = (-1,)
-                    if (ageSDL["sState"][0] == kEntry):
-                        self.ChangeGameState(kNorth, kGameInProgress)
-                        self.ChangeGameState(kSouth, kGameInProgress)
-                    SouthTubeOpen.run(self.key)
-            return
         ### Win region ###
-        if (id == NorthTeamWin.id):
-            if (PtFindAvatar(events) == PtGetLocalAvatar()):
-                PtAtTimeCallback(self.key, 3.0, kLinkToNorthNexus)
-                if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["nState"][0] != kEnd and not PtIsSolo()):
-                    avatar = PtGetLocalAvatar()
-                    currentgender = avatar.avatar.getAvatarClothingGroup()
-                    if currentgender == kFemaleClothingGroup:
-                        clothing = FemaleSuit
-                    else:
-                        clothing = MaleSuit
-                    for item in filter(None, clothing):
-                        if (not self.IItemInCloset(avatar, item)):
-                            PtDebugPrint(f'DEBUG: grsnWallPython.OnNotify():  Adding {item} to your closet and wearing it.')
-                            avatar.avatar.addWardrobeClothingItem(item, ptColor().white(), ptColor().white())
-                            avatar.avatar.saveClothing()
-                            wornItem = []
-                            item = self.IGetItem(item)
-                            if hasattr(item, "description"):
-                                PtSendKIMessage(kKILocalChatStatusMsg,PtGetLocalizedString("KI.Messages.NewClothing", [item.description]))
+        elif (id == NorthTeamWin.id):
+            PtAtTimeCallback(self.key, 3.0, kLinkToNorthNexus)
+            if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["nState"][0] != kEnd and not PtIsSolo()):
+                currentgender = avatar.avatar.getAvatarClothingGroup()
+                if currentgender == kFemaleClothingGroup:
+                    clothing = FemaleSuit
+                else:
+                    clothing = MaleSuit
+                for item in filter(None, clothing):
+                    if (not self.IItemInCloset(avatar, item)):
+                        PtDebugPrint(f'DEBUG: grsnWallPython.OnNotify():  Adding {item} to your closet and wearing it.')
+                        avatar.avatar.addWardrobeClothingItem(item, ptColor().white(), ptColor().white())
+                        avatar.avatar.saveClothing()
+                        wornItem = []
+                        item = self.IGetItem(item)
+                        if hasattr(item, "description"):
+                            PtSendKIMessage(kKILocalChatStatusMsg,PtGetLocalizedString("KI.Messages.NewClothing", [item.description]))
             if (ageSDL["nState"][0] != kEnd):
                 if (eventHandler):
                     eventHandler.Handle(kEventNorthWin)
                 self.ChangeGameState(kNorth, kEnd)
                 self.ChangeGameState(kSouth, kEnd)
             return
-        if (id == SouthTeamWin.id):
-            if (PtFindAvatar(events) == PtGetLocalAvatar()):
-                PtAtTimeCallback(self.key, 3.0, kLinkToSouthNexus)
-                if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["sState"][0] != kEnd and not PtIsSolo()):
-                    avatar = PtGetLocalAvatar()
-                    currentgender = avatar.avatar.getAvatarClothingGroup()
-                    if currentgender == kFemaleClothingGroup:
-                        clothing = FemaleSuit
-                    else:
-                        clothing = MaleSuit
-                    for item in filter(None, clothing):
-                        if (not self.IItemInCloset(avatar, item)):
-                            PtDebugPrint(f'DEBUG: grsnWallPython.OnNotify():  Adding {item} to your closet and wearing it.')
-                            avatar.avatar.addWardrobeClothingItem(item, ptColor().white(), ptColor().white())
-                            avatar.avatar.saveClothing()
-                            wornItem = []
-                            item = self.IGetItem(item)
-                            if hasattr(item, "description"):
-                                PtSendKIMessage(kKILocalChatStatusMsg,PtGetLocalizedString("KI.Messages.NewClothing", [item.description]))
+        elif (id == SouthTeamWin.id):
+            PtAtTimeCallback(self.key, 3.0, kLinkToSouthNexus)
+            if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["sState"][0] != kEnd and not PtIsSolo()):
+                currentgender = avatar.avatar.getAvatarClothingGroup()
+                if currentgender == kFemaleClothingGroup:
+                    clothing = FemaleSuit
+                else:
+                    clothing = MaleSuit
+                for item in filter(None, clothing):
+                    if (not self.IItemInCloset(avatar, item)):
+                        PtDebugPrint(f'DEBUG: grsnWallPython.OnNotify():  Adding {item} to your closet and wearing it.')
+                        avatar.avatar.addWardrobeClothingItem(item, ptColor().white(), ptColor().white())
+                        avatar.avatar.saveClothing()
+                        wornItem = []
+                        item = self.IGetItem(item)
+                        if hasattr(item, "description"):
+                            PtSendKIMessage(kKILocalChatStatusMsg,PtGetLocalizedString("KI.Messages.NewClothing", [item.description]))
             if (ageSDL["sState"][0] != kEnd):
                 if (eventHandler):
                     eventHandler.Handle(kEventSouthWin)
@@ -624,62 +652,27 @@ class grsnWallPython(ptResponder):
                 self.ChangeGameState(kSouth, kEnd)
             return
         ### Quit button ###
-        if (id == NorthTeamQuit.id and state):
-            if (PtFindAvatar(events) == PtGetLocalAvatar()):
-                PtGetLocalAvatar().avatar.runBehaviorSetNotify(NorthQuitBehavior.value, self.key, NorthQuitBehavior.netForce)
+        elif (id == NorthTeamQuit.id and state):
+            avatar.avatar.runBehaviorSetNotify(NorthQuitBehavior.value, self.key, NorthQuitBehavior.netForce)
             if (ageSDL["nState"][0] != kEnd):
                 if (eventHandler):
                     eventHandler.Handle(kEventNorthQuit)
                 self.ChangeGameState(kNorth, kEnd)
                 self.ChangeGameState(kSouth, kEnd)
             return
-        if (id == SouthTeamQuit.id and state):
-            if (PtFindAvatar(events) == PtGetLocalAvatar()):
-                PtGetLocalAvatar().avatar.runBehaviorSetNotify(SouthQuitBehavior.value, self.key, SouthQuitBehavior.netForce)
+        elif (id == SouthTeamQuit.id and state):
+            avatar.avatar.runBehaviorSetNotify(SouthQuitBehavior.value, self.key, SouthQuitBehavior.netForce)
             if (ageSDL["sState"][0] != kEnd):
                 if (eventHandler):
                     eventHandler.Handle(kEventSouthQuit)
                 self.ChangeGameState(kNorth, kEnd)
                 self.ChangeGameState(kSouth, kEnd)
             return
-        if (id == NorthQuitBehavior.id):
-            for event in events:
-                if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage and PtFindAvatar(events) == PtGetLocalAvatar()):
-                    #Touched the Crystal
-                    PtDebugPrint("Trigger North Crystal")
-                    PtAtTimeCallback(self.key, 3.0, kLinkToNorthNexus)
-            return
-        if (id == SouthQuitBehavior.id):
-            for event in events:
-                if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage and PtFindAvatar(events) == PtGetLocalAvatar()):
-                    #Touched the Crystal
-                    PtDebugPrint("Trigger South Crystal")
-                    PtAtTimeCallback(self.key, 3.0, kLinkToSouthNexus)
-            return
         #Check for crafty individuals who try to escape the building while still wearing a suit
-        if (id == EscapeArtist.id and PtFindAvatar(events) == PtGetLocalAvatar()):
+        elif (id == EscapeArtist.id):
             PtAtTimeCallback(self.key, 1.0, kWearOriginalClothes)
             PtSendKIMessage(kEnableEntireYeeshaBook, 0)
             return
-
-        ### Blocker ###
-        for event in events:
-            if (event[0] == kPickedEvent and event[1] == 1):
-                pickedBlockerObj = event[3]
-                team = kNorth
-                try:
-                    index = NorthPanel.value.index(pickedBlockerObj)
-                except:
-                    try:
-                        index = SouthPanel.value.index(pickedBlockerObj)
-                        team = kSouth
-                    except:
-                        PtDebugPrint("grsnWallPython::OnNotify: Blocker not found on either panel")
-                        return
-                if ((team == kNorth or PtIsSolo()) and ageSDL["nState"][0] == kSetBlocker):
-                    self.SetPanelBlocker(kNorth, index, not self.FindBlocker(kNorth, index), eventAvatar=PtFindAvatar(events))
-                if ((team == kSouth or PtIsSolo()) and ageSDL["sState"][0] == kSetBlocker):
-                    self.SetPanelBlocker(kSouth, index, not self.FindBlocker(kSouth, index), eventAvatar=PtFindAvatar(events))
 
 
     def IItemInCloset(self, avatar, clothingName):
@@ -700,11 +693,11 @@ class grsnWallPython(ptResponder):
                 avatar.avatar.tintClothingItem(item[0], DefaultColor1[item[1]], 0)
                 avatar.avatar.tintClothingItemLayer(item[0], DefaultColor2[item[1]], 2, 1)
         elif (id == kLinkToNorthNexus):
-            PtFakeLinkAvatarToObject(PtGetLocalAvatar().getKey(), NorthTeamWinTeleport.value.getKey())
+            PtFakeLinkAvatarToObject(avatar.getKey(), NorthTeamWinTeleport.value.getKey())
             PtFadeOut(1,True,True)
             PtAtTimeCallback(self.key, 3.0, kFakeFadeIn)
         elif (id == kLinkToSouthNexus):
-            PtFakeLinkAvatarToObject(PtGetLocalAvatar().getKey(), SouthTeamWinTeleport.value.getKey())
+            PtFakeLinkAvatarToObject(avatar.getKey(), SouthTeamWinTeleport.value.getKey())
             PtFadeOut(1,True,True)
             PtAtTimeCallback(self.key, 3.0, kFakeFadeIn)
         elif (id == kFakeFadeIn):
@@ -716,23 +709,24 @@ class grsnWallPython(ptResponder):
         ageSDL = PtGetAgeSDL()
         value = ageSDL[VARname][0]
         cID = PtGetLocalClientID()
+        avatar = PtGetLocalAvatar()
         PtDebugPrint("grsn::OnSDLNotify: received SDL '%s' with value %d" % (VARname, value))
         if (VARname == "NumBlockers"):
             if (ageSDL["nState"][0] == kSetBlocker):
                 #South wants another count - set North back to kSelectCount
-                self.ChangeGameState(kNorth, kSelectCount)
+                self.ChangeGameState(kNorth, kSelectCount, True)
             if (ageSDL["sState"][0] == kSetBlocker):
                 #same thing
-                self.ChangeGameState(kSouth, kSelectCount)
+                self.ChangeGameState(kSouth, kSelectCount, True)
             self.SetPanelMode(kNorth,onlNorthLights=True)
             self.SetPanelMode(kSouth,onlNorthLights=True)
         ### BlockerCount ###
-        if (VARname == "northWall"):
+        elif (VARname == "northWall"):
             self.SetPanelMode(kNorth, onlNorthLights=True)
-        if (VARname == "southWall"):
+        elif (VARname == "southWall"):
             self.SetPanelMode(kSouth, onlNorthLights=True)
         ### nState ###
-        if (VARname == "nState"):
+        elif (VARname == "nState"):
             self.PanelLight()
             if (value == kStandby):
                 self.SetPanelMode(kNorth)
@@ -741,7 +735,7 @@ class grsnWallPython(ptResponder):
             if (value == kSelectCount):
                 if (ageSDL["sState"][0] != kSelectCount):
                     #Force South to keep up
-                    self.ChangeGameState(kSouth, kSelectCount)
+                    self.ChangeGameState(kSouth, kSelectCount, True)
                 self.SetPanelMode(kNorth)
             if (value == kSetBlocker and ageSDL["sState"][0] == kSetBlocker):
                 #Both players are ok with the blocker count
@@ -753,11 +747,12 @@ class grsnWallPython(ptResponder):
                 #North player is ready - transmit blockers to the wall
                 for blocker in ageSDL["northWall"]:
                     NorthWall.value[blocker].physics.enable()
-                if (ageSDL["sState"][0] >= kWait and eventHandler):
+                if (ageSDL["sState"][0] >= kWait and eventHandler and self.IAmMaster()):
                     eventHandler.Handle(kEventEntry)
                 NorthTubeOpen.run(self.key)
+                self.SetPanelMode(kNorth)
 
-        if (VARname == "sState"):
+        elif (VARname == "sState"):
             self.PanelLight()
             if (value == kStandby):
                 self.SetPanelMode(kSouth)
@@ -766,7 +761,7 @@ class grsnWallPython(ptResponder):
             if (value == kSelectCount):
                 if (ageSDL["nState"][0] != kSelectCount):
                     #Force North to keep up
-                    self.ChangeGameState(kNorth, kSelectCount)
+                    self.ChangeGameState(kNorth, kSelectCount, True)
                 self.SetPanelMode(kSouth)
             if (value == kSetBlocker and ageSDL["nState"][0] == kSetBlocker):
                 #Both players are ok with the blocker count
@@ -778,35 +773,49 @@ class grsnWallPython(ptResponder):
                 #South player is ready - transmit blockers to the wall
                 for blocker in ageSDL["southWall"]:
                     SouthWall.value[blocker].physics.enable()
-                if (ageSDL["nState"][0] >= kWait and eventHandler and not PtIsSolo()):
+                if (ageSDL["nState"][0] >= kWait and eventHandler and not PtIsSolo() and self.IAmMaster()):
                     eventHandler.Handle(kEventEntry)
                 SouthTubeOpen.run(self.key)
+                self.SetPanelMode(kSouth)
 
-        if (VARname == "nWallPlayer" and ageSDL["nWallPlayer"] != (-1,)):
+        elif (VARname == "nWallPlayer" and ageSDL["nWallPlayer"][0] != -1):
             if (ageSDL["sState"][0] == kEntry or PtIsSolo()):
-                if (eventHandler):
+                if (eventHandler and self.IAmMaster()):
                     eventHandler.Handle(kEventStart)
                 #both players are in the Tube - flush them down
                 if (cID == ageSDL["nWallPlayer"][0]):
-                    PtGetLocalAvatar().avatar.runBehaviorSetNotify(NorthTubeMulti.value, self.key, NorthTubeMulti.netForce)
+                    avatar.avatar.runBehaviorSetNotify(NorthTubeMulti.value, self.key, NorthTubeMulti.netForce)
                 if (cID == ageSDL["sWallPlayer"][0]):
-                    PtGetLocalAvatar().avatar.runBehaviorSetNotify(SouthTubeMulti.value, self.key, SouthTubeMulti.netForce)
+                    avatar.avatar.runBehaviorSetNotify(SouthTubeMulti.value, self.key, SouthTubeMulti.netForce)
             elif (ageSDL["nState"][0] == kGameInProgress and cID == ageSDL["nWallPlayer"][0]):
                 #additional player joining Game In Progress
-                PtGetLocalAvatar().avatar.runBehaviorSetNotify(NorthTubeMulti.value, self.key, NorthTubeMulti.netForce)
+                avatar.avatar.runBehaviorSetNotify(NorthTubeMulti.value, self.key, NorthTubeMulti.netForce)
 
-        if (VARname == "sWallPlayer" and ageSDL["sWallPlayer"] != (-1,)):
+        elif (VARname == "sWallPlayer" and ageSDL["sWallPlayer"][0] != -1):
             if (ageSDL["nState"][0] == kEntry or PtIsSolo()):
-                if (eventHandler):
+                if (eventHandler and self.IAmMaster()):
                     eventHandler.Handle(kEventStart)
                 #both players are in the Tube - flush them down
                 if (cID == ageSDL["nWallPlayer"][0]):
-                    PtGetLocalAvatar().avatar.runBehaviorSetNotify(NorthTubeMulti.value, self.key, NorthTubeMulti.netForce)
+                    avatar.avatar.runBehaviorSetNotify(NorthTubeMulti.value, self.key, NorthTubeMulti.netForce)
                 if (cID == ageSDL["sWallPlayer"][0]):
-                    PtGetLocalAvatar().avatar.runBehaviorSetNotify(SouthTubeMulti.value, self.key, SouthTubeMulti.netForce)
+                    avatar.avatar.runBehaviorSetNotify(SouthTubeMulti.value, self.key, SouthTubeMulti.netForce)
             elif (ageSDL["sState"][0] == kGameInProgress and cID == ageSDL["sWallPlayer"][0]):
                 #additional player joining Game In Progress
-                PtGetLocalAvatar().avatar.runBehaviorSetNotify(SouthTubeMulti.value, self.key, SouthTubeMulti.netForce)
+                avatar.avatar.runBehaviorSetNotify(SouthTubeMulti.value, self.key, SouthTubeMulti.netForce)
+
+        elif (VARname == "nChairOccupant"):
+            self.SetPanelMode(kNorth)
+            if (ageSDL["nChairOccupant"][0] == -1):
+                NorthChair.enable()
+            else:
+                NorthChair.disable()
+        elif (VARname == "sChairOccupant"):
+            self.SetPanelMode(kSouth)
+            if (ageSDL["sChairOccupant"][0] == -1):
+                SouthChair.enable()
+            else:
+                SouthChair.disable()
 
     def FindBlocker(self,team,id):
         ageSDL = PtGetAgeSDL()
@@ -823,7 +832,7 @@ class grsnWallPython(ptResponder):
                     break
         return blockerFound
 
-    def SetPanelMode(self,team,disableAll=False,onlNorthLights=False):
+    def SetPanelMode(self,team,onlNorthLights=False):
         ageSDL = PtGetAgeSDL()
         cID = PtGetLocalClientID()
         if (team == kNorth):
@@ -850,22 +859,12 @@ class grsnWallPython(ptResponder):
             return
 
         PtDebugPrint("grsnWallPython::SetPanelMode: %s - %d" % (team, state))
-        if (disableAll):
-            for i in range(0,171):
-                Panel[team].value[i].physics.disable()
-            goButton[team].disable()
-            upButton[team].disable()
-            dnButton[team].disable()
-            readyButton[team].disable()
-            fiveBtn[team].disable()
-            tenBtn[team].disable()
-            fifteenBtn[team].disable()
-        elif (state == kStandby or state == kEnd):
+        if (state == kStandby or state == kEnd):
             for i in range(0,20):
                 CountLights[team].value[i].runAttachedResponder(kRedOff)
             for i in range(0,171):
                 Panel[team].value[i].physics.disable()
-            goButton[team].disable()
+            goBtnObject[team].value.physics.disable()
             upButton[team].disable()
             dnButton[team].disable()
             readyButton[team].disable()
@@ -874,13 +873,15 @@ class grsnWallPython(ptResponder):
             fifteenBtn[team].disable()
         elif (state == kSit):
             if cID == ageSDL["nChairOccupant"][0] or cID == ageSDL["sChairOccupant"][0]:
-                goButton[team].enable()
-                upButton[team].disable()
-                dnButton[team].disable()
-                readyButton[team].disable()
-                fiveBtn[team].disable()
-                tenBtn[team].disable()
-                fifteenBtn[team].disable()
+                goBtnObject[team].value.physics.enable()
+            else:
+                goBtnObject[team].value.physics.disable()
+            upButton[team].disable()
+            dnButton[team].disable()
+            readyButton[team].disable()
+            fiveBtn[team].disable()
+            tenBtn[team].disable()
+            fifteenBtn[team].disable()
         elif (ageSDL["nState"][0] == kSelectCount or ageSDL["sState"][0] == kSelectCount):
             if ageSDL["NumBlockers"][0] == 0:
                 for i in range(0,171):
@@ -892,53 +893,69 @@ class grsnWallPython(ptResponder):
                 else:
                     CountLights[team].value[i].runAttachedResponder(kRedOff)
             if cID == ageSDL["nChairOccupant"][0] or cID == ageSDL["sChairOccupant"][0]:
-                goButton[team].disable()
+                goBtnObject[team].value.physics.disable()
                 upButton[team].enable()
                 dnButton[team].enable()
                 readyButton[team].enable()
                 fiveBtn[team].enable()
                 tenBtn[team].enable()
                 fifteenBtn[team].enable()
-        elif (state == kSetBlocker):
-            for i in range(0,ageSDL["NumBlockers"][0]):
-                if (i < self.GetNumBlockerSet(team)):
-                    CountLights[team].value[i].runAttachedResponder(kTeamLightsOn)
-                else:
-                    CountLights[team].value[i].runAttachedResponder(kRedOn)
-            for i in range(0,171):
-                Panel[team].value[i].physics.enable()
-            if cID == ageSDL["nChairOccupant"][0] or cID == ageSDL["sChairOccupant"][0]:
-                goButton[team].enable()
+            else:
+                goBtnObject[team].value.physics.disable()
                 upButton[team].disable()
                 dnButton[team].disable()
                 readyButton[team].disable()
                 fiveBtn[team].disable()
                 tenBtn[team].disable()
                 fifteenBtn[team].disable()
+        elif (state == kSetBlocker):
+            for i in range(0,ageSDL["NumBlockers"][0]):
+                if (i < self.GetNumBlockerSet(team)):
+                    CountLights[team].value[i].runAttachedResponder(kTeamLightsOn)
+                else:
+                    CountLights[team].value[i].runAttachedResponder(kRedOn)
+            if cID == ageSDL["nChairOccupant"][0] or cID == ageSDL["sChairOccupant"][0]:
+                goBtnObject[team].value.physics.enable()
+                for i in range(0,171):
+                    Panel[team].value[i].physics.enable()
+            else:
+                goBtnObject[team].value.physics.disable()
+                for i in range(0,171):
+                    Panel[team].value[i].physics.disable()
+            upButton[team].disable()
+            dnButton[team].disable()
+            readyButton[team].disable()
+            fiveBtn[team].disable()
+            tenBtn[team].disable()
+            fifteenBtn[team].disable()
         else:
             for i in range(0,171):
                 Panel[team].value[i].physics.disable()
-            if cID == ageSDL["nChairOccupant"][0] or cID == ageSDL["sChairOccupant"][0]:
-                goButton[team].disable()
+            goBtnObject[team].value.physics.disable()
+            upButton[team].disable()
+            dnButton[team].disable()
+            readyButton[team].disable()
+            fiveBtn[team].disable()
+            tenBtn[team].disable()
+            fifteenBtn[team].disable()
 
-    def ChangeGameState(self,team,state):
-        if (self.IAmMaster()):
+    def ChangeGameState(self,team,state,master=False):
+        PtDebugPrint("grsnWallPython::ChangeGameState: New State %d for team %s" % (state, team))
+        if (master and self.IAmMaster()) or not master:
             ageSDL = PtGetAgeSDL()
-            PtDebugPrint("grsnWallPython::ChangeGameState: New State %d for team %s" % (state, team))
             if (team == kNorth):
                 ageSDL["nState"] = (state,)
             elif (team == kSouth):
                 ageSDL["sState"] = (state,)
 
     def ChangeChuteState(self,team,cID):
-        if (self.IAmMaster()):
-            ageSDL = PtGetAgeSDL()
-            if (team == kNorth and ageSDL["nWallPlayer"] != cID):
-                PtDebugPrint("grsnWallPython::ChangeChuteState: New PlayerID %d for nWallPlayer" % (cID))
-                ageSDL["nWallPlayer"] = (cID,)
-            elif (team == kSouth and ageSDL["sWallPlayer"] != cID):
-                PtDebugPrint("grsnWallPython::ChangeChuteState: New PlayerID %d for sWallPlayer" % (cID))
-                ageSDL["sWallPlayer"] = (cID,)
+        ageSDL = PtGetAgeSDL()
+        if (team == kNorth and ageSDL["nWallPlayer"][0] != cID):
+            PtDebugPrint("grsnWallPython::ChangeChuteState: New PlayerID %d for nWallPlayer" % (cID))
+            ageSDL["nWallPlayer"] = (cID,)
+        elif (team == kSouth and ageSDL["sWallPlayer"][0] != cID):
+            PtDebugPrint("grsnWallPython::ChangeChuteState: New PlayerID %d for sWallPlayer" % (cID))
+            ageSDL["sWallPlayer"] = (cID,)
 
     def PanelLight(self):
         ageSDL = PtGetAgeSDL()
@@ -979,9 +996,8 @@ class grsnWallPython(ptResponder):
                 confirmPanelLightsSouth.value[i].draw.disable()
 
     def ChangeBlockerCount(self,num):
-        if (self.IAmMaster()):
-            ageSDL = PtGetAgeSDL()
-            ageSDL["NumBlockers"] = (num,)
+        ageSDL = PtGetAgeSDL()
+        ageSDL["NumBlockers"] = (num,)
 
     def RequestGameUpdate(self):
         ageSDL = PtGetAgeSDL()
@@ -1014,6 +1030,15 @@ class grsnWallPython(ptResponder):
         else:
             SouthTubeClose.run(self.key, netForce=0, netPropagate=0, fastforward=1)
             SouthTubeExclude.clear(self.key)
+
+        if (ageSDL["nChairOccupant"][0] == -1):
+            NorthChair.enable()
+        else:
+            NorthChair.disable()
+        if (ageSDL["sChairOccupant"][0] == -1):
+            SouthChair.enable()
+        else:
+            SouthChair.disable()
 
         self.PanelLight()
 
@@ -1077,18 +1102,19 @@ class grsnWallPython(ptResponder):
              return 20
 
     def ResetWall(self,resetState=True):
-        if (self.IAmMaster()):
-            ageSDL = PtGetAgeSDL()
-            ageSDL["northWall"] = (-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,)
-            ageSDL["southWall"] = (-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,)
+        ageSDL = PtGetAgeSDL()
+        ageSDL["northWall"] = (-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,)
+        ageSDL["southWall"] = (-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,)
 
-            ageSDL["nWallPlayer"] = (-1,)
-            ageSDL["sWallPlayer"] = (-1,)
-            ageSDL["NumBlockers"] = (0,)
+        ageSDL["nWallPlayer"] = (-1,)
+        ageSDL["sWallPlayer"] = (-1,)
+        ageSDL["NumBlockers"] = (0,)
 
-            if (resetState):
-                ageSDL["nState"] = (kStandby,)
-                ageSDL["sState"] = (kStandby,)
+        if (resetState):
+            ageSDL["nState"] = (kStandby,)
+            ageSDL["sState"] = (kStandby,)
+            ageSDL["nChairOccupant"] = (-1,)
+            ageSDL["sChairOccupant"] = (-1,)
 
         for i in range(0,171):
             NorthWall.value[i].physics.disable()

--- a/Scripts/Python/grsnWallPython.py
+++ b/Scripts/Python/grsnWallPython.py
@@ -607,7 +607,7 @@ class grsnWallPython(ptResponder):
         ### Win region ###
         elif (id == NorthTeamWin.id):
             PtAtTimeCallback(self.key, 3.0, kLinkToNorthNexus)
-            if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["nState"][0] != kEnd and not PtIsSolo()):
+            if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["nState"][0] == kGameInProgress and not PtIsSolo()):
                 currentgender = avatar.avatar.getAvatarClothingGroup()
                 if currentgender == kFemaleClothingGroup:
                     clothing = FemaleSuit
@@ -622,7 +622,7 @@ class grsnWallPython(ptResponder):
                         item = self.IGetItem(item)
                         if hasattr(item, "description"):
                             PtSendKIMessage(kKILocalChatStatusMsg,PtGetLocalizedString("KI.Messages.NewClothing", [item.description]))
-            if (ageSDL["nState"][0] != kEnd):
+            if (ageSDL["nState"][0] == kGameInProgress):
                 if (eventHandler):
                     eventHandler.Handle(kEventNorthWin)
                 self.ChangeGameState(kNorth, kEnd)
@@ -630,7 +630,7 @@ class grsnWallPython(ptResponder):
             return
         elif (id == SouthTeamWin.id):
             PtAtTimeCallback(self.key, 3.0, kLinkToSouthNexus)
-            if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["sState"][0] != kEnd and not PtIsSolo()):
+            if (ageSDL["grsnGrantMaintainerSuit"][0] and ageSDL["sState"][0] == kGameInProgress and not PtIsSolo()):
                 currentgender = avatar.avatar.getAvatarClothingGroup()
                 if currentgender == kFemaleClothingGroup:
                     clothing = FemaleSuit
@@ -645,7 +645,7 @@ class grsnWallPython(ptResponder):
                         item = self.IGetItem(item)
                         if hasattr(item, "description"):
                             PtSendKIMessage(kKILocalChatStatusMsg,PtGetLocalizedString("KI.Messages.NewClothing", [item.description]))
-            if (ageSDL["sState"][0] != kEnd):
+            if (ageSDL["sState"][0] == kGameInProgress):
                 if (eventHandler):
                     eventHandler.Handle(kEventSouthWin)
                 self.ChangeGameState(kNorth, kEnd)
@@ -654,7 +654,7 @@ class grsnWallPython(ptResponder):
         ### Quit button ###
         elif (id == NorthTeamQuit.id and state):
             avatar.avatar.runBehaviorSetNotify(NorthQuitBehavior.value, self.key, NorthQuitBehavior.netForce)
-            if (ageSDL["nState"][0] != kEnd):
+            if (ageSDL["nState"][0] == kGameInProgress):
                 if (eventHandler):
                     eventHandler.Handle(kEventNorthQuit)
                 self.ChangeGameState(kNorth, kEnd)
@@ -662,7 +662,7 @@ class grsnWallPython(ptResponder):
             return
         elif (id == SouthTeamQuit.id and state):
             avatar.avatar.runBehaviorSetNotify(SouthQuitBehavior.value, self.key, SouthQuitBehavior.netForce)
-            if (ageSDL["sState"][0] != kEnd):
+            if (ageSDL["sState"][0] == kGameInProgress):
                 if (eventHandler):
                     eventHandler.Handle(kEventSouthQuit)
                 self.ChangeGameState(kNorth, kEnd)


### PR DESCRIPTION
**grsnMainWallPython.py**

1. Blocker announcements will now only happen during a game.
You could before stay in the game area after it ended and wait for someone to sit at the North panel, and then it would allow announcements again.

**grsnWallImagerDisplay(N|S).py**
1. fix a code crash

**grsnWallPython.py**
Lot of code movement on this change. 
1. Added a check in the OnNotify section to only trigger code for the player that initiated the action @ line 466.
This change made it so I could move only the things that needed to be multiplayer above it that and cause less code to run for players that don't need it.
2. Reduced the for loops for the events. It will now only run through the events loop once for everything that needs that loop.
3. Was able to make it so setting the SDL was not needed to be done by the game master and could be done by the player that triggered the action instead. There are still a few spots that it needs the game master to be the only player setting the SDL, but that is greatly reduced.
4. The panel lights section (SetPanelMode @ line 820) got a few bug fixes and adjustments.
Now disable the panel completely once you lock in the blockers. Before you could click the blockers and cause OnNotify events to trigger even after you locked in the blockers.