### PR TITLE
InputCore Unicode improvements (and slight cleanup)

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -308,7 +308,7 @@ bool    pfConsole::MsgReceive( plMessage *msg )
             // pfConsoleEngine::RunCommand requires a writable C string...
             ST::char_buffer cmdBuf;
             ctrlMsg->GetCmdString().to_buffer(cmdBuf);
-            fEngine->RunCommand(cmdBuf.data(), IAddLineCallback );
+            fEngine->RunCommand(cmdBuf.data(), IAddLineCallback);
             return true;
         }
         return false;

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -305,7 +305,10 @@ bool    pfConsole::MsgReceive( plMessage *msg )
     {
         if( ctrlMsg->ControlActivated() && ctrlMsg->GetControlCode() == B_CONTROL_CONSOLE_COMMAND && plNetClientApp::GetInstance()->GetFlagsBit(plNetClientApp::kPlayingGame))
         {
-            fEngine->RunCommand( ctrlMsg->GetCmdString(), IAddLineCallback );
+            // pfConsoleEngine::RunCommand requires a writable C string...
+            ST::char_buffer cmdBuf;
+            ctrlMsg->GetCmdString().to_buffer(cmdBuf);
+            fEngine->RunCommand(cmdBuf.data(), IAddLineCallback );
             return true;
         }
         return false;

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -3187,31 +3187,6 @@ PF_CONSOLE_CMD( Keyboard, ClearBindings, "", "Resets the keyboard bindings to em
     PrintString( "Keyboard bindings destroyed" );
 }
 
-// FIXME This function duplicates IBindKeyToVKey in pyKeyMap.cpp
-static plKeyCombo   IBindKeyToVKey(ST::string str)
-{
-    plKeyCombo  combo;
-
-    // Find modifiers to set flags with
-    combo.fFlags = 0;
-    if (str.find("_S", ST::case_insensitive) != -1)
-        combo.fFlags |= plKeyCombo::kShift;
-    if (str.find("_C", ST::case_insensitive) != -1)
-        combo.fFlags |= plKeyCombo::kCtrl;
-    
-    // Get rid of modififers
-    str = str.before_first('_');
-
-    // Convert raw key
-    combo.fKey = plKeyMap::ConvertCharToVKey( str );
-    if( combo.fKey == KEY_UNMAPPED )
-        combo = plKeyCombo::kUnmapped;
-
-    // And return!
-    return combo;
-
-}
-
 PF_CONSOLE_CMD( Keyboard,       // groupName
                BindKey,     // fxnName
                "string key1, string action", // paramList
@@ -3226,7 +3201,7 @@ PF_CONSOLE_CMD( Keyboard,       // groupName
 
     if (plInputInterfaceMgr::GetInstance() != nullptr)
     {
-        plKeyCombo key1 = IBindKeyToVKey(ST::string(params[0]));
+        plKeyCombo key1 = plKeyMap::StringToKeyCombo(ST::string(params[0]));
         plInputInterfaceMgr::GetInstance()->BindAction( key1, code );
     }
 }
@@ -3245,8 +3220,8 @@ PF_CONSOLE_CMD( Keyboard,       // groupName
 
     if (plInputInterfaceMgr::GetInstance() != nullptr)
     {
-        plKeyCombo key1 = IBindKeyToVKey(ST::string(params[0]));
-        plKeyCombo key2 = IBindKeyToVKey(ST::string(params[1]));
+        plKeyCombo key1 = plKeyMap::StringToKeyCombo(ST::string(params[0]));
+        plKeyCombo key2 = plKeyMap::StringToKeyCombo(ST::string(params[1]));
         plInputInterfaceMgr::GetInstance()->BindAction( key1, key2, code );
     }
 }
@@ -3256,7 +3231,7 @@ PF_CONSOLE_CMD( Keyboard,       // groupName
                "string key, string command", // paramList
                "Bind console command to key" )  // helpString
 {
-    plKeyCombo key = IBindKeyToVKey(ST::string(params[0]));
+    plKeyCombo key = plKeyMap::StringToKeyCombo(ST::string(params[0]));
 
     if (plInputInterfaceMgr::GetInstance() != nullptr)
         plInputInterfaceMgr::GetInstance()->BindConsoleCmd(key, ST::string(params[1]), plKeyMap::kFirstAlways);

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -3187,26 +3187,20 @@ PF_CONSOLE_CMD( Keyboard, ClearBindings, "", "Resets the keyboard bindings to em
     PrintString( "Keyboard bindings destroyed" );
 }
 
-static plKeyCombo   IBindKeyToVKey( const char *string )
+// FIXME This function duplicates IBindKeyToVKey in pyKeyMap.cpp
+static plKeyCombo   IBindKeyToVKey(ST::string str)
 {
-    char    str[ 16 ];
-    int     i;
-
     plKeyCombo  combo;
-
-
-    strcpy( str, string );
 
     // Find modifiers to set flags with
     combo.fFlags = 0;
-    if( strstr( str, "_S" ) || strstr( str, "_s" ) )
+    if (str.find("_S", ST::case_insensitive) != -1)
         combo.fFlags |= plKeyCombo::kShift;
-    if( strstr( str, "_C" ) || strstr( str, "_c" ) )
+    if (str.find("_C", ST::case_insensitive) != -1)
         combo.fFlags |= plKeyCombo::kCtrl;
     
     // Get rid of modififers
-    for( i = 0; str[ i ] != 0 && str[ i ] != '_'; i++ );
-    str[ i ] = 0;
+    str = str.before_first('_');
 
     // Convert raw key
     combo.fKey = plKeyMap::ConvertCharToVKey( str );
@@ -3218,17 +3212,12 @@ static plKeyCombo   IBindKeyToVKey( const char *string )
 
 }
 
-static ControlEventCode IBindStringToCmdCode( const char *string )
-{
-    return plKeyMap::ConvertCharToControlCode( string );
-}
-
 PF_CONSOLE_CMD( Keyboard,       // groupName
                BindKey,     // fxnName
                "string key1, string action", // paramList
                "Binds the given single key combo to the given action" ) // helpString
 {
-    ControlEventCode code = IBindStringToCmdCode( params[ 1 ] );
+    ControlEventCode code = plKeyMap::ConvertCharToControlCode(ST::string(params[1]));
     if( code == END_CONTROLS )
     {
         PrintString( "ERROR: Invalid command name" );
@@ -3237,7 +3226,7 @@ PF_CONSOLE_CMD( Keyboard,       // groupName
 
     if (plInputInterfaceMgr::GetInstance() != nullptr)
     {
-        plKeyCombo key1 = IBindKeyToVKey( params[ 0 ] );
+        plKeyCombo key1 = IBindKeyToVKey(ST::string(params[0]));
         plInputInterfaceMgr::GetInstance()->BindAction( key1, code );
     }
 }
@@ -3247,7 +3236,7 @@ PF_CONSOLE_CMD( Keyboard,       // groupName
                "string key1, string key2, string action", // paramList
                "Binds the given two keys to the given action (you can specify 'UNDEFINED' for either key if you wish)" )    // helpString
 {
-    ControlEventCode code = IBindStringToCmdCode( params[ 2 ] );
+    ControlEventCode code = plKeyMap::ConvertCharToControlCode(ST::string(params[2]));
     if( code == END_CONTROLS )
     {
         PrintString( "ERROR: Invalid command name" );
@@ -3256,8 +3245,8 @@ PF_CONSOLE_CMD( Keyboard,       // groupName
 
     if (plInputInterfaceMgr::GetInstance() != nullptr)
     {
-        plKeyCombo key1 = IBindKeyToVKey( params[ 0 ] );
-        plKeyCombo key2 = IBindKeyToVKey( params[ 1 ] );
+        plKeyCombo key1 = IBindKeyToVKey(ST::string(params[0]));
+        plKeyCombo key2 = IBindKeyToVKey(ST::string(params[1]));
         plInputInterfaceMgr::GetInstance()->BindAction( key1, key2, code );
     }
 }
@@ -3267,10 +3256,10 @@ PF_CONSOLE_CMD( Keyboard,       // groupName
                "string key, string command", // paramList
                "Bind console command to key" )  // helpString
 {
-    plKeyCombo key = IBindKeyToVKey( params[ 0 ] );
+    plKeyCombo key = IBindKeyToVKey(ST::string(params[0]));
 
     if (plInputInterfaceMgr::GetInstance() != nullptr)
-        plInputInterfaceMgr::GetInstance()->BindConsoleCmd( key, params[ 1 ], plKeyMap::kFirstAlways );
+        plInputInterfaceMgr::GetInstance()->BindConsoleCmd(key, ST::string(params[1]), plKeyMap::kFirstAlways);
 }
 
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -441,9 +441,7 @@ void pfGUIEditBoxMod::SetLastKeyCapture(uint32_t key, uint8_t modifiers)
     fSavedModifiers = modifiers;
 
     // turn key event into string
-    ST::string keyStr;
-    if (plKeyMap::ConvertVKeyToChar( key ))
-        keyStr = ST::string::from_latin_1(plKeyMap::ConvertVKeyToChar( key ));
+    ST::string keyStr = plKeyMap::ConvertVKeyToChar(key);
 
     if(keyStr.empty())
     {
@@ -453,7 +451,7 @@ void pfGUIEditBoxMod::SetLastKeyCapture(uint32_t key, uint8_t modifiers)
             keyStr = ST::string::from_latin_1(&keyChar, 1);
         }
         else
-            keyStr = ST::string::from_latin_1(plKeyMap::GetStringUnmapped());
+            keyStr = plKeyMap::GetStringUnmapped();
     }
     else
     {
@@ -468,9 +466,9 @@ void pfGUIEditBoxMod::SetLastKeyCapture(uint32_t key, uint8_t modifiers)
     // because its SSO buffer is much larger than ST::string's.
     ST::string_stream newKey;
     if( modifiers & kShift )
-        newKey << ST::string::from_latin_1(plKeyMap::GetStringShift());
+        newKey << plKeyMap::GetStringShift();
     if( modifiers & kCtrl )
-        newKey << ST::string::from_latin_1(plKeyMap::GetStringCtrl());
+        newKey << plKeyMap::GetStringCtrl();
     newKey << keyStr;
 
     // set something in the buffer to be displayed

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
@@ -714,7 +714,7 @@ bool    pfGameUIInputInterface::InterpretInputEvent( plInputEventMsg *pMsg )
         // HACK HACK HACK
         if ((!handled) && (pKeyMsg->GetKeyDown()) && !pKeyMsg->GetKeyChar())
         {
-            const plKeyBinding* keymap = plInputInterfaceMgr::GetInstance()->FindBindingByConsoleCmd("Game.KITakePicture");
+            const plKeyBinding* keymap = plInputInterfaceMgr::GetInstance()->FindBindingByConsoleCmd(ST_LITERAL("Game.KITakePicture"));
             if (keymap)
             {
                 unsigned keyFlags = 0;

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -41,6 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <Python.h>
+#include <utility>
 #include "plgDispatch.h"
 #include "hsResMgr.h"
 #include "pyKey.h"
@@ -157,35 +158,29 @@ void cyMisc::SetPythonLoggingLevel(uint32_t new_level)
 //
 //  PURPOSE    : Execute a console command from a python script
 //
-void cyMisc::Console(const char* command)
+void cyMisc::Console(ST::string command)
 {
-    if (command != nullptr)
-    {
-        // create message to send to the console
-        plControlEventMsg* pMsg = new plControlEventMsg;
-        pMsg->SetBCastFlag(plMessage::kBCastByType);
-        pMsg->SetControlCode(B_CONTROL_CONSOLE_COMMAND);
-        pMsg->SetControlActivated(true);
-        pMsg->SetCmdString(command);
-        plgDispatch::MsgSend( pMsg );   // whoosh... off it goes
-    }
+    // create message to send to the console
+    plControlEventMsg* pMsg = new plControlEventMsg;
+    pMsg->SetBCastFlag(plMessage::kBCastByType);
+    pMsg->SetControlCode(B_CONTROL_CONSOLE_COMMAND);
+    pMsg->SetControlActivated(true);
+    pMsg->SetCmdString(std::move(command));
+    plgDispatch::MsgSend( pMsg );   // whoosh... off it goes
 }
 
-void cyMisc::ConsoleNet(const char* command, bool netForce)
+void cyMisc::ConsoleNet(ST::string command, bool netForce)
 {
-    if (command != nullptr)
-    {
-        // create message to send to the console
-        plControlEventMsg* pMsg = new plControlEventMsg;
-        pMsg->SetBCastFlag(plMessage::kBCastByType);
-        pMsg->SetBCastFlag(plMessage::kNetPropagate);
-        if ( netForce )
-            pMsg->SetBCastFlag(plMessage::kNetForce);
-        pMsg->SetControlCode(B_CONTROL_CONSOLE_COMMAND);
-        pMsg->SetControlActivated(true);
-        pMsg->SetCmdString(command);
-        plgDispatch::MsgSend( pMsg );   // whoosh... off it goes
-    }
+    // create message to send to the console
+    plControlEventMsg* pMsg = new plControlEventMsg;
+    pMsg->SetBCastFlag(plMessage::kBCastByType);
+    pMsg->SetBCastFlag(plMessage::kNetPropagate);
+    if ( netForce )
+        pMsg->SetBCastFlag(plMessage::kNetForce);
+    pMsg->SetControlCode(B_CONTROL_CONSOLE_COMMAND);
+    pMsg->SetControlActivated(true);
+    pMsg->SetCmdString(std::move(command));
+    plgDispatch::MsgSend( pMsg );   // whoosh... off it goes
 }
 
 
@@ -265,24 +260,21 @@ PyObject* cyMisc::FindActivator(const ST::string& name)
 //
 //  PURPOSE    : Execute a console command from a python script
 //
-void cyMisc::PopUpConsole(const char* command)
+void cyMisc::PopUpConsole(ST::string command)
 {
-    if (command != nullptr)
-    {
-        // create message to send to the console
-        plControlEventMsg* pMsg1 = new plControlEventMsg;
-        pMsg1->SetBCastFlag(plMessage::kBCastByType);
-        pMsg1->SetControlCode(B_SET_CONSOLE_MODE);
-        pMsg1->SetControlActivated(true);
-        plgDispatch::MsgSend( pMsg1 );  // whoosh... off it goes
-        // create message to send to the console
-        plControlEventMsg* pMsg2 = new plControlEventMsg;
-        pMsg2->SetBCastFlag(plMessage::kBCastByType);
-        pMsg2->SetControlCode(B_CONTROL_CONSOLE_COMMAND);
-        pMsg2->SetControlActivated(true);
-        pMsg2->SetCmdString(command);
-        plgDispatch::MsgSend( pMsg2 );  // whoosh... off it goes
-    }
+    // create message to send to the console
+    plControlEventMsg* pMsg1 = new plControlEventMsg;
+    pMsg1->SetBCastFlag(plMessage::kBCastByType);
+    pMsg1->SetControlCode(B_SET_CONSOLE_MODE);
+    pMsg1->SetControlActivated(true);
+    plgDispatch::MsgSend( pMsg1 );  // whoosh... off it goes
+    // create message to send to the console
+    plControlEventMsg* pMsg2 = new plControlEventMsg;
+    pMsg2->SetBCastFlag(plMessage::kBCastByType);
+    pMsg2->SetControlCode(B_CONTROL_CONSOLE_COMMAND);
+    pMsg2->SetControlActivated(true);
+    pMsg2->SetCmdString(std::move(command));
+    plgDispatch::MsgSend( pMsg2 );  // whoosh... off it goes
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1517,7 +1509,7 @@ void cyMisc::SetClearColor(float red, float green, float blue)
     pMsg->SetBCastFlag(plMessage::kBCastByType);
     pMsg->SetControlCode(B_CONTROL_CONSOLE_COMMAND);
     pMsg->SetControlActivated(true);
-    pMsg->SetCmdString(command.c_str());
+    pMsg->SetCmdString(command);
     plgDispatch::MsgSend( pMsg );   // whoosh... off it goes
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -135,8 +135,8 @@ public:
     //  PURPOSE    : Execute a console command from a python script,
     //                  optionally propagate over the net
     //
-    static void Console(const char* command);
-    static void ConsoleNet(const char* command, bool netForce); 
+    static void Console(ST::string command);
+    static void ConsoleNet(ST::string command, bool netForce); 
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -158,7 +158,7 @@ public:
     //
     //  PURPOSE    : Execute a console command from a python script
     //
-    static void PopUpConsole(const char* command);
+    static void PopUpConsole(ST::string command);
 
     /////////////////////////////////////////////////////////////////////////////
     //

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
@@ -95,8 +95,8 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtSetPythonLoggingLevel, args, "Params: level\nS
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtConsole, args, "Params: command\nThis will execute 'command' as if it were typed into the Plasma console.")
 {
-    char* command;
-    if (!PyArg_ParseTuple(args, "s", &command))
+    ST::string command;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &command))
     {
         PyErr_SetString(PyExc_TypeError, "PtConsole expects a string");
         PYTHON_RETURN_ERROR;
@@ -108,9 +108,9 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtConsole, args, "Params: command\nThis will exe
 PYTHON_GLOBAL_METHOD_DEFINITION(PtConsoleNet, args, "Params: command,netForce\nThis will execute 'command' on the console, over the network, on all clients.\n"
             "If 'netForce' is true then force command to be sent over the network.")
 {
-    char* command;
+    ST::string command;
     char netForce;
-    if (!PyArg_ParseTuple(args, "sb", &command, &netForce))
+    if (!PyArg_ParseTuple(args, "O&b", PyUnicode_STStringConverter, &command, &netForce))
     {
         PyErr_SetString(PyExc_TypeError, "PtConsoleNet expects a string and a boolean");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/FeatureLib/pfPython/pyDrawControl.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDrawControl.cpp
@@ -49,6 +49,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsResMgr.h"
 
 #include "pyDrawControl.h"
+
+#include <string_theory/format>
+
 #ifndef BUILDING_PYPLASMA
 #   include "plAvatar/plArmatureMod.h"
 #   include "plGLight/plShadowCaster.h"
@@ -61,8 +64,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 void pyDrawControl::SetGamma2(float gamma)
 {
 #ifndef BUILDING_PYPLASMA
-    char command[256];
-    sprintf(command,"Graphics.Renderer.Gamma2 %f",gamma);
+    ST::string command = ST::format("Graphics.Renderer.Gamma2 {}", gamma);
     // create message to send to the console
     plControlEventMsg* pMsg = new plControlEventMsg;
     pMsg->SetBCastFlag(plMessage::kBCastByType);

--- a/Sources/Plasma/FeatureLib/pfPython/pyKeyMap.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyKeyMap.cpp
@@ -51,80 +51,71 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnInputCore/plKeyMap.h"
 
 // conversion functions
-const char* pyKeyMap::ConvertVKeyToChar( uint32_t vk, uint32_t flags )
+// FIXME This method duplicates plInputInterfaceMgr::IKeyComboToString
+ST::string pyKeyMap::ConvertVKeyToChar(uint32_t vk, uint32_t flags)
 {
-    const char *key = plKeyMap::ConvertVKeyToChar( vk );
-    static char shortKey[ 2 ];
-    if (key == nullptr)
+    ST::string key = plKeyMap::ConvertVKeyToChar(vk);
+    if (key.empty())
     {
         if( isalnum( vk ) )
         {
-            shortKey[ 0 ] = (char)vk;
-            shortKey[ 1 ] = 0;
-            key = shortKey;
+            char c = (char)vk;
+            key = ST::string::from_latin_1(&c, 1);
         }
         else
-            return "(unmapped)";
+            return ST_LITERAL("(unmapped)");
     }
 
-    static char newKey[ 16 ];
-    strcpy( newKey, key );
     if( flags & kShift )
-        strcat( newKey, "_S" );
+        key += "_S";
     if( flags & kCtrl )
-        strcat( newKey, "_C" );
+        key += "_C";
 
-    return newKey;
+    return key;
 }
 
-uint32_t pyKeyMap::ConvertCharToVKey( const char* charVKey )
-{
-    char    str[ 16 ];
-    int     i;
+// FIXME These two methods duplicate IBindKeyToVKey
 
-    if( strcmp( charVKey, "(unmapped" ) == 0 )
+uint32_t pyKeyMap::ConvertCharToVKey(const ST::string& charVKey)
+{
+    // FIXME The closing parenthesis is missing - it's been this way for at least 12 years, so I'm afraid to fix it
+    if (charVKey == "(unmapped")
         return KEY_UNMAPPED;
 
-    strcpy( str, charVKey );
-
     // Get rid of modififers
-    for( i = 0; str[ i ] != 0 && str[ i ] != '_'; i++ );
-    str[ i ] = 0;
+    ST::string str = charVKey.before_first('_');
 
     // Convert raw key and return
     return plKeyMap::ConvertCharToVKey( str );
 }
 
-uint32_t pyKeyMap::ConvertCharToFlags( const char *charVKey )
+uint32_t pyKeyMap::ConvertCharToFlags(const ST::string& charVKey)
 {
-    char    str[ 16 ];
-    strcpy( str, charVKey );
-
     // Find modifiers to set flags with
     uint32_t keyFlags = 0;
-    if( strstr( str, "_S" ) || strstr( str, "_s" ) )
+    if (charVKey.find("_S", ST::case_insensitive) != -1)
         keyFlags |= plKeyCombo::kShift;
-    if( strstr( str, "_C" ) || strstr( str, "_c" ) )
+    if (charVKey.find("_C", ST::case_insensitive) != -1)
         keyFlags |= plKeyCombo::kCtrl;
 
     return keyFlags;
 }
 
 
-uint32_t pyKeyMap::ConvertCharToControlCode(const char* charCode)
+uint32_t pyKeyMap::ConvertCharToControlCode(const ST::string& charCode)
 {
     ControlEventCode code = plInputMap::ConvertCharToControlCode(charCode);
     return (uint32_t)code;
 }
 
-const char* pyKeyMap::ConvertControlCodeToString( uint32_t code )
+ST::string pyKeyMap::ConvertControlCodeToString(uint32_t code)
 {
     return plInputMap::ConvertControlCodeToString((ControlEventCode)code);
 }
 
 
 // bind a key to an action
-void pyKeyMap::BindKey( const char* keyStr1, const char* keyStr2, const char* act)
+void pyKeyMap::BindKey(const ST::string& keyStr1, const ST::string& keyStr2, const ST::string& act)
 {
     
     ControlEventCode code = plKeyMap::ConvertCharToControlCode( act );
@@ -137,54 +128,38 @@ void pyKeyMap::BindKey( const char* keyStr1, const char* keyStr2, const char* ac
     if (plInputInterfaceMgr::GetInstance() != nullptr)
     {
         plKeyCombo key1 = IBindKeyToVKey( keyStr1 );
-        if (keyStr2)
-        {
-            plKeyCombo key2 = IBindKeyToVKey( keyStr2 );
-            plInputInterfaceMgr::GetInstance()->BindAction( key1, key2, code );
-        }
-        else
-            plInputInterfaceMgr::GetInstance()->BindAction( key1, code );
+        plKeyCombo key2 = IBindKeyToVKey( keyStr2 );
+        plInputInterfaceMgr::GetInstance()->BindAction( key1, key2, code );
     }
 }
 
 // bind a key to an action
-void pyKeyMap::BindKeyToConsoleCommand( const char* keyStr1, const char* command)
+void pyKeyMap::BindKeyToConsoleCommand(const ST::string& keyStr1, const ST::string& command)
 {
-    
-    if (command && plInputInterfaceMgr::GetInstance() != nullptr)
+    if (plInputInterfaceMgr::GetInstance() != nullptr)
     {
-        plKeyCombo key1;
-        if (keyStr1)
-            key1 = IBindKeyToVKey( keyStr1 );
-        else
-            key1 = IBindKeyToVKey( "(unmapped)" );
+        plKeyCombo key1 = IBindKeyToVKey(keyStr1);
         plInputInterfaceMgr::GetInstance()->BindConsoleCmd( key1, command, plKeyMap::kFirstAlways);
     }
 }
 
-plKeyCombo pyKeyMap::IBindKeyToVKey( const char *keyStr )
+// FIXME This method duplicates IBindKeyToVKey in pfConsoleCommands.cpp
+plKeyCombo pyKeyMap::IBindKeyToVKey(ST::string keyStr)
 {
-    char    str[ 16 ];
-    int     i;
-
     plKeyCombo  combo;
-
-
-    strcpy( str, keyStr );
 
     // Find modifiers to set flags with
     combo.fFlags = 0;
-    if( strstr( str, "_S" ) || strstr( str, "_s" ) )
+    if (keyStr.find("_S", ST::case_insensitive) != -1)
         combo.fFlags |= plKeyCombo::kShift;
-    if( strstr( str, "_C" ) || strstr( str, "_c" ) )
+    if (keyStr.find("_C", ST::case_insensitive) != -1)
         combo.fFlags |= plKeyCombo::kCtrl;
     
     // Get rid of modififers
-    for( i = 0; str[ i ] != 0 && str[ i ] != '_'; i++ );
-    str[ i ] = 0;
+    keyStr = keyStr.before_first('_');
 
     // Convert raw key
-    combo.fKey = plKeyMap::ConvertCharToVKey( str );
+    combo.fKey = plKeyMap::ConvertCharToVKey(keyStr);
     if( combo.fKey == KEY_UNMAPPED )
         combo = plKeyCombo::kUnmapped;
 
@@ -248,7 +223,7 @@ uint32_t pyKeyMap::GetBindingFlags2(uint32_t code)
     return 0;
 }
 
-uint32_t pyKeyMap::GetBindingKeyConsole(const char* command)
+uint32_t pyKeyMap::GetBindingKeyConsole(const ST::string& command)
 {
     if (plInputInterfaceMgr::GetInstance() != nullptr)
     {
@@ -262,7 +237,7 @@ uint32_t pyKeyMap::GetBindingKeyConsole(const char* command)
     return 0;
 }
 
-uint32_t pyKeyMap::GetBindingFlagsConsole(const char* command)
+uint32_t pyKeyMap::GetBindingFlagsConsole(const ST::string& command)
 {
     if (plInputInterfaceMgr::GetInstance() != nullptr)
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyKeyMap.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyKeyMap.h
@@ -59,7 +59,7 @@ protected:
     pyKeyMap() {};
 
 private:
-    plKeyCombo IBindKeyToVKey( const char *keyStr );
+    plKeyCombo IBindKeyToVKey(ST::string keyStr);
 
 
 public:
@@ -78,25 +78,25 @@ public:
     static void AddPlasmaClasses(PyObject *m);
 
     // conversion functions
-    const char* ConvertVKeyToChar( uint32_t vk, uint32_t flags );
-    uint32_t ConvertCharToVKey( const char *charVKey );
-    uint32_t ConvertCharToFlags( const char *charVKey );
+    ST::string ConvertVKeyToChar(uint32_t vk, uint32_t flags);
+    uint32_t ConvertCharToVKey(const ST::string& charVKey);
+    uint32_t ConvertCharToFlags(const ST::string& charVKey);
 
-    uint32_t ConvertCharToControlCode(const char* charCode);
-    const char* ConvertControlCodeToString( uint32_t code );
+    uint32_t ConvertCharToControlCode(const ST::string& charCode);
+    ST::string ConvertControlCodeToString(uint32_t code);
 
 
     // bind a key to an action
-    void BindKey( const char* keyStr1, const char* keyStr2, const char* act);
-    void BindKeyToConsoleCommand( const char* keyStr1, const char* command);
+    void BindKey(const ST::string& keyStr1, const ST::string& keyStr2, const ST::string& act);
+    void BindKeyToConsoleCommand(const ST::string& keyStr1, const ST::string& command);
 
     uint32_t GetBindingKey1(uint32_t code);
     uint32_t GetBindingFlags1(uint32_t code);
     uint32_t GetBindingKey2(uint32_t code);
     uint32_t GetBindingFlags2(uint32_t code);
 
-    uint32_t GetBindingKeyConsole(const char* command);
-    uint32_t GetBindingFlagsConsole(const char* command);
+    uint32_t GetBindingKeyConsole(const ST::string& command);
+    uint32_t GetBindingFlagsConsole(const ST::string& command);
 
     void WriteKeyMap();
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyKeyMap.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyKeyMap.h
@@ -58,10 +58,6 @@ class pyKeyMap
 protected:
     pyKeyMap() {};
 
-private:
-    plKeyCombo IBindKeyToVKey(ST::string keyStr);
-
-
 public:
     enum
     {

--- a/Sources/Plasma/FeatureLib/pfPython/pyKeyMapGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyKeyMapGlue.cpp
@@ -63,13 +63,13 @@ PYTHON_METHOD_DEFINITION(ptKeyMap, convertVKeyToChar, args)
         PyErr_SetString(PyExc_TypeError, "convertVKeyToChar expects two unsigned longs");
         PYTHON_RETURN_ERROR;
     }
-    return PyUnicode_FromString(self->fThis->ConvertVKeyToChar(virtualKey, keyFlags));
+    return PyUnicode_FromSTString(self->fThis->ConvertVKeyToChar(virtualKey, keyFlags));
 }
 
 PYTHON_METHOD_DEFINITION(ptKeyMap, convertCharToVKey, args)
 {
-    char* charString;
-    if (!PyArg_ParseTuple(args, "s", &charString))
+    ST::string charString;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &charString))
     {
         PyErr_SetString(PyExc_TypeError, "convertCharToVKey expects a string");
         PYTHON_RETURN_ERROR;
@@ -79,8 +79,8 @@ PYTHON_METHOD_DEFINITION(ptKeyMap, convertCharToVKey, args)
 
 PYTHON_METHOD_DEFINITION(ptKeyMap, convertCharToFlags, args)
 {
-    char* charString;
-    if (!PyArg_ParseTuple(args, "s", &charString))
+    ST::string charString;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &charString))
     {
         PyErr_SetString(PyExc_TypeError, "convertCharToFlags expects a string");
         PYTHON_RETURN_ERROR;
@@ -90,8 +90,8 @@ PYTHON_METHOD_DEFINITION(ptKeyMap, convertCharToFlags, args)
 
 PYTHON_METHOD_DEFINITION(ptKeyMap, convertCharToControlCode, args)
 {
-    char* charString;
-    if (!PyArg_ParseTuple(args, "s", &charString))
+    ST::string charString;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &charString))
     {
         PyErr_SetString(PyExc_TypeError, "convertCharToControlCode expects a string");
         PYTHON_RETURN_ERROR;
@@ -107,15 +107,15 @@ PYTHON_METHOD_DEFINITION(ptKeyMap, convertControlCodeToString, args)
         PyErr_SetString(PyExc_TypeError, "convertControlCodeToString expects an unsigned long");
         PYTHON_RETURN_ERROR;
     }
-    return PyUnicode_FromString(self->fThis->ConvertControlCodeToString(code));
+    return PyUnicode_FromSTString(self->fThis->ConvertControlCodeToString(code));
 }
 
 PYTHON_METHOD_DEFINITION(ptKeyMap, bindKey, args)
 {
-    char* key1;
-    char* key2;
-    char* action;
-    if (!PyArg_ParseTuple(args, "sss", &key1, &key2, &action))
+    ST::string key1;
+    ST::string key2;
+    ST::string action;
+    if (!PyArg_ParseTuple(args, "O&O&O&", PyUnicode_STStringConverter, &key1, PyUnicode_STStringConverter, &key2, PyUnicode_STStringConverter, &action))
     {
         PyErr_SetString(PyExc_TypeError, "bindKey expects three strings");
         PYTHON_RETURN_ERROR;
@@ -170,9 +170,9 @@ PYTHON_METHOD_DEFINITION(ptKeyMap, getBindingFlags2, args)
 
 PYTHON_METHOD_DEFINITION(ptKeyMap, bindKeyToConsoleCommand, args)
 {
-    char* keyStr1;
-    char* command;
-    if (!PyArg_ParseTuple(args, "ss", &keyStr1, &command))
+    ST::string keyStr1;
+    ST::string command;
+    if (!PyArg_ParseTuple(args, "O&O&", PyUnicode_STStringConverter, &keyStr1, PyUnicode_STStringConverter, &command))
     {
         PyErr_SetString(PyExc_TypeError, "bindKeyToConsoleCommand expects two strings");
         PYTHON_RETURN_ERROR;
@@ -183,8 +183,8 @@ PYTHON_METHOD_DEFINITION(ptKeyMap, bindKeyToConsoleCommand, args)
 
 PYTHON_METHOD_DEFINITION(ptKeyMap, getBindingKeyConsole, args)
 {
-    char* command;
-    if (!PyArg_ParseTuple(args, "s", &command))
+    ST::string command;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &command))
     {
         PyErr_SetString(PyExc_TypeError, "getBindingKeyConsole expects a string");
         PYTHON_RETURN_ERROR;
@@ -194,8 +194,8 @@ PYTHON_METHOD_DEFINITION(ptKeyMap, getBindingKeyConsole, args)
 
 PYTHON_METHOD_DEFINITION(ptKeyMap, getBindingFlagsConsole, args)
 {
-    char* command;
-    if (!PyArg_ParseTuple(args, "s", &command))
+    ST::string command;
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &command))
     {
         PyErr_SetString(PyExc_TypeError, "getBindingFlagsConsole expects a string");
         PYTHON_RETURN_ERROR;

--- a/Sources/Plasma/NucleusLib/pnInputCore/plControlDefinition.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plControlDefinition.h
@@ -46,8 +46,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plKeyDef.h"
 #include "hsGeometry3.h"
 
-#include <string_theory/string>
-
 // flags for control event codes
 enum 
 {
@@ -109,19 +107,6 @@ enum
 {
     kMouseNormal    = 0x0000,
     kMouseClickable = 0x0001,
-};
-
-
-struct Win32keyConvert
-{
-    uint32_t  fVKey;
-    ST::string fKeyName;
-};
-
-struct CommandConvert
-{
-    ControlEventCode fCode;
-    ST::string fDesc;
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnInputCore/plControlDefinition.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plControlDefinition.h
@@ -46,6 +46,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plKeyDef.h"
 #include "hsGeometry3.h"
 
+#include <string_theory/string>
+
 // flags for control event codes
 enum 
 {
@@ -113,13 +115,13 @@ enum
 struct Win32keyConvert
 {
     uint32_t  fVKey;
-    const char*   fKeyName;
+    ST::string fKeyName;
 };
 
 struct CommandConvert
 {
     ControlEventCode fCode;
-    const char* fDesc;
+    ST::string fDesc;
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnInputCore/plControlDefinition.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plControlDefinition.h
@@ -125,24 +125,21 @@ struct CommandConvert
 
 struct plMouseInfo
 {
-    plMouseInfo(ControlEventCode _code, uint32_t _flags, hsPoint4 _box, const char* _desc)
+    plMouseInfo(ControlEventCode _code, uint32_t _flags, hsPoint4 _box)
     {
         fCode = _code;
         fControlFlags = _flags;
         fBox = _box;
-        fControlDescription = _desc;
     }
-    plMouseInfo(ControlEventCode _code, uint32_t _flags, float pt1, float pt2, float pt3, float pt4, const char* _desc)
+    plMouseInfo(ControlEventCode _code, uint32_t _flags, float pt1, float pt2, float pt3, float pt4)
     {
         fCode = _code;
         fControlFlags = _flags;
         fBox.Set(pt1,pt2,pt3,pt4);
-        fControlDescription = _desc;
     }
     ControlEventCode    fCode;
     uint32_t            fControlFlags;
     hsPoint4            fBox;
-    const char*         fControlDescription;
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
@@ -40,31 +40,32 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 // plInputMap.cpp
-#include <string>
+#include <cctype>
+#include <utility>
 
 #include "plInputMap.h"
 #include "plKeyMap.h"
 
 #include "plResMgr/plLocalization.h"
 
-ControlEventCode plInputMap::ConvertCharToControlCode(const char* c)
+ControlEventCode plInputMap::ConvertCharToControlCode(const ST::string& c)
 {
     for (int i = 0; fCmdConvert[i].fCode != END_CONTROLS; i++)
     {
-        if (stricmp(fCmdConvert[i].fDesc, c) == 0)
+        if (fCmdConvert[i].fDesc.compare_i(c) == 0)
             return (fCmdConvert[i].fCode);
     }
     return (END_CONTROLS);
 }
 
-const char      *plInputMap::ConvertControlCodeToString( ControlEventCode code )
+ST::string plInputMap::ConvertControlCodeToString(ControlEventCode code)
 {
     for( int i = 0; fCmdConvert[ i ].fCode != END_CONTROLS; i++ )
     {
         if( fCmdConvert[ i ].fCode == code )
             return fCmdConvert[ i ].fDesc;
     }
-    return nullptr;
+    return {};
 }
 
 //
@@ -121,21 +122,16 @@ plKeyBinding::plKeyBinding()
     fCodeFlags = 0;
     fKey1 = plKeyCombo::kUnmapped;
     fKey2 = plKeyCombo::kUnmapped;
-    fString = nullptr;
+    fString = ST::string();
 }
 
-plKeyBinding::plKeyBinding(ControlEventCode code, uint32_t codeFlags, const plKeyCombo &key1, const plKeyCombo &key2, const char *string /*= nullptr*/)
+plKeyBinding::plKeyBinding(ControlEventCode code, uint32_t codeFlags, const plKeyCombo &key1, const plKeyCombo &key2, ST::string string)
 {
     fCode = code;
     fCodeFlags = codeFlags;
     fKey1 = key1;
     fKey2 = key2;
-    fString = (string == nullptr) ? nullptr : hsStrcpy(string);
-}
-
-plKeyBinding::~plKeyBinding()
-{
-    delete [] fString;
+    fString = std::move(string);
 }
 
 const plKeyCombo &plKeyBinding::GetMatchingKey( plKeyDef keyDef ) const
@@ -201,7 +197,7 @@ bool    plKeyMap::AddCode( ControlEventCode code, uint32_t codeFlags )
 //  Same but for console commands. No flags b/c console commands always use 
 //  the same flags.
 
-bool    plKeyMap::AddConsoleCommand( const char *command )
+bool    plKeyMap::AddConsoleCommand(ST::string command)
 {
     if (IFindConsoleBinding(command) != nullptr)
         return false;
@@ -209,7 +205,7 @@ bool    plKeyMap::AddConsoleCommand( const char *command )
     fBindings.emplace_back(new plKeyBinding(B_CONTROL_CONSOLE_COMMAND,
                                             kControlFlagDownEvent | kControlFlagNoRepeat | kControlFlagNoDeactivate,
                                             plKeyCombo::kUnmapped, plKeyCombo::kUnmapped,
-                                            command));
+                                            std::move(command)));
     return true;
 }
 
@@ -271,13 +267,13 @@ void plKeyMap::IFindAllBindingsByKey(const plKeyCombo &combo, std::vector<plKeyB
 //// IFindConsoleBinding /////////////////////////////////////////////////////
 //  You should be able to figure this out by now.
 
-plKeyBinding    *plKeyMap::IFindConsoleBinding( const char *command ) const
+plKeyBinding    *plKeyMap::IFindConsoleBinding(const ST::string& command) const
 {
     for (plKeyBinding* binding : fBindings)
     {
         if (binding->GetCode() == B_CONTROL_CONSOLE_COMMAND)
         {
-            if (stricmp(binding->GetExtendedString(), command) == 0)
+            if (binding->GetExtendedString().compare_i(command) == 0)
                 return binding;
         }
     }
@@ -361,7 +357,7 @@ bool    plKeyMap::BindKey( const plKeyCombo &combo, ControlEventCode code, BindP
 //// BindKeyToConsoleCmd /////////////////////////////////////////////////////
 //  Console command version
 
-bool    plKeyMap::BindKeyToConsoleCmd( const plKeyCombo &combo, const char *command, BindPref pref /*= kNoPreference*/ )
+bool    plKeyMap::BindKeyToConsoleCmd(const plKeyCombo &combo, const ST::string& command, BindPref pref /*= kNoPreference*/)
 {
     plKeyBinding* binding = nullptr;
 
@@ -414,7 +410,7 @@ void plKeyMap::FindAllBindingsByKey(const plKeyCombo &combo, std::vector<const p
 }
 
 
-const plKeyBinding* plKeyMap::FindConsoleBinding( const char *command ) const
+const plKeyBinding* plKeyMap::FindConsoleBinding(const ST::string& command) const
 {
     return IFindConsoleBinding(command);
 }
@@ -492,7 +488,7 @@ void    plKeyMap::EraseBinding( ControlEventCode code )
 }
 
 
-const char* plKeyMap::ConvertVKeyToChar( uint32_t vk )
+ST::string plKeyMap::ConvertVKeyToChar(uint32_t vk)
 {
     Win32keyConvert* keyConvert = &fKeyConversionEnglish[0];
     switch (plLocalization::GetLanguage())
@@ -520,10 +516,10 @@ const char* plKeyMap::ConvertVKeyToChar( uint32_t vk )
             return (keyConvert[i].fKeyName);
     }
 
-    return nullptr;
+    return {};
 }
 
-plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
+plKeyDef plKeyMap::ConvertCharToVKey(const ST::string& c)
 {
     Win32keyConvert* keyConvert = &fKeyConversionEnglish[0];
     switch (plLocalization::GetLanguage())
@@ -547,13 +543,15 @@ plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
     }
     for (int i = 0; keyConvert[i].fVKey != 0xffffffff; i++)
     {
-        if (stricmp(keyConvert[i].fKeyName, c) == 0)
+        if (keyConvert[i].fKeyName.compare_i(c) == 0)
             return (plKeyDef)(keyConvert[i].fVKey);
     }
 
     // Is it just a single character?
-    if( isalnum( *c ) && strlen( c ) == 1 )
-        return (plKeyDef)toupper( *c );
+    // This intentionally only detects and handles ASCII characters.
+    // Non-ASCII characters are handled via the fKeyConversion maps.
+    if (c.size() == 1 && isalnum(c[0]))
+        return (plKeyDef)c.to_upper()[0];
 
     // if we didn't find anything yet...
     // ...then look thru all the other language mappings that we know about,
@@ -562,7 +560,7 @@ plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
     {
         for (int i = 0; fKeyConversionEnglish[i].fVKey != 0xffffffff; i++)
         {
-            if (stricmp(fKeyConversionEnglish[i].fKeyName, c) == 0)
+            if (fKeyConversionEnglish[i].fKeyName.compare_i(c) == 0)
                 return (plKeyDef)(fKeyConversionEnglish[i].fVKey);
         }
     }
@@ -570,7 +568,7 @@ plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
     {
         for (int i = 0; fKeyConversionFrench[i].fVKey != 0xffffffff; i++)
         {
-            if (stricmp(fKeyConversionFrench[i].fKeyName, c) == 0)
+            if (fKeyConversionFrench[i].fKeyName.compare_i(c) == 0)
                 return (plKeyDef)(fKeyConversionFrench[i].fVKey);
         }
     }
@@ -578,7 +576,7 @@ plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
     {
         for (int i = 0; fKeyConversionGerman[i].fVKey != 0xffffffff; i++)
         {
-            if (stricmp(fKeyConversionGerman[i].fKeyName, c) == 0)
+            if (fKeyConversionGerman[i].fKeyName.compare_i(c) == 0)
                 return (plKeyDef)(fKeyConversionGerman[i].fVKey);
         }
     }
@@ -586,7 +584,7 @@ plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
     {
         for (int i = 0; fKeyConversionSpanish[i].fVKey != 0xffffffff; i++)
         {
-            if (stricmp(fKeyConversionSpanish[i].fKeyName, c) == 0)
+            if (fKeyConversionSpanish[i].fKeyName.compare_i(c) == 0)
                 return (plKeyDef)(fKeyConversionSpanish[i].fVKey);
         }
     }
@@ -594,7 +592,7 @@ plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
     {
         for (int i = 0; fKeyConversionItalian[i].fVKey != 0xffffffff; i++)
         {
-            if (stricmp(fKeyConversionItalian[i].fKeyName, c) == 0)
+            if (fKeyConversionItalian[i].fKeyName.compare_i(c) == 0)
                 return (plKeyDef)(fKeyConversionItalian[i].fVKey);
         }
     }
@@ -603,76 +601,76 @@ plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
     return KEY_UNMAPPED;
 }
 
-const char* plKeyMap::GetStringCtrl()
+ST::string plKeyMap::GetStringCtrl()
 {
     switch (plLocalization::GetLanguage())
     {
         case plLocalization::kFrench:
-            return "Ctrl+";
+            return ST_LITERAL("Ctrl+");
             break;
         case plLocalization::kGerman:
-            return "Strg+";
+            return ST_LITERAL("Strg+");
             break;
         case plLocalization::kSpanish:
-            return "Ctrl+";
+            return ST_LITERAL("Ctrl+");
             break;
         case plLocalization::kItalian:
-            return "Ctrl+";
+            return ST_LITERAL("Ctrl+");
             break;
 
         // default is English
         default:
             break;
     }
-    return "Ctrl+";
+    return ST_LITERAL("Ctrl+");
 }
 
-const char* plKeyMap::GetStringShift()
+ST::string plKeyMap::GetStringShift()
 {
     switch (plLocalization::GetLanguage())
     {
         case plLocalization::kFrench:
-            return "Maj+";
+            return ST_LITERAL("Maj+");
             break;
         case plLocalization::kGerman:
-            return "Umschalt+";
+            return ST_LITERAL("Umschalt+");
             break;
         case plLocalization::kSpanish:
-            return "Mayúsculas+";
+            return ST_LITERAL("MayÃºsculas+");
             break;
         case plLocalization::kItalian:
-            return "Shift+";
+            return ST_LITERAL("Shift+");
             break;
 
         // default is English
         default:
             break;
     }
-    return "Shift+";
+    return ST_LITERAL("Shift+");
 }
 
-const char* plKeyMap::GetStringUnmapped()
+ST::string plKeyMap::GetStringUnmapped()
 {
     switch (plLocalization::GetLanguage())
     {
         case plLocalization::kFrench:
-            return "(NonDéfini)";
+            return ST_LITERAL("(NonDÃ©fini)");
             break;
         case plLocalization::kGerman:
-            return "(NichtZugewiesen)";
+            return ST_LITERAL("(NichtZugewiesen)");
             break;
         case plLocalization::kSpanish:
-            return "(SinMapear)";
+            return ST_LITERAL("(SinMapear)");
             break;
         case plLocalization::kItalian:
-            return "(NonAssegnato)";
+            return ST_LITERAL("(NonAssegnato)");
             break;
 
         // default is English
         default:
             break;
     }
-    return "(unmapped)";
+    return ST_LITERAL("(unmapped)");
 }
 
 // If the binding has one of these keys, but not the other, go and bind the other
@@ -705,331 +703,331 @@ void plKeyMap::ICheckAndBindDupe(plKeyDef origKey, plKeyDef dupeKey)
 Win32keyConvert plKeyMap::fKeyConversionEnglish[] =
 { 
 #ifdef HS_BUILD_FOR_WIN32
-    { VK_F1,    "F1"}, 
-    { VK_F2,    "F2"}, 
-    { VK_F3,    "F3"}, 
-    { VK_F4,    "F4"},
-    { VK_F5,    "F5"},
-    { VK_F6,    "F6"},
-    { VK_F7,    "F7"}, 
-    { VK_F8,    "F8"},
-    { VK_F9,    "F9"},
-    { VK_F10,   "F10"},
-    { VK_F11,   "F11"},
-    { VK_F12,   "F12"},
-    { VK_ESCAPE, "Esc"},
-    { VK_TAB,   "Tab"},
-    { VK_UP,    "UpArrow"}, 
-    { VK_DOWN,  "DownArrow"}, 
-    { VK_LEFT,  "LeftArrow"},
-    { VK_RIGHT, "RightArrow"},
-    { VK_BACK,  "Backspace"},
-    { VK_RETURN, "Enter"}, 
-    { VK_PAUSE, "Pause"},
-    { VK_CAPITAL, "CapsLock"},
-    { VK_PRIOR, "PageUp"},
-    { VK_NEXT,  "PageDn"},
-    { VK_END,   "End"},
-    { VK_HOME,  "Home"},
-    { VK_SNAPSHOT,  "PrintScrn"},
-    { VK_INSERT,    "Insert"},
-    { VK_DELETE,    "Delete"},
-    { VK_NUMPAD0,   "NumPad0"}, 
-    { VK_NUMPAD1,   "NumPad1"}, 
-    { VK_NUMPAD2,   "NumPad2"}, 
-    { VK_NUMPAD3,   "NumPad3"},
-    { VK_NUMPAD4,   "NumPad4"},
-    { VK_NUMPAD5,   "NumPad5"},
-    { VK_NUMPAD6,   "NumPad6"}, 
-    { VK_NUMPAD7,   "NumPad7"},
-    { VK_NUMPAD8,   "NumPad8"},
-    { VK_NUMPAD9,   "NumPad9"},
-    { VK_MULTIPLY,  "NumPad*"},
-    { VK_ADD,       "NumPad+"},
-    { VK_SUBTRACT,  "NumPad-"},
-    { VK_DECIMAL,   "NumPad."},
-    { VK_DIVIDE,    "NumPad/"},
-    { VK_SPACE,     "SpaceBar"},
-    { VK_OEM_COMMA, "Comma"},
-    { VK_OEM_PERIOD,"Period"},
-    { VK_OEM_MINUS, "Minus"},
-    { VK_OEM_PLUS,  "Plus"},
-    { VK_SHIFT,     "Shift" },
+    { VK_F1,    ST_LITERAL("F1") },
+    { VK_F2,    ST_LITERAL("F2") },
+    { VK_F3,    ST_LITERAL("F3") },
+    { VK_F4,    ST_LITERAL("F4") },
+    { VK_F5,    ST_LITERAL("F5") },
+    { VK_F6,    ST_LITERAL("F6") },
+    { VK_F7,    ST_LITERAL("F7") }, 
+    { VK_F8,    ST_LITERAL("F8") },
+    { VK_F9,    ST_LITERAL("F9") },
+    { VK_F10,   ST_LITERAL("F10") },
+    { VK_F11,   ST_LITERAL("F11") },
+    { VK_F12,   ST_LITERAL("F12") },
+    { VK_ESCAPE, ST_LITERAL("Esc") },
+    { VK_TAB,   ST_LITERAL("Tab") },
+    { VK_UP,    ST_LITERAL("UpArrow") },
+    { VK_DOWN,  ST_LITERAL("DownArrow") },
+    { VK_LEFT,  ST_LITERAL("LeftArrow") },
+    { VK_RIGHT, ST_LITERAL("RightArrow") },
+    { VK_BACK,  ST_LITERAL("Backspace") },
+    { VK_RETURN, ST_LITERAL("Enter") },
+    { VK_PAUSE, ST_LITERAL("Pause") },
+    { VK_CAPITAL, ST_LITERAL("CapsLock") },
+    { VK_PRIOR, ST_LITERAL("PageUp") },
+    { VK_NEXT,  ST_LITERAL("PageDn") },
+    { VK_END,   ST_LITERAL("End") },
+    { VK_HOME,  ST_LITERAL("Home") },
+    { VK_SNAPSHOT,  ST_LITERAL("PrintScrn") },
+    { VK_INSERT,    ST_LITERAL("Insert") },
+    { VK_DELETE,    ST_LITERAL("Delete") },
+    { VK_NUMPAD0,   ST_LITERAL("NumPad0") },
+    { VK_NUMPAD1,   ST_LITERAL("NumPad1") },
+    { VK_NUMPAD2,   ST_LITERAL("NumPad2") },
+    { VK_NUMPAD3,   ST_LITERAL("NumPad3") },
+    { VK_NUMPAD4,   ST_LITERAL("NumPad4") },
+    { VK_NUMPAD5,   ST_LITERAL("NumPad5") },
+    { VK_NUMPAD6,   ST_LITERAL("NumPad6") },
+    { VK_NUMPAD7,   ST_LITERAL("NumPad7") },
+    { VK_NUMPAD8,   ST_LITERAL("NumPad8") },
+    { VK_NUMPAD9,   ST_LITERAL("NumPad9") },
+    { VK_MULTIPLY,  ST_LITERAL("NumPad*") },
+    { VK_ADD,       ST_LITERAL("NumPad+") },
+    { VK_SUBTRACT,  ST_LITERAL("NumPad-") },
+    { VK_DECIMAL,   ST_LITERAL("NumPad.") },
+    { VK_DIVIDE,    ST_LITERAL("NumPad/") },
+    { VK_SPACE,     ST_LITERAL("SpaceBar") },
+    { VK_OEM_COMMA, ST_LITERAL("Comma") },
+    { VK_OEM_PERIOD,ST_LITERAL("Period") },
+    { VK_OEM_MINUS, ST_LITERAL("Minus") },
+    { VK_OEM_PLUS,  ST_LITERAL("Plus") },
+    { VK_SHIFT,     ST_LITERAL("Shift") },
     // not valid outside USA
-    { VK_OEM_1,     "Semicolon"},
-    { VK_OEM_2,     "ForewardSlash"},
-    { VK_OEM_3,     "Tilde"},
-    { VK_OEM_4,     "LeftBracket"},
-    { VK_OEM_5,     "Backslash"},   
-    { VK_OEM_6,     "RightBracket"},
-    { VK_OEM_7,     "Quote"},
+    { VK_OEM_1,     ST_LITERAL("Semicolon") },
+    { VK_OEM_2,     ST_LITERAL("ForewardSlash") },
+    { VK_OEM_3,     ST_LITERAL("Tilde") },
+    { VK_OEM_4,     ST_LITERAL("LeftBracket") },
+    { VK_OEM_5,     ST_LITERAL("Backslash") },
+    { VK_OEM_6,     ST_LITERAL("RightBracket") },
+    { VK_OEM_7,     ST_LITERAL("Quote") },
 #endif
                 
-    { 0xffffffff,   "Unused"},
+    { 0xffffffff,   ST_LITERAL("Unused") },
 };
 
 Win32keyConvert  plKeyMap::fKeyConversionFrench[] =
 {
 #ifdef HS_BUILD_FOR_WIN32
-    { VK_F1,    "F1"}, 
-    { VK_F2,    "F2"}, 
-    { VK_F3,    "F3"}, 
-    { VK_F4,    "F4"},
-    { VK_F5,    "F5"},
-    { VK_F6,    "F6"},
-    { VK_F7,    "F7"}, 
-    { VK_F8,    "F8"},
-    { VK_F9,    "F9"},
-    { VK_F10,   "F10"},
-    { VK_F11,   "F11"},
-    { VK_F12,   "F12"},
-    { VK_ESCAPE, "Échap"},
-    { VK_TAB,   "Tab"},
-    { VK_UP,    "FlècheHaut"}, 
-    { VK_DOWN,  "FlècheBas"}, 
-    { VK_LEFT,  "FlècheGauche"},
-    { VK_RIGHT, "FlècheDroite"},
-    { VK_BACK,  "Retour"},
-    { VK_RETURN, "Entrée"}, 
-    { VK_PAUSE, "Pause"},
-    { VK_CAPITAL, "CapsLock"},
-    { VK_PRIOR, "PagePréc"},
-    { VK_NEXT,  "PageSuiv"},
-    { VK_END,   "Fin"},
-    { VK_HOME,  "Origine"},
-    { VK_SNAPSHOT,  "ImprÉcran"},
-    { VK_INSERT,    "Inser"},
-    { VK_DELETE,    "Suppr"},
-    { VK_NUMPAD0,   "PavNum0"}, 
-    { VK_NUMPAD1,   "PavNum1"}, 
-    { VK_NUMPAD2,   "PavNum2"}, 
-    { VK_NUMPAD3,   "PavNum3"},
-    { VK_NUMPAD4,   "PavNum4"},
-    { VK_NUMPAD5,   "PavNum5"},
-    { VK_NUMPAD6,   "PavNum6"}, 
-    { VK_NUMPAD7,   "PavNum7"},
-    { VK_NUMPAD8,   "PavNum8"},
-    { VK_NUMPAD9,   "PavNum9"},
-    { VK_MULTIPLY,  "PavNum*"},
-    { VK_ADD,       "PavNum+"},
-    { VK_SUBTRACT,  "PavNum-"},
-    { VK_DECIMAL,   "PavNum."},
-    { VK_DIVIDE,    "PavNum/"},
-    { VK_SPACE,     "Espace"},
-    { VK_OEM_COMMA, "Virgule"},
-    { VK_OEM_PERIOD,"Point"},
-    { VK_OEM_MINUS, "Moins"},
-    { VK_OEM_PLUS,  "Plus"},
-    { VK_SHIFT,     "Maj"   },
+    { VK_F1,    ST_LITERAL("F1") },
+    { VK_F2,    ST_LITERAL("F2") },
+    { VK_F3,    ST_LITERAL("F3") },
+    { VK_F4,    ST_LITERAL("F4") },
+    { VK_F5,    ST_LITERAL("F5") },
+    { VK_F6,    ST_LITERAL("F6") },
+    { VK_F7,    ST_LITERAL("F7") },
+    { VK_F8,    ST_LITERAL("F8") },
+    { VK_F9,    ST_LITERAL("F9") },
+    { VK_F10,   ST_LITERAL("F10") },
+    { VK_F11,   ST_LITERAL("F11") },
+    { VK_F12,   ST_LITERAL("F12") },
+    { VK_ESCAPE, ST_LITERAL("Ã‰chap") },
+    { VK_TAB,   ST_LITERAL("Tab") },
+    { VK_UP,    ST_LITERAL("FlÃ¨cheHaut") },
+    { VK_DOWN,  ST_LITERAL("FlÃ¨cheBas") },
+    { VK_LEFT,  ST_LITERAL("FlÃ¨cheGauche") },
+    { VK_RIGHT, ST_LITERAL("FlÃ¨cheDroite") },
+    { VK_BACK,  ST_LITERAL("Retour") },
+    { VK_RETURN, ST_LITERAL("EntrÃ©e") },
+    { VK_PAUSE, ST_LITERAL("Pause") },
+    { VK_CAPITAL, ST_LITERAL("CapsLock") },
+    { VK_PRIOR, ST_LITERAL("PagePrÃ©c") },
+    { VK_NEXT,  ST_LITERAL("PageSuiv") },
+    { VK_END,   ST_LITERAL("Fin") },
+    { VK_HOME,  ST_LITERAL("Origine") },
+    { VK_SNAPSHOT,  ST_LITERAL("ImprÃ‰cran") },
+    { VK_INSERT,    ST_LITERAL("Inser") },
+    { VK_DELETE,    ST_LITERAL("Suppr") },
+    { VK_NUMPAD0,   ST_LITERAL("PavNum0") },
+    { VK_NUMPAD1,   ST_LITERAL("PavNum1") },
+    { VK_NUMPAD2,   ST_LITERAL("PavNum2") },
+    { VK_NUMPAD3,   ST_LITERAL("PavNum3") },
+    { VK_NUMPAD4,   ST_LITERAL("PavNum4") },
+    { VK_NUMPAD5,   ST_LITERAL("PavNum5") },
+    { VK_NUMPAD6,   ST_LITERAL("PavNum6") },
+    { VK_NUMPAD7,   ST_LITERAL("PavNum7") },
+    { VK_NUMPAD8,   ST_LITERAL("PavNum8") },
+    { VK_NUMPAD9,   ST_LITERAL("PavNum9") },
+    { VK_MULTIPLY,  ST_LITERAL("PavNum*") },
+    { VK_ADD,       ST_LITERAL("PavNum+") },
+    { VK_SUBTRACT,  ST_LITERAL("PavNum-") },
+    { VK_DECIMAL,   ST_LITERAL("PavNum.") },
+    { VK_DIVIDE,    ST_LITERAL("PavNum/") },
+    { VK_SPACE,     ST_LITERAL("Espace") },
+    { VK_OEM_COMMA, ST_LITERAL("Virgule") },
+    { VK_OEM_PERIOD,ST_LITERAL("Point") },
+    { VK_OEM_MINUS, ST_LITERAL("Moins") },
+    { VK_OEM_PLUS,  ST_LITERAL("Plus") },
+    { VK_SHIFT,     ST_LITERAL("Maj") },
     // not valid outside USA
-    { VK_OEM_1,     "Point-virgule"},
-    { VK_OEM_2,     "BarreOblique"},
-    { VK_OEM_3,     "Tilde"},
-    { VK_OEM_4,     "ParenthèseG"},
-    { VK_OEM_5,     "BarreInverse"},    
-    { VK_OEM_6,     "ParenthèseD"},
-    { VK_OEM_7,     "Guillemet"},
+    { VK_OEM_1,     ST_LITERAL("Point-virgule") },
+    { VK_OEM_2,     ST_LITERAL("BarreOblique") },
+    { VK_OEM_3,     ST_LITERAL("Tilde") },
+    { VK_OEM_4,     ST_LITERAL("ParenthÃ¨seG") },
+    { VK_OEM_5,     ST_LITERAL("BarreInverse") },
+    { VK_OEM_6,     ST_LITERAL("ParenthÃ¨seD") },
+    { VK_OEM_7,     ST_LITERAL("Guillemet") },
 #endif
                 
-    { 0xffffffff,   "Unused"},
+    { 0xffffffff,   ST_LITERAL("Unused") },
 };
 
 Win32keyConvert  plKeyMap::fKeyConversionGerman[] =
 {
 #ifdef HS_BUILD_FOR_WIN32
-    { VK_F1,    "F1"}, 
-    { VK_F2,    "F2"}, 
-    { VK_F3,    "F3"}, 
-    { VK_F4,    "F4"},
-    { VK_F5,    "F5"},
-    { VK_F6,    "F6"},
-    { VK_F7,    "F7"}, 
-    { VK_F8,    "F8"},
-    { VK_F9,    "F9"},
-    { VK_F10,   "F10"},
-    { VK_F11,   "F11"},
-    { VK_F12,   "F12"},
-    { VK_ESCAPE, "Esc"},
-    { VK_TAB,   "Tab"},
-    { VK_UP,    "PfeilHoch"}, 
-    { VK_DOWN,  "PfeilRunter"}, 
-    { VK_LEFT,  "PfeilLinks"},
-    { VK_RIGHT, "PfeilRechts"},
-    { VK_BACK,  "Backspace"},
-    { VK_RETURN, "Enter"}, 
-    { VK_PAUSE, "Pause"},
-    { VK_CAPITAL, "Feststelltaste"},
-    { VK_PRIOR, "BildHoch"},
-    { VK_NEXT,  "BildRunter"},
-    { VK_END,   "Ende"},
-    { VK_HOME,  "Pos1"},
-    { VK_SNAPSHOT,  "Druck"},
-    { VK_INSERT,    "Einf"},
-    { VK_DELETE,    "Entf"},
-    { VK_NUMPAD0,   "ZB0"}, 
-    { VK_NUMPAD1,   "ZB1"}, 
-    { VK_NUMPAD2,   "ZB2"}, 
-    { VK_NUMPAD3,   "ZB3"},
-    { VK_NUMPAD4,   "ZB4"},
-    { VK_NUMPAD5,   "ZB5"},
-    { VK_NUMPAD6,   "ZB6"}, 
-    { VK_NUMPAD7,   "ZB7"},
-    { VK_NUMPAD8,   "ZB8"},
-    { VK_NUMPAD9,   "ZB9"},
-    { VK_MULTIPLY,  "ZB*"},
-    { VK_ADD,       "ZB+"},
-    { VK_SUBTRACT,  "ZB-"},
-    { VK_DECIMAL,   "ZB."},
-    { VK_DIVIDE,    "ZB/"},
-    { VK_SPACE,     "Leertaste"},
-    { VK_OEM_COMMA, "Komma"},
-    { VK_OEM_PERIOD,"Punkt"},
-    { VK_OEM_MINUS, "Minus"},
-    { VK_OEM_PLUS,  "Plus"},
-    { VK_SHIFT,     "Umschalt"  },
+    { VK_F1,    ST_LITERAL("F1") },
+    { VK_F2,    ST_LITERAL("F2") },
+    { VK_F3,    ST_LITERAL("F3") },
+    { VK_F4,    ST_LITERAL("F4") },
+    { VK_F5,    ST_LITERAL("F5") },
+    { VK_F6,    ST_LITERAL("F6") },
+    { VK_F7,    ST_LITERAL("F7") },
+    { VK_F8,    ST_LITERAL("F8") },
+    { VK_F9,    ST_LITERAL("F9") },
+    { VK_F10,   ST_LITERAL("F10") },
+    { VK_F11,   ST_LITERAL("F11") },
+    { VK_F12,   ST_LITERAL("F12") },
+    { VK_ESCAPE, ST_LITERAL("Esc") },
+    { VK_TAB,   ST_LITERAL("Tab") },
+    { VK_UP,    ST_LITERAL("PfeilHoch") },
+    { VK_DOWN,  ST_LITERAL("PfeilRunter") },
+    { VK_LEFT,  ST_LITERAL("PfeilLinks") },
+    { VK_RIGHT, ST_LITERAL("PfeilRechts") },
+    { VK_BACK,  ST_LITERAL("Backspace") },
+    { VK_RETURN, ST_LITERAL("Enter") },
+    { VK_PAUSE, ST_LITERAL("Pause") },
+    { VK_CAPITAL, ST_LITERAL("Feststelltaste") },
+    { VK_PRIOR, ST_LITERAL("BildHoch") },
+    { VK_NEXT,  ST_LITERAL("BildRunter") },
+    { VK_END,   ST_LITERAL("Ende") },
+    { VK_HOME,  ST_LITERAL("Pos1") },
+    { VK_SNAPSHOT,  ST_LITERAL("Druck") },
+    { VK_INSERT,    ST_LITERAL("Einf") },
+    { VK_DELETE,    ST_LITERAL("Entf") },
+    { VK_NUMPAD0,   ST_LITERAL("ZB0") },
+    { VK_NUMPAD1,   ST_LITERAL("ZB1") },
+    { VK_NUMPAD2,   ST_LITERAL("ZB2") },
+    { VK_NUMPAD3,   ST_LITERAL("ZB3") },
+    { VK_NUMPAD4,   ST_LITERAL("ZB4") },
+    { VK_NUMPAD5,   ST_LITERAL("ZB5") },
+    { VK_NUMPAD6,   ST_LITERAL("ZB6") },
+    { VK_NUMPAD7,   ST_LITERAL("ZB7") },
+    { VK_NUMPAD8,   ST_LITERAL("ZB8") },
+    { VK_NUMPAD9,   ST_LITERAL("ZB9") },
+    { VK_MULTIPLY,  ST_LITERAL("ZB*") },
+    { VK_ADD,       ST_LITERAL("ZB+") },
+    { VK_SUBTRACT,  ST_LITERAL("ZB-") },
+    { VK_DECIMAL,   ST_LITERAL("ZB.") },
+    { VK_DIVIDE,    ST_LITERAL("ZB/") },
+    { VK_SPACE,     ST_LITERAL("Leertaste") },
+    { VK_OEM_COMMA, ST_LITERAL("Komma") },
+    { VK_OEM_PERIOD,ST_LITERAL("Punkt") },
+    { VK_OEM_MINUS, ST_LITERAL("Minus") },
+    { VK_OEM_PLUS,  ST_LITERAL("Plus") },
+    { VK_SHIFT,     ST_LITERAL("Umschalt") },
     // not valid outside USA
-    { VK_OEM_1,     "Ü"},
-    { VK_OEM_2,     "#"},
-    { VK_OEM_3,     "Ö"},
-    { VK_OEM_4,     "ß"},
-    { VK_OEM_5,     "Backslash"},   
-    { VK_OEM_6,     "Akzent"},
-    { VK_OEM_7,     "Ä"},
+    { VK_OEM_1,     ST_LITERAL("Ãœ") },
+    { VK_OEM_2,     ST_LITERAL("#") },
+    { VK_OEM_3,     ST_LITERAL("Ã–") },
+    { VK_OEM_4,     ST_LITERAL("ÃŸ") },
+    { VK_OEM_5,     ST_LITERAL("Backslash") },
+    { VK_OEM_6,     ST_LITERAL("Akzent") },
+    { VK_OEM_7,     ST_LITERAL("Ã„") },
 #endif
                 
-    { 0xffffffff,   "Unused"},
+    { 0xffffffff,   ST_LITERAL("Unused") },
 };
 
 Win32keyConvert  plKeyMap::fKeyConversionSpanish[] =
 {
 #ifdef HS_BUILD_FOR_WIN32
-    { VK_F1,    "F1"}, 
-    { VK_F2,    "F2"}, 
-    { VK_F3,    "F3"}, 
-    { VK_F4,    "F4"},
-    { VK_F5,    "F5"},
-    { VK_F6,    "F6"},
-    { VK_F7,    "F7"}, 
-    { VK_F8,    "F8"},
-    { VK_F9,    "F9"},
-    { VK_F10,   "F10"},
-    { VK_F11,   "F11"},
-    { VK_F12,   "F12"},
-    { VK_ESCAPE, "Esc"},
-    { VK_TAB,   "Tabulador"},
-    { VK_UP,    "CursorArriba"}, 
-    { VK_DOWN,  "CursorAbajo"}, 
-    { VK_LEFT,  "CursorIzquierdo"},
-    { VK_RIGHT, "CursorDerecho"},
-    { VK_BACK,  "Retroceso"},
-    { VK_RETURN, "Intro"}, 
-    { VK_PAUSE, "Pausa"},
-    { VK_CAPITAL, "BloqMayús"},
-    { VK_PRIOR, "RePág"},
-    { VK_NEXT,  "AVPág"},
-    { VK_END,   "Fin"},
-    { VK_HOME,  "Inicio"},
-    { VK_SNAPSHOT,  "ImprPetSis"},
-    { VK_INSERT,    "Insert"},
-    { VK_DELETE,    "Supr"},
-    { VK_NUMPAD0,   "TecNum0"}, 
-    { VK_NUMPAD1,   "TecNum1"}, 
-    { VK_NUMPAD2,   "TecNum2"}, 
-    { VK_NUMPAD3,   "TecNum3"},
-    { VK_NUMPAD4,   "TecNum4"},
-    { VK_NUMPAD5,   "TecNum5"},
-    { VK_NUMPAD6,   "TecNum6"}, 
-    { VK_NUMPAD7,   "TecNum7"},
-    { VK_NUMPAD8,   "TecNum8"},
-    { VK_NUMPAD9,   "TecNum9"},
-    { VK_MULTIPLY,  "TecNum*"},
-    { VK_ADD,       "TecNum+"},
-    { VK_SUBTRACT,  "TecNum-"},
-    { VK_DECIMAL,   "TecNum."},
-    { VK_DIVIDE,    "TecNum/"},
-    { VK_SPACE,     "BarraEspacio"},
-    { VK_OEM_COMMA, "Coma"},
-    { VK_OEM_PERIOD,"Punto"},
-    { VK_OEM_MINUS, "Menos"},
-    { VK_OEM_PLUS,  "Más"},
-    { VK_SHIFT,     "Mayúsculas"    },
+    { VK_F1,    ST_LITERAL("F1") },
+    { VK_F2,    ST_LITERAL("F2") },
+    { VK_F3,    ST_LITERAL("F3") },
+    { VK_F4,    ST_LITERAL("F4") },
+    { VK_F5,    ST_LITERAL("F5") },
+    { VK_F6,    ST_LITERAL("F6") },
+    { VK_F7,    ST_LITERAL("F7") },
+    { VK_F8,    ST_LITERAL("F8") },
+    { VK_F9,    ST_LITERAL("F9") },
+    { VK_F10,   ST_LITERAL("F10") },
+    { VK_F11,   ST_LITERAL("F11") },
+    { VK_F12,   ST_LITERAL("F12") },
+    { VK_ESCAPE, ST_LITERAL("Esc") },
+    { VK_TAB,   ST_LITERAL("Tabulador") },
+    { VK_UP,    ST_LITERAL("CursorArriba") },
+    { VK_DOWN,  ST_LITERAL("CursorAbajo") },
+    { VK_LEFT,  ST_LITERAL("CursorIzquierdo") },
+    { VK_RIGHT, ST_LITERAL("CursorDerecho") },
+    { VK_BACK,  ST_LITERAL("Retroceso") },
+    { VK_RETURN, ST_LITERAL("Intro") },
+    { VK_PAUSE, ST_LITERAL("Pausa") },
+    { VK_CAPITAL, ST_LITERAL("BloqMayÃºs") },
+    { VK_PRIOR, ST_LITERAL("RePÃ¡g") },
+    { VK_NEXT,  ST_LITERAL("AVPÃ¡g") },
+    { VK_END,   ST_LITERAL("Fin") },
+    { VK_HOME,  ST_LITERAL("Inicio") },
+    { VK_SNAPSHOT,  ST_LITERAL("ImprPetSis") },
+    { VK_INSERT,    ST_LITERAL("Insert") },
+    { VK_DELETE,    ST_LITERAL("Supr") },
+    { VK_NUMPAD0,   ST_LITERAL("TecNum0") },
+    { VK_NUMPAD1,   ST_LITERAL("TecNum1") },
+    { VK_NUMPAD2,   ST_LITERAL("TecNum2") },
+    { VK_NUMPAD3,   ST_LITERAL("TecNum3") },
+    { VK_NUMPAD4,   ST_LITERAL("TecNum4") },
+    { VK_NUMPAD5,   ST_LITERAL("TecNum5") },
+    { VK_NUMPAD6,   ST_LITERAL("TecNum6") }, 
+    { VK_NUMPAD7,   ST_LITERAL("TecNum7") },
+    { VK_NUMPAD8,   ST_LITERAL("TecNum8") },
+    { VK_NUMPAD9,   ST_LITERAL("TecNum9") },
+    { VK_MULTIPLY,  ST_LITERAL("TecNum*") },
+    { VK_ADD,       ST_LITERAL("TecNum+") },
+    { VK_SUBTRACT,  ST_LITERAL("TecNum-") },
+    { VK_DECIMAL,   ST_LITERAL("TecNum.") },
+    { VK_DIVIDE,    ST_LITERAL("TecNum/") },
+    { VK_SPACE,     ST_LITERAL("BarraEspacio") },
+    { VK_OEM_COMMA, ST_LITERAL("Coma") },
+    { VK_OEM_PERIOD,ST_LITERAL("Punto") },
+    { VK_OEM_MINUS, ST_LITERAL("Menos") },
+    { VK_OEM_PLUS,  ST_LITERAL("MÃ¡s") },
+    { VK_SHIFT,     ST_LITERAL("MayÃºsculas") },
     // not valid outside USA
-    { VK_OEM_1,     "PuntoYComa"},
-    { VK_OEM_2,     "Barra"},
-    { VK_OEM_3,     "Tilde"},
-    { VK_OEM_4,     "AbrirParéntesis"},
-    { VK_OEM_5,     "BarraInvertida"},  
-    { VK_OEM_6,     "CerrarParéntesis"},
-    { VK_OEM_7,     "Comillas"},
+    { VK_OEM_1,     ST_LITERAL("PuntoYComa") },
+    { VK_OEM_2,     ST_LITERAL("Barra") },
+    { VK_OEM_3,     ST_LITERAL("Tilde") },
+    { VK_OEM_4,     ST_LITERAL("AbrirParÃ©ntesis") },
+    { VK_OEM_5,     ST_LITERAL("BarraInvertida") },
+    { VK_OEM_6,     ST_LITERAL("CerrarParÃ©ntesis") },
+    { VK_OEM_7,     ST_LITERAL("Comillas") },
 #endif
                 
-    { 0xffffffff,   "Unused"},
+    { 0xffffffff,   ST_LITERAL("Unused") },
 };
 
 Win32keyConvert  plKeyMap::fKeyConversionItalian[] =
 {
 #ifdef HS_BUILD_FOR_WIN32
-    { VK_F1,    "F1"}, 
-    { VK_F2,    "F2"}, 
-    { VK_F3,    "F3"}, 
-    { VK_F4,    "F4"},
-    { VK_F5,    "F5"},
-    { VK_F6,    "F6"},
-    { VK_F7,    "F7"}, 
-    { VK_F8,    "F8"},
-    { VK_F9,    "F9"},
-    { VK_F10,   "F10"},
-    { VK_F11,   "F11"},
-    { VK_F12,   "F12"},
-    { VK_ESCAPE, "Esc"},
-    { VK_TAB,   "Tab"},
-    { VK_UP,    "FrecciaSu"}, 
-    { VK_DOWN,  "FrecciaGiù"}, 
-    { VK_LEFT,  "FrecciaSx"},
-    { VK_RIGHT, "FrecciaDx"},
-    { VK_BACK,  "Backspace"},
-    { VK_RETURN, "Invio"}, 
-    { VK_PAUSE, "Pausa"},
-    { VK_CAPITAL, "BlocMaiusc"},
-    { VK_PRIOR, "PagSu"},
-    { VK_NEXT,  "PagGiù"},
-    { VK_END,   "Fine"},
-    { VK_HOME,  "Home"},
-    { VK_SNAPSHOT,  "Stamp"},
-    { VK_INSERT,    "Ins"},
-    { VK_DELETE,    "Canc"},
-    { VK_NUMPAD0,   "TastNum0"}, 
-    { VK_NUMPAD1,   "TastNum1"}, 
-    { VK_NUMPAD2,   "TastNum2"}, 
-    { VK_NUMPAD3,   "TastNum3"},
-    { VK_NUMPAD4,   "TastNum4"},
-    { VK_NUMPAD5,   "TastNum5"},
-    { VK_NUMPAD6,   "TastNum6"}, 
-    { VK_NUMPAD7,   "TastNum7"},
-    { VK_NUMPAD8,   "TastNum8"},
-    { VK_NUMPAD9,   "TastNum9"},
-    { VK_MULTIPLY,  "TastNum*"},
-    { VK_ADD,       "TastNum+"},
-    { VK_SUBTRACT,  "TastNum-"},
-    { VK_DECIMAL,   "TastNum."},
-    { VK_DIVIDE,    "TastNum/"},
-    { VK_SPACE,     "Spazio"},
-    { VK_OEM_COMMA, "Virgola"},
-    { VK_OEM_PERIOD,"Punto"},
-    { VK_OEM_MINUS, "Meno"},
-    { VK_OEM_PLUS,  "QuadraDx"},
-    { VK_SHIFT,     "Shift" },
+    { VK_F1,    ST_LITERAL("F1") },
+    { VK_F2,    ST_LITERAL("F2") },
+    { VK_F3,    ST_LITERAL("F3") },
+    { VK_F4,    ST_LITERAL("F4") },
+    { VK_F5,    ST_LITERAL("F5") },
+    { VK_F6,    ST_LITERAL("F6") },
+    { VK_F7,    ST_LITERAL("F7") },
+    { VK_F8,    ST_LITERAL("F8") },
+    { VK_F9,    ST_LITERAL("F9") },
+    { VK_F10,   ST_LITERAL("F10") },
+    { VK_F11,   ST_LITERAL("F11") },
+    { VK_F12,   ST_LITERAL("F12") },
+    { VK_ESCAPE, ST_LITERAL("Esc") },
+    { VK_TAB,   ST_LITERAL("Tab") },
+    { VK_UP,    ST_LITERAL("FrecciaSu") },
+    { VK_DOWN,  ST_LITERAL("FrecciaGiÃ¹") },
+    { VK_LEFT,  ST_LITERAL("FrecciaSx") },
+    { VK_RIGHT, ST_LITERAL("FrecciaDx") },
+    { VK_BACK,  ST_LITERAL("Backspace") },
+    { VK_RETURN, ST_LITERAL("Invio") },
+    { VK_PAUSE, ST_LITERAL("Pausa") },
+    { VK_CAPITAL, ST_LITERAL("BlocMaiusc") },
+    { VK_PRIOR, ST_LITERAL("PagSu") },
+    { VK_NEXT,  ST_LITERAL("PagGiÃ¹") },
+    { VK_END,   ST_LITERAL("Fine") },
+    { VK_HOME,  ST_LITERAL("Home") },
+    { VK_SNAPSHOT,  ST_LITERAL("Stamp") },
+    { VK_INSERT,    ST_LITERAL("Ins") },
+    { VK_DELETE,    ST_LITERAL("Canc") },
+    { VK_NUMPAD0,   ST_LITERAL("TastNum0") },
+    { VK_NUMPAD1,   ST_LITERAL("TastNum1") },
+    { VK_NUMPAD2,   ST_LITERAL("TastNum2") },
+    { VK_NUMPAD3,   ST_LITERAL("TastNum3") },
+    { VK_NUMPAD4,   ST_LITERAL("TastNum4") },
+    { VK_NUMPAD5,   ST_LITERAL("TastNum5") },
+    { VK_NUMPAD6,   ST_LITERAL("TastNum6") },
+    { VK_NUMPAD7,   ST_LITERAL("TastNum7") },
+    { VK_NUMPAD8,   ST_LITERAL("TastNum8") },
+    { VK_NUMPAD9,   ST_LITERAL("TastNum9") },
+    { VK_MULTIPLY,  ST_LITERAL("TastNum*") },
+    { VK_ADD,       ST_LITERAL("TastNum+") },
+    { VK_SUBTRACT,  ST_LITERAL("TastNum-") },
+    { VK_DECIMAL,   ST_LITERAL("TastNum.") },
+    { VK_DIVIDE,    ST_LITERAL("TastNum/") },
+    { VK_SPACE,     ST_LITERAL("Spazio") },
+    { VK_OEM_COMMA, ST_LITERAL("Virgola") },
+    { VK_OEM_PERIOD,ST_LITERAL("Punto") },
+    { VK_OEM_MINUS, ST_LITERAL("Meno") },
+    { VK_OEM_PLUS,  ST_LITERAL("QuadraDx") },
+    { VK_SHIFT,     ST_LITERAL("Shift") },
     // not valid outside USA
-    { VK_OEM_1,     "QuadraSx"},
-    { VK_OEM_2,     "ù"},
-    { VK_OEM_3,     "ò"},
-    { VK_OEM_4,     "Apostrofo"},
-    { VK_OEM_5,     "\\"},  
-    { VK_OEM_6,     "ì"},
-    { VK_OEM_7,     "à"},
+    { VK_OEM_1,     ST_LITERAL("QuadraSx") },
+    { VK_OEM_2,     ST_LITERAL("Ã¹") },
+    { VK_OEM_3,     ST_LITERAL("Ã²") },
+    { VK_OEM_4,     ST_LITERAL("Apostrofo") },
+    { VK_OEM_5,     ST_LITERAL("\\") },
+    { VK_OEM_6,     ST_LITERAL("Ã¬") },
+    { VK_OEM_7,     ST_LITERAL("Ã ") },
 #endif
                 
-    { 0xffffffff,   "Unused"},
+    { 0xffffffff,   ST_LITERAL("Unused") },
 };
 
 
@@ -1037,60 +1035,60 @@ Win32keyConvert  plKeyMap::fKeyConversionItalian[] =
 CommandConvert plInputMap::fCmdConvert[] =
 {
 
-    { B_CONTROL_ACTION,         "Use Key"   },
-    { B_CONTROL_JUMP,               "Jump Key"  },
-    { B_CONTROL_DIVE,               "Dive Key"  },
-    { B_CONTROL_MOVE_FORWARD,       "Walk Forward"  },
-    { B_CONTROL_MOVE_BACKWARD,  "Walk Backward" },
-    { B_CONTROL_STRAFE_LEFT,        "Strafe Left"   },
-    { B_CONTROL_STRAFE_RIGHT,       "Strafe Right"  },
-    { B_CONTROL_MOVE_UP,            "Move Up"       },
-    { B_CONTROL_MOVE_DOWN,      "Move Down"     },
-    { B_CONTROL_ROTATE_LEFT,        "Turn Left"     },
-    { B_CONTROL_ROTATE_RIGHT,       "Turn Right"        },
-    { B_CONTROL_ROTATE_UP,      "Turn Up"       },
-    { B_CONTROL_ROTATE_DOWN,        "Turn Down"     },
-    { B_CONTROL_MODIFIER_FAST,              "Fast Modifier" },
-    { B_CONTROL_EQUIP,          "PickUp Item"   },
-    { B_CONTROL_DROP,               "Drop Item"     },
-    { B_TOGGLE_DRIVE_MODE,      "Drive" },
-    { B_CONTROL_ALWAYS_RUN,     "Always Run" },
-    { B_CAMERA_MOVE_FORWARD,        "Camera Forward"},
-    { B_CAMERA_MOVE_BACKWARD,       "Camera Backward"},
-    { B_CAMERA_MOVE_UP,         "Camera Up"},
-    { B_CAMERA_MOVE_DOWN,           "Camera Down"},
-    { B_CAMERA_MOVE_LEFT,           "Camera Left"},
-    { B_CAMERA_MOVE_RIGHT,      "Camera Right"},
-    { B_CAMERA_MOVE_FAST,           "Camera Fast"},
-    { B_CAMERA_ROTATE_RIGHT,        "Camera Yaw Right"},
-    { B_CAMERA_ROTATE_LEFT,     "Camera Yaw Left"},
-    { B_CAMERA_ROTATE_UP,           "Camera Pitch Up"},
-    { B_CAMERA_ROTATE_DOWN,     "Camera Pitch Down"},
-    { B_CAMERA_PAN_UP,          "Camera Pan Up"},
-    { B_CAMERA_PAN_DOWN,        "Camera Pan Down"},
-    { B_CAMERA_PAN_LEFT,        "Camera Pan Left"},
-    { B_CAMERA_PAN_RIGHT,       "Camera Pan Right"},
-    { B_CAMERA_PAN_TO_CURSOR,   "Camera Pan To Cursor"},
-    { B_CAMERA_RECENTER,        "Camera Recenter"},
-    { B_SET_CONSOLE_MODE,           "Console"},
-    { B_CAMERA_DRIVE_SPEED_UP,      "Decrease Camera Drive Speed"   },
-    { B_CAMERA_DRIVE_SPEED_DOWN,    "Increase Camera Drive Speed"   },
-    { S_INCREASE_MIC_VOL,       "Increase Microphone Sensitivity"   },
-    { S_DECREASE_MIC_VOL,       "Decrease Microphone Sensitivity"   },
-    { S_PUSH_TO_TALK,           "Push to talk" },
-    { S_SET_WALK_MODE,          "Set Walk Mode" },          
-    { B_CONTROL_TURN_TO,            "Turn To Click" },
-    { B_CONTROL_TOGGLE_PHYSICAL,    "Toggle Physical" },
-    { S_SET_FIRST_PERSON_MODE,      "Toggle First Person" },
-    { B_CAMERA_ZOOM_IN,             "Camera Zoom In" },
-    { B_CAMERA_ZOOM_OUT,            "Camera Zoom Out" },
-    { B_CONTROL_EXIT_MODE,          "Exit Mode" },
-    { B_CONTROL_OPEN_KI,            "Open KI" },
-    { B_CONTROL_OPEN_BOOK,          "Open Player Book" },
-    { B_CONTROL_EXIT_GUI_MODE,      "Exit GUI Mode" },
-    { B_CONTROL_MODIFIER_STRAFE,    "Strafe Modifier" },
+    { B_CONTROL_ACTION, ST_LITERAL("Use Key") },
+    { B_CONTROL_JUMP, ST_LITERAL("Jump Key") },
+    { B_CONTROL_DIVE, ST_LITERAL("Dive Key") },
+    { B_CONTROL_MOVE_FORWARD, ST_LITERAL("Walk Forward") },
+    { B_CONTROL_MOVE_BACKWARD, ST_LITERAL("Walk Backward") },
+    { B_CONTROL_STRAFE_LEFT, ST_LITERAL("Strafe Left") },
+    { B_CONTROL_STRAFE_RIGHT, ST_LITERAL("Strafe Right") },
+    { B_CONTROL_MOVE_UP, ST_LITERAL("Move Up") },
+    { B_CONTROL_MOVE_DOWN, ST_LITERAL("Move Down") },
+    { B_CONTROL_ROTATE_LEFT, ST_LITERAL("Turn Left") },
+    { B_CONTROL_ROTATE_RIGHT, ST_LITERAL("Turn Right") },
+    { B_CONTROL_ROTATE_UP, ST_LITERAL("Turn Up") },
+    { B_CONTROL_ROTATE_DOWN, ST_LITERAL("Turn Down") },
+    { B_CONTROL_MODIFIER_FAST, ST_LITERAL("Fast Modifier") },
+    { B_CONTROL_EQUIP, ST_LITERAL("PickUp Item") },
+    { B_CONTROL_DROP, ST_LITERAL("Drop Item") },
+    { B_TOGGLE_DRIVE_MODE, ST_LITERAL("Drive") },
+    { B_CONTROL_ALWAYS_RUN, ST_LITERAL("Always Run") },
+    { B_CAMERA_MOVE_FORWARD, ST_LITERAL("Camera Forward") },
+    { B_CAMERA_MOVE_BACKWARD, ST_LITERAL("Camera Backward") },
+    { B_CAMERA_MOVE_UP, ST_LITERAL("Camera Up") },
+    { B_CAMERA_MOVE_DOWN, ST_LITERAL("Camera Down") },
+    { B_CAMERA_MOVE_LEFT, ST_LITERAL("Camera Left") },
+    { B_CAMERA_MOVE_RIGHT, ST_LITERAL("Camera Right") },
+    { B_CAMERA_MOVE_FAST, ST_LITERAL("Camera Fast") },
+    { B_CAMERA_ROTATE_RIGHT, ST_LITERAL("Camera Yaw Right") },
+    { B_CAMERA_ROTATE_LEFT, ST_LITERAL("Camera Yaw Left") },
+    { B_CAMERA_ROTATE_UP, ST_LITERAL("Camera Pitch Up") },
+    { B_CAMERA_ROTATE_DOWN, ST_LITERAL("Camera Pitch Down") },
+    { B_CAMERA_PAN_UP, ST_LITERAL("Camera Pan Up") },
+    { B_CAMERA_PAN_DOWN, ST_LITERAL("Camera Pan Down") },
+    { B_CAMERA_PAN_LEFT, ST_LITERAL("Camera Pan Left") },
+    { B_CAMERA_PAN_RIGHT, ST_LITERAL("Camera Pan Right") },
+    { B_CAMERA_PAN_TO_CURSOR, ST_LITERAL("Camera Pan To Cursor") },
+    { B_CAMERA_RECENTER, ST_LITERAL("Camera Recenter") },
+    { B_SET_CONSOLE_MODE, ST_LITERAL("Console") },
+    { B_CAMERA_DRIVE_SPEED_UP, ST_LITERAL("Decrease Camera Drive Speed") },
+    { B_CAMERA_DRIVE_SPEED_DOWN, ST_LITERAL("Increase Camera Drive Speed") },
+    { S_INCREASE_MIC_VOL, ST_LITERAL("Increase Microphone Sensitivity") },
+    { S_DECREASE_MIC_VOL, ST_LITERAL("Decrease Microphone Sensitivity") },
+    { S_PUSH_TO_TALK, ST_LITERAL("Push to talk") },
+    { S_SET_WALK_MODE, ST_LITERAL("Set Walk Mode") },
+    { B_CONTROL_TURN_TO, ST_LITERAL("Turn To Click") },
+    { B_CONTROL_TOGGLE_PHYSICAL, ST_LITERAL("Toggle Physical") },
+    { S_SET_FIRST_PERSON_MODE, ST_LITERAL("Toggle First Person") },
+    { B_CAMERA_ZOOM_IN, ST_LITERAL("Camera Zoom In") },
+    { B_CAMERA_ZOOM_OUT, ST_LITERAL("Camera Zoom Out") },
+    { B_CONTROL_EXIT_MODE, ST_LITERAL("Exit Mode") },
+    { B_CONTROL_OPEN_KI, ST_LITERAL("Open KI") },
+    { B_CONTROL_OPEN_BOOK, ST_LITERAL("Open Player Book") },
+    { B_CONTROL_EXIT_GUI_MODE, ST_LITERAL("Exit GUI Mode") },
+    { B_CONTROL_MODIFIER_STRAFE, ST_LITERAL("Strafe Modifier") },
 
 
-    { END_CONTROLS,             ""},
+    { END_CONTROLS, {} },
  
 };

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
@@ -488,31 +488,21 @@ void    plKeyMap::EraseBinding( ControlEventCode code )
 }
 
 
+const std::map<uint32_t, ST::string>& plKeyMap::GetKeyConversion() {
+    auto langIter = fKeyConversions.find(plLocalization::GetLanguage());
+    if (langIter == fKeyConversions.end()) {
+        // default is English
+        return fKeyConversionEnglish;
+    } else {
+        return *langIter->second;
+    }
+}
+
 ST::string plKeyMap::ConvertVKeyToChar(uint32_t vk)
 {
-    const std::map<uint32_t, ST::string>* keyConvert = &fKeyConversionEnglish;
-    switch (plLocalization::GetLanguage())
-    {
-        case plLocalization::kFrench:
-            keyConvert = &fKeyConversionFrench;
-            break;
-        case plLocalization::kGerman:
-            keyConvert = &fKeyConversionGerman;
-            break;
-        case plLocalization::kSpanish:
-            keyConvert = &fKeyConversionSpanish;
-            break;
-        case plLocalization::kItalian:
-            keyConvert = &fKeyConversionItalian;
-            break;
-
-        // default is English
-        default:
-            break;
-    }
-
-    auto it = keyConvert->find(vk);
-    if (it == keyConvert->end()) {
+    const std::map<uint32_t, ST::string>& keyConvert = GetKeyConversion();
+    auto it = keyConvert.find(vk);
+    if (it == keyConvert.end()) {
         return {};
     } else {
         return it->second;
@@ -521,27 +511,8 @@ ST::string plKeyMap::ConvertVKeyToChar(uint32_t vk)
 
 plKeyDef plKeyMap::ConvertCharToVKey(const ST::string& c)
 {
-    const std::map<uint32_t, ST::string>* keyConvert = &fKeyConversionEnglish;
-    switch (plLocalization::GetLanguage())
-    {
-        case plLocalization::kFrench:
-            keyConvert = &fKeyConversionFrench;
-            break;
-        case plLocalization::kGerman:
-            keyConvert = &fKeyConversionGerman;
-            break;
-        case plLocalization::kSpanish:
-            keyConvert = &fKeyConversionSpanish;
-            break;
-        case plLocalization::kItalian:
-            keyConvert = &fKeyConversionItalian;
-            break;
-
-        // default is English
-        default:
-            break;
-    }
-    for (const auto& [vKey, keyName] : *keyConvert)
+    const std::map<uint32_t, ST::string>& keyConvert = GetKeyConversion();
+    for (const auto& [vKey, keyName] : keyConvert)
     {
         if (keyName.compare_i(c) == 0)
             return (plKeyDef)vKey;
@@ -556,44 +527,12 @@ plKeyDef plKeyMap::ConvertCharToVKey(const ST::string& c)
     // if we didn't find anything yet...
     // ...then look thru all the other language mappings that we know about,
     // ...just in case they keep switching languages on us
-    if ( plLocalization::GetLanguage() != plLocalization::kEnglish)
-    {
-        for (const auto& [vKey, keyName] : fKeyConversionEnglish)
-        {
-            if (keyName.compare_i(c) == 0)
-                return (plKeyDef)vKey;
-        }
-    }
-    if ( plLocalization::GetLanguage() != plLocalization::kFrench)
-    {
-        for (const auto& [vKey, keyName] : fKeyConversionFrench)
-        {
-            if (keyName.compare_i(c) == 0)
-                return (plKeyDef)vKey;
-        }
-    }
-    if ( plLocalization::GetLanguage() != plLocalization::kGerman)
-    {
-        for (const auto& [vKey, keyName] : fKeyConversionGerman)
-        {
-            if (keyName.compare_i(c) == 0)
-                return (plKeyDef)vKey;
-        }
-    }
-    if ( plLocalization::GetLanguage() != plLocalization::kSpanish)
-    {
-        for (const auto& [vKey, keyName] : fKeyConversionSpanish)
-        {
-            if (keyName.compare_i(c) == 0)
-                return (plKeyDef)vKey;
-        }
-    }
-    if ( plLocalization::GetLanguage() != plLocalization::kItalian)
-    {
-        for (const auto& [vKey, keyName] : fKeyConversionItalian)
-        {
-            if (keyName.compare_i(c) == 0)
-                return (plKeyDef)vKey;
+    for (const auto& [lang, langKeyConvert] : fKeyConversions) {
+        if (lang != plLocalization::GetLanguage()) {
+            for (const auto& [vKey, keyName] : *langKeyConvert) {
+                if (keyName.compare_i(c) == 0)
+                    return (plKeyDef)vKey;
+            }
         }
     }
 
@@ -1020,6 +959,14 @@ const std::map<uint32_t, ST::string> plKeyMap::fKeyConversionItalian =
 #endif
 };
 
+
+const std::map<plLocalization::Language, const std::map<uint32_t, ST::string>*> plKeyMap::fKeyConversions = {
+    { plLocalization::kEnglish, &fKeyConversionEnglish },
+    { plLocalization::kFrench, &fKeyConversionFrench },
+    { plLocalization::kGerman, &fKeyConversionGerman },
+    { plLocalization::kSpanish, &fKeyConversionSpanish },
+    { plLocalization::kItalian, &fKeyConversionItalian },
+};
 
 
 const std::map<ControlEventCode, ST::string> plInputMap::fCmdConvert =

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
@@ -503,12 +503,12 @@ const char* plKeyMap::ConvertVKeyToChar( uint32_t vk )
         case plLocalization::kGerman:
             keyConvert = &fKeyConversionGerman[0];
             break;
-//      case plLocalization::kSpanish:
-//          keyConvert = &fKeyConversionSpanish[0];
-//          break;
-//      case plLocalization::kItalian:
-//          keyConvert = &fKeyConversionItalian[0];
-//          break;
+        case plLocalization::kSpanish:
+            keyConvert = &fKeyConversionSpanish[0];
+            break;
+        case plLocalization::kItalian:
+            keyConvert = &fKeyConversionItalian[0];
+            break;
 
         // default is English
         default:
@@ -534,12 +534,12 @@ plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
         case plLocalization::kGerman:
             keyConvert = &fKeyConversionGerman[0];
             break;
-//      case plLocalization::kSpanish:
-//          keyConvert = &fKeyConversionSpanish[0];
-//          break;
-//      case plLocalization::kItalian:
-//          keyConvert = &fKeyConversionItalian[0];
-//          break;
+        case plLocalization::kSpanish:
+            keyConvert = &fKeyConversionSpanish[0];
+            break;
+        case plLocalization::kItalian:
+            keyConvert = &fKeyConversionItalian[0];
+            break;
 
         // default is English
         default:
@@ -582,7 +582,6 @@ plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
                 return (plKeyDef)(fKeyConversionGerman[i].fVKey);
         }
     }
-    /*
     if ( plLocalization::GetLanguage() != plLocalization::kSpanish)
     {
         for (int i = 0; fKeyConversionSpanish[i].fVKey != 0xffffffff; i++)
@@ -599,7 +598,6 @@ plKeyDef plKeyMap::ConvertCharToVKey( const char *c )
                 return (plKeyDef)(fKeyConversionItalian[i].fVKey);
         }
     }
-    */
 
     // finally, just give up... unmapped!
     return KEY_UNMAPPED;
@@ -615,13 +613,13 @@ const char* plKeyMap::GetStringCtrl()
         case plLocalization::kGerman:
             return "Strg+";
             break;
-/*      case plLocalization::kSpanish:
+        case plLocalization::kSpanish:
             return "Ctrl+";
             break;
         case plLocalization::kItalian:
             return "Ctrl+";
             break;
-*/
+
         // default is English
         default:
             break;
@@ -639,13 +637,13 @@ const char* plKeyMap::GetStringShift()
         case plLocalization::kGerman:
             return "Umschalt+";
             break;
-/*      case plLocalization::kSpanish:
+        case plLocalization::kSpanish:
             return "Mayúsculas+";
             break;
         case plLocalization::kItalian:
             return "Shift+";
             break;
-*/
+
         // default is English
         default:
             break;
@@ -663,13 +661,13 @@ const char* plKeyMap::GetStringUnmapped()
         case plLocalization::kGerman:
             return "(NichtZugewiesen)";
             break;
-/*      case plLocalization::kSpanish:
+        case plLocalization::kSpanish:
             return "(SinMapear)";
             break;
         case plLocalization::kItalian:
             return "(NonAssegnato)";
             break;
-*/
+
         // default is English
         default:
             break;
@@ -902,9 +900,9 @@ Win32keyConvert  plKeyMap::fKeyConversionGerman[] =
     { 0xffffffff,   "Unused"},
 };
 
-/*
 Win32keyConvert  plKeyMap::fKeyConversionSpanish[] =
 {
+#ifdef HS_BUILD_FOR_WIN32
     { VK_F1,    "F1"}, 
     { VK_F2,    "F2"}, 
     { VK_F3,    "F3"}, 
@@ -963,12 +961,14 @@ Win32keyConvert  plKeyMap::fKeyConversionSpanish[] =
     { VK_OEM_5,     "BarraInvertida"},  
     { VK_OEM_6,     "CerrarParéntesis"},
     { VK_OEM_7,     "Comillas"},
+#endif
                 
     { 0xffffffff,   "Unused"},
 };
 
 Win32keyConvert  plKeyMap::fKeyConversionItalian[] =
 {
+#ifdef HS_BUILD_FOR_WIN32
     { VK_F1,    "F1"}, 
     { VK_F2,    "F2"}, 
     { VK_F3,    "F3"}, 
@@ -1027,10 +1027,10 @@ Win32keyConvert  plKeyMap::fKeyConversionItalian[] =
     { VK_OEM_5,     "\\"},  
     { VK_OEM_6,     "ì"},
     { VK_OEM_7,     "à"},
+#endif
                 
     { 0xffffffff,   "Unused"},
 };
-*/
 
 
 

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
@@ -122,7 +122,6 @@ plKeyBinding::plKeyBinding()
     fCodeFlags = 0;
     fKey1 = plKeyCombo::kUnmapped;
     fKey2 = plKeyCombo::kUnmapped;
-    fString = ST::string();
 }
 
 plKeyBinding::plKeyBinding(ControlEventCode code, uint32_t codeFlags, const plKeyCombo &key1, const plKeyCombo &key2, ST::string string)
@@ -488,7 +487,8 @@ void    plKeyMap::EraseBinding( ControlEventCode code )
 }
 
 
-const std::map<uint32_t, ST::string>& plKeyMap::GetKeyConversion() {
+const std::map<uint32_t, ST::string>& plKeyMap::GetKeyConversion()
+{
     auto langIter = fKeyConversions.find(plLocalization::GetLanguage());
     if (langIter == fKeyConversions.end()) {
         // default is English

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
@@ -50,22 +50,22 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 ControlEventCode plInputMap::ConvertCharToControlCode(const ST::string& c)
 {
-    for (int i = 0; fCmdConvert[i].fCode != END_CONTROLS; i++)
+    for (const auto& [code, desc] : fCmdConvert)
     {
-        if (fCmdConvert[i].fDesc.compare_i(c) == 0)
-            return (fCmdConvert[i].fCode);
+        if (desc.compare_i(c) == 0)
+            return code;
     }
     return (END_CONTROLS);
 }
 
 ST::string plInputMap::ConvertControlCodeToString(ControlEventCode code)
 {
-    for( int i = 0; fCmdConvert[ i ].fCode != END_CONTROLS; i++ )
-    {
-        if( fCmdConvert[ i ].fCode == code )
-            return fCmdConvert[ i ].fDesc;
+    auto it = fCmdConvert.find(code);
+    if (it == fCmdConvert.end()) {
+        return {};
+    } else {
+        return it->second;
     }
-    return {};
 }
 
 //
@@ -490,61 +490,61 @@ void    plKeyMap::EraseBinding( ControlEventCode code )
 
 ST::string plKeyMap::ConvertVKeyToChar(uint32_t vk)
 {
-    Win32keyConvert* keyConvert = &fKeyConversionEnglish[0];
+    const std::map<uint32_t, ST::string>* keyConvert = &fKeyConversionEnglish;
     switch (plLocalization::GetLanguage())
     {
         case plLocalization::kFrench:
-            keyConvert = &fKeyConversionFrench[0];
+            keyConvert = &fKeyConversionFrench;
             break;
         case plLocalization::kGerman:
-            keyConvert = &fKeyConversionGerman[0];
+            keyConvert = &fKeyConversionGerman;
             break;
         case plLocalization::kSpanish:
-            keyConvert = &fKeyConversionSpanish[0];
+            keyConvert = &fKeyConversionSpanish;
             break;
         case plLocalization::kItalian:
-            keyConvert = &fKeyConversionItalian[0];
+            keyConvert = &fKeyConversionItalian;
             break;
 
         // default is English
         default:
             break;
     }
-    for (int i = 0; keyConvert[i].fVKey != 0xffffffff; i++)
-    {
-        if (keyConvert[i].fVKey == vk)
-            return (keyConvert[i].fKeyName);
-    }
 
-    return {};
+    auto it = keyConvert->find(vk);
+    if (it == keyConvert->end()) {
+        return {};
+    } else {
+        return it->second;
+    }
 }
 
 plKeyDef plKeyMap::ConvertCharToVKey(const ST::string& c)
 {
-    Win32keyConvert* keyConvert = &fKeyConversionEnglish[0];
+    const std::map<uint32_t, ST::string>* keyConvert = &fKeyConversionEnglish;
     switch (plLocalization::GetLanguage())
     {
         case plLocalization::kFrench:
-            keyConvert = &fKeyConversionFrench[0];
+            keyConvert = &fKeyConversionFrench;
             break;
         case plLocalization::kGerman:
-            keyConvert = &fKeyConversionGerman[0];
+            keyConvert = &fKeyConversionGerman;
             break;
         case plLocalization::kSpanish:
-            keyConvert = &fKeyConversionSpanish[0];
+            keyConvert = &fKeyConversionSpanish;
             break;
         case plLocalization::kItalian:
-            keyConvert = &fKeyConversionItalian[0];
+            keyConvert = &fKeyConversionItalian;
             break;
 
         // default is English
         default:
             break;
     }
-    for (int i = 0; keyConvert[i].fVKey != 0xffffffff; i++)
+    for (const auto& [vKey, keyName] : *keyConvert)
     {
-        if (keyConvert[i].fKeyName.compare_i(c) == 0)
-            return (plKeyDef)(keyConvert[i].fVKey);
+        if (keyName.compare_i(c) == 0)
+            return (plKeyDef)vKey;
     }
 
     // Is it just a single character?
@@ -558,42 +558,42 @@ plKeyDef plKeyMap::ConvertCharToVKey(const ST::string& c)
     // ...just in case they keep switching languages on us
     if ( plLocalization::GetLanguage() != plLocalization::kEnglish)
     {
-        for (int i = 0; fKeyConversionEnglish[i].fVKey != 0xffffffff; i++)
+        for (const auto& [vKey, keyName] : fKeyConversionEnglish)
         {
-            if (fKeyConversionEnglish[i].fKeyName.compare_i(c) == 0)
-                return (plKeyDef)(fKeyConversionEnglish[i].fVKey);
+            if (keyName.compare_i(c) == 0)
+                return (plKeyDef)vKey;
         }
     }
     if ( plLocalization::GetLanguage() != plLocalization::kFrench)
     {
-        for (int i = 0; fKeyConversionFrench[i].fVKey != 0xffffffff; i++)
+        for (const auto& [vKey, keyName] : fKeyConversionFrench)
         {
-            if (fKeyConversionFrench[i].fKeyName.compare_i(c) == 0)
-                return (plKeyDef)(fKeyConversionFrench[i].fVKey);
+            if (keyName.compare_i(c) == 0)
+                return (plKeyDef)vKey;
         }
     }
     if ( plLocalization::GetLanguage() != plLocalization::kGerman)
     {
-        for (int i = 0; fKeyConversionGerman[i].fVKey != 0xffffffff; i++)
+        for (const auto& [vKey, keyName] : fKeyConversionGerman)
         {
-            if (fKeyConversionGerman[i].fKeyName.compare_i(c) == 0)
-                return (plKeyDef)(fKeyConversionGerman[i].fVKey);
+            if (keyName.compare_i(c) == 0)
+                return (plKeyDef)vKey;
         }
     }
     if ( plLocalization::GetLanguage() != plLocalization::kSpanish)
     {
-        for (int i = 0; fKeyConversionSpanish[i].fVKey != 0xffffffff; i++)
+        for (const auto& [vKey, keyName] : fKeyConversionSpanish)
         {
-            if (fKeyConversionSpanish[i].fKeyName.compare_i(c) == 0)
-                return (plKeyDef)(fKeyConversionSpanish[i].fVKey);
+            if (keyName.compare_i(c) == 0)
+                return (plKeyDef)vKey;
         }
     }
     if ( plLocalization::GetLanguage() != plLocalization::kItalian)
     {
-        for (int i = 0; fKeyConversionItalian[i].fVKey != 0xffffffff; i++)
+        for (const auto& [vKey, keyName] : fKeyConversionItalian)
         {
-            if (fKeyConversionItalian[i].fKeyName.compare_i(c) == 0)
-                return (plKeyDef)(fKeyConversionItalian[i].fVKey);
+            if (keyName.compare_i(c) == 0)
+                return (plKeyDef)vKey;
         }
     }
 
@@ -700,7 +700,7 @@ void plKeyMap::ICheckAndBindDupe(plKeyDef origKey, plKeyDef dupeKey)
     }   
 }
 
-Win32keyConvert plKeyMap::fKeyConversionEnglish[] =
+const std::map<uint32_t, ST::string> plKeyMap::fKeyConversionEnglish =
 { 
 #ifdef HS_BUILD_FOR_WIN32
     { VK_F1,    ST_LITERAL("F1") },
@@ -762,11 +762,9 @@ Win32keyConvert plKeyMap::fKeyConversionEnglish[] =
     { VK_OEM_6,     ST_LITERAL("RightBracket") },
     { VK_OEM_7,     ST_LITERAL("Quote") },
 #endif
-                
-    { 0xffffffff,   ST_LITERAL("Unused") },
 };
 
-Win32keyConvert  plKeyMap::fKeyConversionFrench[] =
+const std::map<uint32_t, ST::string> plKeyMap::fKeyConversionFrench =
 {
 #ifdef HS_BUILD_FOR_WIN32
     { VK_F1,    ST_LITERAL("F1") },
@@ -828,11 +826,9 @@ Win32keyConvert  plKeyMap::fKeyConversionFrench[] =
     { VK_OEM_6,     ST_LITERAL("ParenthèseD") },
     { VK_OEM_7,     ST_LITERAL("Guillemet") },
 #endif
-                
-    { 0xffffffff,   ST_LITERAL("Unused") },
 };
 
-Win32keyConvert  plKeyMap::fKeyConversionGerman[] =
+const std::map<uint32_t, ST::string> plKeyMap::fKeyConversionGerman =
 {
 #ifdef HS_BUILD_FOR_WIN32
     { VK_F1,    ST_LITERAL("F1") },
@@ -894,11 +890,9 @@ Win32keyConvert  plKeyMap::fKeyConversionGerman[] =
     { VK_OEM_6,     ST_LITERAL("Akzent") },
     { VK_OEM_7,     ST_LITERAL("Ä") },
 #endif
-                
-    { 0xffffffff,   ST_LITERAL("Unused") },
 };
 
-Win32keyConvert  plKeyMap::fKeyConversionSpanish[] =
+const std::map<uint32_t, ST::string> plKeyMap::fKeyConversionSpanish =
 {
 #ifdef HS_BUILD_FOR_WIN32
     { VK_F1,    ST_LITERAL("F1") },
@@ -960,11 +954,9 @@ Win32keyConvert  plKeyMap::fKeyConversionSpanish[] =
     { VK_OEM_6,     ST_LITERAL("CerrarParéntesis") },
     { VK_OEM_7,     ST_LITERAL("Comillas") },
 #endif
-                
-    { 0xffffffff,   ST_LITERAL("Unused") },
 };
 
-Win32keyConvert  plKeyMap::fKeyConversionItalian[] =
+const std::map<uint32_t, ST::string> plKeyMap::fKeyConversionItalian =
 {
 #ifdef HS_BUILD_FOR_WIN32
     { VK_F1,    ST_LITERAL("F1") },
@@ -1026,13 +1018,11 @@ Win32keyConvert  plKeyMap::fKeyConversionItalian[] =
     { VK_OEM_6,     ST_LITERAL("ì") },
     { VK_OEM_7,     ST_LITERAL("à") },
 #endif
-                
-    { 0xffffffff,   ST_LITERAL("Unused") },
 };
 
 
 
-CommandConvert plInputMap::fCmdConvert[] =
+const std::map<ControlEventCode, ST::string> plInputMap::fCmdConvert =
 {
 
     { B_CONTROL_ACTION, ST_LITERAL("Use Key") },
@@ -1087,8 +1077,4 @@ CommandConvert plInputMap::fCmdConvert[] =
     { B_CONTROL_OPEN_BOOK, ST_LITERAL("Open Player Book") },
     { B_CONTROL_EXIT_GUI_MODE, ST_LITERAL("Exit GUI Mode") },
     { B_CONTROL_MODIFIER_STRAFE, ST_LITERAL("Strafe Modifier") },
-
-
-    { END_CONTROLS, {} },
- 
 };

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
@@ -40,6 +40,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 // plInputMap.cpp
+#include <algorithm>
 #include <cctype>
 #include <utility>
 

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
@@ -167,6 +167,14 @@ bool    plKeyBinding::HasUnmappedKey() const
 //// plKeyMap Implementation /////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
+static const std::map<plLocalization::Language, const std::map<uint32_t, ST::string>*> keyConversions = {
+    { plLocalization::kEnglish, &plKeyMap::fKeyConversionEnglish },
+    { plLocalization::kFrench, &plKeyMap::fKeyConversionFrench },
+    { plLocalization::kGerman, &plKeyMap::fKeyConversionGerman },
+    { plLocalization::kSpanish, &plKeyMap::fKeyConversionSpanish },
+    { plLocalization::kItalian, &plKeyMap::fKeyConversionItalian },
+};
+
 plKeyMap::~plKeyMap()
 {
     ClearAll();
@@ -489,8 +497,8 @@ void    plKeyMap::EraseBinding( ControlEventCode code )
 
 const std::map<uint32_t, ST::string>& plKeyMap::GetKeyConversion()
 {
-    auto langIter = fKeyConversions.find(plLocalization::GetLanguage());
-    if (langIter == fKeyConversions.end()) {
+    auto langIter = keyConversions.find(plLocalization::GetLanguage());
+    if (langIter == keyConversions.end()) {
         // default is English
         return fKeyConversionEnglish;
     } else {
@@ -527,7 +535,7 @@ plKeyDef plKeyMap::ConvertCharToVKey(const ST::string& c)
     // if we didn't find anything yet...
     // ...then look thru all the other language mappings that we know about,
     // ...just in case they keep switching languages on us
-    for (const auto& [lang, langKeyConvert] : fKeyConversions) {
+    for (const auto& [lang, langKeyConvert] : keyConversions) {
         if (lang != plLocalization::GetLanguage()) {
             for (const auto& [vKey, keyName] : *langKeyConvert) {
                 if (keyName.compare_i(c) == 0)
@@ -998,15 +1006,6 @@ const std::map<uint32_t, ST::string> plKeyMap::fKeyConversionItalian =
     { VK_OEM_6,     ST_LITERAL("ì") },
     { VK_OEM_7,     ST_LITERAL("à") },
 #endif
-};
-
-
-const std::map<plLocalization::Language, const std::map<uint32_t, ST::string>*> plKeyMap::fKeyConversions = {
-    { plLocalization::kEnglish, &fKeyConversionEnglish },
-    { plLocalization::kFrench, &fKeyConversionFrench },
-    { plLocalization::kGerman, &fKeyConversionGerman },
-    { plLocalization::kSpanish, &fKeyConversionSpanish },
-    { plLocalization::kItalian, &fKeyConversionItalian },
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.cpp
@@ -540,6 +540,47 @@ plKeyDef plKeyMap::ConvertCharToVKey(const ST::string& c)
     return KEY_UNMAPPED;
 }
 
+ST::string plKeyMap::KeyComboToString(const plKeyCombo &combo)
+{
+    ST::string str = ConvertVKeyToChar(combo.fKey);
+    if (str.empty()) {
+        if (isalnum(combo.fKey)) {
+            char c = (char)combo.fKey;
+            str = ST::string(&c, 1);
+        } else {
+            return ST_LITERAL("(unmapped)");
+        }
+    }
+    if (combo.fFlags & plKeyCombo::kCtrl) {
+        str += "_C";
+    }
+    if (combo.fFlags & plKeyCombo::kShift) {
+        str += "_S";
+    }
+    return str;
+}
+
+plKeyCombo plKeyMap::StringToKeyCombo(const ST::string& keyStr)
+{
+    plKeyCombo combo;
+    
+    // Find modifiers to set flags with
+    combo.fFlags = 0;
+    if (keyStr.find("_S", ST::case_insensitive) != -1) {
+        combo.fFlags |= plKeyCombo::kShift;
+    }
+    if (keyStr.find("_C", ST::case_insensitive) != -1) {
+        combo.fFlags |= plKeyCombo::kCtrl;
+    }
+    
+    // Convert raw key without modifiers
+    combo.fKey = plKeyMap::ConvertCharToVKey(keyStr.before_first('_'));
+    if (combo.fKey == KEY_UNMAPPED)
+        combo = plKeyCombo::kUnmapped;
+    
+    return combo;
+}
+
 ST::string plKeyMap::GetStringCtrl()
 {
     switch (plLocalization::GetLanguage())

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.h
@@ -48,8 +48,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plControlDefinition.h"
 
 #include <map>
-#include <string_theory/string>
 #include <vector>
+
+namespace ST { class string; }
 
 class plInputMap
 {

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.h
@@ -53,8 +53,8 @@ class plInputMap
 {
 public:
     static CommandConvert   fCmdConvert[];
-    static ControlEventCode ConvertCharToControlCode(const char* c);
-    static const char       *ConvertControlCodeToString( ControlEventCode code );
+    static ControlEventCode ConvertCharToControlCode(const ST::string& c);
+    static ST::string ConvertControlCodeToString(ControlEventCode code);
 };
 
 class plMouseMap : public plInputMap

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.h
@@ -47,12 +47,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "plControlDefinition.h"
 
+#include <map>
+#include <string_theory/string>
 #include <vector>
 
 class plInputMap
 {
 public:
-    static CommandConvert   fCmdConvert[];
+    static const std::map<ControlEventCode, ST::string> fCmdConvert;
     static ControlEventCode ConvertCharToControlCode(const ST::string& c);
     static ST::string ConvertControlCodeToString(ControlEventCode code);
 };

--- a/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
@@ -58,8 +58,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <string_theory/string>
 #include <vector>
 
-#include "plResMgr/plLocalization.h"
-
 //// plKeyCombo //////////////////////////////////////////////////////////////
 //  Tiny class/data type representing a single key combo. Ex. shift+C
 
@@ -239,8 +237,6 @@ class plKeyMap : public plInputMap
         static const std::map<uint32_t, ST::string> fKeyConversionGerman;
         static const std::map<uint32_t, ST::string> fKeyConversionSpanish;
         static const std::map<uint32_t, ST::string> fKeyConversionItalian;
-
-        static const std::map<plLocalization::Language, const std::map<uint32_t, ST::string>*> fKeyConversions;
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
@@ -58,6 +58,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <string_theory/string>
 #include <vector>
 
+#include "plResMgr/plLocalization.h"
+
 //// plKeyCombo //////////////////////////////////////////////////////////////
 //  Tiny class/data type representing a single key combo. Ex. shift+C
 
@@ -224,6 +226,8 @@ class plKeyMap : public plInputMap
         const plKeyBinding  &GetBinding(size_t i) const { return *fBindings[i]; }
         void                HandleAutoDualBinding( plKeyDef key1, plKeyDef key2 );
 
+        static const std::map<uint32_t, ST::string>& GetKeyConversion();
+
         static ST::string ConvertVKeyToChar(uint32_t vk);
         static plKeyDef ConvertCharToVKey(const ST::string& c);
 
@@ -233,6 +237,7 @@ class plKeyMap : public plInputMap
         static const std::map<uint32_t, ST::string> fKeyConversionSpanish;
         static const std::map<uint32_t, ST::string> fKeyConversionItalian;
 
+        static const std::map<plLocalization::Language, const std::map<uint32_t, ST::string>*> fKeyConversions;
 };
 
 

--- a/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
@@ -231,6 +231,9 @@ class plKeyMap : public plInputMap
         static ST::string ConvertVKeyToChar(uint32_t vk);
         static plKeyDef ConvertCharToVKey(const ST::string& c);
 
+        static ST::string KeyComboToString(const plKeyCombo &combo);
+        static plKeyCombo StringToKeyCombo(const ST::string& keyStr);
+
         static const std::map<uint32_t, ST::string> fKeyConversionEnglish;
         static const std::map<uint32_t, ST::string> fKeyConversionFrench;
         static const std::map<uint32_t, ST::string> fKeyConversionGerman;

--- a/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
@@ -54,6 +54,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plInputMap.h"
 #include "plControlEventCodes.h"
 
+#include <map>
+#include <string_theory/string>
 #include <vector>
 
 //// plKeyCombo //////////////////////////////////////////////////////////////
@@ -225,11 +227,11 @@ class plKeyMap : public plInputMap
         static ST::string ConvertVKeyToChar(uint32_t vk);
         static plKeyDef ConvertCharToVKey(const ST::string& c);
 
-        static Win32keyConvert  fKeyConversionEnglish[];
-        static Win32keyConvert  fKeyConversionFrench[];
-        static Win32keyConvert  fKeyConversionGerman[];
-        static Win32keyConvert  fKeyConversionSpanish[];
-        static Win32keyConvert  fKeyConversionItalian[];
+        static const std::map<uint32_t, ST::string> fKeyConversionEnglish;
+        static const std::map<uint32_t, ST::string> fKeyConversionFrench;
+        static const std::map<uint32_t, ST::string> fKeyConversionGerman;
+        static const std::map<uint32_t, ST::string> fKeyConversionSpanish;
+        static const std::map<uint32_t, ST::string> fKeyConversionItalian;
 
 };
 

--- a/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
@@ -116,19 +116,18 @@ class plKeyBinding
         uint32_t              fCodeFlags; // Needed?
         plKeyCombo          fKey1;      // KEY_UNMAPPED for not-used
         plKeyCombo          fKey2;
-        char                *fString;
+        ST::string          fString;
 
     public:
 
         plKeyBinding();
-        plKeyBinding(ControlEventCode code, uint32_t codeFlags, const plKeyCombo &key1, const plKeyCombo &key2, const char *string = nullptr);
-        virtual ~plKeyBinding();
+        plKeyBinding(ControlEventCode code, uint32_t codeFlags, const plKeyCombo &key1, const plKeyCombo &key2, ST::string string = {});
 
         ControlEventCode    GetCode() const { return fCode; }
         uint32_t              GetCodeFlags() const { return fCodeFlags; }
         const plKeyCombo    &GetKey1() const { return fKey1; }
         const plKeyCombo    &GetKey2() const { return fKey2; }
-        const char          *GetExtendedString() const { return fString; }
+        ST::string          GetExtendedString() const { return fString; }
         const plKeyCombo    &GetMatchingKey( plKeyDef keyDef ) const;
 
         void    SetKey1( const plKeyCombo &newCombo );
@@ -160,7 +159,7 @@ class plKeyMap : public plInputMap
         plKeyBinding    *IFindBindingByKey( const plKeyCombo &combo ) const;
         void             IFindAllBindingsByKey(const plKeyCombo &combo, std::vector<plKeyBinding*> &result) const;
         plKeyBinding    *IFindBinding( ControlEventCode code ) const;
-        plKeyBinding    *IFindConsoleBinding( const char *command ) const;
+        plKeyBinding    *IFindConsoleBinding(const ST::string& command) const;
 
         void            IActuallyBind( plKeyBinding *binding, const plKeyCombo &combo, BindPref pref );
         void            ICheckAndBindDupe( plKeyDef origKey, plKeyDef dupeKey );
@@ -174,14 +173,14 @@ class plKeyMap : public plInputMap
         bool    AddCode( ControlEventCode code, uint32_t codeFlags );
 
         // Same but for console commands. No flags b/c console commands always use the same flags
-        bool    AddConsoleCommand( const char *command );
+        bool    AddConsoleCommand(ST::string command);
 
 
         // Adds a key binding to a given code. Returns false if the code isn't in this map or if key is already mapped.
         bool    BindKey( const plKeyCombo &combo, ControlEventCode code, BindPref pref = kNoPreference );
 
         // Console command version
-        bool    BindKeyToConsoleCmd( const plKeyCombo &combo, const char *command, BindPref pref = kNoPreference );
+        bool    BindKeyToConsoleCmd(const plKeyCombo &combo, const ST::string& command, BindPref pref = kNoPreference);
 
 
         // Searches for the binding for a given code. Returns nil if not found
@@ -194,7 +193,7 @@ class plKeyMap : public plInputMap
         void FindAllBindingsByKey(const plKeyCombo &combo, std::vector<const plKeyBinding*> &result) const;
         
         // Searches for the binding by console command. Returns nil if not found
-        const plKeyBinding* FindConsoleBinding( const char *command ) const;
+        const plKeyBinding* FindConsoleBinding(const ST::string& command) const;
 
         // Make sure the given keys are clear of bindings, i.e. not used
         void    EnsureKeysClear( const plKeyCombo &key1, const plKeyCombo &key2 );
@@ -214,17 +213,17 @@ class plKeyMap : public plInputMap
         // Clears ALL bindings
         void    ClearAll();
 
-        static const char* GetStringCtrl();
-        static const char* GetStringShift();
-        static const char* GetStringUnmapped();
+        static ST::string GetStringCtrl();
+        static ST::string GetStringShift();
+        static ST::string GetStringUnmapped();
 
 
         size_t              GetNumBindings() const { return fBindings.size(); }
         const plKeyBinding  &GetBinding(size_t i) const { return *fBindings[i]; }
         void                HandleAutoDualBinding( plKeyDef key1, plKeyDef key2 );
 
-        static const char* ConvertVKeyToChar( uint32_t vk );
-        static plKeyDef ConvertCharToVKey( const char *c );
+        static ST::string ConvertVKeyToChar(uint32_t vk);
+        static plKeyDef ConvertCharToVKey(const ST::string& c);
 
         static Win32keyConvert  fKeyConversionEnglish[];
         static Win32keyConvert  fKeyConversionFrench[];

--- a/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plKeyMap.h
@@ -229,8 +229,8 @@ class plKeyMap : public plInputMap
         static Win32keyConvert  fKeyConversionEnglish[];
         static Win32keyConvert  fKeyConversionFrench[];
         static Win32keyConvert  fKeyConversionGerman[];
-        //static Win32keyConvert  fKeyConversionSpanish[];
-        //static Win32keyConvert  fKeyConversionItalian[];
+        static Win32keyConvert  fKeyConversionSpanish[];
+        static Win32keyConvert  fKeyConversionItalian[];
 
 };
 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.cpp
@@ -126,31 +126,31 @@ plAvatarInputInterface::plAvatarInputInterface()
     fControlMap->AddCode( B_CONTROL_DIVE,                   kControlFlagNormal | kControlFlagNoRepeat );
     fControlMap->AddCode( B_CONTROL_IGNORE_AVATARS,         kControlFlagNormal | kControlFlagNoRepeat );
 
-    fControlMap->AddConsoleCommand( "Game.EnterChatMode" );
-    fControlMap->AddConsoleCommand( "Game.Emote.wave" );
-    fControlMap->AddConsoleCommand( "Game.Emote.laugh" );
-    fControlMap->AddConsoleCommand( "Game.Emote.clap" );
-    fControlMap->AddConsoleCommand( "Game.Emote.dance" );
-    fControlMap->AddConsoleCommand( "Game.Emote.talk" );
-    fControlMap->AddConsoleCommand( "Game.Emote.sneeze" );
-    fControlMap->AddConsoleCommand( "Game.Emote.sit" );
-    fControlMap->AddConsoleCommand( "Keyboard.ResetBindings" );
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.EnterChatMode"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.Emote.wave"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.Emote.laugh"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.Emote.clap"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.Emote.dance"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.Emote.talk"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.Emote.sneeze"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.Emote.sit"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Keyboard.ResetBindings"));
     
-    fControlMap->AddConsoleCommand( "Game.KIOpenKI" );
-    fControlMap->AddConsoleCommand( "Game.KIHelp" );
-    fControlMap->AddConsoleCommand( "Game.KICreateMarker" );
-    fControlMap->AddConsoleCommand( "Game.KICreateMarkerFolder" );
-    fControlMap->AddConsoleCommand( "Game.KIOpenYeeshaBook" );
-    fControlMap->AddConsoleCommand( "Game.KIToggleMini" );
-    fControlMap->AddConsoleCommand( "Game.KIPutAway" );
-    fControlMap->AddConsoleCommand( "Game.KIChatPageUp" );
-    fControlMap->AddConsoleCommand( "Game.KIChatPageDown" );
-    fControlMap->AddConsoleCommand( "Game.KIChatToStart" );
-    fControlMap->AddConsoleCommand( "Game.KIChatToEnd" );
-    fControlMap->AddConsoleCommand( "Game.KIUpSizeFont" );
-    fControlMap->AddConsoleCommand( "Game.KIDownSizeFont" );
-    fControlMap->AddConsoleCommand( "Game.KITakePicture" );
-    fControlMap->AddConsoleCommand( "Game.KICreateJournal" );
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIOpenKI"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIHelp"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KICreateMarker"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KICreateMarkerFolder"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIOpenYeeshaBook"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIToggleMini"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIPutAway"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIChatPageUp"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIChatPageDown"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIChatToStart"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIChatToEnd"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIUpSizeFont"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KIDownSizeFont"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KITakePicture"));
+    fControlMap->AddConsoleCommand(ST_LITERAL("Game.KICreateJournal"));
 
 #ifndef PLASMA_EXTERNAL_RELEASE
     fControlMap->AddCode( B_CONTROL_TOGGLE_PHYSICAL,        kControlFlagDownEvent | kControlFlagNoRepeat );
@@ -162,7 +162,7 @@ plAvatarInputInterface::plAvatarInputInterface()
     IDisableControl(B_CONTROL_MOVE_UP);
     IDisableControl(B_CONTROL_MOVE_DOWN);
 
-    fControlMap->AddConsoleCommand( "NextStatusLog" );
+    fControlMap->AddConsoleCommand(ST_LITERAL("NextStatusLog"));
 #endif
 
     // IF YOU ARE LOOKING TO CHANGE THE DEFAULT KEY BINDINGS, DO NOT LOOK HERE. GO TO
@@ -288,7 +288,7 @@ void plAvatarInputInterface::ClearKeyMap()
         fControlMap->UnmapAllBindings();
         
         // Still want this one tho
-        fControlMap->BindKeyToConsoleCmd( plCtrlShiftKeyCombo( KEY_0 ), "Keyboard.ResetBindings" );
+        fControlMap->BindKeyToConsoleCmd(plCtrlShiftKeyCombo(KEY_0), ST_LITERAL("Keyboard.ResetBindings"));
     }
 }
 
@@ -328,32 +328,32 @@ void    plAvatarInputInterface::RestoreDefaultKeyMappings()
 //  fControlMap->BindKey( KEY_D,                        B_CONTROL_DIVE );
     fControlMap->BindKey( KEY_DELETE,                   B_CONTROL_IGNORE_AVATARS );
 
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_1 ),  "Game.Emote.wave" );
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_2 ),  "Game.Emote.laugh" );
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_3 ),  "Game.Emote.clap" );
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_4 ),  "Game.Emote.dance" );
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_5 ),  "Game.Emote.talk" );
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_6 ),  "Game.Emote.sneeze" );
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_7 ),  "Game.Emote.sit" );
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_1), ST_LITERAL("Game.Emote.wave"));
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_2), ST_LITERAL("Game.Emote.laugh"));
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_3), ST_LITERAL("Game.Emote.clap"));
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_4), ST_LITERAL("Game.Emote.dance"));
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_5), ST_LITERAL("Game.Emote.talk"));
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_6), ST_LITERAL("Game.Emote.sneeze"));
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_7), ST_LITERAL("Game.Emote.sit"));
 
