### PR TITLE
Resolve clang implicit conversion warning

### DIFF
--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleGenerator.h
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleGenerator.h
@@ -67,7 +67,7 @@ public:
 
     static void ComputeDirection(float pitch, float yaw, hsVector3 &direction);
     static void ComputePitchYaw(float &pitch, float &yaw, const hsVector3 &dir);
-    static inline float GetRandomVar() { return 2.0f * rand() / RAND_MAX - 1; } // returns a num between +/- 1.0
+    static inline float GetRandomVar() { return 2.0f * rand() / float(RAND_MAX) - 1.0f; } // returns a num between +/- 1.0
 };
 
 class plSimpleParticleGenerator : public plParticleGenerator


### PR DESCRIPTION
> warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648

This was showing up several times in my build logs and it's easy enough to make the cast explicit to silence the warning