### PR TITLE
Conditional compiling as workaround for _PyObject_CallOneArg when using Python 3.8

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonCallable.h
@@ -104,7 +104,11 @@ namespace plPython
             // Use Python's built-in vectorcall optimization for one argument.
             pyObjectRef arg = ConvertFrom(std::forward<Args>(args)...);
             plProfile_BeginTiming(PythonUpdate);
+#if PY_VERSION_HEX >= 0x03090000
             pyObjectRef result = _PyObject_CallOneArg(callable, arg.Get());
+#else
+            pyObjectRef result = PyObject_CallFunctionObjArgs(callable, arg.Get(), NULL);
+#endif
             plProfile_EndTiming(PythonUpdate);
             return result;
         } else if constexpr (sizeof...(args) == 0) {


### PR DESCRIPTION
Patch from Prad to fix building with Python 3.8.

@Hoikas mentioned that this API did exist as experimental/non-standard functionality in Python 3.8, so we might be able to get away with including an internal header instead.