### PR TITLE
Fix player jittering when running into walls.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
@@ -434,7 +434,7 @@ void plWalkingStrategy::Apply(float delSecs)
 
     // Now Cyan's good old "slide along all the contacts" code.
     hsVector3 offset(0.f, 0.f, 0.f);
-    for (const auto contact : fContacts) {
+    for (const auto& contact : fContacts) {
         if (!contact.GetPhysical() || contact.GetPhysical()->GetGroup() == plSimDefs::kGroupDynamic)
             continue;
         if (contact.Normal.fZ >= .5f)

--- a/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.cpp
@@ -439,6 +439,8 @@ void plWalkingStrategy::Apply(float delSecs)
             continue;
         if (contact.Normal.fZ >= .5f)
             continue;
+        if (contact.Displacement < .1f)
+            continue;
         offset += contact.Normal;
         hsVector3 velNorm = velocity;
 


### PR DESCRIPTION
Sometimes, when running into a solid wall, the player will jitter. The most evident side effect when that happens is lots of small transient contacts being reported. Therefore, don't slide against small collisions. As a bonus, don't make a copy of each contact while we're calculating the sliding normal.