### PR TITLE
Improve Unicode support in `pfJournalBook` and related code

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -259,53 +259,7 @@ bool    pfGUIEditBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
                 return true;
             }
 #endif
-            // capture the key
-            fSavedKey = key;
-            fSavedModifiers = modifiers;
-
-            // turn key event into string
-            char keyStr[30];
-            if (plKeyMap::ConvertVKeyToChar( key ))
-                strcpy(keyStr, plKeyMap::ConvertVKeyToChar( key ));
-            else
-                memset(keyStr, 0, sizeof(keyStr));
-
-            static char shortKey[ 2 ];
-            if( strlen(keyStr) == 0 )
-            {
-                if( isalnum( key ) )
-                {
-                    shortKey[ 0 ] = (char)key;
-                    shortKey[ 1 ] = 0;
-                    strcpy(keyStr, shortKey);
-                }
-                else
-                    strcpy(keyStr, plKeyMap::GetStringUnmapped());
-            }
-            else
-            {
-                // check to see the buffer has ForewardSlash and change it to ForwardSlash
-                if ( strcmp(keyStr,"ForewardSlash") == 0)
-                {
-                    strcpy(keyStr,"ForwardSlash");
-                }
-            }
-
-            static char newKey[ 16 ];
-            newKey[0] = 0;
-            if( modifiers & kShift )
-                strcat( newKey, plKeyMap::GetStringShift() );
-            if( modifiers & kCtrl )
-                strcat( newKey, plKeyMap::GetStringCtrl() );
-            strcat( newKey, keyStr );
-
-            // set something in the buffer to be displayed
-            wchar_t* temp = hsStringToWString(newKey);
-            wcsncpy( fBuffer.data(), temp , fBuffer.size() );
-            delete [] temp;
-            fCursorPos = 0;
-            SetCursorToEnd();
-            IUpdate();
+            SetLastKeyCapture((uint32_t)key, modifiers);
 
             // done capturing... tell the handler
             DoSomething();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -340,7 +340,7 @@ bool    pfGUIEditBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
             {
                 if (key == KEY_C) 
                 {
-                    plClipboard::GetInstance().SetClipboardText(fBuffer.c_str());
+                    plClipboard::GetInstance().SetClipboardText(ST::string::from_wchar(fBuffer.c_str(), ST_AUTO_SIZE));
                 }
                 else if (key == KEY_V)
                 {
@@ -401,7 +401,7 @@ bool    pfGUIEditBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
 
 void    pfGUIEditBoxMod::ClearBuffer()
 {
-    fBuffer.allocate(fBuffer.size(), 0);
+    memset(fBuffer.data(), 0, fBuffer.size());
     fCursorPos = 0;
     fScrollPos = 0;
     IUpdate();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -458,7 +458,7 @@ void pfGUIEditBoxMod::SetLastKeyCapture(uint32_t key, uint8_t modifiers)
     else
     {
         // check to see the buffer has ForewardSlash and change it to ForwardSlash
-        if (keyStr == ST_LITERAL("ForewardSlash"))
+        if (keyStr == "ForewardSlash")
         {
             keyStr = ST_LITERAL("ForwardSlash");
         }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -456,14 +456,6 @@ bool    pfGUIEditBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
     }
 }
 
-std::string pfGUIEditBoxMod::GetBuffer()
-{
-    char* temp = hsWStringToString(fBuffer);
-    std::string retVal = temp;
-    delete [] temp;
-    return retVal;
-}
-
 void    pfGUIEditBoxMod::ClearBuffer()
 {
     if (fBuffer != nullptr)
@@ -473,13 +465,6 @@ void    pfGUIEditBoxMod::ClearBuffer()
         fScrollPos = 0;
         IUpdate();
     }
-}
-
-void    pfGUIEditBoxMod::SetText( const char *str )
-{
-    wchar_t* temp = hsStringToWString(str);
-    SetText(temp);
-    delete [] temp;
 }
 
 void    pfGUIEditBoxMod::SetText( const wchar_t *str )

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -441,45 +441,39 @@ void pfGUIEditBoxMod::SetLastKeyCapture(uint32_t key, uint8_t modifiers)
     fSavedModifiers = modifiers;
 
     // turn key event into string
-    char keyStr[30];
+    ST::string keyStr;
     if (plKeyMap::ConvertVKeyToChar( key ))
-        strcpy(keyStr, plKeyMap::ConvertVKeyToChar( key ));
-    else
-        memset(keyStr, 0, sizeof(keyStr));
+        keyStr = ST::string::from_latin_1(plKeyMap::ConvertVKeyToChar( key ));
 
-    static char shortKey[ 2 ];
-    if( strlen(keyStr) == 0 )
+    if(keyStr.empty())
     {
         if( isalnum( key ) )
         {
-            shortKey[ 0 ] = (char)key;
-            shortKey[ 1 ] = 0;
-            strcpy(keyStr, shortKey);
+            char keyChar = (char)key;
+            keyStr = ST::string::from_latin_1(&keyChar, 1);
         }
         else
-            strcpy(keyStr, plKeyMap::GetStringUnmapped());
+            keyStr = ST::string::from_latin_1(plKeyMap::GetStringUnmapped());
     }
     else
     {
         // check to see the buffer has ForewardSlash and change it to ForwardSlash
-        if ( strcmp(keyStr,"ForewardSlash") == 0)
+        if (keyStr == "ForewardSlash")
         {
-            strcpy(keyStr,"ForwardSlash");
+            keyStr = "ForwardSlash";
         }
     }
 
-    static char newKey[ 16 ];
-    newKey[0] = 0;
+    ST::string newKey;
     if( modifiers & kShift )
-        strcat( newKey, plKeyMap::GetStringShift() );
+        newKey += ST::string::from_latin_1(plKeyMap::GetStringShift());
     if( modifiers & kCtrl )
-        strcat( newKey, plKeyMap::GetStringCtrl() );
-    strcat( newKey, keyStr );
+        newKey += ST::string::from_latin_1(plKeyMap::GetStringCtrl());
+    newKey += keyStr;
 
     // set something in the buffer to be displayed
-    wchar_t* temp = hsStringToWString(newKey);
-    wcsncpy( fBuffer.data(), temp , fBuffer.size() );
-    delete [] temp;
+    ST::wchar_buffer temp = newKey.to_wchar();
+    wcsncpy( fBuffer.data(), temp.c_str(), fBuffer.size() );
 
     fCursorPos = 0;
     SetCursorToEnd();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -458,9 +458,9 @@ void pfGUIEditBoxMod::SetLastKeyCapture(uint32_t key, uint8_t modifiers)
     else
     {
         // check to see the buffer has ForewardSlash and change it to ForwardSlash
-        if (keyStr == "ForewardSlash")
+        if (keyStr == ST_LITERAL("ForewardSlash"))
         {
-            keyStr = "ForwardSlash";
+            keyStr = ST_LITERAL("ForwardSlash");
         }
     }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -464,15 +464,17 @@ void pfGUIEditBoxMod::SetLastKeyCapture(uint32_t key, uint8_t modifiers)
         }
     }
 
-    ST::string newKey;
+    // Using ST::string_stream here avoids extra allocations
+    // because its SSO buffer is much larger than ST::string's.
+    ST::string_stream newKey;
     if( modifiers & kShift )
-        newKey += ST::string::from_latin_1(plKeyMap::GetStringShift());
+        newKey << ST::string::from_latin_1(plKeyMap::GetStringShift());
     if( modifiers & kCtrl )
-        newKey += ST::string::from_latin_1(plKeyMap::GetStringCtrl());
-    newKey += keyStr;
+        newKey << ST::string::from_latin_1(plKeyMap::GetStringCtrl());
+    newKey << keyStr;
 
     // set something in the buffer to be displayed
-    ST::wchar_buffer temp = newKey.to_wchar();
+    ST::wchar_buffer temp = newKey.to_string().to_wchar();
     wcsncpy( fBuffer.data(), temp.c_str(), fBuffer.size() );
 
     fCursorPos = 0;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
@@ -109,10 +109,8 @@ class pfGUIEditBoxMod : public pfGUIControlMod
 
         void    SetBufferSize( uint32_t size );
 
-        std::string GetBuffer();
-        std::wstring    GetBufferW() { return fBuffer; }
+        std::wstring    GetBuffer() { return fBuffer; }
         void        ClearBuffer();
-        void        SetText( const char *str );
         void        SetText( const wchar_t *str );
 
         void        SetCursorToHome();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
@@ -50,7 +50,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
-#include <string>
+#include <string_theory/char_buffer>
+#include <string_theory/string>
 
 #include "pfGUIControlMod.h"
 
@@ -64,8 +65,8 @@ class pfGUIEditBoxMod : public pfGUIControlMod
 {
     protected:
 
-        wchar_t         *fBuffer;
-        uint32_t          fBufferSize, fCursorPos;
+        ST::wchar_buffer fBuffer;
+        uint32_t        fCursorPos;
         int32_t           fScrollPos;
         bool            fEscapedFlag;
         bool            fFirstHalfExitKeyPushed;
@@ -88,7 +89,6 @@ class pfGUIEditBoxMod : public pfGUIControlMod
         };
 
         pfGUIEditBoxMod();
-        virtual ~pfGUIEditBoxMod();
 
         CLASSNAME_REGISTER( pfGUIEditBoxMod );
         GETINTERFACE_ANY( pfGUIEditBoxMod, pfGUIControlMod );
@@ -109,9 +109,9 @@ class pfGUIEditBoxMod : public pfGUIControlMod
 
         void    SetBufferSize( uint32_t size );
 
-        std::wstring    GetBuffer() { return fBuffer; }
+        ST::string  GetBuffer() { return fBuffer.c_str(); }
         void        ClearBuffer();
-        void        SetText( const wchar_t *str );
+        void        SetText( const ST::string& str );
 
         void        SetCursorToHome();
         void        SetCursorToEnd();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
@@ -109,7 +109,7 @@ class pfGUIEditBoxMod : public pfGUIControlMod
 
         void    SetBufferSize( uint32_t size );
 
-        ST::string  GetBuffer() { return fBuffer.c_str(); }
+        ST::string  GetBuffer() const { return fBuffer.c_str(); }
         void        ClearBuffer();
         void        SetText( const ST::string& str );
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
@@ -109,7 +109,7 @@ class pfGUIEditBoxMod : public pfGUIControlMod
 
         void    SetBufferSize( uint32_t size );
 
-        ST::string  GetBuffer() const { return fBuffer.c_str(); }
+        ST::string  GetBuffer() const { return ST::string::from_wchar(fBuffer.c_str(), ST_AUTO_SIZE); }
         void        ClearBuffer();
         void        SetText( const ST::string& str );
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.cpp
@@ -76,13 +76,6 @@ pfGUIMenuItem::~pfGUIMenuItem()
     delete [] fName;
 }
 
