### PR TITLE
Convert more character sets with plFontConverter.

### DIFF
--- a/Sources/Tools/plFontConverter/plFontConverter.cpp
+++ b/Sources/Tools/plFontConverter/plFontConverter.cpp
@@ -533,7 +533,6 @@ void plFontConverter::IBatchFreeType(const plFileName &path, void *init)
     ui.fPointSizes->setText(QString::number(info.fSize));
     ui.fFontName->setText(path.GetFileNameNoExt().c_str());
     ui.fResolution->setValue(info.fScreenRes);
-    ui.fMaxChar->setValue(info.fMaxCharLimit);
     if (info.fBitDepth == 1)
         ui.fMonochrome->setChecked(true);
     else
@@ -548,7 +547,6 @@ void plFontConverter::IBatchFreeType(const plFileName &path, void *init)
         iSizes.append(s.toInt());
 
     info.fScreenRes = ui.fResolution->value();
-    info.fMaxCharLimit = ui.fMaxChar->value();
     info.fBitDepth = (ui.fMonochrome->isChecked() ? 1 : 8);
 
     QString outPath = QFileDialog::getExistingDirectory(this,
@@ -612,7 +610,6 @@ void plFontConverter::IImportFreeType(const plFileName &path)
 
     ui.fPointSize->setValue(info.fSize);
     ui.fResolution->setValue(info.fScreenRes);
-    ui.fMaxChar->setValue(info.fMaxCharLimit);
     if (info.fBitDepth == 1)
         ui.fMonochrome->setChecked(true);
     else
@@ -622,7 +619,6 @@ void plFontConverter::IImportFreeType(const plFileName &path)
 
     info.fSize = ui.fPointSize->value();
     info.fScreenRes = ui.fResolution->value();
-    info.fMaxCharLimit = ui.fMaxChar->value();
     info.fBitDepth = (ui.fMonochrome->isChecked() ? 1 : 8);
 
     if (ret == QDialog::Rejected)

--- a/Sources/Tools/plFontConverter/plFontFreeType.cpp
+++ b/Sources/Tools/plFontConverter/plFontFreeType.cpp
@@ -164,7 +164,17 @@ bool    plFontFreeType::ImportFreeType( const plFileName &fontPath, Options *opt
                 if (ftIndex == 0)
                     continue;
 
-                error = FT_Load_Glyph(ftFace, ftIndex, FT_LOAD_DEFAULT);
+                constexpr FT_Int32 kMonochromeLoadFlags = (
+                    FT_LOAD_RENDER | FT_LOAD_TARGET_MONO | FT_LOAD_MONOCHROME | FT_LOAD_NO_AUTOHINT
+                );
+                constexpr FT_Int32 kNormalLoadFlags = (
+                    FT_LOAD_RENDER | FT_LOAD_NO_AUTOHINT
+                );
+                error = FT_Load_Glyph(
+                    ftFace,
+                    ftIndex,
+                    options->fBitDepth == 1 ? kMonochromeLoadFlags : kNormalLoadFlags
+                );
                 if (error || ftChar > kMaxGlyphs)
                     continue;
 
@@ -232,17 +242,6 @@ bool    plFontFreeType::ImportFreeType( const plFileName &fontPath, Options *opt
         // Now re-run through our stored list of glyphs, converting them to bitmaps
         for( uint32_t i = 0; i < numGlyphs; i++ )
         {
-            if( ftGlyphs[ i ]->format != ft_glyph_format_bitmap )
-            {
-                FT_Vector origin;
-                origin.x = 32;      // Half a pixel over
-                origin.y = 0;
-
-                error = FT_Glyph_To_Bitmap( &ftGlyphs[ i ], ( fBPP == 1 ) ? ft_render_mode_mono : ft_render_mode_normal, &origin, 0 );
-                if( error )
-                    throw false;
-            }
-
             if (fCharacters.size() < glyphChars[i] + 1)
                 fCharacters.resize(glyphChars[i] + 1);
 

--- a/Sources/Tools/plFontConverter/plFontFreeType.cpp
+++ b/Sources/Tools/plFontConverter/plFontFreeType.cpp
@@ -49,6 +49,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plFontFreeType.h"
 
+#include <string_theory/format>
+
 #include <memory>
 
 #include "ft2build.h"
@@ -217,18 +219,16 @@ bool    plFontFreeType::ImportFreeType( const plFileName &fontPath, Options *opt
 
         // Set the name and size of our font
         fSize = options->fSize;
-        char str[ 512 ];
         
         if( ftFace->style_flags & FT_STYLE_FLAG_ITALIC )
             SetFlag( kFlagItalic, true );
         if( ftFace->style_flags & FT_STYLE_FLAG_BOLD )
             SetFlag( kFlagBold, true );
         
-        if( IsFlagSet( kFlagItalic | kFlagBold ) )
-            sprintf( str, "%s %s", ftFace->family_name, ftFace->style_name );
+        if (IsFlagSet(kFlagItalic | kFlagBold))
+            SetFace(ST::format("{} {}", ftFace->family_name, ftFace->style_name));
         else
-            strcpy( str, ftFace->family_name );
-        SetFace( str );
+            SetFace(ftFace->family_name);
 
         // # of bytes per row 
         uint32_t stride = ( fBPP == 1 ) ? ( fWidth >> 3 ) : fWidth;

--- a/Sources/Tools/plFontConverter/plFontFreeType.cpp
+++ b/Sources/Tools/plFontConverter/plFontFreeType.cpp
@@ -85,7 +85,15 @@ static_assert(
     std::all_of(
         std::begin(s_Characters), std::end(s_Characters),
         [](const plCharacterRange& range) {
-            return range.fBegin < range.fEnd && range.fEnd < kMaxGlyphs;
+            // Combined high and low surrogates because no individual codepoint
+            // exists in the low surrogate range AFAIK, so who cares about the
+            // distinction.
+            constexpr plCharacterRange kSurrogatePair{ 0xD800, 0xDFFF };
+            return (
+                range.fBegin < range.fEnd && range.fEnd < kMaxGlyphs &&
+                // All characters must fit in a single UTF-16 codepoint
+                (range.fEnd < kSurrogatePair.fBegin || range.fBegin > kSurrogatePair.fEnd)
+            );
         }
     )
 );

--- a/Sources/Tools/plFontConverter/plFontFreeType.cpp
+++ b/Sources/Tools/plFontConverter/plFontFreeType.cpp
@@ -77,9 +77,7 @@ static plCharacterRange s_Characters[]{
     { 0x0500, 0x052F }, // Cyrillic Supplement
 };
 
-/*
- * When we update to C++20, we can verify that the characters are in range at
- * compile time using:
+#if __cpp_lib_constexpr_algorithms >= 201806L
 #include <algorithm>
 static_assert(
     std::all_of(
@@ -97,7 +95,7 @@ static_assert(
         }
     )
 );
-*/
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/Sources/Tools/plFontConverter/plFontFreeType.h
+++ b/Sources/Tools/plFontConverter/plFontFreeType.h
@@ -59,9 +59,8 @@ class plFontFreeType : public plFont
             bool      fUseKerning;
             uint8_t   fBitDepth;
             uint32_t  fScreenRes;
-            uint32_t  fMaxCharLimit;
 
-            Options() : fSize(12), fUseKerning(false), fBitDepth(1), fScreenRes(96), fMaxCharLimit(255) { }
+            Options() : fSize(12), fUseKerning(false), fBitDepth(1), fScreenRes(96) { }
         };
 
         bool    ImportFreeType( const plFileName &fontPath, Options *options, plBDFConvertCallback *callback );

--- a/Sources/Tools/plFontConverter/res/FreeType.ui
+++ b/Sources/Tools/plFontConverter/res/FreeType.ui
@@ -16,6 +16,16 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Screen &amp;Resolution:</string>
+       </property>
+       <property name="buddy">
+        <cstring>fResolution</cstring>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
@@ -33,33 +43,6 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Max &amp;Character:</string>
-       </property>
-       <property name="buddy">
-        <cstring>fMaxChar</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <widget class="QSpinBox" name="fMaxChar">
-       <property name="maximum">
-        <number>1114111</number>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Screen &amp;Resolution:</string>
-       </property>
-       <property name="buddy">
-        <cstring>fResolution</cstring>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="1">
       <widget class="QSpinBox" name="fResolution">
        <property name="maximum">
@@ -67,23 +50,19 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2" colspan="2">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QRadioButton" name="fMonochrome">
-         <property name="text">
-          <string>&amp;Monochrome</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="fGrayscale">
-         <property name="text">
-          <string>&amp;Grayscale</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+     <item row="0" column="2">
+      <widget class="QRadioButton" name="fMonochrome">
+       <property name="text">
+        <string>&amp;Monochrome</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QRadioButton" name="fGrayscale">
+       <property name="text">
+        <string>&amp;Grayscale</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/Sources/Tools/plFontConverter/res/FreeTypeBatch.ui
+++ b/Sources/Tools/plFontConverter/res/FreeTypeBatch.ui
@@ -37,7 +37,24 @@
       <string>Common Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="2" colspan="2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Screen &amp;Resolution:</string>
+        </property>
+        <property name="buddy">
+         <cstring>fResolution</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="fResolution">
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QRadioButton" name="fMonochrome">
@@ -54,40 +71,6 @@
          </widget>
         </item>
        </layout>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Screen &amp;Resolution:</string>
-        </property>
-        <property name="buddy">
-         <cstring>fResolution</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Max &amp;Character:</string>
-        </property>
-        <property name="buddy">
-         <cstring>fMaxChar</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QSpinBox" name="fMaxChar">
-        <property name="maximum">
-         <number>1114111</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QSpinBox" name="fResolution">
-        <property name="maximum">
-         <number>65535</number>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Previously, plFontConverter by default converted the first 255 glyphs that it could find. The user could increase or decrease that limit but not have any other control. This PR removes the character counter specification and instead hardwires certain unicode character sets of interest to be converted, namely Latin and Cyrillic (see H-uru/moul-assets#237). Additional character sets are trivial to add by modifying plFontTrueType.cpp. Useful future work might be allowing .p2f files to be compressed, but that currently seems like overkill.

As a bonus, this improves the conversion of monochrome fonts by pulling in @colincornaby's fixes for crunchy freetype monochrome fonts. Further, some `ST::string` goodness is added.