### PR TITLE
Fix possible use after free in `plRegistryPageNode::UnloadKeys`

### DIFF
--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.cpp
@@ -58,8 +58,9 @@ plRegistryKeyList::~plRegistryKeyList()
 {
     for (auto& key : fKeys) {
         if (key && !key->ObjectIsLoaded()) {
-            delete key;
+            plKeyImp* temp = key;
             key = nullptr;
+            delete temp;
         }
     }
 }

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.cpp
@@ -56,9 +56,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 plRegistryKeyList::~plRegistryKeyList()
 {
-    std::for_each(fKeys.begin(), fKeys.end(),
-        [] (plKeyImp* key) { if (key && !key->ObjectIsLoaded()) delete key; }
-    );
+    for (auto& key : fKeys) {
+        if (key && !key->ObjectIsLoaded()) {
+            delete key;
+            key = nullptr;
+        }
+    }
 }
 
 plKeyImp* plRegistryKeyList::FindKey(const ST::string& keyName) const

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
@@ -186,8 +186,8 @@ void plRegistryPageNode::UnloadKeys()
     for (; it != fKeyLists.end(); it++)
     {
         plRegistryKeyList* keyList = it->second;
-        delete keyList;
         it->second = nullptr;
+        delete keyList;
     }
     fKeyLists.clear();
 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
@@ -187,6 +187,7 @@ void plRegistryPageNode::UnloadKeys()
     {
         plRegistryKeyList* keyList = it->second;
         delete keyList;
+        it->second = nullptr;
     }
     fKeyLists.clear();
 


### PR DESCRIPTION
While doing some multiplayer testing, I encountered a crash on exit that looks very similar to the "`plWin32LinkSound`/`plWin32StaticSound` crash" that's been reported with OpenUru clients for a while now. I can reproduce this reliably with two internal debug H'uru clients running on the same machine, simply by linking two avvies to the Ferry Terminal and then closing the two clients. (I first close the client that linked in first, then wait a couple of seconds, then close the second client, which then crashes. Haven't tested if the order or timing is important.)

<details>
<summary>Stack trace from debugger</summary>

```
[plClient.exe] std::_Iterator_base12::_Adopt_unlocked(const std::_Container_base12 *) xmemory:1145
[plClient.exe] std::_Iterator_base12::_Adopt_locked(const std::_Container_base12 *) xmemory:1153
[plClient.exe] std::_Iterator_base12::_Adopt(const std::_Container_base12 *) xmemory:1093
[plClient.exe] std::_Vector_const_iterator::_Vector_const_iterator<…>(plKeyImp **, const std::_Container_base12 *) vector:42
[plClient.exe] std::vector::end() vector:1478
[plClient.exe] plRegistryKeyList::FindKey(const ST::string &) plRegistryKeyList.cpp:66
[plClient.exe] plRegistryKeyList::SetKeyUnused(plKeyImp *, plRegistryKeyList::LoadStatus &) plRegistryKeyList.cpp:189
[plClient.exe] plRegistryPageNode::SetKeyUnused(plKeyImp *) plRegistryNode.cpp:381
[plClient.exe] plResManager::IKeyUnreffed(plKeyImp *) plResManager.cpp:1665
[plClient.exe] plKey::IDecRef() plKey.cpp:290
[plClient.exe] plKey::~plKey() plKey.cpp:161
[plClient.exe] plSound::~plSound() plSound.cpp:101
[plClient.exe] plWin32Sound::~plWin32Sound() 0x00007ff6b43b8197
[plClient.exe] plWin32StaticSound::~plWin32StaticSound() plWin32StaticSound.cpp:70
[plClient.exe] plWin32LinkSound::~plWin32LinkSound() plWin32StaticSound.h:85
[plClient.exe] plWin32LinkSound::`scalar deleting destructor'(unsigned int) 0x00007ff6b456dd58
[plClient.exe] hsRefCnt::UnRef(const char *) hsRefCnt.cpp:147
[plClient.exe] plKeyImp::UnRegister() plKeyImp.cpp:251
[plClient.exe] plKeyImp::~plKeyImp() plKeyImp.cpp:131
[plClient.exe] plKeyImp::`scalar deleting destructor'(unsigned int) 0x00007ff6b44cf9e8
[plClient.exe] <lambda_65f32318...>::operator()(plKeyImp *) plRegistryKeyList.cpp:60
[plClient.exe] std::for_each<…>(_Vector_iterator<…>, _Vector_iterator<…>, <lambda_65f32318...>) algorithm:233
[plClient.exe] plRegistryKeyList::~plRegistryKeyList() plRegistryKeyList.cpp:59
[plClient.exe] plRegistryKeyList::`scalar deleting destructor'(unsigned int) 0x00007ff6b4931f18
[plClient.exe] plRegistryPageNode::UnloadKeys() plRegistryNode.cpp:197
[plClient.exe] plRegistryPageNode::~plRegistryPageNode() plRegistryNode.cpp:89
[plClient.exe] plRegistryPageNode::`scalar deleting destructor'(unsigned int) 0x00007ff6b49247a8
[plClient.exe] plResManager::IShutdown() plResManager.cpp:218
[plClient.exe] hsgResMgr::Shutdown() pnSingletons.cpp:69
[plClient.exe] plClientLoader::ShutdownEnd() plClientLoader.cpp:107
[plClient.exe] WinMain(HINSTANCE__ *, HINSTANCE__ *, char *, int) winmain.cpp:1278
[plClient.exe] invoke_main() 0x00007ff6b615ee72
[plClient.exe] __scrt_common_main_seh() 0x00007ff6b615ed5e
[plClient.exe] __scrt_common_main() 0x00007ff6b615ec1e
[plClient.exe] WinMainCRTStartup(void *) 0x00007ff6b615ef0e
[kernel32.dll] <unknown> 0x00007ffdf1637614
[ntdll.dll] <unknown> 0x00007ffdf35626f1
```
</details>

This PR slightly adjusts the registry page cleanup code in a way that seems to fix the crash. The commit message for a529e35fd940543752fd74efd0fe63039a03c4a6 contains a somewhat lengthy explanation of what I think is happening (I'm not 100 % sure - feedback welcome).

I've seen somebody suggest that the crash may be caused by a reference leak - if that's true, that should also be fixed separately. I *think* the underlying issue can also happen without any leaked references though.