### PR TITLE
Port `ptVaultChronicleNode` setters to `ST::string`

### DIFF
--- a/Scripts/Python/Ahnonay.py
+++ b/Scripts/Python/Ahnonay.py
@@ -134,29 +134,29 @@ class Ahnonay(ptResponder):
             if linkid == None:
                 PtDebugPrint("Ahnonay.OnServerInitComplete(): Link Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
-                newNode.chronicleSetName("AhnonayLink")
-                newNode.chronicleSetValue(guid)
+                newNode.setName("AhnonayLink")
+                newNode.setValue(guid)
                 ageDataFolder.addNode(newNode)
 
             if locked == None:
                 PtDebugPrint("Ahnonay.OnServerInitComplete(): Locked Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
-                newNode.chronicleSetName("AhnonayLocked")
-                newNode.chronicleSetValue("1")
+                newNode.setName("AhnonayLocked")
+                newNode.setValue("1")
                 ageDataFolder.addNode(newNode)
 
             if volatile == None:
                 PtDebugPrint("Ahnonay.OnServerInitComplete(): Volatile Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
-                newNode.chronicleSetName("AhnonayVolatile")
-                newNode.chronicleSetValue("0")
+                newNode.setName("AhnonayVolatile")
+                newNode.setValue("0")
                 ageDataFolder.addNode(newNode)
 
             if spawn == None:
                 PtDebugPrint("Ahnonay.OnServerInitComplete(): Spawn Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
-                newNode.chronicleSetName("AhnonaySpawnPoints")
-                newNode.chronicleSetValue("Default,LinkInPointDefault")
+                newNode.setName("AhnonaySpawnPoints")
+                newNode.setValue("Default,LinkInPointDefault")
                 ageDataFolder.addNode(newNode)
 
             if volatile and linkid:

--- a/Scripts/Python/AhnonayCathedral.py
+++ b/Scripts/Python/AhnonayCathedral.py
@@ -98,8 +98,8 @@ class AhnonayCathedral(ptResponder):
             if owner == None:
                 PtDebugPrint("I own this Cathedral, but I haven't set myself as Ahnonay owner yet.")
                 newNode = ptVaultChronicleNode(0)
-                newNode.chronicleSetName("AhnonayOwner")
-                newNode.chronicleSetValue(str(PtGetClientIDFromAvatarKey(PtGetLocalAvatar().getKey())))
+                newNode.setName("AhnonayOwner")
+                newNode.setValue(str(PtGetClientIDFromAvatarKey(PtGetLocalAvatar().getKey())))
                 ageDataFolder.addNode(newNode)
 
     def OnNotify(self,state,id,events):

--- a/Scripts/Python/BaronCityOffice.py
+++ b/Scripts/Python/BaronCityOffice.py
@@ -70,11 +70,11 @@ class BaronCityOffice(ptResponder):
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))
             #~ else:
-                #~ count = int(entry.chronicleGetValue())
+                #~ count = int(entry.getValue())
                 #~ count = count + 1
-                #~ entry.chronicleSetValue("%d" % (count))
+                #~ entry.setValue("%d" % (count))
                 #~ entry.save()
-                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.chronicleGetValue()))
+                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.getValue()))
         #~ else:
             #~ PtDebugPrint("%s:\tERROR trying to access vault -- can't update %s variable in chronicle." % (kModuleName,kChronicleVarName))
         pass

--- a/Scripts/Python/Cleft.py
+++ b/Scripts/Python/Cleft.py
@@ -92,7 +92,7 @@ class Cleft(ptResponder):
         vault = ptVault()
         entryTomahna = vault.findChronicleEntry("TomahnaLoad")
         if entryTomahna is not None:
-            entryTomahnaValue = entryTomahna.chronicleGetValue()
+            entryTomahnaValue = entryTomahna.getValue()
             if entryTomahnaValue == "yes":
                 loadTomahna = 1
                 if loadZandi:
@@ -134,7 +134,7 @@ class Cleft(ptResponder):
             #now that Tomahna pages have loaded, reset its chronicle value back to no,
             #so subsequent linking will default to regular Cleft instead of Tomahna,
             #unless a Tomahna link is used, of course...
-            entryTomahna.chronicleSetValue("no")
+            entryTomahna.setValue("no")
             entryTomahna.save()
 
         pass

--- a/Scripts/Python/ErcanaCitySilo.py
+++ b/Scripts/Python/ErcanaCitySilo.py
@@ -100,11 +100,11 @@ class ErcanaCitySilo(ptResponder):
         vault = ptVault()
         entry = vault.findChronicleEntry("GotPellet")
         if entry is not None:
-            entryValue = entry.chronicleGetValue()
+            entryValue = entry.getValue()
             gotPellet = int(entryValue)
             if gotPellet != 0:
                 self._gotTurd = True
-                entry.chronicleSetValue("0")
+                entry.setValue("0")
                 entry.save()
                 avatar = PtGetLocalAvatar()
                 avatar.avatar.registerForBehaviorNotify(self.key)

--- a/Scripts/Python/Garden.py
+++ b/Scripts/Python/Garden.py
@@ -70,11 +70,11 @@ class Garden(ptResponder):
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))
             #~ else:
-                #~ count = int(entry.chronicleGetValue())
+                #~ count = int(entry.getValue())
                 #~ count = count + 1
-                #~ entry.chronicleSetValue("%d" % (count))
+                #~ entry.setValue("%d" % (count))
                 #~ entry.save()
-                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.chronicleGetValue()))
+                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.getValue()))
         #~ else:
             #~ PtDebugPrint("%s:\tERROR trying to access vault -- can't update %s variable in chronicle." % (kModuleName,kChronicleVarName))
         pass

--- a/Scripts/Python/GardenBugs.py
+++ b/Scripts/Python/GardenBugs.py
@@ -87,14 +87,14 @@ class GardenBugs(ptResponder):
             # not found... add chronicle
             vault.addChronicleEntry(chronicleEntryName,0,str(count))
         else:
-            entry.chronicleSetValue(str(count))
+            entry.setValue(str(count))
             entry.save()
     
     def IGetBugCount(self):
         vault = ptVault()
         entry = vault.findChronicleEntry(chronicleEntryName)
         if entry is not None:
-            return int(entry.chronicleGetValue())
+            return int(entry.getValue())
         return 0 # no chronicle var
 
     def OnServerInitComplete(self):

--- a/Scripts/Python/Gira.py
+++ b/Scripts/Python/Gira.py
@@ -69,11 +69,11 @@ class Gira(ptResponder):
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))
             #~ else:
-                #~ count = int(entry.chronicleGetValue())
+                #~ count = int(entry.getValue())
                 #~ count = count + 1
-                #~ entry.chronicleSetValue("%d" % (count))
+                #~ entry.setValue("%d" % (count))
                 #~ entry.save()
-                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.chronicleGetValue()))
+                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.getValue()))
         #~ else:
             #~ PtDebugPrint("%s:\tERROR trying to access vault -- can't update %s variable in chronicle." % (kModuleName,kChronicleVarName))
         pass

--- a/Scripts/Python/GiraBugs.py
+++ b/Scripts/Python/GiraBugs.py
@@ -93,14 +93,14 @@ class GiraBugs(ptResponder):
             # not found... add chronicle
             vault.addChronicleEntry(chronicleEntryName,0,str(count))
         else:
-            entry.chronicleSetValue(str(count))
+            entry.setValue(str(count))
             entry.save()
     
     def IGetBugCount(self):
         vault = ptVault()
         entry = vault.findChronicleEntry(chronicleEntryName)
         if entry is not None:
-            return int(entry.chronicleGetValue())
+            return int(entry.getValue())
         return 0 # no chronicle var
 
     def OnServerInitComplete(self):

--- a/Scripts/Python/Kadish.py
+++ b/Scripts/Python/Kadish.py
@@ -70,11 +70,11 @@ class Kadish(ptResponder):
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))
             #~ else:
-                #~ count = int(entry.chronicleGetValue())
+                #~ count = int(entry.getValue())
                 #~ count = count + 1
-                #~ entry.chronicleSetValue("%d" % (count))
+                #~ entry.setValue("%d" % (count))
                 #~ entry.save()
-                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.chronicleGetValue()))
+                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.getValue()))
         #~ else:
             #~ PtDebugPrint("%s:\tERROR trying to access vault -- can't update %s variable in chronicle." % (kModuleName,kChronicleVarName))
         pass

--- a/Scripts/Python/Neighborhood.py
+++ b/Scripts/Python/Neighborhood.py
@@ -70,11 +70,11 @@ class Neighborhood(ptResponder):
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))
             #~ else:
-                #~ count = int(entry.chronicleGetValue())
+                #~ count = int(entry.getValue())
                 #~ count = count + 1
-                #~ entry.chronicleSetValue("%d" % (count))
+                #~ entry.setValue("%d" % (count))
                 #~ entry.save()
-                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.chronicleGetValue()))
+                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.getValue()))
         #~ else:
             #~ PtDebugPrint("%s:\tERROR trying to access vault -- can't update %s variable in chronicle." % (kModuleName,kChronicleVarName))
         pass

--- a/Scripts/Python/PelletBahroCave.py
+++ b/Scripts/Python/PelletBahroCave.py
@@ -156,10 +156,10 @@ class PelletBahroCave(ptResponder):
             vault = ptVault()
             entry = vault.findChronicleEntry("GotPellet")
             if entry is not None:
-                entryValue = entry.chronicleGetValue()
+                entryValue = entry.getValue()
                 gotPellet = int(entryValue)
                 if gotPellet != 0:
-                    entry.chronicleSetValue("%d" % (0))
+                    entry.setValue("%d" % (0))
                     entry.save()
                     avatar = PtGetLocalAvatar()
                     avatar.avatar.registerForBehaviorNotify(self.key)

--- a/Scripts/Python/Personal.py
+++ b/Scripts/Python/Personal.py
@@ -90,7 +90,7 @@ class Personal(ptResponder):
         # test for first time to play the intro movie
         vault = ptVault()
         entry = vault.findChronicleEntry(kIntroPlayedChronicle)
-        if entry is not None and entry.chronicleGetValue() == "yes":
+        if entry is not None and entry.getValue() == "yes":
             # already played intro sometime in the past... just let 'em play
             # enable twice because if we came from the ACA (closet->ACA->personal) it was disabled twice
             PtSendKIMessage(kEnableKIandBB,0)
