### PR TITLE
Minor fixes for GameMgr-based marker games

### DIFF
--- a/Scripts/Python/ki/xMarkerBrainCGZM.py
+++ b/Scripts/Python/ki/xMarkerBrainCGZM.py
@@ -220,7 +220,7 @@ class VaultCGZMGame(MarkerBrainVaultQuest, CGZMGame):
     def LoadFromVault(cls, mgr: MarkerGameManager) -> Optional[LegacyCGZMGame]:
         if cgzmChron := xMarkerGameUtils.FindNewStyleChronicle("CGZ-Mission"):
             try:
-                cgzmMission = int(cgzmChron.chronicleGetValue().strip())
+                cgzmMission = int(cgzmChron.getValue().strip())
             except ValueError:
                 cgzmMission = -1
             if cgzmMission != -1:

--- a/Scripts/Python/ki/xMarkerBrainQuest.py
+++ b/Scripts/Python/ki/xMarkerBrainQuest.py
@@ -400,14 +400,14 @@ class MarkerBrainVaultQuest(_MarkerGameBrainQuest):
         chron = xMarkerGameUtils.GetNewStyleCaptureChronicle(self.game_id)
         # The double generator is to filter out empty values that would cause int() to error.
         # This can happen under regular gameplay circumstances if the capture chronicle is empty.
-        value = filter(None, (i.strip() for i in chron.chronicleGetValue().split(',')))
+        value = filter(None, (i.strip() for i in chron.getValue().split(',')))
         return set((int(i) for i in value))
 
     @_capture_chronicle.setter
     def _capture_chronicle(self, value: Optional[Set[int]]) -> None:
         chron = xMarkerGameUtils.GetNewStyleCaptureChronicle(self.game_id)
         value = ','.join(map(str, value)) if value else ''
-        chron.chronicleSetValue(value)
+        chron.setValue(value)
 
     def _UpdateCaptureChronicle(self) -> None:
         self._capture_chronicle = self._captures

--- a/Scripts/Python/xMarkerGameUtils.py
+++ b/Scripts/Python/xMarkerGameUtils.py
@@ -74,7 +74,7 @@ class LegacyMarkerChronicle:
 def GetLegacyChronicle() -> LegacyMarkerChronicle:
     vault = ptVault()
     if chron := vault.findChronicleEntry(kLegacyChronicleName):
-        value = chron.chronicleGetValue().strip()
+        value = chron.getValue().strip()
         if not value:
             return LegacyMarkerChronicle()
         try:
@@ -129,7 +129,7 @@ def GetMarkerDataChronicle() -> ptVaultChronicleNode:
 def FindNewStyleChronicle(name: str, *, create: bool = False) -> Optional[ptVaultChronicleNode]:
     root = GetMarkerDataChronicle()
     searchTemplate = ptVaultChronicleNode()
-    searchTemplate.chronicleSetName(name)
+    searchTemplate.setName(name)
     if chron := root.findNode(searchTemplate):
         return chron.upcastToChronicleNode()
     if create:
