### PR TITLE
Drop SafeString "backward compat hack" from 20 years ago

### DIFF
--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -155,12 +155,7 @@ ST::string hsStream::ReadSafeString()
     ST::char_buffer name;
     uint16_t numChars = ReadLE16();
 
-#ifndef REMOVE_ME_SOON
-    // Backward compat hack - remove in a week or so (from 6/30/03)
-    bool oldFormat = !(numChars & 0xf000);
-    if (oldFormat)
-        (void)ReadLE16();
-#endif
+    hsAssert(numChars & 0xf000, "SafeString in old (pre-2003) format");
 
     numChars &= ~0xf000;
     hsAssert(numChars <= GetSizeLeft(), "Bad string");


### PR DESCRIPTION
Happy 20th birthday to this code that was only meant to exist for a week or so! I think it's safe to remove by now. This "old" format is never produced by `WriteSafeString` and doesn't seem to be used in any data files.