### PR TITLE
Fix out-of-bounds list access in `SocketQueueAsyncWrite`

### DIFF
--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceSocket.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceSocket.cpp
@@ -420,8 +420,8 @@ static bool SocketQueueAsyncWrite(AsyncSocket conn, const void* data, size_t byt
     hsLockGuard(s_connectCrit);
 
     // check for data backlog
-    WriteOperation* firstQueuedWrite = conn->fWriteOps.front();
-    if (firstQueuedWrite) {
+    if (!conn->fWriteOps.empty()) {
+        WriteOperation* firstQueuedWrite = conn->fWriteOps.front();
         unsigned currTimeMs = TimeGetMs();
         if (((long)(currTimeMs - firstQueuedWrite->queueTimeMs) >= (long)kBacklogFailMs) && ((long)(currTimeMs - conn->initTimeMs) >= (long)kBacklogInitMs)) {
             PerfAddCounter(kAsyncPerfSocketDisconnectBacklog, 1);


### PR DESCRIPTION
This tripped a debug assertion - calling `front()` on an empty list is undefined behavior according to the standard.