### PR TITLE
Remove particle applicators that cause linker errors

### DIFF
--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleApplicator.cpp
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleApplicator.cpp
@@ -120,18 +120,3 @@ void plParticleScaleMaxApplicator::IApply(const plAGModifier *mod, double time)
     IGetParticleGen(mod->GetTarget(0))->UpdateParam(plParticleUpdateMsg::kParamScaleMax,
                                                     chan->Value(time) / 100.f);
 }
-
-void plParticleGravityApplicator::IApply(const plAGModifier *mod, double time)
-{
-    plScalarChannel *chan = plScalarChannel::ConvertNoRef(fChannel);
-//  IGetParticleGen(mod->GetTarget(0))->UpdateParam(plParticleUpdateMsg::kParamParticlesPerSecond,
-//                                                  chan->Value(time));
-}
-
-void plParticleDragApplicator::IApply(const plAGModifier *mod, double time)
-{
-    plScalarChannel *chan = plScalarChannel::ConvertNoRef(fChannel);
-//  IGetParticleGen(mod->GetTarget(0))->UpdateParam(plParticleUpdateMsg::kParamParticlesPerSecond,
-//                                                  chan->Value(time));
-}
-

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleApplicator.h
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleApplicator.h
@@ -140,24 +140,4 @@ public:
     GETINTERFACE_ANY( plParticleScaleMaxApplicator, plAGApplicator );
 };
 
-class plParticleGravityApplicator : public plParticleApplicator
-{
-protected:
-    void IApply(const plAGModifier *mod, double time) override;
-
-public:
-    CLASSNAME_REGISTER( plParticleGravityApplicator );
-    GETINTERFACE_ANY( plParticleGravityApplicator, plAGApplicator );
-};
-
-class plParticleDragApplicator : public plParticleApplicator
-{
-protected:
-    void IApply(const plAGModifier *mod, double time) override;
-
-public:
-    CLASSNAME_REGISTER( plParticleDragApplicator );
-    GETINTERFACE_ANY( plParticleDragApplicator, plAGApplicator );
-};
-
 #endif

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleCreatable.h
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleCreatable.h
@@ -61,8 +61,6 @@ REGISTER_CREATABLE(plParticleScaleMaxApplicator);
 REGISTER_CREATABLE(plParticleScaleMinApplicator);
 REGISTER_CREATABLE(plParticleVelMaxApplicator);
 REGISTER_CREATABLE(plParticleVelMinApplicator);
-//REGISTER_CREATABLE(plParticleGravityApplicator);
-//REGISTER_CREATABLE(plParticleDragApplicator);
 
 #include "plParticleEffect.h"
 REGISTER_NONCREATABLE(plParticleCollisionEffect);


### PR DESCRIPTION
Neither plParticleGravityApplicator nor plParticleDragApplicator have class indexes that exist in the list of class indexes, and they are not registered as creatables. Most linkers seem to handle this fine by just removing the classes entirely since they are unused, but I've seen errors about the missing class indexes on a few systems.

Since they are unused and have no working implementation, let's just remove them to avoid any potential linking issues.