@@ -138,11 +138,11 @@ class Personal(ptResponder):
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))
             #~ else:
-                #~ count = int(entry.chronicleGetValue())
+                #~ count = int(entry.getValue())
                 #~ count = count + 1
-                #~ entry.chronicleSetValue("%d" % (count))
+                #~ entry.setValue("%d" % (count))
                 #~ entry.save()
-                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.chronicleGetValue()))
+                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.getValue()))
         #~ else:
             #~ PtDebugPrint("%s:\tERROR trying to access vault -- can't update %s variable in chronicle." % (kModuleName,kChronicleVarName))
         pass

--- a/Scripts/Python/Teledahn.py
+++ b/Scripts/Python/Teledahn.py
@@ -70,11 +70,11 @@ class Teledahn(ptResponder):
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))
             #~ else:
-                #~ count = int(entry.chronicleGetValue())
+                #~ count = int(entry.getValue())
                 #~ count = count + 1
-                #~ entry.chronicleSetValue("%d" % (count))
+                #~ entry.setValue("%d" % (count))
                 #~ entry.save()
-                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.chronicleGetValue()))
+                #~ PtDebugPrint("%s:\tyour current count for %s is %s" % (kModuleName,kChronicleVarName,entry.getValue()))
         #~ else:
             #~ PtDebugPrint("%s:\tERROR trying to access vault -- can't update %s variable in chronicle." % (kModuleName,kChronicleVarName))
         pass

--- a/Scripts/Python/ahnyLinkBookGUIPopup.py
+++ b/Scripts/Python/ahnyLinkBookGUIPopup.py
@@ -205,7 +205,7 @@ class ahnyLinkBookGUIPopup(ptModifier):
                                             link.setVolatile(1)
 ##                                            entry = vault.findChronicleEntry("Reset" + name)
 ##                                            if entry:
-##                                                entry.chronicleSetValue("1")
+##                                                entry.setValue("1")
 ##                                                entry.save()
 ##                                            else:
 ##                                                vault.addChronicleEntry("Reset" + name, 0, "1")

--- a/Scripts/Python/bhroBahroYeeshaCave.py
+++ b/Scripts/Python/bhroBahroYeeshaCave.py
@@ -263,7 +263,7 @@ class bhroBahroYeeshaCave(ptModifier):
         journeyComplete = 0
         #vault = ptVault()
         #jcNode = vault.findChronicleEntry("JourneyClothProgress")
-        #if jcNode.chronicleGetValue() == "Z":
+        #if jcNode.getValue() == "Z":
 
         sdl = xPsnlVaultSDL()
         if sdl["CleftVisited"][0]:
@@ -451,7 +451,7 @@ class bhroBahroYeeshaCave(ptModifier):
 
             ageChild = ageChild.upcastToChronicleNode()
 
-            if ageChild.chronicleGetName() == age:
+            if ageChild.getName() == age:
                 return ageChild
 
         return None
@@ -461,7 +461,7 @@ class bhroBahroYeeshaCave(ptModifier):
         node = self.GetAgeNode(age)
 
         if node != None:
-            varlist = node.chronicleGetValue().split(",")
+            varlist = node.getValue().split(",")
             return varlist[ self.varMap[variable] ]            
         else:
             return None
@@ -471,7 +471,7 @@ class bhroBahroYeeshaCave(ptModifier):
         node = self.GetAgeNode(age)
 
         if node != None:
-            varlist = node.chronicleGetValue().split(",")
+            varlist = node.getValue().split(",")
             while len(varlist) < len(self.varMap):
                 varlist.append("0")
             varlist[ self.varMap[variable] ] = str(value)
@@ -480,7 +480,7 @@ class bhroBahroYeeshaCave(ptModifier):
                 varstr += (varlist[var] + ",")
             varstr += varlist[-1]
             
-            node.chronicleSetValue(varstr)
+            node.setValue(varstr)
             node.save()
         else:
             raise RuntimeError("Could not find chronicle variable to set")
@@ -532,8 +532,8 @@ class bhroBahroYeeshaCave(ptModifier):
             agelist = ["Teledahn", "Garden", "Garrison", "Kadish"]
             for v in range(len(agelist)):
                 newnode = ptVaultChronicleNode(0)
-                newnode.chronicleSetName(agelist[v])
-                newnode.chronicleSetValue("0," + str(solutionlist[v]) + ",0")
+                newnode.setName(agelist[v])
+                newnode.setValue("0," + str(solutionlist[v]) + ",0")
                 entry.addNode(newnode)
 
 
@@ -784,7 +784,7 @@ class bhroBahroYeeshaCave(ptModifier):
         vault = ptVault()
         bc = vault.findChronicleEntry("BahroCave")
         if bc is not None:
-            val = bc.chronicleGetValue()
+            val = bc.getValue()
             if val == "":
                 return 0
             else:
@@ -797,12 +797,12 @@ class bhroBahroYeeshaCave(ptModifier):
         vault = ptVault()
         bc = vault.findChronicleEntry("BahroCave")
         if bc is not None:
-            val = bc.chronicleGetValue()
+            val = bc.getValue()
             if val == "":
                 val = 0
             else:
                 val = int(val)
-            bc.chronicleSetValue(str(val + 1))
+            bc.setValue(str(val + 1))
             bc.save()
             PtDebugPrint("bhroBahroYeeshaCave.IncrementAutoStartLevel(): setting BC chron = ",str(val + 1))
         else:

--- a/Scripts/Python/clftGetPersonalBook.py
+++ b/Scripts/Python/clftGetPersonalBook.py
@@ -88,7 +88,7 @@ class clftGetPersonalBook(ptResponder):
         #~ vault = ptVault()
         #~ entry = vault.findChronicleEntry("JourneyClothProgress")
         #~ if entry is not None:
-            #~ FoundJCs = entry.chronicleGetValue()
+            #~ FoundJCs = entry.getValue()
             #~ if "Z" in FoundJCs:
                 #~ PtPageOutNode("clftYeeshaBookVis")
                 #~ PtDebugPrint("clftGetPersonalBook: Paging out the Yeesha Book in the bookroom",level=kDebugDumpLevel)

--- a/Scripts/Python/clftImager.py
+++ b/Scripts/Python/clftImager.py
@@ -602,7 +602,7 @@ class clftImager(ptResponder):
 
                     ageChild = ageChild.upcastToChronicleNode()
 
-                    if ageChild.chronicleGetName() == age:
+                    if ageChild.getName() == age:
                         return ageChild
 
         return None
@@ -612,7 +612,7 @@ class clftImager(ptResponder):
         node = self.GetAgeNode(age)
 
         if node != None:
-            varlist = node.chronicleGetValue().split(",")
+            varlist = node.getValue().split(",")
             return varlist[ 1 ]            
         else:
             return None
@@ -639,7 +639,7 @@ class clftImager(ptResponder):
         vault = ptVault()
         entry = vault.findChronicleEntry("CleftSolved")
         if entry is not None:
-            if entry.chronicleGetValue() == "yes":
+            if entry.getValue() == "yes":
                 boolCleftSolved = 1
 
         if not boolCleftSolved:
@@ -808,7 +808,7 @@ class clftImager(ptResponder):
             if entry is None:
                 vault.addChronicleEntry("YeeshaVisionViewed", 0, "1")
             else:
-                entry.chronicleSetValue("1")
+                entry.setValue("1")
                 entry.save()
             YeeshaName.physics.warpObj(YeeshaWarpVis1.value.getKey())
             YeeshaMultiStage.gotoStage(YeeshaName, 1,dirFlag=1,isForward=1)
