### PR TITLE
Fix potential `UnboundLocalError` in Ahnonay.

### DIFF
--- a/Scripts/Python/Ahnonay.py
+++ b/Scripts/Python/Ahnonay.py
@@ -87,6 +87,8 @@ class Ahnonay(ptResponder):
         ageLinkNode = agevault.getSubAgeLink(ageStruct)
         if ageLinkNode:
             localCathedralGuid = ageLinkNode.getAgeInfo().getAgeInstanceGuid()
+        else:
+            localCathedralGuid = None
 
         folder = vault.getAgesIOwnFolder()
         cathedralInfoTemplate = ptVaultAgeInfoNode(0)


### PR DESCRIPTION
```
(03/18 13:38:35) VeryVerySpecialPythonFileMod - Traceback (most recent call last):
(03/18 13:38:35)   File ".\python\Ahnonay.py", line 127, in OnServerInitComplete
(03/18 13:38:35)     elif chron and chron.getName() == "AhnonayOwner" and personalCathedralGuid and personalCathedralGuid == localCathedralGuid:
(03/18 13:38:35) UnboundLocalError: local variable 'localCathedralGuid' referenced before assignment
```

Broken in #1142.