### PR TITLE
Don't play the look at KI animation while swimming.

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -3401,10 +3401,9 @@ class xKI(ptModifier):
     def ShowBigKI(self):
 
         self.waitingForAnimation = True
-        curBrainMode = PtGetLocalAvatar().avatar.getCurrentMode()
         toggleCB = ptGUIControlCheckBox(KIMini.dialog.getControlFromTag(kGUI.miniToggleBtnID))
         toggleCB.disable()
-        if curBrainMode == PtBrainModes.kNonGeneric:
+        if PtIsCurrentBrainHuman():
             PtDebugPrint("xKI.ShowBigKI(): Entering LookingAtKI mode.", level=kDebugDumpLevel)
             PtAvatarEnterLookingAtKI()
             self.isPlayingLookingAtKIMode = True


### PR DESCRIPTION
Partially addresses #1243 by only allowing the looking-at-KI animation to play while we're a *human* brain, meaning that the avatar is directly under the player's control for walking purposes. The swimming brain has some very interesting problems where it can receive erroneous buoyant forces or fall with gravity when tasks are executed from the water. These are complicated enough that I felt it would be better to submit this incremental fix than spend a lot of time chasing all of that down. This means that linking out from the water will still cause weird behavior.