-void    pfGUIMenuItem::SetName( const char *name )
-{
-    wchar_t *wName = hsStringToWString(name);
-    SetName(wName);
-    delete [] wName;
-}
-
 void    pfGUIMenuItem::SetName( const wchar_t *name )
 {
     delete [] fName;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.h
@@ -117,7 +117,6 @@ class pfGUIMenuItem : public pfGUIButtonMod
         void    PurgeDynaTextMapImage() override;
 
 
-        void        SetName( const char *name );
         void        SetName( const wchar_t *name );
         const wchar_t   *GetName() const { return fName; }
     

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -1906,7 +1906,7 @@ void pfGUIMultiLineEditCtrl::DeleteLinesFromTop(int numLines)
 
         if (hitEnd)
         {
-            SetBuffer(ST::string()); // we are removing too many (or all) lines, just clear it
+            SetBuffer({}); // we are removing too many (or all) lines, just clear it
             return;
         }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -1906,7 +1906,7 @@ void pfGUIMultiLineEditCtrl::DeleteLinesFromTop(int numLines)
 
         if (hitEnd)
         {
-            SetBuffer(L""); // we are removing too many (or all) lines, just clear it
+            SetBuffer(ST::string()); // we are removing too many (or all) lines, just clear it
             return;
         }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -50,6 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsBounds.h"
 
+#include <string_theory/char_buffer>
 #include <string_theory/string>
 #include <tuple>
 #include <vector>
@@ -174,7 +175,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
 
         void    IUpdateScrollRange();
 
-        wchar_t *ICopyRange( int32_t start, int32_t end ) const;
+        ST::wchar_buffer ICopyRange( int32_t start, int32_t end ) const;
 
         int32_t   ICharPosToBufferPos( int32_t charPos ) const;
 
@@ -236,7 +237,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         int32_t GetCursor() const { return fCursorPos; }
 
         void    InsertChar( wchar_t c);
-        void    InsertString( const wchar_t *string );
+        void    InsertString( const ST::string& string );
 
         void    InsertColor( hsColorRGBA &color );
         void    InsertStyle( uint8_t fontStyle );
@@ -249,10 +250,10 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
 
         void    DeleteChar();
         void    ClearBuffer();
-        void    SetBuffer( const wchar_t *text );
+        void    SetBuffer(const ST::string& text);
         void    SetBuffer(const wchar_t *codedText, size_t length);
-        wchar_t *GetNonCodedBuffer() const;
-        wchar_t *GetCodedBuffer(size_t &length) const;
+        ST::wchar_buffer GetNonCodedBuffer() const;
+        ST::wchar_buffer GetCodedBuffer() const;
         size_t  GetBufferSize() const { return fBuffer.size() - 1; }
 
         void    SetBufferLimit(int32_t limit) { fBufferLimit = limit; }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -235,9 +235,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         void    MoveCursor( Direction dir );
         int32_t GetCursor() const { return fCursorPos; }
 
-        void    InsertChar( char c );
         void    InsertChar( wchar_t c);
-        void    InsertString( const char *string );
         void    InsertString( const wchar_t *string );
 
         void    InsertColor( hsColorRGBA &color );
@@ -251,14 +249,10 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
 
         void    DeleteChar();
         void    ClearBuffer();
-        void    SetBuffer( const char *asciiText );
-        void    SetBuffer( const wchar_t *asciiText );
-        void    SetBuffer(const char *codedText, size_t length);
+        void    SetBuffer( const wchar_t *text );
         void    SetBuffer(const wchar_t *codedText, size_t length);
-        char    *GetNonCodedBuffer() const;
-        wchar_t *GetNonCodedBufferW() const;
-        char    *GetCodedBuffer(size_t &length) const;
-        wchar_t *GetCodedBufferW(size_t &length) const;
+        wchar_t *GetNonCodedBuffer() const;
+        wchar_t *GetCodedBuffer(size_t &length) const;
         size_t  GetBufferSize() const { return fBuffer.size() - 1; }
 
         void    SetBufferLimit(int32_t limit) { fBufferLimit = limit; }
@@ -267,7 +261,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         /** Get the link the mouse is currently over. */
         int16_t GetCurrentLink() const { return fCurrLinkId; }
 
-        void    GetThisKeyPressed( char &key, uint8_t &modifiers ) const { key = (char)fLastKeyPressed; modifiers = fLastKeyModifiers; }
+        void    GetThisKeyPressed( wchar_t &key, uint8_t &modifiers ) const { key = fLastKeyPressed; modifiers = fLastKeyModifiers; }
 
         void    Lock();
         void    Unlock();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
@@ -655,13 +655,6 @@ void    pfGUIPopUpMenu::ClearItems()
 //// AddItem /////////////////////////////////////////////////////////////////
 //  Append a new item to the list of things to build the menu from 
 
-void    pfGUIPopUpMenu::AddItem( const char *name, pfGUICtrlProcObject *handler, pfGUIPopUpMenu *subMenu )
-{
-    wchar_t *wName = hsStringToWString(name);
-    AddItem(wName,handler,subMenu);
-    delete [] wName;
-}
-
 void    pfGUIPopUpMenu::AddItem( const wchar_t *name, pfGUICtrlProcObject *handler, pfGUIPopUpMenu *subMenu )
 {
     pfMenuItem  &newItem = fMenuItems.emplace_back();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.h
@@ -163,7 +163,6 @@ class pfGUIPopUpMenu : public pfGUIDialogMod
         void    SetOriginAnchor( plSceneObject *anchor, pfGUIDialogMod *context );
         void    SetAlignment( Alignment a ) { fAlignment = a; }
         void    ClearItems();
-        void    AddItem(const char *name, pfGUICtrlProcObject *handler, pfGUIPopUpMenu *subMenu = nullptr);
         void    AddItem(const wchar_t *name, pfGUICtrlProcObject *handler, pfGUIPopUpMenu *subMenu = nullptr);
         void    SetSkin( pfGUISkin *skin );
 

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -1132,42 +1132,6 @@ void    pfJournalBook::UnloadAllGUIs()
 // the name of the mipmap to use as the cover of the book. The callback
 // key is the keyed object to send event messages to (see <img> tag).
 
-pfJournalBook::pfJournalBook(const char *esHTMLSource, plKey coverImageKey, plKey callbackKey /*= {}*/,
-                             const plLocation &hintLoc /* = plLocation::kGlobalFixedLoc */, const ST::string &guiName /* = {} */)
-{
-    if (!guiName.empty())
-        fCurBookGUI = guiName;
-    else
-        fCurBookGUI = "BkBook";
-    if (fBookGUIs.find(fCurBookGUI) == fBookGUIs.end())
-    {
-        fBookGUIs[fCurBookGUI] = new pfBookData(fCurBookGUI);
-        hsgResMgr::ResMgr()->NewKey(fCurBookGUI,fBookGUIs[fCurBookGUI],pfGameGUIMgr::GetInstance()->GetKey()->GetUoid().GetLocation());
-        fBookGUIs[fCurBookGUI]->LoadGUI();
-    }
-    
-    fCurrentPage = 0;
-    fLastPage = -1;
-    fCoverMipKey = std::move(coverImageKey);
-    fCoverFromHTML = false;
-    fCallbackKey = std::move(callbackKey);
-    fWidthScale = fHeightScale = 0.f;
-    fPageTMargin = fPageLMargin = fPageBMargin = fPageRMargin = 16;
-    fAllowTurning = true;
-    fAreWeShowing = false;
-    fCoverTint.Set( 0.f, 0.f, 0.f, 1.f );
-    fTintFirst = true;
-    fTintCover = false;
-    fAreEditing = false;
-    fWantEditing = false;
-    fDefLoc = hintLoc;
-
-    wchar_t *wESHTMLSource = hsStringToWString(esHTMLSource);
-    fUncompiledSource = wESHTMLSource;
-    ICompileSource( wESHTMLSource, hintLoc );
-    delete [] wESHTMLSource;
-}
-
 pfJournalBook::pfJournalBook(const wchar_t *esHTMLSource, plKey coverImageKey, plKey callbackKey /*= {}*/,
                              const plLocation &hintLoc /* = plLocation::kGlobalFixedLoc */, const ST::string &guiName /* = {} */)
 {

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -3296,7 +3296,7 @@ ST::string pfJournalBook::GetEditableText()
     {
         return left->GetNonCodedBuffer();
     }
-    return L"";
+    return ST::string();
 }
 
 void pfJournalBook::SetEditableText(const ST::string& text)

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -1665,32 +1665,32 @@ void    pfJournalBook::ForceCacheCalculations()
 }
 
 // Tiny helper to convert hex values the *right* way
-static uint32_t   IConvertHex( const wchar_t *str )
+// TODO Is it safe to replace this with str.to_uint(16)?
+static uint32_t   IConvertHex( ST::string& str )
 {
     uint32_t value = 0;
-    while( *str != 0 )
+    for(const char *s = str.begin(); s < str.end(); s++)
     {
         value <<= 4;
-        switch( *str )
+        switch( *s )
         {
-            case L'0':          value |= 0x0;   break;
-            case L'1':          value |= 0x1;   break;
-            case L'2':          value |= 0x2;   break;
-            case L'3':          value |= 0x3;   break;
-            case L'4':          value |= 0x4;   break;
-            case L'5':          value |= 0x5;   break;
-            case L'6':          value |= 0x6;   break;
-            case L'7':          value |= 0x7;   break;
-            case L'8':          value |= 0x8;   break;
-            case L'9':          value |= 0x9;   break;
-            case L'a': case L'A':   value |= 0xa;   break;
-            case L'b': case L'B':   value |= 0xb;   break;
-            case L'c': case L'C':   value |= 0xc;   break;
-            case L'd': case L'D':   value |= 0xd;   break;
-            case L'e': case L'E':   value |= 0xe;   break;
-            case L'f': case L'F':   value |= 0xf;   break;
+            case '0':          value |= 0x0;   break;
+            case '1':          value |= 0x1;   break;
+            case '2':          value |= 0x2;   break;
+            case '3':          value |= 0x3;   break;
+            case '4':          value |= 0x4;   break;
+            case '5':          value |= 0x5;   break;
+            case '6':          value |= 0x6;   break;
+            case '7':          value |= 0x7;   break;
+            case '8':          value |= 0x8;   break;
+            case '9':          value |= 0x9;   break;
+            case 'a': case 'A':   value |= 0xa;   break;
+            case 'b': case 'B':   value |= 0xb;   break;
+            case 'c': case 'C':   value |= 0xc;   break;
+            case 'd': case 'D':   value |= 0xd;   break;
+            case 'e': case 'E':   value |= 0xe;   break;
+            case 'f': case 'F':   value |= 0xf;   break;
         }
-        str++;
     }
 
     return value;
@@ -1707,7 +1707,8 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
 
     pfEsHTMLChunk *chunk, *lastParChunk = new pfEsHTMLChunk(ST::string());
     const wchar_t *c, *start;
-    wchar_t name[128], option[256];
+    ST::string name;
+    ST::string option;
     float bookWidth=1.f, bookHeight=1.f;
     uint8_t movieIndex = 0; // the index of a movie in the source (used for id purposes)
 
@@ -1738,12 +1739,12 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     chunk = new pfEsHTMLChunk(ST::string());
                     chunk->fFlags = IFindLastAlignment();
                     while (IGetNextOption(c, name, option)) {
-                        if (wcsicmp(name, L"align") == 0) {
-                            if (wcsicmp( option, L"left") == 0)
+                        if (name.compare_i(ST_LITERAL("align")) == 0) {
+                            if (option.compare_i(ST_LITERAL("left")) == 0)
                                 chunk->fFlags = pfEsHTMLChunk::kLeft;
-                            else if (wcsicmp(option, L"center") == 0)
+                            else if (option.compare_i(ST_LITERAL("center")) == 0)
                                 chunk->fFlags = pfEsHTMLChunk::kCenter;
-                            else if (wcsicmp(option, L"right") == 0)
+                            else if (option.compare_i(ST_LITERAL("right")) == 0)
                                 chunk->fFlags = pfEsHTMLChunk::kRight;
                         }
                     }
@@ -1755,70 +1756,67 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     c += 4;
                     chunk = new pfEsHTMLChunk(nullptr , 0);
                     while (IGetNextOption(c, name, option)) {
-                        if (wcsicmp(name, L"align") == 0) {
+                        if (name.compare_i(ST_LITERAL("align")) == 0) {
                             chunk->fFlags &= ~pfEsHTMLChunk::kAlignMask;
-                            if (wcsicmp(option, L"left" ) == 0)
+                            if (option.compare_i(ST_LITERAL("left")) == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kLeft;
-                            else if (wcsicmp(option, L"center") == 0)
+                            else if (option.compare_i(ST_LITERAL("center")) == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kCenter;
-                            else if (wcsicmp(option, L"right") == 0)
+                            else if (option.compare_i(ST_LITERAL("right")) == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kRight;
-                        } else if (wcsicmp(name, L"src") == 0) {
+                        } else if (name.compare_i(ST_LITERAL("src")) == 0) {
                             // Name of mipmap source
                             chunk->fImageKey = IGetMipmapKey( option, hintLoc );
-                        } else if (wcsicmp(name, L"link") == 0) {
-                            chunk->fEventID = wcstoul(option, nullptr, 0);
+                        } else if (name.compare_i(ST_LITERAL("link")) == 0) {
+                            chunk->fEventID = option.to_uint();
                             chunk->fFlags |= pfEsHTMLChunk::kCanLink;
-                        } else if (wcsicmp(name, L"blend") == 0) {
-                            if (wcsicmp(option, L"alpha") == 0)
+                        } else if (name.compare_i(ST_LITERAL("blend")) == 0) {
+                            if (option.compare_i(ST_LITERAL("alpha")) == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kBlendAlpha;
-                        } else if (wcsicmp( name, L"pos") == 0) {
+                        } else if (name.compare_i(ST_LITERAL("pos")) == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kFloating;
 
-                            wchar_t* comma = wcschr(option, L',');
-                            if (comma) {
-                                chunk->fAbsoluteY = (uint16_t)wcstoul(comma + 1, nullptr, 0);
-                                *comma = 0;
+                            ST::string comma = option.after_first(',');
+                            if (!comma.empty()) {
+                                chunk->fAbsoluteY = comma.to_ushort();
                             }
-                            chunk->fAbsoluteX = (uint16_t)wcstoul(option, nullptr, 0);
-                        } else if (wcsicmp(name, L"glow") == 0) {
+                            chunk->fAbsoluteX = option.before_first(',').to_ushort();
+                        } else if (name.compare_i(ST_LITERAL("glow")) == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kGlowing;
                             chunk->fFlags &= ~pfEsHTMLChunk::kActAsCB;
 
-                            wchar_t* comma = wcschr(option, L',');
-                            if (comma) {
-                                wchar_t* comma2 = wcschr(comma + 1, L',');
-                                if (comma2) {
-                                    chunk->fMaxOpacity = wcstof(comma2 + 1, nullptr);
-                                    *comma2 = 0;
+                            ST::string comma = option.after_first(',');
+                            if (!comma.empty()) {
+                                ST::string comma2 = comma.after_first(',');
+                                if (!comma2.empty()) {
+                                    chunk->fMaxOpacity = comma2.to_float();
                                 }
-                                chunk->fMinOpacity = wcstof(comma + 1, nullptr);
-                                *comma = 0;
+                                chunk->fMinOpacity = comma.before_first(',').to_float();
                             }
-                            chunk->fSFXTime = wcstof(option, nullptr);
-                        } else if (wcsicmp( name, L"opacity") == 0) {
+                            chunk->fSFXTime = option.before_first(',').to_float();
+                        } else if (name.compare_i(ST_LITERAL("opacity")) == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kTranslucent;
-                            chunk->fCurrOpacity = wcstof(option, nullptr);
-                        } else if (wcsicmp( name, L"check" ) == 0) {
+                            chunk->fCurrOpacity = option.to_float();
+                        } else if (name.compare_i(ST_LITERAL("check")) == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kActAsCB;
                             chunk->fFlags &= ~pfEsHTMLChunk::kGlowing;
 
-                            wchar_t* comma = wcschr(option, L',');
-                            if (comma) {
-                                wchar_t* comma2 = wcschr(comma + 1, L',');
-                                if (comma2) {
-                                    if (wcstol(comma2 + 1, nullptr, 0))
+                            ST::string comma = option.after_first(',');
+                            if (!comma.empty()) {
+                                ST::string comma2 = comma.after_first(',');
+                                if (!comma2.empty()) {
+                                    if (comma2.to_long())
                                         chunk->fFlags |= pfEsHTMLChunk::kChecked;
-                                    *comma2 = 0;
                                 }
-                                uint32_t c = IConvertHex(comma + 1);
-                                if (wcslen(comma + 1) <= 6)
+                                comma = comma.before_first(',');
+                                uint32_t c = IConvertHex(comma);
+                                if (comma.size() <= 6)
                                     c |= 0xff000000;    // Add in full alpha if none specified
                                 chunk->fOffColor.FromARGB32(c);
-                                *comma = 0;
                             }
+                            option = option.before_first(',');
                             uint32_t c = IConvertHex(option);
-                            if (wcslen(option) <= 6)
+                            if (option.size() <= 6)
                                 c |= 0xff000000;    // Add in full alpha if none specified
                             chunk->fOnColor.FromARGB32(c);
 
@@ -1826,8 +1824,8 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 chunk->fCurrColor = chunk->fOnColor;
                             else
                                 chunk->fCurrColor = chunk->fOffColor;
-                        } else if (wcsicmp(name,L"resize") == 0) {
-                            chunk->fNoResizeImg = (wcsicmp(option, L"no") == 0);
+                        } else if (name.compare_i(ST_LITERAL("resize")) == 0) {
+                            chunk->fNoResizeImg = (option.compare_i(ST_LITERAL("no")) == 0);
                         }
                     }
                     if (chunk->fImageKey)
@@ -1844,18 +1842,18 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     // grab the mipmap key for our cover
                     c += 6;
                     while (IGetNextOption(c, name, option)) {
-                        if (wcsicmp(name, L"src") == 0) {
+                        if (name.compare_i(ST_LITERAL("src")) == 0) {
                             // Name of mipmap source
                             anotherKey = IGetMipmapKey( option, hintLoc );
                             if (anotherKey) {
                                 fCoverMipKey = anotherKey;
                                 fCoverFromHTML = true;
                             }
-                        } else if (wcsicmp(name, L"tint") == 0) {
+                        } else if (name.compare_i(ST_LITERAL("tint")) == 0) {
                             fTintCover = true;
-                            fCoverTint.FromARGB32(wcstol( option, nullptr, 16 ) | 0xff000000);
-                        } else if (wcsicmp(name, L"tintfirst") == 0) {
-                            fTintFirst = (wcsicmp(option, L"no") != 0);
+                            fCoverTint.FromARGB32(option.to_long(16) | 0xff000000);
+                        } else if (name.compare_i(ST_LITERAL("tintfirst")) == 0) {
+                            fTintFirst = (option.compare_i(ST_LITERAL("no")) != 0);
                         }
                     }
                     // Still gotta create a new par chunk
@@ -1878,15 +1876,15 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     c += 5;
                     chunk = new pfEsHTMLChunk(ST::string(), 0, 0);
                     while (IGetNextOption(c, name, option)) {
-                        if (wcsicmp(name, L"style") == 0) {
+                        if (name.compare_i(ST_LITERAL("style")) == 0) {
                             uint8_t guiFlags = 0;
-                            if (wcsicmp(option, L"b") == 0) {
+                            if (option.compare_i(ST_LITERAL("b")) == 0) {
                                 chunk->fFlags = pfEsHTMLChunk::kFontBold;
                                 guiFlags = plDynamicTextMap::kFontBold;
-                            } else if (wcsicmp(option, L"i") == 0) {
+                            } else if (option.compare_i(ST_LITERAL("i")) == 0) {
                                 chunk->fFlags = pfEsHTMLChunk::kFontItalic;
                                 guiFlags = plDynamicTextMap::kFontItalic;
-                            } else if (wcsicmp(option, L"bi") == 0) {
+                            } else if (option.compare_i(ST_LITERAL("bi")) == 0) {
                                 chunk->fFlags = pfEsHTMLChunk::kFontBold | pfEsHTMLChunk::kFontItalic;
                                 guiFlags = plDynamicTextMap::kFontBold | plDynamicTextMap::kFontItalic;
                             } else {
@@ -1899,26 +1897,25 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnFrontEditCtrl)->SetFontStyle(guiFlags);
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnBackEditCtrl)->SetFontStyle(guiFlags);
                             }
-                        } else if (wcsicmp(name, L"face") == 0) {
+                        } else if (name.compare_i(ST_LITERAL("face")) == 0) {
                             // Name of mipmap source
                             chunk->fText = option;
                             if (fBookGUIs[fCurBookGUI]->IsEditable()) {
-                                ST::string fontFace = ST::string::from_wchar(option);
-                                fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagRightEditCtrl)->SetFontFace(fontFace);
-                                fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagLeftEditCtrl)->SetFontFace(fontFace);
-                                fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnFrontEditCtrl)->SetFontFace(fontFace);
-                                fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnBackEditCtrl)->SetFontFace(fontFace);
+                                fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagRightEditCtrl)->SetFontFace(option);
+                                fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagLeftEditCtrl)->SetFontFace(option);
+                                fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnFrontEditCtrl)->SetFontFace(option);
+                                fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnBackEditCtrl)->SetFontFace(option);
                             }
-                        } else if (wcsicmp(name, L"size") == 0) {
-                            chunk->fFontSize = (uint8_t)wcstoul(option, nullptr, 0);
+                        } else if (name.compare_i(ST_LITERAL("size")) == 0) {
+                            chunk->fFontSize = (uint8_t)option.to_ulong();
                             if (fBookGUIs[fCurBookGUI]->IsEditable()) {
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagRightEditCtrl)->SetFontSize(chunk->fFontSize);
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagLeftEditCtrl)->SetFontSize(chunk->fFontSize);
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnFrontEditCtrl)->SetFontSize(chunk->fFontSize);
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnBackEditCtrl)->SetFontSize(chunk->fFontSize);
                             }
-                        } else if(wcsicmp(name, L"color") == 0) {
-                            chunk->fColor.FromARGB32(wcstoul(option, nullptr, 16) | 0xff000000);
+                        } else if(name.compare_i(ST_LITERAL("color")) == 0) {
+                            chunk->fColor.FromARGB32(option.to_ulong(16) | 0xff000000);
                             chunk->fFlags |= pfEsHTMLChunk::kFontColor;
                             if (fBookGUIs[fCurBookGUI]->IsEditable()) {
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagRightEditCtrl)->SetFontColor(chunk->fColor);
@@ -1926,8 +1923,8 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnFrontEditCtrl)->SetFontColor(chunk->fColor);
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnBackEditCtrl)->SetFontColor(chunk->fColor);
                             }
-                        } else if(wcsicmp(name, L"spacing") == 0) {
-                            chunk->fLineSpacing = (int16_t)wcstol(option, nullptr, 0);
+                        } else if(name.compare_i(ST_LITERAL("spacing")) == 0) {
+                            chunk->fLineSpacing = option.to_short();
                             chunk->fFlags |= pfEsHTMLChunk::kFontSpacing;
                         }
                     }
