### PR TITLE
Initial support for Accelerate for matrix mult

### DIFF
--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -50,6 +50,7 @@ set(CoreLib_HEADERS
     hsGeometry3.h
     hsLockGuard.h
     hsMatrix44.h
+    hsMatrixMath.h
     hsMemory.h
     hsPoint2.h
     hsPoolVector.h
@@ -86,9 +87,9 @@ target_link_libraries(
         string_theory
         Threads::Threads
         $<$<AND:$<CONFIG:Debug>,$<BOOL:${USE_VLD}>>:VLD::VLD>
+        "$<$<PLATFORM_ID:Darwin>:-framework Accelerate>"
     PRIVATE
         "$<$<PLATFORM_ID:Darwin>:-framework CoreFoundation>"
-        "$<$<PLATFORM_ID:Darwin>:-framework Accelerate>"
 )
 target_include_directories(
     CoreLib

--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -88,6 +88,7 @@ target_link_libraries(
         $<$<AND:$<CONFIG:Debug>,$<BOOL:${USE_VLD}>>:VLD::VLD>
     PRIVATE
         "$<$<PLATFORM_ID:Darwin>:-framework CoreFoundation>"
+        "$<$<PLATFORM_ID:Darwin>:-framework Accelerate>"
 )
 target_include_directories(
     CoreLib

--- a/Sources/Plasma/CoreLib/hsMatrix44.cpp
+++ b/Sources/Plasma/CoreLib/hsMatrix44.cpp
@@ -52,7 +52,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <cmath>
 
 #ifdef HS_BUILD_FOR_APPLE
-#import <simd/simd.h>
+#import <Accelerate/Accelerate.h>
 #endif
 
 static hsMatrix44 myIdent = hsMatrix44().Reset();
@@ -101,7 +101,7 @@ void hsMatrix44::DecompRigid(hsScalarTriple &translate, hsQuat &rotate) const
 }
 
 #ifdef HS_BUILD_FOR_APPLE
-hsMatrix44 hsMatrix44::mult_acclerate(const hsMatrix44 &a, const hsMatrix44 &b)
+hsMatrix44 hsMatrix44::mult_accelerate(const hsMatrix44 &a, const hsMatrix44 &b)
 {
     hsMatrix44 c;
 
@@ -115,11 +115,8 @@ hsMatrix44 hsMatrix44::mult_acclerate(const hsMatrix44 &a, const hsMatrix44 &b)
         return b;
     if( b.fFlags & hsMatrix44::kIsIdent )
         return a;
-
-    const simd_float4x4& a_simd = simd_transpose((simd_float4x4&)a.fMap);
-    const simd_float4x4& b_simd = simd_transpose((simd_float4x4&)b.fMap);
-
-    (simd_float4x4&)c.fMap = simd_transpose(simd_mul(a_simd, b_simd));
+    
+    vDSP_mmul((const float*)a.fMap, 1, (const float*)b.fMap, 1, (float*)&(c.fMap), 1, 4, 4, 4);
     
     return c;
 }

--- a/Sources/Plasma/CoreLib/hsMatrix44.cpp
+++ b/Sources/Plasma/CoreLib/hsMatrix44.cpp
@@ -51,6 +51,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <cmath>
 
+#ifdef HS_BUILD_FOR_APPLE
+#import <Accelerate/Accelerate.h>
+#endif
+
 static hsMatrix44 myIdent = hsMatrix44().Reset();
 const hsMatrix44& hsMatrix44::IdentityMatrix() { return myIdent; }
 

--- a/Sources/Plasma/CoreLib/hsMatrix44.cpp
+++ b/Sources/Plasma/CoreLib/hsMatrix44.cpp
@@ -51,10 +51,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <cmath>
 
-#ifdef HS_BUILD_FOR_APPLE
-#import <Accelerate/Accelerate.h>
-#endif
-
 static hsMatrix44 myIdent = hsMatrix44().Reset();
 const hsMatrix44& hsMatrix44::IdentityMatrix() { return myIdent; }
 

--- a/Sources/Plasma/CoreLib/hsMatrix44.h
+++ b/Sources/Plasma/CoreLib/hsMatrix44.h
@@ -48,10 +48,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <string_theory/formatter>
 
-#ifdef HS_BUILD_FOR_APPLE
-#import <Accelerate/Accelerate.h>
-#endif
-
 class hsQuat;
 
 ////////////////////////////////////////////////////////////////////////////
@@ -181,71 +177,6 @@ private:
 };
 
 ST_DECL_FORMAT_TYPE(const hsMatrix44&);
-
-static inline hsMatrix44 IMatrixMul34(const hsMatrix44& lhs, const hsMatrix44& rhs)
-{
-    hsMatrix44 ret;
-    ret.NotIdentity();
-    
-#ifdef HS_BUILD_FOR_APPLE
-    vDSP_mmul((const float*)lhs.fMap, 1, (const float*)rhs.fMap, 1, (float*)&(ret.fMap), 1, 3, 4, 4);
-#else
-    ret.fMap[0][0] = lhs.fMap[0][0] * rhs.fMap[0][0]
-        + lhs.fMap[0][1] * rhs.fMap[1][0]
-        + lhs.fMap[0][2] * rhs.fMap[2][0];
-
-    ret.fMap[0][1] = lhs.fMap[0][0] * rhs.fMap[0][1]
-        + lhs.fMap[0][1] * rhs.fMap[1][1]
-        + lhs.fMap[0][2] * rhs.fMap[2][1];
-
-    ret.fMap[0][2] = lhs.fMap[0][0] * rhs.fMap[0][2]
-        + lhs.fMap[0][1] * rhs.fMap[1][2]
-        + lhs.fMap[0][2] * rhs.fMap[2][2];
-
-    ret.fMap[0][3] = lhs.fMap[0][0] * rhs.fMap[0][3]
-        + lhs.fMap[0][1] * rhs.fMap[1][3]
-        + lhs.fMap[0][2] * rhs.fMap[2][3]
-        + lhs.fMap[0][3];
-
-    ret.fMap[1][0] = lhs.fMap[1][0] * rhs.fMap[0][0]
-        + lhs.fMap[1][1] * rhs.fMap[1][0]
-        + lhs.fMap[1][2] * rhs.fMap[2][0];
-
-    ret.fMap[1][1] = lhs.fMap[1][0] * rhs.fMap[0][1]
-        + lhs.fMap[1][1] * rhs.fMap[1][1]
-        + lhs.fMap[1][2] * rhs.fMap[2][1];
-
-    ret.fMap[1][2] = lhs.fMap[1][0] * rhs.fMap[0][2]
-        + lhs.fMap[1][1] * rhs.fMap[1][2]
-        + lhs.fMap[1][2] * rhs.fMap[2][2];
-
-    ret.fMap[1][3] = lhs.fMap[1][0] * rhs.fMap[0][3]
-        + lhs.fMap[1][1] * rhs.fMap[1][3]
-        + lhs.fMap[1][2] * rhs.fMap[2][3]
-        + lhs.fMap[1][3];
-
-    ret.fMap[2][0] = lhs.fMap[2][0] * rhs.fMap[0][0]
-        + lhs.fMap[2][1] * rhs.fMap[1][0]
-        + lhs.fMap[2][2] * rhs.fMap[2][0];
-
-    ret.fMap[2][1] = lhs.fMap[2][0] * rhs.fMap[0][1]
-        + lhs.fMap[2][1] * rhs.fMap[1][1]
-        + lhs.fMap[2][2] * rhs.fMap[2][1];
-
-    ret.fMap[2][2] = lhs.fMap[2][0] * rhs.fMap[0][2]
-        + lhs.fMap[2][1] * rhs.fMap[1][2]
-        + lhs.fMap[2][2] * rhs.fMap[2][2];
-
-    ret.fMap[2][3] = lhs.fMap[2][0] * rhs.fMap[0][3]
-        + lhs.fMap[2][1] * rhs.fMap[1][3]
-        + lhs.fMap[2][2] * rhs.fMap[2][3]
-        + lhs.fMap[2][3];
-#endif
-    ret.fMap[3][0] = ret.fMap[3][1] = ret.fMap[3][2] = 0;
-    ret.fMap[3][3] = 1.f;
-
-    return ret;
-}
 
 ////////////////////////////////////////////////////////////////////////////
 #endif

--- a/Sources/Plasma/CoreLib/hsMatrix44.h
+++ b/Sources/Plasma/CoreLib/hsMatrix44.h
@@ -142,7 +142,15 @@ struct hsMatrix44 {
     [[nodiscard]]
     hsVector3 operator*(const hsVector3& p) const;
     [[nodiscard]]
-    hsMatrix44 operator *(const hsMatrix44& other) const { return mat_mult.call(*this, other); }
+    hsMatrix44 operator *(const hsMatrix44& other) const {
+        
+#ifdef HS_BUILD_FOR_APPLE
+        return mult_acclerate(*this, other);
+#else
+        return mat_mult.call(*this, other);
+#endif
+        
+    }
 
     hsPoint3*           MapPoints(long count, hsPoint3 points[]) const;
 
@@ -163,6 +171,9 @@ private:
 
     static hsMatrix44 mult_fpu(const hsMatrix44& a, const hsMatrix44& b);
     static hsMatrix44 mult_sse3(const hsMatrix44& a, const hsMatrix44& b);
+#ifdef HS_BUILD_FOR_APPLE
+    static hsMatrix44 mult_acclerate(const hsMatrix44 &a, const hsMatrix44 &b);
+#endif
 };
 
 ST_DECL_FORMAT_TYPE(const hsMatrix44&);

--- a/Sources/Plasma/CoreLib/hsMatrix44.h
+++ b/Sources/Plasma/CoreLib/hsMatrix44.h
@@ -48,6 +48,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <string_theory/formatter>
 
+#ifdef HS_BUILD_FOR_APPLE
+#import <Accelerate/Accelerate.h>
+#endif
+
 class hsQuat;
 
 ////////////////////////////////////////////////////////////////////////////
@@ -177,6 +181,71 @@ private:
 };
 
 ST_DECL_FORMAT_TYPE(const hsMatrix44&);
