### PR TITLE
Improve Unicode support in Python stdout/stderr handler and `plStatusLog`

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -1143,7 +1143,7 @@ void plClient::IRoomLoaded(plSceneNode* node, bool hold)
             
 #ifndef PLASMA_EXTERNAL_RELEASE
             if (plDispatchLogBase::IsLogging())
-                plDispatchLogBase::GetInstance()->LogStatusBarChange(fProgressBar->GetTitle().c_str(), "displaying messages");
+                plDispatchLogBase::GetInstance()->LogStatusBarChange(fProgressBar->GetTitle(), "displaying messages");
 #endif // PLASMA_EXTERNAL_RELEASE
 #endif
         }
@@ -1253,7 +1253,7 @@ void    plClient::IStartProgress( const char *title, float len )
         fProgressBar = plProgressMgr::GetInstance()->RegisterOperation(len, title, plProgressMgr::kNone, false, true);
 #ifndef PLASMA_EXTERNAL_RELEASE
         if (plDispatchLogBase::IsLogging())
-            plDispatchLogBase::GetInstance()->LogStatusBarChange(fProgressBar->GetTitle().c_str(), "starting");
+            plDispatchLogBase::GetInstance()->LogStatusBarChange(fProgressBar->GetTitle(), "starting");
 #endif // PLASMA_EXTERNAL_RELEASE
 
         ((plResManager*)hsgResMgr::ResMgr())->SetProgressBarProc(IReadKeyedObjCallback);
@@ -1275,7 +1275,7 @@ void    plClient::IStopProgress()
     {
 #ifndef PLASMA_EXTERNAL_RELEASE
         if (plDispatchLogBase::IsLogging())
-            plDispatchLogBase::GetInstance()->LogStatusBarChange(fProgressBar->GetTitle().c_str(), "done");
+            plDispatchLogBase::GetInstance()->LogStatusBarChange(fProgressBar->GetTitle(), "done");
 #endif // PLASMA_EXTERNAL_RELEASE
 
         plDispatch::SetMsgRecieveCallback(nullptr);

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
@@ -210,7 +210,7 @@ plClientLauncher::plClientLauncher() :
     fInstallerThread(new plRedistUpdater()),
     fNetCoreState(kNetCoreInactive)
 {
-    pfPatcher::GetLog()->AddLine(plProduct::ProductString().c_str());
+    pfPatcher::GetLog()->AddLine(plProduct::ProductString());
 }
 
 plClientLauncher::~plClientLauncher() { }

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -615,9 +615,8 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
                 {
                     IAddLine( "" );     // add a blank line
                     PythonInterface::RunStringInteractive("import sys;print(f'Python {sys.version}')", nullptr);
-                    std::string output;
                     // get the messages
-                    PythonInterface::getOutputAndReset(&output);
+                    ST::string output = PythonInterface::getOutputAndReset();
                     AddLine( output.c_str() );
                     fPythonFirstTime = false;       // do this only once!
                 }
@@ -1024,9 +1023,8 @@ void    pfConsole::IExecuteWorkingLine()
                 // now evaluate this mess they made
                 PyObject* mymod = PythonInterface::FindModule("__main__");
                 PythonInterface::RunStringInteractive(biglines, mymod);
-                std::string output;
                 // get the messages
-                PythonInterface::getOutputAndReset(&output);
+                ST::string output = PythonInterface::getOutputAndReset();
                 AddLine(output.c_str());
                 // all done doing multi lines...
                 fPythonMultiLines = 0;
@@ -1044,9 +1042,8 @@ void    pfConsole::IExecuteWorkingLine()
                 {
                     PyObject* mymod = PythonInterface::FindModule("__main__");
                     PythonInterface::RunStringInteractive(fWorkingLine, mymod);
-                    std::string output;
                     // get the messages
-                    PythonInterface::getOutputAndReset(&output);
+                    ST::string output = PythonInterface::getOutputAndReset();
                     AddLine(output.c_str());
                 }
             } else {

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -6201,9 +6201,8 @@ PF_CONSOLE_CMD( Python,
 
     PythonInterface::RunFunctionSafe("xCheat", params[0], args.c_str());
 
-    std::string output;
     // get the messages
-    PythonInterface::getOutputAndReset(&output);
+    ST::string output = PythonInterface::getOutputAndReset();
     PrintString(output.c_str());
 }
 
@@ -6216,9 +6215,8 @@ PF_CONSOLE_CMD( Python,
     PyObject* mymod = PythonInterface::FindModule("__main__");
 
     PythonInterface::RunString("import xCheat;xc=[x for x in dir(xCheat) if not x.startswith('_')]\nfor i in range((len(xc)//4)+1): print(xc[i*4:(i*4)+4])\n",mymod);
-    std::string output;
     // get the messages
-    PythonInterface::getOutputAndReset(&output);
+    ST::string output = PythonInterface::getOutputAndReset();
     PrintString(output.c_str());
 }
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.cpp
@@ -80,7 +80,7 @@ void plDispatchLog::InitInstance()
     fInstance = &dispatchLog;
 }
 