@@ -1940,14 +1937,14 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                 case pfEsHTMLChunk::kMargin:
                     c += 7;
                     while(IGetNextOption(c,name,option)) {
-                        if (wcsicmp(name,L"top") == 0)
-                            fPageTMargin = wcstoul(option, nullptr, 0);
-                        else if (wcsicmp(name,L"left") == 0)
-                            fPageLMargin = wcstoul(option, nullptr, 0);
-                        else if (wcsicmp(name,L"bottom") == 0)
-                            fPageBMargin = wcstoul(option, nullptr, 0);
-                        else if (wcsicmp(name,L"right") == 0)
-                            fPageRMargin = wcstoul(option, nullptr, 0);
+                        if (name.compare_i(ST_LITERAL("top")) == 0)
+                            fPageTMargin = option.to_uint();
+                        else if (name.compare_i(ST_LITERAL("left")) == 0)
+                            fPageLMargin = option.to_uint();
+                        else if (name.compare_i(ST_LITERAL("bottom")) == 0)
+                            fPageBMargin = option.to_uint();
+                        else if (name.compare_i(ST_LITERAL("right")) == 0)
+                            fPageRMargin = option.to_uint();
                     }
                     // set the edit controls to the margins we just set
                     if (fBookGUIs[fCurBookGUI]->IsEditable()) {
@@ -1965,10 +1962,10 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     c += 5;
                     // don't actually create a chunk, just set the book size
                     while (IGetNextOption(c,name,option)) {
-                        if (wcsicmp(name, L"height") == 0)
-                            bookHeight = wcstof(option, nullptr);
-                        else if (wcsicmp(name, L"width") == 0)
-                            bookWidth = wcstof(option, nullptr);
+                        if (name.compare_i(ST_LITERAL("height")) == 0)
+                            bookHeight = option.to_float();
+                        else if (name.compare_i(ST_LITERAL("width")) == 0)
+                            bookWidth = option.to_float();
                     }
                     fHeightScale = 1.f - bookHeight;
                     fWidthScale = 1.f - bookWidth;
@@ -1983,30 +1980,29 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     chunk = new pfEsHTMLChunk(nullptr, 0);
                     chunk->fType = pfEsHTMLChunk::kDecal;
                     while (IGetNextOption(c, name, option)) {
-                        if (wcsicmp(name, L"align") == 0) {
+                        if (name.compare_i(ST_LITERAL("align")) == 0) {
                             chunk->fFlags &= ~pfEsHTMLChunk::kAlignMask;
-                            if (wcsicmp( option, L"left" ) == 0)
+                            if (option.compare_i(ST_LITERAL("left")) == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kLeft;
-                            else if (wcsicmp( option, L"center" ) == 0)
+                            else if (option.compare_i(ST_LITERAL("center")) == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kCenter;
-                            else if (wcsicmp( option, L"right" ) == 0)
+                            else if (option.compare_i(ST_LITERAL("right")) == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kRight;
-                        } else if (wcsicmp(name, L"src") == 0) {
+                        } else if (name.compare_i(ST_LITERAL("src")) == 0) {
                             // Name of mipmap source
                             chunk->fImageKey = IGetMipmapKey(option, hintLoc);
-                        } else if (wcsicmp(name, L"pos") == 0) {
+                        } else if (name.compare_i(ST_LITERAL("pos")) == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kFloating;
 
-                            wchar_t* comma = wcschr(option, L',');
-                            if (comma) {
-                                chunk->fAbsoluteY = (uint16_t)wcstoul(comma + 1, nullptr, 0);
-                                *comma = 0;
+                            ST::string comma = option.after_first(',');
+                            if (!comma.empty()) {
+                                chunk->fAbsoluteY = comma.to_ushort();
                             }
-                            chunk->fAbsoluteX = (uint16_t)wcstoul(option, nullptr, 0);
-                        } else if (wcsicmp(name, L"resize") == 0) {
-                            chunk->fNoResizeImg = (wcsicmp(option, L"no") == 0);
-                        } else if (wcsicmp(name, L"tint") == 0) {
-                            chunk->fTintDecal = (wcsicmp(option, L"yes") == 0);
+                            chunk->fAbsoluteX = option.before_first(',').to_ushort();
+                        } else if (name.compare_i(ST_LITERAL("resize")) == 0) {
+                            chunk->fNoResizeImg = (option.compare_i(ST_LITERAL("no")) == 0);
+                        } else if (name.compare_i(ST_LITERAL("tint")) == 0) {
+                            chunk->fTintDecal = (option.compare_i(ST_LITERAL("yes")) == 0);
                         }
                     }
                     // add it to our cover decals list (this is tag is essentially thrown away as far as the parser cares)
@@ -2024,34 +2020,33 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     chunk = new pfEsHTMLChunk(nullptr, 0);
                     chunk->fType = pfEsHTMLChunk::kMovie;
                     while (IGetNextOption(c, name, option)) {
-                        if (wcsicmp( name, L"align" ) == 0) {
+                        if (name.compare_i(ST_LITERAL("align")) == 0) {
                             chunk->fFlags &= ~pfEsHTMLChunk::kAlignMask;
-                            if (wcsicmp(option, L"left") == 0)
+                            if (option.compare_i(ST_LITERAL("left")) == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kLeft;
-                            else if (wcsicmp( option, L"center") == 0)
+                            else if (option.compare_i(ST_LITERAL("center")) == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kCenter;
-                            else if (wcsicmp( option, L"right") == 0)
+                            else if (option.compare_i(ST_LITERAL("right")) == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kRight;
-                        } else if(wcsicmp(name, L"src") == 0) {
+                        } else if(name.compare_i(ST_LITERAL("src")) == 0) {
                             chunk->fText = option;
-                        } else if(wcsicmp(name, L"link") == 0) {
-                            chunk->fEventID = wcstoul(option, nullptr, 0);
+                        } else if(name.compare_i(ST_LITERAL("link")) == 0) {
+                            chunk->fEventID = option.to_uint();
                             chunk->fFlags |= pfEsHTMLChunk::kCanLink;
-                        } else if(wcsicmp(name, L"pos") == 0) {
+                        } else if(name.compare_i(ST_LITERAL("pos")) == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kFloating;
 
-                            wchar_t* comma = wcschr(option, L',');
-                            if (comma) {
-                                chunk->fAbsoluteY = (uint16_t)wcstoul(comma + 1, nullptr, 0);
-                                *comma = 0;
+                            ST::string comma = option.after_first(',');
+                            if (!comma.empty()) {
+                                chunk->fAbsoluteY = comma.to_ushort();
                             }
-                            chunk->fAbsoluteX = (uint16_t)wcstoul(option, nullptr, 0);
-                        } else if (wcsicmp(name, L"resize") == 0) {
-                            chunk->fNoResizeImg = (wcsicmp(option, L"no") == 0);
-                        } else if (wcsicmp(name, L"oncover") == 0) {
-                            chunk->fOnCover = (wcsicmp(option, L"yes") == 0);
-                        } else if (wcsicmp(name, L"loop") == 0) {
-                            chunk->fLoopMovie = wcsicmp(option, L"no") != 0;
+                            chunk->fAbsoluteX = option.before_first(',').to_ushort();
+                        } else if (name.compare_i(ST_LITERAL("resize")) == 0) {
+                            chunk->fNoResizeImg = (option.compare_i(ST_LITERAL("no")) == 0);
+                        } else if (name.compare_i(ST_LITERAL("oncover")) == 0) {
+                            chunk->fOnCover = (option.compare_i(ST_LITERAL("yes")) == 0);
+                        } else if (name.compare_i(ST_LITERAL("loop")) == 0) {
+                            chunk->fLoopMovie = option.compare_i(ST_LITERAL("no")) != 0;
                         }
                     }
                     chunk->fMovieIndex = movieIndex;
@@ -2151,7 +2146,7 @@ uint8_t   pfJournalBook::IGetTagType( const wchar_t *string )
     return pfEsHTMLChunk::kEmpty;
 }
 
-bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wchar_t *option )
+bool    pfJournalBook::IGetNextOption( const wchar_t *&string, ST::string& name, ST::string& option )
 {
     const wchar_t *c;
 
@@ -2175,9 +2170,7 @@ bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wc
         return false;
 
     // Copy name
-    size_t len = string - c;
-    wcsncpy( name, c, len );
-    name[len] = L'\0';
+    name = ST::string::from_wchar(c, string - c);
 
     // Find start of option value
     string++;
@@ -2195,9 +2188,7 @@ bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wc
         while( *string != L'>' && *string != L'\"' && *string != L'\0' )
             string++;
 
-        len = string - c;
-        wcsncpy( option, c, len );
-        option[len] = L'\0';
+        option = ST::string::from_wchar(c, string - c);
         
         if( *string == L'\"' )
             string++;
@@ -2210,9 +2201,7 @@ bool    pfJournalBook::IGetNextOption( const wchar_t *&string, wchar_t *name, wc
     while( *string != L' ' && *string != L'>' && *string != L'\0' )
         string++;
 
-    len = string - c;
-    wcsncpy( option, c, len );
-    option[len] = L'\0';
+    option = ST::string::from_wchar(c, string - c);
     
     return true;
 }
@@ -2242,27 +2231,26 @@ void    pfJournalBook::IFreeSource()
 // the code will attempt to look in the currently loaded age for a matching
 // image name.
 
-plKey   pfJournalBook::IGetMipmapKey( const wchar_t *name, const plLocation &loc )
+plKey   pfJournalBook::IGetMipmapKey( const ST::string& name, const plLocation &loc )
 {
-    ST::string cName = ST::string::from_wchar(name);
 #ifndef PLASMA_EXTERNAL_RELEASE
-    if( cName.contains( '/' ) || cName.contains( '\\' ) )
+    if( name.contains( '/' ) || name.contains( '\\' ) )
     {
         // For internal use only--allow local path names of PNG and JPEG images, to
         // facilitate fast prototyping
         plMipmap *mip;
-        if( cName.contains( ".png" ) )
-            mip = plPNG::Instance().ReadFromFile( cName.c_str() );
+        if( name.contains( ".png" ) )
+            mip = plPNG::Instance().ReadFromFile( name.c_str() );
         else
-            mip = plJPEG::Instance().ReadFromFile( cName.c_str() );
+            mip = plJPEG::Instance().ReadFromFile( name.c_str() );
 
-        hsgResMgr::ResMgr()->NewKey( cName, mip, loc );
+        hsgResMgr::ResMgr()->NewKey(name, mip, loc );
         return mip->GetKey();
     }
 #endif
 
     // Try first to find in the given location
-    plUoid myUoid( loc, plMipmap::Index(), cName );
+    plUoid myUoid( loc, plMipmap::Index(), name);
     plKey key = hsgResMgr::ResMgr()->FindKey( myUoid );
     if (key != nullptr)
     {
@@ -2272,7 +2260,7 @@ plKey   pfJournalBook::IGetMipmapKey( const wchar_t *name, const plLocation &loc
 
     // Next, try our "global" pre-defined age
     const plLocation &globLoc = plKeyFinder::Instance().FindLocation( "GUI", "BkBookImages" );
-    myUoid = plUoid( globLoc, plMipmap::Index(), cName );
+    myUoid = plUoid( globLoc, plMipmap::Index(), name);
     key = hsgResMgr::ResMgr()->FindKey( myUoid );
     if (key != nullptr)
     {
@@ -2285,7 +2273,7 @@ plKey   pfJournalBook::IGetMipmapKey( const wchar_t *name, const plLocation &loc
         ST::string thisAge = plAgeLoader::GetInstance()->GetCurrAgeDesc().GetAgeName();
         if (!thisAge.empty())
         {
-            key = plKeyFinder::Instance().StupidSearch( thisAge, "", plMipmap::Index(), cName, true );
+            key = plKeyFinder::Instance().StupidSearch( thisAge, "", plMipmap::Index(), name, true );
             if (key != nullptr)
             {
                 return key;

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -3330,7 +3330,7 @@ std::wstring pfJournalBook::GetEditableText()
     pfGUIMultiLineEditCtrl *left = fBookGUIs[fCurBookGUI]->GetEditCtrl( pfJournalDlgProc::kTagLeftEditCtrl );
     if (left)
     {
-        wchar_t *temp = left->GetNonCodedBufferW();
+        wchar_t *temp = left->GetNonCodedBuffer();
         std::wstring retVal = temp;
         delete [] temp;
         return retVal;

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -3296,7 +3296,7 @@ ST::string pfJournalBook::GetEditableText()
     {
         return left->GetNonCodedBuffer();
     }
-    return ST::string();
+    return {};
 }
 
 void pfJournalBook::SetEditableText(const ST::string& text)

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -3325,25 +3325,22 @@ void pfJournalBook::IPurgeDynaTextMaps( )
         turnBackEdit->PurgeDynaTextMapImage();
 }
 
-std::wstring pfJournalBook::GetEditableText()
+ST::string pfJournalBook::GetEditableText()
 {
     pfGUIMultiLineEditCtrl *left = fBookGUIs[fCurBookGUI]->GetEditCtrl( pfJournalDlgProc::kTagLeftEditCtrl );
     if (left)
     {
-        wchar_t *temp = left->GetNonCodedBuffer();
-        std::wstring retVal = temp;
-        delete [] temp;
-        return retVal;
+        return left->GetNonCodedBuffer();
     }
     return L"";
 }
 
-void pfJournalBook::SetEditableText(const std::wstring& text)
+void pfJournalBook::SetEditableText(const ST::string& text)
 {
     pfGUIMultiLineEditCtrl *left = fBookGUIs[fCurBookGUI]->GetEditCtrl( pfJournalDlgProc::kTagLeftEditCtrl );
     if (left)
     {
-        left->SetBuffer(text.c_str());
+        left->SetBuffer(text);
         left->ForceUpdate();
     }
 }

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -1738,12 +1738,12 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     chunk = new pfEsHTMLChunk(ST::string());
                     chunk->fFlags = IFindLastAlignment();
                     while (IGetNextOption(c, name, option)) {
-                        if (name.compare_i(ST_LITERAL("align")) == 0) {
-                            if (option.compare_i(ST_LITERAL("left")) == 0)
+                        if (name.compare_i("align") == 0) {
+                            if (option.compare_i("left") == 0)
                                 chunk->fFlags = pfEsHTMLChunk::kLeft;
-                            else if (option.compare_i(ST_LITERAL("center")) == 0)
+                            else if (option.compare_i("center") == 0)
                                 chunk->fFlags = pfEsHTMLChunk::kCenter;
-                            else if (option.compare_i(ST_LITERAL("right")) == 0)
+                            else if (option.compare_i("right") == 0)
                                 chunk->fFlags = pfEsHTMLChunk::kRight;
                         }
                     }
@@ -1755,24 +1755,24 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     c += 4;
                     chunk = new pfEsHTMLChunk(nullptr , 0);
                     while (IGetNextOption(c, name, option)) {
-                        if (name.compare_i(ST_LITERAL("align")) == 0) {
+                        if (name.compare_i("align") == 0) {
                             chunk->fFlags &= ~pfEsHTMLChunk::kAlignMask;
-                            if (option.compare_i(ST_LITERAL("left")) == 0)
+                            if (option.compare_i("left") == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kLeft;
-                            else if (option.compare_i(ST_LITERAL("center")) == 0)
+                            else if (option.compare_i("center") == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kCenter;
-                            else if (option.compare_i(ST_LITERAL("right")) == 0)
+                            else if (option.compare_i("right") == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kRight;
-                        } else if (name.compare_i(ST_LITERAL("src")) == 0) {
+                        } else if (name.compare_i("src") == 0) {
                             // Name of mipmap source
                             chunk->fImageKey = IGetMipmapKey( option, hintLoc );
-                        } else if (name.compare_i(ST_LITERAL("link")) == 0) {
+                        } else if (name.compare_i("link") == 0) {
                             chunk->fEventID = option.to_uint();
                             chunk->fFlags |= pfEsHTMLChunk::kCanLink;
-                        } else if (name.compare_i(ST_LITERAL("blend")) == 0) {
-                            if (option.compare_i(ST_LITERAL("alpha")) == 0)
+                        } else if (name.compare_i("blend") == 0) {
+                            if (option.compare_i("alpha") == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kBlendAlpha;
-                        } else if (name.compare_i(ST_LITERAL("pos")) == 0) {
+                        } else if (name.compare_i("pos") == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kFloating;
 
                             ST::string comma = option.after_first(',');
@@ -1780,7 +1780,7 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 chunk->fAbsoluteY = comma.to_ushort();
                             }
                             chunk->fAbsoluteX = option.before_first(',').to_ushort();
-                        } else if (name.compare_i(ST_LITERAL("glow")) == 0) {
+                        } else if (name.compare_i("glow") == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kGlowing;
                             chunk->fFlags &= ~pfEsHTMLChunk::kActAsCB;
 
@@ -1793,10 +1793,10 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 chunk->fMinOpacity = comma.before_first(',').to_float();
                             }
                             chunk->fSFXTime = option.before_first(',').to_float();
-                        } else if (name.compare_i(ST_LITERAL("opacity")) == 0) {
+                        } else if (name.compare_i("opacity") == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kTranslucent;
                             chunk->fCurrOpacity = option.to_float();
-                        } else if (name.compare_i(ST_LITERAL("check")) == 0) {
+                        } else if (name.compare_i("check") == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kActAsCB;
                             chunk->fFlags &= ~pfEsHTMLChunk::kGlowing;
 
@@ -1823,8 +1823,8 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 chunk->fCurrColor = chunk->fOnColor;
                             else
                                 chunk->fCurrColor = chunk->fOffColor;
-                        } else if (name.compare_i(ST_LITERAL("resize")) == 0) {
-                            chunk->fNoResizeImg = (option.compare_i(ST_LITERAL("no")) == 0);
+                        } else if (name.compare_i("resize") == 0) {
+                            chunk->fNoResizeImg = (option.compare_i("no") == 0);
                         }
                     }
                     if (chunk->fImageKey)
@@ -1841,18 +1841,18 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     // grab the mipmap key for our cover
                     c += 6;
                     while (IGetNextOption(c, name, option)) {
-                        if (name.compare_i(ST_LITERAL("src")) == 0) {
+                        if (name.compare_i("src") == 0) {
                             // Name of mipmap source
                             anotherKey = IGetMipmapKey( option, hintLoc );
                             if (anotherKey) {
                                 fCoverMipKey = anotherKey;
                                 fCoverFromHTML = true;
                             }
-                        } else if (name.compare_i(ST_LITERAL("tint")) == 0) {
+                        } else if (name.compare_i("tint") == 0) {
                             fTintCover = true;
                             fCoverTint.FromARGB32(option.to_long(16) | 0xff000000);
-                        } else if (name.compare_i(ST_LITERAL("tintfirst")) == 0) {
-                            fTintFirst = (option.compare_i(ST_LITERAL("no")) != 0);
+                        } else if (name.compare_i("tintfirst") == 0) {
+                            fTintFirst = (option.compare_i("no") != 0);
                         }
                     }
                     // Still gotta create a new par chunk
@@ -1875,15 +1875,15 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     c += 5;
                     chunk = new pfEsHTMLChunk(ST::string(), 0, 0);
                     while (IGetNextOption(c, name, option)) {
-                        if (name.compare_i(ST_LITERAL("style")) == 0) {
+                        if (name.compare_i("style") == 0) {
                             uint8_t guiFlags = 0;
-                            if (option.compare_i(ST_LITERAL("b")) == 0) {
+                            if (option.compare_i("b") == 0) {
                                 chunk->fFlags = pfEsHTMLChunk::kFontBold;
                                 guiFlags = plDynamicTextMap::kFontBold;
-                            } else if (option.compare_i(ST_LITERAL("i")) == 0) {
+                            } else if (option.compare_i("i") == 0) {
                                 chunk->fFlags = pfEsHTMLChunk::kFontItalic;
                                 guiFlags = plDynamicTextMap::kFontItalic;
-                            } else if (option.compare_i(ST_LITERAL("bi")) == 0) {
+                            } else if (option.compare_i("bi") == 0) {
                                 chunk->fFlags = pfEsHTMLChunk::kFontBold | pfEsHTMLChunk::kFontItalic;
                                 guiFlags = plDynamicTextMap::kFontBold | plDynamicTextMap::kFontItalic;
                             } else {
@@ -1896,7 +1896,7 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnFrontEditCtrl)->SetFontStyle(guiFlags);
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnBackEditCtrl)->SetFontStyle(guiFlags);
                             }
-                        } else if (name.compare_i(ST_LITERAL("face")) == 0) {
+                        } else if (name.compare_i("face") == 0) {
                             // Name of mipmap source
                             chunk->fText = option;
                             if (fBookGUIs[fCurBookGUI]->IsEditable()) {
@@ -1905,7 +1905,7 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnFrontEditCtrl)->SetFontFace(option);
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnBackEditCtrl)->SetFontFace(option);
                             }
-                        } else if (name.compare_i(ST_LITERAL("size")) == 0) {
+                        } else if (name.compare_i("size") == 0) {
                             chunk->fFontSize = (uint8_t)option.to_ulong();
                             if (fBookGUIs[fCurBookGUI]->IsEditable()) {
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagRightEditCtrl)->SetFontSize(chunk->fFontSize);
@@ -1913,7 +1913,7 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnFrontEditCtrl)->SetFontSize(chunk->fFontSize);
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnBackEditCtrl)->SetFontSize(chunk->fFontSize);
                             }
-                        } else if(name.compare_i(ST_LITERAL("color")) == 0) {
+                        } else if(name.compare_i("color") == 0) {
                             chunk->fColor.FromARGB32(option.to_ulong(16) | 0xff000000);
                             chunk->fFlags |= pfEsHTMLChunk::kFontColor;
                             if (fBookGUIs[fCurBookGUI]->IsEditable()) {
@@ -1922,7 +1922,7 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnFrontEditCtrl)->SetFontColor(chunk->fColor);
                                 fBookGUIs[fCurBookGUI]->GetEditCtrl(pfJournalDlgProc::kTagTurnBackEditCtrl)->SetFontColor(chunk->fColor);
                             }
-                        } else if(name.compare_i(ST_LITERAL("spacing")) == 0) {
+                        } else if(name.compare_i("spacing") == 0) {
                             chunk->fLineSpacing = option.to_short();
                             chunk->fFlags |= pfEsHTMLChunk::kFontSpacing;
                         }
@@ -1936,13 +1936,13 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                 case pfEsHTMLChunk::kMargin:
                     c += 7;
                     while(IGetNextOption(c,name,option)) {
-                        if (name.compare_i(ST_LITERAL("top")) == 0)
+                        if (name.compare_i("top") == 0)
                             fPageTMargin = option.to_uint();
-                        else if (name.compare_i(ST_LITERAL("left")) == 0)
+                        else if (name.compare_i("left") == 0)
                             fPageLMargin = option.to_uint();
-                        else if (name.compare_i(ST_LITERAL("bottom")) == 0)
+                        else if (name.compare_i("bottom") == 0)
                             fPageBMargin = option.to_uint();
-                        else if (name.compare_i(ST_LITERAL("right")) == 0)
+                        else if (name.compare_i("right") == 0)
                             fPageRMargin = option.to_uint();
                     }
                     // set the edit controls to the margins we just set
@@ -1961,9 +1961,9 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     c += 5;
                     // don't actually create a chunk, just set the book size
                     while (IGetNextOption(c,name,option)) {
-                        if (name.compare_i(ST_LITERAL("height")) == 0)
+                        if (name.compare_i("height") == 0)
                             bookHeight = option.to_float();
-                        else if (name.compare_i(ST_LITERAL("width")) == 0)
+                        else if (name.compare_i("width") == 0)
                             bookWidth = option.to_float();
                     }
                     fHeightScale = 1.f - bookHeight;
@@ -1979,18 +1979,18 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     chunk = new pfEsHTMLChunk(nullptr, 0);
                     chunk->fType = pfEsHTMLChunk::kDecal;
                     while (IGetNextOption(c, name, option)) {
-                        if (name.compare_i(ST_LITERAL("align")) == 0) {
+                        if (name.compare_i("align") == 0) {
                             chunk->fFlags &= ~pfEsHTMLChunk::kAlignMask;
-                            if (option.compare_i(ST_LITERAL("left")) == 0)
+                            if (option.compare_i("left") == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kLeft;
-                            else if (option.compare_i(ST_LITERAL("center")) == 0)
+                            else if (option.compare_i("center") == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kCenter;
-                            else if (option.compare_i(ST_LITERAL("right")) == 0)
+                            else if (option.compare_i("right") == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kRight;
-                        } else if (name.compare_i(ST_LITERAL("src")) == 0) {
+                        } else if (name.compare_i("src") == 0) {
                             // Name of mipmap source
                             chunk->fImageKey = IGetMipmapKey(option, hintLoc);
-                        } else if (name.compare_i(ST_LITERAL("pos")) == 0) {
+                        } else if (name.compare_i("pos") == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kFloating;
 
                             ST::string comma = option.after_first(',');
@@ -1998,10 +1998,10 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 chunk->fAbsoluteY = comma.to_ushort();
                             }
                             chunk->fAbsoluteX = option.before_first(',').to_ushort();
-                        } else if (name.compare_i(ST_LITERAL("resize")) == 0) {
-                            chunk->fNoResizeImg = (option.compare_i(ST_LITERAL("no")) == 0);
-                        } else if (name.compare_i(ST_LITERAL("tint")) == 0) {
-                            chunk->fTintDecal = (option.compare_i(ST_LITERAL("yes")) == 0);
+                        } else if (name.compare_i("resize") == 0) {
+                            chunk->fNoResizeImg = (option.compare_i("no") == 0);
+                        } else if (name.compare_i("tint") == 0) {
+                            chunk->fTintDecal = (option.compare_i("yes") == 0);
                         }
                     }
                     // add it to our cover decals list (this is tag is essentially thrown away as far as the parser cares)
@@ -2019,20 +2019,20 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     chunk = new pfEsHTMLChunk(nullptr, 0);
                     chunk->fType = pfEsHTMLChunk::kMovie;
                     while (IGetNextOption(c, name, option)) {
-                        if (name.compare_i(ST_LITERAL("align")) == 0) {
+                        if (name.compare_i("align") == 0) {
                             chunk->fFlags &= ~pfEsHTMLChunk::kAlignMask;
-                            if (option.compare_i(ST_LITERAL("left")) == 0)
+                            if (option.compare_i("left") == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kLeft;
-                            else if (option.compare_i(ST_LITERAL("center")) == 0)
+                            else if (option.compare_i("center") == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kCenter;
-                            else if (option.compare_i(ST_LITERAL("right")) == 0)
+                            else if (option.compare_i("right") == 0)
                                 chunk->fFlags |= pfEsHTMLChunk::kRight;
-                        } else if(name.compare_i(ST_LITERAL("src")) == 0) {
+                        } else if(name.compare_i("src") == 0) {
                             chunk->fText = option;
-                        } else if(name.compare_i(ST_LITERAL("link")) == 0) {
+                        } else if(name.compare_i("link") == 0) {
                             chunk->fEventID = option.to_uint();
                             chunk->fFlags |= pfEsHTMLChunk::kCanLink;
-                        } else if(name.compare_i(ST_LITERAL("pos")) == 0) {
+                        } else if(name.compare_i("pos") == 0) {
                             chunk->fFlags |= pfEsHTMLChunk::kFloating;
 
                             ST::string comma = option.after_first(',');
@@ -2040,12 +2040,12 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                 chunk->fAbsoluteY = comma.to_ushort();
                             }
                             chunk->fAbsoluteX = option.before_first(',').to_ushort();
-                        } else if (name.compare_i(ST_LITERAL("resize")) == 0) {
-                            chunk->fNoResizeImg = (option.compare_i(ST_LITERAL("no")) == 0);
-                        } else if (name.compare_i(ST_LITERAL("oncover")) == 0) {
-                            chunk->fOnCover = (option.compare_i(ST_LITERAL("yes")) == 0);
-                        } else if (name.compare_i(ST_LITERAL("loop")) == 0) {
-                            chunk->fLoopMovie = option.compare_i(ST_LITERAL("no")) != 0;
+                        } else if (name.compare_i("resize") == 0) {
+                            chunk->fNoResizeImg = (option.compare_i("no") == 0);
+                        } else if (name.compare_i("oncover") == 0) {
+                            chunk->fOnCover = (option.compare_i("yes") == 0);
+                        } else if (name.compare_i("loop") == 0) {
+                            chunk->fLoopMovie = option.compare_i("no") != 0;
                         }
                     }
                     chunk->fMovieIndex = movieIndex;

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -3325,20 +3325,20 @@ void pfJournalBook::IPurgeDynaTextMaps( )
         turnBackEdit->PurgeDynaTextMapImage();
 }
 
-std::string pfJournalBook::GetEditableText()
+std::wstring pfJournalBook::GetEditableText()
 {
     pfGUIMultiLineEditCtrl *left = fBookGUIs[fCurBookGUI]->GetEditCtrl( pfJournalDlgProc::kTagLeftEditCtrl );
     if (left)
     {
-        char *temp = left->GetNonCodedBuffer();
-        std::string retVal = temp;
+        wchar_t *temp = left->GetNonCodedBufferW();
+        std::wstring retVal = temp;
         delete [] temp;
         return retVal;
     }
-    return "";
+    return L"";
 }
 
-void pfJournalBook::SetEditableText(const std::string& text)
+void pfJournalBook::SetEditableText(const std::wstring& text)
 {
     pfGUIMultiLineEditCtrl *left = fBookGUIs[fCurBookGUI]->GetEditCtrl( pfJournalDlgProc::kTagLeftEditCtrl );
     if (left)

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -1727,8 +1727,7 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                 delete lastParChunk;
                 lastParChunk = nullptr;
             } else if (lastParChunk) {
-                size_t count = ((uintptr_t)c - (uintptr_t)start) / sizeof(wchar_t); // wchar_t is 2 bytes
-                lastParChunk->fText = ST::string(start, count);
+                lastParChunk->fText = ST::string(start, c - start);
                 fHTMLSource.emplace_back(lastParChunk);
             }
 
@@ -2093,8 +2092,7 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
         delete lastParChunk;
         lastParChunk = nullptr;
     } else if (lastParChunk) {
-        size_t count = (uintptr_t)c - (uintptr_t)start;
-        lastParChunk->fText = ST::string(start, count);
+        lastParChunk->fText = ST::string(start, c - start);
 
         fHTMLSource.emplace_back(lastParChunk);
     }

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -1664,38 +1664,6 @@ void    pfJournalBook::ForceCacheCalculations()
     IRecalcPageStarts( -1 );
 }
 
-// Tiny helper to convert hex values the *right* way
-// TODO Is it safe to replace this with str.to_uint(16)?
-static uint32_t   IConvertHex( ST::string& str )
-{
-    uint32_t value = 0;
-    for(const char *s = str.begin(); s < str.end(); s++)
-    {
-        value <<= 4;
-        switch( *s )
-        {
-            case '0':          value |= 0x0;   break;
-            case '1':          value |= 0x1;   break;
-            case '2':          value |= 0x2;   break;
-            case '3':          value |= 0x3;   break;
-            case '4':          value |= 0x4;   break;
-            case '5':          value |= 0x5;   break;
-            case '6':          value |= 0x6;   break;
-            case '7':          value |= 0x7;   break;
-            case '8':          value |= 0x8;   break;
-            case '9':          value |= 0x9;   break;
-            case 'a': case 'A':   value |= 0xa;   break;
-            case 'b': case 'B':   value |= 0xb;   break;
-            case 'c': case 'C':   value |= 0xc;   break;
-            case 'd': case 'D':   value |= 0xd;   break;
-            case 'e': case 'E':   value |= 0xe;   break;
-            case 'f': case 'F':   value |= 0xf;   break;
-        }
-    }
-
-    return value;
-}
-
 //// ICompileSource //////////////////////////////////////////////////////////
 // Compiles the given string of esHTML source into our compiled chunk list
 
@@ -1807,13 +1775,13 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                                         chunk->fFlags |= pfEsHTMLChunk::kChecked;
                                 }
                                 comma = comma.before_first(',');
-                                uint32_t c = IConvertHex(comma);
+                                uint32_t c = comma.to_uint(16);
                                 if (comma.size() <= 6)
                                     c |= 0xff000000;    // Add in full alpha if none specified
                                 chunk->fOffColor.FromARGB32(c);
                             }
                             option = option.before_first(',');
-                            uint32_t c = IConvertHex(option);
+                            uint32_t c = option.to_uint(16);
                             if (option.size() <= 6)
                                 c |= 0xff000000;    // Add in full alpha if none specified
                             chunk->fOnColor.FromARGB32(c);

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -454,9 +454,9 @@ class pfJournalBook : public hsKeyedObject
         void    SetEditable( bool editable=true );
 
         // returns the text contained by the edit controls
-        std::wstring GetEditableText();
+        ST::string GetEditableText();
 
-        void    SetEditableText(const std::wstring& text);
+        void    SetEditableText(const ST::string& text);
 
     private:
 

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -374,7 +374,6 @@ class pfJournalBook : public hsKeyedObject
         // The constructor takes in the esHTML source for the journal, along with
         // the name of the mipmap to use as the cover of the book. The callback
         // key is the keyed object to send event messages to (see <img> tag).
-        pfJournalBook(const char *esHTMLSource, plKey coverImageKey = {}, plKey callbackKey = {}, const plLocation &hintLoc = plLocation::kGlobalFixedLoc, const ST::string &guiName = {});
         pfJournalBook(const wchar_t *esHTMLSource, plKey coverImageKey = {}, plKey callbackKey = {}, const plLocation &hintLoc = plLocation::kGlobalFixedLoc, const ST::string &guiName = {});
 
         virtual ~pfJournalBook();

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -532,9 +532,9 @@ class pfJournalBook : public hsKeyedObject
 
         // Compile helpers
         uint8_t   IGetTagType( const wchar_t *string );
-        bool    IGetNextOption( const wchar_t *&string, wchar_t *name, wchar_t *option );
+        bool    IGetNextOption( const wchar_t *&string, ST::string& name, ST::string& option );
 
-        plKey   IGetMipmapKey( const wchar_t *name, const plLocation &loc );
+        plKey   IGetMipmapKey( const ST::string& name, const plLocation &loc );
 
         // Renders one (1) page into the given DTMap
         void    IRenderPage( uint32_t page, uint32_t whichDTMap, bool suppressRendering = false );

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -531,8 +531,8 @@ class pfJournalBook : public hsKeyedObject
         void    IFreeSource();
 
         // Compile helpers
-        uint8_t   IGetTagType( const wchar_t *string );
-        bool    IGetNextOption( const wchar_t *&string, ST::string& name, ST::string& option );
+        uint8_t   IGetTagType( const char *string, const char *end );
+        bool    IGetNextOption( const char *&string, const char *end, ST::string& name, ST::string& option );
 
         plKey   IGetMipmapKey( const ST::string& name, const plLocation &loc );
 

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -374,7 +374,7 @@ class pfJournalBook : public hsKeyedObject
         // The constructor takes in the esHTML source for the journal, along with
         // the name of the mipmap to use as the cover of the book. The callback
         // key is the keyed object to send event messages to (see <img> tag).
-        pfJournalBook(const wchar_t *esHTMLSource, plKey coverImageKey = {}, plKey callbackKey = {}, const plLocation &hintLoc = plLocation::kGlobalFixedLoc, const ST::string &guiName = {});
+        pfJournalBook(ST::string esHTMLSource, plKey coverImageKey = {}, plKey callbackKey = {}, const plLocation &hintLoc = plLocation::kGlobalFixedLoc, const ST::string &guiName = {});
 
         virtual ~pfJournalBook();
 
@@ -469,7 +469,7 @@ class pfJournalBook : public hsKeyedObject
         friend class pfBookData;
 
         // Our compiled esHTML source
-        std::wstring                fUncompiledSource;
+        ST::string                  fUncompiledSource;
         plLocation                  fDefLoc;
         std::vector<pfEsHTMLChunk *> fHTMLSource;
         std::vector<pfEsHTMLChunk *> fCoverDecals; // stored in a separate location so we can draw them all immediately
@@ -525,7 +525,7 @@ class pfJournalBook : public hsKeyedObject
         };
 
         // Compiles the given string of esHTML source into our compiled chunk list
-        bool    ICompileSource( const wchar_t *source, const plLocation &hintLoc );
+        bool    ICompileSource( const ST::string& source, const plLocation &hintLoc );
 
         // Frees our source array
         void    IFreeSource();

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -454,9 +454,9 @@ class pfJournalBook : public hsKeyedObject
         void    SetEditable( bool editable=true );
 
         // returns the text contained by the edit controls
-        std::string GetEditableText();
+        std::wstring GetEditableText();
 
-        void    SetEditableText(const std::string& text);
+        void    SetEditableText(const std::wstring& text);
 
     private:
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
@@ -84,7 +84,7 @@ ST::string pyGUIControlEditBox::GetBuffer()
         if ( pebmod )
             return pebmod->GetBuffer();
     }
-    return L"";
+    return ST::string();
 }
 
 void pyGUIControlEditBox::ClearBuffer()

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
@@ -84,7 +84,7 @@ ST::string pyGUIControlEditBox::GetBuffer()
         if ( pebmod )
             return pebmod->GetBuffer();
     }
-    return ST::string();
+    return {};
 }
 
 void pyGUIControlEditBox::ClearBuffer()

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
@@ -82,7 +82,7 @@ std::wstring pyGUIControlEditBox::GetBuffer()
         // get the pointer to the modifier
         pfGUIEditBoxMod* pebmod = pfGUIEditBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pebmod )
-            return pebmod->GetBufferW();
+            return pebmod->GetBuffer();
     }
     return L"";
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
@@ -75,7 +75,7 @@ void pyGUIControlEditBox::SetBufferSize( uint32_t size )
     }
 }
 
-std::wstring pyGUIControlEditBox::GetBuffer()
+ST::string pyGUIControlEditBox::GetBuffer()
 {
     if ( fGCkey )
     {
@@ -98,7 +98,7 @@ void pyGUIControlEditBox::ClearBuffer()
     }
 }
 
-void pyGUIControlEditBox::SetText( const wchar_t *str )
+void pyGUIControlEditBox::SetText( const ST::string& str )
 {
     if ( fGCkey )
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.h
@@ -51,7 +51,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pyGlueHelpers.h"
 #include "pyGUIControl.h"
-#include <string>
+
+#include <string_theory/string>
 
 class pyColor;
 
@@ -75,9 +76,9 @@ public:
     static bool IsGUIControlEditBox(pyKey& gckey);
 
     virtual void    SetBufferSize( uint32_t size );
-    virtual std::wstring GetBuffer();
+    virtual ST::string GetBuffer();
     virtual void    ClearBuffer();
-    virtual void    SetText( const wchar_t *str );
+    virtual void    SetText( const ST::string& str );
     virtual void    SetCursorToHome();
     virtual void    SetCursorToEnd();
     virtual void    SetColor(pyColor& forecolor, pyColor& backcolor);

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBoxGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBoxGlue.cpp
@@ -86,32 +86,21 @@ PYTHON_METHOD_DEFINITION(ptGUIControlEditBox, setStringSize, args)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlEditBox, getString)
 {
-    std::wstring val = self->fThis->GetBuffer();
-    return PyUnicode_FromWideChar(val.c_str(), val.length());
+    return PyUnicode_FromSTString(self->fThis->GetBuffer());
 }
 
 PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlEditBox, clearString, ClearBuffer)
 
 PYTHON_METHOD_DEFINITION(ptGUIControlEditBox, setString, args)
 {
-    PyObject* textObj;
-    if (!PyArg_ParseTuple(args, "O", &textObj))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "setString expects a unicode string");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* text = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->SetText(text);
-        PyMem_Free(text);
-        PYTHON_RETURN_NONE;
-    }
-    else
-    {
-        PyErr_SetString(PyExc_TypeError, "setString expects a unicode string");
-        PYTHON_RETURN_ERROR;
-    }
+    self->fThis->SetText(text);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlEditBox, home, SetCursorToHome)

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
@@ -162,7 +162,7 @@ const wchar_t* pyGUIControlMultiLineEdit::GetText()
         pfGUIMultiLineEditCtrl* pbmod = pfGUIMultiLineEditCtrl::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pbmod )
         {
-            const wchar_t* text = pbmod->GetNonCodedBufferW();
+            const wchar_t* text = pbmod->GetNonCodedBuffer();
             // convert string to a PyObject (which also copies the string)
             return text;
         }
@@ -218,7 +218,7 @@ const wchar_t* pyGUIControlMultiLineEdit::GetEncodedBuffer()
         if ( pbmod )
         {
             size_t length;
-            wchar_t* daBuffer = pbmod->GetCodedBufferW(length);
+            wchar_t* daBuffer = pbmod->GetCodedBuffer(length);
             if ( daBuffer )
             {
                 wchar_t* altBuffer = new wchar_t[length + 1];

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
@@ -166,7 +166,7 @@ ST::string pyGUIControlMultiLineEdit::GetText()
             return pbmod->GetNonCodedBuffer();
         }
     }
-    return "";
+    return ST::string();
 }
 
 void pyGUIControlMultiLineEdit::SetEncodedBuffer( PyObject* buffer_object )
@@ -228,7 +228,7 @@ ST::string pyGUIControlMultiLineEdit::GetEncodedBuffer()
             return buffer;
         }
     }
