### PR TITLE
Adds being able to disable cluster groups in Relto age

### DIFF
--- a/Scripts/Python/psnlYeeshaPageChanges.py
+++ b/Scripts/Python/psnlYeeshaPageChanges.py
@@ -62,7 +62,7 @@ respAudioStop = ptAttribResponder(4,"Audio stop responder")
 
 respEnable = ptAttribResponder(5, "Enabled resp (if necessary)")
 respDisable = ptAttribResponder(6, "Disabled resp (if necessary)")
-bushDistrib = ptAttribClusterList(7, "Bush distributor")
+clusterList = ptAttribClusterList(7, "Cluster Group object list")
 
 #globals
 TotalPossibleYeeshaPages = len(xLinkingBookDefs.xYeeshaPages)
@@ -238,9 +238,8 @@ class psnlYeeshaPageChanges(ptMultiModifier):
 
             respAudioStop.run(self.key,avatar=None,fastforward=0)
             respDisable.run(self.key,avatar=None,fastforward=1)
-            if len(bushDistrib.value) > 0:
-                for x in bushDistrib.value:
-                    x.setVisible(0)
+            for i in clusterList.value:
+                i.setVisible(False)
 
 
     def TimeToGrow(self):

--- a/Scripts/Python/psnlYeeshaPageChanges.py
+++ b/Scripts/Python/psnlYeeshaPageChanges.py
@@ -53,6 +53,7 @@ from PlasmaTypes import *
 from PlasmaVaultConstants import *
 from PlasmaNetConstants import *
 from xPsnlVaultSDL import *
+import xLinkingBookDefs
 
 PageNumber = ptAttribInt(1, "Yeesha Page Number")
 stringShowStates = ptAttribString(2,"States in which shown")
@@ -61,9 +62,9 @@ respAudioStop = ptAttribResponder(4,"Audio stop responder")
 
 respEnable = ptAttribResponder(5, "Enabled resp (if necessary)")
 respDisable = ptAttribResponder(6, "Disabled resp (if necessary)")
+bushDistrib = ptAttribClusterList(7, "Bush distributor")
 
 #globals
-import xLinkingBookDefs
 TotalPossibleYeeshaPages = len(xLinkingBookDefs.xYeeshaPages)
 HideCleftPole = 0
 
@@ -237,6 +238,9 @@ class psnlYeeshaPageChanges(ptMultiModifier):
 
             respAudioStop.run(self.key,avatar=None,fastforward=0)
             respDisable.run(self.key,avatar=None,fastforward=1)
+            if len(bushDistrib.value) > 0:
+                for x in bushDistrib.value:
+                    x.setVisible(0)
 
 
     def TimeToGrow(self):


### PR DESCRIPTION
Adds back the cluster group disabling from URU CC

This is not currently used on the Huru branches, but Blue Flowers Page requires this code to work.
Otherwise the flowers will stay enabled all the time while using the Huru client on any shard that has that page included with it.