### PR TITLE
Finish migrating vault Python glue to `ST::string`

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifierGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifierGlue.cpp
@@ -58,10 +58,10 @@ PYTHON_INIT_DEFINITION(ptSDL, args, keywords)
 
 PYTHON_METHOD_DEFINITION(ptSDL, setIndex, args)
 {
-    char* key;
+    ST::string key;
     int idx;
     PyObject* value = nullptr;
-    if (!PyArg_ParseTuple(args, "siO", &key, &idx, &value))
+    if (!PyArg_ParseTuple(args, "O&iO", PyUnicode_STStringConverter, &key, &idx, &value))
     {
         PyErr_SetString(PyExc_TypeError, "setIndex expects a string, int, and an object");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.cpp
@@ -188,7 +188,7 @@ void pyAgeVault::AddChronicleEntry( const ST::string& name, uint32_t type, const
 
 // AGE DEVICES. AKA IMAGERS, WHATEVER.
 // Add a new device.
-void pyAgeVault::AddDevice( const char * deviceName, PyObject * cbObject, uint32_t cbContext )
+void pyAgeVault::AddDevice(const ST::string& deviceName, PyObject * cbObject, uint32_t cbContext)
 {
     pyVaultNode::pyVaultNodeOperationCallback * cb = new pyVaultNode::pyVaultNodeOperationCallback( cbObject );
     cb->VaultOperationStarted( cbContext );
@@ -200,18 +200,18 @@ void pyAgeVault::AddDevice( const char * deviceName, PyObject * cbObject, uint32
 }
 
 // Remove a device.
-void pyAgeVault::RemoveDevice( const char * deviceName )
+void pyAgeVault::RemoveDevice(const ST::string& deviceName)
 {
     VaultAgeRemoveDevice(deviceName);
 }
 
 // True if device exists in age.
-bool pyAgeVault::HasDevice( const char * deviceName )
+bool pyAgeVault::HasDevice(const ST::string& deviceName)
 {
     return VaultAgeHasDevice(deviceName);
 }
 
-PyObject * pyAgeVault::GetDevice( const char * deviceName )
+PyObject * pyAgeVault::GetDevice(const ST::string& deviceName)
 {
     if (hsRef<RelVaultNode> rvn = VaultAgeGetDevice(deviceName))
         return pyVaultTextNoteNode::New(rvn);
@@ -220,7 +220,7 @@ PyObject * pyAgeVault::GetDevice( const char * deviceName )
 }
 
 // Sets the inbox associated with a device.
-void pyAgeVault::SetDeviceInbox( const char * deviceName, const char * inboxName, PyObject * cbObject, uint32_t cbContext )
+void pyAgeVault::SetDeviceInbox(const ST::string& deviceName, const ST::string& inboxName, PyObject * cbObject, uint32_t cbContext)
 {
     pyVaultNode::pyVaultNodeOperationCallback * cb = new pyVaultNode::pyVaultNodeOperationCallback( cbObject );
     cb->VaultOperationStarted( cbContext );
@@ -231,7 +231,7 @@ void pyAgeVault::SetDeviceInbox( const char * deviceName, const char * inboxName
     cb->VaultOperationComplete( cbContext, cb->GetNode() ? hsOK : hsFail ); // cbHolder deletes itself here.
 }
 
-PyObject * pyAgeVault::GetDeviceInbox( const char * deviceName )
+PyObject * pyAgeVault::GetDeviceInbox(const ST::string& deviceName)
 {
     if (hsRef<RelVaultNode> rvn = VaultAgeGetDeviceInbox(deviceName))
         return pyVaultTextNoteNode::New(rvn);

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.h
@@ -103,17 +103,17 @@ public:
     PyObject*       GetSubAgeLink( const pyAgeInfoStruct & info ); // returns pyVaultAgeLinkNode
     // AGE DEVICES. AKA IMAGERS, WHATEVER.
     // Add a new device.
-    void AddDevice(const char * deviceName, PyObject * cb = nullptr, uint32_t cbContext = 0);
+    void AddDevice(const ST::string& deviceName, PyObject * cb = nullptr, uint32_t cbContext = 0);
     // Remove a device.
-    void RemoveDevice( const char * deviceName );
+    void RemoveDevice(const ST::string& deviceName);
     // True if device exists in age.
-    bool HasDevice( const char * deviceName );
+    bool HasDevice(const ST::string& deviceName);
     // Get the device node by name.
-    PyObject * GetDevice( const char * deviceName ); // returns pyVaultTextNoteNode
+    PyObject * GetDevice(const ST::string& deviceName); // returns pyVaultTextNoteNode
     // Sets the inbox associated with a device.
-    void SetDeviceInbox(const char * deviceName, const char * inboxName, PyObject * cb = nullptr, uint32_t cbContext = 0);
+    void SetDeviceInbox(const ST::string& deviceName, const ST::string& inboxName, PyObject * cb = nullptr, uint32_t cbContext = 0);
     // Get the inbox associated with a device.
-    PyObject * GetDeviceInbox( const char * deviceName ); // returns pyVaultFolderNode
+    PyObject * GetDeviceInbox(const ST::string& deviceName); // returns pyVaultFolderNode
     // find matching node
     PyObject* FindNode( pyVaultNode* templateNode ) const; // returns pyVaultNode
 };

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVaultGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVaultGlue.cpp
@@ -121,10 +121,10 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptAgeVault, getAgeGuid)
 
 PYTHON_METHOD_DEFINITION(ptAgeVault, addDevice, args)
 {
-    char* name;
+    ST::string name;
     PyObject* cbObj = nullptr;
     unsigned long context = 0;
-    if (!PyArg_ParseTuple(args, "s|Ol", &name, &cbObj, &context))
+    if (!PyArg_ParseTuple(args, "O&|Ol", PyUnicode_STStringConverter, &name, &cbObj, &context))
     {
         PyErr_SetString(PyExc_TypeError, "addDevice expects a string, an optional object, and an optional unsigned long");
         PYTHON_RETURN_ERROR;
@@ -135,8 +135,8 @@ PYTHON_METHOD_DEFINITION(ptAgeVault, addDevice, args)
 
 PYTHON_METHOD_DEFINITION(ptAgeVault, removeDevice, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "removeDevice expects a string");
         PYTHON_RETURN_ERROR;
@@ -147,8 +147,8 @@ PYTHON_METHOD_DEFINITION(ptAgeVault, removeDevice, args)
 
 PYTHON_METHOD_DEFINITION(ptAgeVault, hasDevice, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "hasDevice expects a string");
         PYTHON_RETURN_ERROR;
@@ -158,8 +158,8 @@ PYTHON_METHOD_DEFINITION(ptAgeVault, hasDevice, args)
 
 PYTHON_METHOD_DEFINITION(ptAgeVault, getDevice, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "getDevice expects a string");
         PYTHON_RETURN_ERROR;
@@ -169,11 +169,11 @@ PYTHON_METHOD_DEFINITION(ptAgeVault, getDevice, args)
 
 PYTHON_METHOD_DEFINITION(ptAgeVault, setDeviceInbox, args)
 {
-    char* name;
-    char* inboxName;
+    ST::string name;
+    ST::string inboxName;
     PyObject* cb = nullptr;
     unsigned long context = 0;
-    if (!PyArg_ParseTuple(args, "ss|Ol", &name, &inboxName, &cb, &context))
+    if (!PyArg_ParseTuple(args, "O&O&|Ol", PyUnicode_STStringConverter, &name, PyUnicode_STStringConverter, &inboxName, &cb, &context))
     {
         PyErr_SetString(PyExc_TypeError, "setDeviceInbox expects two strings, an optional object, and an optional unsigned long");
         PYTHON_RETURN_ERROR;
@@ -184,8 +184,8 @@ PYTHON_METHOD_DEFINITION(ptAgeVault, setDeviceInbox, args)
 
 PYTHON_METHOD_DEFINITION(ptAgeVault, getDeviceInbox, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "getDeviceInbox expects a string");
         PYTHON_RETURN_ERROR;
@@ -195,8 +195,8 @@ PYTHON_METHOD_DEFINITION(ptAgeVault, getDeviceInbox, args)
 
 PYTHON_METHOD_DEFINITION(ptAgeVault, findChronicleEntry, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "findChronicleEntry expects a string");
         PYTHON_RETURN_ERROR;
@@ -206,10 +206,10 @@ PYTHON_METHOD_DEFINITION(ptAgeVault, findChronicleEntry, args)
 
 PYTHON_METHOD_DEFINITION(ptAgeVault, addChronicleEntry, args)
 {
-    char* name;
+    ST::string name;
     unsigned long entryType;
-    char* val;
-    if (!PyArg_ParseTuple(args, "sls", &name, &entryType, &val))
+    ST::string val;
+    if (!PyArg_ParseTuple(args, "O&lO&", PyUnicode_STStringConverter, &name, &entryType, PyUnicode_STStringConverter, &val))
     {
         PyErr_SetString(PyExc_TypeError, "addChronicleEntry expects a string, an unsigned long, and a string");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pySDL.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySDL.cpp
@@ -165,11 +165,11 @@ bool pySimpleStateVariable::SetInt( int v, int idx )
     return fVar->Set( v, idx );
 }
 
-bool pySimpleStateVariable::SetString( const char * v, int idx )
+bool pySimpleStateVariable::SetString( const ST::string& v, int idx )
 {
     if ( !fVar )
         return false;
-    return fVar->Set( v, idx );
+    return fVar->Set( v.c_str(), idx );
 }
 
 bool pySimpleStateVariable::SetBool( bool v, int idx )

--- a/Sources/Plasma/FeatureLib/pfPython/pySDL.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pySDL.h
@@ -125,7 +125,7 @@ public:
     bool    SetFloat( float v, int idx=0 );
     bool    SetDouble( double v, int idx=0 );
     bool    SetInt( int v, int idx=0 );
-    bool    SetString( const char * v, int idx=0 );
+    bool    SetString( const ST::string& v, int idx=0 );
     bool    SetBool(bool v, int idx=0 );
     uint8_t GetByte( int idx=0 ) const;
     short   GetShort( int idx=0 ) const;

--- a/Sources/Plasma/FeatureLib/pfPython/pySDLGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySDLGlue.cpp
@@ -92,8 +92,8 @@ PYTHON_INIT_DEFINITION(ptSDLStateDataRecord, args, keywords)
 
 PYTHON_METHOD_DEFINITION(ptSDLStateDataRecord, findVar, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "findVar expects a string");
         PYTHON_RETURN_ERROR;
@@ -203,7 +203,19 @@ STATEVAR_SET(setShort, SetShort, short, short, h)
 STATEVAR_SET(setFloat, SetFloat, float, float, f)
 STATEVAR_SET(setDouble, SetDouble, double, double, d)
 STATEVAR_SET(setInt, SetInt, int, int, i)
-STATEVAR_SET(setString, SetString, string, char*, s)
+
+// setString is special because of the ST::string conversion
+PYTHON_METHOD_DEFINITION(ptSimpleStateVariable, setString, args)
+{
+    ST::string val;
+    int idx = 0;
+    if (!PyArg_ParseTuple(args, "O&|i", PyUnicode_STStringConverter, &val, &idx))
+    {
+        PyErr_SetString(PyExc_TypeError, "setString expects a string and an optional int");
+        PYTHON_RETURN_ERROR;
+    }
+    PYTHON_RETURN_BOOL(self->fThis->SetString(val, idx));
+}
 
 // setBool is special cause of the way python represents booleans
 PYTHON_METHOD_DEFINITION(ptSimpleStateVariable, setBool, args)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
@@ -319,7 +319,7 @@ PyObject* pyVault::GetVisitAgeLink( const pyAgeInfoStruct & info)
 
 ///////////////
 // Chronicle
-PyObject* pyVault::FindChronicleEntry( const char * entryName )
+PyObject* pyVault::FindChronicleEntry(const ST::string& entryName)
 {
     if (hsRef<RelVaultNode> rvn = VaultFindChronicleEntry(entryName))
         return pyVaultChronicleNode::New(rvn);
@@ -328,7 +328,7 @@ PyObject* pyVault::FindChronicleEntry( const char * entryName )
     PYTHON_RETURN_NONE;
 }
 
-void pyVault::AddChronicleEntry( const char * name, uint32_t type, const char * value )
+void pyVault::AddChronicleEntry(const ST::string& name, uint32_t type, const ST::string& value)
 {
     // FIXME: We should ideally not block, but for now, the Python assumes that when
     //        we return, the chronicle exists and can be found with findChronicleEntry.
@@ -337,7 +337,7 @@ void pyVault::AddChronicleEntry( const char * name, uint32_t type, const char * 
 }
 
 
-void pyVault::SendToDevice( pyVaultNode& node, const char * deviceName )
+void pyVault::SendToDevice(pyVaultNode& node, const ST::string& deviceName)
 {
     if (!node.GetNode())
         return;
@@ -482,7 +482,7 @@ void pyVault::RegisterOwnedAge( const pyAgeLinkStruct & link )
     VaultRegisterOwnedAgeAndWait(link.GetAgeLink());
 }
 
-void pyVault::UnRegisterOwnedAge( const char * ageFilename )
+void pyVault::UnRegisterOwnedAge(const ST::string& ageFilename)
 {
     plAgeInfoStruct info;
     info.SetAgeFilename(ageFilename);
@@ -494,7 +494,7 @@ void pyVault::RegisterVisitAge( const pyAgeLinkStruct & link )
     VaultRegisterVisitAge(link.GetAgeLink());
 }
 
-void pyVault::UnRegisterVisitAge( const char * guidstr )
+void pyVault::UnRegisterVisitAge(const ST::string& guidstr)
 {
     plAgeInfoStruct info;
     plUUID guid(guidstr);
@@ -526,7 +526,7 @@ void _UninvitePlayerToAge(ENetError result, void* state, void* param, hsWeakRef<
         VaultSendNode(node, (uint32_t)((uintptr_t)param));
 }
 
-void pyVault::UnInvitePlayerToAge( const char * str, uint32_t playerID )
+void pyVault::UnInvitePlayerToAge(const ST::string& str, uint32_t playerID)
 {
     plAgeInfoStruct info;
     plUUID guid(str);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.h
@@ -128,11 +128,11 @@ public:
     PyObject* GetVisitAgeLink( const pyAgeInfoStruct & info ); // returns pyVaultAgeLinkNode
     ///////////////
     // Chronicle
-    PyObject* FindChronicleEntry( const char * entryName ); // returns pyVaultChronicleNode
-    void AddChronicleEntry( const char * name, uint32_t type, const char * value );
+    PyObject* FindChronicleEntry(const ST::string& entryName); // returns pyVaultChronicleNode
+    void AddChronicleEntry(const ST::string& name, uint32_t type, const ST::string& value);
     ///////////////
     // publishing
-    void    SendToDevice( pyVaultNode& node, const char * deviceName );
+    void    SendToDevice(pyVaultNode& node, const ST::string& deviceName);
     ///////////////
     // yeesha pages, etc.
     PyObject* GetPsnlAgeSDL() const; // returns pySDLStateDataRecord
@@ -155,17 +155,17 @@ public:
     ///////////////
     // Registser the given age as owned by player.
     void RegisterOwnedAge( const pyAgeLinkStruct & link );
-    void UnRegisterOwnedAge( const char * ageFilename );
+    void UnRegisterOwnedAge(const ST::string& ageFilename);
     // Register the given age as visitable by player
     void RegisterVisitAge( const pyAgeLinkStruct & link );
-    void UnRegisterVisitAge( const char * guid );
+    void UnRegisterVisitAge(const ST::string& guid);
     // Register a nexus station
     void RegisterMTStation( const ST::string& stationName, const ST::string& mtSpawnPt );
 
     ///////////////
     // Invite player to visit an age.
     void InvitePlayerToAge( const pyAgeLinkStruct & link, uint32_t playerID );
-    void UnInvitePlayerToAge( const char * guid, uint32_t playerID );
+    void UnInvitePlayerToAge(const ST::string& guid, uint32_t playerID);
     // Offer link to player
     void OfferLinkToPlayer( const pyAgeLinkStruct & link, uint32_t playerID );
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.cpp
@@ -231,13 +231,11 @@ plUUID pyVaultAgeInfoNode::GetAgeInstanceGuid() const
     return kNilUuid;
 }
 
-void pyVaultAgeInfoNode::SetAgeInstanceGuid( const char * sguid )
+void pyVaultAgeInfoNode::SetAgeInstanceGuid(const ST::string& sguid)
 {
     if (fNode) {
         VaultAgeInfoNode access(fNode);
-        plUUID uuid;
-        uuid.FromString(sguid);
-        access.SetAgeInstanceGuid(uuid);
+        access.SetAgeInstanceGuid(plUUID(sguid));
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.h
@@ -50,7 +50,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include "pyGlueHelpers.h"
-#include <string>
 #include "pyVaultNode.h"
 
 struct RelVaultNode;
@@ -95,7 +94,7 @@ public:
     void     SetAgeUserDefinedName(const ST::string& v);
 
     plUUID  GetAgeInstanceGuid() const;
-    void    SetAgeInstanceGuid( const char * guid );
+    void    SetAgeInstanceGuid(const ST::string& guid);
 
     ST::string GetAgeDescription() const;
     void     SetAgeDescription(const ST::string& v);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNodeGlue.cpp
@@ -101,8 +101,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultAgeInfoNode, getAgeFilename)
 
 PYTHON_METHOD_DEFINITION(ptVaultAgeInfoNode, setAgeFilename, args)
 {
-    char* filename;
-    if (!PyArg_ParseTuple(args, "s", &filename))
+    ST::string filename;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &filename))
     {
         PyErr_SetString(PyExc_TypeError, "setAgeFilename expects a string");
         PYTHON_RETURN_ERROR;
@@ -118,8 +118,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultAgeInfoNode, getAgeInstanceName)
 
 PYTHON_METHOD_DEFINITION(ptVaultAgeInfoNode, setAgeInstanceName, args)
 {
-    char* instanceName;
-    if (!PyArg_ParseTuple(args, "s", &instanceName))
+    ST::string instanceName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &instanceName))
     {
         PyErr_SetString(PyExc_TypeError, "setAgeInstanceName expects a string");
         PYTHON_RETURN_ERROR;
@@ -135,8 +135,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultAgeInfoNode, getAgeUserDefinedName)
 
 PYTHON_METHOD_DEFINITION(ptVaultAgeInfoNode, setAgeUserDefinedName, args)
 {
-    char* userDefName;
-    if (!PyArg_ParseTuple(args, "s", &userDefName))
+    ST::string userDefName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &userDefName))
     {
         PyErr_SetString(PyExc_TypeError, "setAgeUserDefinedName expects a string");
         PYTHON_RETURN_ERROR;
@@ -152,8 +152,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultAgeInfoNode, getAgeInstanceGuid)
 
 PYTHON_METHOD_DEFINITION(ptVaultAgeInfoNode, setAgeInstanceGuid, args)
 {
-    char* guid;
-    if (!PyArg_ParseTuple(args, "s", &guid))
+    ST::string guid;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &guid))
     {
         PyErr_SetString(PyExc_TypeError, "setAgeInstanceGuid expects a string");
         PYTHON_RETURN_ERROR;
@@ -169,8 +169,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultAgeInfoNode, getAgeDescription)
 
 PYTHON_METHOD_DEFINITION(ptVaultAgeInfoNode, setAgeDescription, args)
 {
-    char* descr;
-    if (!PyArg_ParseTuple(args, "s", &descr))
+    ST::string descr;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &descr))
     {
         PyErr_SetString(PyExc_TypeError, "setAgeDescription expects a string");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.h
@@ -52,7 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGlueHelpers.h"
 #include "pyVaultNode.h"
 #include "plNetCommon/plNetServerSessionInfo.h" // for plAgeLinkStruct
-#include <string>
 
 class pyVaultAgeInfoNode;
 struct RelVaultNode;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNodeGlue.cpp
@@ -159,8 +159,8 @@ PYTHON_METHOD_DEFINITION(ptVaultAgeLinkNode, removeSpawnPoint, args)
 
 PYTHON_METHOD_DEFINITION(ptVaultAgeLinkNode, hasSpawnPoint, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "hasSpawnPoint expects a string");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.cpp
@@ -77,11 +77,11 @@ int pyVaultFolderNode::Folder_GetType()
     return folder.GetFolderType();
 }
 
-void pyVaultFolderNode::Folder_SetName(const wchar_t* name)
+void pyVaultFolderNode::Folder_SetName(const ST::string& name)
 {
     if (fNode) {
         VaultFolderNode folder(fNode);
-        folder.SetFolderName(ST::string::from_wchar(name));
+        folder.SetFolderName(name);
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.h
@@ -72,7 +72,7 @@ public:
 
     virtual void    Folder_SetType( int type );
     virtual int     Folder_GetType();
-    void    Folder_SetName(const wchar_t* name);
+    void    Folder_SetName(const ST::string& name);
     ST::string Folder_GetName() const;
 
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNodeGlue.cpp
@@ -83,21 +83,14 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultFolderNode, getFolderType)
 
 PYTHON_METHOD_DEFINITION(ptVaultFolderNode, setFolderName, args)
 {
-    PyObject* textObj;
-    if (!PyArg_ParseTuple(args, "O", &textObj))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "setFolderName expects a unicode string");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* name = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->Folder_SetName(name);
-        PyMem_Free(name);
-        PYTHON_RETURN_NONE;
-    }
-    PyErr_SetString(PyExc_TypeError, "setFolderName expects a unicode string");
-    PYTHON_RETURN_ERROR;
+    self->fThis->Folder_SetName(name);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultFolderNode, getFolderName)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultGlue.cpp
@@ -182,8 +182,8 @@ PYTHON_METHOD_DEFINITION(ptVault, getVisitAgeLink, args)
 
 PYTHON_METHOD_DEFINITION(ptVault, findChronicleEntry, args)
 {
-    char* entryName;
-    if (!PyArg_ParseTuple(args, "s", &entryName))
+    ST::string entryName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &entryName))
     {
         PyErr_SetString(PyExc_TypeError, "findChronicleEntry expects a string");
         PYTHON_RETURN_ERROR;
@@ -193,10 +193,10 @@ PYTHON_METHOD_DEFINITION(ptVault, findChronicleEntry, args)
 
 PYTHON_METHOD_DEFINITION(ptVault, addChronicleEntry, args)
 {
-    char* entryName;
+    ST::string entryName;
     unsigned long entryType;
-    char* entryValue;
-    if (!PyArg_ParseTuple(args, "sls", &entryName, &entryType, &entryValue))
+    ST::string entryValue;
+    if (!PyArg_ParseTuple(args, "O&lO&", PyUnicode_STStringConverter, &entryName, &entryType, PyUnicode_STStringConverter, &entryValue))
     {
         PyErr_SetString(PyExc_TypeError, "addChronicleEntry expects a string, an unsigned long, and a string");
         PYTHON_RETURN_ERROR;
@@ -230,8 +230,8 @@ PYTHON_METHOD_DEFINITION(ptVault, findNode, args)
 PYTHON_METHOD_DEFINITION(ptVault, sendToDevice, args)
 {
     PyObject* nodeObj = nullptr;
-    char* deviceName;
-    if (!PyArg_ParseTuple(args, "Os", &nodeObj, &deviceName))
+    ST::string deviceName;
+    if (!PyArg_ParseTuple(args, "OO&", &nodeObj, PyUnicode_STStringConverter, &deviceName))
     {
         PyErr_SetString(PyExc_TypeError, "sendToDevice expects a ptVaultNode and a string");
         PYTHON_RETURN_ERROR;
@@ -325,9 +325,9 @@ PYTHON_METHOD_DEFINITION(ptVault, amAgeCzar, args)
 
 PYTHON_METHOD_DEFINITION(ptVault, registerMTStation, args)
 {
-    char* stationName;
-    char* mtSpawnPoint;
-    if (!PyArg_ParseTuple(args, "ss", &stationName, &mtSpawnPoint))
+    ST::string stationName;
+    ST::string mtSpawnPoint;
+    if (!PyArg_ParseTuple(args, "O&O&", PyUnicode_STStringConverter, &stationName, PyUnicode_STStringConverter, &mtSpawnPoint))
     {
         PyErr_SetString(PyExc_TypeError, "registerMTStation expects two strings");
         PYTHON_RETURN_ERROR;
@@ -356,8 +356,8 @@ PYTHON_METHOD_DEFINITION(ptVault, registerOwnedAge, args)
 
 PYTHON_METHOD_DEFINITION(ptVault, unRegisterOwnedAge, args)
 {
-    char* ageFilename;
-    if (!PyArg_ParseTuple(args, "s", &ageFilename))
+    ST::string ageFilename;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &ageFilename))
     {
         PyErr_SetString(PyExc_TypeError, "unRegisterOwnedAge expects a string");
         PYTHON_RETURN_ERROR;
@@ -386,8 +386,8 @@ PYTHON_METHOD_DEFINITION(ptVault, registerVisitAge, args)
 
 PYTHON_METHOD_DEFINITION(ptVault, unRegisterVisitAge, args)
 {
-    char* guid;
-    if (!PyArg_ParseTuple(args, "s", &guid))
+    ST::string guid;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &guid))
     {
         PyErr_SetString(PyExc_TypeError, "unRegisterVisitAge expects a string");
         PYTHON_RETURN_ERROR;
@@ -417,9 +417,9 @@ PYTHON_METHOD_DEFINITION(ptVault, invitePlayerToAge, args)
 
 PYTHON_METHOD_DEFINITION(ptVault, unInvitePlayerToAge, args)
 {
-    char* guid;
+    ST::string guid;
     unsigned long playerID;
-    if (!PyArg_ParseTuple(args, "sl", &guid, &playerID))
+    if (!PyArg_ParseTuple(args, "O&l", PyUnicode_STStringConverter, &guid, &playerID))
     {
         PyErr_SetString(PyExc_TypeError, "unInvitePlayerToAge expects a string and an unsigned long");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.cpp
@@ -100,13 +100,13 @@ pyVaultImageNode::~pyVaultImageNode () {
 //==================================================================
 // class RelVaultNode : public plVaultNode
 //
-void pyVaultImageNode::Image_SetTitle( const wchar_t* text )
+void pyVaultImageNode::Image_SetTitle(const ST::string& text)
 {
     if (!fNode)
         return;
 
     VaultImageNode image(fNode);
-    image.SetImageTitle(ST::string::from_wchar(text));
+    image.SetImageTitle(text);
 }
 
 ST::string pyVaultImageNode::Image_GetTitle() const

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.h
@@ -80,7 +80,7 @@ public:
 //==================================================================
 // class RelVaultNode : public plVaultNode
 //
-    void Image_SetTitle( const wchar_t * text );
+    void Image_SetTitle(const ST::string& text);
     ST::string Image_GetTitle() const;
 
     PyObject* Image_GetImage(); // returns pyImage

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNodeGlue.cpp
@@ -67,21 +67,14 @@ PYTHON_INIT_DEFINITION(ptVaultImageNode, args, keywords)
 
 PYTHON_METHOD_DEFINITION(ptVaultImageNode, setTitle, args)
 {
-    PyObject* textObj;
-    if (!PyArg_ParseTuple(args, "O", &textObj))
+    ST::string title;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &title))
     {
         PyErr_SetString(PyExc_TypeError, "setTitle expects a unicode string");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* title = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->Image_SetTitle(title);
-        PyMem_Free(title);
-        PYTHON_RETURN_NONE;
-    }
-    PyErr_SetString(PyExc_TypeError, "setTitle expects a unicode string");
-    PYTHON_RETURN_ERROR;
+    self->fThis->Image_SetTitle(title);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultImageNode, getTitle)

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -307,12 +307,12 @@ void pyVaultNode::SetCreatorNodeID( uint32_t v )
     fNode->SetCreatorId(v);
 }
 
-void pyVaultNode::SetCreateAgeName( const char * v )
+void pyVaultNode::SetCreateAgeName(const ST::string& v)
 {
     fNode->SetCreateAgeName(v);
 }
 
-void pyVaultNode::SetCreateAgeGuid( const char * v )
+void pyVaultNode::SetCreateAgeGuid(const ST::string& v)
 {
     ASSERT(fNode);
     plUUID uuid(v);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
@@ -150,8 +150,8 @@ public:
     void SetType( int v );
     void SetOwnerNodeID( uint32_t v );
     void SetCreatorNodeID( uint32_t v );
-    void SetCreateAgeName( const char * v );
-    void SetCreateAgeGuid( const char * v );
+    void SetCreateAgeName(const ST::string& v);
+    void SetCreateAgeGuid(const ST::string& v);
 
 
     /////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeGlue.cpp
@@ -223,8 +223,8 @@ PYTHON_METHOD_DEFINITION(ptVaultNode, setCreatorNodeID, args)
 
 PYTHON_METHOD_DEFINITION(ptVaultNode, setCreateAgeName, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "setCreateAgeName expects a string");
         PYTHON_RETURN_ERROR;
@@ -235,8 +235,8 @@ PYTHON_METHOD_DEFINITION(ptVaultNode, setCreateAgeName, args)
 
 PYTHON_METHOD_DEFINITION(ptVaultNode, setCreateAgeGuid, args)
 {
-    char* guid;
-    if (!PyArg_ParseTuple(args, "s", &guid))
+    ST::string guid;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &guid))
     {
         PyErr_SetString(PyExc_TypeError, "setCreateAgeGuid expects a string");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.cpp
@@ -117,7 +117,7 @@ ST::string pyVaultPlayerInfoNode::Player_GetAgeInstanceName() const
     return ST::string();
 }
 
-void pyVaultPlayerInfoNode::Player_SetAgeGuid( const char * guidtext)
+void pyVaultPlayerInfoNode::Player_SetAgeGuid(const ST::string& guidtext)
 {
     if (!fNode)
         return;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.h
@@ -81,7 +81,7 @@ public:
     // age the player is currently in, if any.
     void    Player_SetAgeInstanceName(const ST::string& name);
     ST::string Player_GetAgeInstanceName() const;
-    void    Player_SetAgeGuid( const char * guidtext);
+    void    Player_SetAgeGuid(const ST::string& guidtext);
     plUUID  Player_GetAgeGuid() const;
     // online status
     void    Player_SetOnline( bool b );

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNodeGlue.cpp
@@ -76,8 +76,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultPlayerInfoNode, playerGetID)
 
 PYTHON_METHOD_DEFINITION(ptVaultPlayerInfoNode, playerSetName, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "playerSetName expects a string");
         PYTHON_RETURN_ERROR;
@@ -93,8 +93,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultPlayerInfoNode, playerGetName)
 
 PYTHON_METHOD_DEFINITION(ptVaultPlayerInfoNode, playerSetAgeInstanceName, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "playerSetAgeInstanceName expects a string");
         PYTHON_RETURN_ERROR;
@@ -110,8 +110,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultPlayerInfoNode, playerGetAgeInstanceName)
 
 PYTHON_METHOD_DEFINITION(ptVaultPlayerInfoNode, playerSetAgeGuid, args)
 {
-    char* guid;
-    if (!PyArg_ParseTuple(args, "s", &guid))
+    ST::string guid;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &guid))
     {
         PyErr_SetString(PyExc_TypeError, "playerSetAgeGuid expects a string");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.cpp
@@ -198,7 +198,7 @@ PyObject *pyVaultPlayerNode::GetOwnedAgeLink(const pyAgeInfoStruct *info)
     PYTHON_RETURN_NONE;
 }
 
-void pyVaultPlayerNode::RemoveOwnedAgeLink(const char* ageFilename)
+void pyVaultPlayerNode::RemoveOwnedAgeLink(const ST::string& ageFilename)
 {
     plAgeInfoStruct info;
     info.SetAgeFilename(ageFilename);
@@ -213,7 +213,7 @@ PyObject *pyVaultPlayerNode::GetVisitAgeLink(const pyAgeInfoStruct *info)
     PYTHON_RETURN_NONE;
 }
 
-void pyVaultPlayerNode::RemoveVisitAgeLink(const char *guidstr)
+void pyVaultPlayerNode::RemoveVisitAgeLink(const ST::string& guidstr)
 {
     plAgeInfoStruct info;
     plUUID guid(guidstr);
@@ -221,7 +221,7 @@ void pyVaultPlayerNode::RemoveVisitAgeLink(const char *guidstr)
     VaultUnregisterOwnedAgeAndWait(&info);
 }
 
-PyObject *pyVaultPlayerNode::FindChronicleEntry(const char *entryName)
+PyObject *pyVaultPlayerNode::FindChronicleEntry(const ST::string& entryName)
 {
     if (hsRef<RelVaultNode> rvn = VaultFindChronicleEntry(entryName))
         return pyVaultChronicleNode::New(rvn);
@@ -229,7 +229,7 @@ PyObject *pyVaultPlayerNode::FindChronicleEntry(const char *entryName)
     PYTHON_RETURN_NONE;
 }
 
-void pyVaultPlayerNode::SetPlayerName(const char *value)
+void pyVaultPlayerNode::SetPlayerName(const ST::string& value)
 {
     hsAssert(false, "python may not change a player's name this way");
 }
@@ -243,7 +243,7 @@ ST::string pyVaultPlayerNode::GetPlayerName() const
     return ST::string();
 }
 
-void pyVaultPlayerNode::SetAvatarShapeName(const char *value)
+void pyVaultPlayerNode::SetAvatarShapeName(const ST::string& value)
 {
     hsAssert(false, "python may not change a player's avatar this way");
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.h
@@ -88,17 +88,17 @@ public:
     PyObject *GetLinkToCity(); // returns pyVaultAgeLinkNode
 
     PyObject *GetOwnedAgeLink(const pyAgeInfoStruct *info); // returns pyVaultAgeLinkNode
-    void RemoveOwnedAgeLink(const char* guid);
+    void RemoveOwnedAgeLink(const ST::string& guid);
 
     PyObject *GetVisitAgeLink(const pyAgeInfoStruct *info); // returns pyVaultAgeLinkNode
-    void RemoveVisitAgeLink(const char* guid);
+    void RemoveVisitAgeLink(const ST::string& guid);
 
-    PyObject *FindChronicleEntry(const char *entryName); // returns pyVaultChronicleNode
+    PyObject *FindChronicleEntry(const ST::string& entryName); // returns pyVaultChronicleNode
 
-    void SetPlayerName(const char *value);
+    void SetPlayerName(const ST::string& value);
     ST::string GetPlayerName() const;
 
-    void SetAvatarShapeName(const char *value);
+    void SetAvatarShapeName(const ST::string& value);
     ST::string GetAvatarShapeName() const;
 
     void SetDisabled(bool value);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNodeGlue.cpp
@@ -141,8 +141,8 @@ PYTHON_METHOD_DEFINITION(ptVaultPlayerNode, getOwnedAgeLink, args)
 
 PYTHON_METHOD_DEFINITION(ptVaultPlayerNode, removeOwnedAgeLink, args)
 {
-    char* guid;
-    if (!PyArg_ParseTuple(args, "s", &guid))
+    ST::string guid;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &guid))
     {
         PyErr_SetString(PyExc_TypeError, "removeOwnedAgeLink expects a string");
         PYTHON_RETURN_ERROR;
@@ -170,8 +170,8 @@ PYTHON_METHOD_DEFINITION(ptVaultPlayerNode, getVisitAgeLink, args)
 
 PYTHON_METHOD_DEFINITION(ptVaultPlayerNode, removeVisitAgeLink, args)
 {
-    char* guid;
-    if (!PyArg_ParseTuple(args, "s", &guid))
+    ST::string guid;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &guid))
     {
         PyErr_SetString(PyExc_TypeError, "removeVisitAgeLink expects a string");
         PYTHON_RETURN_ERROR;
@@ -182,8 +182,8 @@ PYTHON_METHOD_DEFINITION(ptVaultPlayerNode, removeVisitAgeLink, args)
 
 PYTHON_METHOD_DEFINITION(ptVaultPlayerNode, findChronicleEntry, args)
 {
-    char* entryName;
-    if (!PyArg_ParseTuple(args, "s", &entryName))
+    ST::string entryName;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &entryName))
     {
         PyErr_SetString(PyExc_TypeError, "findChronicleEntry expects a string");
         PYTHON_RETURN_ERROR;
@@ -193,8 +193,8 @@ PYTHON_METHOD_DEFINITION(ptVaultPlayerNode, findChronicleEntry, args)
 
 PYTHON_METHOD_DEFINITION(ptVaultPlayerNode, setPlayerName, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "setPlayerName expects a string");
         PYTHON_RETURN_ERROR;
@@ -210,8 +210,8 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultPlayerNode, getPlayerName)
 
 PYTHON_METHOD_DEFINITION(ptVaultPlayerNode, setAvatarShapeName, args)
 {
-    char* name;
-    if (!PyArg_ParseTuple(args, "s", &name))
+    ST::string name;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &name))
     {
         PyErr_SetString(PyExc_TypeError, "setAvatarShapeName expects a string");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.cpp
@@ -96,7 +96,7 @@ PyObject * pyVaultSDLNode::GetStateDataRecord() const
     PYTHON_RETURN_NONE;
 }
 
-void pyVaultSDLNode::InitStateDataRecord( const char* agename, int flags)
+void pyVaultSDLNode::InitStateDataRecord(const ST::string& agename, int flags)
 {
     if (fNode) {
         VaultSDLNode sdl(fNode);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.h
@@ -76,7 +76,7 @@ public:
 //
     int     GetIdent() const;
     void    SetIdent( int v );
-    void InitStateDataRecord( const char* agename, int flags);
+    void InitStateDataRecord(const ST::string& agename, int flags);
 
     PyObject * GetStateDataRecord() const; // returns pySDLStateDataRecord
     void SetStateDataRecord( const pySDLStateDataRecord & rec, int writeOptions=0 );

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNodeGlue.cpp
@@ -76,9 +76,9 @@ PYTHON_METHOD_DEFINITION(ptVaultSDLNode, setIdent, args)
 
 PYTHON_METHOD_DEFINITION(ptVaultSDLNode, initStateDataRecord, args)
 {
-    char* fileName;
+    ST::string fileName;
     int flags;
-    if (!PyArg_ParseTuple(args, "si", &fileName, &flags))
+    if (!PyArg_ParseTuple(args, "O&i", PyUnicode_STStringConverter, &fileName, &flags))
     {
         PyErr_SetString(PyExc_TypeError, "initStateDataRecord expects a string and an int");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
@@ -66,13 +66,13 @@ pyVaultTextNoteNode::pyVaultTextNoteNode()
 //==================================================================
 // class RelVaultNode : public plVaultNode
 //
-void pyVaultTextNoteNode::Note_SetTitle( const wchar_t * text )
+void pyVaultTextNoteNode::Note_SetTitle(const ST::string& text)
 {
     if (!fNode)
         return;
 
     VaultTextNoteNode textNote(fNode);
-    textNote.SetNoteTitle(ST::string::from_wchar(text));
+    textNote.SetNoteTitle(text);
 }
 
 ST::string pyVaultTextNoteNode::Note_GetTitle() const
@@ -84,13 +84,13 @@ ST::string pyVaultTextNoteNode::Note_GetTitle() const
     return ST::string();
 }
 
-void pyVaultTextNoteNode::Note_SetText( const wchar_t * text )
+void pyVaultTextNoteNode::Note_SetText(const ST::string& text)
 {
     if (!fNode)
         return;
 
     VaultTextNoteNode textNote(fNode);
-    textNote.SetNoteText(ST::string::from_wchar(text));
+    textNote.SetNoteText(text);
 }
 
 ST::string pyVaultTextNoteNode::Note_GetText() const
@@ -147,7 +147,7 @@ PyObject * pyVaultTextNoteNode::GetDeviceInbox() const
         PYTHON_RETURN_NONE;
 }
 
-void pyVaultTextNoteNode::SetDeviceInbox( const char * devName, PyObject * cbObject, uint32_t cbContext )
+void pyVaultTextNoteNode::SetDeviceInbox(const ST::string& devName, PyObject * cbObject, uint32_t cbContext)
 {
     if (!fNode)
         return;

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.h
@@ -74,9 +74,9 @@ public:
 //==================================================================
 // class RelVaultNode : public plVaultNode
 //
-    void Note_SetTitle( const wchar_t * text );
+    void Note_SetTitle(const ST::string& text);
     ST::string Note_GetTitle() const;
-    void Note_SetText( const wchar_t * text );
+    void Note_SetText(const ST::string& text);
     ST::string Note_GetText() const;
     void Note_SetType( int32_t type );
     int32_t Note_GetType();
@@ -85,7 +85,7 @@ public:
     int32_t Note_GetSubType();
 
     PyObject * GetDeviceInbox() const; // returns pyVaultFolderNode
-    void SetDeviceInbox(const char * devName, PyObject * cb=nullptr, uint32_t cbContext=0);
+    void SetDeviceInbox(const ST::string& devName, PyObject * cb=nullptr, uint32_t cbContext=0);
 };
 
 #endif // _pyVaultTextNoteNode_h_

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNodeGlue.cpp
@@ -58,21 +58,14 @@ PYTHON_INIT_DEFINITION(ptVaultTextNoteNode, args, keywords)
 
 PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, setTitle, args)
 {
-    PyObject* textObj;
-    if (!PyArg_ParseTuple(args, "O", &textObj))
+    ST::string title;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &title))
     {
         PyErr_SetString(PyExc_TypeError, "setTitle expects a unicode string");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* title = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->Note_SetTitle(title);
-        PyMem_Free(title);
-        PYTHON_RETURN_NONE;
-    }
-    PyErr_SetString(PyExc_TypeError, "setTitle expects a unicode string");
-    PYTHON_RETURN_ERROR;
+    self->fThis->Note_SetTitle(title);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultTextNoteNode, getTitle)
@@ -82,21 +75,14 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultTextNoteNode, getTitle)
 
 PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, setText, args)
 {
-    PyObject* textObj;
-    if (!PyArg_ParseTuple(args, "O", &textObj))
+    ST::string text;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &text))
     {
         PyErr_SetString(PyExc_TypeError, "setText expects a unicode string");
         PYTHON_RETURN_ERROR;
     }
-    if (PyUnicode_Check(textObj))
-    {
-        wchar_t* text = PyUnicode_AsWideCharString(textObj, nullptr);
-        self->fThis->Note_SetText(text);
-        PyMem_Free(text);
-        PYTHON_RETURN_NONE;
-    }
-    PyErr_SetString(PyExc_TypeError, "setText expects a unicode string");
-    PYTHON_RETURN_ERROR;
+    self->fThis->Note_SetText(text);
+    PYTHON_RETURN_NONE;
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultTextNoteNode, getText)
@@ -140,10 +126,10 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultTextNoteNode, getNoteSubType)
 
 PYTHON_METHOD_DEFINITION(ptVaultTextNoteNode, setDeviceInbox, args)
 {
-    char* inboxName; 
+    ST::string inboxName; 
     PyObject* cb = nullptr;
     unsigned long context = 0;
-    if (!PyArg_ParseTuple(args, "s|Ol", &inboxName, &cb, &context))
+    if (!PyArg_ParseTuple(args, "O&|Ol", PyUnicode_STStringConverter, &inboxName, &cb, &context))
     {
         PyErr_SetString(PyExc_TypeError, "setDeviceInbox expects a string, an optional object, and an optional unsigned long");
         PYTHON_RETURN_ERROR;


### PR DESCRIPTION
Most of this was already half-ported to `ST::string`. This takes care of the remaining bits.