### PR TITLE
Add Chiso Preniv Book to Relto bookshelf

### DIFF
--- a/Scripts/Python/ki/xKIConstants.py
+++ b/Scripts/Python/ki/xKIConstants.py
@@ -207,7 +207,7 @@ class kAges:
         "Personal", "Nexus", "Cleft", "AvatarCustomization", "city",
         "BahroCave", "LiveBahroCave", "LiveBahroCaves", 
         "BaronCityOffice", "ErcanaCitySilo", "GreatZero", "Shaft",
-        "Descent", "Spyroom", "Myst"
+        "Descent", "Spyroom", "Myst", "ChisoPreniv"
     }
     Replace = {
         "Ercana" : "Er'cana",

--- a/Scripts/Python/nxusBookMachine.py
+++ b/Scripts/Python/nxusBookMachine.py
@@ -203,9 +203,9 @@ kLinkPanels = {
 }
 
 
-kHiddenPersonalAges = ["Personal", "Nexus", "Neighborhood", "city", "AvatarCustomization", "Cleft", "BaronCityOffice", "BahroCave", "PelletBahroCave", "Kveer", "Myst", "LiveBahroCaves", "LiveBahroCave", "Tiam"]
-kHiddenCityLinks = ["islmPalaceBalcony03", "KadishGallery", "islmPalaceBalcony02", "islmDakotahRoof", ]
-kHiddenAgesIfInvited = ["BahroCave", "PelletBahroCave", "Pellet Cave", "LiveBahroCave", "LiveBahroCaves", "Myst", "Tiam"]
+kHiddenPersonalAges = ["Personal", "Nexus", "Neighborhood", "city", "AvatarCustomization", "Cleft", "BaronCityOffice", "BahroCave", "PelletBahroCave", "Kveer", "Myst", "LiveBahroCaves", "LiveBahroCave", "ChisoPreniv", "GoMePubNew", "FahetsHighgarden"]
+kHiddenCityLinks = ["islmPalaceBalcony03", "KadishGallery", "islmPalaceBalcony02", "islmDakotahRoof", "islmGreatTree"]
+kHiddenAgesIfInvited = ["BahroCave", "PelletBahroCave", "Pellet Cave", "LiveBahroCave", "LiveBahroCaves", "Myst", "ChisoPreniv", "GoMePubNew", "FahetsHighgarden"]
 
 #public ages SDL variables to be read from Vault on start (max. population, is link visible)
 kAgeSdlVariables = {

--- a/Scripts/Python/psnlBookshelf.py
+++ b/Scripts/Python/psnlBookshelf.py
@@ -1205,6 +1205,11 @@ class psnlBookshelf(ptModifier):
             ageInfo = ptAgeInfoStruct()
             ageInfo.setAgeFilename(ageName)
             ageInfo.setAgeInstanceName(ageName)
+            link = self.GetOwnedAgeLink(ptAgeVault(), ageName)
+            if link is None:
+                link = self.IGetHoodChildLink(ageName)
+            if link is not None:
+                ageInfo = link.getAgeInfo().asAgeInfoStruct()
             ageInfo.setAgeInstanceGuid(hardcoded)
 
             ageLink = ptAgeLinkStruct()

--- a/Scripts/Python/psnlBookshelf.py
+++ b/Scripts/Python/psnlBookshelf.py
@@ -115,7 +115,7 @@ IsChildLink = 0
 
 stupidHackForLock = None
 
-kPublicBooks = ("Nexus", "Cleft", "City") #These books cannot be linked to by guests, and cannot be deleted by the owner
+kPublicBooks = ("Nexus", "Cleft", "city") #These books cannot be linked to by guests, and cannot be deleted by the owner
 
 # list of ages that show up in the city book
 CityBookAges = { "BaronCityOffice": ["BaronCityOffice", "Default"], "Descent": ["dsntShaftFall"], "GreatZero": ["grtzGrtZeroLinkRm"], "spyroom": ["Spyroom", "Default"], "Kveer": ["Kveer", "Default"]}
@@ -1146,7 +1146,6 @@ class psnlBookshelf(ptModifier):
         # better set this to 0 by default now that we're using it to correct the city book clasp
         IsChildLink = 0
 
-        
         ageName = self.IGetAgeFromBook()
         PtDebugPrint("psnlBookshelf.IGetLinkFromBook(): before city lookup, ageName = ",ageName)
 
@@ -1298,7 +1297,7 @@ class psnlBookshelf(ptModifier):
             if ((ageName == "city" or ageName == "BaronCityOffice") and PtIsSinglePlayerMode()) or (ageName in CityBookAges.keys()):
                 continue
 
-            if ageName == "Cleft":
+            if ageName in kPublicBooks:
                 if not link.getLocked():
                     link.setLocked(True)
                     vault = ptVault()
@@ -1508,7 +1507,7 @@ class psnlBookshelf(ptModifier):
 
                 # find and enable the corresponding clickable modifier for the book
                 PtDebugPrint("psnlBookshelf.IUpdateLinks():\tageName: ",ageName," boolInMyAge: ",boolInMyAge," getLocked(): ",link.getLocked()," getVolatile(): ",link.getVolatile())
-                if link.getVolatile() or ((not boolInMyAge) and (link.getLocked() or ageName == "Cleft")):
+                if link.getVolatile() or ((not boolInMyAge) and (link.getLocked() or ageName in kPublicBooks)):
                     bookName = objBook.getName()
                     for key,value in actBook.byObject.items():
                         parent = value.getParentKey()
@@ -1517,7 +1516,7 @@ class psnlBookshelf(ptModifier):
                                 PtDebugPrint("%s book: DISABLED" % (bookName))
                                 actBook.disable(objectName=key)
                                 break
-                    if (not boolInMyAge) and (link.getLocked() or ageName == "Cleft"):
+                    if (not boolInMyAge) and (link.getLocked() or ageName in kPublicBooks):
                         # owner of book has locked this one -- go on to next link element
                         continue
                 

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -65,6 +65,7 @@ from PlasmaNetConstants import *
 import xLinkingBookDefs
 from xPsnlVaultSDL import *
 import time
+import re
 
 
 # define the attributes that will be entered in max
@@ -641,7 +642,11 @@ class xLinkingBookGUIPopup(ptModifier):
                     PtDebugPrint("xLinkingBookGUIPopup: sorry, don't recognize your bookmark spawn point title")
             else:
                 bookmark = ''
-            
+
+            if fromBookshelf and agePanel in xLinkingBookDefs.CityBookLinks:
+                PtDebugPrint("xLinkingBookGUIPopup: add yeesha stamps to first city link page")
+                bookdef = re.sub(r'<font size=10>(.*?)(?:<img src="xYeeshaBookStampVSquish\*1#0\.hsm" pos=140,255 resize=no blend=alpha>)?$', r'<font size=10>\1<img src="xYeeshaBookStampVSquish*1#0.hsm" pos=140,255 resize=no blend=alpha>', bookdef)
+
             if sharable:
                 try:
                     allPagesDef = bookdef % (bookmark, stampdef,self.IAddShare())

--- a/Scripts/Python/xRegisterAge.py
+++ b/Scripts/Python/xRegisterAge.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+""" *==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+ *==LICENSE==* """
+
+from Plasma import *
+from PlasmaTypes import *
+from PlasmaKITypes import *
+
+act = ptAttribActivator(1, "Act: Buttons")
+resp = ptAttribResponder(2, "Resp: Button Push")
+ageFileName = ptAttribString(3, "age filename")
+ageInstanceName = ptAttribString(4, "age instance name")
+
+class xRegisterAge(ptResponder):
+
+    def __init__(self):
+        # run parent class init
+        ptResponder.__init__(self)
+        self.id = 5008
+        version = 1
+        self.version = version
+        PtDebugPrint("__init__xRegisterAge v.", version)
+        
+    def OnNotify(self,state,id,events):
+        if state and PtFindAvatar(events) == PtGetLocalAvatar():
+            if id==act.id:
+                if not self.IFindAgeLinkInFolder(ageFileName.value):
+                    if resp.value:
+                        resp.run(self.key,events=events)
+                    PtSendKIMessage(kKILocalChatStatusMsg, PtGetLocalizedString("Global.Messages.AgeBookGet", [ageInstanceName.value]))
+                    self.CheckAndRegisterAge(ageFileName.value, ageInstanceName.value)
+
+    def IFindAgeLinkInFolder(self, ageName):
+        vault = ptVault()
+        folder = vault.getAgesIOwnFolder()
+        ageName = ageName.lower()
+        contents = folder.getChildNodeRefList()
+        for content in contents:
+            link = content.getChild().upcastToAgeLinkNode()
+            if link is not None:
+                info = link.getAgeInfo()
+            else:
+                link = content.getChild()
+                info = link.upcastToAgeInfoNode()
+
+            if info.getAgeFilename().lower() == ageName:
+                return link
+        return None
+
+    def CheckAndRegisterAge(self, ageFileName, ageInstanceName):
+        PtDebugPrint("xRegisterAge.CheckAndRegisterAge(): ",ageFileName,"; ",ageInstanceName)
+        vault = ptVault()
+        ageStruct = ptAgeInfoStruct()
+        ageStruct.setAgeFilename(ageFileName)
+        ageLinkNode = vault.getOwnedAgeLink(ageStruct)
+        if not ageLinkNode:
+            info = ptAgeInfoStruct()
+            info.setAgeFilename(ageFileName)
+            info.setAgeInstanceName(ageInstanceName)
+
+            playerName = PtGetClientName()
+            ageGuid = PtGuidGenerate()
+            userDefName = ""
+            desc = ""
+
+            if playerName[-1] == "s" or playerName[-1] == "S":
+                userDefName = "%s'" % playerName
+                desc = "%s' %s" % (playerName, info.getAgeInstanceName())
+            else:
+                userDefName = "%s's" % playerName
+                desc = "%s's %s" % (playerName, info.getAgeInstanceName())
+
+            info.setAgeInstanceGuid(ageGuid)
+            info.setAgeUserDefinedName(userDefName)
+            info.setAgeDescription(desc)
+
+            link = ptAgeLinkStruct()
+            link.setAgeInfo(info)
+
+            ptVault().registerOwnedAge(link)
+            PtDebugPrint("xRegisterAge.CheckAndRegisterAge(): Registered age - ", ageFileName)


### PR DESCRIPTION
Assets - https://github.com/H-uru/moul-assets/pull/220

These changes add a hardcode link to the Relto Bookshelf for linking to the Chiso Preniv Age.

Changes the Chiso Preniv Age so its no longer inviteable in the KI or visible in the Nexus under Personal and Invited links.

Adds a script to click an object and add it to the Owned age links.
This is used to add Chiso Preniv Book to the owned ages. This will be added by @DoobesURU in a seperate PR.