### PR TITLE
Specify older Pillow version to fix cairosvg build

### DIFF
--- a/Scripts/Ports/python3-cairosvg/portfile.cmake
+++ b/Scripts/Ports/python3-cairosvg/portfile.cmake
@@ -5,7 +5,8 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Install cairo on Ubuntu with `sudo apt install libcairo2` and on macOS with `brew install cairo`.")
 endif()
 
-set(CAIROSVG_VERSION "2.5.2")
+set(PILLOW_VERSION "9.5.0")
+set(CAIROSVG_VERSION "2.7.0")
 set(INSTALLED_PYTHON_PREFIX "${CURRENT_INSTALLED_DIR}/tools/python3")
 
 # We are running in script mode, so no toolchains are available. Sad.
@@ -124,7 +125,7 @@ vcpkg_execute_required_process(
 message(STATUS "Installing cairosvg from pip")
 file(TO_NATIVE_PATH "${CURRENT_PYTHON_PREFIX}" _PIP_PREFIX)
 vcpkg_execute_required_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -m pip install --prefix "${_PIP_PREFIX}" "cairosvg==${CAIROSVG_VERSION}"
+    COMMAND "${PYTHON_EXECUTABLE}" -m pip install --prefix "${_PIP_PREFIX}" "pillow==${PILLOW_VERSION}" "cairosvg==${CAIROSVG_VERSION}"
     ALLOW_IN_DOWNLOAD_MODE
     WORKING_DIRECTORY "${CURRENT_PYTHON_PREFIX}"
     LOGNAME install

--- a/Scripts/Ports/python3-cairosvg/vcpkg.json
+++ b/Scripts/Ports/python3-cairosvg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "python3-cairosvg",
-  "version-semver": "2.5.2",
-  "port-version": 1,
+  "version-semver": "2.7.0",
   "description": "CairoSVG is an SVG converter based on Cairo. It can export SVG files to PDF, EPS, PS, and PNG files.",
   "homepage": "https://cairosvg.org/",
   "dependencies": [


### PR DESCRIPTION
Update to latest cairosvg too, since that seems to work fine.

On July 1st, a new major version of Pillow was released, and it requires zlib to compile. For whatever reason, that's not working when pip tries to install it. However cairosvg is fine using the older version so it's easiest to rollback for the moment to fix the builds.