### PR TITLE
Limit HQ DynamicCamMaps to reflections.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
@@ -3472,7 +3472,9 @@ hsGDeviceRef    *plDXPipeline::MakeRenderTargetRef( plRenderTarget *owner )
     plDynamicCamMap* camMap = plDynamicCamMap::ConvertNoRef(owner);
     if (camMap)
     {
-        if ((plQuality::GetCapability() > plQuality::kPS_2) && fSettings.fD3DCaps & kCapsNpotTextures)
+        bool havePS3 = plQuality::GetCapability() > plQuality::kPS_2;
+        bool haveNpot = fSettings.fD3DCaps & kCapsNpotTextures;
+        if (camMap->IsReflection() && havePS3 && haveNpot)
             camMap->ResizeViewport(IGetViewTransform());
     }
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDynamicEnvMap.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDynamicEnvMap.h
@@ -218,6 +218,7 @@ public:
     void        SetRefreshRate(float secs);
     void        AddVisRegion(plVisRegion* reg);
     void        SetVisRegionName(ST::string name) override { fVisRegionNames.emplace_back(std::move(name)); }
+    bool        IsReflection() const { return fCamera == nullptr; }
 
     static bool     GetEnabled() { return (fFlags & kReflectionEnabled) != 0; }
     static void     SetEnabled(bool enable);


### PR DESCRIPTION
It was pointed out in H-uru/moul-assets#209 that the resolution setting in DCMs can be extremely useful for non-reflections. Therefore, use the artist settings for things that aren't reflections.