### PR TITLE
`ptGUIControl` construction improvement.

### DIFF
--- a/Scripts/Python/clftYeeshaPage08.py
+++ b/Scripts/Python/clftYeeshaPage08.py
@@ -179,13 +179,13 @@ class clftYeeshaPage08(ptModifier):
 
             for x in kYeeshaPage:
                 try:
-                    ctrl = mydialog.getControlFromTag(x)
+                    ctrl = mydialog.getControlModFromTag(x)
                 except KeyError:
                     continue
                 else:
-                    ptGUIControlButton(ctrl).hide()
+                    ctrl.hide()
 
-            ptGUIControlButton(mydialog.getControlFromTag(kYeeshaPage[8])).show()
+            mydialog.getControlModFromTag(kYeeshaPage[8]).show()
 
             GUIDialogObject.value.draw.disable()
 

--- a/Scripts/Python/ercaOvenScope.py
+++ b/Scripts/Python/ercaOvenScope.py
@@ -414,12 +414,12 @@ class ercaOvenScope(ptModifier):
         if event == kDialogLoaded:
             if WasPowered == 0:
                 return
-            timeSlider = ptGUIControlKnob(control.getControlFromTag(kTimeSlider))
-            amountSlider = ptGUIControlKnob(control.getControlFromTag(kAmountSlider))            
-            tempSlider = ptGUIControlKnob(control.getControlFromTag(kTempSlider))
-            bakeBtn = ptGUIControlButton(control.getControlFromTag(kBakeBtn))
-            timerWheel = ptGUIControlProgress(control.getControlFromTag(kTimerWheel))
-            tempWheel = ptGUIControlProgress(control.getControlFromTag(kTempWheel))
+            timeSlider = control.getControlModFromTag(kTimeSlider)
+            amountSlider = control.getControlModFromTag(kAmountSlider)
+            tempSlider = control.getControlModFromTag(kTempSlider)
+            bakeBtn = control.getControlModFromTag(kBakeBtn)
+            timerWheel = control.getControlModFromTag(kTimerWheel)
+            tempWheel = control.getControlModFromTag(kTempWheel)
         
         elif event == kShowHide:
             if WasPowered == 0:

--- a/Scripts/Python/grtzMarkerScopeGUI.py
+++ b/Scripts/Python/grtzMarkerScopeGUI.py
@@ -218,7 +218,7 @@ class grtzMarkerScopeGUI(ptModifier):
         elif event == kValueChanged and self._lookingAtGUI:
             rgid = control.getTagID()
             if rgid == kRGMarkerGameSelect:
-                gameSelector = ptGUIControlRadioGroup(MarkerGameDlg.dialog.getControlFromTag(kRGMarkerGameSelect))
+                gameSelector = MarkerGameDlg.dialog.getControlModFromTag(kRGMarkerGameSelect)
                 mission = gameSelector.getValue()
                 if mission == -1:
                     self._StopCGZM(win=False)
@@ -279,7 +279,7 @@ class grtzMarkerScopeGUI(ptModifier):
 
     def _ShowGUI(self):
         MGMachineOnResp.run(self.key, netPropagate=False)
-        gameSelector = ptGUIControlRadioGroup(MarkerGameDlg.dialog.getControlFromTag(kRGMarkerGameSelect))
+        gameSelector = MarkerGameDlg.dialog.getControlModFromTag(kRGMarkerGameSelect)
         if PtDetermineKIMarkerLevel() < kKIMarkerNormalLevel:
             PtDebugPrint("grtzMarkerScopeGUI._ShowGUI():\tKI Level not high enough, disabling GUI controls", level=kWarningLevel)
             gameSelector.setValue(-1)
@@ -316,7 +316,7 @@ class grtzMarkerScopeGUI(ptModifier):
         PtSendKIMessageInt(kMGStopCGZGame, -1)
 
         # Update UI
-        gameSelector = ptGUIControlRadioGroup(MarkerGameDlg.dialog.getControlFromTag(kRGMarkerGameSelect))
+        gameSelector = MarkerGameDlg.dialog.getControlModFromTag(kRGMarkerGameSelect)
         gameSelector.setValue(-1)
 
     def _UpdateGUI(self, mission=-1, quitting=False, score=None, star=None):
@@ -364,9 +364,9 @@ class grtzMarkerScopeGUI(ptModifier):
 
         # Now do the deed
         fieldID = (mission * 10) + kMarkerGameFieldStart
-        numTB = ptGUIControlTextBox(MarkerGameDlg.dialog.getControlFromTag(fieldID + kMarkerGameNumFieldOffset))
+        numTB = MarkerGameDlg.dialog.getControlModFromTag(fieldID + kMarkerGameNumFieldOffset)
         numTB.setString(str(len(grtzMarkerGames.mgs[mission])))
-        timeTB = ptGUIControlTextBox(MarkerGameDlg.dialog.getControlFromTag(fieldID + kMarkerGameNameFieldOffset))
+        timeTB = MarkerGameDlg.dialog.getControlModFromTag(fieldID + kMarkerGameNameFieldOffset)
         timeTB.setString(msg)
 
     def _UpdateScore(self, mission: int, points: int) -> None:

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -126,7 +126,7 @@ class xKIChat(object):
     def ClearBBMini(self, value=-1):
 
         if self.KILevel == kNormalKI:
-            mmRG = ptGUIControlRadioGroup(KIBlackbar.dialog.getControlFromTag(kGUI.MiniMaximizeRGID))
+            mmRG = KIBlackbar.dialog.getControlModFromTag(kGUI.MiniMaximizeRGID)
             mmRG.setValue(value)
 
     ## Check if the chat is faded out.
@@ -167,8 +167,8 @@ class xKIChat(object):
             KIMicro.dialog.show()
         else:
             mKIdialog = KIMini.dialog
-        caret = ptGUIControlTextBox(mKIdialog.getControlFromTag(kGUI.ChatCaretID))
-        chatEdit = ptGUIControlEditBox(mKIdialog.getControlFromTag(kGUI.ChatEditboxID))
+        caret = mKIdialog.getControlModFromTag(kGUI.ChatCaretID)
+        chatEdit = mKIdialog.getControlModFromTag(kGUI.ChatEditboxID)
         if entering:
             self.isChatting = True
             if not KIMini.dialog.isEnabled():
@@ -221,7 +221,7 @@ class xKIChat(object):
         msg = message.casefold()
 
         # Get any selected players.
-        userListBox = ptGUIControlListBox(KIMini.dialog.getControlFromTag(kGUI.PlayerList))
+        userListBox = KIMini.dialog.getControlModFromTag(kGUI.PlayerList)
         iSelect = userListBox.getSelection()
         selPlyrList = []
 
@@ -1028,9 +1028,9 @@ class CommandsProcessor:
 
                         # If remaining message is empty, try to do mousefree KI folder selection instead
                         if remainingMsg == "" or remainingMsg.isspace():
-                            userListBox = ptGUIControlListBox(KIMini.dialog.getControlFromTag(kGUI.PlayerList))
-                            caret = ptGUIControlTextBox(KIMini.dialog.getControlFromTag(kGUI.ChatCaretID))
-                            privateChbox = ptGUIControlCheckBox(KIMini.dialog.getControlFromTag(kGUI.miniPrivateToggle))
+                            userListBox = KIMini.dialog.getControlModFromTag(kGUI.PlayerList)
+                            caret = KIMini.dialog.getControlModFromTag(kGUI.ChatCaretID)
+                            privateChbox = KIMini.dialog.getControlModFromTag(kGUI.miniPrivateToggle)
 
                             # Handling for selecting Age Players, Buddies, or Neighbors
                             folderName = None

--- a/Scripts/Python/nxusBookMachine.py
+++ b/Scripts/Python/nxusBookMachine.py
@@ -995,17 +995,17 @@ class nxusBookMachine(ptModifier):
                     self.ISetDescriptionText(self.currentStatusBarText, False)
 
     def IShowEnableButton(self, controlId):
-        btn = ptGUIControlButton(NexusGUI.dialog.getControlFromTag(controlId))
+        btn = NexusGUI.dialog.getControlModFromTag(controlId)
         btn.show()
         btn.enable()
 
     def IHideDisableButton(self, controlId):
-        btn = ptGUIControlButton(NexusGUI.dialog.getControlFromTag(controlId))
+        btn = NexusGUI.dialog.getControlModFromTag(controlId)
         btn.hide()
         btn.disable()
 
     def ISetDescriptionText(self, description, permanent = True):
-        descrTxt = ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDTxtLinkDescription))
+        descrTxt = NexusGUI.dialog.getControlModFromTag(kIDTxtLinkDescription)
         descrTxt.setString(description)
         if permanent:
             self.currentStatusBarText = description
@@ -1016,14 +1016,14 @@ class nxusBookMachine(ptModifier):
         if oldSelection is not None:
             btnId = oldSelection
             txtId = oldSelection + 1
-            ptGUIControlButton(NexusGUI.dialog.getControlFromTag(btnId)).enable()
-            ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(txtId)).setForeColor(colorNormal)
+            NexusGUI.dialog.getControlModFromTag(btnId).enable()
+            NexusGUI.dialog.getControlModFromTag(txtId).setForeColor(colorNormal)
 
         #disable and highlight new entry
         btnId = newSelection
         txtId = newSelection + 1
-        ptGUIControlButton(NexusGUI.dialog.getControlFromTag(btnId)).disable()
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(txtId)).setForeColor(colorSelected)
+        NexusGUI.dialog.getControlModFromTag(btnId).disable()
+        NexusGUI.dialog.getControlModFromTag(txtId).setForeColor(colorSelected)
         
         self.ISetDescriptionText(description)
 
@@ -1064,9 +1064,9 @@ class nxusBookMachine(ptModifier):
         # set color of name and info
 
         if self.idLinkSelected == idButton or not linkEntry.isEnabled:
-            ptGUIControlButton(NexusGUI.dialog.getControlFromTag(idButton)).disable()
+            NexusGUI.dialog.getControlModFromTag(idButton).disable()
         else:
-            ptGUIControlButton(NexusGUI.dialog.getControlFromTag(idButton)).enable()
+            NexusGUI.dialog.getControlModFromTag(idButton).enable()
 
         if self.idLinkSelected == idButton:
             self.ISetDescriptionText(linkEntry.description)
@@ -1078,11 +1078,11 @@ class nxusBookMachine(ptModifier):
 
         color = self.IGetControlColor(idButton, linkEntry.isEnabled)
 
-        txtName = ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(idTxtName))
+        txtName = NexusGUI.dialog.getControlModFromTag(idTxtName)
         txtName.setForeColor(color)
         txtName.setString(displayName)
 
-        txtInfo = ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(idTxtInfo))
+        txtInfo = NexusGUI.dialog.getControlModFromTag(idTxtInfo)
         txtInfo.setForeColor(color)
         txtInfo.setString(linkEntry.displayInfo)
 
@@ -1093,16 +1093,16 @@ class nxusBookMachine(ptModifier):
             self.IHideDisableButton(idButton)
 
     def IDisableLanguageControls(self):
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDEngText)).setString("")
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDFreText)).setString("")
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDGerText)).setString("")
+        getControl = NexusGUI.dialog.getControlModFromTag
+        for id in (kIDEngText, kIDFreText, kIDGerText):
+            getControl(id).setString("")
         for id in kLanguageControls.keys():
-            ptGUIControlButton(NexusGUI.dialog.getControlFromTag(id)).hide()
+            getControl(id).hide()
 
     def IToggleSortControls(self, enabled):
         active = kSortControlId.get(self.publicHoodSort)
         for id in kSortControlId.values():
-            control = ptGUIControlButton(NexusGUI.dialog.getControlFromTag(id))
+            control = NexusGUI.dialog.getControlModFromTag(id)
             if enabled and id == active:
                 control.show()
                 control.enable()