+
+static inline hsMatrix44 IMatrixMul34(const hsMatrix44& lhs, const hsMatrix44& rhs)
+{
+    hsMatrix44 ret;
+    ret.NotIdentity();
+    
+#ifdef HS_BUILD_FOR_APPLE
+    vDSP_mmul((const float*)lhs.fMap, 1, (const float*)rhs.fMap, 1, (float*)&(ret.fMap), 1, 3, 4, 4);
+#else
+    ret.fMap[0][0] = lhs.fMap[0][0] * rhs.fMap[0][0]
+        + lhs.fMap[0][1] * rhs.fMap[1][0]
+        + lhs.fMap[0][2] * rhs.fMap[2][0];
+
+    ret.fMap[0][1] = lhs.fMap[0][0] * rhs.fMap[0][1]
+        + lhs.fMap[0][1] * rhs.fMap[1][1]
+        + lhs.fMap[0][2] * rhs.fMap[2][1];
+
+    ret.fMap[0][2] = lhs.fMap[0][0] * rhs.fMap[0][2]
+        + lhs.fMap[0][1] * rhs.fMap[1][2]
+        + lhs.fMap[0][2] * rhs.fMap[2][2];
+
+    ret.fMap[0][3] = lhs.fMap[0][0] * rhs.fMap[0][3]
+        + lhs.fMap[0][1] * rhs.fMap[1][3]
+        + lhs.fMap[0][2] * rhs.fMap[2][3]
+        + lhs.fMap[0][3];
+
+    ret.fMap[1][0] = lhs.fMap[1][0] * rhs.fMap[0][0]
+        + lhs.fMap[1][1] * rhs.fMap[1][0]
+        + lhs.fMap[1][2] * rhs.fMap[2][0];
+
+    ret.fMap[1][1] = lhs.fMap[1][0] * rhs.fMap[0][1]
+        + lhs.fMap[1][1] * rhs.fMap[1][1]
+        + lhs.fMap[1][2] * rhs.fMap[2][1];
+
+    ret.fMap[1][2] = lhs.fMap[1][0] * rhs.fMap[0][2]
+        + lhs.fMap[1][1] * rhs.fMap[1][2]
+        + lhs.fMap[1][2] * rhs.fMap[2][2];
+
+    ret.fMap[1][3] = lhs.fMap[1][0] * rhs.fMap[0][3]
+        + lhs.fMap[1][1] * rhs.fMap[1][3]
+        + lhs.fMap[1][2] * rhs.fMap[2][3]
+        + lhs.fMap[1][3];
+
+    ret.fMap[2][0] = lhs.fMap[2][0] * rhs.fMap[0][0]
+        + lhs.fMap[2][1] * rhs.fMap[1][0]
+        + lhs.fMap[2][2] * rhs.fMap[2][0];
+
+    ret.fMap[2][1] = lhs.fMap[2][0] * rhs.fMap[0][1]
+        + lhs.fMap[2][1] * rhs.fMap[1][1]
+        + lhs.fMap[2][2] * rhs.fMap[2][1];
+
+    ret.fMap[2][2] = lhs.fMap[2][0] * rhs.fMap[0][2]
+        + lhs.fMap[2][1] * rhs.fMap[1][2]
+        + lhs.fMap[2][2] * rhs.fMap[2][2];
+
+    ret.fMap[2][3] = lhs.fMap[2][0] * rhs.fMap[0][3]
+        + lhs.fMap[2][1] * rhs.fMap[1][3]
+        + lhs.fMap[2][2] * rhs.fMap[2][3]
+        + lhs.fMap[2][3];
+#endif
+    ret.fMap[3][0] = ret.fMap[3][1] = ret.fMap[3][2] = 0;
+    ret.fMap[3][3] = 1.f;
+
+    return ret;
+}
 
 ////////////////////////////////////////////////////////////////////////////
 #endif

