### PR TITLE
Fix Bahro Cave TPP camera

### DIFF
--- a/Scripts/Python/bhroBahroBlueSpiral.py
+++ b/Scripts/Python/bhroBahroBlueSpiral.py
@@ -84,7 +84,7 @@ class bhroBahroBlueSpiral(ptResponder):
         gAgeStartedIn = PtGetAgeName()
         PtSendKIMessage(kDisableYeeshaBook,0)
 
-    def BeginAgeUnLoad(self,avatar):
+    def BeginAgeUnLoad(self, avatar):
         ptCamera().enableFirstPersonOverride()
 
     ###########################

--- a/Scripts/Python/bhroBahroBlueSpiral.py
+++ b/Scripts/Python/bhroBahroBlueSpiral.py
@@ -60,6 +60,8 @@ clkBSDelin              = ptAttribActivator(2, "clk: Delin Blue Spiral")
 respWedges              = ptAttribResponder(3, "resp: Ground Wedges", ['Delin', 'Tsogal'])
 respRings               = ptAttribResponder(4, "resp: Floating Rings", ['Delin', 'Tsogal'])
 
+rgnCaveJump             = ptAttribActivator(5, "Cave jump region")
+
 # define global variables
 
 #====================================
@@ -81,6 +83,9 @@ class bhroBahroBlueSpiral(ptResponder):
 
         gAgeStartedIn = PtGetAgeName()
         PtSendKIMessage(kDisableYeeshaBook,0)
+
+    def BeginAgeUnLoad(self,avatar):
+        ptCamera().enableFirstPersonOverride()
 
     ###########################
     def OnServerInitComplete(self):
@@ -120,4 +125,11 @@ class bhroBahroBlueSpiral(ptResponder):
             if not sdlVal:
                 PtDebugPrint("bhroBahroBlueSpiral.OnNotify:  Tturning wedge SDL of psnlBahroWedge05 to On")
                 psnlSDL["psnlBahroWedge05"] = (1,)
+
+        # notify from cave jump force 3rd person region
+        elif id == rgnCaveJump.id:
+            cam = ptCamera()
+            cam.undoFirstPerson()
+            cam.disableFirstPersonOverride()
+            PtDebugPrint("undid first person and disabled override")
 

--- a/Scripts/Python/bhroBahroMink.py
+++ b/Scripts/Python/bhroBahroMink.py
@@ -81,7 +81,7 @@ class bhroBahroMink(ptResponder):
         gAgeStartedIn = PtGetAgeName()
         PtSendKIMessage(kDisableYeeshaBook,0)
 
-    def BeginAgeUnLoad(self,avatar):
+    def BeginAgeUnLoad(self, avatar):
         ptCamera().enableFirstPersonOverride()
 
     ###########################

--- a/Scripts/Python/bhroBahroMink.py
+++ b/Scripts/Python/bhroBahroMink.py
@@ -57,6 +57,8 @@ from xPsnlVaultSDL import *
 clickable       = ptAttribActivator(1, "clickable")
 respRing        = ptAttribResponder(2, "resp: Ring")
 
+rgnCaveJump     = ptAttribActivator(3, "Cave jump region")
+
 # define global variables
 
 #====================================
@@ -79,6 +81,9 @@ class bhroBahroMink(ptResponder):
         gAgeStartedIn = PtGetAgeName()
         PtSendKIMessage(kDisableYeeshaBook,0)
 
+    def BeginAgeUnLoad(self,avatar):
+        ptCamera().enableFirstPersonOverride()
+
     ###########################
     def OnServerInitComplete(self):
         psnlSDL = xPsnlVaultSDL()
@@ -100,3 +105,11 @@ class bhroBahroMink(ptResponder):
             if not sdlVal:
                 PtDebugPrint("bhroBahroMink.OnNotify:  Turning wedge SDL of psnlBahroWedge11 to On")
                 psnlSDL["psnlBahroWedge11"] = (1,)
+
+        # notify from cave jump force 3rd person region
+        elif id == rgnCaveJump.id:
+            cam = ptCamera()
+            cam.undoFirstPerson()
+            cam.disableFirstPersonOverride()
+            PtDebugPrint("undid first person and disabled override")
+

--- a/Scripts/Python/bhroBahroPOTS.py
+++ b/Scripts/Python/bhroBahroPOTS.py
@@ -60,6 +60,7 @@ respWedges  = ptAttribResponder(3, "resp: Ground Wedges", ['Ercana','Ahnonay'])
 respErcanaRing  = ptAttribResponder(4, "resp: Ercana Floating Ring")
 respAhnonayRing = ptAttribResponder(5, "resp: Ahnonay Floating Ring")
 
+rgnCaveJump     = ptAttribActivator(6, "Cave jump region")
 
 class bhroBahroPOTS(ptResponder):
     def __init__(self):
@@ -75,6 +76,8 @@ class bhroBahroPOTS(ptResponder):
         gAgeStartedIn = PtGetAgeName()
         PtSendKIMessage(kDisableYeeshaBook,0)
 
