### PR TITLE
Avoid exposing `plKey` implementation details

### DIFF
--- a/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
+++ b/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
@@ -216,12 +216,12 @@ public:
 
     bool EatKey(const plKey& key) override
     {
-        plKeyImp* imp = (plKey)key;
+        const plKeyImp* imp = plKeyImp::GetFromKey(key);
 
-        fStream.WriteString(imp->GetName());
+        fStream.WriteString(key->GetName());
         fStream.WriteString(",");
 
-        fStream.WriteString(plFactory::GetNameOfClass(imp->GetUoid().GetClassType()));
+        fStream.WriteString(plFactory::GetNameOfClass(key->GetUoid().GetClassType()));
         fStream.WriteString(",");
 
         char buf[30];

--- a/Sources/Plasma/Apps/plPageOptimizer/plPageOptimizer.cpp
+++ b/Sources/Plasma/Apps/plPageOptimizer/plPageOptimizer.cpp
@@ -185,13 +185,7 @@ void plPageOptimizer::KeyedObjectProc(const plKey& key)
 
 void plPageOptimizer::IWriteKeyData(hsStream* oldPage, hsStream* newPage, plKey& key)
 {
-    class plUpdateKeyImp : public plKeyImp
-    {
-    public:
-        void SetStartPos(uint32_t startPos) { fStartPos = startPos; }
-    };
-
-    plUpdateKeyImp* keyImp = static_cast<plUpdateKeyImp*>(plKeyImp::GetFromKey(key));
+    plKeyImp* keyImp = plKeyImp::GetFromKey(key);
     uint32_t startPos = keyImp->GetStartPos();
     uint32_t len = keyImp->GetDataLen();
 
@@ -206,7 +200,7 @@ void plPageOptimizer::IWriteKeyData(hsStream* oldPage, hsStream* newPage, plKey&
     if (newStartPos != startPos)
         fOptimized = false;
 
-    keyImp->SetStartPos(newStartPos);
+    keyImp->fStartPos = newStartPos;
     newPage->Write(len, &fBuf[0]);
 }
 

--- a/Sources/Plasma/Apps/plPageOptimizer/plPageOptimizer.cpp
+++ b/Sources/Plasma/Apps/plPageOptimizer/plPageOptimizer.cpp
@@ -191,7 +191,7 @@ void plPageOptimizer::IWriteKeyData(hsStream* oldPage, hsStream* newPage, plKey&
         void SetStartPos(uint32_t startPos) { fStartPos = startPos; }
     };
 
-    plUpdateKeyImp* keyImp = (plUpdateKeyImp*)(plKeyImp*)key;
+    plUpdateKeyImp* keyImp = static_cast<plUpdateKeyImp*>(plKeyImp::GetFromKey(key));
     uint32_t startPos = keyImp->GetStartPos();
     uint32_t len = keyImp->GetDataLen();
 
@@ -267,7 +267,7 @@ void plPageOptimizer::IRewritePage()
                 uint32_t dataLen = oldPage.ReadLE32();
 
                 // Get the new start pos
-                plKeyImp* key = (plKeyImp*)fResMgr->FindKey(uoid);
+                const plKeyImp* key = plKeyImp::GetFromKey(fResMgr->FindKey(uoid));
                 startPos = key->GetStartPos();
 
                 uoid.Write(&newPage);

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -2571,8 +2571,6 @@ PF_CONSOLE_CMD( Registry, SetLoggingLevel, "int level", "Sets the logging level 
 class plActiveRefPeekerKey : public plKeyImp
 {
     public:
-        size_t      PeekNumNotifies() { return GetNumNotifyCreated(); }
-        plRefMsg*   PeekNotifyCreated(size_t i) { return GetNotifyCreated(i); }
         bool        PeekIsActiveRef(size_t i) const { return IsActiveRef(i); }
 };
 
@@ -2583,15 +2581,15 @@ void MyHandyPrintFunction(const plKey &obj, void (*PrintString)(const ST::string
 
     if( peeker->GetUoid().IsClone() )
         PrintString(ST::format("{} refs on {}, clone {}:{}: loaded={}",
-            peeker->PeekNumNotifies(), obj->GetUoid().GetObjectName(),
+            peeker->GetNumNotifyCreated(), obj->GetUoid().GetObjectName(),
             peeker->GetUoid().GetCloneID(), peeker->GetUoid().GetClonePlayerID(),
             obj->ObjectIsLoaded() ? 1 : 0));
     else
         PrintString(ST::format("{} refs on {}: loaded={}",
-            peeker->PeekNumNotifies(), obj->GetUoid().GetObjectName(),
+            peeker->GetNumNotifyCreated(), obj->GetUoid().GetObjectName(),
             obj->ObjectIsLoaded() ? 1 : 0));
 
-    if( peeker->PeekNumNotifies() == 0 )
+    if( peeker->GetNumNotifyCreated() == 0 )
         return;
 
     uint32_t a, j, limit = 30, count = 0;
@@ -2599,11 +2597,11 @@ void MyHandyPrintFunction(const plKey &obj, void (*PrintString)(const ST::string
     {
         PrintString( ( a == 0 ) ? "  Active:" : "  Passive:" );
 
-        for (size_t i = 0; i < peeker->PeekNumNotifies(); i++)
+        for (size_t i = 0; i < peeker->GetNumNotifyCreated(); i++)
         {
             if( ( a == 0 && peeker->PeekIsActiveRef( i ) ) || ( a == 1 && !peeker->PeekIsActiveRef( i ) ) )
             {
-                plRefMsg *msg = peeker->PeekNotifyCreated( i );
+                plRefMsg *msg = peeker->GetNotifyCreated( i );
                 if (msg != nullptr)
                 {
                     for( j = 0; j < msg->GetNumReceivers(); j++ )

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -2579,7 +2579,7 @@ class plActiveRefPeekerKey : public plKeyImp
 // Not static so others can call it - making it even handier
 void MyHandyPrintFunction(const plKey &obj, void (*PrintString)(const ST::string&))
 {
-    plActiveRefPeekerKey *peeker = (plActiveRefPeekerKey *)(plKeyImp *)obj;
+    auto peeker = static_cast<plActiveRefPeekerKey*>(plKeyImp::GetFromKey(obj));
 
     if( peeker->GetUoid().IsClone() )
         PrintString(ST::format("{} refs on {}, clone {}:{}: loaded={}",
@@ -2644,12 +2644,12 @@ PF_CONSOLE_CMD( Registry, ListRefs, "string keyType, string keyName", "For the g
 
     MyHandyPrintFunction( obj, PrintString );
     
-    plActiveRefPeekerKey *peeker = (plActiveRefPeekerKey *)(plKeyImp *)obj;
-    if( peeker->GetNumClones() > 0 )
+    plKeyImp* imp = plKeyImp::GetFromKey(obj);
+    if (imp->GetNumClones() > 0)
     {
-        for (size_t i = 0; i < peeker->GetNumClones(); i++)
+        for (size_t i = 0; i < imp->GetNumClones(); i++)
         {
-            MyHandyPrintFunction( peeker->GetCloneByIdx( i ), PrintString );
+            MyHandyPrintFunction(imp->GetCloneByIdx(i), PrintString);
         }
     }
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -2708,7 +2708,7 @@ PyObject* cyMisc::FindClones(pyKey* object) {
     plKey obj = object->getKey();
     plUoid uoid = obj->GetUoid();
 
-    plKeyImp* imp = ((plKeyImp*)obj);
+    plKeyImp* imp = plKeyImp::GetFromKey(obj);
     size_t cloneNum = imp->GetNumClones();
     PyObject* keyList = PyList_New(cloneNum);
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -729,7 +729,7 @@ ST::string plPythonFileMod::IMakeModuleName(const plSceneObject* sobj)
     name << soName << pmName;
 
     // check to see if we are attaching to a clone?
-    const plKeyImp* pKeyImp = (plKeyImp*)(sKey);
+    const plKeyImp* pKeyImp = plKeyImp::GetFromKey(sKey);
     if (pKeyImp->GetCloneOwner()) {
         // we have an owner... so we must be a clone.
         // add the cloneID to the end of the module name

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/hsKeyedObject.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/hsKeyedObject.cpp
@@ -52,13 +52,13 @@ void hsKeyedObject::SetKey(plKey k)
     if (fpKey != nullptr)
     {
         hsAssert(k == nullptr || k == fpKey, "Changing an object's key is not allowed");
-        ((plKeyImp*)fpKey)->SetObjectPtr(nullptr);
+        plKeyImp::GetFromKey(fpKey)->SetObjectPtr(nullptr);
     }
 
     fpKey = std::move(k);
 
     if (fpKey != nullptr)
-        ((plKeyImp*)fpKey)->SetObjectPtr(this); 
+        plKeyImp::GetFromKey(fpKey)->SetObjectPtr(this); 
 }   
 
 bool hsKeyedObject::SendRef(plRefMsg* refMsg, plRefFlags::Type flags)
@@ -96,7 +96,7 @@ void hsKeyedObject::UnRegister()
         if (plgDispatch::Dispatch())
             plgDispatch::Dispatch()->UnRegisterAll(fpKey);
         
-        ((plKeyImp *)fpKey)->SetObjectPtr(nullptr);
+        plKeyImp::GetFromKey(fpKey)->SetObjectPtr(nullptr);
     }
 }
 
@@ -112,7 +112,7 @@ plKey hsKeyedObject::RegisterAs(plFixedKeyId fixedKey)
 
         //  the key list "helpfully" assigns us an object id.
         // we don't want one for fixed keys however (initialization order might bite us in the ass)
-        static_cast<plKeyImp*>(key)->SetObjectID(0);
+        plKeyImp::GetFromKey(key)->SetObjectID(0);
     }
     else
     {
@@ -154,7 +154,7 @@ void hsKeyedObject::UnRegisterAsManual(plUoid& inUoid)
                            fpKey->GetName(), inUoid, myUoid).c_str());
 #endif
         }
-        ((plKeyImp*)fpKey)->UnRegister();
+        plKeyImp::GetFromKey(fpKey)->UnRegister();
     }
 }
 

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
@@ -82,7 +82,7 @@ public:
     plKeyData* operator->() const;
     plKeyData& operator*() const;
 
-    operator bool() const { return fKeyData; }
+    operator bool() const { return fKeyData != nullptr; }
 
     static plKey Make(plKeyData* data) { return plKey(data); }
 

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
@@ -92,7 +92,7 @@ protected:
     void IIncRef();
     void IDecRef();
 
-    // Internal constructor, extra param is to distinguish it from the void* constructor
+    // Internal constructor
     plKey(plKeyData* data);
 };
 

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
@@ -55,7 +55,6 @@ class hsBitVector;
 //  Pointer to a plKeyData struct, which is a handle to a keyedObject
 
 class plKeyData;
-class plKeyImp;
 
 class plKey 
 {
@@ -83,7 +82,7 @@ public:
     plKeyData* operator->() const;
     plKeyData& operator*() const;
 
-    operator plKeyImp*() const { return (plKeyImp*)fKeyData; }
+    operator bool() const { return fKeyData; }
 
     static plKey Make(plKeyData* data) { return plKey(data); }
 

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
@@ -122,7 +122,7 @@ plKeyImp::~plKeyImp()
     if (fCloneOwner != nullptr)
     {
         // Must be a clone, remove us from our parent list
-        ((plKeyImp*)fCloneOwner)->RemoveClone(this);
+        plKeyImp::GetFromKey(fCloneOwner)->RemoveClone(this);
     }
 
     for (plKeyImp* clone : fClones)
@@ -435,7 +435,7 @@ plKey plKeyImp::GetCloneByIdx(size_t idx)
 void plKeyImp::SatisfyPending(plRefMsg* msg) const
 {
     for (int i = 0; i < msg->GetNumReceivers(); i++)
-        ((plKeyImp*)msg->GetReceiver(i))->SatisfyPending();
+        plKeyImp::GetFromKey(msg->GetReceiver(i))->SatisfyPending();
 }
 
 void plKeyImp::SatisfyPending() const
@@ -458,7 +458,7 @@ void plKeyImp::ISetupNotify(plRefMsg* msg, plRefFlags::Type flags)
 
     hsAssert(msg->GetNumReceivers(), "nil object getting a reference");
     for (int i = 0; i < msg->GetNumReceivers(); i++)
-        ((plKeyImp*)msg->GetReceiver(i))->AddRef(plKey::Make(this));
+        plKeyImp::GetFromKey(msg->GetReceiver(i))->AddRef(plKeyImp::GetFromKey(plKey::Make(this)));
 }
 
 void plKeyImp::SetupNotify(plRefMsg* msg, plRefFlags::Type flags)
@@ -584,13 +584,13 @@ void plKeyImp::IClearRefs()
     {
         plRefMsg* msg = GetNotifyCreated(i);
         for (size_t j = 0; j < msg->GetNumReceivers(); j++)
-            ((plKeyImp*)msg->GetReceiver(j))->RemoveRef(this);
+            plKeyImp::GetFromKey(msg->GetReceiver(j))->RemoveRef(this);
     }
 }
 
 void plKeyImp::Release(plKey targetKey)
 {
-    IRelease((plKeyImp*)targetKey);
+    IRelease(plKeyImp::GetFromKey(targetKey));
 }
 
 void plKeyImp::IRelease(plKeyImp* iTargetKey)

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.h
@@ -60,6 +60,11 @@ public:
     plKeyImp(plUoid, uint32_t pos,uint32_t len);
     virtual ~plKeyImp();
 
+    static plKeyImp* GetFromKey(const plKey& key)
+    {
+        return static_cast<plKeyImp*>(&*key);
+    }
+
     const plUoid&           GetUoid() const override { return fUoid; }
     ST::string              GetName() const override;
 

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.h
@@ -177,6 +177,9 @@ protected:
     mutable int16_t             fPendingRefs;   // Outstanding requests I have out.
     mutable std::vector<plKeyImp*>  fClones;    // clones of me
     mutable plKey               fCloneOwner;    // pointer for clones back to the owning key
+
+    friend class pfConsoleActiveRefPeeker;
+    friend class plPageOptimizer; // needs to update fStartPos
 };
 
 #endif // hsRegistry_inc

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -1206,7 +1206,7 @@ bool plArmatureMod::MsgReceive(plMessage* msg)
     {
         // First, do we have the system?
         plSceneObject *dstSysSO = GetFollowerParticleSystemSO();
-        if (!dstSysSO || ((plKeyImp*)dstSysSO->GetKey())->GetCloneOwner() != partMsg->fSysSOKey) 
+        if (!dstSysSO || plKeyImp::GetFromKey(dstSysSO->GetKey())->GetCloneOwner() != partMsg->fSysSOKey) 
         {
             // Need to clone and resend.
             if (plNetClientApp::GetInstance()->GetLocalPlayer() != GetTarget(0))

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
@@ -206,8 +206,7 @@ public:
 
     bool EatKey(const plKey& key) override
     {
-        plKeyImp* imp = (plKeyImp*)key;
-        imp->WriteObject(fStream);
+        plKeyImp::GetFromKey(key)->WriteObject(fStream);
         return true;
     }
 };

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
@@ -284,7 +284,7 @@ void plResManager::LogReadTimes(bool logReadTimes)
 
 hsKeyedObject* plResManager::IGetSharedObject(plKeyImp* pKey)
 {
-    plKeyImp* origKey = (plKeyImp*)pKey->GetCloneOwner();
+    plKeyImp* origKey = plKeyImp::GetFromKey(pKey->GetCloneOwner());
 
     // Find the first non-nil key and ask it to clone itself
     size_t count = origKey->GetNumClones();
@@ -583,7 +583,7 @@ plKey plResManager::FindKey(const plUoid& uoid)
 
     // If we're looking for a clone, get the clone instead of the original
     if (key && uoid.IsClone())
-        key = ((plKeyImp*)key)->GetClone(uoid.GetClonePlayerID(), uoid.GetCloneID());
+        key = plKeyImp::GetFromKey(key)->GetClone(uoid.GetClonePlayerID(), uoid.GetCloneID());
 
     return key;
 }
@@ -626,7 +626,7 @@ bool plResManager::AddViaNotify(const plKey &key, plRefMsg* msg, plRefFlags::Typ
         return false;
     }
 
-    ((plKeyImp*)key)->SetupNotify(msg,flags);
+    plKeyImp::GetFromKey(key)->SetupNotify(msg,flags);
     
     if (flags != plRefFlags::kPassiveRef)
     {
@@ -666,7 +666,7 @@ bool plResManager::SendRef(const plKey& key, plRefMsg* refMsg, plRefFlags::Type 
         return false;
     }
 
-    plKeyImp* iKey = (plKeyImp*)key;
+    plKeyImp* iKey = plKeyImp::GetFromKey(key);
     iKey->ISetupNotify(refMsg, flags);
     hsRefCnt_SafeUnRef(refMsg);
 
@@ -713,7 +713,7 @@ plKey plResManager::ReadKeyNotifyMe(hsStream* stream, plRefMsg* msg, plRefFlags:
         return nullptr;
     }
 
-    ((plKeyImp*)key)->SetupNotify(msg,flags);
+    plKeyImp::GetFromKey(key)->SetupNotify(msg,flags);
 
     hsKeyedObject* ko = key->ObjectIsLoaded();
 
@@ -795,7 +795,7 @@ plKey plResManager::ReRegister(const ST::string& nm, const plUoid& oid)
     {
         if (pOrigKey)
         {
-            plKey cloneKey = ((plKeyImp*)pOrigKey)->GetClone(fCurClonePlayerID, fCurCloneID);
+            plKey cloneKey = plKeyImp::GetFromKey(pOrigKey)->GetClone(fCurClonePlayerID, fCurCloneID);
             if (cloneKey)
                 return cloneKey;
         }
@@ -804,8 +804,8 @@ plKey plResManager::ReRegister(const ST::string& nm, const plUoid& oid)
     plKeyImp* pKey = new plKeyImp;
     if (canClone && pOrigKey)
     {   
-        pKey->CopyForClone((plKeyImp*)pOrigKey, fCurClonePlayerID, fCurCloneID);
-        ((plKeyImp*)pOrigKey)->AddClone(pKey);
+        pKey->CopyForClone(plKeyImp::GetFromKey(pOrigKey), fCurClonePlayerID, fCurCloneID);
+        plKeyImp::GetFromKey(pOrigKey)->AddClone(pKey);
     }
     else
     {
@@ -927,7 +927,7 @@ bool plResManager::Unload(const plKey& objKey)
 {
     if (objKey)
     {
-        ((plKeyImp*)objKey)->UnRegister();
+        plKeyImp::GetFromKey(objKey)->UnRegister();
         fDispatch->UnRegisterAll(objKey);
         return true;
     }
@@ -1583,7 +1583,7 @@ void plResManager::UnloadPageObjects(plRegistryPageNode* pageNode, uint16_t clas
     public:
         bool EatKey(const plKey& key) override
         {
-            sIReportLeak((plKeyImp*)key, nullptr);
+            sIReportLeak(plKeyImp::GetFromKey(key), nullptr);
             return true;
         }
     };

--- a/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
+++ b/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
@@ -1292,7 +1292,7 @@ hsGMaterial* hsMaterialConverter::IInsertDoneMaterial(Mtl *mtl, hsGMaterial *hMa
         plKey matKey = hMat->GetKey();
         matKey->RefObject();
         matKey->UnRefObject();
-        ((plKeyImp *)matKey)->SetObjectPtr(nullptr);
+        plKeyImp::GetFromKey(matKey)->SetObjectPtr(nullptr);
         matKey = nullptr;
 
         hMat = equivalent->fHsMaterial;

--- a/Sources/Tools/MaxMain/plPluginResManager.cpp
+++ b/Sources/Tools/MaxMain/plPluginResManager.cpp
@@ -506,14 +506,14 @@ bool plPluginResManager::NukeKeyAndObject(plKey& objectKey)
         uint16_t GetRefCount() const { return fRefCount; }
     };
 
-    plKeyImp* keyData = (plKeyImp*)objectKey;
+    plKeyImp* keyData = plKeyImp::GetFromKey(objectKey);
 
     // Check the ref count on the object. Nobody should have a ref to it
     // except the key
     hsKeyedObject* object = objectKey->ObjectIsLoaded();
     if (object != nullptr)
     {
-        if (keyData->GetActiveRefs())
+        if (objectKey->GetActiveRefs())
             // Somebody still has a ref to this object, so we can't nuke it
             return false;
     }

--- a/Sources/Tools/plFontConverter/plFontConverter.cpp
+++ b/Sources/Tools/plFontConverter/plFontConverter.cpp
@@ -259,7 +259,7 @@ void plFontConverter::ExportP2F()
 void plFontConverter::IMakeFontGoAway()
 {
     if (fFont != nullptr) {
-        plKeyImp *imp = (plKeyImp *)(fFont->GetKey());
+        plKeyImp* imp = plKeyImp::GetFromKey(fFont->GetKey());
         if (imp != nullptr)
             imp->SetObjectPtr(nullptr);
         fFont = nullptr;

--- a/Sources/Tools/plResBrowser/plResBrowser.cpp
+++ b/Sources/Tools/plResBrowser/plResBrowser.cpp
@@ -235,13 +235,13 @@ void plResBrowser::SaveSelectedObject()
 
     if (!fileName.isEmpty())
     {
-        plKeyImp *keyImp = static_cast<plKeyImp *>(itemKey);
+        plKeyImp* keyImp = plKeyImp::GetFromKey(itemKey);
 
         if (keyImp->GetDataLen() <= 0)
             return;
 
         plResManager *resMgr = static_cast<plResManager *>(hsgResMgr::ResMgr());
-        plRegistryPageNode *pageNode = resMgr->FindPage(keyImp->GetUoid().GetLocation());
+        plRegistryPageNode* pageNode = resMgr->FindPage(itemKey->GetUoid().GetLocation());
 
         hsStream *stream = pageNode->OpenStream();
         if (!stream)
@@ -317,7 +317,7 @@ void plResBrowser::UpdateInfoPage()
             fUI->fObjectClass->setText(QString("%1 (%2)").arg(cname ? cname : "<unknown>")
                                        .arg(key->GetUoid().GetClassType()));
 
-            plKeyImp *imp = static_cast<plKeyImp *>(key);
+            plKeyImp* imp = plKeyImp::GetFromKey(key);
             if (showAsHex)
                 fUI->fStartPos->setText(QString("0x%1").arg(imp->GetStartPos(), 0, 16));
             else


### PR DESCRIPTION
`plKey`'s contents are separated into a public interface `plKeyData` and an internal implementation subclass `plKeyImp`. However, the main `plKey` API had an implicit conversion to `plKeyImp`, making it relatively easy to access the implementation details anyway.

This changes that to require an explicit method call, which only becomes available if you include the implementation header. This will make it easier to find all the places that rely on this conversion.

Confusingly, the implicit conversion was used quite often whenever a `plKey` was used as a boolean (to check if its underlying pointer is null). Those uses don't actually need the implementation details and are now handled by a simple `operator bool`.