--- a/Sources/Plasma/CoreLib/hsMatrix44.h
+++ b/Sources/Plasma/CoreLib/hsMatrix44.h
@@ -145,7 +145,7 @@ struct hsMatrix44 {
     hsMatrix44 operator *(const hsMatrix44& other) const {
         
 #ifdef HS_BUILD_FOR_APPLE
-        return mult_acclerate(*this, other);
+        return mult_accelerate(*this, other);
 #else
         return mat_mult.call(*this, other);
 #endif
@@ -172,7 +172,7 @@ private:
     static hsMatrix44 mult_fpu(const hsMatrix44& a, const hsMatrix44& b);
     static hsMatrix44 mult_sse3(const hsMatrix44& a, const hsMatrix44& b);
 #ifdef HS_BUILD_FOR_APPLE
-    static hsMatrix44 mult_acclerate(const hsMatrix44 &a, const hsMatrix44 &b);
+    static hsMatrix44 mult_accelerate(const hsMatrix44 &a, const hsMatrix44 &b);
 #endif
 };
 

--- a/Sources/Plasma/CoreLib/hsMatrixMath.h
+++ b/Sources/Plasma/CoreLib/hsMatrixMath.h
@@ -1,0 +1,118 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef hsMatrixMath_inc
+#define hsMatrixMath_inc
+
+#include "HeadSpin.h"
+#include "hsGeometry3.h"
+
+#ifdef HS_BUILD_FOR_APPLE
+#import <Accelerate/Accelerate.h>
+#endif
+
+static inline hsMatrix44 IMatrixMul34(const hsMatrix44& lhs, const hsMatrix44& rhs)
+{
+    hsMatrix44 ret;
+    ret.NotIdentity();
+    
+#ifdef HS_BUILD_FOR_APPLE
+    vDSP_mmul((const float*)lhs.fMap, 1, (const float*)rhs.fMap, 1, (float*)&(ret.fMap), 1, 3, 4, 4);
+#else
+    ret.fMap[0][0] = lhs.fMap[0][0] * rhs.fMap[0][0]
+        + lhs.fMap[0][1] * rhs.fMap[1][0]
+        + lhs.fMap[0][2] * rhs.fMap[2][0];
+
+    ret.fMap[0][1] = lhs.fMap[0][0] * rhs.fMap[0][1]
+        + lhs.fMap[0][1] * rhs.fMap[1][1]
+        + lhs.fMap[0][2] * rhs.fMap[2][1];
+
+    ret.fMap[0][2] = lhs.fMap[0][0] * rhs.fMap[0][2]
+        + lhs.fMap[0][1] * rhs.fMap[1][2]
+        + lhs.fMap[0][2] * rhs.fMap[2][2];
+
+    ret.fMap[0][3] = lhs.fMap[0][0] * rhs.fMap[0][3]
+        + lhs.fMap[0][1] * rhs.fMap[1][3]
+        + lhs.fMap[0][2] * rhs.fMap[2][3]
+        + lhs.fMap[0][3];
+
+    ret.fMap[1][0] = lhs.fMap[1][0] * rhs.fMap[0][0]
+        + lhs.fMap[1][1] * rhs.fMap[1][0]
+        + lhs.fMap[1][2] * rhs.fMap[2][0];
+
+    ret.fMap[1][1] = lhs.fMap[1][0] * rhs.fMap[0][1]
+        + lhs.fMap[1][1] * rhs.fMap[1][1]
+        + lhs.fMap[1][2] * rhs.fMap[2][1];
+
+    ret.fMap[1][2] = lhs.fMap[1][0] * rhs.fMap[0][2]
+        + lhs.fMap[1][1] * rhs.fMap[1][2]
+        + lhs.fMap[1][2] * rhs.fMap[2][2];
+
+    ret.fMap[1][3] = lhs.fMap[1][0] * rhs.fMap[0][3]
+        + lhs.fMap[1][1] * rhs.fMap[1][3]
+        + lhs.fMap[1][2] * rhs.fMap[2][3]
+        + lhs.fMap[1][3];
+
+    ret.fMap[2][0] = lhs.fMap[2][0] * rhs.fMap[0][0]
+        + lhs.fMap[2][1] * rhs.fMap[1][0]
+        + lhs.fMap[2][2] * rhs.fMap[2][0];
+
+    ret.fMap[2][1] = lhs.fMap[2][0] * rhs.fMap[0][1]
+        + lhs.fMap[2][1] * rhs.fMap[1][1]
+        + lhs.fMap[2][2] * rhs.fMap[2][1];
+
+    ret.fMap[2][2] = lhs.fMap[2][0] * rhs.fMap[0][2]
+        + lhs.fMap[2][1] * rhs.fMap[1][2]
+        + lhs.fMap[2][2] * rhs.fMap[2][2];
+
+    ret.fMap[2][3] = lhs.fMap[2][0] * rhs.fMap[0][3]
+        + lhs.fMap[2][1] * rhs.fMap[1][3]
+        + lhs.fMap[2][2] * rhs.fMap[2][3]
+        + lhs.fMap[2][3];
+#endif
+    ret.fMap[3][0] = ret.fMap[3][1] = ret.fMap[3][2] = 0;
+    ret.fMap[3][3] = 1.f;
+
+    return ret;
+}
+
+#endif

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plCoordinateInterface.cpp
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plCoordinateInterface.cpp
@@ -58,10 +58,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plProfile.h"
 
-#ifdef HS_BUILD_FOR_APPLE
-#import <Accelerate/Accelerate.h>
-#endif
-
 uint8_t plCoordinateInterface::fTransformPhase = plCoordinateInterface::kTransformPhaseNormal;
 bool plCoordinateInterface::fDelayedTransformsEnabled = true;
 
@@ -381,71 +377,6 @@ plProfile_CreateTimer("CITransT", "Object", CITransT);
 plProfile_CreateTimer("   CIRecalcT", "Object", CIRecalcT);
 plProfile_CreateTimer("   CIDirtyT", "Object", CIDirtyT);
 plProfile_CreateTimer("   CISetT", "Object", CISetT);
-
-static inline hsMatrix44 IMatrixMul34(const hsMatrix44& lhs, const hsMatrix44& rhs)
-{
-    hsMatrix44 ret;
-    ret.NotIdentity();
-    
-#ifdef HS_BUILD_FOR_APPLE
-    vDSP_mmul((const float*)lhs.fMap, 1, (const float*)rhs.fMap, 1, (float*)&(ret.fMap), 1, 3, 4, 4);
-#else
-    ret.fMap[0][0] = lhs.fMap[0][0] * rhs.fMap[0][0]
-        + lhs.fMap[0][1] * rhs.fMap[1][0]
-        + lhs.fMap[0][2] * rhs.fMap[2][0];
-
-    ret.fMap[0][1] = lhs.fMap[0][0] * rhs.fMap[0][1]
-        + lhs.fMap[0][1] * rhs.fMap[1][1]
-        + lhs.fMap[0][2] * rhs.fMap[2][1];
-
-    ret.fMap[0][2] = lhs.fMap[0][0] * rhs.fMap[0][2]
-        + lhs.fMap[0][1] * rhs.fMap[1][2]
-        + lhs.fMap[0][2] * rhs.fMap[2][2];
-
-    ret.fMap[0][3] = lhs.fMap[0][0] * rhs.fMap[0][3]
-        + lhs.fMap[0][1] * rhs.fMap[1][3]
-        + lhs.fMap[0][2] * rhs.fMap[2][3]
-        + lhs.fMap[0][3];
-
-    ret.fMap[1][0] = lhs.fMap[1][0] * rhs.fMap[0][0]
-        + lhs.fMap[1][1] * rhs.fMap[1][0]
-        + lhs.fMap[1][2] * rhs.fMap[2][0];
-
-    ret.fMap[1][1] = lhs.fMap[1][0] * rhs.fMap[0][1]
-        + lhs.fMap[1][1] * rhs.fMap[1][1]
-        + lhs.fMap[1][2] * rhs.fMap[2][1];
-
-    ret.fMap[1][2] = lhs.fMap[1][0] * rhs.fMap[0][2]
-        + lhs.fMap[1][1] * rhs.fMap[1][2]
-        + lhs.fMap[1][2] * rhs.fMap[2][2];
-
-    ret.fMap[1][3] = lhs.fMap[1][0] * rhs.fMap[0][3]
-        + lhs.fMap[1][1] * rhs.fMap[1][3]
-        + lhs.fMap[1][2] * rhs.fMap[2][3]
-        + lhs.fMap[1][3];
-
-    ret.fMap[2][0] = lhs.fMap[2][0] * rhs.fMap[0][0]
-        + lhs.fMap[2][1] * rhs.fMap[1][0]
-        + lhs.fMap[2][2] * rhs.fMap[2][0];
-
-    ret.fMap[2][1] = lhs.fMap[2][0] * rhs.fMap[0][1]
-        + lhs.fMap[2][1] * rhs.fMap[1][1]
-        + lhs.fMap[2][2] * rhs.fMap[2][1];
-
-    ret.fMap[2][2] = lhs.fMap[2][0] * rhs.fMap[0][2]
-        + lhs.fMap[2][1] * rhs.fMap[1][2]
-        + lhs.fMap[2][2] * rhs.fMap[2][2];
-
-    ret.fMap[2][3] = lhs.fMap[2][0] * rhs.fMap[0][3]
-        + lhs.fMap[2][1] * rhs.fMap[1][3]
-        + lhs.fMap[2][2] * rhs.fMap[2][3]
-        + lhs.fMap[2][3];
-#endif
-    ret.fMap[3][0] = ret.fMap[3][1] = ret.fMap[3][2] = 0;
-    ret.fMap[3][3] = 1.f;
-
-    return ret;
-}
 
 void plCoordinateInterface::IRecalcTransforms()
 {

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plCoordinateInterface.cpp
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plCoordinateInterface.cpp
@@ -54,6 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsResMgr.h"
 #include "plgDispatch.h"
 #include "pnKeyedObject/plKey.h"
+#include "hsMatrixMath.h"
 #include "hsStream.h"
 
 #include "plProfile.h"

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plCoordinateInterface.cpp
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plCoordinateInterface.cpp
@@ -58,6 +58,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plProfile.h"
 
+#ifdef HS_BUILD_FOR_APPLE
+#import <Accelerate/Accelerate.h>
+#endif
+
 uint8_t plCoordinateInterface::fTransformPhase = plCoordinateInterface::kTransformPhaseNormal;
 bool plCoordinateInterface::fDelayedTransformsEnabled = true;
 
@@ -382,9 +386,10 @@ static inline hsMatrix44 IMatrixMul34(const hsMatrix44& lhs, const hsMatrix44& r
 {
     hsMatrix44 ret;
     ret.NotIdentity();
-    ret.fMap[3][0] = ret.fMap[3][1] = ret.fMap[3][2] = 0;
-    ret.fMap[3][3] = 1.f;
-
+    
+#ifdef HS_BUILD_FOR_APPLE
+    vDSP_mmul((const float*)lhs.fMap, 1, (const float*)rhs.fMap, 1, (float*)&(ret.fMap), 1, 3, 4, 4);
+#else
     ret.fMap[0][0] = lhs.fMap[0][0] * rhs.fMap[0][0]
         + lhs.fMap[0][1] * rhs.fMap[1][0]
         + lhs.fMap[0][2] * rhs.fMap[2][0];
@@ -435,6 +440,9 @@ static inline hsMatrix44 IMatrixMul34(const hsMatrix44& lhs, const hsMatrix44& r
         + lhs.fMap[2][1] * rhs.fMap[1][3]
         + lhs.fMap[2][2] * rhs.fMap[2][3]
         + lhs.fMap[2][3];
+#endif
+    ret.fMap[3][0] = ret.fMap[3][1] = ret.fMap[3][2] = 0;
+    ret.fMap[3][3] = 1.f;
 
     return ret;
 }

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
@@ -406,66 +406,6 @@ bool plDrawableSpans::IBoundsInvalid(const hsBounds3Ext& bnd) const
 }
 
 //// SetTransform ////////////////////////////////////////////////////////////
-static inline hsMatrix44 IMatrixMul34(const hsMatrix44& lhs, const hsMatrix44& rhs)
-{
-    hsMatrix44 ret;
-    ret.NotIdentity();
-    ret.fMap[3][0] = ret.fMap[3][1] = ret.fMap[3][2] = 0;
-    ret.fMap[3][3] = 1.f;
-
-    ret.fMap[0][0] = lhs.fMap[0][0] * rhs.fMap[0][0]
-        + lhs.fMap[0][1] * rhs.fMap[1][0]
-        + lhs.fMap[0][2] * rhs.fMap[2][0];
-
-    ret.fMap[0][1] = lhs.fMap[0][0] * rhs.fMap[0][1]
-        + lhs.fMap[0][1] * rhs.fMap[1][1]
-        + lhs.fMap[0][2] * rhs.fMap[2][1];
-
-    ret.fMap[0][2] = lhs.fMap[0][0] * rhs.fMap[0][2]
-        + lhs.fMap[0][1] * rhs.fMap[1][2]
-        + lhs.fMap[0][2] * rhs.fMap[2][2];
-
-    ret.fMap[0][3] = lhs.fMap[0][0] * rhs.fMap[0][3]
-        + lhs.fMap[0][1] * rhs.fMap[1][3]
-        + lhs.fMap[0][2] * rhs.fMap[2][3]
-        + lhs.fMap[0][3];
-
-    ret.fMap[1][0] = lhs.fMap[1][0] * rhs.fMap[0][0]
-        + lhs.fMap[1][1] * rhs.fMap[1][0]
-        + lhs.fMap[1][2] * rhs.fMap[2][0];
-
-    ret.fMap[1][1] = lhs.fMap[1][0] * rhs.fMap[0][1]
-        + lhs.fMap[1][1] * rhs.fMap[1][1]
-        + lhs.fMap[1][2] * rhs.fMap[2][1];
-
-    ret.fMap[1][2] = lhs.fMap[1][0] * rhs.fMap[0][2]
-        + lhs.fMap[1][1] * rhs.fMap[1][2]
-        + lhs.fMap[1][2] * rhs.fMap[2][2];
-
-    ret.fMap[1][3] = lhs.fMap[1][0] * rhs.fMap[0][3]
-        + lhs.fMap[1][1] * rhs.fMap[1][3]
-        + lhs.fMap[1][2] * rhs.fMap[2][3]
-        + lhs.fMap[1][3];
-
-    ret.fMap[2][0] = lhs.fMap[2][0] * rhs.fMap[0][0]
-        + lhs.fMap[2][1] * rhs.fMap[1][0]
-        + lhs.fMap[2][2] * rhs.fMap[2][0];
-
-    ret.fMap[2][1] = lhs.fMap[2][0] * rhs.fMap[0][1]
-        + lhs.fMap[2][1] * rhs.fMap[1][1]
-        + lhs.fMap[2][2] * rhs.fMap[2][1];
-
-    ret.fMap[2][2] = lhs.fMap[2][0] * rhs.fMap[0][2]
-        + lhs.fMap[2][1] * rhs.fMap[1][2]
-        + lhs.fMap[2][2] * rhs.fMap[2][2];
-
-    ret.fMap[2][3] = lhs.fMap[2][0] * rhs.fMap[0][3]
-        + lhs.fMap[2][1] * rhs.fMap[1][3]
-        + lhs.fMap[2][2] * rhs.fMap[2][3]
-        + lhs.fMap[2][3];
-
-    return ret;
-}
 
 #ifdef MF_TEST_UPDATE
 plProfile_CreateCounter("DSSetTrans", "Update", DSSetTrans);

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
@@ -60,6 +60,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plPipeDebugFlags.h"
 #include "plPipeline.h"
 #include "plProfile.h"
+#include "hsMatrixMath.h"
 #include "hsResMgr.h"
 #include "hsStream.h"
 


### PR DESCRIPTION
This adds support for Accelerate for matrix multiplication in Plasma. I'm not quite sure how we would want to patch this in, in since it doesn't quite fit the previous model of capability checks.

Accelerate automatically supports:
- SSE3/SSE4/AVX/AVX512 on Intel
- NEON/AMX on Apple Silicon