@@ -1120,35 +1120,35 @@ class nxusBookMachine(ptModifier):
 
     def IClearGUI(self):
         # clear header titles and disable their buttons
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDNameHeaderText)).setString("")
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDPopHeaderText)).setString("")
-        ptGUIControlButton(NexusGUI.dialog.getControlFromTag(kIDNameHeaderBtn)).disable()
-        ptGUIControlButton(NexusGUI.dialog.getControlFromTag(kIDPopHeaderBtn)).disable()
+        NexusGUI.dialog.getControlModFromTag(kIDNameHeaderText).setString("")
+        NexusGUI.dialog.getControlModFromTag(kIDPopHeaderText).setString("")
+        NexusGUI.dialog.getControlModFromTag(kIDNameHeaderBtn).disable()
+        NexusGUI.dialog.getControlModFromTag(kIDPopHeaderBtn).disable()
 
         self.IDisableLanguageControls()
         self.IClearEntryList()
         self.IToggleSortControls(False)
 
         # hide create hood button
-        ptGUIControlButton(NexusGUI.dialog.getControlFromTag(kIDBtnNeighborhoodCreate)).hide()
+        NexusGUI.dialog.getControlModFromTag(kIDBtnNeighborhoodCreate).hide()
 
-        ptGUIControlButton(NexusGUI.dialog.getControlFromTag(kIDBtnNeighborhoodPublic)).disable()
-        ptGUIControlButton(NexusGUI.dialog.getControlFromTag(kIDBtnNeighborhoodPublic)).hide()
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDTxtNeighborhoodPublic)).setString("")
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDBtnNeighborhoodSelect)).setNotifyOnInteresting(1)
+        NexusGUI.dialog.getControlModFromTag(kIDBtnNeighborhoodPublic).disable()
+        NexusGUI.dialog.getControlModFromTag(kIDBtnNeighborhoodPublic).hide()
+        NexusGUI.dialog.getControlModFromTag(kIDTxtNeighborhoodPublic).setString("")
+        NexusGUI.dialog.getControlModFromTag(kIDBtnNeighborhoodSelect).setNotifyOnInteresting(1)
 
         self.ISetDescriptionText("")
 
         #highlight selected category
         for (txtId, btnId) in kGUICategoryControls:
-            btn = ptGUIControlButton(NexusGUI.dialog.getControlFromTag(btnId))
+            btn = NexusGUI.dialog.getControlModFromTag(btnId)
             if self.idCategorySelected == btnId:
                 color = colorSelected
                 btn.disable()
             else:
                 color = colorNormal
                 btn.enable()
-            ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(txtId)).setForeColor(color)
+            NexusGUI.dialog.getControlModFromTag(txtId).setForeColor(color)
 
     def IClearEntryList(self):
         #reset scrolling
@@ -1164,10 +1164,10 @@ class nxusBookMachine(ptModifier):
                 del self.controlIdToAgeEntry[btnSelectId]
             except KeyError:
                 pass
-            ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(txtNameId)).setString("")
-            ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(txtInfoId)).setString("")
+            NexusGUI.dialog.getControlModFromTag(txtNameId).setString("")
+            NexusGUI.dialog.getControlModFromTag(txtInfoId).setString("")
 
-            ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(btnSelectId)).setNotifyOnInteresting(1)
+            NexusGUI.dialog.getControlModFromTag(btnSelectId).setNotifyOnInteresting(1)
 
             self.IHideDisableButton(btnSelectId)
             self.IHideDisableButton(btnDeleteId)
@@ -1460,8 +1460,8 @@ class nxusBookMachine(ptModifier):
         self.IHideDisableButton(kIDBtnNeighborhoodPublic)
         self.IHideDisableButton(kIDBtnNeighborhoodSelect)
 
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDTxtNeighborhoodName)).setString("")
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDTxtNeighborhoodInfo)).setString("")
+        NexusGUI.dialog.getControlModFromTag(kIDTxtNeighborhoodName).setString("")
+        NexusGUI.dialog.getControlModFromTag(kIDTxtNeighborhoodInfo).setString("")
         self.ISetDescriptionText("")
 
     def IUpdateHoodLink(self):
@@ -1491,20 +1491,20 @@ class nxusBookMachine(ptModifier):
             hoodPubPriv = PtGetLocalizedString("Nexus.Neighborhood.MakePrivate")
         else:
             hoodPubPriv = PtGetLocalizedString("Nexus.Neighborhood.MakePublic")
-        ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDTxtNeighborhoodPublic)).setString(hoodPubPriv)
+        NexusGUI.dialog.getControlModFromTag(kIDTxtNeighborhoodPublic).setString(hoodPubPriv)
 
     def IUpdateGUILinkList(self):
         if self.idCategorySelected == kCategoryPublic:
-            ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDNameHeaderText)).setString(PtGetLocalizedString("Nexus.Headers.Name"))
-            ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDPopHeaderText)).setString(PtGetLocalizedString("Nexus.Headers.Population"))
+            NexusGUI.dialog.getControlModFromTag(kIDNameHeaderText).setString(PtGetLocalizedString("Nexus.Headers.Name"))
+            NexusGUI.dialog.getControlModFromTag(kIDPopHeaderText).setString(PtGetLocalizedString("Nexus.Headers.Population"))
             # show our header sorting buttons
             self.IShowEnableButton(kIDNameHeaderBtn)
             self.IShowEnableButton(kIDPopHeaderBtn)
             #show current sort direction
             self.IToggleSortControls(True)
         else:
-            ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDNameHeaderText)).setString("")
-            ptGUIControlTextBox(NexusGUI.dialog.getControlFromTag(kIDPopHeaderText)).setString("")
+            NexusGUI.dialog.getControlModFromTag(kIDNameHeaderText).setString("")
+            NexusGUI.dialog.getControlModFromTag(kIDPopHeaderText).setString("")
             self.IToggleSortControls(False)
 
         ageList = self.categoryLinksList[self.idCategorySelected]

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -5014,9 +5014,17 @@ class ptGUIDialog:
         """Returns the ptKey of the control with the specified index (not tag ID!)"""
         pass
 
+    def getControlModFromIndex(self, index: int) -> ptGUIControl:
+        """Returns the ptGUIControl with the specified index (not tag ID!)"""
+        ...
+
     def getControlFromTag(self,tagID):
         """Returns the ptKey of the control with the specified tag ID"""
         pass
+
+    def getControlModFromTag(self, tagID: int) -> ptGUIControl:
+        """Returns the GUI control with the specified tag ID"""
+        ...
 
     def getFontSize(self):
         """Returns the font size"""

--- a/Scripts/Python/tldnPwrTwrPeriscope.py
+++ b/Scripts/Python/tldnPwrTwrPeriscope.py
@@ -277,7 +277,7 @@ class tldnPwrTwrPeriscope(ptResponder):
                     
                     if boolScopeOperator:
                         GUIDialog = PtGetDialogFromString(Vignette.value)
-                        GUICbxBlocker = ptGUIControlCheckBox(GUIDialog.getControlFromTag(kGUIBlocker))
+                        GUICbxBlocker = GUIDialog.getControlModFromTag(kGUIBlocker)
                         GUICbxBlocker.setChecked(kScopeClear)
                         GUIDialog.refreshAllControls()
                 else:
@@ -291,7 +291,7 @@ class tldnPwrTwrPeriscope(ptResponder):
                     
                     if boolScopeOperator:
                         GUIDialog = PtGetDialogFromString(Vignette.value)
-                        GUICbxBlocker = ptGUIControlCheckBox(GUIDialog.getControlFromTag(kGUIBlocker))                    
+                        GUICbxBlocker = GUIDialog.getControlModFromTag(kGUIBlocker)
                         GUICbxBlocker.setChecked(kScopeBlocked)
                         GUIDialog.refreshAllControls()
                     if boolPwrMain and not boolTwrRaised: # power on, tower being lowered
@@ -412,7 +412,7 @@ class tldnPwrTwrPeriscope(ptResponder):
                 PtDebugPrint("tldnPwrTwrPeriscope.OnNotify:\twrote SDL - scope operator id = %d" % (avID))
                 PtDebugPrint("tldnPwrTwrPeriscope.OnNotify:\tSDL OperatorID = %d" % (self.SDL["OperatorID"]))
                 GUIDialog = PtGetDialogFromString(Vignette.value)
-                GUICbxBlocker = ptGUIControlCheckBox(GUIDialog.getControlFromTag(kGUIBlocker))
+                GUICbxBlocker = GUIDialog.getControlModFromTag(kGUIBlocker)
                 if boolTwrRaised:
                     GUICbxBlocker.setChecked(kScopeClear)
                 else:

--- a/Scripts/Python/tldnVaporScope.py
+++ b/Scripts/Python/tldnVaporScope.py
@@ -215,7 +215,7 @@ class tldnVaporScope(ptModifier):
                 # get the FOV and set the Zoom slider
                 curCam = ptCamera()
                 gInitialFOV = curCam.getFOV()
-                zoomSlider = ptGUIControlKnob(control.getControlFromTag(kZoomSlider))
+                zoomSlider = control.getControlModFromTag(kZoomSlider)
                 if gInitialFOV > kMinFOV:
                     gInitialFOV = kMinFOV
                 elif gInitialFOV < kMaxFOV:
@@ -279,7 +279,7 @@ class tldnVaporScope(ptModifier):
                         PtDebugPrint("tldnVaporScope:GUINotify Shoot vapor",level=kDebugDumpLevel)
                         respShootGun.run(self.key)
                         ####-# reset the slider back to initialFOV, cause the animation of the scope will set it back
-                        ####-zoomSlider = ptGUIControlKnob(control.getOwnerDialog().getControlFromTag(kZoomSlider))
+                        ####-zoomSlider = control.getOwnerDialog().getControlModFromTag(kZoomSlider)
                         ####-zsliderValue = (gInitialFOV-kMaxFOV)/kDegreesPerSlider
                         ####-zoomSlider.setValue(zsliderValue)
                         # need to see if we hit anything and run their responder
@@ -290,7 +290,7 @@ class tldnVaporScope(ptModifier):
                                 scopeDlg = PtGetDialogFromString(Vignette.value)
                                 if scopeDlg:
                                     try:
-                                        fireBtn = ptGUIControlButton(scopeDlg.getControlFromTag(kFireScopeBtn))
+                                        fireBtn = scopeDlg.getControlModFromTag(kFireScopeBtn)
                                         fireBtn.disable()
                                     except KeyError:
                                         PtDebugPrint("tldnVaporScope:GUINotify can't find the fire button",level=kDebugDumpLevel)
@@ -417,7 +417,7 @@ class tldnVaporScope(ptModifier):
                     scopeDlg = PtGetDialogFromString(Vignette.value)
                     if scopeDlg:
                         try:
-                            fireBtn = ptGUIControlButton(scopeDlg.getControlFromTag(kFireScopeBtn))
+                            fireBtn = scopeDlg.getControlModFromTag(kFireScopeBtn)
                             fireBtn.enable()
                         except KeyError:
                             PtDebugPrint("tldnVaporScope:Timer can't find the fire button",level=kDebugDumpLevel)

--- a/Scripts/Python/xAvatarCustomization.py
+++ b/Scripts/Python/xAvatarCustomization.py
@@ -640,7 +640,7 @@ class xAvatarCustomization(ptModifier):
         "Activated... we just landed in the AvaCusta Age"
         if state and id == InRoomActivator.id:
             ZoomResponder.run(self.key, state="ZoomOut")
-            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarCameraID)).disable()
+            AvCustGUI.dialog.getControlModFromTag(kAvatarCameraID).disable()
             TestMap.textmap.clearToColor(ptColor(0.92,0.82,0.63,1))
             TestMap.textmap.flush()
             # disable the KI until further notice
