### PR TITLE
Let zlib handle the gzip header instead of parsing it manually

### DIFF
--- a/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.cpp
@@ -89,178 +89,65 @@ uint32_t plZlibStream::Write(uint32_t byteCount, const void* buffer)
 {
     uint8_t* byteBuf = (uint8_t*)buffer;
 
-    // Check if we've read in the full gzip header yet
-    if (fHeader == kNeedMoreData)
-    {
-        int cutAmt = IValidateGzHeader(byteCount, buffer);
+    if (fErrorOccurred) {
+        return 0;
+    }
 
-        // Once we've read in the whole header, cut out whatever part of it is
-        // in this buffer, leaving raw compressed data
-        if (cutAmt != 0)
-        {
-            byteCount -= cutAmt;
-            byteBuf += cutAmt;
+    if (fZStream == nullptr) {
+        // Initialize the zlib stream
+        z_streamp zstream = new z_stream_s;
+        memset(zstream, 0, sizeof(z_stream_s));
+        zstream->zalloc = ZlibAlloc;
+        zstream->zfree = ZlibFree;
+        zstream->opaque = nullptr;
+        zstream->avail_in = byteCount;
+        zstream->next_in = byteBuf;
+        // windowBits = 31 means require a gzip header and window size 15.
+        bool initOk = (inflateInit2(zstream, 31) == Z_OK);
+        fZStream = zstream;
+
+        if (!initOk) {
+            hsAssert(0, "Zip init failed");
+            fErrorOccurred = true;
+            return 0;
         }
     }
 
-    if (fHeader == kInvalidHeader)
-        return 0;
+    ASSERT(fOutput);
+    ASSERT(fZStream);
+    z_streamp zstream = (z_streamp)fZStream;
+    zstream->avail_in = byteCount;
+    zstream->next_in = byteBuf;
 
-    if (fHeader == kValidHeader)
-    {
-        ASSERT(fOutput);
-        ASSERT(fZStream);
-        z_streamp zstream = (z_streamp)fZStream;
-        zstream->avail_in = byteCount;
-        zstream->next_in = byteBuf;
+    char outBuf[2048];
+    while (zstream->avail_in != 0) {
+        zstream->avail_out = sizeof(outBuf);
+        zstream->next_out = (uint8_t*)outBuf;
 
-        char outBuf[2048];
-        while (zstream->avail_in != 0)
-        {
-            zstream->avail_out = sizeof(outBuf);
-            zstream->next_out = (uint8_t*)outBuf;
+        uint32_t amtWritten = zstream->total_out;
 
-            uint32_t amtWritten = zstream->total_out;
+        int ret = inflate(zstream, Z_NO_FLUSH);
 
-            int ret = inflate(zstream, Z_NO_FLUSH);
+        bool inflateErr = (ret == Z_NEED_DICT || ret == Z_DATA_ERROR ||
+                            ret == Z_STREAM_ERROR || ret == Z_MEM_ERROR || ret == Z_BUF_ERROR);
+        // If we have a decompression error, just fail
+        if (inflateErr) {
+            hsAssert(!inflateErr, "Error in inflate");
+            fErrorOccurred = true;
+            break;
+        }
 
-            bool inflateErr = (ret == Z_NEED_DICT || ret == Z_DATA_ERROR ||
-                                ret == Z_STREAM_ERROR || ret == Z_MEM_ERROR || ret == Z_BUF_ERROR);
-            // If we have a decompression error, just fail
-            if (inflateErr)
-            {
-                hsAssert(!inflateErr, "Error in inflate");
-                fHeader = kInvalidHeader;
-                break;
-            }
+        amtWritten = zstream->total_out - amtWritten;
+        fOutput->Write(amtWritten, outBuf);
 
-            amtWritten = zstream->total_out - amtWritten;
-            fOutput->Write(amtWritten, outBuf);
-
-            // If zlib says we hit the end of the stream, ignore avail_in
-            if (ret == Z_STREAM_END)
-            {
-                fDecompressedOk = true;
-                break;
-            }
+        // If zlib says we hit the end of the stream, ignore avail_in
+        if (ret == Z_STREAM_END) {
+            fDecompressedOk = true;
+            break;
         }
     }
 
     return byteCount;
-}
-
-int plZlibStream::IValidateGzHeader(uint32_t byteCount, const void* buffer)
-{
-    // Ripped from gzio.cpp
-    #define HEAD_CRC     0x02
-    #define EXTRA_FIELD  0x04
-    #define ORIG_NAME    0x08
-    #define COMMENT      0x10
-    #define RESERVED     0xE0
-    static int gz_magic[2] = {0x1f, 0x8b}; // gzip magic header
-    
-    #define CheckForEnd() if (s.AtEnd()) { fHeader = kNeedMoreData; return 0; }
-
-    int i;
-
-    int initCacheSize = fHeaderCache.size();
-    for (i = 0; i < byteCount; i++)
-        fHeaderCache.push_back(((uint8_t*)buffer)[i]);
-    hsReadOnlyStream s(fHeaderCache.size(), &fHeaderCache[0]);
-    
-    // Check the gzip magic header
-    for (i = 0; i < 2; i++)
-    {
-        uint8_t c = s.ReadByte();
-        if (c != gz_magic[i])
-        {
-            CheckForEnd();
-            fHeader = kInvalidHeader;
-            return 0;
-        }
-    }
-    
-    int method = s.ReadByte();
-    int flags = s.ReadByte();
-    if (method != Z_DEFLATED || (flags & RESERVED) != 0)
-    {
-        CheckForEnd();
-        fHeader = kInvalidHeader;
-        return 0;
-    }
-    
-    // Discard time, xflags and OS code:
-    for (i = 0; i < 6; i++)
-        (void)s.ReadByte();
-    CheckForEnd();
-    
-    if ((flags & EXTRA_FIELD) != 0)
-    {
-        // skip the extra field
-        uint16_t len = s.ReadLE16();
-        while (len-- != 0 && s.ReadByte())
-        {
-            CheckForEnd();
-        }
-    }
-    
-    int c;
-
-    // skip the original file name
-    if ((flags & ORIG_NAME) != 0)
-    {
-        while ((c = s.ReadByte()) != 0)
-        {
-            CheckForEnd();
-        }
-    }
-    
-    // skip the .gz file comment
-    if ((flags & COMMENT) != 0)
-    {
-        while ((c = s.ReadByte()) != 0)
-        {
-            CheckForEnd();
-        }
-    }
-
-    // skip the header crc
-    if ((flags & HEAD_CRC) != 0)
-    {
-        (void)s.ReadLE16();
-        CheckForEnd();
-    }
-    
-    CheckForEnd();
-    
-    uint32_t headerSize = s.GetPosition();
-    uint32_t clipBuffer = headerSize - initCacheSize;
-    
-    // Initialize the zlib stream
-    z_streamp zstream = new z_stream_s;
-    memset(zstream, 0, sizeof(z_stream_s));
-    zstream->zalloc = ZlibAlloc;
-    zstream->zfree = ZlibFree;
-    zstream->opaque = nullptr;
-    zstream->avail_in = byteCount - clipBuffer;
-    zstream->next_in = (uint8_t*)&fHeaderCache[clipBuffer];
-    // Gotta use inflateInit2, because there's no header for zlib to look at.
-    // The -15 tells it to not try and find a header
-    bool initOk = (inflateInit2(zstream, -15) == Z_OK);
-    fZStream = zstream;
-
-    fHeaderCache.clear();
-
-    if (!initOk)
-    {
-        hsAssert(0, "Zip init failed");
-        fHeader = kInvalidHeader;
-        return 0;
-    }
-    ASSERT(fZStream);
-
-    fHeader = kValidHeader;
-    return clipBuffer;
 }
 
 bool plZlibStream::AtEnd()
@@ -285,7 +172,7 @@ void plZlibStream::Rewind()
     // hack so rewind will work (someone thought it would be funny to not implement base class functions)
     Close();
     Open(fFilename, fMode);
-    fHeader = kNeedMoreData;
+    fErrorOccurred = false;
     fDecompressedOk = false;
 }
 

--- a/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.h
+++ b/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.h
@@ -43,7 +43,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plZlibStream_h_inc
 
 #include "hsStream.h"
-#include <string>
 
 //
 // This is for reading a .gz file from a buffer, and writing the uncompressed data to a file.
@@ -54,20 +53,15 @@ class plZlibStream : public hsStream
 protected:
     hsStream* fOutput;
     void* fZStream;
+    bool fErrorOccurred;
     bool fDecompressedOk;
-
-    enum Validate { kNeedMoreData, kInvalidHeader, kValidHeader };
-    Validate fHeader;
-    std::vector<uint8_t> fHeaderCache;
 
     // needed for rewind function
     plFileName fFilename;
     const char* fMode;
 
-    int IValidateGzHeader(uint32_t byteCount, const void* buffer);
-
 public:
-    plZlibStream() : fOutput(), fZStream(), fHeader(kNeedMoreData), fDecompressedOk(), fMode() { }
+    plZlibStream() : fOutput(), fZStream(), fErrorOccurred(), fDecompressedOk(), fMode() { }
     virtual ~plZlibStream();
 
     bool     Open(const plFileName& filename, const char* mode) override;


### PR DESCRIPTION
For some reason, the code in `IValidateGzHeader` was copied from zlib, when they could have just used it through the API... (Perhaps this is *really* old code from before the main zlib API had gzip support?)