@@ -897,16 +897,16 @@ class clftImager(ptResponder):
         vault = ptVault()
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
-            valCityLinks = entryCityLinks.chronicleGetValue()
+            valCityLinks = entryCityLinks.getValue()
             PtDebugPrint("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
             PtDebugPrint("CityLinks = ",CityLinks)
             if agePanel not in CityLinks:
                 NewLinks = valCityLinks + "," + agePanel
-                entryCityLinks.chronicleSetValue(NewLinks)
+                entryCityLinks.setValue(NewLinks)
                 entryCityLinks.save()
                 PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
-                valCityLinks = entryCityLinks.chronicleGetValue()
+                valCityLinks = entryCityLinks.getValue()
                 CityLinks = valCityLinks.split(",")
                 PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  citylinks now = ",CityLinks)
             else:

--- a/Scripts/Python/clftNpcZandi.py
+++ b/Scripts/Python/clftNpcZandi.py
@@ -126,7 +126,7 @@ class clftNpcZandi(ptModifier):
         vault = ptVault()
         #~ entry = vault.findChronicleEntry("JourneyClothProgress")
         #~ if entry is not None:
-            #~ FoundJCs = entry.chronicleGetValue()
+            #~ FoundJCs = entry.getValue()
             #~ if "Z" in FoundJCs:
                 #~ PtPageOutNode("clftZandiVis")
                 #~ PtDebugPrint("Zandi seems to have stepped away from the Airstream. Hmmm...")
@@ -231,8 +231,8 @@ class clftNpcZandi(ptModifier):
 
                 ageChild = ageChild.upcastToChronicleNode()
 
-                if ageChild.chronicleGetName() == "Cleft":
-                    return ageChild.chronicleGetValue()
+                if ageChild.getName() == "Cleft":
+                    return ageChild.getValue()
 
         return ""
 
@@ -272,7 +272,7 @@ class clftNpcZandi(ptModifier):
             PtDebugPrint("ERROR: clftNpcZandi.HaventSeenImagerMessage: cannot find YeeshaVisionViewed chronicle entry")
             return 1
 
-        if entry.chronicleGetValue() == "1":
+        if entry.getValue() == "1":
             return 0
         else:
             return 1
@@ -290,11 +290,11 @@ class clftNpcZandi(ptModifier):
                 vault.addChronicleEntry("ZandiWelcome", 0, "1")
             return 1
 
-        if entry.chronicleGetValue() == "1":
+        if entry.getValue() == "1":
             return 0
         else:
             if not clicked:
-                entry.chronicleSetValue("1")
+                entry.setValue("1")
                 entry.save()
             return 1
 

--- a/Scripts/Python/dsntKILightMachine.py
+++ b/Scripts/Python/dsntKILightMachine.py
@@ -181,12 +181,12 @@ class dsntKILightMachine(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry("KILightStop")
         if entry is not None:
-            entryValue = entry.chronicleGetValue()
+            entryValue = entry.getValue()
             oldVal = int(entryValue)
             if remaining == oldVal:
                 return
             PtDebugPrint("set KI light chron to: ",remaining)
-            entry.chronicleSetValue("%d" % (remaining))
+            entry.setValue("%d" % (remaining))
             entry.save()
         else:
             vault.addChronicleEntry("KILightStop",1,"%d" % (remaining))

--- a/Scripts/Python/ercaPelletRoom.py
+++ b/Scripts/Python/ercaPelletRoom.py
@@ -153,10 +153,10 @@ class ercaPelletRoom(ptResponder):
         vault = ptVault()
         entry = vault.findChronicleEntry("GotPellet")
         if entry is not None:
-            entryValue = entry.chronicleGetValue()
+            entryValue = entry.getValue()
             oldGotPellet = int(entryValue)
             if oldGotPellet != 0:
-                entry.chronicleSetValue("%d" % (0))
+                entry.setValue("%d" % (0))
                 entry.save()
                 PtDebugPrint("ercaPelletRoom.OnServerInitComplete(): chron entry GotPellet still contained a recipe, setting to 0")
 
@@ -549,7 +549,7 @@ class ercaPelletRoom(ptResponder):
             vault = ptVault()
             entry = vault.findChronicleEntry("GotPellet")
             if entry is not None:
-                entry.chronicleSetValue("%d" % (Recipe))
+                entry.setValue("%d" % (Recipe))
                 entry.save()
                 PtDebugPrint("Chronicle entry GotPellet already added, setting to Recipe value of %d" % (Recipe))
             else:

--- a/Scripts/Python/grtzKIMarkerMachine.py
+++ b/Scripts/Python/grtzKIMarkerMachine.py
@@ -120,7 +120,7 @@ def ResetMarkerGame():
     # First, reset the KI Marker Level
     entry = vault.findChronicleEntry(kChronicleKIMarkerLevel)
     if entry is not None:
-        entry.chronicleSetValue("0")
+        entry.setValue("0")
         entry.save()
 
     # Next, reset the Marker's Aquired Data
@@ -130,7 +130,7 @@ def ResetMarkerGame():
     resetString = "0 off:off 0:0"
     entry = vault.findChronicleEntry(kChronicleGZGames)
     if entry is not None:
-        entry.chronicleSetValue(resetString)
+        entry.setValue(resetString)
 
     #Who knows what state we were in so we'll reset the CGZs as well!!!
     PtSendKIMessage(kMGStopCGZGame, 0)
@@ -149,9 +149,9 @@ def UpdateGZMarkers(markerStatus):
     vault = ptVault()
     entry = vault.findChronicleEntry(kChronicleGZMarkersAquired)
     if entry is not None:
-        markers = entry.chronicleGetValue()
+        markers = entry.getValue()
         resetValue = markerStatus * len(markers)
-        entry.chronicleSetValue(resetValue)
+        entry.setValue(resetValue)
         entry.save()
     else:
         markers = markerStatus * kNumGZMarkers
@@ -232,7 +232,7 @@ class grtzKIMarkerMachine(ptModifier):
                         vault.addChronicleEntry(kChronicleGZMarkersAquired,kChronicleGZMarkersAquiredType,markers)
                     else:
                         markers = kGZMarkerAvailable * kNumGZMarkers
-                        entry.chronicleSetValue(markers)
+                        entry.setValue(markers)
                         entry.save()
 
                     # after fun with lights then the activator will be enabled
@@ -277,7 +277,7 @@ class grtzKIMarkerMachine(ptModifier):
         entry = vault.findChronicleEntry(kChronicleGZGames)
         error = 0
         if entry is not None:
-            markerGameString = entry.chronicleGetValue()
+            markerGameString = entry.getValue()
             args = markerGameString.split()
             
             if len(args) == 3:
@@ -339,7 +339,7 @@ class grtzKIMarkerMachine(ptModifier):
         entry = vault.findChronicleEntry(kChronicleGZGames)
         upstring = "%d %s:%s %d:%d" % (gGZPlaying,gMarkerGottenColor,gMarkerToGetColor,gMarkerGottenNumber,gMarkerToGetNumber)
         if entry is not None:
-            entry.chronicleSetValue(upstring)
+            entry.setValue(upstring)
             entry.save()
         else:
             # if there is none, then just add another entry
@@ -409,7 +409,7 @@ class grtzKIMarkerMachine(ptModifier):
                 # is there a chronicle for the GZ games?
                 entry = vault.findChronicleEntry(kChronicleGZGames)
                 if entry is not None:
-                    entry.chronicleSetValue("0")
+                    entry.setValue("0")
                     entry.save()
                 # they've made it to the next level
                 PtSendKIMessageInt(kUpgradeKIMarkerLevel,kKIMarkerNormalLevel)
@@ -525,16 +525,16 @@ class grtzKIMarkerMachine(ptModifier):
         vault = ptVault()
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
-            valCityLinks = entryCityLinks.chronicleGetValue()
+            valCityLinks = entryCityLinks.getValue()
             PtDebugPrint("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
             PtDebugPrint("CityLinks = ",CityLinks)
             if agePanel not in CityLinks:
                 NewLinks = valCityLinks + "," + agePanel
-                entryCityLinks.chronicleSetValue(NewLinks)
+                entryCityLinks.setValue(NewLinks)
                 entryCityLinks.save()
                 PtDebugPrint("grtzKIMarkerMachine.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
-                valCityLinks = entryCityLinks.chronicleGetValue()
+                valCityLinks = entryCityLinks.getValue()
                 CityLinks = valCityLinks.split(",")
                 PtDebugPrint("grtzKIMarkerMachine.IDoCityLinksChron():  citylinks now = ",CityLinks)
             else:

--- a/Scripts/Python/islmRegisterNexusLink.py
+++ b/Scripts/Python/islmRegisterNexusLink.py
@@ -99,9 +99,9 @@ class islmRegisterNexusLink(ptModifier):
                 entryName = "GotLinkToKveerPublic"
                 entry = vault.findChronicleEntry(entryName)
                 if entry is not None:
-                    entryValue = entry.chronicleGetValue()
+                    entryValue = entry.getValue()
                     if entryValue != "yes":
-                        entry.chronicleSetValue("yes")
+                        entry.setValue("yes")
                         entry.save()
                         PtDebugPrint("islmRegisterNexusLink.OnNotify(): Chronicle entry 'GotLinkToKveerPublic' already added, setting to 'yes'")
                 else:
@@ -113,9 +113,9 @@ class islmRegisterNexusLink(ptModifier):
                 entryName = "GotLinkToGoMePublic"
                 entry = vault.findChronicleEntry(entryName)
                 if entry is not None:
-                    entryValue = entry.chronicleGetValue()
+                    entryValue = entry.getValue()
                     if entryValue != "yes":
-                        entry.chronicleSetValue("yes")
+                        entry.setValue("yes")
                         entry.save()
                         PtDebugPrint("islmRegisterNexusLink.OnNotify(): Chronicle entry 'GotLinkToGoMePublic' already added, setting to 'yes'")
                 else:

--- a/Scripts/Python/kemoJourneyClothGate.py
+++ b/Scripts/Python/kemoJourneyClothGate.py
@@ -155,17 +155,17 @@ class kemoJourneyClothGate(ptResponder):
             vault = ptVault()
             entry = vault.findChronicleEntry("JourneyClothProgress")
             if entry is not None:
-                FoundJCs = entry.chronicleGetValue()
+                FoundJCs = entry.getValue()
                 length = len(FoundJCs)
                 PtDebugPrint ("Are you the one? You've found %s Cloths." % (length))
                 
                 if length == 10:
                     vault = ptVault()
                     entry = vault.findChronicleEntry("JourneyClothProgress")
-                    FoundJCs = entry.chronicleGetValue()
+                    FoundJCs = entry.getValue()
                     FoundJCs = FoundJCs + "Z"
                     PtDebugPrint("Updating Chronicle entry to ", FoundJCs)
-                    entry.chronicleSetValue("%s" % (FoundJCs)) 
+                    entry.setValue("%s" % (FoundJCs)) 
                     entry.save()
                     respBackofCave.run(self.key, events=events)
             
@@ -196,7 +196,7 @@ class kemoJourneyClothGate(ptResponder):
         if entry is None: # is this the player's first Journey Cloth?
             PtDebugPrint("No cloths have been found. Get to work!")
         else:
-            FoundJCs = entry.chronicleGetValue()
+            FoundJCs = entry.getValue()
             length = len(FoundJCs)
             all = len(AllCloths)
 

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -914,11 +914,11 @@ class xKI(ptModifier):
                 vault = ptVault()
                 entry = vault.findChronicleEntry(kChronicleGZMarkersAquired)
                 if entry is not None:
-                    markers = entry.chronicleGetValue()
+                    markers = entry.getValue()
                     if len(markers) < value:
                         # Need to increase the capacity of the markers; start as active.
                         markers += kGZMarkerAvailable * (value - len(markers))
-                        entry.chronicleSetValue(markers)
+                        entry.setValue(markers)
                         entry.save()
                 else:
                     # If there are none, then just add another entry; start as active.
@@ -1415,7 +1415,7 @@ class xKI(ptModifier):
             # Not found, set to 0 by default.
             vault.addChronicleEntry(kChron.OnlyPMs, kChron.OnlyPMsType, str(int(self.onlyGetPMsFromBuddies)))
         else:
-            self.onlyGetPMsFromBuddies = int(entry.chronicleGetValue())
+            self.onlyGetPMsFromBuddies = int(entry.getValue())
 
         # Only allow the player to be buddied on request.
         entry = vault.findChronicleEntry(kChron.BuddiesOnRequest)
@@ -1423,7 +1423,7 @@ class xKI(ptModifier):
             # Not found, set to 0 by default.
             vault.addChronicleEntry(kChron.BuddiesOnRequest, kChron.BuddiesOnRequestType, str(int(self.onlyAllowBuddiesOnRequest)))
         else:
-            self.onlyAllowBuddiesOnRequest = int(entry.chronicleGetValue())
+            self.onlyAllowBuddiesOnRequest = int(entry.getValue())
 
     ## Save the KI Flags to the Chronicle.
     def SaveKIFlags(self):
@@ -1432,7 +1432,7 @@ class xKI(ptModifier):
         # Only get PMs and KI Mails from Buddies.
         entry = vault.findChronicleEntry(kChron.OnlyPMs)
         if entry is not None:
-            entry.chronicleSetValue(str(int(self.onlyGetPMsFromBuddies)))
+            entry.setValue(str(int(self.onlyGetPMsFromBuddies)))
             entry.save()
         else:
             vault.addChronicleEntry(kChron.OnlyPMs, kChron.OnlyPMsType, str(int(self.onlyGetPMsFromBuddies)))
@@ -1440,7 +1440,7 @@ class xKI(ptModifier):
         # Only allow the player to be buddied on request.
         entry = vault.findChronicleEntry(kChron.BuddiesOnRequest)
         if entry is not None:
-            entry.chronicleSetValue(str(int(self.onlyAllowBuddiesOnRequest)))
+            entry.setValue(str(int(self.onlyAllowBuddiesOnRequest)))
             entry.save()
         else:
             vault.addChronicleEntry(kChron.BuddiesOnRequest, kChron.BuddiesOnRequestType, str(int(self.onlyAllowBuddiesOnRequest)))
@@ -1469,7 +1469,7 @@ class xKI(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry("KILightStop")
         if entry is not None:
-            entryValue = entry.chronicleGetValue()
+            entryValue = entry.getValue()
             remaining = int(entryValue)
             return remaining
         else:
@@ -1482,12 +1482,12 @@ class xKI(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry("KILightStop")
         if entry is not None:
-            entryValue = entry.chronicleGetValue()
+            entryValue = entry.getValue()
             oldVal = int(entryValue)
             if remaining == oldVal:
                 return
             PtDebugPrint("xKI.SetKILightChron(): Set KI light chron to: ", remaining, level=kDebugDumpLevel)
-            entry.chronicleSetValue(str(int(remaining)))
+            entry.setValue(str(int(remaining)))
             entry.save()
 
     ## Manages the KI light.
@@ -1654,7 +1654,7 @@ class xKI(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry(kChronicleKITextColor)
         if entry is not None:
-            if colorStr := entry.chronicleGetValue():
+            if colorStr := entry.getValue():
                 PtDebugPrint(f"xKI.DetermineTextColor(): KI Text Color is: \"{colorStr}\".", level=kWarningLevel)
                 args = colorStr.split(",")
                 try:
@@ -1684,7 +1684,7 @@ class xKI(ptModifier):
                 entry = vault.findChronicleEntry(kChronicleGZGames)
                 error = 0
                 if entry is not None:
-                    gameString = entry.chronicleGetValue()
+                    gameString = entry.getValue()
                     PtDebugPrint("xKI.DetermineGZ(): Game string is: \"{}\".".format(gameString), level=kWarningLevel)
                     args = gameString.split()
                     if len(args) == 3:
@@ -1789,7 +1789,7 @@ class xKI(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry(kChronicleGZGames)
         if entry is not None:
-            if gameString == entry.chronicleGetValue():
+            if gameString == entry.getValue():
                 PtDebugPrint("xKI.GZFlashUpdate(): Vault corrupted: trying to gracefully reset to a default state.", level=kErrorLevel)
                 import grtzKIMarkerMachine
                 grtzKIMarkerMachine.ResetMarkerGame()
@@ -1804,7 +1804,7 @@ class xKI(ptModifier):
             entry = vault.findChronicleEntry(kChronicleGZGames)
             upString = "{} {}:{} {}:{}".format(self.gGZPlaying, self.gMarkerGottenColor, self.gMarkerToGetColor, self.gMarkerGottenNumber, self.gMarkerToGetNumber)
             if entry is not None:
-                entry.chronicleSetValue(upString)
+                entry.setValue(upString)
                 entry.save()
             else:
                 vault.addChronicleEntry(kChronicleGZGames, kChronicleGZGamesType, upString)
@@ -1817,14 +1817,14 @@ class xKI(ptModifier):
             vault = ptVault()
             entry = vault.findChronicleEntry(kChronicleGZMarkersAquired)
             if entry is not None:
-                markers = entry.chronicleGetValue()
+                markers = entry.getValue()
                 markerIdx = self.gGZMarkerInRange - 1
                 if markerIdx >= 0 and markerIdx < len(markers):
                     if len(markers) - (markerIdx + 1) != 0:
                         markers = markers[:markerIdx] + kGZMarkerCaptured + markers[-(len(markers) - (markerIdx + 1)):]
                     else:
                         markers = markers[:markerIdx] + kGZMarkerCaptured
-                    entry.chronicleSetValue(markers)
+                    entry.setValue(markers)
                     entry.save()
                     # Update the "marker gotten" count.
                     totalGotten = markers.count(kGZMarkerCaptured)
@@ -2259,7 +2259,7 @@ class xKI(ptModifier):
             # Not found, set to MicroKI by default.
             vault.addChronicleEntry(kChronicleKILevel, kChronicleKILevelType, str(self.KILevel))
         else:
-            oldLevel = int(entry.chronicleGetValue())
+            oldLevel = int(entry.getValue())
             if oldLevel >= kLowestKILevel and oldLevel <= kHighestKILevel:
                 self.KILevel = oldLevel
             elif oldLevel < kLowestKILevel:
@@ -2276,10 +2276,10 @@ class xKI(ptModifier):
             vault.addChronicleEntry(kChronicleKIMarkerLevel, kChronicleKIMarkerLevelType, str(self.gKIMarkerLevel))
         else:
             try:
-                self.gKIMarkerLevel = int(entry.chronicleGetValue())
+                self.gKIMarkerLevel = int(entry.getValue())
             except:
                 PtDebugPrint("xKI.DetermineKILevel(): Chronicle entry error with the KI's Marker Level, resetting to the default value.", level=kErrorLevel)
-                entry.chronicleSetValue(str(self.gKIMarkerLevel))
+                entry.setValue(str(self.gKIMarkerLevel))
                 entry.save()
         PtDebugPrint("xKI.DetermineKILevel(): The KI Marker Level is {}.".format(self.gKIMarkerLevel), level=kWarningLevel)
 
@@ -2288,7 +2288,7 @@ class xKI(ptModifier):
             self.chatMgr.gFeather = 0
         else:
             try:
-                self.chatMgr.gFeather = int(entry.chronicleGetValue())
+                self.chatMgr.gFeather = int(entry.getValue())
             except ValueError:
                 self.chatMgr.gFeather = 0
 
@@ -2305,7 +2305,7 @@ class xKI(ptModifier):
                 vault.addChronicleEntry(kChronicleKIMarkerLevel, kChronicleKIMarkerLevelType, str(self.gKIMarkerLevel))
             else:
                 PtDebugPrint("xKI.UpgradeKIMarkerLevel(): Upgrading existing KI Marker Level to {}.".format(self.gKIMarkerLevel), level=kWarningLevel)
-                entry.chronicleSetValue(str(self.gKIMarkerLevel))
+                entry.setValue(str(self.gKIMarkerLevel))
                 entry.save()
 
     ## Updates the KI level's Chronicle value.
@@ -2314,7 +2314,7 @@ class xKI(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry(kChronicleKILevel)
         if entry is not None:
-            entry.chronicleSetValue(str(self.KILevel))
+            entry.setValue(str(self.KILevel))
             entry.save()
         else:
             vault.addChronicleEntry(kChronicleKILevel, kChronicleKILevelType, str(self.KILevel))
@@ -2405,7 +2405,7 @@ class xKI(ptModifier):
         if entry is None:
             vault.addChronicleEntry(kChronicleCensorLevel, kChronicleCensorLevelType, str(self.censorLevel))
         else:
-            self.censorLevel = int(entry.chronicleGetValue())
+            self.censorLevel = int(entry.getValue())
         PtDebugPrint("xKI.DetermineCensorLevel(): The censor level is {}.".format(self.censorLevel), level=kWarningLevel)
 
     def GetCensorLevel(self):
@@ -2425,7 +2425,7 @@ class xKI(ptModifier):
             # Not found, add the current size to the Chronicle.
             vault.addChronicleEntry(kChron.FontSize, kChron.FontSizeType, str(fontSize))
         else:
-            fontSize = int(entry.chronicleGetValue())
+            fontSize = int(entry.getValue())
             self.SetFontSize(fontSize)
         PtDebugPrint("xKI.DetermineFontSize(): The saved font size is {}.".format(fontSize), level=kWarningLevel)
 
@@ -2436,7 +2436,7 @@ class xKI(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry(kChron.FontSize)
         if entry is not None:
-            entry.chronicleSetValue(str(fontSize))
+            entry.setValue(str(fontSize))
             entry.save()
         else:
             vault.addChronicleEntry(kChron.FontSize, kChron.FontSizeType, str(fontSize))
@@ -2497,7 +2497,7 @@ class xKI(ptModifier):
             # Not found, add the current fade time to the Chronicle.
             vault.addChronicleEntry(kChron.FadeTime, kChron.FadeTimeType, str(self.chatMgr.ticksOnFull))
         else:
-            self.chatMgr.ticksOnFull = int(entry.chronicleGetValue())
+            self.chatMgr.ticksOnFull = int(entry.getValue())
             if self.chatMgr.ticksOnFull == kChat.FadeTimeMax:
                 # Disable the fade altogether.
                 self.chatMgr.fadeEnableFlag = False
@@ -2513,7 +2513,7 @@ class xKI(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry(kChron.FadeTime)
         if entry is not None:
-            entry.chronicleSetValue(str(self.chatMgr.ticksOnFull))
+            entry.setValue(str(self.chatMgr.ticksOnFull))
             entry.save()
         else:
             vault.addChronicleEntry(kChron.FadeTime, kChron.FadeTimeType, str(self.chatMgr.ticksOnFull))
@@ -3925,7 +3925,7 @@ class xKI(ptModifier):
                     entry = vault.findChronicleEntry("CleftSolved")
                     cleftSolved = False
                     if entry is not None:
-                        if entry.chronicleGetValue() == "yes":
+                        if entry.getValue() == "yes":
                             cleftSolved = True
                     if self.GetAgeInstanceName() != "D'ni-Riltagamin" or cleftSolved:
                         instAgeName = self.GetAgeInstanceName()

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -1549,7 +1549,7 @@ class CommandsProcessor:
         if entry is None:
             vault.addChronicleEntry("feather", 1, str(self.chatMgr.gFeather))
             entry = vault.findChronicleEntry("feather")
-        entry.chronicleSetValue(str(self.chatMgr.gFeather))
+        entry.setValue(str(self.chatMgr.gFeather))
         entry.save()
 
     ## Looks for feathers in the player's "inventory".
@@ -1604,15 +1604,15 @@ class CommandsProcessor:
             child = child.upcastToChronicleNode()
             if not child:
                 continue
-            if child.chronicleGetName() == kChron.Party:
+            if child.getName() == kChron.Party:
                 party = child
                 break
 
         # Let's see what we need to do
         if not params:
             # No params = LINK ME!
-            if party and party.chronicleGetValue():
-                data = party.chronicleGetValue().split(";", 3)
+            if party and party.getValue():
+                data = party.getValue().split(";", 3)
                 ageInfo = ptAgeInfoStruct()
                 ageInfo.setAgeFilename(data[0])
                 ageInfo.setAgeInstanceGuid(data[1])
@@ -1634,7 +1634,7 @@ class CommandsProcessor:
             except NameError:
                 # Garbage SO = kill party
                 if party:
-                    party.chronicleSetValue("")
+                    party.setValue("")
                     party.save()
                     self.chatMgr.AddChatLine(None, "Party Crashed.", 0)
                 else:
@@ -1645,12 +1645,12 @@ class CommandsProcessor:
                 data = "%s;%s;%s" % (ageInfo.getAgeFilename(), ageInfo.getAgeInstanceGuid(), params)
                 if not party:
                     party = ptVaultChronicleNode()
-                    party.chronicleSetName(kChron.Party)
-                    party.chronicleSetValue(data)
+                    party.setName(kChron.Party)
+                    party.setValue(data)
                     party.save() # creates node on server (and blocks) so we can add it to the global inbox
                     inbox.addNode(party)
                 else:
-                    party.chronicleSetValue(data)
+                    party.setValue(data)
                     party.save()
 
     ## Export the local avatar's clothing to a file

--- a/Scripts/Python/mystFireplace.py
+++ b/Scripts/Python/mystFireplace.py
@@ -207,8 +207,8 @@ class mystFireplace(ptModifier):
                 if not entry:
                     vault.addChronicleEntry("Blah", 0, "1")
                 else:
-                    if int(entry.chronicleGetValue()) < 1:
-                        entry.chronicleSetValue("1")
+                    if int(entry.getValue()) < 1:
+                        entry.setValue("1")
                 # show kveer book
                 ageSDL["KveerBookVis"] = (1,)
                 ageSDL["YeeshaPageVis"] = (0,)

--- a/Scripts/Python/nxusBookMachine.py
+++ b/Scripts/Python/nxusBookMachine.py
@@ -436,7 +436,7 @@ class nxusBookMachine(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry("GotLinkToKveerPublic")
         if entry is not None:
-            entryValue = entry.chronicleGetValue()
+            entryValue = entry.getValue()
             if entryValue == "yes":
                 PtDebugPrint("nxusBookMachine.OnServerInitComplete(): chron says you have the link to public Kveer, woo hoo")
                 self.publicAges['Kveer'].linkVisible = True
@@ -445,7 +445,7 @@ class nxusBookMachine(ptModifier):
         # copy pasta for the Pub
         entrygmpn = vault.findChronicleEntry("GotLinkToGoMePublic")
         if entrygmpn is not None:
-            entryValue02 = entrygmpn.chronicleGetValue()
+            entryValue02 = entrygmpn.getValue()
             if entryValue02 == "yes":
                 PtDebugPrint("nxusBookMachine.OnServerInitComplete(): chron says you have the link to public GoMePub, hooray!")
                 self.publicAges['GoMePubNew'].linkVisible = True
@@ -468,7 +468,7 @@ class nxusBookMachine(ptModifier):
         if entry is None:
             return True # we haven't created a hood before, so let them!
 
-        temp = float(entry.chronicleGetValue())
+        temp = float(entry.getValue())
         lastTime = datetime.date.fromtimestamp(temp)
         temp = PtGetDniTime()
         curTime = datetime.date.fromtimestamp(temp)
@@ -608,7 +608,7 @@ class nxusBookMachine(ptModifier):
             # not found... add current level chronicle
             vault.addChronicleEntry("LastHoodCreationTime", kChronicleVarType, str(PtGetDniTime()))
         else:
-            entry.chronicleSetValue(str(PtGetDniTime()))
+            entry.setValue(str(PtGetDniTime()))
             entry.save()
 
     def IPushGetBookBtn(self):
@@ -1641,7 +1641,7 @@ class nxusBookMachine(ptModifier):
         if not GUIDChronFound:
             PtDebugPrint("creating PelletCave GUID chron")
             newNode = ptVaultChronicleNode(0)
-            newNode.chronicleSetName("PelletCaveGUID")
-            newNode.chronicleSetValue(pelletCaveGUID)
+            newNode.setName("PelletCaveGUID")
+            newNode.setValue(pelletCaveGUID)
             ageDataFolder.addNode(newNode)
             PtDebugPrint("created pelletCaveGUID age chron, = ", pelletCaveGUID)

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -7669,30 +7669,6 @@ class ptVaultChronicleNode(ptVaultNode):
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def chronicleGetName(self):
-        """LEGACY: Returns the name of the chronicle node."""
-        pass
-
-    def chronicleGetType(self):
-        """LEGACY: Returns the user defined type of the chronicle node."""
-        pass
-
-    def chronicleGetValue(self):
-        """LEGACY: Returns the value as a string of this chronicle node."""
-        pass
-
-    def chronicleSetName(self,name):
-        """LEGACY: Sets the name of the chronicle node."""
-        pass
-
-    def chronicleSetType(self,type):
-        """LEGACY: Sets this chronicle node to a user defined type."""
-        pass
-
-    def chronicleSetValue(self,value):
-        """LEGACY: Sets the chronicle to a value that is a string"""
-        pass
-
     def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass

--- a/Scripts/Python/plasma/PlasmaKITypes.py
+++ b/Scripts/Python/plasma/PlasmaKITypes.py
@@ -166,7 +166,7 @@ def PtDetermineKILevel():
     vault = Plasma.ptVault()
     entry = vault.findChronicleEntry(kChronicleKILevel)
     if entry is not None:
-        level = int(entry.chronicleGetValue())
+        level = int(entry.getValue())
         # make sure it is a valid level
         if level >= kLowestKILevel and level <= kHighestKILevel:
             return level
@@ -180,7 +180,7 @@ def PtDetermineCensorLevel():
     vault = Plasma.ptVault()
     entry = vault.findChronicleEntry(kChronicleCensorLevel)
     if entry is not None:
-        level = int(entry.chronicleGetValue())
+        level = int(entry.getValue())
         return level
     # if couldn't be determine... just assume lowest form
     return 0
@@ -192,7 +192,7 @@ def PtDetermineKIMarkerLevel():
     vault = Plasma.ptVault()
     entry = vault.findChronicleEntry(kChronicleKIMarkerLevel)
     if entry is not None:
-        level = int(entry.chronicleGetValue())
+        level = int(entry.getValue())
         return level
     # if couldn't be determine... just assume lowest form
     return kKIMarkerNotUpgraded

--- a/Scripts/Python/psnlBahroPoles.py
+++ b/Scripts/Python/psnlBahroPoles.py
@@ -244,7 +244,7 @@ class psnlBahroPoles(ptModifier):
             if ptVault().amOwnerOfCurrentAge():
                 entry = vault.findChronicleEntry("CleftSolved")
                 if entry is not None:
-                    if entry.chronicleGetValue() == "yes":
+                    if entry.getValue() == "yes":
                         boolCleftSolved = 1
                         ageSDL["psnlCleftSolved"] = (1,)
         
@@ -738,8 +738,8 @@ class psnlBahroPoles(ptModifier):
 
                 ageChild = ageChild.upcastToChronicleNode()
 
-                if ageChild.chronicleGetName() == age:
-                    return len(ageChild.chronicleGetValue() )
+                if ageChild.getName() == age:
+                    return len(ageChild.getValue() )
 
         return 0
 
@@ -910,7 +910,7 @@ class psnlBahroPoles(ptModifier):
         chron = vault.findChronicleEntry("JourneyClothProgress")
 
         if chron is not None:
-            chron.chronicleSetValue("Z")
+            chron.setValue("Z")
             chron.save()
 
         #sdl = xPsnlVaultSDL(1)
@@ -1140,8 +1140,8 @@ class psnlBahroPoles(ptModifier):
         PtDebugPrint("creating BahroCave solution in the chronicle...")
         for v in range(len(agelist)):
             newnode = ptVaultChronicleNode(0)
-            newnode.chronicleSetName(agelist[v])
-            newnode.chronicleSetValue("0," + str(bahroSolList[v]) + ",0")
+            newnode.setName(agelist[v])
+            newnode.setValue("0," + str(bahroSolList[v]) + ",0")
             entry = vault.findChronicleEntry("BahroCave")
             entry.addNode(newnode)
         PtDebugPrint("new bahro cave solution = ",self.GetBahroCaveSolution())
@@ -1169,7 +1169,7 @@ class psnlBahroPoles(ptModifier):
         for ageChron in ageChronRefList:
             ageChild = ageChron.getChild()
             ageChild = ageChild.upcastToChronicleNode()
-            if ageChild.chronicleGetName() == age:
+            if ageChild.getName() == age:
                 return ageChild
         return None
 
@@ -1177,7 +1177,7 @@ class psnlBahroPoles(ptModifier):
     def GetAgeVariable(self, age, variable):
         node = self.GetAgeNode(age)
         if node != None:
-            varlist = node.chronicleGetValue().split(",")
+            varlist = node.getValue().split(",")
             self.varMap = {'YeeshaSymbolTouched': 0, 'SolutionSymbol': 1, 'YeeshaSpeech': 2}
             return varlist[ self.varMap[variable] ]
         else:
@@ -1235,11 +1235,11 @@ class psnlBahroPoles(ptModifier):
             ageInfoNode.addNode(ageDataFolder)
 
         if pelletSolution:
-            solutionChron.chronicleSetValue(solution)
+            solutionChron.setValue(solution)
         else:
             newNode = ptVaultChronicleNode(0)
-            newNode.chronicleSetName("PelletCaveSolution")
-            newNode.chronicleSetValue(solution)
+            newNode.setName("PelletCaveSolution")
+            newNode.setValue(solution)
             ageDataFolder.addNode(newNode)
 
 

--- a/Scripts/Python/psnlBookshelf.py
+++ b/Scripts/Python/psnlBookshelf.py
@@ -1892,7 +1892,7 @@ class psnlBookshelf(ptModifier):
         vault = ptVault()
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
-            valCityLinks = entryCityLinks.chronicleGetValue()
+            valCityLinks = entryCityLinks.getValue()
             PtDebugPrint("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
             PtDebugPrint("CityLinks = ",CityLinks)

--- a/Scripts/Python/psnlBugs.py
+++ b/Scripts/Python/psnlBugs.py
@@ -70,14 +70,14 @@ class psnlBugs(ptResponder):
             # not found... add chronicle
             vault.addChronicleEntry(chronicleEntryName,0,str(count))
         else:
-            entry.chronicleSetValue(str(count))
+            entry.setValue(str(count))
             entry.save()
     
     def IGetBugCount(self):
         vault = ptVault()
         entry = vault.findChronicleEntry(chronicleEntryName)
         if entry is not None:
-            return int(entry.chronicleGetValue())
+            return int(entry.getValue())
         return 0 # no chronicle var
 
     def OnServerInitComplete(self):

--- a/Scripts/Python/xBugsGoAway.py
+++ b/Scripts/Python/xBugsGoAway.py
@@ -67,14 +67,14 @@ class xBugsGoAway(ptResponder):
             # not found... add chronicle
             vault.addChronicleEntry(chronicleEntryName,0,str(count))
         else:
-            entry.chronicleSetValue(str(count))
+            entry.setValue(str(count))
             entry.save()
     
     def IGetBugCount(self):
         vault = ptVault()
         entry = vault.findChronicleEntry(chronicleEntryName)
         if entry is not None:
-            return int(entry.chronicleGetValue())
+            return int(entry.getValue())
         return 0 # no chronicle var
 
     def OnServerInitComplete(self):

--- a/Scripts/Python/xCheat.py
+++ b/Scripts/Python/xCheat.py
@@ -123,17 +123,17 @@ def GetAgeJourneyCloths(args):
 
         ageChild = ageChild.upcastToChronicleNode()
 
-        if ageChild.chronicleGetName() == ageName:
+        if ageChild.getName() == ageName:
             ageChronNode = ageChild
             break
 
     if ageChronNode is None:
         newNode = Plasma.ptVaultChronicleNode(0)
-        newNode.chronicleSetName(ageName)
-        newNode.chronicleSetValue("abcdefg")
+        newNode.setName(ageName)
+        newNode.setValue("abcdefg")
         chron.addNode(newNode)
     else:
-        ageChronNode.chronicleSetValue("abcdefg")
+        ageChronNode.setValue("abcdefg")
         ageChronNode.save()
 
 
@@ -187,10 +187,10 @@ def GenerateCleftSolution(args):
         agelist = ["Teledahn", "Garrison", "Garden", "Kadish"]
         for v in range(len(agelist)):
             newnode = Plasma.ptVaultChronicleNode(0)
-            newnode.chronicleSetName(agelist[v])
+            newnode.setName(agelist[v])
             ageVal = str(solutionlist[v])            
-            newnode.chronicleSetValue("1," + ageVal + "," + str(v + 1))
-            #newnode.chronicleSetValue("1," + str(solutionlist[v]) + "," + str(v + 1))
+            newnode.setValue("1," + ageVal + "," + str(v + 1))
+            #newnode.setValue("1," + str(solutionlist[v]) + "," + str(v + 1))
             entry.addNode(newnode)
             print("%s solution is %s" % (agelist[v], ageVal))
 
@@ -271,7 +271,7 @@ def GZSetGame(args):
     # is there a chronicle for the GZ games?
     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZGames)
     if entry is not None:
-        entry.chronicleSetValue(gameString)
+        entry.setValue(gameString)
         entry.save()
     else:
         # if there is none, then just add another entry
@@ -298,7 +298,7 @@ def GZGetMarkers(args):
         # is there a chronicle for the GZ games?
         entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZGames)
         if entry is not None:
-            gameString = entry.chronicleGetValue()
+            gameString = entry.getValue()
             gargs = gameString.split()
             if len(gargs) == 3:
                 try:
@@ -314,13 +314,13 @@ def GZGetMarkers(args):
                         newgotten = markerToGetNumber
                     print("Updating markers gotten to %d from %d" % (newgotten,markerToGetNumber))
                     upstring = "%d %s:%s %d:%d" % (markerGame,markerGottenColor,markerToGetColor,newgotten,markerToGetNumber)
-                    entry.chronicleSetValue(upstring)
+                    entry.setValue(upstring)
                     entry.save()
                     # just pick some marker to have gotten
                     # is there a chronicle for the GZ games?
                     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZMarkersAquired)
                     if entry is not None:
-                        markers = entry.chronicleGetValue()
+                        markers = entry.getValue()
                         for mnum in range(markersToGet):
                             markerIdx = markers.index(PlasmaKITypes.kGZMarkerAvailable)
                             if markerIdx >= 0 and markerIdx < len(markers):
@@ -330,7 +330,7 @@ def GZGetMarkers(args):
                                 else:
                                     markers = markers[:markerIdx] + PlasmaKITypes.kGZMarkerCaptured
                                 print("Update marker #%d - out string is '%s'" % (markerIdx+1,markers))
-                                entry.chronicleSetValue(markers)
+                                entry.setValue(markers)
                                 entry.save()
                     # update the 
                     Plasma.PtSendKIMessage(PlasmaKITypes.kGZUpdated,0)
@@ -364,7 +364,7 @@ def GZGiveMeFullAccess(args):
     vault = Plasma.ptVault()
     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZGames)
     if entry is not None:
-        entry.chronicleSetValue(resetString)
+        entry.setValue(resetString)
 
     # Finally, update the KI display
     Plasma.PtSendKIMessage(PlasmaKITypes.kGZUpdated,0)
@@ -388,17 +388,17 @@ def RemoveMarkerTag(args):
     # is there a chronicle for the GZ games?
     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleKIMarkerLevel)
     if entry is not None:
-        entry.chronicleSetValue(newlevel)
+        entry.setValue(newlevel)
         entry.save()
     # is there a chronicle for the GZ games?
     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZGames)
     if entry is not None:
-        entry.chronicleSetValue("0")
+        entry.setValue("0")
         entry.save()
     # is there a chronicle for the GZ games?
     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZMarkersAquired)
     if entry is not None:
-        entry.chronicleSetValue("")
+        entry.setValue("")
         entry.save()
     Plasma.PtSendKIMessage(PlasmaKITypes.kGZUpdated,0)
     # get rid of the CGZ marker games
@@ -406,12 +406,12 @@ def RemoveMarkerTag(args):
     for mg in MGs:
         entry = vault.findChronicleEntry(mg)
         if entry is not None:
-            entry.chronicleSetValue("")
+            entry.setValue("")
             entry.save()
    
     entry = vault.findChronicleEntry("CGZPlaying")
     if entry is not None:
-        entry.chronicleSetValue("")
+        entry.setValue("")
         entry.save()
     # remove the marker games from the hidden folder--- later
 
@@ -425,11 +425,11 @@ def CGZKillAll(args):
     for mg in MGs:
         entry = vault.findChronicleEntry(mg)
         if entry is not None:
-            entry.chronicleSetValue("")
+            entry.setValue("")
             entry.save()
     entry = vault.findChronicleEntry("CGZPlaying")
     if entry is not None:
-        entry.chronicleSetValue("")
+        entry.setValue("")
         entry.save()
 
 def ShowHiddenFolder(args):

--- a/Scripts/Python/xChronicleCounter.py
+++ b/Scripts/Python/xChronicleCounter.py
@@ -91,8 +91,8 @@ class xChronicleCounter(ptResponder):
                 vault.addChronicleEntry(var.value,kChronicleVarType,"%d" %(kInitialValue))
                 PtDebugPrint("xChronicleCounter:\tentered new chronicle counter %s, count is %d" % (var.value,kInitialValue))
             else:
-                count = int(entry.chronicleGetValue())
+                count = int(entry.getValue())
                 count = count + 1
-                entry.chronicleSetValue("%d" % (count))
+                entry.setValue("%d" % (count))
                 entry.save()
-                PtDebugPrint("xChronicleCounter:\tyour current count for %s is %s" % (var.value,entry.chronicleGetValue()))
+                PtDebugPrint("xChronicleCounter:\tyour current count for %s is %s" % (var.value,entry.getValue()))

--- a/Scripts/Python/xDialogStartUp.py
+++ b/Scripts/Python/xDialogStartUp.py
@@ -471,7 +471,7 @@ class xDialogStartUp(ptResponder):
 
             start = ptVault().findChronicleEntry("StartPathChosen")
             if start is not None:
-                gPlayerStart = start.chronicleGetValue()
+                gPlayerStart = start.getValue()
             if StartInACA():
                 ageInfo.setAgeFilename("AvatarCustomization")
             elif StartInCleft():

--- a/Scripts/Python/xGZMarker.py
+++ b/Scripts/Python/xGZMarker.py
@@ -103,7 +103,7 @@ class xGZMarker(ptMultiModifier):
         # is there a chronicle for the GZ games?
         entry = vault.findChronicleEntry(kChronicleGZMarkersAquired)
         if entry is not None:
-            markers = entry.chronicleGetValue()
+            markers = entry.getValue()
             markerIdx = aGZSerialNumber.value - 1
             if markerIdx >= 0 and markerIdx < len(markers):
                 if markers[markerIdx] == kGZMarkerAvailable:

--- a/Scripts/Python/xJourneyClothGate.py
+++ b/Scripts/Python/xJourneyClothGate.py
@@ -156,7 +156,7 @@ class xJourneyClothGate(ptResponder):
                 if entry is None:
                     PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: Sorry, couldn't find journey cloth chronicle for this age")
                     return
-                FoundJCs = entry.chronicleGetValue()
+                FoundJCs = entry.getValue()
                     
 
             length = len(FoundJCs)
@@ -237,7 +237,7 @@ class xJourneyClothGate(ptResponder):
             if entry is None:
                 PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: Sorry, couldn't find journey cloth chronicle for this age")
                 return
-            FoundJCs = entry.chronicleGetValue()
+            FoundJCs = entry.getValue()
             length = len(FoundJCs)
             all = len(AllCloths)
 
@@ -269,7 +269,7 @@ class xJourneyClothGate(ptResponder):
 
             ageChild = ageChild.upcastToChronicleNode()
 
-            if ageChild.chronicleGetName() == Age.value:
+            if ageChild.getName() == Age.value:
                 return ageChild
 
         return None

--- a/Scripts/Python/xJourneyCloths.py
+++ b/Scripts/Python/xJourneyCloths.py
@@ -137,7 +137,7 @@ class xJourneyCloths(ptModifier):
             self.IPlayHandAnim(1)
         
         else:
-            FoundJCs = entry.chronicleGetValue()
+            FoundJCs = entry.getValue()
             PtDebugPrint("previously found JCs: ", FoundJCs)
             if ClothLetter.value in FoundJCs:
                 PtDebugPrint("You've already found this cloth.")
@@ -149,7 +149,7 @@ class xJourneyCloths(ptModifier):
                 FoundJCs = FoundJCs + ClothLetter.value
                 PtDebugPrint("trying to update JourneyClothProgress to ", FoundJCs)
 
-                entry.chronicleSetValue("%s" % (FoundJCs)) 
+                entry.setValue("%s" % (FoundJCs)) 
                 entry.save() 
                 
                 self.RandomBahroSounds()

--- a/Scripts/Python/xJourneyClothsGen2.py
+++ b/Scripts/Python/xJourneyClothsGen2.py
@@ -240,8 +240,8 @@ class xJourneyClothsGen2(ptModifier):
 
     def AddNodeWithCurrentValue(self, node):
         newNode = ptVaultChronicleNode(0)
-        newNode.chronicleSetName(Age.value)
-        newNode.chronicleSetValue(ClothLetter.value)
+        newNode.setName(Age.value)
+        newNode.setValue(ClothLetter.value)
         node.addNode(newNode)
 
         return self.GetCurrentAgeChronicle(node)
@@ -255,7 +255,7 @@ class xJourneyClothsGen2(ptModifier):
 
             ageChild = ageChild.upcastToChronicleNode()
 
-            if ageChild.chronicleGetName() == Age.value:
+            if ageChild.getName() == Age.value:
                 return ageChild
 
         return None
@@ -374,7 +374,7 @@ class xJourneyClothsGen2(ptModifier):
                     FoundJCs = ClothLetter.value
                     self.RandomBahroSounds()
                 else:
-                    FoundJCs = currentAgeChron.chronicleGetValue()
+                    FoundJCs = currentAgeChron.getValue()
                     PtDebugPrint("previously found JCs: ", FoundJCs)
                     if ClothLetter.value in FoundJCs:
                         PtDebugPrint("You've already found this cloth.")
@@ -385,7 +385,7 @@ class xJourneyClothsGen2(ptModifier):
                         FoundJCs = FoundJCs + ClothLetter.value
                         PtDebugPrint("trying to update JourneyClothProgress to ", FoundJCs)
 
-                        currentAgeChron.chronicleSetValue("%s" % (FoundJCs)) 
+                        currentAgeChron.setValue("%s" % (FoundJCs)) 
                         currentAgeChron.save() 
                         
                         self.RandomBahroSounds()

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -353,9 +353,9 @@ class xLinkingBookGUIPopup(ptModifier):
                                         entry = vault.findChronicleEntry("TomahnaLoad")
                                         if entry is not None:
                                             if linkTitle == "Tomahna":
-                                                entry.chronicleSetValue("yes")
+                                                entry.setValue("yes")
                                             else:
-                                                entry.chronicleSetValue("no")
+                                                entry.setValue("no")
                                     
                                     # this book was taken off the personal age bookshelf. Send a note telling to link
                                     note = ptNotify(self.key)
@@ -435,9 +435,9 @@ class xLinkingBookGUIPopup(ptModifier):
                                         ageDataTemplate.setFolderName("AgeData")
                                         if ageDataFolder := ageInfoNode.findNode(ageDataTemplate):
                                             chronTemplate = ptVaultChronicleNode()
-                                            chronTemplate.chronicleSetName("AhnonayVolatile")
+                                            chronTemplate.setName("AhnonayVolatile")
                                             if (chron := ageDataFolder.findNode(chronTemplate)) and (chron := chron.upcastToChronicleNode()):
-                                                chron.chronicleSetValue("1")
+                                                chron.setValue("1")
                                             else:
                                                 PtDebugPrint(f"xLinkingBookGUIPopup.OnNotify():\tHmmm... The AhnonayVolatile chronicle is missing! This deletion may cause oddness.")
                                         else:
@@ -481,7 +481,7 @@ class xLinkingBookGUIPopup(ptModifier):
                 vault = ptVault()
                 entry = vault.findChronicleEntry("TomahnaLoad")
                 if entry is not None:
-                    entry.chronicleSetValue("yes")
+                    entry.setValue("yes")
                     entry.save()
                     PtDebugPrint("Chronicle entry TomahnaLoad already added, setting to yes")
                 else:
@@ -794,16 +794,16 @@ class xLinkingBookGUIPopup(ptModifier):
         vault = ptVault()
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
-            valCityLinks = entryCityLinks.chronicleGetValue()
+            valCityLinks = entryCityLinks.getValue()
             PtDebugPrint("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
             PtDebugPrint("CityLinks = ",CityLinks)
             if agePanel not in CityLinks:
                 NewLinks = valCityLinks + "," + agePanel
-                entryCityLinks.chronicleSetValue(NewLinks)
+                entryCityLinks.setValue(NewLinks)
                 entryCityLinks.save()
                 PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
-                valCityLinks = entryCityLinks.chronicleGetValue()
+                valCityLinks = entryCityLinks.getValue()
                 CityLinks = valCityLinks.split(",")
                 PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  citylinks now = ",CityLinks)
             else:
@@ -824,7 +824,7 @@ class xLinkingBookGUIPopup(ptModifier):
         vault = ptVault()
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
-            valCityLinks = entryCityLinks.chronicleGetValue()
+            valCityLinks = entryCityLinks.getValue()
             PtDebugPrint("xLinkingBookGUIPopup.IGetCityLinksChron(): valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
         return CityLinks	
@@ -1127,8 +1127,8 @@ class xLinkingBookGUIPopup(ptModifier):
         if not GUIDChronFound:
             PtDebugPrint("creating PelletCave GUID chron")
             newNode = ptVaultChronicleNode(0)
-            newNode.chronicleSetName("PelletCaveGUID")
-            newNode.chronicleSetValue(pelletCaveGUID)
+            newNode.setName("PelletCaveGUID")
+            newNode.setValue(pelletCaveGUID)
             ageDataFolder.addNode(newNode)
             PtDebugPrint("created pelletCaveGUID age chron, = ",pelletCaveGUID)
 

--- a/Scripts/Python/xMusicBox.py
+++ b/Scripts/Python/xMusicBox.py
@@ -109,14 +109,14 @@ class xMusicBox(ptModifier):
             ageInfoNode.addNode(newFolder)
             
             newNode = ptVaultChronicleNode(0)
-            newNode.chronicleSetName("MusicBoxSongs")
-            newNode.chronicleSetValue(strInitialSong.value)
+            newNode.setName("MusicBoxSongs")
+            newNode.setValue(strInitialSong.value)
             newFolder.addNode(newNode)
 
         elif not musicBoxChronFound:
             newNode = ptVaultChronicleNode(0)
-            newNode.chronicleSetName("MusicBoxSongs")
-            newNode.chronicleSetValue(strInitialSong.value)
+            newNode.setName("MusicBoxSongs")
+            newNode.setValue(strInitialSong.value)
             ageDataFolder.addNode(newNode)
 
         SoundObjIndex = soSoundObj.value.getSoundIndex(strSoundObj.value)

--- a/Scripts/Python/xOpeningSequence.py
+++ b/Scripts/Python/xOpeningSequence.py
@@ -429,7 +429,7 @@ class xOpeningSequence(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry(kIntroPlayedChronicle)
         if entry is not None:
-            entry.chronicleSetValue("yes")
+            entry.setValue("yes")
             entry.save()
         elif IsTutorialPath():
             vault.addChronicleEntry(kIntroPlayedChronicle, 2, "no")

--- a/Scripts/Python/xOptionsMenu.py
+++ b/Scripts/Python/xOptionsMenu.py
@@ -1772,9 +1772,9 @@ class xOptionsMenu(ptModifier):
             vault.addChronicleEntry(chronicleVar,kChronicleVarType,str(value))
             PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar))
         else:
-            entry.chronicleSetValue(str(value))
+            entry.setValue(str(value))
             entry.save()
-            PtDebugPrint("%s:\tyour current value for %s is %s" % (kModuleName,chronicleVar,entry.chronicleGetValue()))
+            PtDebugPrint("%s:\tyour current value for %s is %s" % (kModuleName,chronicleVar,entry.getValue()))
 
     def getChronicleVar(self, chronicleVar):
         kModuleName = "Personal"
@@ -1789,7 +1789,7 @@ class xOptionsMenu(ptModifier):
             #PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar))
             return None
         else:
-            value = entry.chronicleGetValue()
+            value = entry.getValue()
             PtDebugPrint("getChronicleVar(): " + chronicleVar + " = " + value)
             return value
         

--- a/Scripts/Python/xSimpleImager.py
+++ b/Scripts/Python/xSimpleImager.py
@@ -219,7 +219,7 @@ class xSimpleImager(ptModifier):
             # not found... add current level chronicle
             vault.addChronicleEntry(kChronicleCensorLevel,kChronicleCensorLevelType,"%d" % (theCensorLevel))
         else:
-            theCensorLevel = int(entry.chronicleGetValue())
+            theCensorLevel = int(entry.getValue())
         PtDebugPrint("xSimpleImager: the censor level is %d" % (theCensorLevel),level=kWarningLevel)
 
     def OnTimer(self,id):

--- a/Scripts/Python/xSndLogTracks.py
+++ b/Scripts/Python/xSndLogTracks.py
@@ -54,7 +54,7 @@ def LogTrack(currentState,nextState):
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogTrackVarname)
     if entry is not None:
-        state = entry.chronicleGetValue()
+        state = entry.getValue()
         if state == currentState:
             avatar = PtGetLocalAvatar()
             worn = avatar.avatar.getAvatarClothingList()
@@ -68,7 +68,7 @@ def LogTrack(currentState,nextState):
                 if item[0] == clothingName:
                     itsThere = 1
             if itsThere:
-                entry.chronicleSetValue(nextState)
+                entry.setValue(nextState)
                 entry.save()
                 updated = 1
                 PtDebugPrint("updated to %s" % (nextState))
@@ -77,7 +77,7 @@ def LogTrack(currentState,nextState):
         if not updated:
             # ha, ha ...start over
             PtDebugPrint("not updated")
-#            entry.chronicleSetValue("15")
+#            entry.setValue("15")
 #            entry.save()
     return updated
 
@@ -85,7 +85,7 @@ def InitLogTrack(nextState):
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogTrackVarname)
     if entry is not None:
-        entry.chronicleSetValue(nextState)
+        entry.setValue(nextState)
         entry.save()
     else:
         vault.addChronicleEntry(kLogTrackVarname,1,nextState)
@@ -94,7 +94,7 @@ def SetLogMode():
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogModeVarname)
     if entry is not None:
-        entry.chronicleSetValue("white")
+        entry.setValue("white")
         entry.save()
     else:
         vault.addChronicleEntry(kLogModeVarname,1,"white")
@@ -103,14 +103,14 @@ def UnsetLogMode():
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogModeVarname)
     if entry is not None:
-        entry.chronicleSetValue("blue")
+        entry.setValue("blue")
         entry.save()
 
 def IsLogMode():
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogModeVarname)
     if entry is not None:
-        if entry.chronicleGetValue() == "white":
+        if entry.getValue() == "white":
             return 1
     return 0
 
@@ -118,7 +118,7 @@ def WhatIsLog():
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogTrackVarname)
     if entry is not None:
-        PtDebugPrint(entry.chronicleGetValue())
+        PtDebugPrint(entry.getValue())
     else:
         PtDebugPrint("not initialized")
 

--- a/Scripts/Python/xStartPathHelpers.py
+++ b/Scripts/Python/xStartPathHelpers.py
@@ -56,7 +56,7 @@ def _GetPathValue() -> Optional[str]:
     if start is None:
         return None
 
-    value = start.chronicleGetValue()
+    value = start.getValue()
     assert value in {kTutorialPathValue, kAdvancedPathValue}, f"Invalid path value {value}"
     return value
 
@@ -74,7 +74,7 @@ def IsAdvancedPath() -> bool:
 def IsCleftSolved() -> bool:
     """Determines whether or not the Cleft has been solved."""
     entry = ptVault().findChronicleEntry(kCleftChronicle)
-    return entry is not None and entry.chronicleGetValue() == "yes"
+    return entry is not None and entry.getValue() == "yes"
 
 def SelectPath(path: Literal[kTutorialPathValue, kAdvancedPathValue]) -> None:
     assert path in {kTutorialPathValue, kAdvancedPathValue}, "Path must be cleft or relto"
@@ -85,7 +85,7 @@ def SelectPath(path: Literal[kTutorialPathValue, kAdvancedPathValue]) -> None:
 def StartInACA() -> bool:
     """Returns if the first Age the player links to should be AvatarCustomization."""
     entry = ptVault().findChronicleEntry(kACAChronicle)
-    return entry is None or entry.chronicleGetValue() != "1"
+    return entry is None or entry.getValue() != "1"
 
 def StartInCleft() -> bool:
     """Returns if the first Age the player links to should be Cleft. This means that the player

--- a/Scripts/Python/xTrackActivatorUsage.py
+++ b/Scripts/Python/xTrackActivatorUsage.py
@@ -71,7 +71,7 @@ class xTrackActivatorUsage(ptModifier):
             entry = vault.findChronicleEntry(strChronVar.value)
 
             if entry is not None:
-                entry.chronicleSetValue( str(self.currentValue) )
+                entry.setValue( str(self.currentValue) )
                 entry.save()
             else:
                 vault.addChronicleEntry(strChronVar.value, 0, str(self.currentValue) )
@@ -84,7 +84,7 @@ class xTrackActivatorUsage(ptModifier):
             entry = vault.findChronicleEntry(strChronVar.value)
 
             if entry is not None:
-                self.currentValue = int(entry.chronicleGetValue())
+                self.currentValue = int(entry.getValue())
 
         self.startingValue = self.currentValue
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.cpp
@@ -63,7 +63,7 @@ pyVaultChronicleNode::pyVaultChronicleNode()
 //==================================================================
 // class RelVaultNode : public plVaultNode
 //
-void pyVaultChronicleNode::Chronicle_SetName( const char * text )
+void pyVaultChronicleNode::Chronicle_SetName( const ST::string& text )
 {
     if (!fNode)
         return;
@@ -81,7 +81,7 @@ ST::string pyVaultChronicleNode::Chronicle_GetName() const
     return ST::string();
 }
 
-void pyVaultChronicleNode::Chronicle_SetValue( const char * text )
+void pyVaultChronicleNode::Chronicle_SetValue( const ST::string& text )
 {
     if (fNode) {
         VaultChronicleNode chron(fNode);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.h
@@ -52,6 +52,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGlueHelpers.h"
 #include "pyVaultNode.h"
 
+#include <string_theory/string>
+
 struct RelVaultNode;
 
 class pyVaultChronicleNode : public pyVaultNode
@@ -74,9 +76,9 @@ public:
 //==================================================================
 // class RelVaultNode : public plVaultNode
 //
-    void Chronicle_SetName( const char * text );
+    void Chronicle_SetName( const ST::string& text );
     ST::string Chronicle_GetName() const;
-    void Chronicle_SetValue( const char * text );
+    void Chronicle_SetValue( const ST::string& text );
     ST::string Chronicle_GetValue() const;
     void Chronicle_SetType( uint32_t type );
     uint32_t Chronicle_GetType();

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNodeGlue.cpp
@@ -63,57 +63,6 @@ PYTHON_INIT_DEFINITION(ptVaultChronicleNode, args, keywords)
     PYTHON_RETURN_INIT_OK;
 }
 
-PYTHON_METHOD_DEFINITION(ptVaultChronicleNode, chronicleSetName, args)
-{
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
-    {
-        PyErr_SetString(PyExc_TypeError, "chronicleSetName expects a string");
-        PYTHON_RETURN_ERROR;
-    }
-    self->fThis->Chronicle_SetName(name);
-    PYTHON_RETURN_NONE;
-}
-
-PYTHON_METHOD_DEFINITION_NOARGS(ptVaultChronicleNode, chronicleGetName)
-{
-    return PyUnicode_FromSTString(self->fThis->Chronicle_GetName());
-}
-
-PYTHON_METHOD_DEFINITION(ptVaultChronicleNode, chronicleSetValue, args)
-{
-    char* val;
-    if (!PyArg_ParseTuple(args, "s", &val))
-    {
-        PyErr_SetString(PyExc_TypeError, "chronicleSetValue expects a string");
-        PYTHON_RETURN_ERROR;
-    }
-    self->fThis->Chronicle_SetValue(val);
-    PYTHON_RETURN_NONE;
-}
-
-PYTHON_METHOD_DEFINITION_NOARGS(ptVaultChronicleNode, chronicleGetValue)
-{
-    return PyUnicode_FromSTString(self->fThis->Chronicle_GetValue());
-}
-
-PYTHON_METHOD_DEFINITION(ptVaultChronicleNode, chronicleSetType, args)
-{
-    unsigned long chronType;
-    if (!PyArg_ParseTuple(args, "l", &chronType))
-    {
-        PyErr_SetString(PyExc_TypeError, "chronicleSetType expects an unsigned long");
-        PYTHON_RETURN_ERROR;
-    }
-    self->fThis->Chronicle_SetType(chronType);
-    PYTHON_RETURN_NONE;
-}
-
-PYTHON_METHOD_DEFINITION_NOARGS(ptVaultChronicleNode, chronicleGetType)
-{
-    return PyLong_FromUnsignedLong(self->fThis->Chronicle_GetType());
-}
-
 PYTHON_METHOD_DEFINITION(ptVaultChronicleNode, setName, args)
 {
     char* name;
@@ -166,14 +115,6 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultChronicleNode, getEntryType)
 }
 
 PYTHON_START_METHODS_TABLE(ptVaultChronicleNode)
-    // legacy glue
-    PYTHON_METHOD(ptVaultChronicleNode, chronicleSetName, "Params: name\nLEGACY: Sets the name of the chronicle node."),
-    PYTHON_METHOD_NOARGS(ptVaultChronicleNode, chronicleGetName, "LEGACY: Returns the name of the chronicle node."),
-    PYTHON_METHOD(ptVaultChronicleNode, chronicleSetValue, "Params: value\nLEGACY: Sets the chronicle to a value that is a string"),
-    PYTHON_METHOD_NOARGS(ptVaultChronicleNode, chronicleGetValue, "LEGACY: Returns the value as a string of this chronicle node."),
-    PYTHON_METHOD(ptVaultChronicleNode, chronicleSetType, "Params: type\nLEGACY: Sets this chronicle node to a user defined type."),
-    PYTHON_METHOD_NOARGS(ptVaultChronicleNode, chronicleGetType, "LEGACY: Returns the user defined type of the chronicle node."),
-    // new glue
     PYTHON_METHOD(ptVaultChronicleNode, setName, "Params: name\nSets the name of the chronicle node."),
     PYTHON_METHOD_NOARGS(ptVaultChronicleNode, getName, "Returns the name of the chronicle node."),
     PYTHON_METHOD(ptVaultChronicleNode, setValue, "Params: value\nSets the chronicle to a value that is a string"),

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNodeGlue.cpp
@@ -65,8 +65,8 @@ PYTHON_INIT_DEFINITION(ptVaultChronicleNode, args, keywords)
 
 PYTHON_METHOD_DEFINITION(ptVaultChronicleNode, setName, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "setName expects a string");
         PYTHON_RETURN_ERROR;
@@ -82,8 +82,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultChronicleNode, getName)
 
 PYTHON_METHOD_DEFINITION(ptVaultChronicleNode, setValue, args)
 {
-    char* val;
-    if (!PyArg_ParseTuple(args, "s", &val))
+    ST::string val;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &val))
     {
         PyErr_SetString(PyExc_TypeError, "setValue expects a string");
         PYTHON_RETURN_ERROR;


### PR DESCRIPTION
Includes a lot of dumb Python changes to remove the duplicate "legacy" glue methods. The actual `ST::string` changes are very small.

Chronicles are almost always pure ASCII, so this has little effect on overall Unicode support. French key bindings might be *less* broken now (they are still somewhat broken).