@@ -652,7 +652,7 @@ class xAvatarCustomization(ptModifier):
             # callback from the reset confirmation dialog box
             if state:
                 self.dirty = 0 # we are resetting the avatar, so hide the reset button
-                ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarResetID)).hide()
+                AvCustGUI.dialog.getControlModFromTag(kAvatarResetID).hide()
                 self.IResetAvatar()
 
     def OnGUINotify(self,id,control,event):
@@ -678,7 +678,7 @@ class xAvatarCustomization(ptModifier):
                 # is it one of the knobbies?
                 if isinstance(control,ptGUIControlValue):
                     self.dirty = 1 # we changed something! so show the "reset" button
-                    ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarResetID)).show()
+                    AvCustGUI.dialog.getControlModFromTag(kAvatarResetID).show()
                     if tagID >= kMorphSliderOffset and tagID < kMorphSliderOffset+kNumberOfMorphs:
                         # it is a morph slider
                         self.IMorphItem(tagID)
@@ -686,12 +686,12 @@ class xAvatarCustomization(ptModifier):
                         self.ITexMorphItem(tagID)
                 elif isinstance(control,ptGUIControlClickMap):
                     self.dirty = 1 # we changed something! so show the "reset" button
-                    ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarResetID)).show()
+                    AvCustGUI.dialog.getControlModFromTag(kAvatarResetID).show()
                     self.IColorShowingItem(tagID)
                 # is it one of the list boxes, probably one of the clothing listboxes
                 elif isinstance(control,ptGUIControlListBox):
                     self.dirty = 1 # we changed something! so show the "reset" button
-                    ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarResetID)).show()
+                    AvCustGUI.dialog.getControlModFromTag(kAvatarResetID).show()
                     # find the clothing group they are working with
                     clothing_group = TheCloset[tagID]
                     if tagID == kUpperBodyOptionsLB or tagID == kLwrBodyOptionsLB:
@@ -710,7 +710,7 @@ class xAvatarCustomization(ptModifier):
                             listboxDict[tagID + kAccessoryLBOffset].SelectItem(0) # select the first texture option
                             listboxDict[tagID + kAccessoryLBOffset].UpdateScrollArrows()
                             listboxDict[tagID + kAccessoryLBOffset].UpdateListbox()
-                            listbox = ptGUIControlListBox(AvCustGUI.dialog.getControlFromTag(tagID+kAccessoryLBOffset))
+                            listbox = AvCustGUI.dialog.getControlModFromTag(tagID+kAccessoryLBOffset)
                             self.OnGUINotify(AvCustGUI.id, listbox, kValueChanged) # fake a mouse down
                     elif clothing_group is not None:
                         # found list box
@@ -729,7 +729,7 @@ class xAvatarCustomization(ptModifier):
 
                             if newitem.isClothingSet:
                                 self.IWearClothingSet(newitem.clothingSet)
-                                descbox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kClothingDesc))
+                                descbox = AvCustGUI.dialog.getControlModFromTag(kClothingDesc)
                                 descbox.setString(newitem.description)
                                 return None
                             # get the current worn item to see what color it was
@@ -755,10 +755,10 @@ class xAvatarCustomization(ptModifier):
                             avatar.avatar.tintClothingItemLayer(newitem.name,lastcolor2,2)
                             self.IMorphOneItem(kWeightKnob,newitem.name) # propigate the weight morph to the new clothing item
                             # then set the description box
-                            descbox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kClothingDesc))
+                            descbox = AvCustGUI.dialog.getControlModFromTag(kClothingDesc)
                             descbox.setString(newitem.description)
                             # set up the color pickers
-                            colorbar1 = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName1))
+                            colorbar1 = pAvCustGUI.dialog.getControlModFromTag(kColorbarName1)
                             if newitem.colorlabel1 == "":
                                 self.IHideColorPicker(kColor1ClickMap)
                             else:
@@ -768,7 +768,7 @@ class xAvatarCustomization(ptModifier):
                                     self.IDrawPickerThingy(kHairClickMap,lastcolor1)
                                 else:
                                     self.IDrawPickerThingy(kColor1ClickMap,lastcolor1)
-                            colorbar2 = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName2))
+                            colorbar2 = AvCustGUI.dialog.getControlModFromTag(kColorbarName2)
                             if newitem.colorlabel2 == "":
                                 self.IHideColorPicker(kColor2ClickMap)
                             else:
@@ -800,7 +800,7 @@ class xAvatarCustomization(ptModifier):
 
                                     if newitem.isClothingSet:
                                         self.IWearClothingSet(newitem.clothingSet)
-                                        descbox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kClothingDesc))
+                                        descbox = AvCustGUI.dialog.getControlModFromTag(kClothingDesc)
                                         descbox.setString(newitem.description)
                                         return None
                                     avatar = PtGetLocalAvatar()
@@ -819,17 +819,17 @@ class xAvatarCustomization(ptModifier):
                                     avatar.avatar.tintClothingItemLayer(newitem.name,lastcolor2,2)
                                     self.IMorphOneItem(kWeightKnob,newitem.name) # propigate the weight morph to the new clothing item
                                     # then set the description box
-                                    descbox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kClothingDesc))
+                                    descbox = AvCustGUI.dialog.getControlModFromTag(kClothingDesc)
                                     descbox.setString(newitem.description)
                                     # set up the color pickers
-                                    colorbar1 = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName1))
+                                    colorbar1 = AvCustGUI.dialog.getControlModFromTag(kColorbarName1)
                                     if newitem.colorlabel1 == "":
                                         self.IHideColorPicker(kColor1ClickMap)
                                     else:
                                         self.IShowColorPicker(kColor1ClickMap)
                                         colorbar1.setString(newitem.colorlabel1)
                                         self.IDrawPickerThingy(kColor1ClickMap,lastcolor1)
-                                    colorbar2 = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName2))
+                                    colorbar2 = AvCustGUI.dialog.getControlModFromTag(kColorbarName2)
                                     if newitem.colorlabel2 == "":
                                         self.IHideColorPicker(kColor2ClickMap)
                                     else:
@@ -852,7 +852,7 @@ class xAvatarCustomization(ptModifier):
 
                                 if newitem.isClothingSet:
                                     self.IWearClothingSet(newitem.clothingSet)
-                                    descbox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kClothingDesc))
+                                    descbox = AvCustGUI.dialog.getControlModFromTag(kClothingDesc)
                                     descbox.setString(newitem.description)
                                     return None
                                 avatar = PtGetLocalAvatar()
@@ -877,7 +877,7 @@ class xAvatarCustomization(ptModifier):
                                         # if this is a head accessory, we can tint it, so restore last tint
                                         if tagID == kHeadAccLB and not (newitem.name in untintableHeadAcc):
                                             self.IShowColorPicker(kColor2ClickMap)
-                                            colorbar2 = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName2))
+                                            colorbar2 = AvCustGUI.dialog.getControlModFromTag(kColorbarName2)
                                             colorbar2.setString(GetItemName("Glasses"))
                                             if not lastitem == "":
                                                 lastcolor = avatar.avatar.getTintClothingItem(lastitem,1)
@@ -895,12 +895,12 @@ class xAvatarCustomization(ptModifier):
                                         self.IHideColorPicker(kColor2ClickMap)
                 elif isinstance(control,ptGUIControlRadioGroup):
                     if tagID == kPanelsRGID:
-                        panelRG = ptGUIControlRadioGroup(AvCustGUI.dialog.getControlFromTag(kPanelsRGID))
+                        panelRG = AvCustGUI.dialog.getControlModFromTag(kPanelsRGID)
                         rgVal = panelRG.getValue()
-                        zoomBtn = ptGUIControlCheckBox(AvCustGUI.dialog.getControlFromTag(kZoomButton))
+                        zoomBtn = AvCustGUI.dialog.getControlModFromTag(kZoomButton)
                         if rgVal == 1:
                             ZoomResponder.run(self.key, state="ZoomIn")
-                            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarCameraID)).enable()
+                            AvCustGUI.dialog.getControlModFromTag(kAvatarCameraID).enable()
                             # enable the zoom button
                             zoomBtn.show()
                             # zoom in on face automatically
@@ -911,7 +911,7 @@ class xAvatarCustomization(ptModifier):
                         else:
                             zoomBtn.hide()
                         # unset the description box
-                        descbox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kClothingDesc))
+                        descbox = AvCustGUI.dialog.getControlModFromTag(kClothingDesc)
                         descbox.setString("")
                         self.ISetStandardControls()
                 elif isinstance(control,ptGUIControlButton):
@@ -996,7 +996,7 @@ class xAvatarCustomization(ptModifier):
                         # and ask if they want to quit (KI will quit if they answer yes)
                         PtSendKIMessage(kQuitDialog,0)
                     elif IsAccArrow(btnID):
-                        panelRG = ptGUIControlRadioGroup(AvCustGUI.dialog.getControlFromTag(kPanelsRGID))
+                        panelRG = AvCustGUI.dialog.getControlModFromTag(kPanelsRGID)
                         rgVal = panelRG.getValue()
                         listboxID = panelAccListboxOffset + rgVal
                         if IsLeftArrow(btnID):
@@ -1006,7 +1006,7 @@ class xAvatarCustomization(ptModifier):
                         listboxDict[listboxID].UpdateScrollArrows()
                         listboxDict[listboxID].UpdateListbox()
                     elif IsOptArrow(btnID):
-                        panelRG = ptGUIControlRadioGroup(AvCustGUI.dialog.getControlFromTag(kPanelsRGID))
+                        panelRG = AvCustGUI.dialog.getControlModFromTag(kPanelsRGID)
                         rgVal = panelRG.getValue()
                         listboxID = panelOptListboxOffset + rgVal
                         if IsLeftArrow(btnID):
@@ -1022,7 +1022,7 @@ class xAvatarCustomization(ptModifier):
                         if PtIsInternalRelease():
                             self.IRestoreAvatarFromDisk()
                             self.dirty = 1 # we are changing the avatar, so show the reset button
-                            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarResetID)).show()
+                            AvCustGUI.dialog.getControlModFromTag(kAvatarResetID).show()
                     elif btnID == kAvatarSaveID:
                         if PtIsInternalRelease():
                             SaveAvatarToDisk()
@@ -1045,17 +1045,17 @@ class xAvatarCustomization(ptModifier):
                 elif isinstance(control,ptGUIControlCheckBox):
                     chkBoxID = control.getTagID()
                     if chkBoxID == kZoomButton:
-                        zoomBtn = ptGUIControlCheckBox(AvCustGUI.dialog.getControlFromTag(chkBoxID))
-                        radioGroup = ptGUIControlRadioGroup(AvCustGUI.dialog.getControlFromTag(kPanelsRGID))
+                        zoomBtn = AvCustGUI.dialog.getControlModFromTag(chkBoxID)
+                        radioGroup = AvCustGUI.dialog.getControlModFromTag(kPanelsRGID)
                         if zoomBtn.isChecked():
                             ZoomResponder.run(self.key, state="ZoomIn")
-                            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarCameraID)).enable()
+                            AvCustGUI.dialog.getControlModFromTag(kAvatarCameraID).enable()
                             ZoomCamera.sceneobject.pushCutsceneCamera(1,PtGetLocalAvatar().getKey())
                             radioGroup.hide()
                             self.SetupCamera()
                         else:
                             ZoomResponder.run(self.key, state="ZoomOut")
-                            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarCameraID)).disable()
+                            AvCustGUI.dialog.getControlModFromTag(kAvatarCameraID).disable()
                             ZoomCamera.sceneobject.popCutsceneCamera(PtGetLocalAvatar().getKey())
                             radioGroup.show()
                             self.SetupCamera()
@@ -1373,11 +1373,7 @@ class xAvatarCustomization(ptModifier):
         SetDefaultSettings() # grab the stuff we came in with
         PtDisableAvatarCursorFade()
 