-    fControlMap->BindKeyToConsoleCmd( plCtrlShiftKeyCombo( KEY_0 ), "Keyboard.ResetBindings" );
+    fControlMap->BindKeyToConsoleCmd(plCtrlShiftKeyCombo(KEY_0), ST_LITERAL("Keyboard.ResetBindings"));
     
     // KI shortcut keyboard commands
-    fControlMap->BindKeyToConsoleCmd( KEY_F2,                                   "Game.KIOpenKI" );
-    fControlMap->BindKeyToConsoleCmd( KEY_F3,                                   "Game.KIOpenYeeshaBook" );
-    fControlMap->BindKeyToConsoleCmd( KEY_F4,                                   "Game.KIHelp" );
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_HOME ),               "Game.KIToggleMini" );
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_END ),                "Game.KIPutAway" );
-    fControlMap->BindKeyToConsoleCmd( KEY_PAGEUP,                               "Game.KIChatPageUp" );
-    fControlMap->BindKeyToConsoleCmd( KEY_PAGEDOWN,                             "Game.KIChatPageDown" );
-    fControlMap->BindKeyToConsoleCmd( KEY_HOME,                                 "Game.KIChatToStart" );
-    fControlMap->BindKeyToConsoleCmd( KEY_END,                                  "Game.KIChatToEnd" );
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_NUMPAD_ADD ),         "Game.KIUpSizeFont" );
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_NUMPAD_SUBTRACT ),    "Game.KIDownSizeFont" );
-    fControlMap->BindKeyToConsoleCmd( KEY_F5,                                   "Game.KITakePicture" );
-    fControlMap->BindKeyToConsoleCmd( KEY_F6,                                   "Game.KICreateJournal" );
-    fControlMap->BindKeyToConsoleCmd( KEY_F7,                                   "Game.KICreateMarker" );
-    fControlMap->BindKeyToConsoleCmd( KEY_F8,                                   "Game.KICreateMarkerFolder" );
+    fControlMap->BindKeyToConsoleCmd(KEY_F2,                              ST_LITERAL("Game.KIOpenKI"));
+    fControlMap->BindKeyToConsoleCmd(KEY_F3,                              ST_LITERAL("Game.KIOpenYeeshaBook"));
+    fControlMap->BindKeyToConsoleCmd(KEY_F4,                              ST_LITERAL("Game.KIHelp"));
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_HOME),            ST_LITERAL("Game.KIToggleMini"));
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_END),             ST_LITERAL("Game.KIPutAway"));
+    fControlMap->BindKeyToConsoleCmd(KEY_PAGEUP,                          ST_LITERAL("Game.KIChatPageUp"));
+    fControlMap->BindKeyToConsoleCmd(KEY_PAGEDOWN,                        ST_LITERAL("Game.KIChatPageDown"));
+    fControlMap->BindKeyToConsoleCmd(KEY_HOME,                            ST_LITERAL("Game.KIChatToStart"));
+    fControlMap->BindKeyToConsoleCmd(KEY_END,                             ST_LITERAL("Game.KIChatToEnd"));
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_NUMPAD_ADD),      ST_LITERAL("Game.KIUpSizeFont"));
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_NUMPAD_SUBTRACT), ST_LITERAL("Game.KIDownSizeFont"));
+    fControlMap->BindKeyToConsoleCmd(KEY_F5,                              ST_LITERAL("Game.KITakePicture"));
+    fControlMap->BindKeyToConsoleCmd(KEY_F6,                              ST_LITERAL("Game.KICreateJournal"));
+    fControlMap->BindKeyToConsoleCmd(KEY_F7,                              ST_LITERAL("Game.KICreateMarker"));
+    fControlMap->BindKeyToConsoleCmd(KEY_F8,                              ST_LITERAL("Game.KICreateMarkerFolder"));
 
 #ifndef PLASMA_EXTERNAL_RELEASE
     fControlMap->BindKey( plCtrlKeyCombo( KEY_P ),      B_CONTROL_TOGGLE_PHYSICAL );
