### PR TITLE
Fix journals not rendering Unicode text correctly (fixes #1403)

### DIFF
--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -2364,22 +2364,19 @@ void    pfJournalBook::IRenderPage( uint32_t page, uint32_t whichDTMap, bool sup
                             idx--;
                         break;
                     }
-                    if (lastChar < chunk->fText.size() && chunk->fText[lastChar] != 0)
+                    if (lastChar < chunk->fText.size())
                     {
                         // Didn't get to render the whole paragraph in this go, so we're going to cheat
                         // and split the paragraph up into two so that we can handle it properly. Note:
                         // this changes the chunk array beyond this point, so we need to invalidate the
                         // cache, but that's ok 'cause if we're doing this, it's probably invalid (or empty)
                         // anyway
-                        ST::wchar_buffer s = chunk->fText.to_wchar();
-
-                        // Note: Makes a copy of the string
-                        pfEsHTMLChunk *c2 = new pfEsHTMLChunk( &s[ lastChar ] );
+                        pfEsHTMLChunk *c2 = new pfEsHTMLChunk(chunk->fText.substr(lastChar));
                         c2->fFlags = chunk->fFlags;
                         fHTMLSource.emplace(fHTMLSource.begin() + idx + 1, c2);
 
                         // Clip and reallocate so we don't have two copies laying around
-                        chunk->fText = ST::string::from_wchar(s.c_str(), lastChar);
+                        chunk->fText = chunk->fText.left(lastChar);
 
                         // Invalidate our cache starting with the next page
                         if (fPageStarts.size() > page + 1)

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
@@ -592,7 +592,16 @@ void    plDynamicTextMap::SetFirstLineIndent( int16_t indent )
 void    plDynamicTextMap::CalcWrappedStringSize( const ST::string &text, uint16_t *width, uint16_t *height, uint32_t *firstClippedChar, uint16_t *maxAscent, uint16_t *lastX, uint16_t *lastY )
 {
     // TEMP
-    CalcWrappedStringSize(text.to_wchar().data(), width, height, firstClippedChar, maxAscent, lastX, lastY);
+    ST::wchar_buffer wcharBuf = text.to_wchar();
+    uint32_t firstClippedWchar;
+    CalcWrappedStringSize(wcharBuf.data(), width, height, &firstClippedWchar, maxAscent, lastX, lastY);
+
+    if (firstClippedChar != nullptr) {
+        // Convert the firstClippedChar offset from wchar_t units to UTF-8 byte units.
+        // This is a bit inefficient, because it creates an actual UTF-8 string
+        // even though we just need the count, but string_theory has no better alternative.
+        *firstClippedChar = ST::string::from_wchar(wcharBuf.data(), firstClippedWchar).size();
+    }
 }
 
 void    plDynamicTextMap::CalcWrappedStringSize( const wchar_t *text, uint16_t *width, uint16_t *height, uint32_t *firstClippedChar, uint16_t *maxAscent, uint16_t *lastX, uint16_t *lastY )

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -1176,8 +1176,7 @@ void    plFont::IRenderCharNull( const plCharacter &c )
 uint16_t  plFont::CalcStringWidth( const ST::string &string )
 {
     uint16_t w, h, a, lX, lY;
-    uint32_t s;
-    CalcStringExtents( string, w, h, a, s, lX, lY );
+    CalcStringExtents( string, w, h, a, lX, lY );
     return w;
 }
 
@@ -1189,9 +1188,13 @@ uint16_t  plFont::CalcStringWidth( const wchar_t *string )
     return w;
 }
 
-void    plFont::CalcStringExtents( const ST::string &string, uint16_t &width, uint16_t &height, uint16_t &ascent, uint32_t &firstClippedChar, uint16_t &lastX, uint16_t &lastY )
+void    plFont::CalcStringExtents( const ST::string &string, uint16_t &width, uint16_t &height, uint16_t &ascent, uint16_t &lastX, uint16_t &lastY )
 {
     // convert the char string to a wchar_t string
+    // We don't expose firstClippedChar as an out parameter in the ST::string overload,
+    // because converting it to a correct UTF-8-based count is a bit complicated
+    // and currently nothing uses this information.
+    uint32_t firstClippedChar;
     CalcStringExtents(string.to_wchar().data(), width, height, ascent, firstClippedChar, lastX, lastY);
 }
 

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.h
@@ -278,7 +278,7 @@ class plFont : public hsKeyedObject
 
         uint16_t  CalcStringWidth( const ST::string &string );
         uint16_t  CalcStringWidth( const wchar_t *string );
-        void    CalcStringExtents( const ST::string &string, uint16_t &width, uint16_t &height, uint16_t &ascent, uint32_t &firstClippedChar, uint16_t &lastX, uint16_t &lastY );
+        void    CalcStringExtents( const ST::string &string, uint16_t &width, uint16_t &height, uint16_t &ascent, uint16_t &lastX, uint16_t &lastY );
         void    CalcStringExtents( const wchar_t *string, uint16_t &width, uint16_t &height, uint16_t &ascent, uint32_t &firstClippedChar, uint16_t &lastX, uint16_t &lastY );
 
         bool    LoadFromFNT( const plFileName &path );

--- a/Sources/Tools/plFontConverter/plFontPreview.cpp
+++ b/Sources/Tools/plFontConverter/plFontPreview.cpp
@@ -72,8 +72,7 @@ void plFontPreview::Update(plFont *font, const QString &text)
     fFont->SetRenderFlag(plFont::kRenderClip, true);
     fFont->SetRenderClipRect(0, 0, (int16_t)width(), (int16_t)height());
     uint16_t w, h, a, lastX, lastY;
-    uint32_t firstCC;
-    fFont->CalcStringExtents(testString, w, h, a, firstCC, lastX, lastY);
+    fFont->CalcStringExtents(testString, w, h, a, lastX, lastY);
 
     int cY = ((height() - h) >> 1) + a;
 


### PR DESCRIPTION
For the `ST::string` overloads of the text rendering methods, the `firstClippedChar` output parameter still counted in `wchar_t` units, not UTF-8 bytes as needed for indexing into `ST::string`.