### PR TITLE
Use standard versions of `snprintf`/`swprintf` on Windows

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -319,8 +319,6 @@ int hsMessageBoxWithOwner(hsWindowHndl owner, const wchar_t* message, const wcha
 
 #if HS_BUILD_FOR_WIN32
      // This is for Windows
-#    define snprintf        _snprintf
-
 #    ifndef fileno
 #        define fileno(__F)       _fileno(__F)
 #    endif

--- a/Sources/Tools/MaxExport/plExportDlg.cpp
+++ b/Sources/Tools/MaxExport/plExportDlg.cpp
@@ -122,7 +122,7 @@ plExportDlgImp::plExportDlgImp()
 BOOL WritePrivateProfileIntW(LPCWSTR lpAppName, LPCWSTR lpKeyName, int val, LPCWSTR lpFileName)
 {
     wchar_t buf[12];
-    _snwprintf(buf, 12, L"%d", val);
+    swprintf(buf, 12, L"%d", val);
 
     return WritePrivateProfileStringW(lpAppName, lpKeyName, buf, lpFileName);
 }

--- a/Sources/Tools/MaxMain/plMaxMenu.cpp
+++ b/Sources/Tools/MaxMain/plMaxMenu.cpp
@@ -320,7 +320,7 @@ void plCreateMenu()
 
         // Update the menu version
         wchar_t buf[12];
-        _snwprintf(buf, std::size(buf), L"%d", kMenuVersion);
+        swprintf(buf, std::size(buf), L"%d", kMenuVersion);
         WritePrivateProfileStringW(L"Menu", L"Version", buf, plMaxConfig::GetPluginIni().WideString().data());
     }
     


### PR DESCRIPTION
I thought there was some reason why the non-standard versions were still used, but apparently not. After re-reading the Microsoft docs ([`snprintf`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=msvc-170), [`swprintf`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/sprintf-sprintf-l-swprintf-swprintf-l-swprintf-l?view=msvc-170)), I'm pretty sure we can safely switch to the standard functions on Windows too.

`snprintf` is supported since VS 2015 and the standard-compliant version of `swprintf` since at least VS 2010, which is definitely enough for our purposes.