### PR TITLE
Rename `GetMessage` method to avoid conflict with Win32 macro

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -1385,7 +1385,7 @@ void cyMisc::SendChatToCCR(const char* message,int32_t CCRPlayerID)
 {
     // create the mesage to send
     plCCRCommunicationMsg *msg = new plCCRCommunicationMsg();
-    msg->SetMessage(message);
+    msg->SetMessageText(message);
     msg->SetType(plCCRCommunicationMsg::kReturnChatMsg);
     msg->SetBCastFlag(plMessage::kNetAllowInterAge);
     msg->SetBCastFlag(plMessage::kNetPropagate);

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -1358,7 +1358,7 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
     // are they looking for a CCR communication message?
     auto ccrmsg = IScriptWantsMsg<plCCRCommunicationMsg>(kfunc_OnCCRMsg, msg);
     if (ccrmsg) {
-        const char* textmessage = ccrmsg->GetMessage();
+        const char* textmessage = ccrmsg->GetMessageText();
         if (!textmessage)
             textmessage = "";
         ICallScriptMethod(kfunc_OnCCRMsg, (int)ccrmsg->GetType(), textmessage, ccrmsg->GetCCRPlayerID());

--- a/Sources/Plasma/PubUtilLib/plMessage/plCCRMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plCCRMsg.h
@@ -133,8 +133,8 @@ public:
     GETINTERFACE_ANY( plCCRCommunicationMsg, plCCRMessage );    
 
     // getters and setters
-    void SetMessage(const char* n) { fString=n; }
-    const char* GetMessage() const { return fString.c_str();    }
+    void SetMessageText(const char* n) { fString=n; }
+    const char* GetMessageText() const { return fString.c_str(); }
 
     void SetType(Type t) { fType=t; }
     Type GetType() const { return fType; }


### PR DESCRIPTION
This didn't actually break anything, because apparently all places that use this method also include windows.h (without defining `UNICODE`), so the method was just silently renamed to `GetMessageA`.