-void plDispatchLog::LogStatusBarChange(const char* name, const char* action)
+void plDispatchLog::LogStatusBarChange(const ST::string& name, const char* action)
 {
     fLog->AddLineF("----- Status bar '{}' {} -----", name, action);
 
@@ -110,7 +110,7 @@ void plDispatchLog::LogStatusBarChange(const char* name, const char* action)
 #endif // HS_BUILD_FOR_WIN32
 }
 
-void plDispatchLog::LogLongReceive(const char* keyname, const char* className, uint32_t clonePlayerID, plMessage* msg, float ms)
+void plDispatchLog::LogLongReceive(const ST::string& keyname, const char* className, uint32_t clonePlayerID, plMessage* msg, float ms)
 {
     ST::string info;
     if (DumpSpecificMsgInfo(msg, info))

--- a/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.h
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.h
@@ -49,6 +49,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plMessage;
 class plStatusLog;
+namespace ST { class string; }
 
 class plDispatchLog : public plDispatchLogBase
 {
@@ -69,8 +70,8 @@ public:
     void RemoveFilterType(uint16_t type) override;
     void RemoveFilterExactType(uint16_t type) override;
 
-    void LogStatusBarChange(const char* name, const char* action) override;
-    void LogLongReceive(const char* keyname, const char* className, uint32_t clonePlayerID, plMessage* msg, float ms) override;
+    void LogStatusBarChange(const ST::string& name, const char* action) override;
+    void LogLongReceive(const ST::string& keyname, const char* className, uint32_t clonePlayerID, plMessage* msg, float ms) override;
 
     void DumpMsg(plMessage* msg, int numReceivers, int sendTimeMs, int32_t indent) override;
 };

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -1001,7 +1001,7 @@ PyObject* cyMisc::GetNPCCount()
 //
 // TEMP SCREEN PRINT CODE FOR NON-DBG TEXT DISPLAY
 //
-void cyMisc::PrintToScreen(const char* msg)
+void cyMisc::PrintToScreen(const ST::string& msg)
 {
     static plStatusLog* gStatusLog = nullptr;
     if (gStatusLog == nullptr)

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -104,7 +104,7 @@ public:
     // TEMP SCREEN PRINT CODE FOR NON-DBG TEXT DISPLAY
     //
 public:
-    static void PrintToScreen(const char* msg);
+    static void PrintToScreen(const ST::string& msg);
 #endif
 
     enum PythonDebugPrintLevels

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
@@ -123,8 +123,8 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtConsoleNet, args, "Params: command,netForce\nT
 // TEMP
 PYTHON_GLOBAL_METHOD_DEFINITION(PtPrintToScreen, args, "Params: message\nPrints 'message' to the status log, for debug only.")
 {
-    char* message;
-    if (!PyArg_ParseTuple(args, "s", &message))
+    ST::string message;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &message))
     {
         PyErr_SetString(PyExc_TypeError, "PtPrintToScreen expects a string");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -48,6 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 
 #include <functional>
+#include <string_theory/string>
 #include <string_theory/string_stream>
 
 #include <Python.h>
@@ -190,6 +191,7 @@ bool PythonInterface::requestedExit = false;
 #if defined(HAVE_CYPYTHONIDE) && !defined(PLASMA_EXTERNAL_RELEASE)
 // Special includes for debugging
 #include <string>
+#include <vector>
 #include <frameobject.h>
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -1280,7 +1280,7 @@ ST::string PythonInterface::getOutputAndReset()
         if (dbgOut != nullptr)
         {
             // then send it the new text
-            pyObjectRef retVal = plPython::CallObject(dbgOut, PyUnicode_FromSTString(strVal));
+            pyObjectRef retVal = plPython::CallObject(dbgOut, strVal);
             if (!retVal) {
                 // for some reason this function didn't, remember that and not call it again
                 dbgOut = nullptr;

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -48,6 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 
 #include <functional>
+#include <string_theory/string_stream>
 
 #include <Python.h>
 #include <marshal.h>
@@ -188,6 +189,7 @@ bool PythonInterface::requestedExit = false;
 
 #if defined(HAVE_CYPYTHONIDE) && !defined(PLASMA_EXTERNAL_RELEASE)
 // Special includes for debugging
+#include <string>
 #include <frameobject.h>
 
 /////////////////////////////////////////////////////////////////////////////
@@ -575,7 +577,7 @@ static int PythonTraceCallback(PyObject*, PyFrameObject* frame, int what, PyObje
 class pyOutputRedirector
 {
 private:
-    std::string fData;
+    ST::string_stream fData;
     static bool fTypeCreated;
 
 protected:
@@ -588,23 +590,17 @@ public:
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyOutputRedirector object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyOutputRedirector); // converts a PyObject to a pyOutputRedirector (throws error if not correct type)
 
-    void Write(const std::string& data) {fData += data;}
-    void Write(const std::wstring& data)
-    {
-        char* strData = hsWStringToString(data.c_str());
-        Write(strData);
-        delete [] strData;
-    }
+    void Write(const ST::string& data) {fData << data;}
 
     // accessor functions for the PyObject*
 
     // returns the current data stored
-    static std::string GetData(PyObject *redirector)
+    static ST::string GetData(PyObject *redirector)
     {
         if (!pyOutputRedirector::Check(redirector))
-            return ""; // it's not a redirector object
+            return {}; // it's not a redirector object
         pyOutputRedirector *obj = pyOutputRedirector::ConvertFrom(redirector);
-        return obj->fData;
+        return obj->fData.to_string();
     }
 
     // clears the internal buffer out
@@ -613,7 +609,7 @@ public:
         if (!pyOutputRedirector::Check(redirector))
             return; // it's not a redirector object
         pyOutputRedirector *obj = pyOutputRedirector::ConvertFrom(redirector);
-        obj->fData = "";
+        obj->fData.erase(SIZE_MAX);
     }
 };
 
@@ -632,21 +628,14 @@ PYTHON_INIT_DEFINITION(ptOutputRedirector, args, keywords)
 
 PYTHON_METHOD_DEFINITION(ptOutputRedirector, write, args)
 {
-    PyObject* textObj;
-    if (!PyArg_ParseTuple(args, "O", &textObj))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "write expects a string or unicode string");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* text = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->Write(text);
-        PyMem_Free(text);
-        PYTHON_RETURN_NONE;
-    }
-    PyErr_SetString(PyExc_TypeError, "write expects a string or unicode string");
-    PYTHON_RETURN_ERROR;
+    self->fThis->Write(text);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_START_METHODS_TABLE(ptOutputRedirector)
@@ -681,7 +670,7 @@ class pyErrorRedirector
 private:
     static bool fTypeCreated;
 
-    std::string fData;
+    ST::string_stream fData;
     bool        fLog;
 
 protected:
@@ -699,7 +688,7 @@ public:
         fLog = log;
     }
 
-    void Write(const std::string& data)
+    void Write(const ST::string& data)
     {
         PyObject* stdOut = PythonInterface::GetStdOut();
 
@@ -710,14 +699,7 @@ public:
         }
 
         if (fLog)
-            fData += data;
-    }
-
-    void Write(const std::wstring& data)
-    {
-        char* strData = hsWStringToString(data.c_str());
-        Write(strData);
-        delete [] strData;
+            fData << data;
     }
 
     void ExceptHook(PyObject* except, PyObject* val, PyObject* tb)