@@ -361,7 +361,7 @@ void    plAvatarInputInterface::RestoreDefaultKeyMappings()
     fControlMap->BindKey( KEY_H,                        B_CONTROL_MOVE_DOWN );
     fControlMap->BindKey( plCtrlKeyCombo( KEY_D ),      B_TOGGLE_DRIVE_MODE );
 
-    fControlMap->BindKeyToConsoleCmd( plCtrlKeyCombo( KEY_L ),                  "NextStatusLog" );
+    fControlMap->BindKeyToConsoleCmd(plCtrlKeyCombo(KEY_L), ST_LITERAL("NextStatusLog"));
 #endif
 }
 
@@ -664,8 +664,8 @@ bool plAvatarInputInterface::IsEnterChatModeBound()
     {
         const plKeyBinding &binding = fControlMap->GetBinding( i );
 
-        const char* extString = binding.GetExtendedString();
-        if ( extString && strcmp("Game.EnterChatMode",extString) == 0 )
+        ST::string extString = binding.GetExtendedString();
+        if (extString == "Game.EnterChatMode")
         {
             if (binding.GetKey1() != plKeyCombo::kUnmapped )
                 return true;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.cpp
@@ -1005,50 +1005,50 @@ plAvatarInputMap::~plAvatarInputMap()
         
 plSuspendedMovementMap::plSuspendedMovementMap() : plAvatarInputMap()
 {
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_ACTION_MOUSE,      kControlFlagLeftButtonEx, 0.0f, 1.0f, 0.0f, 1.0f, "The Picked key") );
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_PICK,              kControlFlagLeftButton, 0.0f, 1.0f, 0.0f, 1.0f, "The Picked key") );
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_ACTION_MOUSE,      kControlFlagLeftButtonEx, 0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_PICK,              kControlFlagLeftButton, 0.0f, 1.0f, 0.0f, 1.0f));
 }
 
 plBasicControlMap::plBasicControlMap() : plSuspendedMovementMap()
 {
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_ROTATE_RIGHT,      kControlFlagLeftButton | kControlFlagBoxDisable,    0.95f, 1.0f, 0.0f, 1.0f,        "Rotate Player Right") );
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_ROTATE_LEFT,       kControlFlagLeftButton | kControlFlagBoxDisable,    0.0f, 0.05f,    0.0f, 1.0f,     "Rotate Player Left") );
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_ROTATE_RIGHT,      kControlFlagLeftButton | kControlFlagBoxDisable,    0.95f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_ROTATE_LEFT,       kControlFlagLeftButton | kControlFlagBoxDisable,    0.0f, 0.05f,    0.0f, 1.0f));
     
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_TURN_TO,           kControlFlagLeftButtonEx, 0.05f, 0.95f, 0.0f, 0.95f,        "Turn to") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_WALK_MODE,             kControlFlagLeftButton, 0.05f, 0.95f,   0.0f, 0.95f,        "Set Walk Mode") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_WALK_BACK_LB_MODE,     kControlFlagLeftButton, 0.05f, 0.95f,   0.95f, 1.0f,        "Set Walk Back LB Mode") );
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_WALK_BACK_MODE,        kControlFlagMiddleButton,   0.05f, 0.95f,   0.0f, 1.0f,     "Set Walk Back Mode") ); 
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_TURN_TO,           kControlFlagLeftButtonEx, 0.05f, 0.95f, 0.0f, 0.95f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_WALK_MODE,             kControlFlagLeftButton, 0.05f, 0.95f,   0.0f, 0.95f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_WALK_BACK_LB_MODE,     kControlFlagLeftButton, 0.05f, 0.95f,   0.95f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_WALK_BACK_MODE,        kControlFlagMiddleButton,   0.05f, 0.95f,   0.0f, 1.0f)); 
 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_CURSOR_UP,             kControlFlagNormal | kControlFlagInBox,     0.05f, 0.95f, 0.0f, 0.95f,  "set cursor up") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_CURSOR_DOWN,           kControlFlagNormal | kControlFlagInBox,     0.05f, 0.95f, 0.95f, 1.0f,  "set cursor down") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_CURSOR_RIGHT,          kControlFlagNormal | kControlFlagInBox,     0.95f, 1.0f, 0.0f, 1.0f,    "set cursor right") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_CURSOR_LEFT,           kControlFlagNormal | kControlFlagInBox,     0.0f, 0.05f, 0.0f, 1.0f,    "set cursor left") ); 
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_CURSOR_UP,             kControlFlagNormal | kControlFlagInBox,     0.05f, 0.95f, 0.0f, 0.95f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_CURSOR_DOWN,           kControlFlagNormal | kControlFlagInBox,     0.05f, 0.95f, 0.95f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_CURSOR_RIGHT,          kControlFlagNormal | kControlFlagInBox,     0.95f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_CURSOR_LEFT,           kControlFlagNormal | kControlFlagInBox,     0.0f, 0.05f, 0.0f, 1.0f));
 }
 
 plLadderControlMap::plLadderControlMap() : plSuspendedMovementMap()
 {
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_MOVE_FORWARD,      kControlFlagLeftButton | kControlFlagBoxDisable,    0.0f, 1.0f, 0.0f, 0.5f,     "Set Walk Mode") ); 
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_MOVE_BACKWARD,     kControlFlagLeftButton | kControlFlagBoxDisable, 0.0f, 1.0f,    0.5f, 1.0f,     "Set Walk Back LB Mode") );
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_MOVE_FORWARD,      kControlFlagLeftButton | kControlFlagBoxDisable,    0.0f, 1.0f, 0.0f, 0.5f) ); 
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_MOVE_BACKWARD,     kControlFlagLeftButton | kControlFlagBoxDisable, 0.0f, 1.0f,    0.5f, 1.0f) );
 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_CURSOR_UPWARD,         kControlFlagNormal | kControlFlagInBox,     0.0f, 1.0f, 0.0f, 0.5f, "set cursor up") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_CURSOR_DOWN,           kControlFlagNormal | kControlFlagInBox,     0.0f, 1.0f, 0.5f, 1.0f, "set cursor down") ); 
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_CURSOR_UPWARD,         kControlFlagNormal | kControlFlagInBox,     0.0f, 1.0f, 0.0f, 0.5f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_CURSOR_DOWN,           kControlFlagNormal | kControlFlagInBox,     0.0f, 1.0f, 0.5f, 1.0f));
 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_FREELOOK,              kControlFlagRightButton,    0.05f, 0.95f,   0.0f, 0.95f,        "Set Camera first-person z-axis panning") ); 
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_FREELOOK,              kControlFlagRightButton,    0.05f, 0.95f,   0.0f, 0.95f));
 }
 
 
 plLadderMountMap::plLadderMountMap() : plSuspendedMovementMap()
 {
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_LADDER_CONTROL,                kControlFlagLeftButtonUp,   0.0f, 1.0f, 0.0f, 1.0f,     "Set Ladder Mode") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_LADDER_CONTROL,                kControlFlagRightButtonUp,  0.0f, 1.0f, 0.0f, 1.0f,     "Set Ladder Mode") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_LADDER_CONTROL,                kControlFlagMiddleButtonUp, 0.0f, 1.0f, 0.0f, 1.0f,     "Set Ladder Mode") ); 
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_LADDER_CONTROL,                kControlFlagLeftButtonUp,   0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_LADDER_CONTROL,                kControlFlagRightButtonUp,  0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_LADDER_CONTROL,                kControlFlagMiddleButtonUp, 0.0f, 1.0f, 0.0f, 1.0f));
 }
 
 plLadderDismountMap::plLadderDismountMap() : plSuspendedMovementMap()
 {
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_BASIC_MODE,                kControlFlagLeftButtonUp,   0.0f, 1.0f, 0.0f, 1.0f,     "Set Basic Mode") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_BASIC_MODE,                kControlFlagRightButtonUp,  0.0f, 1.0f, 0.0f, 1.0f,     "Set Basic Mode") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_BASIC_MODE,                kControlFlagMiddleButtonUp, 0.0f, 1.0f, 0.0f, 1.0f,     "Set Basic Mode") ); 
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_BASIC_MODE,                kControlFlagLeftButtonUp,   0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_BASIC_MODE,                kControlFlagRightButtonUp,  0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_BASIC_MODE,                kControlFlagMiddleButtonUp, 0.0f, 1.0f, 0.0f, 1.0f));
 }
 
 