-        if InAvatarCloset:
-            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarSwitchID)).hide()
-        else:
-            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarSwitchID)).hide()
-
+        AvCustGUI.dialog.getControlModFromTag(kAvatarSwitchID).hide()
         AvCustGUI.dialog.show()
         PtDisableAvatarJump()
         self.ILocalizeStaticText()
@@ -1435,15 +1431,15 @@ class xAvatarCustomization(ptModifier):
         "Update all the dialog controls to reflect what the avatar is currently"
         # do the global settings
         avatar = PtGetLocalAvatar()
-        namebox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kNameTBID))
+        namebox = AvCustGUI.dialog.getControlModFromTag(kNameTBID)
         namebox.show()
-        editbox = ptGUIControlEditBox(AvCustGUI.dialog.getControlFromTag(kNameEBID))
+        editbox = AvCustGUI.dialog.getControlModFromTag(kNameEBID)
         editbox.hide() # don't want people changing their name
         localplayer = PtGetLocalPlayer()
         namebox.setString(localplayer.getPlayerName())
-        panelRG = ptGUIControlRadioGroup(AvCustGUI.dialog.getControlFromTag(kPanelsRGID))
+        panelRG = AvCustGUI.dialog.getControlModFromTag(kPanelsRGID)
         clothing_panel = panelRG.getValue()
-        zoomBtn = ptGUIControlCheckBox(AvCustGUI.dialog.getControlFromTag(kZoomButton))
+        zoomBtn = AvCustGUI.dialog.getControlModFromTag(kZoomButton)
         if clothing_panel == 1:
             # enable the zoom button
             zoomBtn.show()
@@ -1470,7 +1466,7 @@ class xAvatarCustomization(ptModifier):
         global TheCloset
         global listboxDict
         # assume that there is no accessories
-        listbox = ptGUIControlListBox(AvCustGUI.dialog.getControlFromTag(kAccessOptionsLB))
+        listbox = AvCustGUI.dialog.getControlModFromTag(kAccessOptionsLB)
         listbox.hide()
         # get (or re-get) the closet
         TheCloset = ClothingCloset()
@@ -1535,7 +1531,7 @@ class xAvatarCustomization(ptModifier):
         global WornList
 
         # Find what to color
-        panelRG = ptGUIControlRadioGroup(AvCustGUI.dialog.getControlFromTag(kPanelsRGID))
+        panelRG = AvCustGUI.dialog.getControlModFromTag(kPanelsRGID)
         clothing_panel = panelRG.getValue()
         foundItem = 0
         if clothing_panel >= 0 and clothing_panel < len(CLxref):
@@ -1547,18 +1543,17 @@ class xAvatarCustomization(ptModifier):
                 # if the saturation is zero then don't allow tiniting
                 if controlID == kColor1ClickMap or controlID == kColor2ClickMap:
                     #Make sure that we're not zoomed in (changing eye color)
-                    panelRG = ptGUIControlRadioGroup(AvCustGUI.dialog.getControlFromTag(kPanelsRGID))
                     rgVal = panelRG.getValue()
 
                     # get the color
                     if controlID == kColor2ClickMap:
                         layer = 2
-                        colormap = ptGUIControlClickMap(AvCustGUI.dialog.getControlFromTag(kColor2ClickMap)).getLastMouseUpPoint()
+                        colormap = AvCustGUI.dialog.getControlModFromTag(kColor2ClickMap).getLastMouseUpPoint()
                         colorit = ColorMaterial.map.getPixelColor(colormap.getX(),colormap.getY())
                         self.IDrawCrosshair(kColor2ClickMap,colormap.getX(),colormap.getY())
                     else:
                         layer = 1
-                        colormap = ptGUIControlClickMap(AvCustGUI.dialog.getControlFromTag(kColor1ClickMap)).getLastMouseUpPoint()
+                        colormap = AvCustGUI.dialog.getControlModFromTag(kColor1ClickMap).getLastMouseUpPoint()
                         colorit = ColorMaterial.map.getPixelColor(colormap.getX(),colormap.getY())
                         self.IDrawCrosshair(kColor1ClickMap,colormap.getX(),colormap.getY())
                     avatar = PtGetLocalAvatar()
@@ -1575,7 +1570,7 @@ class xAvatarCustomization(ptModifier):
                                 avatar.avatar.tintClothingItem(aitem.name,colorit)
                 elif controlID == kSkinClickMap:
                     # then this is a skin tinting affair
-                    colormap = ptGUIControlClickMap(AvCustGUI.dialog.getControlFromTag(kSkinClickMap)).getLastMouseUpPoint()
+                    colormap = AvCustGUI.dialog.getControlModFromTag(kSkinClickMap).getLastMouseUpPoint()
                     colorskin = SkinMaterial.map.getPixelColor(colormap.getX(),colormap.getY())
                     self.IDrawCrosshair(kSkinClickMap,colormap.getX(),colormap.getY())
                     avatar = PtGetLocalAvatar()
@@ -1584,7 +1579,7 @@ class xAvatarCustomization(ptModifier):
                     # then this is a hair tinting affair
 
 
-                    colormap = ptGUIControlClickMap(AvCustGUI.dialog.getControlFromTag(kHairClickMap)).getLastMouseUpPoint()
+                    colormap = AvCustGUI.dialog.getControlModFromTag(kHairClickMap).getLastMouseUpPoint()
                     colorit = HairMaterial.map.getPixelColor(colormap.getX(),colormap.getY())
                     self.IDrawCrosshair(kHairClickMap,colormap.getX(),colormap.getY())
                     avatar = PtGetLocalAvatar()
@@ -1600,7 +1595,7 @@ class xAvatarCustomization(ptModifier):
 
         if knobID < kMorphSliderOffset or knobID >= kMorphSliderOffset+kNumberOfMorphs:
             return
-        morphKnob = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(knobID))
+        morphKnob = AvCustGUI.dialog.getControlModFromTag(knobID)
         morphVal = self.ISliderToMorph(morphKnob.getValue())
         avatar = PtGetLocalAvatar()
         item = TheCloset.getItemByName(itemName)
@@ -1622,7 +1617,7 @@ class xAvatarCustomization(ptModifier):
         # for now, skip out on an invalid control
         if knobID < kMorphSliderOffset or knobID >= kMorphSliderOffset+kNumberOfMorphs:
             return
-        morphKnob = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(knobID))
+        morphKnob = AvCustGUI.dialog.getControlModFromTag(knobID)
         morphVal = self.ISliderToMorph(morphKnob.getValue())
         avatar = PtGetLocalAvatar()
         gender = avatar.avatar.getAvatarClothingGroup()
@@ -1638,7 +1633,7 @@ class xAvatarCustomization(ptModifier):
 
         if knobID <= kTexMorphSliderOffset or knobID > kTexMorphSliderOffset+kNumberOfTexMorphs:
             return
-        morphKnob = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(knobID))
+        morphKnob = AvCustGUI.dialog.getControlModFromTag(knobID)
         morphVal = self.ISliderToTexMorph(morphKnob.getValue())
         avatar = PtGetLocalAvatar()
 
@@ -1658,8 +1653,8 @@ class xAvatarCustomization(ptModifier):
             else:
                 morphID1 = kEthnic1TexMorph
                 morphID2 = kEthnic2TexMorph
-            morphKnob1 = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(morphID1))
-            morphKnob2 = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(morphID2))
+            morphKnob1 = AvCustGUI.dialog.getControlModFromTag(morphID1)
+            morphKnob2 = AvCustGUI.dialog.getControlModFromTag(morphID2)
             morphVal1 = self.ISliderToTexMorph(morphKnob1.getValue())
             morphVal2 = self.ISliderToTexMorph(morphKnob2.getValue())
             total = morphVal + morphVal1 + morphVal2
@@ -1687,21 +1682,24 @@ class xAvatarCustomization(ptModifier):
 
     def ISetStandardControls(self):
         "Set the color knobs depending on the color of the clothing item panel showing"
+        resetBtn = AvCustGUI.dialog.getControlModFromTag(kAvatarResetID)
         if self.dirty: # has the clothing changed at all?
-            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarResetID)).show() # then show the reset button
+            resetBtn.show() # then show the reset button
         else:
-            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarResetID)).hide() # otherwise, hide it
+            resetBtn.hide() # otherwise, hide it
 
+        readBtn = AvCustGUI.dialog.getControlModFromTag(kAvatarReadID)
+        saveBtn = AvCustGUI.dialog.getControlModFromTag(kAvatarSaveID)
         if PtIsInternalRelease():
-            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarReadID)).show()
-            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarSaveID)).show()
+            readBtn.show()
+            saveBtn.show()
         else:
-            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarReadID)).hide()
-            ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(kAvatarSaveID)).hide()
+            readBtn.hide()
+            saveBtn.hide()
 
         foundItem = 0
         # get the panel and the worn item
-        panelRG = ptGUIControlRadioGroup(AvCustGUI.dialog.getControlFromTag(kPanelsRGID))
+        panelRG = AvCustGUI.dialog.getControlModFromTag(kPanelsRGID)
         clothing_panel = panelRG.getValue()
         avatar = PtGetLocalAvatar()
         if clothing_panel >= 0 and clothing_panel < len(CLxref):
@@ -1709,15 +1707,15 @@ class xAvatarCustomization(ptModifier):
             # find the clothing type in what is being worn
             wornitem = FindWornItem(clothing_type)
             if wornitem is not None:
-                descbox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kClothingDesc))
+                descbox = AvCustGUI.dialog.getControlModFromTag(kClothingDesc)
                 descbox.setString(wornitem.description)
-                colorbar1 = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName1))
+                colorbar1 = AvCustGUI.dialog.getControlModFromTag(kColorbarName1)
                 if wornitem.colorlabel1 == "":
                     self.IHideColorPicker(kColor1ClickMap)
                 else:
                     self.IShowColorPicker(kColor1ClickMap)
                     colorbar1.setString(wornitem.colorlabel1)
-                colorbar2 = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName2))
+                colorbar2 = AvCustGUI.dialog.getControlModFromTag(kColorbarName2)
                 if wornitem.colorlabel2 == "":
                     self.IHideColorPicker(kColor2ClickMap)
                 else:
@@ -1757,7 +1755,7 @@ class xAvatarCustomization(ptModifier):
         allMorphsLoaded = 1
         for morphID in range(kNumberOfMorphs):
             knobID = morphID + kMorphSliderOffset
-            morphKnob = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(knobID))
+            morphKnob = AvCustGUI.dialog.getControlModFromTag(knobID)
             morphKnob.show()
             morphVal = 0
             gender = avatar.avatar.getAvatarClothingGroup()
@@ -1774,7 +1772,7 @@ class xAvatarCustomization(ptModifier):
                 pass
         for texMorphID in range(1,kNumberOfTexMorphs+1):
             knobID = texMorphID + kTexMorphSliderOffset
-            morphKnob = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(knobID))
+            morphKnob = AvCustGUI.dialog.getControlModFromTag(knobID)
             morphKnob.show()
             try:
                 if (knobID == kAgeTexMorph):
@@ -1794,13 +1792,13 @@ class xAvatarCustomization(ptModifier):
 
     def IShowColorPicker(self,id):
         if (id == kColor1ClickMap):
-            clickMap = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(kColor1ClickMap))
+            clickMap = AvCustGUI.dialog.getControlModFromTag(kColor1ClickMap)
         elif (id == kColor2ClickMap):
-            clickMap = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(kColor2ClickMap))
+            clickMap = AvCustGUI.dialog.getControlModFromTag(kColor2ClickMap)
         elif (id == kHairClickMap):
-            clickMap = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(kHairClickMap))
+            clickMap = AvCustGUI.dialog.getControlModFromTag(kHairClickMap)
         else:
-            clickMap = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(kSkinClickMap))
+            clickMap = AvCustGUI.dialog.getControlModFromTag(kSkinClickMap)
 
         clickMap.enable()
         clickMap.show()
