### PR TITLE
Change xAgeSDLBoolActivatorComboSet to use more accurate responder list attrib type

### DIFF
--- a/Scripts/Python/xAgeSDLBoolActivatorComboSet.py
+++ b/Scripts/Python/xAgeSDLBoolActivatorComboSet.py
@@ -51,7 +51,7 @@ combination = ptAttribString(4, "Combination")
 resetOnEmpty = ptAttribBoolean(5, "Reset when the Age shuts down", default=False)
 disableOnSolve = ptAttribBoolean(6, "Disable activators on solve", default=True)
 actButtons = ptAttribActivatorList(7, "Act: Buttons")
-respButtonPush = ptAttribResponder(8, "Resp: Button Push")
+respButtonPush = ptAttribResponderList(8, "Resp: Button Pushes")
 allowSlidingSolution = ptAttribBoolean(9, "Allow solving by sliding solution rather than needing feedback on failure", default=False)
 
 class xAgeSDLBoolActivatorComboSet(ptResponder):


### PR DESCRIPTION
This will not change the current Python functionality, but will help Max plugin users to be able to set the respButtonPush value correctly with a list of responders.