### PR TITLE
Allow swimming forward to satisfy walking forward condition.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainSwim.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainSwim.cpp
@@ -437,6 +437,15 @@ bool plAvBrainSwim::IsSwimming()
     return (fMode == kSwimming2D || fMode == kSwimming3D);
 }
 
+bool plAvBrainSwim::IsMovingForward() const
+{
+    if (fBehaviors.size() > kSwimForward && fBehaviors[kSwimForward]->GetStrength() > 0.0f)
+        return true;
+    if (fBehaviors.size() > kSwimForwardFast && fBehaviors[kSwimForwardFast]->GetStrength() > 0.0f)
+        return true;
+    return false;
+}
+
 void plAvBrainSwim::IStartWading()
 {
     plArmatureBrain *nextBrain = fAvMod->GetNextBrain(this);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainSwim.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainSwim.h
@@ -69,6 +69,7 @@ public:
     bool IsWalking();
     bool IsWading();
     bool IsSwimming();
+    bool IsMovingForward() const;
     float GetSurfaceDistance() { return fSurfaceDistance; }
 
     plSwimStrategy *fSwimStrategy;

--- a/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
@@ -57,6 +57,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plAvatar/plArmatureMod.h"
 #include "plAvatar/plAvatarMgr.h"
 #include "plAvatar/plAvBrainHuman.h"
+#include "plAvatar/plAvBrainSwim.h"
 #include "plAvatar/plAvBrainDrive.h"
 #include "plAvatar/plPhysicalControllerCore.h"
 #include "plMessage/plActivatorMsg.h"
@@ -444,16 +445,18 @@ void plObjectInVolumeAndFacingDetector::ICheckForTrigger()
         bool facing = dot >= fFacingTolerance;
 
         bool movingForward = false;
-        if (fNeedWalkingForward)
-        {
-            // And are we walking towards it?
-            plArmatureBrain* abrain =  armMod->FindBrainByClass(plAvBrainHuman::Index()); //armMod->GetCurrentBrain();
-            plAvBrainHuman* brain = plAvBrainHuman::ConvertNoRef(abrain);
-            if (brain && brain->IsMovingForward() && brain->fWalkingStrategy->IsOnGround())
+        if (fNeedWalkingForward) {
+            plAvBrainHuman* hbrain = plAvBrainHuman::ConvertNoRef(armMod->FindBrainByClass(plAvBrainHuman::Index()));
+            plAvBrainSwim* sbrain = plAvBrainSwim::ConvertNoRef(armMod->FindBrainByClass(plAvBrainSwim::Index()));
+
+            // And are we walking or swimming toward it?
+            if (hbrain && hbrain->IsMovingForward() && hbrain->fWalkingStrategy->IsOnGround())
                 movingForward = true;
-        }
-        else
+            else if (sbrain && sbrain->IsMovingForward() && sbrain->IsSwimming())
+                movingForward = true;
+        } else {
             movingForward = true;
+        }
 
         if (facing && movingForward && !fTriggered)
         {


### PR DESCRIPTION
The `plObjectInVolumeAndFacingDetector` is used to, for example, trigger ladder mounts and dismounts when walking forward. It makes sense that we might want to do similar animations when swimming forward (eg climbing up out of a body of water using a special animation). Unfortunately, swimming is a special brain type with a forward movement behavior that isn't working. So, update the logic to allow swimming forward to trigger the walking forward condition.

To better understand what this fixes, a video of the new behavior can be found here: https://youtu.be/dGraK0O7584. Without this fix, setting `fNeedWalkingForward = true` would prevent the climb out animation from executing at all. This would have to be disabled, causing the animation to fire any time the avatar was in the regions sensor and facing the correct direction.