@@ -725,12 +707,11 @@ public:
         PyErr_Display(except, val, tb);
 
         // Send to the log server
-        ST::utf16_buffer wdata = ST::utf8_to_utf16(fData.c_str(), fData.size(),
-                                                   ST::substitute_invalid);
+        ST::utf16_buffer wdata = fData.to_string().to_utf16();
         NetCliAuthLogPythonTraceback(wdata.data());
 
         if (fLog)
-            fData.clear();
+            fData.erase(SIZE_MAX);
     }
 };
 
@@ -749,21 +730,14 @@ PYTHON_INIT_DEFINITION(ptErrorRedirector, args, keywords)
 
 PYTHON_METHOD_DEFINITION(ptErrorRedirector, write, args)
 {
-    PyObject* textObj;
-    if (!PyArg_ParseTuple(args, "O", &textObj))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "write expects a string or unicode string");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* text = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->Write(text);
-        PyMem_Free(text);
-        PYTHON_RETURN_NONE;
-    }
-    PyErr_SetString(PyExc_TypeError, "write expects a string or unicode string");
-    PYTHON_RETURN_ERROR;
+    self->fThis->Write(text);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION(ptErrorRedirector, excepthook, args)
@@ -1284,13 +1258,12 @@ PyObject* PythonInterface::GetStdErr()
 //
 //  PURPOSE    : get the Output to the error file to be displayed
 //
