### PR TITLE
Migrate avatar brain Python glue to `ST::string`

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfAvatarConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfAvatarConsoleCommands.cpp
@@ -408,9 +408,9 @@ PF_CONSOLE_CMD( Avatar_Multistage, Mode, "string stage1, string stage2, string s
 {
     plArmatureMod *avatar = plAvatarMgr::GetInstance()->GetLocalAvatar();
     
-    const char *one = params[0];
-    const char *two = params[1];
-    const char *three = params[2];
+    ST::string one(params[0]);
+    ST::string two(params[1]);
+    ST::string three(params[2]);
     
     PushSimpleMultiStage(avatar, one, two, three, true, true, plAGAnim::kBodyFull);
 }

--- a/Sources/Plasma/FeatureLib/pfConsole/pfGameConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfGameConsoleCommands.cpp
@@ -381,7 +381,7 @@ PF_CONSOLE_CMD( Game, LimitAvatarLOD, "int newLOD", "Zero is (always) highest de
 
 PF_CONSOLE_SUBGROUP( Game, Emote)       // Game.Emote.Shakefist
 
-void Emote(const char *emotion, float fadeIn = 2.0, float fadeOut = 2.0)
+void Emote(const ST::string& emotion, float fadeIn = 2.0, float fadeOut = 2.0)
 {
     plArmatureMod *avatar = plAvatarMgr::GetInstance()->GetLocalAvatar();
     AvatarEmote(avatar, emotion);
@@ -389,38 +389,38 @@ void Emote(const char *emotion, float fadeIn = 2.0, float fadeOut = 2.0)
 
 PF_CONSOLE_CMD( Game_Emote, Wave, "", "")
 {
-    Emote("Wave", 4.0, 1.0);
+    Emote(ST_LITERAL("Wave"), 4.0, 1.0);
 }
 
 PF_CONSOLE_CMD( Game_Emote, Sneeze, "", "")
 {
-    Emote("Sneeze");
+    Emote(ST_LITERAL("Sneeze"));
 }
 
 PF_CONSOLE_CMD( Game_Emote, Dance, "", "")
 {
-    Emote("Dance");
+    Emote(ST_LITERAL("Dance"));
 }
 
 PF_CONSOLE_CMD( Game_Emote, Laugh, "", "")
 {
-    Emote("Laugh");
+    Emote(ST_LITERAL("Laugh"));
 }
 
 PF_CONSOLE_CMD( Game_Emote, Clap, "", "")
 {
-    Emote("Clap", 4.0, 3.0);
+    Emote(ST_LITERAL("Clap"), 4.0, 3.0);
 }
 
 PF_CONSOLE_CMD( Game_Emote, Talk, "", "")
 {
-    Emote("Talk");
+    Emote(ST_LITERAL("Talk"));
 }
 
 PF_CONSOLE_CMD( Game_Emote, Sit, "", "")
 {
     plArmatureMod *avatar = plAvatarMgr::GetInstance()->GetLocalAvatar();
-    PushSimpleMultiStage(avatar, "SitDownGround", "SitIdleGround", "SitStandGround", true, true, plAGAnim::kBodyLower, plAvBrainGeneric::kSitOnGround);
+    PushSimpleMultiStage(avatar, ST_LITERAL("SitDownGround"), ST_LITERAL("SitIdleGround"), ST_LITERAL("SitStandGround"), true, true, plAGAnim::kBodyLower, plAvBrainGeneric::kSitOnGround);
 }
 
 #ifndef PLASMA_EXTERNAL_RELEASE

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatar.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatar.cpp
@@ -41,6 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <Python.h>
+#include <string_theory/string>
 #include "plgDispatch.h"
 #include "pyKey.h"
 #include "plPhysical.h"
@@ -85,7 +86,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // LOCAL FORWARD DECLs
 //
 ///////////////////////////////////////////////////////////////////////////
-bool IEnterGenericMode(const char *enterAnim, const char *idleAnim, const char *exitAnim, bool autoExit, plAGAnim::BodyUsage bodyUsage,
+bool IEnterGenericMode(const ST::string& enterAnim, const ST::string& idleAnim, const ST::string& exitAnim, bool autoExit, plAGAnim::BodyUsage bodyUsage,
                        plAvBrainGeneric::BrainType = plAvBrainGeneric::kGeneric);
 bool IExitTopmostGenericMode();
 
@@ -1631,7 +1632,7 @@ bool cyAvatar::LoadClothingFromFile(plFileName filename)
 //    Male
 //    Female
 //
-void cyAvatar::ChangeAvatar(const char* genderName)
+void cyAvatar::ChangeAvatar(const ST::string& genderName)
 {
 #ifndef PLASMA_EXTERNAL_RELEASE
     plClothingMgr::ChangeAvatar(genderName);
@@ -1651,7 +1652,7 @@ void cyAvatar::ChangeAvatar(const char* genderName)
 //
 //  PURPOSE    : Change the local player's avatar name
 //
-void cyAvatar::ChangePlayerName(const char* playerName)
+void cyAvatar::ChangePlayerName(const ST::string& playerName)
 {
     hsRef<RelVaultNode> rvnPlr = VaultGetPlayerNode();
     if (rvnPlr) {
@@ -1667,7 +1668,7 @@ void cyAvatar::ChangePlayerName(const char* playerName)
 //
 //  PURPOSE    : plays an emote on a the local avatar (net propagated)
 //
-bool cyAvatar::Emote(const char* emoteName)
+bool cyAvatar::Emote(const ST::string& emoteName)
 {
     // can we find an emote of this name?
     plArmatureMod *avatar = plAvatarMgr::GetInstance()->GetLocalAvatar();
@@ -1687,7 +1688,7 @@ bool cyAvatar::Emote(const char* emoteName)
 //
 bool cyAvatar::Sit()
 {
-    return IEnterGenericMode("SitDownGround", "SitIdleGround", "SitStandGround", true, plAGAnim::kBodyLower, plAvBrainGeneric::kSitOnGround);
+    return IEnterGenericMode(ST_LITERAL("SitDownGround"), ST_LITERAL("SitIdleGround"), ST_LITERAL("SitStandGround"), true, plAGAnim::kBodyLower, plAvBrainGeneric::kSitOnGround);
 }
 
 
@@ -1700,7 +1701,7 @@ bool cyAvatar::Sit()
 //
 bool cyAvatar::EnterKiMode()
 {
-    return IEnterGenericMode("KiBegin", "KiUse", "KiEnd", false, plAGAnim::kBodyFull);
+    return IEnterGenericMode(ST_LITERAL("KiBegin"), ST_LITERAL("KiUse"), ST_LITERAL("KiEnd"), false, plAGAnim::kBodyFull);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1725,7 +1726,7 @@ bool cyAvatar::ExitKiMode()
 //
 bool cyAvatar::EnterAFKMode()
 {
-    return IEnterGenericMode("AFKEnter", "AFKIdle", "AFKExit", true, plAGAnim::kBodyFull, plAvBrainGeneric::kAFK);
+    return IEnterGenericMode(ST_LITERAL("AFKEnter"), ST_LITERAL("AFKIdle"), ST_LITERAL("AFKExit"), true, plAGAnim::kBodyFull, plAvBrainGeneric::kAFK);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1750,7 +1751,7 @@ bool cyAvatar::ExitAFKMode()
 //
 bool cyAvatar::EnterPBMode()
 {
-    return IEnterGenericMode("PersonalBookEnter", "PersonalBookIdle", "PersonalBookExit", false, plAGAnim::kBodyFull);
+    return IEnterGenericMode(ST_LITERAL("PersonalBookEnter"), ST_LITERAL("PersonalBookIdle"), ST_LITERAL("PersonalBookExit"), false, plAGAnim::kBodyFull);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1955,7 +1956,7 @@ void cyAvatar::UnRegisterForBehaviorNotify(pyKey &selfKey)
 //  PURPOSE    : Three-stage multistage animations (sit down, sit, get up) are really common.
 //             : This does the basic setup.
 //
-bool IEnterGenericMode(const char *enterAnim, const char *idleAnim, const char *exitAnim, bool autoExit, plAGAnim::BodyUsage bodyUsage, 
+bool IEnterGenericMode(const ST::string& enterAnim, const ST::string& idleAnim, const ST::string& exitAnim, bool autoExit, plAGAnim::BodyUsage bodyUsage, 
                        plAvBrainGeneric::BrainType type /* = kGeneric */)
 {
     plArmatureMod *avatar = plAvatarMgr::GetInstance()->GetLocalAvatar();

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatar.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatar.h
@@ -54,14 +54,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pyGlueHelpers.h"
 
-#include <string>
-
 class pySceneObject;
 class pyColor;
 class plMipmap;
 class plClothingItem;
 class plArmatureMod;
 class plMorphSequence;
+namespace ST { class string; }
 
 class cyAvatar
 {
@@ -72,9 +71,6 @@ protected:
 
     virtual const plArmatureMod* IFindArmatureMod(const plKey& avObj);
     virtual plKey IFindArmatureModKey(const plKey& avObj);
-    
-// XX   static bool IEnterGenericMode(const char *enterAnim, const char *idleAnim, const char *exitAnim, bool autoExit);
-// XX   static bool IExitTopmostGenericMode();
 
 protected:
     cyAvatar() : fNetForce() { }
@@ -427,7 +423,7 @@ public:
     //    Male
     //    Female
     //
-    static void ChangeAvatar(const char* genderName);
+    static void ChangeAvatar(const ST::string& genderName);
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -436,7 +432,7 @@ public:
     //
     //  PURPOSE    : Change the local player's avatar name
     //
-    static void ChangePlayerName(const char* playerName);
+    static void ChangePlayerName(const ST::string& playerName);
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -445,7 +441,7 @@ public:
     //
     //  PURPOSE    : plays an emote on the local avatar (net propagated)
     //
-    static bool Emote(const char* emoteName);
+    static bool Emote(const ST::string& emoteName);
 
     /////////////////////////////////////////////////////////////////////////////
     //

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatarGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatarGlue.cpp
@@ -76,9 +76,9 @@ PYTHON_METHOD_DEFINITION(ptAvatar, oneShot, args)
     PyObject* keyObj = nullptr;
     float duration;
     char usePhysics;
-    char* animName = nullptr;
+    ST::string animName;
     char drivable, reversable;
-    if (!PyArg_ParseTuple(args, "Ofbsbb", &keyObj, &duration, &usePhysics, &animName, &drivable, &reversable))
+    if (!PyArg_ParseTuple(args, "OfbO&bb", &keyObj, &duration, &usePhysics, PyUnicode_STStringConverter, &animName, &drivable, &reversable))
     {
         PyErr_SetString(PyExc_TypeError, "oneShot expects a ptKey, float, boolean, string, and two booleans");
         PYTHON_RETURN_ERROR;
@@ -90,7 +90,7 @@ PYTHON_METHOD_DEFINITION(ptAvatar, oneShot, args)
     }
 
     pyKey* key = pyKey::ConvertFrom(keyObj);
-    self->fThis->OneShot(*key, duration, usePhysics != 0, ST::string::from_utf8(animName), drivable != 0, reversable != 0);
+    self->fThis->OneShot(*key, duration, usePhysics != 0, animName, drivable != 0, reversable != 0);
     PYTHON_RETURN_NONE;
 }
 
@@ -275,51 +275,48 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptAvatar, getAvatarClothingList)
 
 PYTHON_METHOD_DEFINITION(ptAvatar, getMatchingClothingItem, args)
 {
-    char* clothingName = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &clothingName))
+    ST::string clothingName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &clothingName))
     {
         PyErr_SetString(PyExc_TypeError, "getMatchingClothingItem expects a string");
         PYTHON_RETURN_ERROR;
     }
 
-    std::string clothingNameStr = clothingName; // convert to string (for safety)
-    return self->fThis->GetMatchingClothingItem(clothingNameStr.c_str());
+    return self->fThis->GetMatchingClothingItem(clothingName);
 }
 
 PYTHON_METHOD_DEFINITION(ptAvatar, wearClothingItem, args)
 {
-    char* clothingName = nullptr;
+    ST::string clothingName;
     char update = 1;
-    if (!PyArg_ParseTuple(args, "s|b", &clothingName, &update))
+    if (!PyArg_ParseTuple(args, "O&|b", PyUnicode_STStringConverter, &clothingName, &update))
     {
         PyErr_SetString(PyExc_TypeError, "wearClothingItem expects a string and an optional boolean");
         PYTHON_RETURN_ERROR;
     }
 
-    std::string clothingNameStr = clothingName; // convert to string (for safety)
-    PYTHON_RETURN_BOOL(self->fThis->WearClothingItemU(clothingNameStr.c_str(), update != 0));
+    PYTHON_RETURN_BOOL(self->fThis->WearClothingItemU(clothingName, update != 0));
 }
 
 PYTHON_METHOD_DEFINITION(ptAvatar, removeClothingItem, args)
 {
-    char* clothingName = nullptr;
+    ST::string clothingName;
     char update = 1;
-    if (!PyArg_ParseTuple(args, "s|b", &clothingName, &update))
+    if (!PyArg_ParseTuple(args, "O&|b", PyUnicode_STStringConverter, &clothingName, &update))
     {
         PyErr_SetString(PyExc_TypeError, "removeClothingItem expects a string and an optional boolean");
         PYTHON_RETURN_ERROR;
     }
 
-    std::string clothingNameStr = clothingName; // convert to string (for safety)
-    PYTHON_RETURN_BOOL(self->fThis->RemoveClothingItemU(clothingNameStr.c_str(), update != 0));
+    PYTHON_RETURN_BOOL(self->fThis->RemoveClothingItemU(clothingName, update != 0));
 }
 
 PYTHON_METHOD_DEFINITION(ptAvatar, tintClothingItem, args)
 {
-    char* clothingName = nullptr;
+    ST::string clothingName;
     PyObject* tintObj = nullptr;
     char update = 1;
-    if (!PyArg_ParseTuple(args, "sO|b", &clothingName, &tintObj, &update))
+    if (!PyArg_ParseTuple(args, "O&O|b", PyUnicode_STStringConverter, &clothingName, &tintObj, &update))
     {
         PyErr_SetString(PyExc_TypeError, "tintClothingItem expects a string, a ptColor, and an optional boolean");
         PYTHON_RETURN_ERROR;
@@ -330,18 +327,17 @@ PYTHON_METHOD_DEFINITION(ptAvatar, tintClothingItem, args)
         PYTHON_RETURN_ERROR;
     }
 
-    std::string clothingNameStr = clothingName; // convert to string (for safety)
     pyColor* tint = pyColor::ConvertFrom(tintObj);
-    PYTHON_RETURN_BOOL(self->fThis->TintClothingItemU(clothingNameStr.c_str(), *tint, update != 0));
+    PYTHON_RETURN_BOOL(self->fThis->TintClothingItemU(clothingName, *tint, update != 0));
 }
 
 PYTHON_METHOD_DEFINITION(ptAvatar, tintClothingItemLayer, args)
 {
-    char* clothingName = nullptr;
+    ST::string clothingName;
     PyObject* tintObj = nullptr;
     unsigned char layer;
     char update = 1;
-    if (!PyArg_ParseTuple(args, "sOB|b", &clothingName, &tintObj, &layer, &update))
+    if (!PyArg_ParseTuple(args, "O&OB|b", PyUnicode_STStringConverter, &clothingName, &tintObj, &layer, &update))
     {
         PyErr_SetString(PyExc_TypeError, "tintClothingItemLayer expects a string, a ptColor, an unsigned 8-bit int, and an optional boolean");
         PYTHON_RETURN_ERROR;
@@ -352,23 +348,21 @@ PYTHON_METHOD_DEFINITION(ptAvatar, tintClothingItemLayer, args)
         PYTHON_RETURN_ERROR;
     }
 
-    std::string clothingNameStr = clothingName; // convert to string (for safety)
     pyColor* tint = pyColor::ConvertFrom(tintObj);
-    PYTHON_RETURN_BOOL(self->fThis->TintClothingItemLayerU(clothingNameStr.c_str(), *tint, layer, update != 0));
+    PYTHON_RETURN_BOOL(self->fThis->TintClothingItemLayerU(clothingName, *tint, layer, update != 0));
 }
 
 PYTHON_METHOD_DEFINITION(ptAvatar, getTintClothingItem, args)
 {
-    char* clothingName = nullptr;
+    ST::string clothingName;
     unsigned char layer = 1;
-    if (!PyArg_ParseTuple(args, "s|B", &clothingName, &layer))
+    if (!PyArg_ParseTuple(args, "O&|B", PyUnicode_STStringConverter, &clothingName, &layer))
     {
         PyErr_SetString(PyExc_TypeError, "getTintClothingItem expects a string and an optional unsigned 8-bit int");
         PYTHON_RETURN_NONE;
     }
     
-    std::string clothingNameStr = clothingName; // convert to string (for safety)
-    return self->fThis->GetTintClothingItemL(clothingNameStr.c_str(), layer);
+    return self->fThis->GetTintClothingItemL(clothingName, layer);
 }
 
 PYTHON_METHOD_DEFINITION(ptAvatar, tintSkin, args)
@@ -419,32 +413,30 @@ PYTHON_BASIC_METHOD_DEFINITION(ptAvatar, exitSubWorld, ExitSubWorld)
 
 PYTHON_METHOD_DEFINITION(ptAvatar, setMorph, args)
 {
-    char* clothingName = nullptr;
+    ST::string clothingName;
     unsigned char layer;
     float value;
-    if (!PyArg_ParseTuple(args, "sBf", &clothingName, &layer, &value))
+    if (!PyArg_ParseTuple(args, "O&Bf", PyUnicode_STStringConverter, &clothingName, &layer, &value))
     {
         PyErr_SetString(PyExc_TypeError, "setMorph expects a string, unsigned 8-bit int, and a float");
         PYTHON_RETURN_ERROR;
     }
 
-    std::string clothingNameStr = clothingName; // convert to string (for safety)
-    self->fThis->SetMorph(clothingNameStr.c_str(), layer, value);
+    self->fThis->SetMorph(clothingName, layer, value);
     PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION(ptAvatar, getMorph, args)
 {
-    char* clothingName = nullptr;
+    ST::string clothingName;
     unsigned char layer;
-    if (!PyArg_ParseTuple(args, "sB", &clothingName, &layer))
+    if (!PyArg_ParseTuple(args, "O&B", PyUnicode_STStringConverter, &clothingName, &layer))
     {
         PyErr_SetString(PyExc_TypeError, "getMorph expects a string, and an unsignd 8-bit int");
         PYTHON_RETURN_ERROR;
     }
 
-    std::string clothingNameStr = clothingName; // convert to string (for safety)
-    return PyFloat_FromDouble(self->fThis->GetMorph(clothingNameStr.c_str(), layer));
+    return PyFloat_FromDouble(self->fThis->GetMorph(clothingName, layer));
 }
 
 PYTHON_METHOD_DEFINITION(ptAvatar, setSkinBlend, args)
@@ -493,15 +485,14 @@ PYTHON_METHOD_DEFINITION(ptAvatar, getUniqueMeshList, args)
 
 PYTHON_METHOD_DEFINITION(ptAvatar, getAllWithSameMesh, args)
 {
-    char* clothingName = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &clothingName))
+    ST::string clothingName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &clothingName))
     {
         PyErr_SetString(PyExc_TypeError, "getAllWithSameMesh expects a string");
         PYTHON_RETURN_ERROR;
     }
 
-    std::string clothingNameStr = clothingName; // convert to string (for safety)
-    std::vector<PyObject*> clothingList = self->fThis->GetAllWithSameMesh(clothingNameStr.c_str());
+    std::vector<PyObject*> clothingList = self->fThis->GetAllWithSameMesh(clothingName);
     PyObject* retVal = PyList_New(clothingList.size());
     for (int i = 0; i < clothingList.size(); i++)
         PyList_SetItem(retVal, i, clothingList[i]); // steals the ref, so no need to decref
@@ -519,10 +510,10 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptAvatar, getWardrobeClothingList)
 
 PYTHON_METHOD_DEFINITION(ptAvatar, addWardrobeClothingItem, args)
 {
-    char* clothingName = nullptr;
+    ST::string clothingName;
     PyObject* tint1Obj = nullptr;
     PyObject* tint2Obj = nullptr;
-    if (!PyArg_ParseTuple(args, "sOO", &clothingName, &tint1Obj, &tint2Obj))
+    if (!PyArg_ParseTuple(args, "O&OO", PyUnicode_STStringConverter, &clothingName, &tint1Obj, &tint2Obj))
     {
         PyErr_SetString(PyExc_TypeError, "addWardrobeClothingItem expects a string and two ptColor objects");
         PYTHON_RETURN_ERROR;
@@ -533,10 +524,9 @@ PYTHON_METHOD_DEFINITION(ptAvatar, addWardrobeClothingItem, args)
         PYTHON_RETURN_ERROR;
     }
 
-    std::string clothingNameStr = clothingName; // convert to string (for safety)
     pyColor* tint1 = pyColor::ConvertFrom(tint1Obj);
     pyColor* tint2 = pyColor::ConvertFrom(tint2Obj);
-    self->fThis->AddWardrobeClothingItem(clothingNameStr.c_str(), *tint1, *tint2);
+    self->fThis->AddWardrobeClothingItem(clothingName, *tint1, *tint2);
     PYTHON_RETURN_NONE;
 }
 
@@ -604,14 +594,14 @@ PYTHON_METHOD_DEFINITION(ptAvatar, unRegisterForBehaviorNotify, args)
 
 PYTHON_METHOD_DEFINITION(ptAvatar, playSimpleAnimation, args)
 {
-    char* animName = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &animName))
+    ST::string animName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &animName))
     {
         PyErr_SetString(PyExc_TypeError, "playSimpleAnimation expects a string object");
         PYTHON_RETURN_ERROR;
     }
 
-    self->fThis->PlaySimpleAnimation(ST::string::from_utf8(animName));
+    self->fThis->PlaySimpleAnimation(animName);
     PYTHON_RETURN_NONE;
 }
 
@@ -736,43 +726,40 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtSetBehaviorLoopCount, args, "Params: behaviorK
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtChangeAvatar, args, "Params: gender\nChange the local avatar's gender (or clothing type)")
 {
-    char* gender = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &gender))
+    ST::string gender;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &gender))
     {
         PyErr_SetString(PyExc_TypeError, "PtChangeAvatar expects a string");
         PYTHON_RETURN_ERROR;
     }
 
