### PR TITLE
Update README to point to website instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ enhanced features.
 
 For more information on Myst Online, see http://mystonline.com/developers/
 
-For a project roadmap, see https://github.com/H-uru/Plasma/wiki/Roadmap
-
 
 Related Projects
 ----------------
@@ -31,7 +29,8 @@ Plasma currently requires the following third-party libraries:
 - OpenSSL - http://www.slproweb.com/products/Win32OpenSSL.html
 - OpenAL Soft - https://openal-soft.org/
 - eXpat - http://expat.sourceforge.net/
-- libJPEG - http://libjpeg-turbo.virtualgl.org/
+- Freetype - http://freetype.org/
+- libJPEG-turbo - http://libjpeg-turbo.virtualgl.org/
 - libPNG - http://www.libpng.org/
 - zlib - http://zlib.net/
 - libcurl - http://curl.haxx.se/
@@ -42,8 +41,9 @@ The following libraries are optional:
 
 - (for building resource.dat) CairoSVG - https://cairosvg.org/
 - (for building resource.dat) Pillow - https://python-pillow.org/
-- (for plFontConverter) Freetype - http://freetype.org/
-- (for the GUI tools) Qt5 - http://www.qt.io/download-open-source/
+- (for the GUI tools) Qt - http://www.qt.io/download-open-source/
+- (for experimental OpenGL support) epoxy - https://github.com/anholt/libepoxy
+- (for Linux font support) fontconfig - https://www.fontconfig.org/
 - (for video) VPX - http://www.webmproject.org/
 - (for video and voice chat) Opus - http://www.opus-codec.org/
 - (for legacy voice chat) speex - http://www.speex.org/downloads/
@@ -52,70 +52,26 @@ All required libraries are available as [vcpkg](https://github.com/microsoft/vcp
 ports or can be built using their individual build instructions.
 
 
-Compiling Instructions
-----------------------
+Compiling & Running Instructions
+--------------------------------
 
-Currently, compilation only targets Windows systems and requires Visual Studio
-2019 (including Visual Studio 2019 Community).
+The Plasma development site includes steps for
+[compiling](https://h-uru.github.io/Plasma/building.html) and
+[running](https://h-uru.github.io/Plasma/running.html) the client.
 
-1. Clone the repository, including all submodules, in a git client or by
-   executing the following at the command line:
-   ```
-   git clone --recurse-submodules https://github.com/H-uru/Plasma.git
-   ```
-2. Open **Microsoft Visual Studio 2019**.
-3. Select **Open a local folder** and choose the folder where you cloned the
-   repository.
-4. Open the CMake Settings by chosing **Project > CMake Settings for Plasma**
-   from the Visual Studio menu bar.
-5. Add a new configuration in CMakeSettings.json by clicking the **green +**
-   button.
-6. Select **x86-Release** in the window that pops up.
-7. Compile the client by using **Build > Install Plasma** from the Visual
-   Studio menu bar.
-8. The client will be built and installed into the `out\install\x86-Release`
-   subfolder of where you cloned the repository. This will be referred to as
-   the *MOUL-OS* folder.
-
-
-Running Instructions
---------------------
-
-To run the Internal Client for testing with MOULa content, you will need the a
-fully-patched installation of MOULa provided by Cyan Worlds.
-
-1. Copy the folders *avi*, *dat*, and *sfx* **from your existing MOULa installation**
-   to the *MOUL-OS* folder.
-2. Copy the example_server.ini file from the root of the Plasma repository into
-   your *MOUL-OS* folder, and rename it as **server.ini**. If you are running
-   your own dirtsand server or are connecting to one run by someone else, use
-   the server.ini generated from that.
-3. Create a **shortcut** in the *MOUL-OS* folder to the compiled plClient.exe.
-4. Edit the shortcut's **properties**, and after the final quotation mark in the
-   *Target* field, add `/LocalData`. Also, change the *Start in* field to the
-   path of your *MOUL-OS* folder.
-5. Double-click the shortcut to **connect** to your server and test!
-
-Alternatively, if you wish to be able to debug using a single content folder
-from inside Visual Studio:
-
-1. Open the Plasma folder in Visual Studio.
-2. Switch to *CMake Targets View* in the Solution Explorer.
-3. Right-click on the *plClient (executable)* target in the Solution Explorer.
-4. Select *Debug and Launch Settings > plClient.exe (Install)*.
-5. Add the following to the *configurations*:
-   ```json
-   "args": "/LocalData"
-   ```
-
+You can also download pre-built artifacts from our [last successful automated
+build](https://github.com/H-uru/Plasma/releases/tag/last-successful) on
+GitHub.
 
 Additional Information
 ----------------------
 
 - Myst Online is available to play for free at http://mystonline.com/play/
-- For more information on this fork and more in-depth building instructions,
-  see the [Guild of Writers wiki](http://guildofwriters.org/wiki/Development:CyanWorlds.com_Engine).
 - This code was forked from the initial release repository at [OpenUru.org](http://openuru.org/).
+
+**There are lots of opportunities to get involved!** Find out how you can [get
+involved](https://h-uru.github.io/Plasma/involvement.html) and help improve Uru
+for everyone.
 
 
 About Non-Free Libraries


### PR DESCRIPTION
It's better to maintain these in a single place rather than multiple places where they can get out of date and out of sync (although yes it would be nice for the instructions to be available after cloning the repo).

Also update the list of libraries to keep it accurate.