-int PythonInterface::getOutputAndReset(std::string *output)
+ST::string PythonInterface::getOutputAndReset()
 {
     if (stdOut != nullptr)
     {
-        std::string strVal = pyOutputRedirector::GetData(stdOut);
-        int size = strVal.length();
-        dbgLog->AddLine(strVal.c_str());
+        ST::string strVal = pyOutputRedirector::GetData(stdOut);
+        dbgLog->AddLine(strVal);
 
         // reset the file back to zero
         pyOutputRedirector::ClearData(stdOut);
@@ -1305,7 +1278,7 @@ int PythonInterface::getOutputAndReset(std::string *output)
         if (dbgOut != nullptr)
         {
             // then send it the new text
-            pyObjectRef retVal = plPython::CallObject(dbgOut, PyUnicode_FromStdString(strVal));
+            pyObjectRef retVal = plPython::CallObject(dbgOut, PyUnicode_FromSTString(strVal));
             if (!retVal) {
                 // for some reason this function didn't, remember that and not call it again
                 dbgOut = nullptr;
@@ -1315,11 +1288,9 @@ int PythonInterface::getOutputAndReset(std::string *output)
             }
         }
 
-        if (output)
-            (*output) = strVal;
-        return size;
+        return strVal;
     }
-    return 0;
+    return {};
 }
 
 void PythonInterface::WriteToLog(const ST::string& text)
@@ -1327,7 +1298,7 @@ void PythonInterface::WriteToLog(const ST::string& text)
     dbgLog->AddLine(text);
 }
 
