### PR TITLE
Minor tweaks to hsMatrix44 Accelerate.framework support

### DIFF
--- a/Sources/Plasma/CoreLib/hsMatrix44.cpp
+++ b/Sources/Plasma/CoreLib/hsMatrix44.cpp
@@ -52,7 +52,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <cmath>
 
 #ifdef HS_BUILD_FOR_APPLE
-#import <Accelerate/Accelerate.h>
+#include <Accelerate/Accelerate.h>
 #endif
 
 static hsMatrix44 myIdent = hsMatrix44().Reset();
@@ -115,9 +115,9 @@ hsMatrix44 hsMatrix44::mult_accelerate(const hsMatrix44 &a, const hsMatrix44 &b)
         return b;
     if( b.fFlags & hsMatrix44::kIsIdent )
         return a;
-    
-    vDSP_mmul((const float*)a.fMap, 1, (const float*)b.fMap, 1, (float*)&(c.fMap), 1, 4, 4, 4);
-    
+
+    vDSP_mmul(const_cast<float*>(a.fMap[0]), 1, const_cast<float*>(b.fMap[0]), 1, c.fMap[0], 1, 4, 4, 4);
+
     return c;
 }
 #endif

--- a/Sources/Plasma/CoreLib/hsMatrixMath.h
+++ b/Sources/Plasma/CoreLib/hsMatrixMath.h
@@ -48,7 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsMatrix44.h"
 
 #ifdef HS_BUILD_FOR_APPLE
-#import <Accelerate/Accelerate.h>
+#include <Accelerate/Accelerate.h>
 #endif
 
 static inline hsMatrix44 IMatrixMul34(const hsMatrix44& lhs, const hsMatrix44& rhs)
@@ -57,7 +57,7 @@ static inline hsMatrix44 IMatrixMul34(const hsMatrix44& lhs, const hsMatrix44& r
     ret.NotIdentity();
     
 #ifdef HS_BUILD_FOR_APPLE
-    vDSP_mmul((const float*)lhs.fMap, 1, (const float*)rhs.fMap, 1, (float*)&(ret.fMap), 1, 3, 4, 4);
+    vDSP_mmul(const_cast<float*>(lhs.fMap[0]), 1, const_cast<float*>(rhs.fMap[0]), 1, ret.fMap[0], 1, 3, 4, 4);
 #else
     ret.fMap[0][0] = lhs.fMap[0][0] * rhs.fMap[0][0]
         + lhs.fMap[0][1] * rhs.fMap[1][0]


### PR DESCRIPTION
1. This is a C++ file, and Accelerate is a C library, so we should use `#include` instead of `#import`.

2. Somewhere around Mac OS X 10.10, some parameters to `vDSP_mmul` were changed from `float*` to `const float*`. But earlier versions complain if you try to pass them `const float*` values, so just cast to `float*`.

Tested and successfully compiled on Mac OS X 10.5 PowerPC 😛 