@@ -1056,22 +1056,22 @@ plLadderDismountMap::plLadderDismountMap() : plSuspendedMovementMap()
 
 plBasicThirdPersonControlMap::plBasicThirdPersonControlMap() : plBasicControlMap()
 {   
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_FREELOOK,              kControlFlagRightButton,    0.0f, 1.0f, 0.0f, 1.0f,     "Freelook Mode") );     
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_FREELOOK,              kControlFlagRightButton,    0.0f, 1.0f, 0.0f, 1.0f));
 }   
 
 plBasicFirstPersonControlMap::plBasicFirstPersonControlMap() : plBasicControlMap()
 {
-    fMouseMap->AddMapping( new plMouseInfo(A_CONTROL_TURN,              kControlFlagRightButtonRepeat | kControlFlagXAxisEvent | kControlFlagDelta, 0.0f, 1.0f, 0.0f, 1.0f,     "Rotate Player") ); 
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_FREELOOK,              kControlFlagRightButton,    0.05f, 0.95f,   0.0f, 0.95f,        "Set Camera first-person z-axis panning") ); 
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_CAMERA_WALK_PAN,   kControlFlagRightButton,    0.05f, 0.95f,   0.0f, 0.95f,        "Set Camera first-person z-axis panning") ); 
+    fMouseMap->AddMapping(new plMouseInfo(A_CONTROL_TURN,              kControlFlagRightButtonRepeat | kControlFlagXAxisEvent | kControlFlagDelta, 0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_FREELOOK,              kControlFlagRightButton,    0.05f, 0.95f,   0.0f, 0.95f));
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_CAMERA_WALK_PAN,   kControlFlagRightButton,    0.05f, 0.95f,   0.0f, 0.95f));
 }
 
 // also used in 1st person walk mode    
 pl3rdWalkMap::pl3rdWalkMap() : plAvatarInputMap()
 {
     // control special to this mode.
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_MODIFIER_FAST,     kControlFlagRightButton,    0.0f, 1.0f, 0.0f, 1.0f, "Run Modifier"  ) );
-    fMouseMap->AddMapping( new plMouseInfo(A_CONTROL_TURN,              kControlFlagXAxisEvent | kControlFlagDelta, 0.0f, 1.0f, 0.0f, 1.0f,     "Rotate Player") );
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_MODIFIER_FAST,     kControlFlagRightButton,    0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(A_CONTROL_TURN,              kControlFlagXAxisEvent | kControlFlagDelta, 0.0f, 1.0f, 0.0f, 1.0f));
 
     plInputManager::SetRecenterMouse(true);     
     plMouseDevice::HideCursor();