-void PythonInterface::WriteToStdErr(const char* text)
+void PythonInterface::WriteToStdErr(const ST::string& text)
 {
     PyObject* stdErr = PythonInterface::GetStdErr();
     if (stdErr && pyErrorRedirector::Check(stdErr))

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
@@ -50,9 +50,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // NOTE: Eventually, this will be made into a separate dll, because there should
 //       only be one instance of this interface. 
 //
-#include "HeadSpin.h"
-#include <string_theory/string>
-#include <vector>
 
 #if defined(HAVE_CYPYTHONIDE) && !defined(PLASMA_EXTERNAL_RELEASE)
 #include "../../Apps/CyPythonIDE/plCyDebug/plCyDebServer.h"
@@ -62,6 +59,7 @@ class plStatusLog;
 class pyKey;
 typedef struct _object PyObject;
 typedef struct PyMethodDef PyMethodDef;
+namespace ST { class string; }
 
 class  PythonInterface
 {

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
@@ -52,7 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 #include "HeadSpin.h"
 #include <string_theory/string>
-#include <string>
 #include <vector>
 
 #if defined(HAVE_CYPYTHONIDE) && !defined(PLASMA_EXTERNAL_RELEASE)
@@ -130,13 +129,13 @@ public:
     static PyObject* GetStdErr();
 
     // get the Output to the error file to be displayed
-    static int getOutputAndReset(std::string* output = nullptr);
+    static ST::string getOutputAndReset();
 
     // Writes 'text' to the Python log
     static void WriteToLog(const ST::string& text);
 
     // Writes 'text' to stderr specified in the python interface
-    static void WriteToStdErr(const char* text);
+    static void WriteToStdErr(const ST::string& text);
 
     static PyObject* ImportModule(const char* module);
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonConvert.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonConvert.h
@@ -108,6 +108,16 @@ namespace plPython
         return PyLong_FromLongLong(value);
     }
 
+    inline PyObject* ConvertFrom(const ST::string& value)
+    {
+        return PyUnicode_FromSTString(value);
+    }
+
+    inline PyObject* ConvertFrom(ST::string& value)
+    {
+        return PyUnicode_FromSTString(value);
+    }
+
     inline PyObject* ConvertFrom(ST::string&& value)
     {
         return PyUnicode_FromSTString(value);

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -1673,7 +1673,7 @@ void plPythonFileMod::ReportError()
     ST::string objectName = this->GetKeyName();
     objectName += " - ";
 
-    PythonInterface::WriteToStdErr(objectName.c_str());
+    PythonInterface::WriteToStdErr(objectName);
 
     PyErr_Print();      // make sure the error is printed
     PyErr_Clear();      // clear the error
@@ -1699,9 +1699,9 @@ void plPythonFileMod::DisplayPythonOutput()
 //
 //  PURPOSE    : get the Output to the error file to be displayed
 //
-int  plPythonFileMod::getPythonOutput(std::string* line)
+ST::string plPythonFileMod::getPythonOutput()
 {
-     return PythonInterface::getOutputAndReset(line);
+     return PythonInterface::getOutputAndReset();
 }
 
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.h
@@ -214,7 +214,7 @@ public:
     bool WasLocalNotify() const { return fLocalNotify; }
     plPipeline* GetPipeline() const { return fPipe; }
     void SetSourceFile(const ST::string& filename) { fPythonFile = filename; }
-    int getPythonOutput(std::string* line);
+    ST::string getPythonOutput();
     void ReportError();
     void DisplayPythonOutput();
     static void SetAtConvertTime() { fAtConvertTime = true; }

--- a/Sources/Plasma/NucleusLib/pnDispatch/plDispatchLogBase.h
+++ b/Sources/Plasma/NucleusLib/pnDispatch/plDispatchLogBase.h
@@ -49,6 +49,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 class plMessage;
 class plReceiver;
+namespace ST { class string; }
 
 class plDispatchLogBase
 {
@@ -80,8 +81,8 @@ public:
     virtual void RemoveFilterType(uint16_t type)=0;
     virtual void RemoveFilterExactType(uint16_t type)=0;
 
-    virtual void LogStatusBarChange(const char* name, const char* action)=0;
-    virtual void LogLongReceive(const char* keyname, const char* className, uint32_t clonePlayerID, plMessage* msg, float ms)=0;
+    virtual void LogStatusBarChange(const ST::string& name, const char* action)=0;
+    virtual void LogLongReceive(const ST::string& keyname, const char* className, uint32_t clonePlayerID, plMessage* msg, float ms)=0;
 
     virtual void DumpMsg(plMessage* msg, int numReceivers, int sendTime, int32_t indent)=0;
 };

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
@@ -98,7 +98,7 @@ plSound::~plSound()
     plProfile_Dec(SoundNumLoaded);
 }
 
-void plSound::IPrintDbgMessage( const char *msg, bool isError )
+void plSound::IPrintDbgMessage( const ST::string& msg, bool isError )
 {
     ST::string keyName = GetKey() ? GetKeyName() : ST_LITERAL("unkeyed");
     if( isError )

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.h
@@ -73,6 +73,7 @@ class plGraphPlate;
 struct hsMatrix44;
 class plSceneObject;
 class plSoundVolumeApplicator;
+namespace ST { class string; }
 
 // Set this to 1 to do our own distance attenuation (model doesn't work yet tho)
 #define MCN_HACK_OUR_ATTEN  0
@@ -340,7 +341,7 @@ protected:
     bool                fLoading;
 
     void            IUpdateDebugPlate();
-    void            IPrintDbgMessage( const char *msg, bool isErr = false );
+    void            IPrintDbgMessage( const ST::string& msg, bool isErr = false );
 
     virtual void    ISetActualVolume(float v) = 0;
     virtual void    IActuallyStop();

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32GroupedSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32GroupedSound.cpp
@@ -145,7 +145,7 @@ bool    plWin32GroupedSound::LoadSound( bool is3D )
     if( retVal == plSoundBuffer::kError) 
     {
         ST::string str = ST::format("Unable to open .wav file {}", fDataBufferKey ? fDataBufferKey->GetName() : "nil");
-        IPrintDbgMessage( str.c_str(), true );
+        IPrintDbgMessage(str, true);
         fFailed = true;
         return false;
     }
@@ -197,7 +197,7 @@ bool    plWin32GroupedSound::LoadSound( bool is3D )
         ST::string str = ST::format("Can't create sound buffer for {}.wav. This could happen if the wav file is a stereo file."
                                     " Stereo files are not supported on 3D sounds. If the file is not stereo then please report this error.",
                                     GetFileName());
-        IPrintDbgMessage(str.c_str(), true);
+        IPrintDbgMessage(str, true);
         fFailed = true;
 
         delete fDSoundBuffer;
@@ -221,7 +221,7 @@ bool    plWin32GroupedSound::LoadSound( bool is3D )
 #else
                             0);
 #endif
-    IPrintDbgMessage( str.c_str() );
+    IPrintDbgMessage(str);
     if (GetKey() != nullptr && GetKeyName().contains("Footstep"))
         ;
     else

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StaticSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StaticSound.cpp
@@ -113,7 +113,7 @@ bool plWin32StaticSound::LoadSound( bool is3D )
         if( retVal == plSoundBuffer::kError )
         {
             ST::string str = ST::format("Unable to open .wav file {}", fDataBufferKey ? fDataBufferKey->GetName() : "nil");
-            IPrintDbgMessage( str.c_str(), true );
+            IPrintDbgMessage(str, true);
             fFailed = true;
             return false;
         }
@@ -152,7 +152,7 @@ bool plWin32StaticSound::LoadSound( bool is3D )
             ST::string str = ST::format("Can't create sound buffer for {}.wav. This could happen if the wav file is a stereo file."
                                         " Stereo files are not supported on 3D sounds. If the file is not stereo then please report this error.",
                                         GetFileName());
-            IPrintDbgMessage(str.c_str(), true);
+            IPrintDbgMessage(str, true);
             fFailed = true;
 
             delete fDSoundBuffer;

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StreamingSound.cpp
@@ -185,7 +185,7 @@ plSoundBuffer::ELoadReturnVal plWin32StreamingSound::IPreLoadBuffer( bool playWh
             return plSoundBuffer::kError;
         }
 
-        IPrintDbgMessage(ST::format("   Readied file {} for streaming", fSrcFilename).c_str());
+        IPrintDbgMessage(ST::format("   Readied file {} for streaming", fSrcFilename));
 
         // dont free sound data until we have a chance to use it in load sound
 
@@ -243,7 +243,7 @@ bool plWin32StreamingSound::LoadSound( bool is3D )
     {
         ST::string str = ST::format("Unable to open streaming source {}",
                                     fDataBufferKey->GetName());
-        IPrintDbgMessage( str.c_str(), true );
+        IPrintDbgMessage(str, true);
         fFailed = true;
         return false;
     }
@@ -284,7 +284,7 @@ bool plWin32StreamingSound::LoadSound( bool is3D )
         ST::string str = ST::format("Can't create sound buffer for {}.wav. This could happen if the wav file is a stereo file."
                                     " Stereo files are not supported on 3D sounds. If the file is not stereo then please report this error.",
                                     GetFileName());
-        IPrintDbgMessage(str.c_str(), true);
+        IPrintDbgMessage(str, true);
         fFailed = true;
         return false;
     }
