### PR TITLE
Fix `OnOwnershipChanged` callbacks.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
@@ -184,7 +184,12 @@ MSG_HANDLER_DEFN(plNetClientMsgHandler,plNetMsgGroupOwner)
         delete netOwnMsg;
     */
 
+    // Simplified object ownership model means that one client owns everything.
+    hsLogEntry(nc->DebugMsg("<RCV> plNetMsgGroupOwner, isOwner={}", m->IsOwner()));
     nc->SetObjectOwner(m->IsOwner());
+
+    plNetOwnershipMsg* netOwnMsg = new plNetOwnershipMsg();
+    netOwnMsg->Send();
 
     return hsOK;
 }


### PR DESCRIPTION
Although we are indeed using a simplified object ownership model, we do still want to send out broadcasts to game scripts about when the ownership was changed.

This is needed for the upcoming rewrite of xBlueSpiral to use swappable backends. See #1217.