### PR TITLE
Migrate plLocalization to `ST::string`

### DIFF
--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -857,11 +857,6 @@ def PtUnloadDialog(dialogName):
     """This will unload the GUI dialog by name. If not loaded then nothing will happen"""
     pass
 
-
-def PtUsingUnicode():
-    """Returns true if the current language is a unicode language (like Japanese)"""
-    pass
-
 def PtValidateKey(key):
     """Returns true(1) if 'key' is valid and loaded,
 otherwise returns false(0)"""

--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -792,7 +792,8 @@ INT_PTR CALLBACK UruLoginDialogProc( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
 
             for (int i = 0; i < plLocalization::GetNumLocales(); i++)
             {
-                SendMessage(GetDlgItem(hwndDlg, IDC_LANGUAGE), CB_ADDSTRING, 0, (LPARAM)plLocalization::GetLanguageName((plLocalization::Language)i));
+                ST::wchar_buffer languageNameBuf = plLocalization::GetLanguageName((plLocalization::Language)i).to_wchar();
+                SendMessageW(GetDlgItem(hwndDlg, IDC_LANGUAGE), CB_ADDSTRING, 0, (LPARAM)languageNameBuf.c_str());
             }
             SendMessage(GetDlgItem(hwndDlg, IDC_LANGUAGE), CB_SETCURSEL, (WPARAM)plLocalization::GetLanguage(), 0);
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.cpp
@@ -50,7 +50,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "hsStream.h"
 
-#include <string>
 #include <vector>
 
 #include "plAnimation/plAGModifier.h"
@@ -111,12 +110,12 @@ void    pfGUITextBoxMod::IUpdate()
 
     fDynTextMap->ClearToColor( GetColorScheme()->fBackColor );
 
-    std::wstring drawStr;
+    ST::string drawStr;
     if (fUseLocalizationPath && !fLocalizationPath.empty() && pfLocalizationMgr::InstanceValid()) {
-        drawStr = pfLocalizationMgr::Instance().GetString(fLocalizationPath).to_std_wstring();
+        drawStr = pfLocalizationMgr::Instance().GetString(fLocalizationPath);
     } else if (!fText.empty()) {
         plLocalization::Language lang = plLocalization::GetLanguage();
-        std::vector<std::wstring> translations = plLocalization::StringToLocal(fText.to_std_wstring());
+        std::vector<ST::string> translations = plLocalization::StringToLocal(fText);
 
         // if the translations doesn't exist, draw English
         if (translations[lang].empty())
@@ -126,7 +125,7 @@ void    pfGUITextBoxMod::IUpdate()
     }
 
     if (!drawStr.empty())
-        fDynTextMap->DrawWrappedString( 4, 4, drawStr.c_str(), fDynTextMap->GetVisibleWidth() - 8, fDynTextMap->GetVisibleHeight() - 8 );
+        fDynTextMap->DrawWrappedString(4, 4, drawStr, fDynTextMap->GetVisibleWidth() - 8, fDynTextMap->GetVisibleHeight() - 8);
 
     fDynTextMap->FlushToHost();
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -1731,18 +1731,6 @@ int cyMisc::GetLanguage()
 
 //////////////////////////////////////////////////////////////////////////////
 //
-// Function   : UsingUnicode
-// PARAMETERS :
-//
-// PURPOSE    : Returns true if the current language uses Unicode (like Japanese)
-//
-bool cyMisc::UsingUnicode()
-{
-    return plLocalization::UsingUnicode();
-}
-
-//////////////////////////////////////////////////////////////////////////////
-//
 //
 //  particle system management
 //

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -681,15 +681,6 @@ public:
     
     //////////////////////////////////////////////////////////////////////////////
     //
-    // Function   : UsingUnicode
-    // PARAMETERS :
-    //
-    // PURPOSE    : Returns true if the current language uses Unicode (like Japanese)
-    //
-    static bool UsingUnicode();
-
-    //////////////////////////////////////////////////////////////////////////////
-    //
     // Function   : RequestLOSScreen
     // PARAMETERS : lots...
     //

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
@@ -569,11 +569,6 @@ PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetLanguage, "Returns the current langu
     return PyLong_FromLong(cyMisc::GetLanguage());
 }
 
-PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtUsingUnicode, "Returns true if the current language is a unicode language (like Japanese)")
-{
-    PYTHON_RETURN_BOOL(cyMisc::UsingUnicode());
-}
-
 PYTHON_GLOBAL_METHOD_DEFINITION(PtFakeLinkAvatarToObject, args, "Params: avatar,object\nPseudo-links avatar to object within the same age\n")
 {
     PyObject* avatarObj = nullptr;
@@ -713,7 +708,6 @@ void cyMisc::AddPlasmaMethods3(PyObject* m)
         PYTHON_GLOBAL_METHOD(PtGetControlEvents)
 
         PYTHON_GLOBAL_METHOD_NOARGS(PtGetLanguage)
-        PYTHON_GLOBAL_METHOD_NOARGS(PtUsingUnicode)
 
         PYTHON_GLOBAL_METHOD(PtFakeLinkAvatarToObject)
 

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
@@ -428,15 +428,7 @@ void    plDynamicTextMap::SetFont( const ST::string &face, uint16_t size, uint8_
 //  if( !IIsValid() )
 //      return;
 
-    if (plLocalization::UsingUnicode())
-    {
-        // unicode has a bunch of chars that most fonts don't have, so we override the font choice with one
-        // that will work with the desired language
-        hsStatusMessageF("We are using a unicode language, overriding font choice of %s", face.c_str("nil"));
-        fFontFace = "Unicode";
-    }
-    else
-        fFontFace = face;
+    fFontFace = face;
     fFontSize = size;
     fFontFlags = fontFlags;
     fFontAntiAliasRGB = antiAliasRGB;

--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
@@ -78,16 +78,6 @@ const char* plLocalization::fLangNames[] =
     "Japanese" // kJapanese
 };
 
-plLocalization::encodingTypes plLocalization::fUnicodeEncoding[] =
-{
-    Enc_Unencoded,  // kEnglish
-    Enc_Unencoded,  // kFrench
-    Enc_Unencoded,  // kGerman
-    Enc_Unencoded,  // kSpanish
-    Enc_Unencoded,  // kItalian
-    Enc_UTF8,       // kJapanese
-};
-
 plFileName plLocalization::IGetLocalized(const plFileName& name, Language lang)
 {
     ST_ssize_t underscore = name.AsString().find_last('_');

--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
@@ -78,16 +78,6 @@ const char* plLocalization::fLangNames[] =
     "Japanese" // kJapanese
 };
 
-bool plLocalization::fUsesUnicode[] =
-{
-    false,  // kEnglish
-    false,  // kFrench
-    false,  // kGerman
-    false,  // kSpanish
-    false,  // kItalian
-    true    // kJapanese
-};
-
 plLocalization::encodingTypes plLocalization::fUnicodeEncoding[] =
 {
     Enc_Unencoded,  // kEnglish

--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
@@ -42,18 +42,18 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "plLocalization.h"
 
-#include <sstream>
+#include <string_theory/string_stream>
 
 plLocalization::Language plLocalization::fLanguage = plLocalization::kEnglish;
 
-const char* plLocalization::fLangTags[] =
+const ST::string plLocalization::fLangTags[] =
 {
-    "_eng", // kEnglish
-    "_fre", // kFrench
-    "_ger", // kGerman
-    "_spa", // kSpanish
-    "_ita", // kItalian
-    "_jpn"  // kJapanese
+    ST_LITERAL("_eng"), // kEnglish
+    ST_LITERAL("_fre"), // kFrench
+    ST_LITERAL("_ger"), // kGerman
+    ST_LITERAL("_spa"), // kSpanish
+    ST_LITERAL("_ita"), // kItalian
+    ST_LITERAL("_jpn")  // kJapanese
 };
 const int kLangTagLen = 4;
 
@@ -68,14 +68,14 @@ std::set<ST::string> plLocalization::fLangCodes[] =
     {"jpn", "ja"}
 };
 
-const char* plLocalization::fLangNames[] =
+const ST::string plLocalization::fLangNames[] =
 {
-    "English", // kEnglish
-    "French",  // kFrench
-    "German",  // kGerman
-    "Spanish", // kSpanish
-    "Italian", // kItalian
-    "Japanese" // kJapanese
+    ST_LITERAL("English"), // kEnglish
+    ST_LITERAL("French"),  // kFrench
+    ST_LITERAL("German"),  // kGerman
+    ST_LITERAL("Spanish"), // kSpanish
+    ST_LITERAL("Italian"), // kItalian
+    ST_LITERAL("Japanese") // kJapanese
 };
 
 plFileName plLocalization::IGetLocalized(const plFileName& name, Language lang)
@@ -102,74 +102,34 @@ plFileName plLocalization::ExportGetLocalized(const plFileName& name, int lang)
     return "";
 }
 
