### PR TITLE
Some NucleusLib Cleanups

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMessage/pfGameGUIMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfGameGUIMsg.h
@@ -80,6 +80,7 @@ class pfGameGUIMsg : public plMessage
         void Read(hsStream* s, hsResMgr* mgr) override;
         void Write(hsStream* s, hsResMgr* mgr) override;
 
+        void        SetCommand(uint8_t cmd) { fCommand = cmd; }
         uint8_t     GetCommand() const { return fCommand; }
 
         void        SetString(const ST::string &str) { fString = str; }

--- a/Sources/Plasma/NucleusLib/inc/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/inc/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(
         pnModifier
         pnNetCommon
         pnSceneObject
+        pnTimer
 )
 
 target_include_directories(pnNucleusInc INTERFACE ${CMAKE_CURRENT_LIST_DIR})

--- a/Sources/Plasma/NucleusLib/inc/hsResMgr.h
+++ b/Sources/Plasma/NucleusLib/inc/hsResMgr.h
@@ -145,6 +145,9 @@ private:
 public:
     static hsResMgr* ResMgr() { return (hsResMgr*)fResMgr; }
 
+    // External modifier use only
+    static void SetTheResMgr(hsResMgr* mgr) { fResMgr = mgr; }
+
     static plDispatchBase* Dispatch() { hsAssert(fResMgr, "No resmgr"); return fResMgr->Dispatch(); }
 
     static bool Init(hsResMgr* m);

--- a/Sources/Plasma/NucleusLib/inc/plClassIndexMacros.h
+++ b/Sources/Plasma/NucleusLib/inc/plClassIndexMacros.h
@@ -56,13 +56,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //  --For use outside of plExternalCreatableIndex
 #define EXTERN_CLASS_INDEX_SCOPED(plClassName) plExternalCreatableIndex::EXTERN_CLASS_INDEX(plClassName)
 
+static constexpr int EXTERNAL_KEYED_DLL_BEGIN      = 256;
+static constexpr int EXTERNAL_KEYED_DLL_END        = 511;
+static constexpr int KEYED_OBJ_DELINEATOR          = 512;
+static constexpr int EXTERNAL_NONKEYED_DLL_BEGIN   = 1436;
+static constexpr int EXTERNAL_NONKEYED_DLL_END     = 1536;
+
 // Macros for the start and end of the class index list