@@ -141,7 +141,7 @@ def FindNewStyleChronicle(name: str, *, create: bool = False) -> Optional[ptVaul
 def GetNewStyleCaptureChronicle(name: str) -> ptVaultChronicleNode:
     questChron = FindNewStyleChronicle("Quest", create=True)
     captureTemplate = ptVaultChronicleNode()
-    captureTemplate.chronicleSetName(name)
+    captureTemplate.setName(name)
     if chron := questChron.findNode(captureTemplate):
         return chron.upcastToChronicleNode()
     questChron.addNode(captureTemplate)
@@ -149,12 +149,12 @@ def GetNewStyleCaptureChronicle(name: str) -> ptVaultChronicleNode:
 
 def GetNewStyleActiveQuest() -> Optional[int]:
     chron = GetMarkerDataChronicle()
-    if chron.chronicleGetValue() != "quest":
+    if chron.getValue() != "quest":
         PtDebugPrint("xMarkerGameUtils.GetNewStyleActiveQuest():\tMarkerBrain is not in quest mode", level=kDebugDumpLevel)
         return None
     if chron := FindNewStyleChronicle("ActiveQuest"):
         try:
-            value = int(chron.chronicleGetValue().strip())
+            value = int(chron.getValue().strip())
         except ValueError:
             PtDebugPrint("xMarkerGameUtils.GetNewStyleActiveQuest():\tActiveQuest chronicle contained nonsense.")
         else:
@@ -170,7 +170,7 @@ def SetNewStyleActiveQuest(name: Optional[str] = None) -> None:
     chron = GetMarkerDataChronicle()
     chron.setValue("quest" if name != "-1" else "")
     chron = FindNewStyleChronicle("ActiveQuest", create=True)
-    chron.chronicleSetValue(name)
+    chron.setValue(name)
 
 def GetCurrentTime() -> int:
     # No, your eyes do not deceive you. For some reason, the Cyan programmer who wrote the
@@ -189,7 +189,7 @@ def GetCurrentCGZM() -> int:
         return chron.CGZGameNum
     elif chron := FindNewStyleChronicle("CGZ-Mission"):
         try:
-            return int(chron.chronicleGetValue().strip())
+            return int(chron.getValue().strip())
         except ValueError:
             pass
     return -1
@@ -203,13 +203,13 @@ def SetCurrentCGZM(missionID: int) -> None:
         chron = GetMarkerDataChronicle()
         chron.setValue("quest" if missionID == -1 else "cgz")
         chron = FindNewStyleChronicle("CGZ-Mission", create=True)
-        chron.chronicleSetValue(str(missionID))
+        chron.setValue(str(missionID))
 
 def GetCGZMTimes(missionID: int, *, forceLegacy: bool = False) -> CGZMTimes:
     vault = ptVault()
     if forceLegacy or ptGmMarker.isSupported():
         if chron := vault.findChronicleEntry(f"MG{missionID+1:02}"):
-            data = filter(None, (i.strip() for i in chron.chronicleGetValue().split(",")))
+            data = filter(None, (i.strip() for i in chron.getValue().split(",")))
 
             # The legacy MOULa client stored these times as floats in the chronicle, but the game
             # returns whole seconds. Therefore, we're exposing ints. However, we have to manually
@@ -226,7 +226,7 @@ def GetCGZMTimes(missionID: int, *, forceLegacy: bool = False) -> CGZMTimes:
         # Only start times can be retrieved for now.
         if startTimeChron := FindNewStyleChronicle("CGZ-StartTime"):
             try:
-                startTime = int(startTimeChron.chronicleGetValue().strip())
+                startTime = int(startTimeChron.getValue().strip())
             except ValueError:
                 pass
             else:
@@ -260,7 +260,7 @@ def SetCGZMTimes(missionID: int, newTimes: CGZMTimes, *, legacyOnly: bool = Fals
             raise RuntimeError("Can only set the times for the current CGZM.")
         if newStartTimes is not None:
             startTimeChron = FindNewStyleChronicle("CGZ-StartTime", create=True)
-            startTimeChron.chronicleSetValue(str(newStartTimes))
+            startTimeChron.setValue(str(newStartTimes))
 
 def IsCGZMComplete() -> bool:
     missionID = GetCurrentCGZM()
@@ -273,6 +273,6 @@ def IsCGZMComplete() -> bool:
         return False
     else:
         chron = GetNewStyleCaptureChronicle("cgz")
-        caps = set(filter(None, (i.strip() for i in chron.chronicleGetValue().split(','))))
+        caps = set(filter(None, (i.strip() for i in chron.getValue().split(','))))
         return len(grtzMarkerGames.mgs[missionID]) <= len(caps)
 

--- a/Scripts/Python/xMarkerGameUtils.py
+++ b/Scripts/Python/xMarkerGameUtils.py
@@ -258,9 +258,9 @@ def SetCGZMTimes(missionID: int, newTimes: CGZMTimes, *, legacyOnly: bool = Fals
     if not legacyOnly and not ptGmMarker.isSupported():
         if not missionID != GetCurrentCGZM():
             raise RuntimeError("Can only set the times for the current CGZM.")
-        if newStartTimes is not None:
+        if newTimes.start_time is not None:
             startTimeChron = FindNewStyleChronicle("CGZ-StartTime", create=True)
-            startTimeChron.setValue(str(newStartTimes))
+            startTimeChron.setValue(str(newTimes.start_time))
 
 def IsCGZMComplete() -> bool:
     missionID = GetCurrentCGZM()

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -58,6 +58,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyMatrix44.h"
 #include "pyObjectRef.h"
 
+#include "pnNetBase/pnNetBase.h"
+
 // CPython specific init stuff
 #include <cpython/initconfig.h>
 #include <pylifecycle.h>
@@ -685,6 +687,11 @@ PYTHON_CLASS_CONVERT_FROM_IMPL(ptOutputRedirector, pyOutputRedirector)
 class pyErrorRedirector
 {
 private:
+    static constexpr char16_t kTracebackTruncatedMarker[5] = {u'[', u'.', u'.', u'.', u']'};
+    // Maximum length of a traceback chunk to still leave room for the truncation marker.
+    // Like kMaxTracebackLength, includes one char16_t extra for the zero terminator.
+    static constexpr unsigned int kTracebackChunkLength = kMaxTracebackLength - std::size(kTracebackTruncatedMarker);
+
     static bool fTypeCreated;
 
     ST::string_stream fData;
@@ -725,7 +732,20 @@ public:
 
         // Send to the log server
         ST::utf16_buffer wdata = fData.to_string().to_utf16();
-        NetCliAuthLogPythonTraceback(wdata.data());
+        if (wdata.size() < kMaxTracebackLength - 1) {
+            NetCliAuthLogPythonTraceback(wdata.data());
+        } else {
+            // The traceback is too long for a single LogPythonTraceback message,
+            // so split it up into multiple small messages
+            // and add a truncation marker at the end of every message but the last.
+            auto pos = wdata.begin();
+            for (; wdata.end() - pos >= kMaxTracebackLength - 1; pos += kTracebackChunkLength - 1) {
+                ST::utf16_buffer chunk = ST::utf16_buffer(pos, kMaxTracebackLength - 1);
+                memcpy(&chunk[kTracebackChunkLength - 1], kTracebackTruncatedMarker, sizeof(kTracebackTruncatedMarker));
+                NetCliAuthLogPythonTraceback(chunk.data());
+            }
+            NetCliAuthLogPythonTraceback(pos);
+        }
 
         if (fLog)
             fData.erase(SIZE_MAX);

--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbConst.h
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbConst.h
@@ -81,6 +81,7 @@ const unsigned kMaxPublisherAuthKeyLength       = 64;
 const unsigned kMaxGTOSIdLength                 = 8;
 const unsigned kMaxGameScoreNameLength          = 64;
 const unsigned kMaxEmailAddressLength           = 64;
+const unsigned kMaxTracebackLength              = 1024;
 
 /*****************************************************************************
 *

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
@@ -250,11 +250,11 @@ static const NetMsgField kClientSetCCRLevelFields[] = {
 };
 
 static const NetMsgField kLogPythonTracebackFields[] = {
-    NET_MSG_FIELD_STRING(1024),                 // traceback text
+    NET_MSG_FIELD_STRING(kMaxTracebackLength), // traceback text
 };
 
 static const NetMsgField kLogStackDumpFields[] = {
-    NET_MSG_FIELD_STRING(1024),                 // stackdump text
+    NET_MSG_FIELD_STRING(kMaxTracebackLength), // stackdump text
 };
 
 static const NetMsgField kLogClientDebuggerConnectFields[] = {

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -48,6 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plNetClientComm.h"
 
 #include <chrono>
+#include <string_view>
 #include <thread>
 
 #include "HeadSpin.h"
@@ -71,6 +72,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plVault/plVault.h"
 
 #include "pfMessage/pfKIMsg.h"
+
+using namespace std::literals::string_view_literals;
 
 extern  bool    gDataServerLocal;
 
@@ -1256,7 +1259,7 @@ void NetCommSendFriendInvite (
     );
 }
 
-static constexpr char16_t kTracebackTruncatedMarker[5] = {u'[', u'.', u'.', u'.', u']'};
+static constexpr std::u16string_view kTracebackTruncatedMarker = u"[...]"sv;
 // Maximum length of a traceback chunk to still leave room for the truncation marker.
 // Like kMaxTracebackLength, includes one char16_t extra for the zero terminator.
 static constexpr unsigned int kTracebackChunkLength = kMaxTracebackLength - std::size(kTracebackTruncatedMarker);
@@ -1276,7 +1279,7 @@ static void NetCommLogChunkedError(const ST::string& errorText)
         auto pos = wdata.begin();
         for (; wdata.end() - pos >= kMaxTracebackLength - 1; pos += kTracebackChunkLength - 1) {
             ST::utf16_buffer chunk = ST::utf16_buffer(pos, kMaxTracebackLength - 1);
-            memcpy(&chunk[kTracebackChunkLength - 1], kTracebackTruncatedMarker, sizeof(kTracebackTruncatedMarker));
+            kTracebackTruncatedMarker.copy(&chunk[kTracebackChunkLength - 1], kTracebackTruncatedMarker.size());
             logErrorFunc(chunk.data());
         }
         logErrorFunc(pos);

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.h
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.h
@@ -284,6 +284,8 @@ void NetCommSendFriendInvite (
     const ST::string& toName,
     const plUUID&     inviteUuid
 );
+void NetCommLogPythonTraceback(const ST::string& traceback);
+void NetCommLogStackDump(const ST::string& stackDump);
 
 #endif // PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETCLIENTCOMM_PLNETCLIENTCOMM_H
 


### PR DESCRIPTION
Fixes a few small errors in #1217 that I encountered during normal testing. (Haven't done any in-depth testing of marker or GameMgr stuff, so there may be other problems lurking still.)

One of the tracebacks was longer than the `LogPythonTraceback` network message formally allows (1023 characters), so I added a workaround for that as well.