@@ -1087,22 +1087,22 @@ pl3rdWalkMap::~pl3rdWalkMap()
 
 pl3rdWalkForwardMap::pl3rdWalkForwardMap() : pl3rdWalkMap()
 {
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_BASIC_MODE,            kControlFlagLeftButtonUp, 0.0f, 1.0f, 0.0f, 1.0f,       "Third Person") ); 
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_MOVE_FORWARD,      kControlFlagLeftButton, 0.0f, 1.0f, 0.0f, 1.0f,     "Walk forward") );
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_CAMERA_WALK_PAN,   kControlFlagLeftButton, 0.0f, 1.0f, 0.0f, 1.0f,     "Set Camera first-person z-axis panning") );    
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_BASIC_MODE,            kControlFlagLeftButtonUp, 0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_MOVE_FORWARD,      kControlFlagLeftButton, 0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_CAMERA_WALK_PAN,   kControlFlagLeftButton, 0.0f, 1.0f, 0.0f, 1.0f));
 }
 
 pl3rdWalkBackwardMap::pl3rdWalkBackwardMap() : pl3rdWalkMap()
 {
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_BASIC_MODE,            kControlFlagMiddleButtonUp, 0.0f, 1.0f, 0.0f, 1.0f,     "Third Person") ); 
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_MOVE_BACKWARD,     kControlFlagMiddleButton, 0.0f, 1.0f, 0.0f, 1.0f,       "Walk backward") );
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_CAMERA_WALK_PAN,   kControlFlagMiddleButton, 0.0f, 1.0f, 0.0f, 1.0f,       "Set Camera first-person z-axis panning") ); 
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_BASIC_MODE,            kControlFlagMiddleButtonUp, 0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_MOVE_BACKWARD,     kControlFlagMiddleButton, 0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_CAMERA_WALK_PAN,   kControlFlagMiddleButton, 0.0f, 1.0f, 0.0f, 1.0f));
 }
 
 // same as the other backward walk map, but this one is triggered by the left mouse button.
 pl3rdWalkBackwardLBMap::pl3rdWalkBackwardLBMap() : pl3rdWalkMap()
 {
-    fMouseMap->AddMapping( new plMouseInfo(S_SET_BASIC_MODE,            kControlFlagLeftButtonUp, 0.0f, 1.0f, 0.0f, 1.0f,       "Third Person") ); 
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_MOVE_BACKWARD,     kControlFlagLeftButton, 0.0f, 1.0f, 0.0f, 1.0f,     "Walk backward") );
-    fMouseMap->AddMapping( new plMouseInfo(B_CONTROL_CAMERA_WALK_PAN,   kControlFlagLeftButton, 0.0f, 1.0f, 0.0f, 1.0f,     "Set Camera first-person z-axis panning") ); 
+    fMouseMap->AddMapping(new plMouseInfo(S_SET_BASIC_MODE,            kControlFlagLeftButtonUp, 0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_MOVE_BACKWARD,     kControlFlagLeftButton, 0.0f, 1.0f, 0.0f, 1.0f));
+    fMouseMap->AddMapping(new plMouseInfo(B_CONTROL_CAMERA_WALK_PAN,   kControlFlagLeftButton, 0.0f, 1.0f, 0.0f, 1.0f));
 }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plAvatarInputInterface.h
