### PR TITLE
Return a real bool from `PYTHON_RETURN_BOOL`.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -444,13 +444,12 @@ static PyObject *pythonClassName##_##methodName(pythonClassName *self) \
 // Different basic return types
 #define PYTHON_RETURN_ERROR { return nullptr; }
 #define PYTHON_RETURN_NONE {Py_INCREF(Py_None); return Py_None;}
-#define PYTHON_RETURN_BOOL(testValue) \
-{ \
-    if (testValue) \
-        return PyLong_FromLong((long)1); \
-    else \
-        return PyLong_FromLong((long)0); \
-}
+#define PYTHON_RETURN_BOOL(testValue)                     \
+{                                                         \
+    PyObject* retVal = (testValue) ? Py_True : Py_False;  \
+    Py_INCREF(retVal);                                    \
+    return retVal;                                        \
+}                                                         //
 #define PYTHON_RETURN_NOT_IMPLEMENTED {Py_INCREF(Py_NotImplemented); return Py_NotImplemented;}
 
 // method table start


### PR DESCRIPTION
Previously, an integer was returned. Returning an actual boolean enables improved Python code (eg `meow() is True`) and allows f-strings with these booleans to print the words `True` and `False` instead of the integers `1` and `0`.