### PR TITLE
Enable pfPython tests on all platforms

### DIFF
--- a/Sources/Tests/FeatureTests/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/CMakeLists.txt
@@ -6,6 +6,4 @@ include_directories("${PLASMA_SOURCE_ROOT}/PubUtilLib/inc")
 include_directories("${PLASMA_SOURCE_ROOT}/FeatureLib")
 include_directories("${PLASMA_SOURCE_ROOT}/FeatureLib/inc")
 
-if(WIN32)
-    add_subdirectory(pfPythonTest)
-endif()
+add_subdirectory(pfPythonTest)


### PR DESCRIPTION
These haven't needed to be Win32-only for a while now...