-std::string plLocalization::LocalToString(const std::vector<std::string> & localizedText)
+ST::string plLocalization::LocalToString(const std::vector<ST::string>& localizedText)
 {
-    std::stringstream ss;
+    ST::string_stream ss;
     for (size_t i = 0; i < localizedText.size(); i++)
     {
         if (i > kNumLanguages - 1)
             break;
-        std::string langName = GetLanguageName((Language)i);
+        ST::string langName = GetLanguageName((Language)i);
         ss << '$' << langName.substr(0, 2) << '$' << localizedText[i];
     }
-    return ss.str();
+    return ss.to_string();
 }
 
-std::wstring plLocalization::LocalToString(const std::vector<std::wstring>& localizedText)
+std::vector<ST::string> plLocalization::StringToLocal(const ST::string& localizedText)
 {
-    std::wstringstream ss;
-    for (size_t i = 0; i < localizedText.size(); i++)
-    {
-        if (i > kNumLanguages - 1)
-            break;
-        wchar_t* temp = hsStringToWString(GetLanguageName((Language)i));
-        std::wstring langName = temp;
-        delete[] temp;
-        ss << '$' << langName.substr(0, 2) << '$' << localizedText[i];
-    }
-    return ss.str();
-}
-
-std::vector<std::string> plLocalization::StringToLocal(const std::string & localizedText)
-{
-    std::vector<std::string> retVal;
-    wchar_t *temp = hsStringToWString(localizedText.c_str());
-    std::wstring wLocalizedText = temp;
-    delete [] temp;
-
-    std::vector<std::wstring> wStringVector = StringToLocal(wLocalizedText);
-    int i;
-    for (i=0; i<wStringVector.size(); i++)
-    {
-        char *local = hsWStringToString(wStringVector[i].c_str());
-        std::string val = local;
-        delete [] local;
-        retVal.push_back(val);
-    }
-
-    return retVal;
-}
-
-std::vector<std::wstring> plLocalization::StringToLocal(const std::wstring & localizedText)
-{
-    std::vector<std::wstring> tags;
+    std::vector<ST::string> tags;
     std::vector<int> tagLocs;
     std::vector<int> sortedTagLocs;
-    std::vector<std::wstring> retVal;
+    std::vector<ST::string> retVal;
     int i;
     for (i=0; i<kNumLanguages; i++)
     {
-        std::wstring tag = L"$";
-        std::string temp = GetLanguageName((Language)i);
-        wchar_t *wTemp = hsStringToWString(temp.c_str());
-        std::wstring langName = wTemp;
-        delete [] wTemp;
-        
-        tag += langName.substr(0,2) + L"$";
+        ST::string langName = GetLanguageName((Language)i);
+        ST::string tag = "$" + langName.substr(0, 2) + "$";
         tags.push_back(tag);
         tagLocs.push_back(localizedText.find(tag));
         sortedTagLocs.push_back(i);
-        retVal.push_back(L"");
+        retVal.emplace_back();
     }
     for (i=0; i<kNumLanguages-1; i++)
     {
@@ -187,10 +147,10 @@ std::vector<std::wstring> plLocalization::StringToLocal(const std::wstring & loc
         if (tagLocs[lang] != -1)
         {
             noTags = false; // at least one tag was found in the text
-            int startLoc = tagLocs[lang] + tags[lang].length();
+            int startLoc = tagLocs[lang] + tags[lang].size();
             int endLoc;
             if (i+1 == kNumLanguages)
-                endLoc = localizedText.length();
+                endLoc = localizedText.size();
             else
                 endLoc = tagLocs[sortedTagLocs[i+1]];
             retVal[lang] = localizedText.substr(startLoc,endLoc-startLoc);

--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.cpp
@@ -39,9 +39,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
       Mead, WA   99021
 
 *==LICENSE==*/
-#include "HeadSpin.h"
+
 #include "plLocalization.h"
 
+#include "HeadSpin.h"
+#include "plFileSystem.h"
+
+#include <string_theory/string>
 #include <string_theory/string_stream>
 
 plLocalization::Language plLocalization::fLanguage = plLocalization::kEnglish;
@@ -91,6 +95,21 @@ plFileName plLocalization::IGetLocalized(const plFileName& name, Language lang)
     }
 
     return plFileName();
+}
+
+ST::string plLocalization::GetLanguageName(plLocalization::Language lang)
+{
+    return fLangNames[lang];
+}
+
+std::set<ST::string> plLocalization::GetLanguageCodes(plLocalization::Language lang)
+{
+    return fLangCodes[lang];
+}
+
+plFileName plLocalization::GetLocalized(plFileName const &name)
+{
+    return IGetLocalized(name, fLanguage);
 }
 
 plFileName plLocalization::ExportGetLocalized(const plFileName& name, int lang)

--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.h
@@ -81,7 +81,6 @@ protected:
     static const char* fLangTags[kNumLanguages];
     static std::set<ST::string> fLangCodes[kNumLanguages];
     static const char* fLangNames[kNumLanguages];
-    static bool fUsesUnicode[kNumLanguages];
     static encodingTypes fUnicodeEncoding[kNumLanguages];
 
     static plFileName IGetLocalized(const plFileName& name, Language lang);
@@ -93,7 +92,6 @@ public:
     static const char* GetLanguageName(Language lang) { return fLangNames[lang]; }
     static std::set<ST::string> GetLanguageCodes(Language lang) { return fLangCodes[lang]; }
 
-    static bool UsingUnicode() { return fUsesUnicode[fLanguage]; }
     static encodingTypes UnicodeEncoding() { return fUnicodeEncoding[fLanguage]; }
 
     // Returns true if we're using localized assets.  If it returns false, you

--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.h
@@ -61,27 +61,12 @@ public:
 
         kNumLanguages,
     };
-    
-    enum encodingTypes
-    {
-        Enc_Unencoded,  // This can also mean that python did the decoding for us and we don't need to tweak it on our end
-        Enc_Split_String,
-        Enc_Hybrid_Split_String,
-        Enc_UTF8,
-        Enc_UTF16,
-        Enc_Unicode_Escape,
-        Enc_Raw_Unicode_Escape,
-        Enc_Latin_1,
-        Enc_ASCII,
-        Enc_MBCS
-    };
 
 protected:
     static Language fLanguage;
     static const char* fLangTags[kNumLanguages];
     static std::set<ST::string> fLangCodes[kNumLanguages];
     static const char* fLangNames[kNumLanguages];
-    static encodingTypes fUnicodeEncoding[kNumLanguages];
 
     static plFileName IGetLocalized(const plFileName& name, Language lang);
 
@@ -91,8 +76,6 @@ public:
 
     static const char* GetLanguageName(Language lang) { return fLangNames[lang]; }
     static std::set<ST::string> GetLanguageCodes(Language lang) { return fLangCodes[lang]; }
-
-    static encodingTypes UnicodeEncoding() { return fUnicodeEncoding[fLanguage]; }
 
     // Returns true if we're using localized assets.  If it returns false, you
     // don't need to bother calling GetLocalized

--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.h
@@ -102,8 +102,6 @@ public:
     //
     static int GetNumLocales() { return kNumLanguages - 1; }
     static plFileName ExportGetLocalized(const plFileName& name, int lang);
-    // Just tells us if this is localized, doesn't actually convert it for us
-    static bool IsLocalizedName(const plFileName& name) { return IGetLocalized(name, kEnglish).IsValid(); }
 
     // Converts a vector of translated strings to a encoded string that can be decoded by StringToLocal()
     // The index in the vector of a string is it's language

--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.h
@@ -43,9 +43,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plLocalization_h_inc
 
 #include <set>
-#include <string_theory/string>
 #include <vector>
-#include "plFileSystem.h"
+
+class plFileName;
+namespace ST { class string; }
 
 class plLocalization
 {
@@ -74,8 +75,8 @@ public:
     static void SetLanguage(Language lang) { fLanguage = lang; }
     static Language GetLanguage() { return fLanguage; }
 
-    static ST::string GetLanguageName(Language lang) { return fLangNames[lang]; }
-    static std::set<ST::string> GetLanguageCodes(Language lang) { return fLangCodes[lang]; }
+    static ST::string GetLanguageName(Language lang);
+    static std::set<ST::string> GetLanguageCodes(Language lang);
 
     // Returns true if we're using localized assets.  If it returns false, you
     // don't need to bother calling GetLocalized
@@ -83,7 +84,7 @@ public:
 
     // Pass in a key name and this will give you the localized name
     // Returns an invalid filename if the original keyname is not for a localized asset
-    static plFileName GetLocalized(const plFileName& name) { return IGetLocalized(name, fLanguage); }
+    static plFileName GetLocalized(const plFileName& name);
 
     //
     // Export only

--- a/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plLocalization.h
@@ -42,9 +42,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plLocalization_h_inc
 #define plLocalization_h_inc
 
-#include <vector>
-#include <string>
 #include <set>
+#include <string_theory/string>
+#include <vector>
 #include "plFileSystem.h"
 
 class plLocalization
@@ -64,9 +64,9 @@ public:
 
 protected:
     static Language fLanguage;
-    static const char* fLangTags[kNumLanguages];
+    static const ST::string fLangTags[kNumLanguages];
     static std::set<ST::string> fLangCodes[kNumLanguages];
-    static const char* fLangNames[kNumLanguages];
+    static const ST::string fLangNames[kNumLanguages];
 
     static plFileName IGetLocalized(const plFileName& name, Language lang);
 
@@ -74,7 +74,7 @@ public:
     static void SetLanguage(Language lang) { fLanguage = lang; }
     static Language GetLanguage() { return fLanguage; }
 
-    static const char* GetLanguageName(Language lang) { return fLangNames[lang]; }
+    static ST::string GetLanguageName(Language lang) { return fLangNames[lang]; }
     static std::set<ST::string> GetLanguageCodes(Language lang) { return fLangCodes[lang]; }
 
     // Returns true if we're using localized assets.  If it returns false, you
@@ -107,11 +107,9 @@ public:
 
     // Converts a vector of translated strings to a encoded string that can be decoded by StringToLocal()
     // The index in the vector of a string is it's language
-    static std::string LocalToString(const std::vector<std::string> & localizedText);
-    static std::wstring LocalToString(const std::vector<std::wstring> & localizedText);
+    static ST::string LocalToString(const std::vector<ST::string>& localizedText);
     // Converts a string encoded by LocalToString to a vector of translated strings
-    static std::vector<std::string> StringToLocal(const std::string & localizedText);
-    static std::vector<std::wstring> StringToLocal(const std::wstring & localizedText);
+    static std::vector<ST::string> StringToLocal(const ST::string& localizedText);
 };
 
 #endif // plLocalization_h_inc

--- a/Sources/Tools/MaxComponent/plGUIComponents.cpp
+++ b/Sources/Tools/MaxComponent/plGUIComponents.cpp
@@ -3056,9 +3056,9 @@ public:
 class plGUITextBoxProc : public ParamMap2UserDlgProc
 {
 private:
-    std::vector<M_STD_STRING> fTranslations;
+    std::vector<ST::string> fTranslations;
     int fCurLanguage;
-    void ISetTranslation(int lang, M_STD_STRING text)
+    void ISetTranslation(int lang, ST::string text)
     {
         while (lang >= fTranslations.size())
             fTranslations.emplace_back();
@@ -3080,14 +3080,14 @@ public:
                 if ( pmap->GetParamBlock()->GetStr( plGUITextBoxComponent::kRefInitText ) )
                 {
                     fTranslations = plLocalization::StringToLocal(pmap->GetParamBlock()->GetStr( plGUITextBoxComponent::kRefInitText ) );
-                    SetDlgItemText( hWnd, IDC_GUI_INITTEXT, fTranslations[0].c_str() );
+                    SetDlgItemText(hWnd, IDC_GUI_INITTEXT, ST2T(fTranslations[0]));
                 }
                 else
                     // if there is no text, then there is nothing to translate
                     SetDlgItemText( hWnd, IDC_GUI_INITTEXT, pmap->GetParamBlock()->GetStr( plGUITextBoxComponent::kRefInitText ) );
                 SendMessage( GetDlgItem( hWnd, IDC_GUI_LANGUAGE ), CB_RESETCONTENT, 0, 0 );
                 for (i=0; i<plLocalization::kNumLanguages; i++)
-                    SendMessageA( GetDlgItem( hWnd, IDC_GUI_LANGUAGE ), CB_ADDSTRING, 0, (LPARAM)plLocalization::GetLanguageName((plLocalization::Language)i) );
+                    SendMessage(GetDlgItem(hWnd, IDC_GUI_LANGUAGE), CB_ADDSTRING, 0, (LPARAM)ST2T(plLocalization::GetLanguageName((plLocalization::Language)i)));
                 SendMessage( GetDlgItem( hWnd, IDC_GUI_LANGUAGE ), CB_SETCURSEL, 0, 0 );
                 fCurLanguage = 0;
 
@@ -3121,20 +3121,16 @@ public:
                 {
                     if( HIWORD( wParam ) == EN_CHANGE )
                     {
-                        int strLen = (int)SendDlgItemMessage(hWnd, IDC_GUI_INITTEXT, WM_GETTEXTLENGTH, 0, 0);
+                        int strLen = (int)SendDlgItemMessageW(hWnd, IDC_GUI_INITTEXT, WM_GETTEXTLENGTH, 0, 0);
                         if( strLen > 0 )
                         {
-                            auto str = std::make_unique<TCHAR[]>(strLen + 1);
-                            GetDlgItemText( hWnd, IDC_GUI_INITTEXT, str.get(), strLen + 1 );
-                            str[ strLen ] = 0;
-                            ISetTranslation(fCurLanguage, str.get());
+                            ST::wchar_buffer strBuf;
+                            strBuf.allocate(strLen);
+                            GetDlgItemTextW(hWnd, IDC_GUI_INITTEXT, strBuf.data(), strLen + 1);
+                            ISetTranslation(fCurLanguage, strBuf);
 
-                            auto translation = plLocalization::LocalToString(fTranslations);
-                            str = std::make_unique<TCHAR[]>(translation.length() + 1);
-                            _tcsncpy(str.get(), translation.c_str(), strLen + 1);
-                            str[translation.length()] = 0;
-                
-                            pmap->GetParamBlock()->SetValue( plGUITextBoxComponent::kRefInitText, 0, str.get() );
+                            ST::string translation = plLocalization::LocalToString(fTranslations);
+                            pmap->GetParamBlock()->SetValue(plGUITextBoxComponent::kRefInitText, 0, ST2M(translation));
                         }
                     }
                     else if( HIWORD( wParam ) == EN_KILLFOCUS )
@@ -3177,7 +3173,7 @@ public:
                         if (idx >= fTranslations.size())
                             SetDlgItemText( hWnd, IDC_GUI_INITTEXT, _T("") );
                         else
-                            SetDlgItemText( hWnd, IDC_GUI_INITTEXT, fTranslations[idx].c_str() );
+                            SetDlgItemText(hWnd, IDC_GUI_INITTEXT, ST2T(fTranslations[idx]));
                         fCurLanguage = idx;
                     }
                 }

--- a/Sources/Tools/plLocalizationEditor/plAddDlgs.cpp
+++ b/Sources/Tools/plLocalizationEditor/plAddDlgs.cpp
@@ -161,10 +161,7 @@ std::vector<ST::string> IGetAllLanguageNames()
 
     for (int curLocale = 0; curLocale <= numLocales; curLocale++)
     {
-        const char *name = plLocalization::GetLanguageName((plLocalization::Language)curLocale);
-        wchar_t *wName = hsStringToWString(name);
-        retVal.push_back(ST::string::from_wchar(wName));
-        delete [] wName;
+        retVal.emplace_back(plLocalization::GetLanguageName((plLocalization::Language)curLocale));
     }
 
     return retVal;


### PR DESCRIPTION
And remove some unused and/or obsolete methods.

The changes touch a few parts of the Max plugin, which I cannot test properly, as usual.

This class could use some further cleanup too:

* The language numbers are typed weirdly - they're often cast back and forth between `plLocalization::Language` and plain `int`, sometimes offset by 1 for mysterious reasons.
* `kNumLanguages` is one higher than `GetNumLocales()`, presumably so that `kJapanese` (the last language in the enum) isn't shown to players.
* The `LocalToString`/`StringToLocal` mechanism seems to be obsolete - everything now uses pfLocalizationDataMgr instead of storing translations in the PRPs. `pfGUITextBoxMod` is the only place still using this old mechanism, but even there it's effectively dead. PRPs still have `$`-separated strings stored in text boxes, but have all translations blank except English, relying on pfLocalizationDataMgr for the actual translations.