### PR TITLE
Allow setting the `blockRGB` argument in xDynTextLoc.py.

### DIFF
--- a/Scripts/Python/xDynTextLoc.py
+++ b/Scripts/Python/xDynTextLoc.py
@@ -63,6 +63,7 @@ clearColorR = ptAttribFloat(15, "Clear Color (Red)", default=0.0)
 clearColorG = ptAttribFloat(16, "Clear Color (Green)", default=0.0)
 clearColorB = ptAttribFloat(17, "Clear Color (Blue)", default=0.0)
 clearColorA = ptAttribFloat(18, "Clear Color (Alpha)", default=0.0)
+blockRGB = ptAttribBoolean(19, "Render into alpha channel")
 
 _JUSTIFY_LUT = {
     "left": PtJustify.kLeftJustify,
@@ -84,7 +85,7 @@ class xDynTextLoc(ptModifier):
         wrappingHeight = textMap.getHeight() - marginBottom.value - marginTop.value
 
         textMap.clearToColor(self._clearColor)
-        textMap.setTextColor(self._fontColor)
+        textMap.setTextColor(self._fontColor, blockRGB.value)
         textMap.setWrapping(wrappingWidth, wrappingHeight)
         textMap.setFont(fontFace.value, fontSize.value)
         textMap.setJustify(self._justify)


### PR DESCRIPTION
For H-uru/Korman#372

Before:
![image](https://github.com/H-uru/korman/assets/714455/a7074d72-198f-469a-b3eb-3d7ce071be0d)

After:
![image](https://github.com/H-uru/korman/assets/714455/ce9066c2-7fb3-4822-82cd-e2eb78c01eb5)