-    return "";
+    return ST::string();
 }
 
 size_t pyGUIControlMultiLineEdit::GetBufferSize() const

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
@@ -166,7 +166,7 @@ ST::string pyGUIControlMultiLineEdit::GetText()
             return pbmod->GetNonCodedBuffer();
         }
     }
-    return ST::string();
+    return {};
 }
 
 void pyGUIControlMultiLineEdit::SetEncodedBuffer( PyObject* buffer_object )
@@ -228,7 +228,7 @@ ST::string pyGUIControlMultiLineEdit::GetEncodedBuffer()
             return buffer;
         }
     }
-    return ST::string();
+    return {};
 }
 
 size_t pyGUIControlMultiLineEdit::GetBufferSize() const

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
@@ -56,6 +56,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class pyColor;
 
+namespace ST { class string; }
+
 class pyGUIControlMultiLineEdit : public pyGUIControl
 {
 protected:
@@ -84,10 +86,10 @@ public:
     virtual void    MoveCursor( int32_t dir );
     int32_t GetCursor() const;
     virtual void    ClearBuffer();
-    virtual void    SetText( const wchar_t *text );
-    virtual const wchar_t* GetText();
+    virtual void    SetText( const ST::string& text );
+    virtual ST::string GetText();
     virtual void    SetEncodedBuffer( PyObject* buffer_object );
-    virtual const wchar_t* GetEncodedBuffer();
+    virtual ST::string GetEncodedBuffer();
     size_t  GetBufferSize() const;
 
     virtual void    SetBufferLimit(int32_t limit);
@@ -95,7 +97,7 @@ public:
     int16_t GetCurrentLink() const;
 
     virtual void    InsertChar( wchar_t c );
-    virtual void    InsertString( const wchar_t *string );
+    virtual void    InsertString( const ST::string& string );
     virtual void    InsertColor( pyColor& color );
     virtual void    InsertStyle( uint8_t fontStyle );
     void InsertLink(int16_t linkId);

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEditGlue.cpp
@@ -121,30 +121,19 @@ PYTHON_BASIC_METHOD_DEFINITION(ptGUIControlMultiLineEdit, clearBuffer, ClearBuff
 
 PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, setString, args)
 {
-    PyObject* textObj;
-    if (!PyArg_ParseTuple(args, "O", &textObj))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "setString expects a unicode string");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* temp = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->SetText(temp);
-        PyMem_Free(temp);
-        PYTHON_RETURN_NONE;
-    }
-    else
-    {
-        PyErr_SetString(PyExc_TypeError, "setString expects a unicode string");
-        PYTHON_RETURN_ERROR;
-    }
+    self->fThis->SetText(text);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, getString)
 {
-    const wchar_t* text = self->fThis->GetText();
-    return PyUnicode_FromWideChar(text, wcslen(text));
+    return PyUnicode_FromSTString(self->fThis->GetText());
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, setEncodedBuffer, args)
@@ -161,10 +150,7 @@ PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, setEncodedBuffer, args)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, getEncodedBuffer)
 {
-    const wchar_t* text = self->fThis->GetEncodedBuffer();
-    PyObject* retVal = PyUnicode_FromWideChar(text, wcslen(text));
-    delete [] text;
-    return retVal;
+    return PyUnicode_FromSTString(self->fThis->GetEncodedBuffer());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGUIControlMultiLineEdit, getBufferSize)
@@ -204,24 +190,14 @@ PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, insertChar, args)
 
 PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, insertString, args)
 {
-    PyObject* textObj;
-    if (!PyArg_ParseTuple(args, "O", &textObj))
+    ST::string string;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &string))
     {
         PyErr_SetString(PyExc_TypeError, "insertString expects a unicode string");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* temp = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->InsertString(temp);
-        PyMem_Free(temp);
-        PYTHON_RETURN_NONE;
-    }
-    else
-    {
-        PyErr_SetString(PyExc_TypeError, "insertString expects a unicode string");
-        PYTHON_RETURN_ERROR;
-    }
+    self->fThis->InsertString(string);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION(ptGUIControlMultiLineEdit, insertColor, args)

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
@@ -281,14 +281,14 @@ void    pyJournalBook::SetEditable( bool editable )
         fBook->SetEditable(editable);
 }
 