@@ -337,7 +337,7 @@ bool plWin32StreamingSound::LoadSound( bool is3D )
 
     // Debug info
     ST::string dbg = ST::format("   Streaming {}.", fSrcFilename);
-    IPrintDbgMessage(dbg.c_str());
+    IPrintDbgMessage(dbg);
 
     plStatusLog::AddLineSF("audioTimes.log", 0xffffffff, "Streaming {4.2f} secs of {}",
                            fDataStream->GetLengthInSecs(), GetKey()->GetUoid().GetObjectName() );

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvTaskSeek.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvTaskSeek.cpp
@@ -601,7 +601,7 @@ void plAvTaskSeek::DumpDebug(const char *name, int &x, int&y, int lineHeight, pl
 void plAvTaskSeek::DumpToAvatarLog(plArmatureMod *avatar)
 {
     plStatusLog *log = plAvatarMgr::GetInstance()->GetLog();
-    log->AddLine(avatar->GetMoveKeyString().c_str());
+    log->AddLine(avatar->GetMoveKeyString());
 
     log->AddLine(ST::format("    duration: {.2f} pos: ({.3f}, {.3f}, {.3f}) goalPos: ({.3f}, {.3f}, {.3f}) ",
             hsTimer::GetSysSeconds() - fStartTime,

--- a/Sources/Plasma/PubUtilLib/plPipeline/plStatusLogDrawer.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plStatusLogDrawer.cpp
@@ -120,8 +120,7 @@ void    plStatusLogDrawer::Draw(plStatusLog* curLog, plStatusLog* firstLog)
     y += lineHt * 2;
     for( i = 0; i < IGetMaxNumLines( curLog ); i++ )
     {
-        if (IGetLines(curLog)[i] != nullptr)
-            drawText.DrawString( x + 4, y, IGetLines( curLog )[ i ], IGetColors( curLog )[ i ] );
+        drawText.DrawString( x + 4, y, IGetLines( curLog )[ i ], IGetColors( curLog )[ i ] );
         y += lineHt;
     }
 

--- a/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
@@ -354,7 +354,7 @@ bool plAutoProfileImp::MsgReceive(plMessage* msg)
                 ms);
 
             plStatusLog::AddLineSF("agetimings.log", "Age {} took {.1f} ms",
-                fAges[fNextAge-1].c_str(),
+                fAges[fNextAge-1],
                 ms);
         }
 

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
@@ -533,19 +533,19 @@ bool plStatusLog::IPrintLineToFile(const ST::string& line)
         {
             if ( fFlags & kTimestamp )
             {
-                buf << "(" << plUnifiedTime(kNow).Format("%m/%d %H:%M:%S") << ") ";
+                buf << '(' << plUnifiedTime(kNow).Format("%m/%d %H:%M:%S") << ") ";
             }
             if ( fFlags & kTimestampGMT )
             {
-                buf << "(" << plUnifiedTime::GetCurrent().Format("%m/%d %H:%M:%S UTC") << ") ";
+                buf << '(' << plUnifiedTime::GetCurrent().Format("%m/%d %H:%M:%S UTC") << ") ";
             }
             if ( fFlags & kTimeInSeconds )
             {
-                buf << "(" << plUnifiedTime(kNow).GetSecs() << ") ";
+                buf << '(' << plUnifiedTime(kNow).GetSecs() << ") ";
             }
             if ( fFlags & kTimeAsDouble )
             {
-                buf << "(" << plUnifiedTime(kNow).GetSecsDouble() << ") ";
+                buf << '(' << plUnifiedTime(kNow).GetSecsDouble() << ") ";
             }
             if (fFlags & kRawTimeStamp)
             {

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
@@ -629,7 +629,8 @@ bool plStatusLog::IPrintLineToFile( const char *line, uint32_t count )
 
 #if HS_BUILD_FOR_WIN32
 #ifndef PLASMA_EXTERNAL_RELEASE
-        OutputDebugString(out_str.c_str());
+        ST::wchar_buffer buf = out_str.to_wchar();
+        OutputDebugStringW(buf.c_str());
 #endif
 #else
         fputs(out_str.c_str(), stderr);

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
@@ -554,14 +554,6 @@ bool plStatusLog::IPrintLineToFile( const char *line, uint32_t count )
     if( fFlags & kDontWriteFile )
         return true;
 
-#ifdef PLASMA_EXTERNAL_RELEASE
-    uint8_t hint = 0;
-    if( fFlags & kAppendToLast )
-    {
-        hint = (uint8_t)fSize;
-    }
-#endif
-
     if (!fFileHandle)
         IReOpen();
 
@@ -572,7 +564,7 @@ bool plStatusLog::IPrintLineToFile( const char *line, uint32_t count )
         char work[256];
         ST::string_stream buf;
 
-        //build line to encrypt
+        //build line to write to log file
 
         if( count != 0 )
         {

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.h
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.h
@@ -86,7 +86,7 @@ class plStatusLog : public plLog
 
         uint32_t     fMaxNumLines;
         plFileName   fFilename;
-        char**       fLines;
+        ST::string*  fLines;
         uint32_t*    fColors;
         hsGlobalSemaphore* fSema;
         FILE*        fFileHandle;
@@ -300,7 +300,7 @@ class plStatusLogDrawerStub
     protected:
 
         uint32_t      IGetMaxNumLines( plStatusLog *log ) const { return log->fMaxNumLines; }
-        char        **IGetLines( plStatusLog *log ) const { return log->fLines; }
+        const ST::string* IGetLines( plStatusLog *log ) const { return log->fLines; }
         plFileName    IGetFilename( plStatusLog *log ) const { return log->GetFileName(); }
         uint32_t     *IGetColors( plStatusLog *log ) const { return log->fColors; }
         uint32_t      IGetFlags( plStatusLog *log ) const { return log->fFlags; }

--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.h
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.h
@@ -100,8 +100,8 @@ class plStatusLog : public plLog
         void    IUnlink();
         void    ILink( plStatusLog **back );
 
-        bool    IAddLine( const char *line, int32_t count, uint32_t color );
-        bool    IPrintLineToFile( const char *line, uint32_t count );
+        bool    IAddLine(const ST::string& line, uint32_t color);
+        bool    IPrintLineToFile(const ST::string& line);
         void    IParseFileName(plFileName &fileNoExt, ST::string &ext) const;
         static plStatusLog* IFindLog(const plFileName& filename);
 
@@ -160,10 +160,10 @@ class plStatusLog : public plLog
 
         ~plStatusLog();
 
-        bool AddLine(uint32_t color, const char* line);
-        bool AddLine(const char* line) { return AddLine(kWhite, line); }
-        bool AddLine(uint32_t color, const ST::string& line) { return AddLine(color, line.c_str()); }
-        bool AddLine(const ST::string& line) override { return AddLine(line.c_str()); }
+        bool AddLine(uint32_t color, const char* line) { return AddLine(color, ST::string(line)); };
+        bool AddLine(const char* line) { return AddLine(kWhite, ST::string(line)); }
+        bool AddLine(uint32_t color, const ST::string& line);
+        bool AddLine(const ST::string& line) override { return AddLine(kWhite, line); }
 
         template<typename... _Args>
         bool AddLineF(const char* format, _Args&&... args)

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -1459,7 +1459,7 @@ void RelVaultNode::Print (const ST::string& tag, unsigned level) {
 #undef STNAME
     }
 
-    plStatusLog::AddLineS("VaultClient.log", ss.to_string().c_str());
+    plStatusLog::AddLineS("VaultClient.log", ss.to_string());
 }
 
 //============================================================================
@@ -3365,12 +3365,12 @@ bool VaultSetCCRStatus (bool online) {
 
 //============================================================================
 void VaultDump (const ST::string& tag, unsigned vaultId) {
-    plStatusLog::AddLineS("VaultClient.log", ST::format("<---- ID:{}, Begin Vault {} ---->", vaultId, tag).c_str());
+    plStatusLog::AddLineSF("VaultClient.log", "<---- ID:{}, Begin Vault {} ---->", vaultId, tag);
 
     if (hsRef<RelVaultNode> rvn = VaultGetNode(vaultId))
         rvn->PrintTree(0);
 
-    plStatusLog::AddLineS("VaultClient.log", ST::format("<---- ID:{}, End Vault {} ---->", vaultId, tag).c_str());
+    plStatusLog::AddLineSF("VaultClient.log", "<---- ID:{}, End Vault {} ---->", vaultId, tag);
 }
 
 //============================================================================


### PR DESCRIPTION
This migrates `plStatusLog` and some related code to `ST::string` and makes the following improvements to Unicode support in logging:

* The Python stdout/stderr handler now supports full Unicode, not just the ANSI code page.
* Non-ASCII characters in Python stdout/stderr were badly mis-encoded before. They are now output correctly everywhere that supports Unicode (i. e. except in the in-game console and log drawer).
* When `plStatusLog` calls `OutputDebugString`, it now supports full Unicode and no longer mis-decodes non-ASCII characters.
* `plStatusLogDrawer`'s internal line buffer now supports Unicode (even though the rendering code is still ASCII-only).