@@ -1808,19 +1806,19 @@ class xAvatarCustomization(ptModifier):
     def IHideColorPicker(self,id):
         textBox = None
         if (id == kColor1ClickMap):
-            textBox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName1))
-            clickMap = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(kColor1ClickMap))
+            textBox = AvCustGUI.dialog.getControlModFromTag(kColorbarName1)
+            clickMap = AvCustGUI.dialog.getControlModFromTag(kColor1ClickMap)
             texMap = Color1Map.textmap
         elif (id == kColor2ClickMap):
-            textBox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName2))
-            clickMap = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(kColor2ClickMap))
+            textBox = AvCustGUI.dialog.getControlModFromTag(kColorbarName2)
+            clickMap = AvCustGUI.dialog.getControlModFromTag(kColor2ClickMap)
             texMap = Color2Map.textmap
         elif (id == kHairClickMap):
-            textBox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName1))
-            clickMap = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(kHairClickMap))
+            textBox = AvCustGUI.dialog.getControlModFromTag(kColorbarName1)
+            clickMap = AvCustGUI.dialog.getControlModFromTag(kHairClickMap)
             texMap = Color1Map.textmap
         else:
-            clickMap = ptGUIControlValue(AvCustGUI.dialog.getControlFromTag(kSkinClickMap))
+            clickMap = AvCustGUI.dialog.getControlModFromTag(kSkinClickMap)
             texMap = SkinMap.textmap
         clickMap.disable()
         clickMap.hide()
@@ -2532,13 +2530,13 @@ class ScrollingListBox:
 
     def UpdateScrollArrows(self):
         if self.listboxID >= kHairAccLB and self.listboxID <= kAccessAccLB:
-            leftArrow = ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(self.listboxID+kIDBtnLeftAccOffset))
-            rightArrow = ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(self.listboxID+kIDBtnRightAccOffset))
+            leftArrow = AvCustGUI.dialog.getControlModFromTag(self.listboxID+kIDBtnLeftAccOffset)
+            rightArrow = AvCustGUI.dialog.getControlModFromTag(self.listboxID+kIDBtnRightAccOffset)
         else:
             if self.listboxID == kHeadOptionsLB:
                 return # there aren't any head options, just accessories
-            leftArrow = ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(self.listboxID+kIDBtnLeftOptOffset))
-            rightArrow = ptGUIControlButton(AvCustGUI.dialog.getControlFromTag(self.listboxID+kIDBtnRightOptOffset))
+            leftArrow = AvCustGUI.dialog.getControlModFromTag(self.listboxID+kIDBtnLeftOptOffset)
+            rightArrow = AvCustGUI.dialog.getControlModFromTag(self.listboxID+kIDBtnRightOptOffset)
         if self.IShowLeftArrow():
             leftArrow.show()
         if self.IShowRightArrow():
@@ -2546,7 +2544,7 @@ class ScrollingListBox:
         pass
 
     def UpdateListbox(self):
-        listbox = ptGUIControlListBox(AvCustGUI.dialog.getControlFromTag(self.listboxID))
+        listbox = AvCustGUI.dialog.getControlModFromTag(self.listboxID)
         listbox.clearAllElements()
         listbox.hide()
         listbox.disallowNoSelect()

--- a/Scripts/Python/xDialogClothingBB.py
+++ b/Scripts/Python/xDialogClothingBB.py
@@ -260,7 +260,7 @@ class xDialogClothingBB(ptModifier):
         pantsWornIdx = self.IWhatPantsAmIWearing(avatar)
         shirtWornIdx = self.IWhatShirtAmIWearing(avatar)
         # set the pants radio group
-        psRG = ptGUIControlRadioGroup(KIBlackbar.dialog.getControlFromTag(kPantRadioGroupID))
+        psRG = KIBlackbar.dialog.getControlModFromTag(kPantRadioGroupID)
         if pantsWornIdx != psRG.getValue():
             if pantsWornIdx == kNoPantsIdx:
                 PtDebugPrint("xDialogClothingBB: currently wearing no pants")
@@ -272,7 +272,7 @@ class xDialogClothingBB(ptModifier):
                     PtDebugPrint("xDialogClothingBB: currently wearing unknown pants %s" % (PantNames[pantsWornIdx]))
                     psRG.setValue(-1)   # there is nothing that is selected for nopant wearers
         # set the pants radio group
-        ssRG = ptGUIControlRadioGroup(KIBlackbar.dialog.getControlFromTag(kShirtRadioGroupID))
+        ssRG = KIBlackbar.dialog.getControlModFromTag(kShirtRadioGroupID)
         if shirtWornIdx != ssRG.getValue():
             if shirtWornIdx == kNoShirtIdx:
                 PtDebugPrint("xDialogClothingBB: currently wearing no shirt")
@@ -284,7 +284,7 @@ class xDialogClothingBB(ptModifier):
                     PtDebugPrint("xDialogClothingBB: currently wearing unknown shirt %s" % (ShirtNames[shirtWornIdx]))
                     ssRG.setValue(-1)   # there is nothing that is selected for barechested
         # get current color
-        scRG = ptGUIControlRadioGroup(KIBlackbar.dialog.getControlFromTag(kTintRadioGroupID))
+        scRG = KIBlackbar.dialog.getControlModFromTag(kTintRadioGroupID)
         if shirtWornIdx != kNoShirtIdx:
             # make sure that it is enabled
             scRG.setVisible(1)

--- a/Scripts/Python/xDialogStartUp.py
+++ b/Scripts/Python/xDialogStartUp.py
@@ -200,8 +200,8 @@ class xDialogStartUp(ptResponder):
 
         self.InitPlayerList(GUIDiag4b, gExp_HotSpot, gExp_TxtBox, gExp_HiLite)
 
-        ptGUIControlEditBox(GUIDiag6.dialog.getControlFromTag(k6NameID)).setStringSize(63)
-        ptGUIControlEditBox(GUIDiag6.dialog.getControlFromTag(k6InviteID)).setStringSize(63)
+        GUIDiag6.dialog.getControlModFromTag(k6NameID).setStringSize(63)
+        GUIDiag6.dialog.getControlModFromTag(k6InviteID).setStringSize(63)
 
         WebLaunchCmd = webbrowser.open_new
 
@@ -286,7 +286,7 @@ class xDialogStartUp(ptResponder):
                 elif  tagID == k4bDeleteID: ## Delete Explorer ##
                     if gSelectedSlot and gPlayerList[gSelectedSlot-gMinusExplorer]:
                         deleteString = "Would you like to delete the EXPLORER " + str(gPlayerList[gSelectedSlot-gMinusExplorer][0]) + "?"
-                        ptGUIControlTextBox(GUIDiag4c.dialog.getControlFromTag(k4cStaticID)).setString(deleteString)
+                        GUIDiag4c.dialog.getControlModFromTag(k4cStaticID).setString(deleteString)
                         self.PlayerListNotify(GUIDiag4b, gExp_HotSpot, 0)
                         PtShowDialog("GUIDialog04c")
                     ## Or Else?? ##
@@ -326,7 +326,7 @@ class xDialogStartUp(ptResponder):
                     self.ToggleColor(GUIDiag4b, k4bPlayer03)
                     self.PlayerListNotify(GUIDiag4b, gExp_HotSpot, 1)
                     PtHideDialog("GUIDialog04d")
-                    ptGUIControlButton(GUIDiag6.dialog.getControlFromTag(k6PlayID)).enable()
+                    GUIDiag6.dialog.getControlModFromTag(k6PlayID).enable()
 
         #################################
         ##        Create Player        ##
@@ -344,32 +344,32 @@ class xDialogStartUp(ptResponder):
                         self.SelectSlot(GUIDiag4b, 0)
 
                 elif  tagID == k6PlayID: ## Play ##
-                    playerName = ptGUIControlEditBox(GUIDiag6.dialog.getControlFromTag(k6NameID)).getString()
+                    playerName = GUIDiag6.dialog.getControlModFromTag(k6NameID).getString()
                     playerGender = ""
                     playerStart = ""
 
-                    if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6MaleID)).isChecked():
+                    if GUIDiag6.dialog.getControlModFromTag(k6MaleID).isChecked():
                         playerGender = "male"
-                    if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6FemaleID)).isChecked():
+                    if GUIDiag6.dialog.getControlModFromTag(k6FemaleID).isChecked():
                         playerGender = "female"
-                    if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6CleftID)).isChecked():
+                    if GUIDiag6.dialog.getControlModFromTag(k6CleftID).isChecked():
                         playerStart = "cleft"
-                    if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6ReltoID)).isChecked():
+                    if GUIDiag6.dialog.getControlModFromTag(k6ReltoID).isChecked():
                         playerStart = "relto"
 
                     if playerName == "" or playerName.isspace():
                         errorString = PtGetLocalizedString("GUI.Dialog04d.ErrorName")
-                        ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setString(errorString)
+                        GUIDiag4d.dialog.getControlModFromTag(k4dTextID).setString(errorString)
                         PtShowDialog("GUIDialog04d")
                         self.ToggleColor(GUIDiag4b, k4bPlayer03)
                     elif playerGender == "":
                         errorString = PtGetLocalizedString("GUI.Dialog04d.ErrorGender")
-                        ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setString(errorString)
+                        GUIDiag4d.dialog.getControlModFromTag(k4dTextID).setString(errorString)
                         PtShowDialog("GUIDialog04d")
                         self.ToggleColor(GUIDiag4b, k4bPlayer03)
                     elif playerStart == "":
                         errorString = PtGetLocalizedString("GUI.Dialog04d.ErrorPath")
-                        ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setString(errorString)
+                        GUIDiag4d.dialog.getControlModFromTag(k4dTextID).setString(errorString)
                         PtShowDialog("GUIDialog04d")
                         self.ToggleColor(GUIDiag4b, k4bPlayer03)
                     else:
@@ -382,43 +382,39 @@ class xDialogStartUp(ptResponder):
                                 errorString = PtGetLocalizedString("GUI.Dialog04d.InvalidCharacters")
                             else:
                                 errorString = PtGetLocalizedString("GUI.Dialog04d.IncorrectFormatting")
-                            ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setString(errorString)
+                            GUIDiag4d.dialog.getControlModFromTag(k4dTextID).setString(errorString)
                             PtShowDialog("GUIDialog04d")
                             self.ToggleColor(GUIDiag4b, k4bPlayer03)
 
-                            ptGUIControlEditBox(GUIDiag6.dialog.getControlFromTag(k6NameID)).setString(fixedPlayerName)
+                            GUIDiag6.dialog.getControlModFromTag(k6NameID).setString(fixedPlayerName)
                         else:
                             PtDebugPrint("Creating Player")
                             PtShowDialog("GUIDialog06a")
-                            ptGUIControlButton(GUIDiag6.dialog.getControlFromTag(k6PlayID)).disable()
+                            GUIDiag6.dialog.getControlModFromTag(k6PlayID).disable()
                             gPlayerStart = playerStart
                             PtCreatePlayer(fixedPlayerName, playerGender, "")  #                                                  <---
 
                 elif  tagID == k6MaleID: ## Gender Male ##
-                    if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6FemaleID)).isChecked():
-                        ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6FemaleID)).setChecked(False)
+                    GUIDiag6.dialog.getControlModFromTag(k6FemaleID).setChecked(False)
 
                 elif  tagID == k6FemaleID: ## Gender Female ##
-                    if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6MaleID)).isChecked():
-                        ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6MaleID)).setChecked(False)
+                    GUIDiag6.dialog.getControlModFromTag(k6MaleID).setChecked(False)
 
                 elif  tagID == k6CleftID: ## Start Cleft ##
-                    if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6ReltoID)).isChecked():
-                        ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6ReltoID)).setChecked(False)
+                    GUIDiag6.dialog.getControlModFromTag(k6ReltoID).setChecked(False)
 
                 elif  tagID == k6ReltoID: ## Start Relto ##