-std::string pyJournalBook::GetEditableText() const
+std::wstring pyJournalBook::GetEditableText() const
 {
     if (fBook != nullptr)
         return fBook->GetEditableText();
-    return "";
+    return L"";
 }
 
-void    pyJournalBook::SetEditableText( const std::string& text )
+void    pyJournalBook::SetEditableText( const std::wstring& text )
 {
     if (fBook != nullptr)
         fBook->SetEditableText(text);

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
@@ -281,14 +281,14 @@ void    pyJournalBook::SetEditable( bool editable )
         fBook->SetEditable(editable);
 }
 
-std::wstring pyJournalBook::GetEditableText() const
+ST::string pyJournalBook::GetEditableText() const
 {
     if (fBook != nullptr)
         return fBook->GetEditableText();
     return L"";
 }
 
-void    pyJournalBook::SetEditableText( const std::wstring& text )
+void    pyJournalBook::SetEditableText( const ST::string& text )
 {
     if (fBook != nullptr)
         fBook->SetEditableText(text);

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
@@ -244,7 +244,7 @@ ST::string pyJournalBook::GetEditableText() const
 {
     if (fBook != nullptr)
         return fBook->GetEditableText();
-    return L"";
+    return ST::string();
 }
 
 void    pyJournalBook::SetEditableText( const ST::string& text )

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
@@ -244,7 +244,7 @@ ST::string pyJournalBook::GetEditableText() const
 {
     if (fBook != nullptr)
         return fBook->GetEditableText();
-    return ST::string();
+    return {};
 }
 
 void    pyJournalBook::SetEditableText( const ST::string& text )

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
@@ -72,22 +72,9 @@ pyJournalBook::pyJournalBook()
     fBook = nullptr;
 }
 
