### PR TITLE
Migrate remainder of pfGameGUIMgr to `ST::string`

### DIFF
--- a/Sources/Plasma/FeatureLib/pfCharacter/pfConfirmationMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfCharacter/pfConfirmationMgr.cpp
@@ -352,7 +352,7 @@ void pfConfirmationMgr::ILoadDialog()
         fProc->OnInit();
     } else {
         fState = State::WaitingForDialogLoad;
-        gui->LoadDialog("KIYesNo"_st, GetKey(), "GUI");
+        gui->LoadDialog("KIYesNo"_st, GetKey());
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfGameConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfGameConsoleCommands.cpp
@@ -195,16 +195,16 @@ PF_CONSOLE_CMD( Game_GUI, SetDynamicCtrlColor, "float bgRed, float bgGreen, floa
 
 PF_CONSOLE_CMD( Game_GUI, CreateRectButton, "string title, float x, float y, float width, float height, string command", "" )
 {
-    pfGUICtrlGenerator::Instance().GenerateRectButton( params[ 0 ], params[ 1 ], params[ 2 ],
+    pfGUICtrlGenerator::Instance().GenerateRectButton( ST::string(params[0]), params[ 1 ], params[ 2 ],
                                             params[ 3 ], params[ 4 ], 
-                                            params[ 5 ], 
+                                            ST::string(params[5]), 
                                             sDynCtrlColor, sDynCtrlTextColor );
 }
 
 PF_CONSOLE_CMD( Game_GUI, CreateRoundButton, "float x, float y, float radius, string command", "" )
 {
     pfGUICtrlGenerator::Instance().GenerateSphereButton( params[ 0 ], params[ 1 ], params[ 2 ], 
-                                            params[ 3 ], 
+                                            ST::string(params[3]), 
                                             sDynCtrlColor );
 }
 
@@ -215,7 +215,7 @@ PF_CONSOLE_CMD( Game_GUI, CreateDragBar, "float x, float y, float width, float h
 
 PF_CONSOLE_CMD( Game_GUI, CreateDialog, "string name", "" )
 {
-    pfGUICtrlGenerator::Instance().GenerateDialog( params[ 0 ] );
+    pfGUICtrlGenerator::Instance().GenerateDialog(ST::string(params[0]));
 }
 
 PF_CONSOLE_CMD(Game_GUI, Confirm, "int type", "Shows a sample confirmation dialog")

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.cpp
@@ -284,7 +284,7 @@ pfGUIButtonMod  *pfGUICtrlGenerator::GenerateRectButton( const char *title, floa
     // Get us a material
     material = ICreateTextMaterial( title, color, textColor, width * 20.f, height * 20.f );
 
-    pfGUIButtonMod *but = CreateRectButton( dlgToAddTo, title, x, y, width, height, material );
+    pfGUIButtonMod *but = CreateRectButton(dlgToAddTo, x, y, width, height, material);
     if (but != nullptr)
         but->SetHandler( new pfGUIConsoleCmdProc( consoleCmd ) );
 
@@ -293,16 +293,7 @@ pfGUIButtonMod  *pfGUICtrlGenerator::GenerateRectButton( const char *title, floa
 
 //// CreateRectButton ////////////////////////////////////////////////////////
 
-pfGUIButtonMod  *pfGUICtrlGenerator::CreateRectButton( pfGUIDialogMod *parent, const char *title, float x, float y, float width, float height,
-                                    hsGMaterial *material, bool asMenuItem )
-{
-    wchar_t *wTitle = hsStringToWString(title);
-    pfGUIButtonMod *retVal = CreateRectButton(parent,wTitle,x,y,width,height,material,asMenuItem);
-    delete [] wTitle;
-    return retVal;
-}
-
-pfGUIButtonMod  *pfGUICtrlGenerator::CreateRectButton( pfGUIDialogMod *parent, const wchar_t *title, float x, float y, float width, float height,
+pfGUIButtonMod  *pfGUICtrlGenerator::CreateRectButton( pfGUIDialogMod *parent, float x, float y, float width, float height,
                                     hsGMaterial *material, bool asMenuItem )
 {
     plDrawableSpans *myDraw;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.cpp
@@ -123,7 +123,7 @@ pfGUICtrlGenerator  &pfGUICtrlGenerator::Instance()
 
 //// IGetNextKeyName /////////////////////////////////////////////////////////
 
-ST::string pfGUICtrlGenerator::IGetNextKeyName( const char *prefix )
+ST::string pfGUICtrlGenerator::IGetNextKeyName(const ST::string& prefix)
 {
     static uint32_t keyCount = 0;
 
@@ -132,7 +132,7 @@ ST::string pfGUICtrlGenerator::IGetNextKeyName( const char *prefix )
 
 //// IAddKey /////////////////////////////////////////////////////////////////
 
-plKey pfGUICtrlGenerator::IAddKey( hsKeyedObject *ko, const char *prefix )
+plKey pfGUICtrlGenerator::IAddKey(hsKeyedObject *ko, const ST::string& prefix)
 {
     ST::string keyName;
 
@@ -158,7 +158,7 @@ hsGMaterial *pfGUICtrlGenerator::ICreateSolidMaterial( hsColorRGBA &color )
 
     // Create a material with a simple blank layer, fully ambient
     hsGMaterial *material = new hsGMaterial;
-    IAddKey( material, "GUIMaterial" );
+    IAddKey(material, ST_LITERAL("GUIMaterial"));
 
     plLayer *lay = material->MakeBaseLayer();
     black.Set( 0.f,0.f,0.f,1.f );
@@ -173,7 +173,7 @@ hsGMaterial *pfGUICtrlGenerator::ICreateSolidMaterial( hsColorRGBA &color )
 //// ICreateTextMaterial /////////////////////////////////////////////////////
 //  Creates a material with a texture that has a string centered on it.
 
-hsGMaterial *pfGUICtrlGenerator::ICreateTextMaterial( const char *text, hsColorRGBA &bgColor, 
+hsGMaterial *pfGUICtrlGenerator::ICreateTextMaterial( const ST::string& text, hsColorRGBA &bgColor, 
                                                      hsColorRGBA &textColor, float objWidth, float objHeight )
 {
     uint16_t          pixWidth, pixHeight, strWidth, strHeight;
@@ -187,21 +187,22 @@ hsGMaterial *pfGUICtrlGenerator::ICreateTextMaterial( const char *text, hsColorR
 
     // Create blank mipmap
     plMipmap *bitmap = new plMipmap( 1, 1, plMipmap::kRGB32Config, 1 );
-    IAddKey( bitmap, "GUIMipmap" );
+    IAddKey(bitmap, ST_LITERAL("GUIMipmap"));
 
     // Create textGen to write string with
     plTextGenerator *textGen = new plTextGenerator( bitmap, pixWidth, pixHeight );
     textGen->SetFont( fFontFace, (uint16_t)fFontSize );
     textGen->ClearToColor( bgColor );
     textGen->SetTextColor( textColor );
-    strWidth = textGen->CalcStringWidth( text, &strHeight );
-    textGen->DrawString( ( pixWidth - strWidth ) >> 1, ( pixHeight - strHeight ) >> 1, text );
+    ST::wchar_buffer textBuf = text.to_wchar();
+    strWidth = textGen->CalcStringWidth(textBuf.c_str(), &strHeight);
+    textGen->DrawString((pixWidth - strWidth) >> 1, (pixHeight - strHeight) >> 1, textBuf.c_str());
     textGen->FlushToHost();
     fTextGens.emplace_back(textGen);
 
     // Create a material with a simple blank layer, fully ambient
     hsGMaterial *material = new hsGMaterial;
-    IAddKey( material, "GUIMaterial" );
+    IAddKey(material, ST_LITERAL("GUIMaterial"));
 
     plLayer *lay = material->MakeBaseLayer();
     white.Set( 1.f,1.f,1.f,1.f );
@@ -220,9 +221,9 @@ hsGMaterial *pfGUICtrlGenerator::ICreateTextMaterial( const char *text, hsColorR
 
 //// GenerateDialog //////////////////////////////////////////////////////////
 
-void    pfGUICtrlGenerator::GenerateDialog( const char *name )
+void    pfGUICtrlGenerator::GenerateDialog(ST::string name)
 {
-    IGenerateDialog( name, 20.f, false );
+    IGenerateDialog(std::move(name), 20.f, false);
 }
 
 //// IGenSceneObject /////////////////////////////////////////////////////////
@@ -237,13 +238,13 @@ plSceneObject   *pfGUICtrlGenerator::IGenSceneObject( pfGUIDialogMod *dlg, plDra
     hsgResMgr::ResMgr()->SendRef( myDraw->GetKey(), new plNodeRefMsg( snKey, plRefMsg::kOnCreate, 0, plNodeRefMsg::kDrawable ), plRefFlags::kActiveRef );       
 
     plDrawInterface *newDI = new plDrawInterface;
-    IAddKey( newDI, "GUIDrawIFace" );
+    IAddKey(newDI, ST_LITERAL("GUIDrawIFace"));
 
     plSceneObject   *newObj = new plSceneObject;
-    IAddKey( newObj, "GUISceneObject" );
+    IAddKey(newObj, ST_LITERAL("GUISceneObject"));
 
     plCoordinateInterface *newCI = new plCoordinateInterface;
-    IAddKey( newCI, "GUICoordIFace" );
+    IAddKey(newCI, ST_LITERAL("GUICoordIFace"));
 
     hsgResMgr::ResMgr()->SendRef( newCI->GetKey(), new plObjRefMsg( newObj->GetKey(), plRefMsg::kOnCreate, 0, plObjRefMsg::kInterface ), plRefFlags::kActiveRef );
     hsgResMgr::ResMgr()->SendRef( newDI->GetKey(), new plObjRefMsg( newObj->GetKey(), plRefMsg::kOnCreate, 0, plObjRefMsg::kInterface ), plRefFlags::kActiveRef );
@@ -274,8 +275,8 @@ plSceneObject   *pfGUICtrlGenerator::IGenSceneObject( pfGUIDialogMod *dlg, plDra
 
 //// GenerateRectButton //////////////////////////////////////////////////////
 
-pfGUIButtonMod  *pfGUICtrlGenerator::GenerateRectButton( const char *title, float x, float y, float width, float height,
-                                    const char *consoleCmd, hsColorRGBA &color, hsColorRGBA &textColor )
+pfGUIButtonMod  *pfGUICtrlGenerator::GenerateRectButton( const ST::string& title, float x, float y, float width, float height,
+                                    ST::string consoleCmd, hsColorRGBA &color, hsColorRGBA &textColor )
 {
     hsGMaterial     *material;
     pfGUIDialogMod  *dlgToAddTo = IGetDialog();
@@ -286,7 +287,7 @@ pfGUIButtonMod  *pfGUICtrlGenerator::GenerateRectButton( const char *title, floa
 
     pfGUIButtonMod *but = CreateRectButton(dlgToAddTo, x, y, width, height, material);
     if (but != nullptr)
-        but->SetHandler( new pfGUIConsoleCmdProc( consoleCmd ) );
+        but->SetHandler(new pfGUIConsoleCmdProc(std::move(consoleCmd)));
 
     return but;
 }
@@ -319,7 +320,7 @@ pfGUIButtonMod  *pfGUICtrlGenerator::CreateRectButton( pfGUIDialogMod *parent, f
     plSceneObject *newObj = IGenSceneObject( parent, myDraw );
 
     pfGUIButtonMod *newBtn = asMenuItem ? new pfGUIMenuItem : new pfGUIButtonMod;
-    IAddKey( newBtn, "GUIButton" );
+    IAddKey(newBtn, ST_LITERAL("GUIButton"));
     hsgResMgr::ResMgr()->SendRef( newBtn->GetKey(), new plObjRefMsg( newObj->GetKey(), plRefMsg::kOnCreate, 0, plObjRefMsg::kModifier ), plRefFlags::kActiveRef );
     parent->AddControl( newBtn );
     hsgResMgr::ResMgr()->AddViaNotify( newBtn->GetKey(), new plGenRefMsg( parent->GetKey(), plRefMsg::kOnCreate, parent->GetNumControls() - 1, pfGUIDialogMod::kControlRef ), plRefFlags::kActiveRef );
@@ -330,7 +331,7 @@ pfGUIButtonMod  *pfGUICtrlGenerator::CreateRectButton( pfGUIDialogMod *parent, f
 //// GenerateSphereButton ////////////////////////////////////////////////////
 
 pfGUIButtonMod  *pfGUICtrlGenerator::GenerateSphereButton( float x, float y, float radius,
-                                                            const char *consoleCmd, hsColorRGBA &color )
+                                                            ST::string consoleCmd, hsColorRGBA &color )
 {
     hsGMaterial     *material;
     plDrawableSpans *myDraw;
@@ -363,8 +364,8 @@ pfGUIButtonMod  *pfGUICtrlGenerator::GenerateSphereButton( float x, float y, flo
     plSceneObject *newObj = IGenSceneObject(dlgToAddTo, myDraw);//, nullptr, &l2w, &w2l);
 
     pfGUIButtonMod *newBtn = new pfGUIButtonMod;
-    IAddKey( newBtn, "GUIButton" );
-    newBtn->SetHandler( new pfGUIConsoleCmdProc( consoleCmd ) );
+    IAddKey(newBtn, ST_LITERAL("GUIButton"));
+    newBtn->SetHandler(new pfGUIConsoleCmdProc(std::move(consoleCmd)));
     hsgResMgr::ResMgr()->AddViaNotify( newBtn->GetKey(), new plObjRefMsg( newObj->GetKey(), plRefMsg::kOnCreate, 0, plObjRefMsg::kModifier ), plRefFlags::kActiveRef );
     dlgToAddTo->AddControl( newBtn );
 
@@ -411,7 +412,7 @@ pfGUIDragBarCtrl *pfGUICtrlGenerator::GenerateDragBar( float x, float y, float w
     fDynDragBars.back() = newObj;
 
     pfGUIDragBarCtrl *newBtn = new pfGUIDragBarCtrl;
-    IAddKey( newBtn, "GUIDragBar" );
+    IAddKey(newBtn, ST_LITERAL("GUIDragBar"));
     hsgResMgr::ResMgr()->AddViaNotify( newBtn->GetKey(), new plObjRefMsg( newObj->GetKey(), plRefMsg::kOnCreate, 0, plObjRefMsg::kModifier ), plRefFlags::kActiveRef );
     dlgToAddTo->AddControl( newBtn );
 
@@ -430,7 +431,7 @@ pfGUIDragBarCtrl *pfGUICtrlGenerator::GenerateDragBar( float x, float y, float w
 pfGUIDialogMod  *pfGUICtrlGenerator::IGetDialog()
 {
     if (fDynDialogs.empty())
-        IGenerateDialog( "GUIBaseDynamicDlg", 20.f );
+        IGenerateDialog(ST_LITERAL("GUIBaseDynamicDlg"), 20.f);
 
     hsAssert(!fDynDialogs.empty(), "Unable to get a dynamic dialog to add buttons to");
     return fDynDialogs.back();
@@ -438,7 +439,7 @@ pfGUIDialogMod  *pfGUICtrlGenerator::IGetDialog()
 
 //// IGenerateDialog /////////////////////////////////////////////////////////
 
-pfGUIDialogMod  *pfGUICtrlGenerator::IGenerateDialog( const char *name, float scrnWidth, bool show )
+pfGUIDialogMod  *pfGUICtrlGenerator::IGenerateDialog(ST::string name, float scrnWidth, bool show)
 {
     float           fovX, fovY;
     plSceneNode     *node;
@@ -447,7 +448,7 @@ pfGUIDialogMod  *pfGUICtrlGenerator::IGenerateDialog( const char *name, float sc
 
     // Create the rendermod
     plPostEffectMod *renderMod = new plPostEffectMod;
-    IAddKey( renderMod, "GUIRenderMod" );
+    IAddKey(renderMod, ST_LITERAL("GUIRenderMod"));
 
     renderMod->SetHither( 0.5f );
     renderMod->SetYon( 200.f );
@@ -461,7 +462,7 @@ pfGUIDialogMod  *pfGUICtrlGenerator::IGenerateDialog( const char *name, float sc
 
     // Create the sceneNode to go with it
     node = new plSceneNode;
-    IAddKey( node, "GUISceneNode" );
+    IAddKey(node, ST_LITERAL("GUISceneNode"));
     node->GetKey()->RefObject();
     fDynDlgNodes.emplace_back(node);
     fDynDragBars.emplace_back(nullptr);
@@ -470,18 +471,18 @@ pfGUIDialogMod  *pfGUICtrlGenerator::IGenerateDialog( const char *name, float sc
 
     // Create the dialog
     dialog = new pfGUIDialogMod;
-    IAddKey( dialog, "GUIDialog" );
+    IAddKey(dialog, ST_LITERAL("GUIDialog"));
 
     dialog->SetRenderMod( renderMod );
-    dialog->SetName( name );
+    dialog->SetName(std::move(name));
 
     // Create the dummy scene object to hold the dialog
     plSceneObject   *newObj = new plSceneObject;
-    IAddKey( newObj, "GUISceneObject" );
+    IAddKey(newObj, ST_LITERAL("GUISceneObject"));
 
     // *#&$(*@&#$ need a coordIface...
     plCoordinateInterface *newCI = new plCoordinateInterface;
-    IAddKey( newCI, "GUICoordIFace" );
+    IAddKey(newCI, ST_LITERAL("GUICoordIFace"));
 
     hsMatrix44 l2w, w2l;
     l2w.Reset();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.h
@@ -122,9 +122,7 @@ class pfGUICtrlGenerator
         void            GenerateDialog( const char *name );
 
 
-        pfGUIButtonMod  *CreateRectButton( pfGUIDialogMod *parent, const char *title, float x, float y, 
-                                                float width, float height, hsGMaterial *material, bool asMenuItem = false );
-        pfGUIButtonMod  *CreateRectButton( pfGUIDialogMod *parent, const wchar_t *title, float x, float y,
+        pfGUIButtonMod  *CreateRectButton( pfGUIDialogMod *parent, float x, float y,
                                                 float width, float height, hsGMaterial *material, bool asMenuItem = false );
 
         static pfGUICtrlGenerator   &Instance();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUICtrlGenerator.h
@@ -85,16 +85,16 @@ class pfGUICtrlGenerator
         std::vector<plSceneObject *>   fDynDragBars;
 
 
-        plKey       IAddKey( hsKeyedObject *ko, const char *prefix );
-        ST::string  IGetNextKeyName( const char *prefix );
+        plKey       IAddKey(hsKeyedObject *ko, const ST::string& prefix);
+        ST::string  IGetNextKeyName(const ST::string& prefix);
 
         hsGMaterial *ICreateSolidMaterial( hsColorRGBA &color );
 
-        hsGMaterial *ICreateTextMaterial( const char *text, hsColorRGBA &bgColor, 
+        hsGMaterial *ICreateTextMaterial( const ST::string& text, hsColorRGBA &bgColor, 
                                                  hsColorRGBA &textColor, float objWidth, float objHeight );
 
         pfGUIDialogMod  *IGetDialog();
-        pfGUIDialogMod  *IGenerateDialog( const char *name, float scrnWidth, bool show = true );
+        pfGUIDialogMod  *IGenerateDialog(ST::string name, float scrnWidth, bool show = true);
 
         plSceneObject   *IGenSceneObject(pfGUIDialogMod *dlg, plDrawable *myDraw,
                                          plSceneObject *parent = nullptr,
@@ -111,15 +111,15 @@ class pfGUICtrlGenerator
         void            SetFont( const char *face, uint16_t size );
 
 
-        pfGUIButtonMod  *GenerateRectButton( const char *title, float x, float y, float width, float height,
-                                                const char *consoleCmd, hsColorRGBA &color, hsColorRGBA &textColor );
+        pfGUIButtonMod  *GenerateRectButton( const ST::string& title, float x, float y, float width, float height,
+                                                ST::string consoleCmd, hsColorRGBA &color, hsColorRGBA &textColor );
 
         pfGUIButtonMod  *GenerateSphereButton( float x, float y, float radius,
-                                                const char *consoleCmd, hsColorRGBA &color );
+                                                ST::string consoleCmd, hsColorRGBA &color );
 
         pfGUIDragBarCtrl *GenerateDragBar( float x, float y, float width, float height, hsColorRGBA &color );
 
-        void            GenerateDialog( const char *name );
+        void            GenerateDialog(ST::string name);
 
 
         pfGUIButtonMod  *CreateRectButton( pfGUIDialogMod *parent, float x, float y,

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.cpp
@@ -73,20 +73,11 @@ pfGUIMenuItem::pfGUIMenuItem()
 pfGUIMenuItem::~pfGUIMenuItem()
 {
     SetSkin(nullptr, kTop);
-    delete [] fName;
 }
 
-void    pfGUIMenuItem::SetName( const wchar_t *name )
+void    pfGUIMenuItem::SetName(ST::string name)
 {
-    delete [] fName;
-    if (name != nullptr)
-    {
-        fName = new wchar_t[wcslen(name)+1];
-        wcscpy(fName,name);
-    }
-    else
-        fName = nullptr;
-
+    fName = std::move(name);
     IUpdate();
 }
 
@@ -306,7 +297,7 @@ void    pfGUIMenuItem::IUpdate()
 
     fDynTextMap->SetJustify( plDynamicTextMap::kLeftJustify );
 
-    if (fName != nullptr)
+    if (!fName.empty())
     {
         uint16_t ht;
         fDynTextMap->CalcStringWidth( fName, &ht );
@@ -370,10 +361,7 @@ void pfGUIMenuItem::PurgeDynaTextMapImage()
 
 void    pfGUIMenuItem::GetTextExtents( uint16_t &width, uint16_t &height )
 {
-    if (fName == nullptr)
-        width = height = 0;
-    else
-        width = fDynTextMap->CalcStringWidth( fName, &height );
+    width = fDynTextMap->CalcStringWidth( fName, &height );
 }
 
 //// MsgReceive //////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMenuItem.h
@@ -50,6 +50,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef _pfGUIMenuItem_h
 #define _pfGUIMenuItem_h
 
+#include <string_theory/string>
+
 #include "pfGUIButtonMod.h"
 
 class pfGUISkin;
@@ -68,7 +70,7 @@ class pfGUIMenuItem : public pfGUIButtonMod
 
     protected:
 
-        wchar_t         *fName;
+        ST::string      fName;
         bool            fReportingHover;
 
         HowToSkin       fHowToSkin;
@@ -117,8 +119,8 @@ class pfGUIMenuItem : public pfGUIButtonMod
         void    PurgeDynaTextMapImage() override;
 
 
-        void        SetName( const wchar_t *name );
-        const wchar_t   *GetName() const { return fName; }
+        void        SetName(ST::string name);
+        ST::string GetName() const { return fName; }
     
         void    GetTextExtents( uint16_t &width, uint16_t &height );
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
@@ -232,8 +232,9 @@ void    pfGUIPopUpMenu::Read( hsStream *s, hsResMgr *mgr )
     fMenuItems.resize(count);
     for (uint32_t i = 0; i < count; i++)
     {
-        char readTemp[ 256 ];
-        s->Read( sizeof( readTemp ), readTemp );
+        char readTemp[257];
+        s->Read(sizeof(readTemp) - 1, readTemp);
+        readTemp[sizeof(readTemp) - 1] = '\0';
         fMenuItems[ i ].fName = ST::string::from_latin_1(readTemp);
         
         fMenuItems[ i ].fHandler = pfGUICtrlProcWriteableObject::Read( s );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
@@ -546,7 +546,7 @@ bool    pfGUIPopUpMenu::IBuildMenu()
         float thisMargin = (i == 0 || i == fMenuItems.size() - 1) ? topMargin : 0.f;
         float thisOffset = (i == fMenuItems.size() - 1) ? topMargin : 0.f;
 
-        pfGUIMenuItem *button = pfGUIMenuItem::ConvertNoRef( pfGUICtrlGenerator::Instance().CreateRectButton( this, fMenuItems[ i ].fName.c_str(), x, y + thisOffset, width, height + thisMargin, mat, true ) );
+        pfGUIMenuItem *button = pfGUIMenuItem::ConvertNoRef(pfGUICtrlGenerator::Instance().CreateRectButton(this, x, y + thisOffset, width, height + thisMargin, mat, true));
         if (button != nullptr)
         {
             button->SetColorScheme( scheme );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.h
@@ -54,7 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsBounds.h"
 
-#include <string>
+#include <string_theory/string>
 
 #include "pfGUIDialogMod.h"
 
@@ -93,7 +93,7 @@ class pfGUIPopUpMenu : public pfGUIDialogMod
         {
             // Simple wrapper class that tells us how to build our menu
             public:
-                std::wstring        fName;
+                ST::string          fName;
                 pfGUICtrlProcObject *fHandler;
                 pfGUIPopUpMenu      *fSubMenu;
                 float               fYOffsetToNext;     // Filled in by IBuildMenu()
@@ -163,10 +163,10 @@ class pfGUIPopUpMenu : public pfGUIDialogMod
         void    SetOriginAnchor( plSceneObject *anchor, pfGUIDialogMod *context );
         void    SetAlignment( Alignment a ) { fAlignment = a; }
         void    ClearItems();
-        void    AddItem(const wchar_t *name, pfGUICtrlProcObject *handler, pfGUIPopUpMenu *subMenu = nullptr);
+        void    AddItem(ST::string name, pfGUICtrlProcObject *handler, pfGUIPopUpMenu *subMenu = nullptr);
         void    SetSkin( pfGUISkin *skin );
 
-        static pfGUIPopUpMenu   *Build( const char *name, pfGUIDialogMod *parent, float x, float y, const plLocation &destLoc = plLocation::kGlobalFixedLoc );
+        static pfGUIPopUpMenu   *Build(const ST::string& name, pfGUIDialogMod *parent, float x, float y, const plLocation &destLoc = plLocation::kGlobalFixedLoc);
 
 };
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
@@ -174,11 +174,11 @@ bool    pfGameGUIMgr::MsgReceive( plMessage* pMsg )
     if (guiMsg != nullptr)
     {
         if( guiMsg->GetCommand() == pfGameGUIMsg::kLoadDialog )
-            LoadDialog(guiMsg->GetString(), nullptr, guiMsg->GetAge().c_str());
+            LoadDialog(guiMsg->GetString(), nullptr, guiMsg->GetAge());
         else if( guiMsg->GetCommand() == pfGameGUIMsg::kShowDialog )
-            IShowDialog(guiMsg->GetString().c_str());
+            IShowDialog(guiMsg->GetString());
         else if( guiMsg->GetCommand() == pfGameGUIMsg::kHideDialog )
-            IHideDialog(guiMsg->GetString().c_str());
+            IHideDialog(guiMsg->GetString());
 
         return true;
     }
@@ -267,7 +267,7 @@ void    pfGameGUIMgr::IRemoveDlgFromList( hsKeyedObject *obj )
 
 //// LoadDialog //////////////////////////////////////////////////////////////
 
-void    pfGameGUIMgr::LoadDialog(const ST::string& name, plKey recvrKey, const char *ageName)
+void    pfGameGUIMgr::LoadDialog(const ST::string& name, plKey recvrKey, const ST::string& ageName)
 {
     // see if they want to set the receiver key once the dialog is loaded
     if (recvrKey != nullptr)
@@ -285,14 +285,13 @@ void    pfGameGUIMgr::LoadDialog(const ST::string& name, plKey recvrKey, const c
     }
 
     plStatusLog::AddLineSF("plasmadbg.log", "Loading Dialog {} {} ... {}",
-                           name, (ageName != nullptr) ? ageName : "GUI",
-                           hsTimer::GetSeconds());
+                           name, ageName, hsTimer::GetSeconds());
 
     plKey clientKey = hsgResMgr::ResMgr()->FindKey( kClient_KEY );
 
     plClientMsg *msg = new plClientMsg( plClientMsg::kLoadRoomHold );
     msg->AddReceiver( clientKey );
-    msg->AddRoomLoc(plKeyFinder::Instance().FindLocation(ageName ? ageName : "GUI", name));
+    msg->AddRoomLoc(plKeyFinder::Instance().FindLocation(ageName, name));
     msg->Send();
 }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.h
@@ -195,7 +195,7 @@ class pfGameGUIMgr : public hsKeyedObject
 
         bool    MsgReceive(plMessage* pMsg) override;
 
-        void    LoadDialog(const ST::string& name, plKey recvrKey = {}, const char *ageName = nullptr);  // AgeName = nil defaults to "GUI"
+        void    LoadDialog(const ST::string& name, plKey recvrKey = {}, const ST::string& ageName = ST_LITERAL("GUI"));
         void    ShowDialog( const ST::string& name ) { IShowDialog(name); }
         void    HideDialog( const ST::string&  name ) { IHideDialog(name); }
         void    UnloadDialog( const ST::string& name );

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -420,7 +420,7 @@ void pfBookData::LoadGUI()
     // has the dialog been loaded yet?
     if (!pfGameGUIMgr::GetInstance()->IsDialogLoaded(fGUIName))
         // no then load and set handler
-        pfGameGUIMgr::GetInstance()->LoadDialog(fGUIName, GetKey(), "GUI");
+        pfGameGUIMgr::GetInstance()->LoadDialog(fGUIName, GetKey());
     else
         // yes then just set the handler
         pfGameGUIMgr::GetInstance()->SetDialogToNotify(fGUIName, GetKey());

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -807,22 +807,6 @@ void cyMisc::LoadDialog(const ST::string& name)
 }
 
 // Load dialog and set the GUINotifyMsg receiver key
-void cyMisc::LoadDialogK(const ST::string& name, pyKey& rKey)
-{
-    pfGameGUIMgr    *mgr = pfGameGUIMgr::GetInstance();
-    if ( mgr )
-    {
-        // has the dialog been loaded yet?
-        if ( !mgr->IsDialogLoaded(name) )
-            // no then load and set handler
-            mgr->LoadDialog( name, rKey.getKey() );
-        else
-            // yes then just set the handler
-            mgr->SetDialogToNotify(name,rKey.getKey());
-    }
-}
-
-// Load dialog and set the GUINotifyMsg receiver key
 void cyMisc::LoadDialogKA(const ST::string& name, pyKey& rKey, const ST::string& ageName)
 {
     pfGameGUIMgr    *mgr = pfGameGUIMgr::GetInstance();

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -823,7 +823,7 @@ void cyMisc::LoadDialogK(const ST::string& name, pyKey& rKey)
 }
 
 // Load dialog and set the GUINotifyMsg receiver key
-void cyMisc::LoadDialogKA(const ST::string& name, pyKey& rKey, const char* ageName)
+void cyMisc::LoadDialogKA(const ST::string& name, pyKey& rKey, const ST::string& ageName)
 {
     pfGameGUIMgr    *mgr = pfGameGUIMgr::GetInstance();
     if ( mgr )

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -846,7 +846,7 @@ void cyMisc::LoadDialogKA(const ST::string& name, pyKey& rKey, const char* ageNa
 //  PURPOSE    : UnLoads the dialog by name
 //             : optionally sets the receiver key for the GUINotifyMsg
 //
-void cyMisc::UnloadDialog(const char* name)
+void cyMisc::UnloadDialog(const ST::string& name)
 {
     pfGameGUIMgr    *mgr = pfGameGUIMgr::GetInstance();
     if ( mgr )
@@ -863,7 +863,7 @@ void cyMisc::UnloadDialog(const char* name)
 //
 //  PURPOSE    : Test to see if a dialog is loaded (according to the dialog manager)
 //
-bool cyMisc::IsDialogLoaded(const char* name)
+bool cyMisc::IsDialogLoaded(const ST::string& name)
 {
     pfGameGUIMgr    *mgr = pfGameGUIMgr::GetInstance();
     if ( mgr )
@@ -879,13 +879,13 @@ bool cyMisc::IsDialogLoaded(const char* name)
 //
 //  PURPOSE    : Show or Hide a dialog by name
 //
-void cyMisc::ShowDialog(const char* name)
+void cyMisc::ShowDialog(const ST::string& name)
 {
     pfGameGUIMgr    *mgr = pfGameGUIMgr::GetInstance();
     if ( mgr )
         mgr->ShowDialog(name);
 }
-void cyMisc::HideDialog(const char* name)
+void cyMisc::HideDialog(const ST::string& name)
 {
     pfGameGUIMgr    *mgr = pfGameGUIMgr::GetInstance();
     if ( mgr )

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -373,7 +373,7 @@ public:
     //  PURPOSE    : UnLoads the dialog by name
     //             : optionally sets the receiver key for the GUINotifyMsg
     //
-    static void UnloadDialog(const char* name);
+    static void UnloadDialog(const ST::string& name);
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -382,7 +382,7 @@ public:
     //
     //  PURPOSE    : Test to see if a dialog is loaded (according to the dialog manager)
     //
-    static bool IsDialogLoaded(const char* name);
+    static bool IsDialogLoaded(const ST::string& name);
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -392,8 +392,8 @@ public:
     //
     //  PURPOSE    : Show or Hide a dialog by name
     //
-    static void ShowDialog(const char* name);
-    static void HideDialog(const char* name);
+    static void ShowDialog(const ST::string& name);
+    static void HideDialog(const ST::string& name);
 
     /////////////////////////////////////////////////////////////////////////////
     //

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -363,7 +363,7 @@ public:
     //
     static void LoadDialog(const ST::string& name);
     static void LoadDialogK(const ST::string& name, pyKey& modKey);
-    static void LoadDialogKA(const ST::string& name, pyKey& rKey, const char* ageName);
+    static void LoadDialogKA(const ST::string& name, pyKey& rKey, const ST::string& ageName);
 
     /////////////////////////////////////////////////////////////////////////////
     //

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -362,7 +362,6 @@ public:
     //             : optionally sets the receiver key for the GUINotifyMsg
     //
     static void LoadDialog(const ST::string& name);
-    static void LoadDialogK(const ST::string& name, pyKey& modKey);
     static void LoadDialogKA(const ST::string& name, pyKey& rKey, const ST::string& ageName);
 
     /////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
@@ -404,8 +404,8 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtLoadDialog, args, "Params: dialogName,selfKey=
 {
     ST::string dialogName;
     PyObject* keyObj = nullptr;
-    char* ageName = nullptr;
-    if (!PyArg_ParseTuple(args, "O&|Os", PyUnicode_STStringConverter, &dialogName, &keyObj, &ageName))
+    ST::string ageName;
+    if (!PyArg_ParseTuple(args, "O&|OO&", PyUnicode_STStringConverter, &dialogName, &keyObj, PyUnicode_STStringConverter, &ageName))
     {
         PyErr_SetString(PyExc_TypeError, "PtLoadDialog expects a string, and optionally a ptKey and second string");
         PYTHON_RETURN_ERROR;
@@ -418,7 +418,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtLoadDialog, args, "Params: dialogName,selfKey=
             PYTHON_RETURN_ERROR;
         }
         pyKey* key = pyKey::ConvertFrom(keyObj);
-        if (ageName)
+        if (!ageName.empty())
             cyMisc::LoadDialogKA(dialogName, *key, ageName);
         else
             cyMisc::LoadDialogK(dialogName, *key);

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
@@ -404,7 +404,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtLoadDialog, args, "Params: dialogName,selfKey=
 {
     ST::string dialogName;
     PyObject* keyObj = nullptr;
-    ST::string ageName;
+    ST::string ageName = ST_LITERAL("GUI");
     if (!PyArg_ParseTuple(args, "O&|OO&", PyUnicode_STStringConverter, &dialogName, &keyObj, PyUnicode_STStringConverter, &ageName))
     {
         PyErr_SetString(PyExc_TypeError, "PtLoadDialog expects a string, and optionally a ptKey and second string");
@@ -418,10 +418,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtLoadDialog, args, "Params: dialogName,selfKey=
             PYTHON_RETURN_ERROR;
         }
         pyKey* key = pyKey::ConvertFrom(keyObj);
-        if (!ageName.empty())
-            cyMisc::LoadDialogKA(dialogName, *key, ageName);
-        else
-            cyMisc::LoadDialogK(dialogName, *key);
+        cyMisc::LoadDialogKA(dialogName, *key, ageName);
     }
     else
         cyMisc::LoadDialog(dialogName);

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
@@ -402,10 +402,10 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtFogSetDefExp2, args, "Params: end,density\nSet
 PYTHON_GLOBAL_METHOD_DEFINITION(PtLoadDialog, args, "Params: dialogName,selfKey=None,ageName=\"\"\nLoads a GUI dialog by name and optionally set the Notify proc key\n"
             "If the dialog is already loaded then it won't load it again")
 {
-    char* dialogName;
+    ST::string dialogName;
     PyObject* keyObj = nullptr;
     char* ageName = nullptr;
-    if (!PyArg_ParseTuple(args, "s|Os", &dialogName, &keyObj, &ageName))
+    if (!PyArg_ParseTuple(args, "O&|Os", PyUnicode_STStringConverter, &dialogName, &keyObj, &ageName))
     {
         PyErr_SetString(PyExc_TypeError, "PtLoadDialog expects a string, and optionally a ptKey and second string");
         PYTHON_RETURN_ERROR;
@@ -430,8 +430,8 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtLoadDialog, args, "Params: dialogName,selfKey=
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtUnloadDialog, args, "Params: dialogName\nThis will unload the GUI dialog by name. If not loaded then nothing will happen")
 {
-    char* dialogName;
-    if (!PyArg_ParseTuple(args, "s", &dialogName))
+    ST::string dialogName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &dialogName))
     {
         PyErr_SetString(PyExc_TypeError, "PtUnloadDialog expects a string");
         PYTHON_RETURN_ERROR;
@@ -442,8 +442,8 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtUnloadDialog, args, "Params: dialogName\nThis 
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtIsDialogLoaded, args, "Params: dialogName\nTest to see if a GUI dialog is loaded, by name")
 {
-    char* dialogName;
-    if (!PyArg_ParseTuple(args, "s", &dialogName))
+    ST::string dialogName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &dialogName))
     {
         PyErr_SetString(PyExc_TypeError, "PtIsDialogLoaded expects a string");
         PYTHON_RETURN_ERROR;
@@ -453,8 +453,8 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtIsDialogLoaded, args, "Params: dialogName\nTes
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtShowDialog, args, "Params: dialogName\nShow a GUI dialog by name (does not load dialog)")
 {
-    char* dialogName;
-    if (!PyArg_ParseTuple(args, "s", &dialogName))
+    ST::string dialogName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &dialogName))
     {
         PyErr_SetString(PyExc_TypeError, "PtShowDialog expects a string");
         PYTHON_RETURN_ERROR;
@@ -465,8 +465,8 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtShowDialog, args, "Params: dialogName\nShow a 
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtHideDialog, args, "Params: dialogName\nHide a GUI dialog by name (does not unload dialog)")
 {
-    char* dialogName;
-    if (!PyArg_ParseTuple(args, "s", &dialogName))
+    ST::string dialogName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &dialogName))
     {
         PyErr_SetString(PyExc_TypeError, "PtHideDialog expects a string");
         PYTHON_RETURN_ERROR;
@@ -488,8 +488,8 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtGetDialogFromTagID, args, "Params: tagID\nRetu
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtGetDialogFromString, args, "Params: dialogName\nGet a ptGUIDialog from its name")
 {
-    char* dialogName;
-    if (!PyArg_ParseTuple(args, "s", &dialogName))
+    ST::string dialogName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &dialogName))
     {
         PyErr_SetString(PyExc_TypeError, "PtHideDialog expects a string");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.cpp
@@ -90,7 +90,7 @@ pyGUIPopUpMenu::pyGUIPopUpMenu()
     fBuiltMenu = nullptr;
 }
 
-pyGUIPopUpMenu::pyGUIPopUpMenu( const char *name, float screenOriginX, float screenOriginY, const plLocation &destLoc/* = plLocation::kGlobalFixedLoc */)
+pyGUIPopUpMenu::pyGUIPopUpMenu(const ST::string& name, float screenOriginX, float screenOriginY, const plLocation &destLoc/* = plLocation::kGlobalFixedLoc */)
 {
     fBuiltMenu = pfGUIPopUpMenu::Build(name, nullptr, screenOriginX, screenOriginY, destLoc);
     if (fBuiltMenu != nullptr)
@@ -102,7 +102,7 @@ pyGUIPopUpMenu::pyGUIPopUpMenu( const char *name, float screenOriginX, float scr
         fGCkey = nullptr;
 }
 
-pyGUIPopUpMenu::pyGUIPopUpMenu( const char *name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY )
+pyGUIPopUpMenu::pyGUIPopUpMenu(const ST::string& name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY)
 {
     pfGUIPopUpMenu *parentMenu = pfGUIPopUpMenu::ConvertNoRef( parent.fGCkey->ObjectIsLoaded() );
     
@@ -141,7 +141,7 @@ void pyGUIPopUpMenu::setup(plKey objkey)
     fGCkey = std::move(objkey);
 }
 
-void pyGUIPopUpMenu::setup(const char *name, float screenOriginX, float screenOriginY, const plLocation &destLoc /* = plLocation::kGlobalFixedLoc */)
+void pyGUIPopUpMenu::setup(const ST::string& name, float screenOriginX, float screenOriginY, const plLocation &destLoc /* = plLocation::kGlobalFixedLoc */)
 {
     // kill any previous menu
     if (fBuiltMenu != nullptr)
@@ -161,7 +161,7 @@ void pyGUIPopUpMenu::setup(const char *name, float screenOriginX, float screenOr
         fGCkey = nullptr;
 }
 
-void pyGUIPopUpMenu::setup(const char *name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY)
+void pyGUIPopUpMenu::setup(const ST::string& name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY)
 {
     // kill any previous menu
     if (fBuiltMenu != nullptr)
@@ -360,19 +360,19 @@ void pyGUIPopUpMenu::SetBackSelColor( float r, float g, float b, float a )
         color->fSelBackColor.a = a;
 }
 
-void    pyGUIPopUpMenu::AddConsoleCmdItem( const std::wstring& name, const char *consoleCmd )
+void    pyGUIPopUpMenu::AddConsoleCmdItem(const ST::string& name, const ST::string& consoleCmd)
 {
     kGetMenuPtr( ; );
-    menu->AddItem(name.c_str(), new pfGUIConsoleCmdProc(consoleCmd), nullptr);
+    menu->AddItem(name, new pfGUIConsoleCmdProc(consoleCmd), nullptr);
 }
 
-void    pyGUIPopUpMenu::AddNotifyItem( const std::wstring& name )
+void    pyGUIPopUpMenu::AddNotifyItem(const ST::string& name)
 {
     kGetMenuPtr( ; );
-    menu->AddItem(name.c_str(), (pfGUICtrlProcObject *)(menu->GetHandler()), nullptr);
+    menu->AddItem(name, (pfGUICtrlProcObject *)(menu->GetHandler()), nullptr);
 }
 
-void    pyGUIPopUpMenu::AddSubMenuItem( const std::wstring& name, pyGUIPopUpMenu &subMenu )
+void    pyGUIPopUpMenu::AddSubMenuItem(const ST::string& name, pyGUIPopUpMenu &subMenu)
 {
     kGetMenuPtr( ; );
 
@@ -382,5 +382,5 @@ void    pyGUIPopUpMenu::AddSubMenuItem( const std::wstring& name, pyGUIPopUpMenu
     if (subM == nullptr)
         return;
 
-    menu->AddItem(name.c_str(), nullptr, subM);
+    menu->AddItem(name, nullptr, subM);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.h
@@ -52,7 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnKeyedObject/plKey.h"
 #include "pyGlueHelpers.h"
 #include "pnKeyedObject/plUoid.h"
-#include <string>
 
 class pfGUIPopUpMenu;
 class pyColor;
@@ -69,8 +68,8 @@ protected:
     pyGUIPopUpMenu(plKey objkey);
     pyGUIPopUpMenu();
     // For creating new menus on the fly
-    pyGUIPopUpMenu( const char *name, float screenOriginX, float screenOriginY, const plLocation &destLoc = plLocation::kGlobalFixedLoc );
-    pyGUIPopUpMenu( const char *name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY );
+    pyGUIPopUpMenu(const ST::string& name, float screenOriginX, float screenOriginY, const plLocation &destLoc = plLocation::kGlobalFixedLoc);
+    pyGUIPopUpMenu(const ST::string& name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY);
 
 public:
     virtual ~pyGUIPopUpMenu();
@@ -80,8 +79,8 @@ public:
     PYTHON_CLASS_NEW_DEFINITION;
     static PyObject *New(pyKey& gckey);
     static PyObject *New(plKey objkey);
-    static PyObject *New(const char *name, float screenOriginX, float screenOriginY, const plLocation &destLoc = plLocation::kGlobalFixedLoc);
-    static PyObject *New(const char *name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY);
+    static PyObject *New(const ST::string& name, float screenOriginX, float screenOriginY, const plLocation &destLoc = plLocation::kGlobalFixedLoc);
+    static PyObject *New(const ST::string& name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY);
     PYTHON_CLASS_CHECK_DEFINITION; // returns true if the PyObject is a pyGUIPopUpMenu object
     PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyGUIPopUpMenu); // converts a PyObject to a pyGUIPopUpMenu (throws error if not correct type)
 
@@ -89,8 +88,8 @@ public:
 
     // these three are for the python glue only, do NOT call
     void setup(plKey objkey);
-    void setup(const char *name, float screenOriginX, float screenOriginY, const plLocation &destLoc = plLocation::kGlobalFixedLoc);
-    void setup(const char *name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY);
+    void setup(const ST::string& name, float screenOriginX, float screenOriginY, const plLocation &destLoc = plLocation::kGlobalFixedLoc);
+    void setup(const ST::string& name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY);
 
     static bool IsGUIPopUpMenu(pyKey& gckey);
 
@@ -127,9 +126,9 @@ public:
     virtual void        SetBackSelColor( float r, float g, float b, float a );
 
     // Menu item functions
-    virtual void        AddConsoleCmdItem( const std::wstring& name, const char *consoleCmd );
-    virtual void        AddNotifyItem( const std::wstring& name );
-    virtual void        AddSubMenuItem( const std::wstring& name, pyGUIPopUpMenu &subMenu );
+    virtual void        AddConsoleCmdItem(const ST::string& name, const ST::string& consoleCmd);
+    virtual void        AddNotifyItem(const ST::string& name);
+    virtual void        AddSubMenuItem(const ST::string& name, pyGUIPopUpMenu &subMenu);
 };
 
 #endif // _pyGUIPopUpMenu_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenuGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenuGlue.cpp
@@ -84,7 +84,7 @@ PYTHON_INIT_DEFINITION(ptGUIPopUpMenu, args, keywords)
     else if (PyUnicode_Check(arg1))
     {
         // arg list 2 or 3
-        const char* name = PyUnicode_AsUTF8(arg1);
+        ST::string name = PyUnicode_AsSTString(arg1);
         if (PyFloat_Check(arg2))
         {
             // arg list 2
@@ -274,9 +274,9 @@ PYTHON_METHOD_DEFINITION(ptGUIPopUpMenu, setBackSelectColor, args)
 
 PYTHON_METHOD_DEFINITION(ptGUIPopUpMenu, addConsoleCmdItem, args)
 {
-    wchar_t* name;
-    char* consoleCmd;
-    if (!PyArg_ParseTuple(args, "us", &name, &consoleCmd))
+    ST::string name;
+    ST::string consoleCmd;
+    if (!PyArg_ParseTuple(args, "O&O&", PyUnicode_STStringConverter, &name, PyUnicode_STStringConverter, &consoleCmd))
     {
         PyErr_SetString(PyExc_TypeError, "addConsoleCmdItem expects a unicode string and a string");
         PYTHON_RETURN_ERROR;
@@ -287,8 +287,8 @@ PYTHON_METHOD_DEFINITION(ptGUIPopUpMenu, addConsoleCmdItem, args)
 
 PYTHON_METHOD_DEFINITION(ptGUIPopUpMenu, addNotifyItem, args)
 {
-    wchar_t* name;
-    if (!PyArg_ParseTuple(args, "u", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "addNotifyItem expects a unicode string");
         PYTHON_RETURN_ERROR;
@@ -299,9 +299,9 @@ PYTHON_METHOD_DEFINITION(ptGUIPopUpMenu, addNotifyItem, args)
 
 PYTHON_METHOD_DEFINITION(ptGUIPopUpMenu, addSubMenuItem, args)
 {
-    wchar_t* name;
+    ST::string name;
     PyObject* subMenuObj = nullptr;
-    if (!PyArg_ParseTuple(args, "uO", &name, &subMenuObj))
+    if (!PyArg_ParseTuple(args, "O&O", PyUnicode_STStringConverter, &name, &subMenuObj))
     {
         PyErr_SetString(PyExc_TypeError, "addSubMenuItem expects a unicode string and a ptGUIPopUpMenu");
         PYTHON_RETURN_ERROR;
@@ -373,14 +373,14 @@ PyObject *pyGUIPopUpMenu::New(plKey objkey)
     return (PyObject*)newObj;
 }
 
-PyObject *pyGUIPopUpMenu::New(const char *name, float screenOriginX, float screenOriginY, const plLocation &destLoc /* = plLocation::kGlobalFixedLoc */)
+PyObject *pyGUIPopUpMenu::New(const ST::string& name, float screenOriginX, float screenOriginY, const plLocation &destLoc /* = plLocation::kGlobalFixedLoc */)
 {
     ptGUIPopUpMenu *newObj = (ptGUIPopUpMenu*)ptGUIPopUpMenu_type.tp_new(&ptGUIPopUpMenu_type, nullptr, nullptr);
     newObj->fThis->setup(name, screenOriginX, screenOriginY, destLoc);
     return (PyObject*)newObj;
 }
 
-PyObject *pyGUIPopUpMenu::New(const char *name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY)
+PyObject *pyGUIPopUpMenu::New(const ST::string& name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY)
 {
     ptGUIPopUpMenu *newObj = (ptGUIPopUpMenu*)ptGUIPopUpMenu_type.tp_new(&ptGUIPopUpMenu_type, nullptr, nullptr);
     newObj->fThis->setup(name, parent, screenOriginX, screenOriginY);


### PR DESCRIPTION
This one is also just internal refactoring with (I think) no player-visible Unicode improvements. Some of this is code is probably dead anyway - the `Game.GUI` console commands seem to be unused...

Closes #473, except for a few small bits that I'll do later (together with other modules).