-                    if ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6CleftID)).isChecked():
-                        ptGUIControlCheckBox(GUIDiag6.dialog.getControlFromTag(k6CleftID)).setChecked(False)
+                    GUIDiag6.dialog.getControlModFromTag(k6CleftID).setChecked(False)
 
                 elif tagID == k6CleftHelpID: ## Cleft Help Button ##
                     errorString = PtGetLocalizedString("GUI.Dialog04d.CleftHelp")
-                    ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setString(errorString)
+                    GUIDiag4d.dialog.getControlModFromTag(k4dTextID).setString(errorString)
                     PtShowDialog("GUIDialog04d")
                     self.ToggleColor(GUIDiag4b, k4bPlayer03)
 
                 elif tagID == k6ReltoHelpID: ## Relto Help Button ##
                     errorString = PtGetLocalizedString("GUI.Dialog04d.ReltoHelp")
-                    ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setString(errorString)
+                    GUIDiag4d.dialog.getControlModFromTag(k4dTextID).setString(errorString)
                     PtShowDialog("GUIDialog04d")
                     self.ToggleColor(GUIDiag4b, k4bPlayer03)
 
@@ -438,15 +434,15 @@ class xDialogStartUp(ptResponder):
 
             if result == 12:
                 errorString = PtGetLocalizedString("GUI.Dialog04d.NameAlreadyExists")
-                ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setString(errorString)
+                GUIDiag4d.dialog.getControlModFromTag(k4dTextID).setString(errorString)
                 PtShowDialog("GUIDialog04d")
             elif result == 28:
                 errorString = PtGetLocalizedString("GUI.Dialog04d.IllegalName")
-                ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setString(errorString)
+                GUIDiag4d.dialog.getControlModFromTag(k4dTextID).setString(errorString)
                 PtShowDialog("GUIDialog04d")
             else:
                 errorString = PtGetLocalizedString("GUI.Dialog04d.NetworkError")
-                ptGUIControlTextBox(GUIDiag4d.dialog.getControlFromTag(k4dTextID)).setString(errorString)
+                GUIDiag4d.dialog.getControlModFromTag(k4dTextID).setString(errorString)
                 PtShowDialog("GUIDialog04d")
             return
 
@@ -521,18 +517,18 @@ class xDialogStartUp(ptResponder):
         global gExp_HotSpot
         global gExp_HiLite
 
-        currentColor = ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(tagID+10)).getForeColor()
+        currentColor = dlgObj.dialog.getControlModFromTag(tagID+10).getForeColor()
 
         idx = gExp_HotSpot.index(tagID)
         respToRun = gExp_HiLite[idx]
 
         if currentColor == gBlueColor:
             #PtDebugPrint("toggle tagID(%d) off" % (tagID))
-            ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(tagID+10)).setForeColor(gTanColor)
+            dlgObj.dialog.getControlModFromTag(tagID+10).setForeColor(gTanColor)
             respToRun.run(self.key,state="out")
         else:
             #PtDebugPrint("toggle tagID(%d) on" % (tagID))
-            ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(tagID+10)).setForeColor(gBlueColor)
+            dlgObj.dialog.getControlModFromTag(tagID+10).setForeColor(gBlueColor)
             respToRun.run(self.key,state="in")
 
     ###########################
@@ -543,11 +539,11 @@ class xDialogStartUp(ptResponder):
             PtDebugPrint("xDialogStartUp.SelectSlot: tagID = %d   gSelectedSlot = %d" % (tagID, gSelectedSlot))
             if gSelectedSlot:
                 self.ToggleColor(dlgObj, gSelectedSlot)
-                ptGUIControlButton(dlgObj.dialog.getControlFromTag(gSelectedSlot)).setNotifyOnInteresting(True)
+                dlgObj.dialog.getControlModFromTag(gSelectedSlot).setNotifyOnInteresting(True)
                 PtDebugPrint("xDialogStartUp.SelectSlot: Setting old slot to Interesting")
 
             gSelectedSlot = tagID
-            ptGUIControlButton(dlgObj.dialog.getControlFromTag(gSelectedSlot)).setNotifyOnInteresting(False)
+            dlgObj.dialog.getControlModFromTag(gSelectedSlot).setNotifyOnInteresting(False)
             PtDebugPrint("xDialogStartUp.SelectSlot: Setting gSelectedSlot to new val and removing Interesting")
         elif tagID == 0:
             PtDebugPrint("xDialogStartUp.SelectSlot: Setting gSelectedSlot to %d" % (tagID))
@@ -570,8 +566,9 @@ class xDialogStartUp(ptResponder):
 
         for tagID in listTxtBox: ## Setup The Slot Colors And Default Titles ##
             createExplorer = PtGetLocalizedString("GUI.Dialog04b.CreateExplorer")
-            ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(tagID)).setString(createExplorer)
-            ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(tagID)).setForeColor(gTanColor)
+            textbox = dlgObj.dialog.getControlModFromTag(tagID)
+            textbox.setString(createExplorer)
+            textbox.setForeColor(gTanColor)
         for respToRun in listHiLite:
             respToRun.run(self.key,state="out")
 
@@ -586,7 +583,7 @@ class xDialogStartUp(ptResponder):
 
         for idx in range(1, len(gPlayerList[1:]) + 1): ## Setup The Explorer Slots ##
             player = gPlayerList[idx]
-            ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(listTxtBox[idx])).setString(str(player[0]))
+            dlgObj.dialog.getControlModFromTag(listTxtBox[idx]).setString(player[0])
             try:
                 filename = basePath + str(player[1]) + ".jpg"
                 PtDebugPrint("xDialogStartUp: Trying to load \"" + filename + "\"")
@@ -614,11 +611,11 @@ class xDialogStartUp(ptResponder):
 
         for tagID in listHotSpot:
             PtDebugPrint("xDialogStartUp.PlayerListNotify: setting tagID (%d) to Interesting = %d" % (tagID, toggle))
-            ptGUIControlButton(dlgObj.dialog.getControlFromTag(tagID)).setNotifyOnInteresting(toggle)
+            dlgObj.dialog.getControlModFromTag(tagID).setNotifyOnInteresting(toggle)
 
         if toggle and gSelectedSlot:
             PtDebugPrint("xDialogStartUp.PlayerListNotify: setting gSelectedSlot (%d) to not Interesting" % (gSelectedSlot))
-            ptGUIControlButton(dlgObj.dialog.getControlFromTag(gSelectedSlot)).setNotifyOnInteresting(False)
+            dlgObj.dialog.getControlModFromTag(gSelectedSlot).setNotifyOnInteresting(False)
 
         # Everyone is an explorer, so disable the button for visiting.
-        btn = ptGUIControlButton(dlgObj.dialog.getControlFromTag(listHotSpot[0])).disable()
+        dlgObj.dialog.getControlModFromTag(listHotSpot[0]).disable()