-pyJournalBook::pyJournalBook( const char *esHTMLSource )
-{
-    fBook = new pfJournalBook( esHTMLSource );
-    IMakeNewKey();
-}
-
 pyJournalBook::pyJournalBook( const std::wstring& esHTMLSource )
 {
     fBook = new pfJournalBook( esHTMLSource.c_str() );
-    IMakeNewKey();
-}
-
-pyJournalBook::pyJournalBook( const char *esHTMLSource, pyImage &coverImage, const pyKey& callbackKey )
-{
-    fBook = new pfJournalBook( esHTMLSource, coverImage.GetKey(), callbackKey.getKey(), 
-                               callbackKey.getKey() != nullptr ? callbackKey.getKey()->GetUoid().GetLocation() : plLocation::kGlobalFixedLoc);
     IMakeNewKey();
 }
 
@@ -98,25 +85,10 @@ pyJournalBook::pyJournalBook( const std::wstring& esHTMLSource, pyImage &coverIm
     IMakeNewKey();
 }
 
-pyJournalBook::pyJournalBook( const char *esHTMLSource, pyImage &coverImage, const pyKey& callbackKey, const ST::string &guiName )
-{
-    fBook = new pfJournalBook( esHTMLSource, coverImage.GetKey(), callbackKey.getKey(), 
-                               callbackKey.getKey() != nullptr ? callbackKey.getKey()->GetUoid().GetLocation() : plLocation::kGlobalFixedLoc, guiName);
-    IMakeNewKey();
-}
-
 pyJournalBook::pyJournalBook( const std::wstring& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey, const ST::string &guiName )
 {
     fBook = new pfJournalBook( esHTMLSource.c_str(), coverImage.GetKey(), callbackKey.getKey(), 
                                callbackKey.getKey() != nullptr ? callbackKey.getKey()->GetUoid().GetLocation() : plLocation::kGlobalFixedLoc, guiName);
-    IMakeNewKey();
-}
-
-pyJournalBook::pyJournalBook( const char *esHTMLSource, const pyKey& callbackKey )
-{
-    fBook = new pfJournalBook(esHTMLSource, nullptr, callbackKey.getKey(),
-                              callbackKey.getKey() != nullptr ? callbackKey.getKey()->GetUoid().GetLocation() : plLocation::kGlobalFixedLoc);
-
     IMakeNewKey();
 }
 
