### PR TITLE
Fix Python Parameter display on pre-2022 Max Plugins.

### DIFF
--- a/Sources/Tools/MaxComponent/plAutoUIBase.cpp
+++ b/Sources/Tools/MaxComponent/plAutoUIBase.cpp
@@ -501,6 +501,7 @@ void plAutoUIBase::ICreateControls()
     RECT rect;
     GetWindowRect(fhDlg, &rect);
 
+#if MAX_VERSION_MAJOR >= 24 // Max 2022
     // This used to use MoveWindow() to resize the rollup, but in Max 2022,
     // that does not seem to work anymore. So, we now do the same thing
     // that WM_SIZE_PANEL does.
@@ -511,6 +512,9 @@ void plAutoUIBase::ICreateControls()
         rollup->SetPageDlgHeight(index, yOffset + 5);
 
     InvalidateRect(fhDlg, nullptr, TRUE);
+#else
+    MoveWindow(fhDlg, rect.left, rect.top, rect.right - rect.left, yOffset + 5, FALSE);
+#endif
 }
 
 void plAutoUIBase::CreateAutoRollup(IParamBlock2 *pb)


### PR DESCRIPTION
The change introduced by 107af8272 breaks the plugin as far back as Max 7.  This applies the fix only to versions that were confirmed as requiring it.