### PR TITLE
plPipeline needs to link against CoreText

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPipeline/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plPipeline/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(plPipeline
         pfGameGUIMgr # plCaptureRender
         $<$<BOOL:${WIN32}>:plWinDpi>
         freetype
+        "$<$<PLATFORM_ID:Darwin>:-framework CoreText>"
     INTERFACE
         pnFactory
 )


### PR DESCRIPTION
plTextFont uses CoreText on macOS but didn't explicitly declare a dependency.  In the full macOS client, I think this was being masked by something else that brought in CoreText.