@@ -135,19 +107,6 @@ pyJournalBook::~pyJournalBook()
         fBook->GetKey()->UnRefObject();
         fBook = nullptr;
     }
-}
-
-void pyJournalBook::MakeBook(const std::string& esHTMLSource, plKey coverImageKey /* = {} */, plKey callbackKey /* = {} */, const ST::string &guiName /* = "" */)
-{
-    if (fBook)
-        fBook->GetKey()->UnRefObject();
-
-    plLocation loc = plLocation::kGlobalFixedLoc;
-    if (callbackKey != nullptr)
-        loc = callbackKey->GetUoid().GetLocation();
-
-    fBook = new pfJournalBook(esHTMLSource.c_str(), std::move(coverImageKey), std::move(callbackKey), loc, guiName);
-    IMakeNewKey();
 }
 
 void pyJournalBook::MakeBook(const std::wstring& esHTMLSource, plKey coverImageKey /* = {} */, plKey callbackKey /* = {} */, const ST::string &guiName /* = "" */)

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.cpp
@@ -72,29 +72,29 @@ pyJournalBook::pyJournalBook()
     fBook = nullptr;
 }
 
-pyJournalBook::pyJournalBook( const std::wstring& esHTMLSource )
+pyJournalBook::pyJournalBook( const ST::string& esHTMLSource )
 {
-    fBook = new pfJournalBook( esHTMLSource.c_str() );
+    fBook = new pfJournalBook( esHTMLSource );
     IMakeNewKey();
 }
 
-pyJournalBook::pyJournalBook( const std::wstring& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey )
+pyJournalBook::pyJournalBook( const ST::string& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey )
 {
-    fBook = new pfJournalBook( esHTMLSource.c_str(), coverImage.GetKey(), callbackKey.getKey(), 
+    fBook = new pfJournalBook( esHTMLSource, coverImage.GetKey(), callbackKey.getKey(), 
                                callbackKey.getKey() != nullptr ? callbackKey.getKey()->GetUoid().GetLocation() : plLocation::kGlobalFixedLoc);
     IMakeNewKey();
 }
 
-pyJournalBook::pyJournalBook( const std::wstring& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey, const ST::string &guiName )
+pyJournalBook::pyJournalBook( const ST::string& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey, const ST::string &guiName )
 {
-    fBook = new pfJournalBook( esHTMLSource.c_str(), coverImage.GetKey(), callbackKey.getKey(), 
+    fBook = new pfJournalBook( esHTMLSource, coverImage.GetKey(), callbackKey.getKey(), 
                                callbackKey.getKey() != nullptr ? callbackKey.getKey()->GetUoid().GetLocation() : plLocation::kGlobalFixedLoc, guiName);
     IMakeNewKey();
 }
 
-pyJournalBook::pyJournalBook( const std::wstring& esHTMLSource, const pyKey& callbackKey )
+pyJournalBook::pyJournalBook( const ST::string& esHTMLSource, const pyKey& callbackKey )
 {
-    fBook = new pfJournalBook(esHTMLSource.c_str(), nullptr, callbackKey.getKey(),
+    fBook = new pfJournalBook(esHTMLSource, nullptr, callbackKey.getKey(),
                               callbackKey.getKey() != nullptr ? callbackKey.getKey()->GetUoid().GetLocation() : plLocation::kGlobalFixedLoc);
 
     IMakeNewKey();
@@ -109,7 +109,7 @@ pyJournalBook::~pyJournalBook()
     }
 }
 
-void pyJournalBook::MakeBook(const std::wstring& esHTMLSource, plKey coverImageKey /* = {} */, plKey callbackKey /* = {} */, const ST::string &guiName /* = "" */)
+void pyJournalBook::MakeBook(const ST::string& esHTMLSource, plKey coverImageKey /* = {} */, plKey callbackKey /* = {} */, const ST::string &guiName /* = "" */)
 {
     if (fBook)
         fBook->GetKey()->UnRefObject();
@@ -118,7 +118,7 @@ void pyJournalBook::MakeBook(const std::wstring& esHTMLSource, plKey coverImageK
     if (callbackKey != nullptr)
         loc = callbackKey->GetUoid().GetLocation();
 
-    fBook = new pfJournalBook(esHTMLSource.c_str(), std::move(coverImageKey), std::move(callbackKey), loc, guiName);
+    fBook = new pfJournalBook(esHTMLSource, std::move(coverImageKey), std::move(callbackKey), loc, guiName);
     IMakeNewKey();
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
@@ -123,8 +123,8 @@ public:
     virtual PyObject *GetMovie( uint8_t index ); // returns cyAnimation
     
     virtual void    SetEditable( bool editable );
-    virtual std::wstring GetEditableText() const;
-    virtual void    SetEditableText( const std::wstring& text );
+    virtual ST::string GetEditableText() const;
+    virtual void    SetEditableText( const ST::string& text );
 };
 
 #endif // _pyJournalBook_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
@@ -123,8 +123,8 @@ public:
     virtual PyObject *GetMovie( uint8_t index ); // returns cyAnimation
     
     virtual void    SetEditable( bool editable );
-    virtual std::string GetEditableText() const;
-    virtual void    SetEditableText( const std::string& text );
+    virtual std::wstring GetEditableText() const;
+    virtual void    SetEditableText( const std::wstring& text );
 };
 
 #endif // _pyJournalBook_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
@@ -69,13 +69,9 @@ protected:
     void    IMakeNewKey();
 
     pyJournalBook(); // used by python glue only, do NOT call
-    pyJournalBook( const char *esHTMLSource );
     pyJournalBook( const std::wstring& esHTMLSource );
-    pyJournalBook( const char *esHTMLSource, const pyKey& callbackKey );
     pyJournalBook( const std::wstring& esHTMLSource, const pyKey& callbackKey );
-    pyJournalBook( const char *esHTMLSource, pyImage &coverImage, const pyKey& callbackKey );
     pyJournalBook( const std::wstring& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey );
-    pyJournalBook( const char *esHTMLSource, pyImage &coverImage, const pyKey& callbackKey, const ST::string &guiName );
     pyJournalBook( const std::wstring& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey, const ST::string &guiName );
 
 public:
@@ -85,7 +81,6 @@ public:
 
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptBook);
-    static PyObject *New(const std::string& htmlSource, plKey coverImageKey = {}, plKey callbackKey = {}, const ST::string &guiName = {});
     static PyObject *New(const std::wstring& htmlSource, plKey coverImageKey = {}, plKey callbackKey = {}, const ST::string &guiName = {});
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyJournalBook object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyJournalBook); // converts a PyObject to a pyJournalBook (throws error if not correct type)
@@ -95,7 +90,6 @@ public:
     static void AddPlasmaConstantsClasses(PyObject *m);
 
     // Deletes the existing book and re-creates it, for use by the python glue
