### PR TITLE
Fix broken colors in `plStatusLogDrawer`

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.h
@@ -123,7 +123,12 @@ class plDebugText
             DrawString_TEMP(x, y, string, hex, style);
         }
 
-        void DrawString(uint16_t x, uint16_t y, const ST::string &string, uint8_t r = 255, uint8_t g = 255, uint8_t b = 255, uint8_t a = 255, uint8_t style = 0)
+        void DrawString(uint16_t x, uint16_t y, const ST::string& string)
+        {
+            DrawString_TEMP(x, y, string, 0xffffffff, 0);
+        }
+
+        void DrawString(uint16_t x, uint16_t y, const ST::string &string, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255, uint8_t style = 0)
         {
             DrawString_TEMP(x, y, string, (uint32_t)( ( a << 24 ) | ( r << 16 ) | ( g << 8 ) | ( b ) ), style);
         }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plStatusLogDrawer.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plStatusLogDrawer.cpp
@@ -120,7 +120,7 @@ void    plStatusLogDrawer::Draw(plStatusLog* curLog, plStatusLog* firstLog)
     y += lineHt * 2;
     for( i = 0; i < IGetMaxNumLines( curLog ); i++ )
     {
-        drawText.DrawString( x + 4, y, IGetLines( curLog )[ i ], IGetColors( curLog )[ i ] );
+        drawText.DrawString_TEMP( x + 4, y, IGetLines( curLog )[ i ], IGetColors( curLog )[ i ] );
         y += lineHt;
     }
 


### PR DESCRIPTION
Fixes #1355.

I checked and couldn't find any other calls broken in the same way.

Perhaps we should remove the `_TEMP` suffix and make it an overload like all the others. That would avoid this issue - but might also cause *more* silent breakage if we're unlucky...