### PR TITLE
Mark python-cairosvg as a host dependency

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -41,7 +41,10 @@
             "platform": "windows",
             "default-features": false
           },
-          "python3-cairosvg"
+          {
+            "name": "python3-cairosvg",
+            "host": true
+          }
         ]
       }
     }


### PR DESCRIPTION
If we're cross-compiling Plasma to run on a different architecture, we still want to build python-cairosvg for the host architecture because it runs as part of the build process on the host machine rather than at runtime on the target architecture.