-    void MakeBook(const std::string& esHTMLSource, plKey coverImageKey = {}, plKey callbackKey = {}, const ST::string &guiName = {});
     void MakeBook(const std::wstring& esHTMLSource, plKey coverImageKey = {}, plKey callbackKey = {}, const ST::string &guiName = {});
 
     // Interface functions per book

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBook.h
@@ -50,7 +50,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pyGlueHelpers.h"
 #include <vector>
-#include <string>
 
 class cyAnimation;
 class pyImage;
@@ -69,10 +68,10 @@ protected:
     void    IMakeNewKey();
 
     pyJournalBook(); // used by python glue only, do NOT call
-    pyJournalBook( const std::wstring& esHTMLSource );
-    pyJournalBook( const std::wstring& esHTMLSource, const pyKey& callbackKey );
-    pyJournalBook( const std::wstring& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey );
-    pyJournalBook( const std::wstring& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey, const ST::string &guiName );
+    pyJournalBook( const ST::string& esHTMLSource );
+    pyJournalBook( const ST::string& esHTMLSource, const pyKey& callbackKey );
+    pyJournalBook( const ST::string& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey );
+    pyJournalBook( const ST::string& esHTMLSource, pyImage &coverImage, const pyKey& callbackKey, const ST::string &guiName );
 
 public:
     virtual ~pyJournalBook();
@@ -81,7 +80,7 @@ public:
 
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptBook);
-    static PyObject *New(const std::wstring& htmlSource, plKey coverImageKey = {}, plKey callbackKey = {}, const ST::string &guiName = {});
+    static PyObject *New(const ST::string& htmlSource, plKey coverImageKey = {}, plKey callbackKey = {}, const ST::string &guiName = {});
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyJournalBook object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyJournalBook); // converts a PyObject to a pyJournalBook (throws error if not correct type)
 
@@ -90,7 +89,7 @@ public:
     static void AddPlasmaConstantsClasses(PyObject *m);
 
     // Deletes the existing book and re-creates it, for use by the python glue
-    void MakeBook(const std::wstring& esHTMLSource, plKey coverImageKey = {}, plKey callbackKey = {}, const ST::string &guiName = {});
+    void MakeBook(const ST::string& esHTMLSource, plKey coverImageKey = {}, plKey callbackKey = {}, const ST::string &guiName = {});
 
     // Interface functions per book
     virtual void    Show( bool startOpened );

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
@@ -61,9 +61,9 @@ PYTHON_INIT_DEFINITION(ptBook, args, keywords)
     ST::string source;
     PyObject* coverObj = nullptr;
     PyObject* callbackObj = nullptr;
-    char* guiName = nullptr;
-    if (!PyArg_ParseTupleAndKeywords(args, keywords, "O&|OOs", const_cast<char **>(kwlist),
-                                     PyUnicode_STStringConverter, &source, &coverObj, &callbackObj, &guiName))
+    ST::string guiName;
+    if (!PyArg_ParseTupleAndKeywords(args, keywords, "O&|OOO&", const_cast<char **>(kwlist),
+                                     PyUnicode_STStringConverter, &source, &coverObj, &callbackObj, PyUnicode_STStringConverter, &guiName))
     {
         PyErr_SetString(PyExc_TypeError, "__init__ expects a string or unicode string, and optionally a ptImage, ptKey, and string");
         PYTHON_RETURN_INIT_ERROR;
@@ -104,11 +104,7 @@ PYTHON_INIT_DEFINITION(ptBook, args, keywords)
         callbackKey = pyKey::ConvertFrom(callbackObj)->getKey();
     }
 
-    ST::string guiNameStr;
-    if (guiName)
-        guiNameStr = ST::string::from_utf8(guiName);
-
-    self->fThis->MakeBook(source, coverKey, callbackKey, guiNameStr);
+    self->fThis->MakeBook(source, coverKey, callbackKey, guiName);
     PYTHON_RETURN_INIT_OK;
 }
 
@@ -296,25 +292,25 @@ void pyJournalBook::AddPlasmaClasses(PyObject *m)
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtLoadBookGUI, args, "Params: guiName\nLoads the gui specified, a gui must be loaded before it can be used. If the gui is already loaded, doesn't do anything")
 {
-    char* guiName;
-    if (!PyArg_ParseTuple(args, "s", &guiName))
+    ST::string guiName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &guiName))
     {
         PyErr_SetString(PyExc_TypeError, "PtLoadBookGUI expects a string");
         PYTHON_RETURN_ERROR;
     }
-    pyJournalBook::LoadGUI(ST::string::from_utf8(guiName));
+    pyJournalBook::LoadGUI(guiName);
     PYTHON_RETURN_NONE;
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtUnloadBookGUI, args, "Params: guiName\nUnloads the gui specified. If the gui isn't loaded, doesn't do anything")
 {
-    char* guiName;
-    if (!PyArg_ParseTuple(args, "s", &guiName))
+    ST::string guiName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &guiName))
     {
         PyErr_SetString(PyExc_TypeError, "PtUnloadBookGUI expects a string");
         PYTHON_RETURN_ERROR;
     }
-    pyJournalBook::UnloadGUI(ST::string::from_utf8(guiName));
+    pyJournalBook::UnloadGUI(guiName);
     PYTHON_RETURN_NONE;
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
@@ -58,12 +58,12 @@ PYTHON_DEFAULT_DEALLOC_DEFINITION(ptBook)
 PYTHON_INIT_DEFINITION(ptBook, args, keywords)
 {
     const char* kwlist[] = {"esHTMLSource", "coverImage", "callbackKey", "guiName", nullptr};
-    PyObject* sourceObj = nullptr;
+    ST::string source;
     PyObject* coverObj = nullptr;
     PyObject* callbackObj = nullptr;
     char* guiName = nullptr;
-    if (!PyArg_ParseTupleAndKeywords(args, keywords, "O|OOs", const_cast<char **>(kwlist),
-                                     &sourceObj, &coverObj, &callbackObj, &guiName))
+    if (!PyArg_ParseTupleAndKeywords(args, keywords, "O&|OOs", const_cast<char **>(kwlist),
+                                     PyUnicode_STStringConverter, &source, &coverObj, &callbackObj, &guiName))
     {
         PyErr_SetString(PyExc_TypeError, "__init__ expects a string or unicode string, and optionally a ptImage, ptKey, and string");
         PYTHON_RETURN_INIT_ERROR;
@@ -108,20 +108,8 @@ PYTHON_INIT_DEFINITION(ptBook, args, keywords)
     if (guiName)
         guiNameStr = ST::string::from_utf8(guiName);
 
-    // convert the sourcecode object
-    if (PyUnicode_Check(sourceObj))
-    {
-        wchar_t* temp = PyUnicode_AsWideCharString(sourceObj, nullptr);
-        std::wstring source = temp;
-        PyMem_Free(temp);
-
-        self->fThis->MakeBook(source, coverKey, callbackKey, guiNameStr);
-        PYTHON_RETURN_INIT_OK;
-    }
-
-    // source wasn't a string or unicode string
-    PyErr_SetString(PyExc_TypeError, "__init__ expects a string or unicode string, and optionally a ptImage, ptKey, and string");
-    PYTHON_RETURN_INIT_ERROR;
+    self->fThis->MakeBook(source, coverKey, callbackKey, guiNameStr);
+    PYTHON_RETURN_INIT_OK;
 }
 
 PYTHON_METHOD_DEFINITION(ptBook, show, args)
@@ -285,7 +273,7 @@ PYTHON_END_METHODS_TABLE;
 PLASMA_DEFAULT_TYPE(ptBook, "Params: esHTMLSource,coverImage=None,callbackKey=None,guiName=''\nCreates a new book");
 
 // required functions for PyObject interoperability
-PyObject *pyJournalBook::New(const std::wstring& htmlSource, plKey coverImageKey /* = {} */, plKey callbackKey /* = {} */, const ST::string &guiName /* = "" */)
+PyObject *pyJournalBook::New(const ST::string& htmlSource, plKey coverImageKey /* = {} */, plKey callbackKey /* = {} */, const ST::string &guiName /* = "" */)
 {
     ptBook *newObj = (ptBook*)ptBook_type.tp_new(&ptBook_type, nullptr, nullptr);
     newObj->fThis->MakeBook(htmlSource, std::move(coverImageKey), std::move(callbackKey), guiName);

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
@@ -246,14 +246,13 @@ PYTHON_METHOD_DEFINITION(ptBook, setEditable, args)
 
 PYTHON_METHOD_DEFINITION(ptBook, getEditableText, args)
 {
-    std::wstring text = self->fThis->GetEditableText();
-    return PyUnicode_FromWideChar(text.c_str(), text.size());
+    return PyUnicode_FromSTString(self->fThis->GetEditableText());
 }
 
 PYTHON_METHOD_DEFINITION(ptBook, setEditableText, args)
 {
-    wchar_t* text;
-    if (!PyArg_ParseTuple(args, "u", &text))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "setEditableText expects a string");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
@@ -285,13 +285,6 @@ PYTHON_END_METHODS_TABLE;
 PLASMA_DEFAULT_TYPE(ptBook, "Params: esHTMLSource,coverImage=None,callbackKey=None,guiName=''\nCreates a new book");
 
 // required functions for PyObject interoperability
-PyObject *pyJournalBook::New(const std::string& htmlSource, plKey coverImageKey /* = {} */, plKey callbackKey /* = {} */, const ST::string &guiName /* = "" */)
-{
-    ptBook *newObj = (ptBook*)ptBook_type.tp_new(&ptBook_type, nullptr, nullptr);
-    newObj->fThis->MakeBook(htmlSource, std::move(coverImageKey), std::move(callbackKey), guiName);
-    return (PyObject*)newObj;
-}
-
 PyObject *pyJournalBook::New(const std::wstring& htmlSource, plKey coverImageKey /* = {} */, plKey callbackKey /* = {} */, const ST::string &guiName /* = "" */)
 {
     ptBook *newObj = (ptBook*)ptBook_type.tp_new(&ptBook_type, nullptr, nullptr);

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
@@ -211,13 +211,13 @@ PYTHON_METHOD_DEFINITION(ptBook, setPageMargin, args)
 
 PYTHON_METHOD_DEFINITION(ptBook, setGUI, args)
 {
-    char* guiName;
-    if (!PyArg_ParseTuple(args, "s", &guiName))
+    ST::string guiName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &guiName))
     {
         PyErr_SetString(PyExc_TypeError, "setGUI expects a string");
         PYTHON_RETURN_ERROR;
     }
-    self->fThis->SetGUI(ST::string::from_utf8(guiName));
+    self->fThis->SetGUI(guiName);
     PYTHON_RETURN_NONE;
 }
 
@@ -246,13 +246,14 @@ PYTHON_METHOD_DEFINITION(ptBook, setEditable, args)
 
 PYTHON_METHOD_DEFINITION(ptBook, getEditableText, args)
 {
-    return PyUnicode_FromStdString(self->fThis->GetEditableText());
+    std::wstring text = self->fThis->GetEditableText();
+    return PyUnicode_FromWideChar(text.c_str(), text.size());
 }
 
 PYTHON_METHOD_DEFINITION(ptBook, setEditableText, args)
 {
-    char* text;
-    if (!PyArg_ParseTuple(args, "s", &text))
+    wchar_t* text;
+    if (!PyArg_ParseTuple(args, "u", &text))
     {
         PyErr_SetString(PyExc_TypeError, "setEditableText expects a string");
         PYTHON_RETURN_ERROR;


### PR DESCRIPTION
Migrates `pfJournalBook` to `ST::string`, along with `pfGUIMultiLineEditCtrl` (which it uses) and `pfGUIEditBoxMod` (which isn't directly related, but seemed logical to do along with the multiline version). This is my first time doing anything serious with string_theory, so expect silly mistakes :)

A few places in this code used `wchar_t` arrays as buffers containing a variably-sized string. I replaced those with `ST::wchar_buffer`, as that seems to be the closest equivalent, but unfortunately `ST::wchar_buffer` can't be resized dynamically without destroying its contents. On second thought, it might make more sense to use `std::vector<wchar_t>` instead, to avoid moving data manually and having to track the actual string length.