--- a/Scripts/Python/xOpeningSequence.py
+++ b/Scripts/Python/xOpeningSequence.py
@@ -239,48 +239,30 @@ class xOpeningSequence(ptModifier):
                 PtDebugPrint("xOpeningSequence - quiet sounds and show background",level=kDebugDumpLevel)
                 # this SHOULD be in the max file, but since someone has the KI max file tied up, it will have to go here
                 # set the text localized strings
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kHelpTitle))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Title"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kWalkText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Walk"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kRunText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Run"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kTurnLeftText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.TurnLeft"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kBackwardsText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.WalkBackwards"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kTurnRightText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.TurnRight"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kToggleViewText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.ToggleView"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kJumpText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.KeyCommands.Jump"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kMouseWalkText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Walk"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kMouseRunText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Run"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kSelectText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Select"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kMousePanCam))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.MousePanCam"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kMouseBackwards))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.WalkBackwards"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kMousePresetsTitle))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.MousePresets"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kMouseNormalText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Normal"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kMouseNoviceText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Novice"))
-                textField = ptGUIControlTextBox(FirstHelpDlg.dialog.getControlFromTag(kOkButton))
-                textField.setString(PtGetLocalizedString("OptionsMenu.Main.Ok"))
+                getControl = FirstHelpDlg.dialog.getControlModFromTag
+                getControl(kHelpTitle).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Title"))
+                getControl(kWalkText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Walk"))
+                getControl(kRunText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Run"))
+                getControl(kTurnLeftText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.TurnLeft"))
+                getControl(kBackwardsText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.WalkBackwards"))
+                getControl(kTurnRightText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.TurnRight"))
+                getControl(kToggleViewText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.ToggleView"))
+                getControl(kJumpText).setString(PtGetLocalizedString("OptionsMenu.KeyCommands.Jump"))
+                getControl(kMouseWalkText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Walk"))
+                getControl(kMouseRunText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Run"))
+                getControl(kSelectText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Select"))
+                getControl(kMousePanCam).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.MousePanCam"))
+                getControl(kMouseBackwards).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.WalkBackwards"))
+                getControl(kMousePresetsTitle).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.MousePresets"))
+                getControl(kMouseNormalText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Normal"))
+                getControl(kMouseNoviceText).setString(PtGetLocalizedString("OptionsMenu.StartupHelp.Novice"))
+                getControl(kOkButton).setString(PtGetLocalizedString("OptionsMenu.Main.Ok"))
                 # hide the ok button until they agree to the terms... or pick normal or novice
-                ##textField.setString(" ")
-                ##okBtn = ptGUIControlButton(FirstHelpDlg.dialog.getControlFromTag(kFirstHelpOkBtn))
-                ##okBtn.hide()
+                ##getControl(kFirstHelpOkBtn).hide()
             elif event == kShowHide:
                 # reset the edit text lines
                 if control.isEnabled():
-                    nnRG = ptGUIControlRadioGroup(FirstHelpDlg.dialog.getControlFromTag(kNormNoviceRGID))
+                    nnRG = FirstHelpDlg.dialog.getControlModFromTag(kNormNoviceRGID)
                     if PtIsClickToTurn():
                         nnRG.setValue(1)
                     else:
@@ -292,7 +274,7 @@ class xOpeningSequence(ptModifier):
                 helpID = control.getTagID()
                 if helpID == kFirstHelpOkBtn:
                     # get the setting of the novice/normal radio group
-                    nnRG = ptGUIControlRadioGroup(FirstHelpDlg.dialog.getControlFromTag(kNormNoviceRGID))
+                    nnRG = FirstHelpDlg.dialog.getControlModFromTag(kNormNoviceRGID)
                     vault = ptVault()
                     entry = vault.findChronicleEntry(kIntroPlayedChronicle)
                     if nnRG.getValue() == 1:
@@ -384,10 +366,10 @@ class xOpeningSequence(ptModifier):
                 OrientationPBIcon01.value.draw.disable()
                 OrientationPBIcon02.value.draw.disable()
                 OrientationPBIcon01Zandi.value.draw.enable()
-                ptGUIControlTextBox(OrientationDlg.dialog.getControlFromTag(kOrientPBText)).setString(PtGetLocalizedString("GUI.OrientationGUI.OrientPBTextZandi"))
+                OrientationDlg.dialog.getControlModFromTag(kOrientPBText).setString(PtGetLocalizedString("GUI.OrientationGUI.OrientPBTextZandi"))
             else:
                 OrientationPBIcon01Zandi.value.draw.disable()
-                ptGUIControlTextBox(OrientationDlg.dialog.getControlFromTag(kOrientPBText)).setString(PtGetLocalizedString("GUI.OrientationGUI.OrientPBText"))
+                OrientationDlg.dialog.getControlModFromTag(kOrientPBText).setString(PtGetLocalizedString("GUI.OrientationGUI.OrientPBText"))
         PtFadeIn(kHelpFadeInSeconds,0)
 
 

--- a/Scripts/Python/xOptionsMenu.py
+++ b/Scripts/Python/xOptionsMenu.py
@@ -1840,19 +1840,21 @@ class xOptionsMenu(ptModifier):
 
     def IRefreshAdvSettings(self):
         "refresh the volume settings to the current settings"
+        getControl = AdvGameSettingDlg.dialog.getControlModFromTag
+
         # shadows
         
         # We'll have to do this later, since it's no longer part of the AdvDisplaySettings Dialog
-        #~ shadowDistKnob = ptGUIControlValue(AdvGameSettingDlg.dialog.getControlFromTag(kGSDisplayShadowDistSlider))
+        #~ shadowDistKnob = getControl(kGSDisplayShadowDistSlider)
         #~ setting = PtGetShadowVisDistance()
         #~ shadowDistKnob.setValue(setting*10.0)
         
         #Will have to wire this into Audio panel later
-        #~ soundPriKnob = ptGUIControlValue(AdvGameSettingDlg.dialog.getControlFromTag(kGSSoundPrioritySlider))
+        #~ soundPriKnob = getControl(kGSSoundPrioritySlider)
         #~ audio = ptAudioControl()
         #~ soundPriKnob.setValue(audio.getPriorityCutoff()*(11.0/10.0))
         
-        mouseSensKnob = ptGUIControlValue(AdvGameSettingDlg.dialog.getControlFromTag(kGSMouseTurnSensSlider))
+        mouseSensKnob = getControl(kGSMouseTurnSensSlider)
         PtDebugPrint("IRefreshAdvSettings: PtGetMouseTurnSensitivity() = %d" % (PtGetMouseTurnSensitivity()))
         sensitive = PtGetMouseTurnSensitivity() - 50.0
         if sensitive <= 0.0:
@@ -1868,18 +1870,13 @@ class xOptionsMenu(ptModifier):
                     mouseSensKnob.setValue(5.0)
                 else:
                     mouseSensKnob.setValue(sensitive/20.0)
-                            
-        pukeCamCheckbox = ptGUIControlCheckBox(AdvGameSettingDlg.dialog.getControlFromTag(kGSPukeCamCheckbox))
+
         cam = ptCamera()
-        pukeCamCheckbox.setChecked(cam.isSmootherCam())
-        mouseInvertCheckbox = ptGUIControlCheckBox(AdvGameSettingDlg.dialog.getControlFromTag(kGSMouseInvertCheckbox))
-        mouseInvertCheckbox.setChecked(PtIsMouseInverted())
-        walkAndPanCheckbox = ptGUIControlCheckBox(AdvGameSettingDlg.dialog.getControlFromTag(kGSWalkAndPan))
-        walkAndPanCheckbox.setChecked(cam.isWalkAndVerticalPan())
-        stayInFirstCheckbox = ptGUIControlCheckBox(AdvGameSettingDlg.dialog.getControlFromTag(kGSStayInFirstPerson))
-        stayInFirstCheckbox.setChecked(cam.isStayInFirstPerson())
-        clickToTurnCheckbox = ptGUIControlCheckBox(AdvGameSettingDlg.dialog.getControlFromTag(kGSClickToTurn))
-        clickToTurnCheckbox.setChecked(PtIsClickToTurn())
+        getControl(kGSPukeCamCheckbox).setChecked(cam.isSmootherCam())
+        getControl(kGSMouseInvertCheckbox).setChecked(PtIsMouseInverted())
+        getControl(kGSWalkAndPan).setChecked(cam.isWalkAndVerticalPan())
+        getControl(kGSStayInFirstPerson).setChecked(cam.isStayInFirstPerson())
+        getControl(kGSClickToTurn).setChecked(PtIsClickToTurn())
 
 
     def LoadAdvSettings(self):

--- a/Scripts/Python/xYeeshaPages.py
+++ b/Scripts/Python/xYeeshaPages.py
@@ -182,14 +182,14 @@ class xYeeshaPages(ptModifier):
 #        PtDebugPrint("PageNumber = ", PageNumber.value)
         for x in kYeeshaPage:
             try:
-                ctrl = mydialog.getControlFromTag(x)
+                ctrl = mydialog.getControlModFromTag(x)
             except KeyError:
                 continue
             else:
-                ptGUIControlButton(ctrl).hide()
+                ctrl.hide()
 
         #now draw correct panel
-        ptGUIControlButton(mydialog.getControlFromTag(kYeeshaPage[PageNumber.value])).show()
+        mydialog.getControlModFromTag(kYeeshaPage[PageNumber.value]).show()
         return
 
 #

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.h
@@ -150,7 +150,7 @@ class pfGUIDialogMod : public plSingleModifier
 
         void            AddControl( pfGUIControlMod *ctrl );
         size_t          GetNumControls() const { return fControls.size(); }
-        pfGUIControlMod *GetControl(size_t idx) { return fControls[idx]; }
+        pfGUIControlMod *GetControl(size_t idx) const { return fControls[idx]; }
 
         pfGUIColorScheme    *GetColorScheme() const { return fColorScheme; }
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -1151,64 +1151,10 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
         pyObjectRef pyControl;
         if (pGUIMsg->GetControlKey()) {
             // now create the control... but first we need to find out what it is
-            pyObjectRef pyCtrlKey = pyKey::New(pGUIMsg->GetControlKey());
-            uint32_t control_type = pyGUIDialog::WhatControlType(*(pyKey::ConvertFrom(pyCtrlKey.Get())));
-
-            switch (control_type) {
-                case pyGUIDialog::kDialog:
-                    pyControl = pyGUIDialog::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kButton:
-                    pyControl = pyGUIControlButton::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kListBox:
-                    pyControl = pyGUIControlListBox::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kTextBox:
-                    pyControl = pyGUIControlTextBox::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kEditBox:
-                    pyControl = pyGUIControlEditBox::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kUpDownPair:
-                case pyGUIDialog::kKnob:
-                    pyControl = pyGUIControlValue::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kCheckBox:
-                    pyControl = pyGUIControlCheckBox::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kRadioGroup:
-                    pyControl = pyGUIControlRadioGroup::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kDynamicText:
-                    pyControl = pyGUIControlDynamicText::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kMultiLineEdit:
-                    pyControl = pyGUIControlMultiLineEdit::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kPopUpMenu:
-                    pyControl = pyGUIPopUpMenu::New(pGUIMsg->GetControlKey());
-                    break;
-
-                case pyGUIDialog::kClickMap:
-                    pyControl = pyGUIControlClickMap::New(pGUIMsg->GetControlKey());
-                    break;
-
-                default:
-                    // we don't know what it is... just send 'em the pyKey
-                    pyControl = pyKey::New(pGUIMsg->GetControlKey());
-                    break;
-
+            pyControl = pyGUIDialog::ConvertControl(pGUIMsg->GetControlKey());
+            if (!pyControl) {
+                // we don't know what it is... just send 'em the pyKey
+                pyControl = pyKey::New(pGUIMsg->GetControlKey());
             }
         }
         // Need to determine which of the GUIDialogs sent this plGUINotifyMsg

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlButton.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlButton.cpp
@@ -53,9 +53,9 @@ pyGUIControlButton::pyGUIControlButton(plKey objkey) : pyGUIControl(std::move(ob
 {
 }
 
-bool pyGUIControlButton::IsGUIControlButton(pyKey& gckey)
+bool pyGUIControlButton::IsGUIControlButton(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUIButtonMod::ConvertNoRef(gckey.getKey()->ObjectIsLoaded()) )
+    if ( key && pfGUIButtonMod::ConvertNoRef(key->ObjectIsLoaded()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlButton.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlButton.h
@@ -74,7 +74,7 @@ public:
     static void AddPlasmaClasses(PyObject *m);
     static void AddPlasmaConstantsClasses(PyObject *m);
 
-    static bool IsGUIControlButton(pyKey& gckey);
+    static bool IsGUIControlButton(const plKey& key);
     
     void SetNotifyType(int32_t kind);
     int32_t GetNotifyType();

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlCheckBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlCheckBox.cpp
@@ -57,9 +57,9 @@ pyGUIControlCheckBox::pyGUIControlCheckBox(plKey objkey) : pyGUIControl(std::mov
 }
 
 
-bool pyGUIControlCheckBox::IsGUIControlCheckBox(pyKey& gckey)
+bool pyGUIControlCheckBox::IsGUIControlCheckBox(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUICheckBoxCtrl::ConvertNoRef(gckey.getKey()->ObjectIsLoaded()) )
+    if ( key && pfGUICheckBoxCtrl::ConvertNoRef(key->ObjectIsLoaded()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlCheckBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlCheckBox.h
@@ -73,7 +73,7 @@ public:
 
     static void AddPlasmaClasses(PyObject *m);
 
-    static bool IsGUIControlCheckBox(pyKey& gckey);
+    static bool IsGUIControlCheckBox(const plKey& key);
 
     void SetChecked(bool checked);
     bool IsChecked();

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlClickMap.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlClickMap.cpp
@@ -59,9 +59,9 @@ pyGUIControlClickMap::pyGUIControlClickMap(plKey objkey) : pyGUIControl(std::mov
 }
 
 
-bool pyGUIControlClickMap::IsGUIControlClickMap(pyKey& gckey)
+bool pyGUIControlClickMap::IsGUIControlClickMap(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUIClickMapCtrl::ConvertNoRef(gckey.getKey()->ObjectIsLoaded()) )
+    if ( key && pfGUIClickMapCtrl::ConvertNoRef(key->ObjectIsLoaded()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlClickMap.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlClickMap.h
@@ -72,7 +72,7 @@ public:
 
     static void AddPlasmaClasses(PyObject *m);
 
-    static bool IsGUIControlClickMap(pyKey& gckey);
+    static bool IsGUIControlClickMap(const plKey& key);
 
     PyObject* GetLastMousePt(); // returns pyPoint3
     PyObject* GetLastMouseUpPt(); // returns pyPoint3

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDynamicText.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDynamicText.cpp
@@ -58,9 +58,9 @@ pyGUIControlDynamicText::pyGUIControlDynamicText(plKey objkey) : pyGUIControl(st
 }
 
 
-bool pyGUIControlDynamicText::IsGUIControlDynamicText(pyKey& gckey)
+bool pyGUIControlDynamicText::IsGUIControlDynamicText(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUIDynDisplayCtrl::ConvertNoRef(gckey.getKey()->ObjectIsLoaded()) )
+    if ( key && pfGUIDynDisplayCtrl::ConvertNoRef(key->ObjectIsLoaded()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDynamicText.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlDynamicText.h
@@ -72,7 +72,7 @@ public:
 
     static void AddPlasmaClasses(PyObject *m);
 
-    static bool IsGUIControlDynamicText(pyKey& gckey);
+    static bool IsGUIControlDynamicText(const plKey& key);
 
     //specific interface functions
     uint32_t GetNumMaps();

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.cpp
@@ -58,9 +58,9 @@ pyGUIControlEditBox::pyGUIControlEditBox(plKey objkey) : pyGUIControl(std::move(
 }
 
 
-bool pyGUIControlEditBox::IsGUIControlEditBox(pyKey& gckey)
+bool pyGUIControlEditBox::IsGUIControlEditBox(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUIEditBoxMod::ConvertNoRef(gckey.getKey()->ObjectIsLoaded()) )
+    if ( key && pfGUIEditBoxMod::ConvertNoRef(key->ObjectIsLoaded()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.h
@@ -74,7 +74,7 @@ public:
 
     static void AddPlasmaClasses(PyObject *m);
 
-    static bool IsGUIControlEditBox(pyKey& gckey);
+    static bool IsGUIControlEditBox(const plKey& key);
 
     void SetBufferSize(uint32_t size);
     ST::string GetBuffer();

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
@@ -345,9 +345,9 @@ pyGUIControlListBox::pyGUIControlListBox(plKey objkey) : pyGUIControl(std::move(
 {
 }
 
-bool pyGUIControlListBox::IsGUIControlListBox(pyKey& gckey)
+bool pyGUIControlListBox::IsGUIControlListBox(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUIListBoxMod::ConvertNoRef(gckey.getKey()->ObjectIsLoaded()) )
+    if ( key && pfGUIListBoxMod::ConvertNoRef(key->ObjectIsLoaded()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
@@ -82,7 +82,7 @@ public:
 
     static void AddPlasmaClasses(PyObject *m);
 
-    static bool IsGUIControlListBox(pyKey& gckey);
+    static bool IsGUIControlListBox(const plKey& key);
 
     // special case control for the listbox
     // ...this allows the listbox to be used without being selectable

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.cpp
@@ -58,9 +58,9 @@ pyGUIControlMultiLineEdit::pyGUIControlMultiLineEdit(plKey objkey) : pyGUIContro
 {
 }
 
-bool pyGUIControlMultiLineEdit::IsGUIControlMultiLineEdit(pyKey& gckey)
+bool pyGUIControlMultiLineEdit::IsGUIControlMultiLineEdit(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUIMultiLineEditCtrl::ConvertNoRef(gckey.getKey()->ObjectIsLoaded()) )
+    if ( key && pfGUIMultiLineEditCtrl::ConvertNoRef(key->ObjectIsLoaded()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
@@ -77,7 +77,7 @@ public:
     static void AddPlasmaClasses(PyObject *m);
     static void AddPlasmaConstantsClasses(PyObject *m);
 
-    static bool IsGUIControlMultiLineEdit(pyKey& gckey);
+    static bool IsGUIControlMultiLineEdit(const plKey& key);
 
     void Clickable();
     void Unclickable();

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlRadioGroup.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlRadioGroup.cpp
@@ -54,9 +54,9 @@ pyGUIControlRadioGroup::pyGUIControlRadioGroup(plKey objkey) : pyGUIControl(std:
 {
 }
 
-bool pyGUIControlRadioGroup::IsGUIControlRadioGroup(pyKey& gckey)
+bool pyGUIControlRadioGroup::IsGUIControlRadioGroup(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUIRadioGroupCtrl::ConvertNoRef(gckey.getKey()->ObjectIsLoaded()) )
+    if ( key && pfGUIRadioGroupCtrl::ConvertNoRef(key->ObjectIsLoaded()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlRadioGroup.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlRadioGroup.h
@@ -73,7 +73,7 @@ public:
 
     static void AddPlasmaClasses(PyObject *m);
 
-    static bool IsGUIControlRadioGroup(pyKey& gckey);
+    static bool IsGUIControlRadioGroup(const plKey& gckey);
 
     int32_t GetValue();
     void SetValue(int32_t value);

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.cpp
@@ -61,9 +61,9 @@ pyGUIControlTextBox::pyGUIControlTextBox(plKey objkey) : pyGUIControl(std::move(
 }
 
 
-bool pyGUIControlTextBox::IsGUIControlTextBox(pyKey& gckey)
+bool pyGUIControlTextBox::IsGUIControlTextBox(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUITextBoxMod::ConvertNoRef(gckey.getKey()->ObjectIsLoaded()) )
+    if ( key && pfGUITextBoxMod::ConvertNoRef(key->ObjectIsLoaded()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.h
@@ -79,7 +79,7 @@ public:
 
     static void AddPlasmaClasses(PyObject *m);
 
-    static bool IsGUIControlTextBox(pyKey& gckey);
+    static bool IsGUIControlTextBox(const plKey& key);
 
     void SetText(ST::string text);
     ST::string GetText() const;

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlValue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlValue.cpp
@@ -57,9 +57,9 @@ pyGUIControlValue::pyGUIControlValue(plKey objkey) : pyGUIControl(std::move(objk
 {
 }
 
-bool pyGUIControlValue::IsGUIControlValue(pyKey& gckey)
+bool pyGUIControlValue::IsGUIControlValue(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUIValueCtrl::ConvertNoRef(gckey.getKey()->ObjectIsLoaded()) )
+    if ( key && pfGUIValueCtrl::ConvertNoRef(key->ObjectIsLoaded()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlValue.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlValue.h
@@ -73,7 +73,7 @@ public:
 
     static void AddPlasmaClasses(PyObject *m);
 
-    static bool IsGUIControlValue(pyKey& gckey);
+    static bool IsGUIControlValue(const plKey& key);
 
     float GetValue();
     void SetValue(float v);

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.h
@@ -80,7 +80,7 @@ public:
     static void AddPlasmaClasses(PyObject *m);
     static void AddPlasmaMethods(PyObject* m);
 
-    static bool IsGUIDialog(pyKey& gckey);
+    static bool IsGUIDialog(const plKey& key);
 
     void setKey(plKey key) { fGCkey = std::move(key); } // used by python glue, do NOT call
 
@@ -102,7 +102,8 @@ public:
         kPopUpMenu=14,
         kClickMap=15,
     };
-    static uint32_t WhatControlType(pyKey& gckey);
+    static PyObject* ConvertControl(const plKey& key);
+    static uint32_t WhatControlType(const plKey& key);
     static void GUICursorOff();
     static void GUICursorOn();
     static void GUICursorDimmed();
@@ -127,12 +128,14 @@ public:
 
     size_t GetNumControls();
     PyObject* GetControl(uint32_t idx); // returns pyKey
+    PyObject* GetControlMod(uint32_t idx) const;
     void SetFocus(pyKey& gcKey);
     void NoFocus();
     void Show();
     void ShowNoReset();
     void Hide();
     PyObject* GetControlFromTag(uint32_t tagID); // returns pyKey
+    PyObject* GetControlModFromTag(uint32_t tagID) const;
 
     // get color schemes
     PyObject* GetForeColor(); // returns pyColor

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialogGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialogGlue.cpp
@@ -160,6 +160,16 @@ PYTHON_METHOD_DEFINITION(ptGUIDialog, getControlFromIndex, args)
     return self->fThis->GetControl(index);
 }
 
+PYTHON_METHOD_DEFINITION(ptGUIDialog, getControlModFromIndex, args)
+{
+    unsigned long index;
+    if (!PyArg_ParseTuple(args, "l", &index)) {
+        PyErr_SetString(PyExc_TypeError, "getControlModFromIndex expects an unsigned long");
+        PYTHON_RETURN_ERROR;
+    }
+    return self->fThis->GetControlMod(index);
+}
+
 PYTHON_METHOD_DEFINITION(ptGUIDialog, setFocus, args)
 {
     PyObject* keyObj = nullptr;
@@ -193,6 +203,16 @@ PYTHON_METHOD_DEFINITION(ptGUIDialog, getControlFromTag, args)
         PYTHON_RETURN_ERROR;
     }
     return self->fThis->GetControlFromTag(tagID);
+}
+
+PYTHON_METHOD_DEFINITION(ptGUIDialog, getControlModFromTag, args)
+{
+    unsigned long tagID;
+    if (!PyArg_ParseTuple(args, "l", &tagID)) {
+        PyErr_SetString(PyExc_TypeError, "getControlModFromTag expects an unsigned long");
+        PYTHON_RETURN_ERROR;
+    }
+    return self->fThis->GetControlModFromTag(tagID);
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptGUIDialog, getForeColor)
@@ -293,12 +313,14 @@ PYTHON_START_METHODS_TABLE(ptGUIDialog)
     PYTHON_METHOD_NOARGS(ptGUIDialog, getVersion, "UNKNOWN"),
     PYTHON_METHOD_NOARGS(ptGUIDialog, getNumControls, "Returns the number of controls in this dialog"),
     PYTHON_METHOD(ptGUIDialog, getControlFromIndex, "Params: index\nReturns the ptKey of the control with the specified index (not tag ID!)"),
+    PYTHON_METHOD(ptGUIDialog, getControlModFromIndex, "Params: index\nReturns the ptGUIControl with the specified index (not tag ID!)"),
     PYTHON_METHOD(ptGUIDialog, setFocus, "Params: ctrlKey\nSets the control that has input focus"),
     PYTHON_BASIC_METHOD(ptGUIDialog, noFocus, "Makes sure no control has input focus"),
     PYTHON_BASIC_METHOD(ptGUIDialog, show, "Shows the dialog"),
     PYTHON_BASIC_METHOD(ptGUIDialog, showNoReset, "Show dialog without resetting clickables"),
     PYTHON_BASIC_METHOD(ptGUIDialog, hide, "Hides the dialog"),
     PYTHON_METHOD(ptGUIDialog, getControlFromTag, "Params: tagID\nReturns the ptKey of the control with the specified tag ID"),
+    PYTHON_METHOD(ptGUIDialog, getControlModFromTag, "Params: tagID\nReturns the ptGUIControl with the specified tag ID"),
     PYTHON_METHOD_NOARGS(ptGUIDialog, getForeColor, "Returns the fore color as a ptColor object"),
     PYTHON_METHOD_NOARGS(ptGUIDialog, getSelectColor, "Returns the select color as a ptColor object"),
     PYTHON_METHOD_NOARGS(ptGUIDialog, getBackColor, "Returns the back color as a ptColor object"),
@@ -370,7 +392,7 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtWhatGUIControlType, args, "Params: guiKey\nRet
         PYTHON_RETURN_ERROR;
     }
     pyKey* guiKey = pyKey::ConvertFrom(guiKeyObj);
-    return PyLong_FromUnsignedLong(pyGUIDialog::WhatControlType(*guiKey));
+    return PyLong_FromUnsignedLong(pyGUIDialog::WhatControlType(guiKey->getKey()));
 }
 
 PYTHON_BASIC_GLOBAL_METHOD_DEFINITION(PtGUICursorOff, pyGUIDialog::GUICursorOff, "Turns the GUI cursor off")

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.cpp
@@ -174,9 +174,9 @@ void pyGUIPopUpMenu::setup(const ST::string& name, pyGUIPopUpMenu &parent, float
         fGCkey = nullptr;
 }
 
-bool pyGUIPopUpMenu::IsGUIPopUpMenu(pyKey& gckey)
+bool pyGUIPopUpMenu::IsGUIPopUpMenu(const plKey& key)
 {
-    if ( gckey.getKey() && pfGUIPopUpMenu::ConvertNoRef(gckey.getKey()->GetObjectPtr()) )
+    if ( key && pfGUIPopUpMenu::ConvertNoRef(key->GetObjectPtr()) )
         return true;
     return false;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.h
@@ -93,7 +93,7 @@ public:
     void setup(const ST::string& name, float screenOriginX, float screenOriginY, const plLocation &destLoc = plLocation::kGlobalFixedLoc);
     void setup(const ST::string& name, pyGUIPopUpMenu &parent, float screenOriginX, float screenOriginY);
 
-    static bool IsGUIPopUpMenu(pyKey& gckey);
+    static bool IsGUIPopUpMenu(const plKey& key);
 
     // override the equals to operator
     bool operator==(const pyGUIPopUpMenu &gdobj) const;


### PR DESCRIPTION
This allows the scripter to avoid indirections through `ptKey` in their python code such that instead of writing something like:
```python
ctrl = ptGUIControlButton(MyGUIAttr.dialog.getControlFromTag(kButtonTag))
ctrl.show()
```

The following can be used:
```python
ctrl = MyGUIAttr.dialog.getControlModFromTag(kButtonTag))
ctrl.show()
```

This allows for more concise Python code and avoids constructing temporary `pyKey` objects in the engine. This API change is backwards incompatible, so I opted to make this a new method. I elected to not make `ptGUIDialog` a mapping type because controls can be fetched by both ID and tag, which are distinct values. It's better to be explicit in this case, IMO.

Further, I have applied the new methods to all Python code except for the KI (ki module and xOptionsMenu) because there are roughly 500 instances of the old junk in those files, and I'm getting tired.