@@ -49,6 +49,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plAvatarInputInterface_inc
 
 #include "plInputInterface.h"
+
+#include <string_theory/string>
+
 #include "pnInputCore/plInputMap.h"
 
 #include "hsGeometry3.h"
@@ -80,7 +83,7 @@ class plAvatarInputMap
 
         plAvatarInputMap();
         virtual ~plAvatarInputMap();
-        virtual const char *GetName() = 0;
+        virtual ST::string GetName() = 0;
         virtual bool IsBasic() { return false; }
 
         plMouseMap      *fMouseMap;
@@ -92,7 +95,7 @@ class plSuspendedMovementMap : public plAvatarInputMap
 {
 public:
     plSuspendedMovementMap();
-    const char *GetName() override { return "Suspended Movement"; }
+    ST::string GetName() override { return ST_LITERAL("Suspended Movement"); }
 };
 
 // The above, plus movement
@@ -100,7 +103,7 @@ class plBasicControlMap : public plSuspendedMovementMap
 {
 public:
     plBasicControlMap();
-    const char *GetName() override { return "Basic"; }
+    ST::string GetName() override { return ST_LITERAL("Basic"); }
     bool IsBasic() override { return true; }
 
 };
@@ -109,28 +112,28 @@ class plBasicThirdPersonControlMap : public plBasicControlMap
 {
 public:
     plBasicThirdPersonControlMap();
-    const char *GetName() override { return "Basic Third Person"; }
+    ST::string GetName() override { return ST_LITERAL("Basic Third Person"); }
 };
 
 class plLadderControlMap : public plSuspendedMovementMap
 {
 public:
     plLadderControlMap();
-    const char *GetName() override { return "LadderClimb"; }
+    ST::string GetName() override { return ST_LITERAL("LadderClimb"); }
 };
 
 class plLadderMountMap : public plSuspendedMovementMap
 {
 public:
     plLadderMountMap();
-    const char *GetName() override { return "Ladder Mount"; }
+    ST::string GetName() override { return ST_LITERAL("Ladder Mount"); }
 };
 
 class plLadderDismountMap : public plSuspendedMovementMap
 {
 public:
     plLadderDismountMap();
-    const char *GetName() override { return "Ladder Dismount"; }
+    ST::string GetName() override { return ST_LITERAL("Ladder Dismount"); }
 };
 
 
