### PR TITLE
Remove `CDECL` modifiers where not needed

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.h
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.h
@@ -117,7 +117,7 @@ class pfConsole : public hsKeyedObject
 
         static uint32_t       fConsoleTextColor;
         static pfConsole    *fTheConsole;
-        static void CDECL IAddLineCallback( const char *string );
+        static void IAddLineCallback( const char *string );
 
         static plPipeline   *fPipeline;
 

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcLog.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcLog.cpp
@@ -55,12 +55,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 ***/
 
 //===========================================================================
-void CDECL LogMsg (ELogSeverity severity, const char* line) {
+void LogMsg(ELogSeverity severity, const char* line) {
     ASSERT(line);
     plStatusLog::AddLineS("OLD_ASYNC_LOG.log", line);
 }
 
 //===========================================================================
-void CDECL LogMsg (ELogSeverity severity, const ST::string& line) {
+void LogMsg(ELogSeverity severity, const ST::string& line) {
     plStatusLog::AddLineS("OLD_ASYNC_LOG.log", line);
 }


### PR DESCRIPTION
These functions/methods are declared, defined, and used only within Plasma itself, so it doesn't matter which calling convention they use.

The only uses of `CDECL` where it actually matters are in hsSystemInfo.cpp, for the Wine version functions. (Even those *could* be safely removed I think... [the MSVC docs](https://learn.microsoft.com/en-us/cpp/build/reference/gd-gr-gv-gz-calling-convention?view=msvc-170) say that `__cdecl` is the default calling convention for C and C++.)