### PR TITLE
Fix pfMoviePlayer when libwebm is not available

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.cpp
@@ -181,13 +181,13 @@ plMoviePlayer::plMoviePlayer()
       fTexture(),
 #ifdef USE_WEBM
       fReader(),
+      fLastImg(),
 #endif
       fMovieTime(),
       fLastFrameTime(),
       fPosition(),
       fPlaying(),
-      fPaused(),
-      fLastImg()
+      fPaused()
 {
     fScale.Set(1.0f, 1.0f);
 }
@@ -469,10 +469,12 @@ bool plMoviePlayer::Stop()
         fAudioSound->Stop();
     if (fPlate)
         fPlate->SetVisible(false);
+#ifdef USE_WEBM
     if (fLastImg) {
         vpx_img_free(fLastImg);
         fLastImg = nullptr;
     }
+#endif
 
     for (auto cb : fCallbacks)
         cb->Send();


### PR DESCRIPTION
`fLastImg` is only declared in the header if `USE_WEBM` is true, and we can't call `vpx_img_free` if `USE_WEBM` is not true