### PR TITLE
Fix `GrabCubeCam` suffixes.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfSurface/plGrabCubeMap.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plGrabCubeMap.cpp
@@ -116,8 +116,8 @@ void plGrabCubeMap::ISetupRenderRequests(plPipeline* pipe, const hsPoint3& cente
     const char* suff[6] = {
         "LF",
         "RT",
-        "BK",
         "FR",
+        "BK",
         "UP",
         "DN" };
 


### PR DESCRIPTION
The front and back face suffix strings were reveresed compared to the output of `hsMatrix44::MakeEnvMapMatrices()`.