### PR TITLE
Audit all `ComboBox_AddString` macro calls.

### DIFF
--- a/Sources/Tools/MaxComponent/plAnimCompProc.cpp
+++ b/Sources/Tools/MaxComponent/plAnimCompProc.cpp
@@ -309,7 +309,7 @@ void plMtlAnimProc::ILoadAnimCombo(HWND hWnd, IParamBlock2* pb)
     HWND hAnim = GetDlgItem(hWnd, fAnimComboID);
 
     ComboBox_ResetContent(hAnim);
-    int sel = ComboBox_AddString(hAnim, ENTIRE_ANIMATION_NAME);
+    int sel = ComboBox_AddString(hAnim, _T(ENTIRE_ANIMATION_NAME));
     ComboBox_SetCurSel(hAnim, sel);
     
     auto savedName = pb->GetStr(fAnimParamID);
@@ -323,7 +323,7 @@ void plMtlAnimProc::ILoadAnimCombo(HWND hWnd, IParamBlock2* pb)
         ST::string animName;
         while (!(animName = anim.GetNextAnimName()).empty())
         {
-            int idx = ComboBox_AddString(hAnim, animName.c_str());
+            int idx = ComboBox_AddString(hAnim, ST2T(animName));
             ComboBox_SetItemData(hAnim, idx, 1);
             if (!animName.compare(savedName))
                 ComboBox_SetCurSel(hAnim, idx);

--- a/Sources/Tools/MaxComponent/plClimbComponent.cpp
+++ b/Sources/Tools/MaxComponent/plClimbComponent.cpp
@@ -91,15 +91,15 @@ enum Commands
 };
 
 // these synchronized ^^^^VVVVV
-const char * fCommandStrs[] =
+static const TCHAR* fCommandStrs[] =
 {
-    "Start Climbing",
-    "Enable Dismount",
-    "Disable Dismount",
-    "Enable Climb",
-    "Disable Climb",
-    "Fall Off",
-    "Let Go"
+    _T("Start Climbing"),
+    _T("Enable Dismount"),
+    _T("Disable Dismount"),
+    _T("Enable Climb"),
+    _T("Disable Climb"),
+    _T("Fall Off"),
+    _T("Let Go")
 };
 
 enum Directions
@@ -111,12 +111,12 @@ enum Directions
     kMaxDirections
 };
 
-const char * fDirectionStrs[] =
+static const TCHAR* fDirectionStrs[] =
 {
-    "Up",
-    "Down",
-    "Left",
-    "Right"
+    _T("Up"),
+    _T("Down"),
+    _T("Left"),
+    _T("Right")
 };
 
 

--- a/Sources/Tools/MaxComponent/plNavigableComponents.cpp
+++ b/Sources/Tools/MaxComponent/plNavigableComponents.cpp
@@ -99,9 +99,9 @@ public:
             {
                 HWND hLadder = GetDlgItem(hWnd,IDC_COMP_NAV_LADDER_COMBO);
 
-                ComboBox_AddString(hLadder, "Big");
-                ComboBox_AddString(hLadder, "4 feet");
-                ComboBox_AddString(hLadder, "2 feet");
+                ComboBox_AddString(hLadder, _T("Big"));
+                ComboBox_AddString(hLadder, _T("4 feet"));
+                ComboBox_AddString(hLadder, _T("2 feet"));
 
                 int type = map->GetParamBlock()->GetInt(kTypeCombo);
                 ComboBox_SetCurSel(hLadder, type);

--- a/Sources/Tools/MaxComponent/plResponderAnim.cpp
+++ b/Sources/Tools/MaxComponent/plResponderAnim.cpp
@@ -763,7 +763,7 @@ void plResponderAnimProc::ILoadUser(HWND hWnd, IParamBlock2 *pb)
         ST::string loopName;
         while (!(loopName = info.GetNextLoopName()).empty())
         {
-            int idx = ComboBox_AddString(hLoop, loopName.c_str());
+            int idx = ComboBox_AddString(hLoop, ST2T(loopName));
             ComboBox_SetItemData(hLoop, idx, 1);
 
             if (!loopName.compare(savedName))

--- a/Sources/Tools/MaxComponent/plResponderMtl.cpp
+++ b/Sources/Tools/MaxComponent/plResponderMtl.cpp
@@ -524,7 +524,7 @@ void plResponderMtlProc::ILoadUser(HWND hWnd, IParamBlock2 *pb)
         savedName = _M("");
 
     ComboBox_ResetContent(hLoop);
-    int sel = ComboBox_AddString(hLoop, ENTIRE_ANIMATION_NAME);
+    int sel = ComboBox_AddString(hLoop, _T(ENTIRE_ANIMATION_NAME));
     ComboBox_SetCurSel(hLoop, sel);
     
     // Get the NoteTrack animations off the selected material

--- a/Sources/Tools/MaxComponent/plTypesComponents.cpp
+++ b/Sources/Tools/MaxComponent/plTypesComponents.cpp
@@ -542,7 +542,7 @@ protected:
         ST::string animName;
         while (!(animName = anim.GetNextAnimName()).empty())
         {
-            int sel = ComboBox_AddString(hCombo, animName.c_str());
+            int sel = ComboBox_AddString(hCombo, ST2T(animName));
             if (animName.compare(savedName) == 0)
                 ComboBox_SetCurSel(hCombo, sel);
         }

--- a/Sources/Tools/MaxMain/plTextureSearch.cpp
+++ b/Sources/Tools/MaxMain/plTextureSearch.cpp
@@ -330,12 +330,9 @@ void plTextureSearch::IUpdateTextures(plTextureSearch::Update update)
             sizeX = FloorPow2(sizeX);
             sizeY = FloorPow2(sizeY);
 
-            char buf[256];
-
             while (sizeX >= 4 && sizeY >= 4)
             {
-                sprintf(buf, "%d x %d", sizeX, sizeY);
-                int idx = ComboBox_AddString(hCombo, buf);
+                int idx = ComboBox_AddString(hCombo, ST2T(ST::format("{} x {}", sizeX, sizeY)));
                 ComboBox_SetItemData(hCombo, idx, MAKELPARAM(sizeX, sizeY));
 
                 sizeX >>= 1;


### PR DESCRIPTION
And fix them to properly pass in `TCHAR*`. There may still be more Chinese left to uncover, but this is the worst offender.