### PR TITLE
Fix buffer overread and incorrect termination of server status message

### DIFF
--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -720,8 +720,9 @@ static size_t CurlCallback(void *buffer, size_t size, size_t nmemb, void *param)
 
     HWND hwnd = (HWND)param;
 
-    strncpy(status, (const char *)buffer, std::min<size_t>(size * nmemb, 256));
-    status[255] = 0;
+    size_t count = std::min<size_t>(size * nmemb, std::size(status) - 1);
+    memcpy(status, buffer, count);
+    status[count] = 0;
     PostMessage(hwnd, WM_USER_SETSTATUSMSG, 0, (LPARAM) status);
     return size * nmemb;
 }

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
@@ -95,8 +95,9 @@ static size_t ICurlCallback(void* buffer, size_t size, size_t nmemb, void* threa
 {
     static char status[256];
 
-    strncpy(status, (const char *)buffer, std::min<size_t>(size * nmemb, std::size(status)));
-    status[std::size(status) - 1] = 0;
+    size_t count = std::min<size_t>(size * nmemb, std::size(status) - 1);
+    memcpy(status, buffer, count);
+    status[count] = 0;
     static_cast<plShardStatus*>(thread)->fShardFunc(status);
     return size * nmemb;
 }


### PR DESCRIPTION
The previous code incorrectly assumed that the buffer from curl is a zero-terminated string.

This issue was almost never noticeable, because I guess in practice both buffers start out zero-initialized. One case where it was noticeable: when the server dynamically changes the status message to a shorter message, the client displayed garbage characters from the previous (longer) message at the end.