### PR TITLE
Fix `EmptyClipboard` result assert

### DIFF
--- a/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
+++ b/Sources/Plasma/PubUtilLib/plClipboard/plClipboard.cpp
@@ -125,7 +125,7 @@ void plClipboard::SetClipboardText(const ST::string& text)
     // SetClipboardData() to fail.
     if (hWnd != nullptr) {
         BOOL result = EmptyClipboard();
-        hsAssert(result == 0, ST::format("EmptyClipboard() failed:\n{}", hsCOMError(hsLastWin32Error, GetLastError())).c_str());
+        hsAssert(result, ST::format("EmptyClipboard() failed:\n{}", hsCOMError(hsLastWin32Error, GetLastError())).c_str());
     }
 
     if (SetClipboardData(CF_UNICODETEXT, copy.get()) != nullptr) {


### PR DESCRIPTION
[`EmptyClipboard`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-emptyclipboard) returns nonzero on success and zero on error.