@@ -138,7 +141,7 @@ class plBasicFirstPersonControlMap : public plBasicControlMap
 {
 public:
     plBasicFirstPersonControlMap();
-    const char *GetName() override { return "Basic First Person"; }
+    ST::string GetName() override { return ST_LITERAL("Basic First Person"); }
 };
 
 // Mouse walk mode
@@ -153,21 +156,21 @@ class pl3rdWalkForwardMap : public pl3rdWalkMap
 {
 public:
     pl3rdWalkForwardMap();
-    const char *GetName() override { return "Walking Forward"; }
+    ST::string GetName() override { return ST_LITERAL("Walking Forward"); }
 };
 
 class pl3rdWalkBackwardMap : public pl3rdWalkMap
 {
 public:
     pl3rdWalkBackwardMap();
-    const char *GetName() override { return "Walking Backward"; }
+    ST::string GetName() override { return ST_LITERAL("Walking Backward"); }
 };
 
 class pl3rdWalkBackwardLBMap : public pl3rdWalkMap
 {
 public:
     pl3rdWalkBackwardLBMap();
-    const char *GetName() override { return "Walking Backward (LB)"; }
+    ST::string GetName() override { return ST_LITERAL("Walking Backward (LB)"); }
 };
 
 ///////////////////////////////////////////////////////////////////////////////////
@@ -229,7 +232,7 @@ class plAvatarInputInterface : public plInputInterface
         uint32_t        GetPriorityLevel() const override { return kAvatarInputPriority; }
         uint32_t        GetCurrentCursorID() const override { return fCurrentCursor; }
         float           GetCurrentCursorOpacity() const override { return fCursorOpacity; }
-        const char*         GetInputMapName() { return fInputMap ? fInputMap->GetName() : ""; }
+        ST::string      GetInputMapName() { return fInputMap ? fInputMap->GetName() : ST::string(); }
 
         bool        InterpretInputEvent(plInputEventMsg *pMsg) override;
         void        MissedInputEvent(plInputEventMsg *pMsg) override;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
@@ -47,6 +47,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plInputDevice.h"
 #include "plInputManager.h"
 #include "plAvatarInputInterface.h"
+
+#include <utility>
+
 #include "plMessage/plInputEventMsg.h"
 #include "pnMessage/plTimeMsg.h"
 
@@ -231,7 +234,7 @@ plMouseDevice* plMouseDevice::fInstance = nullptr;
 
 plMouseDevice::plMouseDevice()
     : fXPos(), fYPos(), fOpacity(1.f), fButtonState(),
-      fCursor(), fCursorID(CURSOR_UP),
+      fCursor(), fCursorID(ST_LITERAL(CURSOR_UP)),
       fXMsg(), fYMsg(), fB2Msg(),
       fLeftBMsg(), fMiddleBMsg(), fRightBMsg(),
       fWXPos(), fWYPos()
@@ -253,7 +256,7 @@ void plMouseDevice::SetDisplayResolution(float Width, float Height)
     IUpdateCursorSize();
 }
 
-void    plMouseDevice::CreateCursor( const char* cursor )
+void    plMouseDevice::CreateCursor(const ST::string& cursor)
 {
     if (fCursor == nullptr)
     {
@@ -301,9 +304,7 @@ void plMouseDevice::AddIDNumToCursor(uint32_t idNum)
     if (fInstance && idNum)
     {
         plDebugText     &txt = plDebugText::Instance();
-        char str[256];
-        sprintf(str, "%d",idNum);
-        txt.DrawString(fInstance->fWXPos + 12 ,fInstance->fWYPos + 3,str);
+        txt.DrawString(fInstance->fWXPos + 12, fInstance->fWYPos + 3, ST::string::from_uint(idNum));
     }
 }
         
@@ -365,10 +366,10 @@ void plMouseDevice::ShowCursor(bool override)
     }
 }
 
-void plMouseDevice::NewCursor(const char* cursor)
+void plMouseDevice::NewCursor(ST::string cursor)
 {
-    fInstance->fCursorID = cursor;
-    fInstance->CreateCursor(cursor);
+    fInstance->fCursorID = std::move(cursor);
+    fInstance->CreateCursor(fInstance->fCursorID);
     fInstance->SetCursorX(fInstance->GetCursorX());
     fInstance->SetCursorY(fInstance->GetCursorY());
 }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
@@ -72,8 +72,6 @@ public:
     { }
     virtual ~plInputDevice() { }
 
-    virtual const char* GetInputName() = 0;
-
     uint32_t GetFlags() { return fFlags; }
     void SetFlags(uint32_t f) { fFlags = f; }
     virtual void HandleKeyEvent(plKeyDef key, bool bKeyDown, bool bKeyRepeat, wchar_t c = 0) { }
@@ -116,7 +114,6 @@ public:
 
     void SetControlMode(int i) { fControlMode = i; }
 
-    const char* GetInputName() override { return "keyboard"; }
     void HandleKeyEvent(plKeyDef key, bool bKeyDown, bool bKeyRepeat, wchar_t c = 0) override;
     void HandleWindowActivate(bool bActive, hsWindowHndl hWnd) override;
     virtual bool IsCapsLockKeyOn();
@@ -159,8 +156,6 @@ class plMouseDevice : public plInputDevice
 public:
     plMouseDevice();
     ~plMouseDevice();
-
-    const char* GetInputName() override { return "mouse"; }
 
     bool    HasControlFlag(int f) const { return fControlFlags.IsBitSet(f); }
     void    SetControlFlag(int f) 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.h
@@ -46,6 +46,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
+#include <string_theory/string>
+
 //#include "pnInputCore/plControlDefinition.h"
 #include "pnInputCore/plKeyDef.h"
 #include "hsBitVector.h"
@@ -53,8 +55,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plMessage;
 struct plMouseInfo;
 class plPipeline;
-
-namespace ST { class string; }
 
 class plInputDevice 
 {
@@ -177,7 +177,7 @@ public:
     
     static void SetMsgAlways(bool b) { plMouseDevice::bMsgAlways = b; }
     static void ShowCursor(bool override = false);
-    static void NewCursor(const char* cursor);
+    static void NewCursor(ST::string cursor);
     static void HideCursor(bool override = false);
     static bool GetHideCursor() { return plMouseDevice::bCursorHidden; }
     static void SetCursorOpacity( float opacity = 1.f );
@@ -207,11 +207,11 @@ protected:
     
     
     plPlate *fCursor;
-    const char*    fCursorID;
+    ST::string fCursorID;
 
     static plMouseDevice* fInstance;
     static plMouseInfo  fDefaultMouseControlMap[];
-    void    CreateCursor(const char* cursor );
+    void CreateCursor(const ST::string& cursor);
     void IUpdateCursorSize();
     static bool bMsgAlways;
     static bool bCursorHidden;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -59,7 +59,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plDebugInputInterface.h"
 #include "plTelescopeInputInterface.h"
 
-#include <string_theory/format>
+#include <string_theory/stdio>
 
 #include "pnInputCore/plKeyMap.h"
 #include "plMessage/plInputEventMsg.h"
@@ -790,7 +790,7 @@ void    plInputInterfaceMgr::WriteKeyMap()
         
         for (const auto& [code, desc] : plKeyMap::fCmdConvert)
         {
-            fprintf(gKeyFile, "#  %s\n", desc.c_str());
+            ST::printf(gKeyFile, "#  {}\n", desc);
         }
 
         fprintf(gKeyFile, "#\n");
@@ -800,7 +800,7 @@ void    plInputInterfaceMgr::WriteKeyMap()
         const std::map<uint32_t, ST::string>& keyConvert = plKeyMap::GetKeyConversion();
         for (const auto& [vKey, keyName] : keyConvert)
         {   
-            fprintf(gKeyFile, "#  %s\n", keyName.c_str());
+            ST::printf(gKeyFile, "#  {}\n", keyName);
         }
         fclose(gKeyFile);
     }
@@ -835,9 +835,7 @@ void    plInputInterfaceMgr::IWriteNonConsoleCmdKeys( plKeyMap *keyMap, FILE *ke
         ST::string key1 = plKeyMap::KeyComboToString(binding.GetKey1());
         ST::string key2 = plKeyMap::KeyComboToString(binding.GetKey2());
         ST::string desc = plInputMap::ConvertControlCodeToString(binding.GetCode());
-
-        ST::string line = ST::format("Keyboard.BindAction \t\t{}\t{}\t\t\t\t\"{}\"\n", key1, key2, desc);
-        fputs(line.c_str(), keyFile);
+        ST::printf(keyFile, "Keyboard.BindAction \t\t{}\t{}\t\t\t\t\"{}\"\n", key1, key2, desc);
     }
 
 }