-    std::string genderStr = gender; // convert to string (for safety)
-    cyAvatar::ChangeAvatar(genderStr.c_str());
+    cyAvatar::ChangeAvatar(gender);
     PYTHON_RETURN_NONE;
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtChangePlayerName, args, "Params: name\nChange the local avatar's name")
 {
-    char* name = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "PtChangePlayerName expects a string");
         PYTHON_RETURN_ERROR;
     }
 
-    std::string nameStr = name; // convert to string (for safety)
-    cyAvatar::ChangePlayerName(nameStr.c_str());
+    cyAvatar::ChangePlayerName(name);
     PYTHON_RETURN_NONE;
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtEmoteAvatar, args, "Params: emote\nPlay an emote on the local avatar (netpropagated)")
 {
-    char* emote = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &emote))
+    ST::string emote;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &emote))
     {
         PyErr_SetString(PyExc_TypeError, "PtEmoteAvatar expects a string");
         PYTHON_RETURN_ERROR;
     }
 
-    std::string emoteStr = emote; // convert to string (for safety)
-    PYTHON_RETURN_BOOL(cyAvatar::Emote(emoteStr.c_str()));
+    PYTHON_RETURN_BOOL(cyAvatar::Emote(emote));
 }
 
 PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtAvatarSitOnGround, "Tells the local avatar to sit on ground and enter sit idle loop (netpropagated)")

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrain.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrain.cpp
@@ -80,7 +80,7 @@ PyObject* pyCritterBrain::GetSceneObject()
     PYTHON_RETURN_NONE;
 }
 
