### PR TITLE
Fix Linking Book cover function

### DIFF
--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -529,6 +529,8 @@ class xLinkingBookGUIPopup(ptModifier):
                 # make sure there is a cover to show
                 if not showOpen and not self.IsThereACover(bookdef):
                     showOpen = 1
+                elif showOpen and not self.IsThereACover(bookdef):
+                    showOpen = 1
                 else:
                     showOpen = 0
                 gLinkingBook.setGUI(gui)

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -527,7 +527,7 @@ class xLinkingBookGUIPopup(ptModifier):
                 gLinkingBook = ptBook(bookdef,self.key)
                 gLinkingBook.setSize( width, height )
                 # make sure there is a cover to show
-                if showOpen and self.IsThereACover(bookdef):
+                if showOpen and not self.IsThereACover(bookdef):
                     showOpen = 0
                 gLinkingBook.setGUI(gui)
                 gLinkingBook.show(showOpen)

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -527,11 +527,7 @@ class xLinkingBookGUIPopup(ptModifier):
                 gLinkingBook = ptBook(bookdef,self.key)
                 gLinkingBook.setSize( width, height )
                 # make sure there is a cover to show
-                if not showOpen and not self.IsThereACover(bookdef):
-                    showOpen = 1
-                elif showOpen and not self.IsThereACover(bookdef):
-                    showOpen = 1
-                else:
+                if showOpen and self.IsThereACover(bookdef):
                     showOpen = 0
                 gLinkingBook.setGUI(gui)
                 gLinkingBook.show(showOpen)
@@ -867,7 +863,7 @@ class xLinkingBookGUIPopup(ptModifier):
     def IsThereACover(self,bookHtml):
         # search the bookhtml string looking for a cover
         idx = bookHtml.find('<cover')
-        if idx > 0:
+        if idx >= 0:
             return 1
         return 0
 

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -527,9 +527,10 @@ class xLinkingBookGUIPopup(ptModifier):
                 gLinkingBook = ptBook(bookdef,self.key)
                 gLinkingBook.setSize( width, height )
                 # make sure there is a cover to show
-                if not showOpen:
-                    if not self.IsThereACover(bookdef):
-                        showOpen = 1
+                if not showOpen and not self.IsThereACover(bookdef):
+                    showOpen = 1
+                else:
+                    showOpen = 0
                 gLinkingBook.setGUI(gui)
                 gLinkingBook.show(showOpen)
             except LookupError:


### PR DESCRIPTION
Adjust script to actually use cover image defined in `xLinkingBookDefs.py`. Fixes #1338 

The script currently makes the Relto shelf and some other Books gain the "default" cover and/or extra pages, so it's a draft for now.