@@ -862,15 +860,13 @@ void    plInputInterfaceMgr::IWriteConsoleCmdKeys( plKeyMap *keyMap, FILE *keyFi
 //      if( binding.GetKey1() != plKeyCombo::kUnmapped )
 //      {
             ST::string key = plKeyMap::KeyComboToString(binding.GetKey1());
-            ST::string line = ST::format("Keyboard.BindConsoleCmd\t{}\t\t\t\"{}\"\n", key, binding.GetExtendedString());
-            fputs(line.c_str(), keyFile);
+            ST::printf(keyFile, "Keyboard.BindConsoleCmd\t{}\t\t\t\"{}\"\n", key, binding.GetExtendedString());
 //      }
 
         if( binding.GetKey2() != plKeyCombo::kUnmapped )
         {
             ST::string key2 = plKeyMap::KeyComboToString(binding.GetKey2());
-            ST::string line2 = ST::format("Keyboard.BindConsoleCmd\t{}\t\t\t\"{}\"\n", key2, binding.GetExtendedString());
-            fputs(line2.c_str(), keyFile);
+            ST::printf(keyFile, "Keyboard.BindConsoleCmd\t{}\t\t\t\"{}\"\n", key2, binding.GetExtendedString());
         }
     }
 }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -317,7 +317,7 @@ bool plInputInterfaceMgr::IEval( double secs, float del, uint32_t dirty )
             pMsg->SetControlCode(ctrlMsg->fControlCode);
             pMsg->SetControlPct(ctrlMsg->fPct);
             pMsg->SetTurnToPt(ctrlMsg->fPt);
-            pMsg->SetCmdString(ctrlMsg->GetCmdString().c_str());
+            pMsg->SetCmdString(ctrlMsg->GetCmdString());
             pMsg->SetSender( GetKey() );    
             plgDispatch::MsgSend( pMsg );
 
@@ -337,7 +337,7 @@ bool plInputInterfaceMgr::IEval( double secs, float del, uint32_t dirty )
                     pMsg->SetControlCode(ctrlMsg->fControlCode);
                     pMsg->SetControlPct(ctrlMsg->fPct);
                     pMsg->SetTurnToPt(ctrlMsg->fPt);
-                    pMsg->SetCmdString(ctrlMsg->GetCmdString().c_str());
+                    pMsg->SetCmdString(ctrlMsg->GetCmdString());
                     pMsg->SetSender( GetKey() );
                     pMsg->SetBCastFlag(plMessage::kNetPropagate | plMessage::kPropagateToModifiers | 
                         plMessage::kNetUseRelevanceRegions);    // bcast only to other players who care about the region I'm in

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -788,39 +788,37 @@ void    plInputInterfaceMgr::WriteKeyMap()
         fprintf(gKeyFile, "# Available game commands:\n");
         fprintf(gKeyFile, "#\n");
         
-        for( int j = 0; plKeyMap::fCmdConvert[ j ].fCode != END_CONTROLS; j++ )
+        for (const auto& [code, desc] : plKeyMap::fCmdConvert)
         {
-            fprintf(gKeyFile, "#  %s\n", plKeyMap::fCmdConvert[j].fDesc.c_str());
+            fprintf(gKeyFile, "#  %s\n", desc.c_str());
         }
 
         fprintf(gKeyFile, "#\n");
         fprintf(gKeyFile, "# Key name list (for a-z or 0-9 just use the character)\n");
         fprintf(gKeyFile, "#\n");
 
-        Win32keyConvert* keyConvert = &plKeyMap::fKeyConversionEnglish[0];
+        const std::map<uint32_t, ST::string>* keyConvert = &plKeyMap::fKeyConversionEnglish;
         switch (plLocalization::GetLanguage())
         {
             case plLocalization::kFrench:
-                keyConvert = &plKeyMap::fKeyConversionFrench[0];
+                keyConvert = &plKeyMap::fKeyConversionFrench;
                 break;
             case plLocalization::kGerman:
-                keyConvert = &plKeyMap::fKeyConversionGerman[0];
+                keyConvert = &plKeyMap::fKeyConversionGerman;
                 break;
             case plLocalization::kSpanish:
-                keyConvert = &plKeyMap::fKeyConversionSpanish[0];
+                keyConvert = &plKeyMap::fKeyConversionSpanish;
                 break;
             case plLocalization::kItalian:
-                keyConvert = &plKeyMap::fKeyConversionItalian[0];
+                keyConvert = &plKeyMap::fKeyConversionItalian;
                 break;
             // default is English
             default:
                 break;
         }
-        for (size_t i = 0; keyConvert[i].fVKey != 0xffffffff; i++)
+        for (const auto& [vKey, keyName] : *keyConvert)
         {   
-//              if (stricmp(fKeyMap->fKeyConversion[i].fKeyName, "Shift") == 0)
-//                  continue;
-            fprintf(gKeyFile, "#  %s\n", keyConvert[i].fKeyName.c_str());
+            fprintf(gKeyFile, "#  %s\n", keyName.c_str());
         }
         fclose(gKeyFile);
     }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -797,7 +797,7 @@ void    plInputInterfaceMgr::WriteKeyMap()
         fprintf(gKeyFile, "# Key name list (for a-z or 0-9 just use the character)\n");
         fprintf(gKeyFile, "#\n");
 
-        const std::map<uint32_t, ST::string> keyConvert = plKeyMap::GetKeyConversion();
+        const std::map<uint32_t, ST::string>& keyConvert = plKeyMap::GetKeyConversion();
         for (const auto& [vKey, keyName] : keyConvert)
         {   
             fprintf(gKeyFile, "#  %s\n", keyName.c_str());

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -807,12 +807,12 @@ void    plInputInterfaceMgr::WriteKeyMap()
             case plLocalization::kGerman:
                 keyConvert = &plKeyMap::fKeyConversionGerman[0];
                 break;
-            //case plLocalization::kSpanish:
-            //  keyConvert = &plKeyMap::fKeyConversionSpanish[0];
-            //  break;
-            //case plLocalization::kItalian:
-            //  keyConvert = &plKeyMap::fKeyConversionItalian[0];
-            //  break;
+            case plLocalization::kSpanish:
+                keyConvert = &plKeyMap::fKeyConversionSpanish[0];
+                break;
+            case plLocalization::kItalian:
+                keyConvert = &plKeyMap::fKeyConversionItalian[0];
+                break;
             // default is English
             default:
                 break;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -818,42 +818,6 @@ void plInputInterfaceMgr::ReleaseCurrentFocus(plInputInterface *focus)
 }
 
 
-//// IKeyComboToString ///////////////////////////////////////////////////////
-
-ST::string plInputInterfaceMgr::IKeyComboToString(const plKeyCombo &combo)
-{
-    bool            unmapped = false;
-
-
-    if( combo == plKeyCombo::kUnmapped )
-        return ST_LITERAL("(unmapped)");
-    else
-    {
-        ST::string str = plKeyMap::ConvertVKeyToChar( combo.fKey );
-        if (str.empty())
-        {
-            if( isalnum( combo.fKey ) )
-            {
-                char c = (char)combo.fKey;
-                str = ST::string(&c, 1);
-            }
-            else
-            {
-                str = ST_LITERAL("(unmapped)");
-                unmapped = true;
-            }
-        }
-        if( !unmapped )
-        {
-            if( combo.fFlags & plKeyCombo::kCtrl )
-                str += "_C";
-            if( combo.fFlags & plKeyCombo::kShift )
-                str += "_S";
-        }
-        return str;
-    }
-}
-
 //// IWriteNonConsoleCmdKeys /////////////////////////////////////////////////
 
 void    plInputInterfaceMgr::IWriteNonConsoleCmdKeys( plKeyMap *keyMap, FILE *keyFile )
@@ -868,8 +832,8 @@ void    plInputInterfaceMgr::IWriteNonConsoleCmdKeys( plKeyMap *keyMap, FILE *ke
         if( binding.GetCode() == B_CONTROL_CONSOLE_COMMAND )
             continue;
 
-        ST::string key1 = IKeyComboToString(binding.GetKey1());
-        ST::string key2 = IKeyComboToString(binding.GetKey2());
+        ST::string key1 = plKeyMap::KeyComboToString(binding.GetKey1());
+        ST::string key2 = plKeyMap::KeyComboToString(binding.GetKey2());
         ST::string desc = plInputMap::ConvertControlCodeToString(binding.GetCode());
 
         ST::string line = ST::format("Keyboard.BindAction \t\t{}\t{}\t\t\t\t\"{}\"\n", key1, key2, desc);
@@ -897,14 +861,14 @@ void    plInputInterfaceMgr::IWriteConsoleCmdKeys( plKeyMap *keyMap, FILE *keyFi
         // 2 commands, which is perfectly valid
 //      if( binding.GetKey1() != plKeyCombo::kUnmapped )
 //      {
-            ST::string key = IKeyComboToString(binding.GetKey1());
+            ST::string key = plKeyMap::KeyComboToString(binding.GetKey1());
             ST::string line = ST::format("Keyboard.BindConsoleCmd\t{}\t\t\t\"{}\"\n", key, binding.GetExtendedString());
             fputs(line.c_str(), keyFile);
 //      }
 
         if( binding.GetKey2() != plKeyCombo::kUnmapped )
         {
-            ST::string key2 = IKeyComboToString(binding.GetKey2());
+            ST::string key2 = plKeyMap::KeyComboToString(binding.GetKey2());
             ST::string line2 = ST::format("Keyboard.BindConsoleCmd\t{}\t\t\t\"{}\"\n", key2, binding.GetExtendedString());
             fputs(line2.c_str(), keyFile);
         }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -797,26 +797,8 @@ void    plInputInterfaceMgr::WriteKeyMap()
         fprintf(gKeyFile, "# Key name list (for a-z or 0-9 just use the character)\n");
         fprintf(gKeyFile, "#\n");
 
-        const std::map<uint32_t, ST::string>* keyConvert = &plKeyMap::fKeyConversionEnglish;
-        switch (plLocalization::GetLanguage())
-        {
-            case plLocalization::kFrench:
-                keyConvert = &plKeyMap::fKeyConversionFrench;
-                break;
-            case plLocalization::kGerman:
-                keyConvert = &plKeyMap::fKeyConversionGerman;
-                break;
-            case plLocalization::kSpanish:
-                keyConvert = &plKeyMap::fKeyConversionSpanish;
-                break;
-            case plLocalization::kItalian:
-                keyConvert = &plKeyMap::fKeyConversionItalian;
-                break;
-            // default is English
-            default:
-                break;
-        }
-        for (const auto& [vKey, keyName] : *keyConvert)
+        const std::map<uint32_t, ST::string> keyConvert = plKeyMap::GetKeyConversion();
+        for (const auto& [vKey, keyName] : keyConvert)
         {   
             fprintf(gKeyFile, "#  %s\n", keyName.c_str());
         }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -790,8 +790,6 @@ void    plInputInterfaceMgr::WriteKeyMap()
         
         for( int j = 0; plKeyMap::fCmdConvert[ j ].fCode != END_CONTROLS; j++ )
         {
-            if (plKeyMap::fCmdConvert[j].fDesc.compare_i("Run Modifier") == 0)
-                continue;
             fprintf(gKeyFile, "#  %s\n", plKeyMap::fCmdConvert[j].fDesc.c_str());
         }
 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -246,38 +246,37 @@ void plInputInterfaceMgr::ResetClickableState()
 
 void    plInputInterfaceMgr::IUpdateCursor( int32_t newCursor )
 {
-    const char*     mouseCursorResID;
-
-
     if (newCursor == plInputInterface::kCursorHidden) {
         plMouseDevice::HideCursor();
     } else {
         if (fCurrentCursor == plInputInterface::kCursorHidden)
             plMouseDevice::ShowCursor();
+
+        ST::string mouseCursorResID;
         switch (newCursor) {
-            case plInputInterface::kCursorUp:                   mouseCursorResID = CURSOR_UP;                   break;
-            case plInputInterface::kCursorLeft:                 mouseCursorResID = CURSOR_LEFT;                 break;
-            case plInputInterface::kCursorRight:                mouseCursorResID = CURSOR_RIGHT;                break;
-            case plInputInterface::kCursorDown:                 mouseCursorResID = CURSOR_DOWN;                 break;
-            case plInputInterface::kCursorPoised:               mouseCursorResID = CURSOR_POISED;               break;
-            case plInputInterface::kCursorClicked:              mouseCursorResID = CURSOR_CLICKED;              break;
-            case plInputInterface::kCursorUnClicked:            mouseCursorResID = CURSOR_POISED;               break;
-            case plInputInterface::kCursorOpen:                 mouseCursorResID = CURSOR_OPEN;                 break;
-            case plInputInterface::kCursorGrab:                 mouseCursorResID = CURSOR_GRAB;                 break;
-            case plInputInterface::kCursorArrow:                mouseCursorResID = CURSOR_ARROW;                break;
-            case plInputInterface::kCursor4WayDraggable:        mouseCursorResID = CURSOR_4WAY_OPEN;            break;
-            case plInputInterface::kCursor4WayDragging:         mouseCursorResID = CURSOR_4WAY_CLOSED;          break;
-            case plInputInterface::kCursorUpDownDraggable:      mouseCursorResID = CURSOR_UPDOWN_OPEN;          break;
-            case plInputInterface::kCursorUpDownDragging:       mouseCursorResID = CURSOR_UPDOWN_CLOSED;        break;
-            case plInputInterface::kCursorLeftRightDraggable:   mouseCursorResID = CURSOR_LEFTRIGHT_OPEN;       break;
-            case plInputInterface::kCursorLeftRightDragging:    mouseCursorResID = CURSOR_LEFTRIGHT_CLOSED;     break;
-            case plInputInterface::kCursorOfferBook:            mouseCursorResID = CURSOR_OFFER_BOOK;           break;
-            case plInputInterface::kCursorOfferBookHilite:      mouseCursorResID = CURSOR_OFFER_BOOK_HI;        break;
-            case plInputInterface::kCursorOfferBookClicked:     mouseCursorResID = CURSOR_OFFER_BOOK_CLICKED;   break;
-            case plInputInterface::kCursorClickDisabled:        mouseCursorResID = CURSOR_CLICK_DISABLED;       break;
-            case plInputInterface::kCursorHand:                 mouseCursorResID = CURSOR_HAND;                 break;
-            case plInputInterface::kCursorUpward:               mouseCursorResID = CURSOR_UPWARD;               break;
-            default:                                            mouseCursorResID = CURSOR_OPEN;                 break;
+            case plInputInterface::kCursorUp:                 mouseCursorResID = ST_LITERAL(CURSOR_UP);                 break;
+            case plInputInterface::kCursorLeft:               mouseCursorResID = ST_LITERAL(CURSOR_LEFT);               break;
+            case plInputInterface::kCursorRight:              mouseCursorResID = ST_LITERAL(CURSOR_RIGHT);              break;
+            case plInputInterface::kCursorDown:               mouseCursorResID = ST_LITERAL(CURSOR_DOWN);               break;
+            case plInputInterface::kCursorPoised:             mouseCursorResID = ST_LITERAL(CURSOR_POISED);             break;
+            case plInputInterface::kCursorClicked:            mouseCursorResID = ST_LITERAL(CURSOR_CLICKED);            break;
+            case plInputInterface::kCursorUnClicked:          mouseCursorResID = ST_LITERAL(CURSOR_POISED);             break;
+            case plInputInterface::kCursorOpen:               mouseCursorResID = ST_LITERAL(CURSOR_OPEN);               break;
+            case plInputInterface::kCursorGrab:               mouseCursorResID = ST_LITERAL(CURSOR_GRAB);               break;
+            case plInputInterface::kCursorArrow:              mouseCursorResID = ST_LITERAL(CURSOR_ARROW);              break;
+            case plInputInterface::kCursor4WayDraggable:      mouseCursorResID = ST_LITERAL(CURSOR_4WAY_OPEN);          break;
+            case plInputInterface::kCursor4WayDragging:       mouseCursorResID = ST_LITERAL(CURSOR_4WAY_CLOSED);        break;
+            case plInputInterface::kCursorUpDownDraggable:    mouseCursorResID = ST_LITERAL(CURSOR_UPDOWN_OPEN);        break;
+            case plInputInterface::kCursorUpDownDragging:     mouseCursorResID = ST_LITERAL(CURSOR_UPDOWN_CLOSED);      break;
+            case plInputInterface::kCursorLeftRightDraggable: mouseCursorResID = ST_LITERAL(CURSOR_LEFTRIGHT_OPEN);     break;
+            case plInputInterface::kCursorLeftRightDragging:  mouseCursorResID = ST_LITERAL(CURSOR_LEFTRIGHT_CLOSED);   break;
+            case plInputInterface::kCursorOfferBook:          mouseCursorResID = ST_LITERAL(CURSOR_OFFER_BOOK);         break;
+            case plInputInterface::kCursorOfferBookHilite:    mouseCursorResID = ST_LITERAL(CURSOR_OFFER_BOOK_HI);      break;
+            case plInputInterface::kCursorOfferBookClicked:   mouseCursorResID = ST_LITERAL(CURSOR_OFFER_BOOK_CLICKED); break;
+            case plInputInterface::kCursorClickDisabled:      mouseCursorResID = ST_LITERAL(CURSOR_CLICK_DISABLED);     break;
+            case plInputInterface::kCursorHand:               mouseCursorResID = ST_LITERAL(CURSOR_HAND);               break;
+            case plInputInterface::kCursorUpward:             mouseCursorResID = ST_LITERAL(CURSOR_UPWARD);             break;
+            default:                                          mouseCursorResID = ST_LITERAL(CURSOR_OPEN);               break;
         }
 
         plMouseDevice::NewCursor(mouseCursorResID);

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
@@ -108,8 +108,6 @@ class plInputInterfaceMgr : public plSingleModifier
         plKeyMap    *IGetRoutedKeyMap( ControlEventCode code ); // Null for console commands
         void        IUnbind( const plKeyCombo &key );
 
-        ST::string IKeyComboToString(const plKeyCombo &combo);
-        
     public:
 
         plInputInterfaceMgr();

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
@@ -53,6 +53,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define _plInputInterfaceMgr_h
 
 #include "hsGeometry3.h"
+
+#include <string_theory/string>
+#include <utility>
 #include <vector>
 
 #include "pnModifier/plSingleModifier.h"
@@ -105,7 +108,7 @@ class plInputInterfaceMgr : public plSingleModifier
         plKeyMap    *IGetRoutedKeyMap( ControlEventCode code ); // Null for console commands
         void        IUnbind( const plKeyCombo &key );
 
-        const char  *IKeyComboToString( const plKeyCombo &combo );
+        ST::string IKeyComboToString(const plKeyCombo &combo);
         
     public:
 
@@ -137,10 +140,10 @@ class plInputInterfaceMgr : public plSingleModifier
         // Binding routers
         void    BindAction( const plKeyCombo &key, ControlEventCode code );
         void    BindAction( const plKeyCombo &key1, const plKeyCombo &key2, ControlEventCode code );
-        void    BindConsoleCmd( const plKeyCombo &key, const char *cmd, plKeyMap::BindPref pref = plKeyMap::kNoPreference );
+        void    BindConsoleCmd(const plKeyCombo &key, const ST::string& cmd, plKeyMap::BindPref pref = plKeyMap::kNoPreference);
 
         const plKeyBinding* FindBinding( ControlEventCode code );
-        const plKeyBinding* FindBindingByConsoleCmd( const char *cmd );
+        const plKeyBinding* FindBindingByConsoleCmd(const ST::string& cmd);
 
         void    ClearAllKeyMaps();
         void    ResetClickableState();
@@ -153,7 +156,7 @@ class plInputInterfaceMgr : public plSingleModifier
 class plCtrlCmd
 {
     private:
-        char*               fCmd;
+        ST::string          fCmd;
         plInputInterface    *fSource;
 
     public:
@@ -161,10 +164,9 @@ class plCtrlCmd
             : fCmd(), fPct(1.f), fSource(source),
               fControlCode(), fControlActivated(), fNetPropagateToPlayers()
         { }
-        ~plCtrlCmd() { delete [] fCmd; }
 
-        const char* GetCmdString()          { return fCmd; }
-        void SetCmdString(const char* cs)   { delete [] fCmd; fCmd=hsStrcpy(cs); }
+        ST::string GetCmdString() { return fCmd; }
+        void SetCmdString(ST::string cs) { fCmd = std::move(cs); }
 
         ControlEventCode    fControlCode;
         bool                fControlActivated;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
@@ -163,7 +163,7 @@ class plCtrlCmd
               fControlCode(), fControlActivated(), fNetPropagateToPlayers()
         { }
 
-        ST::string GetCmdString() { return fCmd; }
+        ST::string GetCmdString() const { return fCmd; }
         void SetCmdString(ST::string cs) { fCmd = std::move(cs); }
 
         ControlEventCode    fControlCode;

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.cpp
@@ -126,11 +126,6 @@ plControlEventMsg::plControlEventMsg(const plKey &s,
     SetBCastFlag(plMessage::kPropagateToModifiers);
 }
 
-plControlEventMsg::~plControlEventMsg()
-{   
-    delete [] fCmd;
-}
-
 void plControlEventMsg::Read(hsStream* stream, hsResMgr* mgr)
 {
     plInputEventMsg::Read(stream, mgr);

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.h
@@ -47,6 +47,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnInputCore/plControlDefinition.h"
 #include "hsGeometry3.h"
 
+#include <utility>
+
 class plKeyEventMsg;
 class plMouseEventMsg;
 
@@ -81,7 +83,7 @@ public:
 class plControlEventMsg : public plInputEventMsg
 {
 private:
-    char*               fCmd;
+    ST::string          fCmd;
 protected:
     
     ControlEventCode    fControlCode;
@@ -94,12 +96,11 @@ public:
     plControlEventMsg(const plKey &s, 
                     const plKey &r, 
                     const double* t);
-    ~plControlEventMsg();
 
     CLASSNAME_REGISTER( plControlEventMsg );
     GETINTERFACE_ANY( plControlEventMsg, plInputEventMsg );
 
-    void SetCmdString(const char* cs)       { delete [] fCmd; fCmd=hsStrcpy(cs); }
+    void SetCmdString(ST::string cs)        { fCmd = std::move(cs); }
     void SetControlCode(ControlEventCode c) { fControlCode = c; }
     void SetControlActivated(bool b)        { fControlActivated = b; }
     void SetTurnToPt(const hsPoint3& pt)    { fTurnToPt = pt; }
@@ -109,7 +110,7 @@ public:
     bool                ControlActivated()  const { return fControlActivated; }
     hsPoint3            GetTurnToPt()       const { return fTurnToPt; }
     float               GetPct()            const { return fControlPct; }
-    char*               GetCmdString()      const { return fCmd; }
+    ST::string          GetCmdString()      const { return fCmd; }
 
     // IO
     void Read(hsStream* stream, hsResMgr* mgr) override;


### PR DESCRIPTION
Migrates pnInputCore and plInputCore to `ST::string`, fixing some weird issues with non-ASCII characters in the code that translates `plKeyCombo`s from/to strings. As a result, you can now successfully change all key bindings in French without any hangs or silent errors.

This does *not* address some of the other internationalization issues in the input system, such as localized strings being passed around internally and stored in the vault. It only fixes Unicode support in the strings.

I also did other small modernization/refactoring where I think it's safe, and re-enabled some commented out Spanish/Italian translations. See commits for details (the single commit diffs may also be easier to read too).