### PR TITLE
Remove dead code in SDL parser.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plSDL/plSDLParser.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDLParser.cpp
@@ -277,23 +277,6 @@ bool plSDLParser::IParseVarDesc(const plFileName& fileName, hsStream* stream, ch
                 hsAssert(false, ST::format("missing defaultOption string, fileName={}", fileName).c_str());
             }
         }
-
-#if 1   // delete me in May 2003
-        else
-        if (!strcmp(token, "INTERNAL"))
-        {
-            hsAssert(curVar, ST::format("Syntax problem with .sdl file, fileName={}", fileName).c_str());
-            curVar->SetInternal(true);
-            dbgStr += ST_LITERAL(" ") + token;
-        }
-        else
-        if (!strcmp(token, "PHASED"))
-        {
-            hsAssert(curVar, ST::format("Syntax problem with .sdl file, fileName={}", fileName).c_str());
-            curVar->SetAlwaysNew(true);
-            dbgStr += ST_LITERAL(" ") + token;
-        }
-#endif
         else
         {
             skipNext=true;


### PR DESCRIPTION
Note: The `SetInternal()` and `SetAlwaysNew()` methods are still used, but are flagged from `DISPLAYOPTION=hidden` and `DEFAULTOPTION=vault` respectively.