### PR TITLE
Fix "Value out of range" warnings from openal-soft

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
@@ -48,6 +48,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plProfile.h"
 #include "plgDispatch.h"
 
+#include <algorithm>
+
 #include "plAudioSystem.h"
 #include "plSound.h"
 #include "plWin32Sound.h"
@@ -1228,7 +1230,8 @@ void plSound::IRead( hsStream *s, hsResMgr *mgr )
         fCurrVolume = 1.f;
     fMaxVolume = fDesiredVol;
 
-    fOuterVol = s->ReadLE32();
+    // Many plWin32Sound objects in PRPs have fOuterVol set to -10000 even though the actual minimum is -5000.
+    fOuterVol = std::clamp(static_cast<int>(s->ReadLE32()), -5000, 0);
     fInnerCone = s->ReadLE32();
     fOuterCone = s->ReadLE32();
     s->ReadLEFloat(&fFadedVolume);

--- a/Sources/Tools/MaxComponent/plAudioComponents.cpp
+++ b/Sources/Tools/MaxComponent/plAudioComponents.cpp
@@ -2095,7 +2095,7 @@ void    plSound3DEmitterComponent::ISetParameters( plWin32Sound *destSound, plEr
     }
     else
     {
-        OutVol = 0;
+        OutVol = 5000;
         innerCone = 360;
         outerCone = 360;
     }


### PR DESCRIPTION
A lot of warnings like this appear on the console for debug builds:

```
[ALSOFT] (WW) Error generated on context 00000178631E5D10, code 0xa003, "Value out of range"
```

These are caused by out-of-range values for `plSound.fOuterVol` read from some PRPs. Because there are quite a few of these incorrect values (e. g. for many avatar sound effects), the easiest fix is to clamp the value  on read to the expected range.