-#define CLASS_INDEX_LIST_START      const int KEYED_OBJ_DELINEATOR  = 512; \
-                                    const int EXTERNAL_KEYED_DLL_BEGIN  = 256; \
-                                    const int EXTERNAL_KEYED_DLL_END    = 511; \
-                                    const int EXTERNAL_NONKEYED_DLL_BEGIN   = 1436; \
-                                    const int EXTERNAL_NONKEYED_DLL_END = 1536; \
-                                    class plCreatableIndex { public: enum {
+#define CLASS_INDEX_LIST_START  class plCreatableIndex { public: enum {
 #define CLASS_INDEX_LIST_END    plNumClassIndices = EXTERNAL_NONKEYED_DLL_END + 1, }; };
 // Macro to mark which class index is the start of the nonkeyed object section
 #define CLASS_INDEX_NONKEYED_OBJ_START      kKeyedObjDelineator = KEYED_OBJ_DELINEATOR-1,

--- a/Sources/Plasma/NucleusLib/pnFactory/plCreator.h
+++ b/Sources/Plasma/NucleusLib/pnFactory/plCreator.h
@@ -95,6 +95,18 @@ static_assert(plCreator::VerifyNonKeyedIndex<plClassName, CLASS_INDEX_SCOPED(plC
               #plClassName " is in the non-KeyedObject section of plCreatableIndex but "      \
               "derives from hsKeyedObject.");                                                   //
 
+
+#define VERIFY_EXTERNAL_CREATABLE(plClassName)                                               \
+                                                                                              \
+static_assert(plCreator::VerifyKeyedIndex<plClassName, EXTERN_CLASS_INDEX_SCOPED(plClassName)>(),    \
+              #plClassName " is in the KeyedObject section of plCreatableIndex but "          \
+              "does not derive from hsKeyedObject.");                                         \
+                                                                                              \
+static_assert(plCreator::VerifyNonKeyedIndex<plClassName, EXTERN_CLASS_INDEX_SCOPED(plClassName)>(), \
+              #plClassName " is in the non-KeyedObject section of plCreatableIndex but "      \
+              "derives from hsKeyedObject.");                                                 //
+
+
 #define REGISTER_CREATABLE( plClassName )                                           \
                                                                                     \
 VERIFY_CREATABLE(plClassName);                                                      \
@@ -123,6 +135,7 @@ static plClassName##__Creator   static##plClassName##__Creator;                 
 uint16_t plClassName::plClassName##ClassIndex = 0;                                  \
 VERIFY_CREATABLE(plClassName);                                                        //
 
+
 #define REGISTER_NONCREATABLE( plClassName )                                        \
                                                                                     \
 class plClassName##__Creator : public plCreator                                     \
@@ -149,6 +162,7 @@ public:                                                                         
 static plClassName##__Creator   static##plClassName##__Creator;                     \
 uint16_t plClassName::plClassName##ClassIndex = 0;                                  \
 VERIFY_CREATABLE(plClassName);                                                        //
+
 
 #define DECLARE_EXTERNAL_CREATABLE( plClassName )                                   \
                                                                                     \
@@ -182,13 +196,16 @@ public:                                                                         
 };                                                                                  \
 static plClassName##__Creator   static##plClassName##__Creator;                     \
 uint16_t plClassName::plClassName##ClassIndex = 0;                                  \
-VERIFY_CREATABLE(plClassName);                                                        //
+VERIFY_EXTERNAL_CREATABLE(plClassName);                                             //
+
 
 #define REGISTER_EXTERNAL_CREATABLE(plClassName)                                    \
 static##plClassName##__Creator.Register();                                          //
 
+
 #define UNREGISTER_EXTERNAL_CREATABLE(plClassName)                                  \
 plFactory::UnRegister(EXTERN_CLASS_INDEX_SCOPED(plClassName), &static##plClassName##__Creator);
+
 
 #define REGISTER_EXTERNAL_NONCREATABLE( plClassName )                               \
                                                                                     \
@@ -215,7 +232,7 @@ public:                                                                         
 };                                                                                  \
 static plClassName##__Creator   static##plClassName##__Creator;                     \
 uint16_t plClassName::plClassName##ClassIndex = 0;                                  \
-VERIFY_CREATABLE(plClassName);                                                        //
+VERIFY_EXTERNAL_CREATABLE(plClassName);                                             //
 
 
 #endif // plCreator_inc

--- a/Sources/Plasma/NucleusLib/pnModifier/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnModifier/CMakeLists.txt
@@ -28,12 +28,9 @@ target_link_libraries(
         pnNetCommon
     PRIVATE
         pnMessage
-        plNetMessage
         pnNucleusInc
         pnSceneObject
 )
-
-target_include_directories(pnModifier PRIVATE "${PLASMA_SOURCE_ROOT}/PubUtilLib")
 
 source_group("Header Files" FILES ${pnModifier_HEADERS})
 source_group("Source Files" FILES ${pnModifier_SOURCES})

--- a/Sources/Plasma/NucleusLib/pnModifier/plLogicModBase.h
+++ b/Sources/Plasma/NucleusLib/pnModifier/plLogicModBase.h
@@ -76,13 +76,13 @@ protected:
     bool                    fDisabled;
 
     bool IEval(double secs, float del, uint32_t dirty) override { return false; }
-    void IUpdateSharedState(bool triggered) const;
     void IHandleArbitration(class plServerReplyMsg* msg);
     bool IEvalCounter();
     virtual void PreTrigger(bool netRequest);
     virtual void Trigger(bool netRequest);
     virtual void UnTrigger();
-    
+    virtual void UpdateSharedState(bool triggered) const = 0;
+
     void CreateNotifyMsg();
 
 public:

--- a/Sources/Plasma/PubUtilLib/plModifier/plLogicModifier.h
+++ b/Sources/Plasma/PubUtilLib/plModifier/plLogicModifier.h
@@ -55,6 +55,7 @@ protected:
     std::vector<plConditionalObject*> fConditionList;
 
     void PreTrigger(bool netRequest) override;
+    void UpdateSharedState(bool triggered) const override;
 
 public:
     plLogicModifier();


### PR DESCRIPTION
This fixes a longstanding cross-project linking issue from plLogicModBase (by extracting that particular bit of behaviour into plLogicModifier).