### PR TITLE
Add missing hsMatrix44.h include

### DIFF
--- a/Sources/Plasma/CoreLib/hsMatrixMath.h
+++ b/Sources/Plasma/CoreLib/hsMatrixMath.h
@@ -45,6 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include "hsGeometry3.h"
+#include "hsMatrix44.h"
 
 #ifdef HS_BUILD_FOR_APPLE
 #import <Accelerate/Accelerate.h>


### PR DESCRIPTION
Went unnoticed because of unity builds again, I assume.