### PR TITLE
Fix Win32 ifdef check in DisplayScaleChangedMsg

### DIFF
--- a/Sources/Plasma/PubUtilLib/plMessage/plDisplayScaleChangedMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plDisplayScaleChangedMsg.h
@@ -81,7 +81,7 @@ public:
     float GetScale() const { return fScale; }
     std::optional<ClientWindow> GetSuggestedLocation() const { return fNewLocation; }
 
-#if WIN32
+#ifdef HS_BUILD_FOR_WIN32
     static RECT ConvertRect(const plDisplayScaleChangedMsg::ClientWindow& rect)
     {
         return *((const LPRECT)&rect);


### PR DESCRIPTION
This is more consistent with how we do compile-time checking in the rest of the codebase, and avoid issues on compilers producing Windows binaries that somehow don't define `WIN32` by default (aka mingw-w64)