-void pyCritterBrain::AddBehavior(const std::string& animationName, const std::string& behaviorName, bool loop /* = true */,
+void pyCritterBrain::AddBehavior(const ST::string& animationName, const ST::string& behaviorName, bool loop /* = true */,
     bool randomStartPos /* = true */, float fadeInLen /* = 2.f */, float fadeOutLen /* = 2.f */)
 {
     if (!fBrain)
@@ -88,31 +88,31 @@ void pyCritterBrain::AddBehavior(const std::string& animationName, const std::st
     fBrain->AddBehavior(animationName, behaviorName, loop, randomStartPos, fadeInLen, fadeOutLen);
 }
 
-void pyCritterBrain::StartBehavior(const std::string& behaviorName, bool fade /* = true */)
+void pyCritterBrain::StartBehavior(const ST::string& behaviorName, bool fade /* = true */)
 {
     if (!fBrain)
         return;
     fBrain->StartBehavior(behaviorName, fade);
 }
 
-bool pyCritterBrain::RunningBehavior(const std::string& behaviorName) const
+bool pyCritterBrain::RunningBehavior(const ST::string& behaviorName) const
 {
     if (!fBrain)
         return false;
     return fBrain->RunningBehavior(behaviorName);
 }
 
-std::string pyCritterBrain::BehaviorName(int behavior) const
+ST::string pyCritterBrain::BehaviorName(int behavior) const
 {
     if (!fBrain)
-        return nullptr;
+        return {};
     return fBrain->BehaviorName(behavior);
 }
 
 ST::string pyCritterBrain::AnimationName(int behavior) const
 {
     if (!fBrain)
-        return ST::string();
+        return {};
     return fBrain->AnimationName(behavior);
 }
 
@@ -130,17 +130,17 @@ int pyCritterBrain::NextBehavior() const
     return fBrain->NextBehavior();
 }
 
-std::string pyCritterBrain::IdleBehaviorName() const
+ST::string pyCritterBrain::IdleBehaviorName() const
 {
     if (!fBrain)
-        return nullptr;
+        return {};
     return fBrain->IdleBehaviorName();
 }
 
-std::string pyCritterBrain::RunBehaviorName() const
+ST::string pyCritterBrain::RunBehaviorName() const
 {
     if (!fBrain)
-        return nullptr;
+        return {};
     return fBrain->RunBehaviorName();
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrain.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrain.h
@@ -43,10 +43,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define _pyCritterBrain_h_
 
 #include "pyGlueHelpers.h"
-#include <string>
 
 class plAvBrainCritter;
 struct hsPoint3;
+namespace ST { class string; }
 
 // simply here so we can pass our message types on to python
 class pyAIMsg
@@ -81,18 +81,18 @@ public:
 
     PyObject* GetSceneObject();
 
-    void AddBehavior(const std::string& animationName, const std::string& behaviorName, bool loop = true, bool randomStartPos = true,
+    void AddBehavior(const ST::string& animationName, const ST::string& behaviorName, bool loop = true, bool randomStartPos = true,
         float fadeInLen = 2.f, float fadeOutLen = 2.f);
-    void StartBehavior(const std::string& behaviorName, bool fade = true);
-    bool RunningBehavior(const std::string& behaviorName) const;
+    void StartBehavior(const ST::string& behaviorName, bool fade = true);
+    bool RunningBehavior(const ST::string& behaviorName) const;
 
-    std::string BehaviorName(int behavior) const;
+    ST::string BehaviorName(int behavior) const;
     ST::string AnimationName(int behavior) const;
     int CurBehavior() const;
     int NextBehavior() const;
 
-    std::string IdleBehaviorName() const;
-    std::string RunBehaviorName() const;
+    ST::string IdleBehaviorName() const;
+    ST::string RunBehaviorName() const;
 
     void GoToGoal(hsPoint3 newGoal, bool avoidingAvatars = false);
     PyObject* CurrentGoal() const; // returns ptPoint3

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
@@ -150,12 +150,14 @@ PYTHON_METHOD_DEFINITION_WKEY(ptCritterBrain, addBehavior, args, keywords)
 {
     const char* kwlist[] = {"animationName", "behaviorName", "loop", "randomStartPos",
                             "fadeInLen", "fadeOutLen", nullptr};
-    char* animName;
-    char* behName;
+    ST::string animName;
+    ST::string behName;
     char loop = 1, randomStartPos = 1;
     float fadeInLen = 2.f, fadeOutLen = 2.f;
-    if (!PyArg_ParseTupleAndKeywords(args, keywords, "ss|bbff", const_cast<char **>(kwlist),
-                                     &animName, &behName, &loop, &randomStartPos,
+    if (!PyArg_ParseTupleAndKeywords(args, keywords, "O&O&|bbff", const_cast<char **>(kwlist),
+                                     PyUnicode_STStringConverter, &animName,
+                                     PyUnicode_STStringConverter, &behName,
+                                     &loop, &randomStartPos,
                                      &fadeInLen, &fadeOutLen))
     {
         PyErr_SetString(PyExc_TypeError, "addBehavior expects two strings, and optionally two booleans and two floats");
@@ -169,10 +171,10 @@ PYTHON_METHOD_DEFINITION_WKEY(ptCritterBrain, addBehavior, args, keywords)
 PYTHON_METHOD_DEFINITION_WKEY(ptCritterBrain, startBehavior, args, keywords)
 {
     const char* kwlist[] = {"behaviorName", "fade", nullptr};
-    char* behName;
+    ST::string behName;
     char fade = 1;
-    if (!PyArg_ParseTupleAndKeywords(args, keywords, "s|b", const_cast<char**>(kwlist),
-                                     &behName, &fade)) {
+    if (!PyArg_ParseTupleAndKeywords(args, keywords, "O&|b", const_cast<char**>(kwlist),
+                                     PyUnicode_STStringConverter, &behName, &fade)) {
         PyErr_SetString(PyExc_TypeError, "startBehavior expects a string, and an optional boolean");
         PYTHON_RETURN_NONE;
     }
@@ -183,8 +185,8 @@ PYTHON_METHOD_DEFINITION_WKEY(ptCritterBrain, startBehavior, args, keywords)
 
 PYTHON_METHOD_DEFINITION(ptCritterBrain, runningBehavior, args)
 {
-    char* behName = nullptr;
-    if (!PyArg_ParseTuple(args, "s", &behName))
+    ST::string behName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &behName))
     {
         PyErr_SetString(PyExc_TypeError, "runningBehavior expects a string");
         PYTHON_RETURN_ERROR;
@@ -200,8 +202,7 @@ PYTHON_METHOD_DEFINITION(ptCritterBrain, behaviorName, args)
         PyErr_SetString(PyExc_TypeError, "behaviorName expects an integer");
         PYTHON_RETURN_ERROR;
     }
-    std::string beh = self->fThis->BehaviorName(behavior);
-    return PyUnicode_FromStdString(beh);
+    return PyUnicode_FromSTString(self->fThis->BehaviorName(behavior));
 }
 
 PYTHON_METHOD_DEFINITION(ptCritterBrain, animationName, args)
@@ -212,7 +213,7 @@ PYTHON_METHOD_DEFINITION(ptCritterBrain, animationName, args)
         PyErr_SetString(PyExc_TypeError, "animationName expects an integer");
         PYTHON_RETURN_ERROR;
     }
-    return PyUnicode_FromStdString(self->fThis->AnimationName(behavior));
+    return PyUnicode_FromSTString(self->fThis->AnimationName(behavior));
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptCritterBrain, curBehavior)
@@ -227,12 +228,12 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptCritterBrain, nextBehavior)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptCritterBrain, idleBehaviorName)
 {
-    return PyUnicode_FromStdString(self->fThis->IdleBehaviorName());
+    return PyUnicode_FromSTString(self->fThis->IdleBehaviorName());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptCritterBrain, runBehaviorName)
 {
-    return PyUnicode_FromStdString(self->fThis->RunBehaviorName());
+    return PyUnicode_FromSTString(self->fThis->RunBehaviorName());
 }
 
 PYTHON_METHOD_DEFINITION_WKEY(ptCritterBrain, goToGoal, args, keywords)

--- a/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGlueHelpers.h
@@ -55,7 +55,6 @@ int PyUnicode_PlFileNameDecoder(PyObject* obj, void* str);
 
 PyObject* PyUnicode_FromSTString(const ST::string& str);
 #define PyUnicode_FromSTString(x) PyUnicode_FromStringAndSize((x).c_str(), (x).size())
-#define PyUnicode_FromStdString(x) PyUnicode_FromStringAndSize((x).c_str(), (x).size())
 
 // A set of macros to take at least some of the tediousness out of creating straight python glue code
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -2337,12 +2337,12 @@ int plArmatureMod::GetCurrentGenericType()
         return brain->GetType();
 }
 
-bool plArmatureMod::FindMatchingGenericBrain(const char *names[], int count)
+bool plArmatureMod::FindMatchingGenericBrain(const std::vector<ST::string>& names)
 {
     for (size_t i = 0; i < GetBrainCount(); i++)
     {
         plAvBrainGeneric *brain = plAvBrainGeneric::ConvertNoRef(GetBrain(i));
-        if (brain && brain->MatchAnimNames(names, count))
+        if (brain && brain->MatchAnimNames(names))
             return true;
     }
     return false;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.h
@@ -304,7 +304,7 @@ public:
     void SetBodyType(int type) { fBodyType = type; }
     int  GetBodyType(int type) { return fBodyType; }
     int  GetCurrentGenericType();
-    bool FindMatchingGenericBrain(const char *names[], int count);
+    bool FindMatchingGenericBrain(const std::vector<ST::string>& names);
     ST::string MakeAnimationName(const ST::string& baseName) const;
     ST::string GetRootName();
     void SetRootName(const ST::string &name);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.h
@@ -43,7 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define PL_AV_BRAIN_CRITTER_H
 
 #include <map>
-#include <string>
+#include <string_theory/string>
 #include <vector>
 
 #include "plAvBrain.h"
@@ -101,18 +101,18 @@ public:
      */
     plSceneObject* GetTarget() const;
 
-    void AddBehavior(const std::string& animationName, const std::string& behaviorName, bool loop = true, bool randomStartPos = true,
+    void AddBehavior(const ST::string& animationName, const ST::string& behaviorName, bool loop = true, bool randomStartPos = true,
         float fadeInLen = 2.f, float fadeOutLen = 2.f);
-    void StartBehavior(const std::string& behaviorName, bool fade = true);
-    bool RunningBehavior(const std::string& behaviorName) const;
+    void StartBehavior(const ST::string& behaviorName, bool fade = true);
+    bool RunningBehavior(const ST::string& behaviorName) const;
 
-    std::string BehaviorName(int behavior) const;
+    ST::string BehaviorName(int behavior) const;
     ST::string AnimationName(int behavior) const;
     int CurBehavior() const {return fCurMode;}
     int NextBehavior() const {return fNextMode;}
 
-    std::string IdleBehaviorName() const;
-    std::string RunBehaviorName() const;
+    ST::string IdleBehaviorName() const;
+    ST::string RunBehaviorName() const;
 
     void GoToGoal(hsPoint3 newGoal, bool avoidingAvatars = false);
     hsPoint3 CurrentGoal() const {return fFinalGoalPos;}
@@ -149,7 +149,7 @@ protected:
     virtual bool IInitBaseAnimations();
 
     int IPickBehavior(int behavior) const;
-    int IPickBehavior(const std::string& behavior) const;
+    int IPickBehavior(const ST::string& behavior) const;
 
     void IFadeOutBehavior(); // fades out fCurMode
     void IStartBehavior(); // fades in and initializes fNextMode, then sets fCurMode
@@ -187,7 +187,7 @@ protected:
     float fHearingDistanceSquared; // the above, squared, for faster calculation
     float fLoudHearingDistanceSquared; // how far away we can hear loud noises, squared, for faster calculation
 
-    std::map<std::string, std::vector<int> > fUserBehaviors; // string is behavior name, internal vector is the list of behaviors that are randomly picked from
+    std::map<ST::string, std::vector<int> > fUserBehaviors; // string is behavior name, internal vector is the list of behaviors that are randomly picked from
 
     std::vector<plKey> fReceivers; // list of people that want messages from us
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainGeneric.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainGeneric.cpp
@@ -213,13 +213,12 @@ bool plAvBrainGeneric::IsRunningTask() const
     return false;
 }
 
-bool plAvBrainGeneric::MatchAnimNames(const char *names[], int count)
+bool plAvBrainGeneric::MatchAnimNames(const std::vector<ST::string>& names)
 {
-    if (count != GetStageCount())
+    if (names.size() != GetStageCount())
         return false;
 
-    int i;
-    for (i = 0; i < count; i++)
+    for (size_t i = 0; i < names.size(); i++)
     {
         if (GetStage(i)->GetAnimName() != names[i])
             return false; // different names.

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainGeneric.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainGeneric.h
@@ -44,6 +44,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 // base class
 #include "plAvBrain.h"
+
+#include <vector>
+
 #include "plAnimation/plAGAnim.h"
 
 class plAnimStage;
@@ -173,7 +176,7 @@ public:
     
     /** Compare the names of the anims in our stages.
         Return true on a match (order matters). */
-    bool MatchAnimNames(const char *names[], int count);
+    bool MatchAnimNames(const std::vector<ST::string>& names);
 
     /** Add the given stage to the end of the stage sequence.
         Returns the zero-based index of the stage.

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
@@ -64,6 +64,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plPhysicalControllerCore.h"
 
 #include <cmath>
+#include <vector>
 
 #include "pnEncryption/plRandom.h"
 #include "pnSceneObject/plCoordinateInterface.h"
@@ -1337,11 +1338,11 @@ bool PushWalk::PreCondition(double time, float elapsed)
 //
 /////////////////////////////////////////////////////////////////////////////////////////
 
-static bool CanPushGenericBrain(plArmatureMod* avatar, const char** anims, size_t numAnims, plAvBrainGeneric::BrainType type)
+static bool CanPushGenericBrain(plArmatureMod* avatar, const std::vector<ST::string>& anims, plAvBrainGeneric::BrainType type)
 {
     plAvBrainHuman *huBrain = plAvBrainHuman::ConvertNoRef(avatar->FindBrainByClass(plAvBrainHuman::Index()));
     if (!huBrain || !huBrain->fWalkingStrategy->IsOnGround() || !huBrain->fWalkingStrategy->HitGroundInThisAge() || huBrain->IsRunningTask() ||
-        !avatar->IsPhysicsEnabled() || avatar->FindMatchingGenericBrain(anims, numAnims))
+        !avatar->IsPhysicsEnabled() || avatar->FindMatchingGenericBrain(anims))
         return false;
 
     // XXX
@@ -1356,11 +1357,10 @@ static bool CanPushGenericBrain(plArmatureMod* avatar, const char** anims, size_
     return true;
 }
 
-bool PushSimpleMultiStage(plArmatureMod *avatar, const char *enterAnim, const char *idleAnim, const char *exitAnim,
+bool PushSimpleMultiStage(plArmatureMod *avatar, const ST::string& enterAnim, const ST::string& idleAnim, const ST::string& exitAnim,
                           bool netPropagate, bool autoExit, plAGAnim::BodyUsage bodyUsage, plAvBrainGeneric::BrainType type /* = kGeneric */)
 {
-    const char* names[3] = {enterAnim, idleAnim, exitAnim};
-    if (!CanPushGenericBrain(avatar, names, std::size(names), type))
+    if (!CanPushGenericBrain(avatar, {enterAnim, idleAnim, exitAnim}, type))
         return false;
 
     // if autoExit is true, then we will immediately exit the idle loop when the user hits a move
@@ -1402,8 +1402,7 @@ bool PushSimpleMultiStage(plArmatureMod *avatar, const char *enterAnim, const ch
 
 bool PushRepeatEmote(plArmatureMod* avatar, const ST::string& anim)
 {
-    const char* names[1] = { anim.c_str() };
-    if (!CanPushGenericBrain(avatar, names, std::size(names), plAvBrainGeneric::kGeneric))
+    if (!CanPushGenericBrain(avatar, {anim}, plAvBrainGeneric::kGeneric))
         return false;
 
      plAnimStageVec* v = new plAnimStageVec;
@@ -1427,7 +1426,7 @@ bool PushRepeatEmote(plArmatureMod* avatar, const ST::string& anim)
     return true;
 }
 
-bool AvatarEmote(plArmatureMod *avatar, const char *emoteName)
+bool AvatarEmote(plArmatureMod *avatar, const ST::string& emoteName)
 {
     bool result = false;
     ST::string fullName = avatar->MakeAnimationName(emoteName);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.h
@@ -59,6 +59,7 @@ class plControlEventMsg;
 class plMatrixChannel;
 class plMatrixMultiplyApplicator;
 class plWalkingStrategy;
+namespace ST { class string; }
 
 class plAvBrainHuman : public plArmatureBrain
 {
@@ -396,11 +397,11 @@ public:
     bool PreCondition(double time, float elapsed) override;
 };
 
-bool PushSimpleMultiStage(plArmatureMod *avatar, const char *enterAnim, const char *idleAnim,
-                          const char *exitAnim, bool netPropagate, bool autoExit, plAGAnim::BodyUsage bodyUsage,
+bool PushSimpleMultiStage(plArmatureMod *avatar, const ST::string& enterAnim, const ST::string& idleAnim,
+                          const ST::string& exitAnim, bool netPropagate, bool autoExit, plAGAnim::BodyUsage bodyUsage,
                           plAvBrainGeneric::BrainType type = plAvBrainGeneric::kGeneric);
 bool PushRepeatEmote(plArmatureMod* avatar, const ST::string& anim);
-bool AvatarEmote(plArmatureMod *avatar, const char *emoteName);
+bool AvatarEmote(plArmatureMod *avatar, const ST::string& emoteName);
 
 
 #endif // PLAVBRAINHUMAN_INC


### PR DESCRIPTION
Again not because of concrete Unicode bugs, just `ST::string`-ifying more Python glue. This removes almost all uses of `std::string` in pfPython.