+    def BeginAgeUnLoad(self,avatar):
+        ptCamera().enableFirstPersonOverride()
 
     def OnServerInitComplete(self):
         # if the age is not the one that I'm from then run the responder to make it back off
@@ -118,4 +121,10 @@ class bhroBahroPOTS(ptResponder):
                 PtDebugPrint("bhroBahroPOTS.OnNotify:  Turning wedge SDL of psnlBahroWedge13 to On")
                 psnlSDL["psnlBahroWedge13"] = (1,)
 
+        # notify from cave jump force 3rd person region
+        elif id == rgnCaveJump.id:
+            cam = ptCamera()
+            cam.undoFirstPerson()
+            cam.disableFirstPersonOverride()
+            PtDebugPrint("undid first person and disabled override")
 

--- a/Scripts/Python/bhroBahroPOTS.py
+++ b/Scripts/Python/bhroBahroPOTS.py
@@ -76,7 +76,7 @@ class bhroBahroPOTS(ptResponder):
         gAgeStartedIn = PtGetAgeName()
         PtSendKIMessage(kDisableYeeshaBook,0)
 
-    def BeginAgeUnLoad(self,avatar):
+    def BeginAgeUnLoad(self, avatar):
         ptCamera().enableFirstPersonOverride()
 
     def OnServerInitComplete(self):

--- a/Scripts/Python/bhroBahroPod.py
+++ b/Scripts/Python/bhroBahroPod.py
@@ -89,7 +89,7 @@ class bhroBahroPod(ptResponder):
         gAgeStartedIn = PtGetAgeName()
         PtSendKIMessage(kDisableYeeshaBook,0)
 
-    def BeginAgeUnLoad(self,avatar):
+    def BeginAgeUnLoad(self, avatar):
         ptCamera().enableFirstPersonOverride()
 
     ###########################

--- a/Scripts/Python/bhroBahroPod.py
+++ b/Scripts/Python/bhroBahroPod.py
@@ -65,6 +65,8 @@ respDerenoRing          = ptAttribResponder(7, "resp: Dereno Floating Ring")
 respPayiferenRing       = ptAttribResponder(8, "resp: Payiferen Floating Ring")
 respTetsonotRing        = ptAttribResponder(9, "resp: Tetsonot Floating Ring")
 
+rgnCaveJump             = ptAttribActivator(10, "Cave jump region")
+
 # define global variables
 
 #====================================
@@ -86,6 +88,9 @@ class bhroBahroPod(ptResponder):
 
         gAgeStartedIn = PtGetAgeName()
         PtSendKIMessage(kDisableYeeshaBook,0)
+
+    def BeginAgeUnLoad(self,avatar):
+        ptCamera().enableFirstPersonOverride()
 
     ###########################
     def OnServerInitComplete(self):
@@ -171,3 +176,9 @@ class bhroBahroPod(ptResponder):
                 PtDebugPrint("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge10 to On")
                 psnlSDL["psnlBahroWedge10"] = (1,)
 
+        # notify from cave jump force 3rd person region
+        elif id == rgnCaveJump.id:
+            cam = ptCamera()
+            cam.undoFirstPerson()
+            cam.disableFirstPersonOverride()
+            PtDebugPrint("undid first person and disabled override")

--- a/Scripts/Python/bhroBahroYeeshaCave.py
+++ b/Scripts/Python/bhroBahroYeeshaCave.py
@@ -148,6 +148,8 @@ class bhroBahroYeeshaCave(ptModifier):
         self.SpeechRespReset = 1
         self.IsStarfield = 1
 
+    def BeginAgeUnLoad(self,avatar):
+        ptCamera().enableFirstPersonOverride()
 
     def OnFirstUpdate(self):
         PtDebugPrint("DEBUG: bhroBahroYeeshaCave.OnFirstUpdate():\tEverything ok so far")

--- a/Scripts/Python/bhroBahroYeeshaCave.py
+++ b/Scripts/Python/bhroBahroYeeshaCave.py
@@ -148,7 +148,7 @@ class bhroBahroYeeshaCave(ptModifier):
         self.SpeechRespReset = 1
         self.IsStarfield = 1
 
-    def BeginAgeUnLoad(self,avatar):
+    def BeginAgeUnLoad(self, avatar):
         ptCamera().enableFirstPersonOverride()
 
     def OnFirstUpdate(self):


### PR DESCRIPTION
Assets - https://github.com/H-uru/moul-assets/pull/216

@EhrenCG pointed out that when your camera is forced to third person in the Bahro Pole cave it doesnt revert that camera and your arrival in Relto will have a messed up third person camera. He also provided a fix for this behavior.

This fix reverts the camera properly on leaving the bahro cave ages.


The Live bahro caves did not force third person camera when falling out of the caves.
Ive added the code required to do that.

All caves should force third person camera when you fall out of them.