### PR TITLE
Fix non-standard uses of preprocessor paste operator `##`

### DIFF
--- a/Sources/Tools/MaxComponent/plAudioComponents.cpp
+++ b/Sources/Tools/MaxComponent/plAudioComponents.cpp
@@ -1148,7 +1148,7 @@ enum
 
 //// Shared ParamBlock for All Sounds ///////////////////////////////////////////////////////////
 
-#define sSoundSharedPBHeader(s)     kSndSharedParams,   IDD_COMP_SOUNDBASE,         s##,            0, 0, &gSoundCompProc,  \
+#define sSoundSharedPBHeader(s)     kSndSharedParams,   IDD_COMP_SOUNDBASE,         s,            0, 0, &gSoundCompProc,  \
                                     kSoundFadeParams,   IDD_COMP_SOUND_FADEPARAMS,  IDS_COMP_SOUNDFADEPARAMS,   0, 0, &gSoundFadeParamsProc
 
 static ParamBlockDesc2 sSoundSharedPB

--- a/Sources/Tools/MaxComponent/plCAnimParamBlock.h
+++ b/Sources/Tools/MaxComponent/plCAnimParamBlock.h
@@ -125,7 +125,7 @@ class plPBBaseDec
 //  Ex. Usage: kDefineAnimPB( gAnimBlock, &gAnimDesc, PASS_ANIM, PASS_ANIM_EASE, gAnimMainProc, gAnimEaseProc );
 
 #define kDefineAnimPB( blockName, descPtr, mainResIDName, easeResIDName, mainProc, easeProc ) \
-    static ParamBlockDesc2 blockName##( \
+    static ParamBlockDesc2 blockName( \
                                         \
         plPBBaseDec::kPlComponentBlkID, _T("animation"), 0, descPtr, P_AUTO_CONSTRUCT + P_AUTO_UI + P_MULTIMAP + P_INCLUDE_PARAMS, plPBBaseDec::kPlComponentRefID, \
         2,  /* # rollouts */            \

--- a/Sources/Tools/MaxComponent/plComponentReg.h
+++ b/Sources/Tools/MaxComponent/plComponentReg.h
@@ -95,7 +95,7 @@ DECLARE_CLASS_DESC(classname, varname)
 
 #define FUNC_CLASS_DESC(classname, longname, shortname, category, id)   \
 public:                                                                 \
-    void*         Create(BOOL loading) override { return new classname##; } \
+    void*         Create(BOOL loading) override { return new classname; } \
     const TCHAR*  ClassName()    override { return _T(longname); }      \
     Class_ID      ClassID()      override { return id; }                \
     const TCHAR*  Category()     override { return _T(category); }      \
@@ -116,10 +116,10 @@ TARG_BLOCK(classname, varname)
 //  EXCEPT the CLASS_DESC line, then change CLASS_DESC to OBSOLETE_CLASS. This macro
 //  will handle the rest for you! -mcn
 //
-#define OBSOLETE_CLASS( classname, descname, strname, sn, type, classid ) class classname : public plComponent { public:    classname##(); bool Convert( plMaxNode *n, plErrorMsg *e ) { return true; } }; \
+#define OBSOLETE_CLASS( classname, descname, strname, sn, type, classid ) class classname : public plComponent { public:    classname(); bool Convert( plMaxNode *n, plErrorMsg *e ) { return true; } }; \
                             OBSOLETE_CLASS_DESC( classname, descname, strname, sn, type, classid ) \
-                            classname##::##classname() { fClassDesc = &##descname##; fClassDesc->MakeAutoParamBlocks(this); } \
-                            ParamBlockDesc2 classname##blk ( plComponent::kBlkComp, _T("##descname##"), 0, &##descname##, P_AUTO_CONSTRUCT, plComponent::kRefComp, p_end );
+                            classname::classname() { fClassDesc = &descname; fClassDesc->MakeAutoParamBlocks(this); } \
+                            ParamBlockDesc2 classname##blk ( plComponent::kBlkComp, _T(#descname), 0, &descname, P_AUTO_CONSTRUCT, plComponent::kRefComp, p_end );
 
 //
 // Creates the targets paramblock for a component

--- a/Sources/Tools/MaxComponent/plGUIComponents.cpp
+++ b/Sources/Tools/MaxComponent/plGUIComponents.cpp
@@ -2020,12 +2020,12 @@ static plPlasmaAnimSelectDlgProc    sGUIButtonProc( plGUIButtonComponent::kRefMo
 
 
 #define GUI_SOUND_REF( comp, evt, allCapsEvt )      \
-        comp##::kRefMouse##evt##Sound,  _T( "mouse##evt##Sound" ), TYPE_BOOL, 0, 0,                 \
+        comp::kRefMouse##evt##Sound,  _T("mouse" #evt "Sound"), TYPE_BOOL, 0, 0,                 \
             p_ui, plGUIControlBase::kRollMain, TYPE_SINGLECHEKBOX, IDC_GUI_M##allCapsEvt##SND,      \
             p_default, FALSE,                                                                       \
-            p_enable_ctrls, 1, comp##::kRefMouse##evt##SoundComp,                                   \
+            p_enable_ctrls, 1, comp::kRefMouse##evt##SoundComp,                                   \
             p_end,                                                                                  \
-        comp##::kRefMouse##evt##SoundComp, _T("mouse##evt##SoundComp"), TYPE_INODE,     0, 0,       \
+        comp::kRefMouse##evt##SoundComp, _T("mouse" #evt "SoundComp"), TYPE_INODE,     0, 0,       \
             p_accessor, &sGUIButtonAccessor,                                                        \
             p_end
 
@@ -4583,10 +4583,10 @@ static pfGUISkinProc gGUISkinProc;
 
 // Component defined in pfGUISkinProc.h
 
-#define kDeclSkinRectValues( ref ) (plGUISkinComp::##ref + 0), _T("f##ref##.left"), TYPE_INT, 0, 0, p_default, 0, p_end,  \
-                                   (plGUISkinComp::##ref + 1), _T("f##ref##.top"), TYPE_INT, 0, 0, p_default, 0, p_end,   \
-                                   (plGUISkinComp::##ref + 2), _T("f##ref##.width"), TYPE_INT, 0, 0, p_default, 8, p_end, \
-                                   (plGUISkinComp::##ref + 3), _T("f##ref##.height"), TYPE_INT, 0, 0, p_default, 8, p_end
+#define kDeclSkinRectValues( ref ) (plGUISkinComp::ref + 0), _T("f" #ref ".left"), TYPE_INT, 0, 0, p_default, 0, p_end,  \
+                                   (plGUISkinComp::ref + 1), _T("f" #ref ".top"), TYPE_INT, 0, 0, p_default, 0, p_end,   \
+                                   (plGUISkinComp::ref + 2), _T("f" #ref ".width"), TYPE_INT, 0, 0, p_default, 8, p_end, \
+                                   (plGUISkinComp::ref + 3), _T("f" #ref ".height"), TYPE_INT, 0, 0, p_default, 8, p_end
 
 #define kSetSkinRectValues( pb, ref, l, t, w, h ) { pb->SetValue( ref + 0, 0, (int) l ); \
                                                     pb->SetValue( ref + 1, 0, (int) t ); \


### PR DESCRIPTION
See commit message for details.

These are all in the Max plugin code, which I can't test properly. The compiler is happy though and CLion/clangd no longer complains.