### PR TITLE
Document SDL read/write options in more detail

### DIFF
--- a/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
@@ -159,7 +159,7 @@ public:
     ST::string GetHintString() const { return fHintString; }
 
     void Read(hsStream* s, uint32_t readOptions);
-    void Write(hsStream* s, uint32_t writeOptions) const;
+    void Write(hsStream* s) const;
 };
 
 //
@@ -299,8 +299,8 @@ protected:
     bool IConvertFromRGB8(plVarDescriptor::Type newType);
     bool IConvertFromRGBA8(plVarDescriptor::Type newType);
 
-    bool IReadData(hsStream* s, float timeConvert, int idx, uint32_t readOptions);    
-    bool IWriteData(hsStream* s, float timeConvert, int idx, uint32_t writeOptions) const;
+    bool IReadData(hsStream* s, float timeConvert, int idx);
+    bool IWriteData(hsStream* s, float timeConvert, int idx) const;
 
 public:
 

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
@@ -86,17 +86,58 @@ namespace plSDL
 
     enum RWOptions
     {
-        kDirtyOnly              = 1<< 0,            // write option
-        kSkipNotificationInfo   = 1<< 1,            // read/write option
-        kBroadcast              = 1<< 2,            // send option
-        kWriteTimeStamps        = 1<< 3,            // write out time stamps    
-        kTimeStampOnRead        = 1<< 4,            // read: timestamp each var when it gets read. write: request that the reader timestamp the dirty vars.
-        kTimeStampOnWrite       = 1<< 5,            // read: n/a. write: timestamp each var when it gets written.
-        kKeepDirty              = 1<< 6,            // don't clear dirty flag on read
-        kDontWriteDirtyFlag     = 1<< 7,            // write option. don't write var dirty flag.
-        kMakeDirty              = 1<< 8,            // read/write: set dirty flag on var read/write. 
-        kDirtyNonDefaults       = 1<< 9,            // dirty the var if non default value.
-        kForceConvert           = 1<<10,            // always try to convert rec to latest on read
+        // General note: when writing nested SDL variables (plSDStateVariable),
+        // only the kDirtyOnly option applies recursively.
+        // All other write options are ignored when writing the nested records!
+
+        // When writing: only write variables marked dirty.
+        // Default is to write all used variables, dirty or not.
+        kDirtyOnly = 1 << 0,
+
+        // When reading: ignore any notification infos in blob and leave them empty in the variables in memory.
+        // When writing: don't write notification infos to the blob and don't set kHasNotificationInfo flags.
+        kSkipNotificationInfo = 1 << 1,
+
+        // Only applies to plStateDataRecord::PrepNetMsg.
+        // Create a message of type plNetMsgSDLStateBCast instead of plNetMsgSDLState.
+        kBroadcast = 1 << 2,
+
+        // When writing: write timestamps of variables that have one.
+        // Default is to not write any variable timestamps unless specifically requested.
+        // If plSDLMgr has kDisallowTimeStamping set, this flag causes a debug assert.
+        kWriteTimeStamps = 1 << 3,
+
+        // When reading: for variables that will be set as dirty (depending on other read options) and that don't have a timestamp,
+        // set their timestamp to the current time upon reading, even if the variables don't have kWantTimeStamp set.
+        // Ignored if plSDLMgr has kDisallowTimeStamping set.
+        // When writing: set kWantTimeStamp flag for all variables.
+        kTimeStampOnRead = 1 << 4,
+
+        // When writing: enable writing variable timestamps and set all variables' timestamps to the current time before writing them.
+        kTimeStampOnWrite = 1 << 5,
+
+        // When reading: update variables' dirty status based on kHasDirtyFlag.
+        // May be overridden by kMakeDirty and kDirtyNonDefaults.
+        kKeepDirty = 1 << 6,
+
+        // When writing: don't set kHasDirtyFlag based on variables' dirty status.
+        // kMakeDirty and kDirtyNonDefaults may still cause kHasDirtyFlag to be set.
+        kDontWriteDirtyFlag = 1 << 7,
+
+        // When reading: set all variables as dirty, regardless of whether they have kHasDirtyFlag set.
+        // Takes priority over kKeepDirty and kDirtyNonDefaults.
+        // When writing: set kHasDirtyFlag for all variables, regardless of their dirty status.
+        // Takes priority over kDontWriteDirtyFlag.
+        kMakeDirty = 1 << 8,
+
+        // When reading: for variables that don't have kSameAsDefault set, always set them as dirty, even if they don't have kHasDirtyFlag.
+        // Takes priority over kKeepDirty, but may be overridden by kMakeDirty.
+        // When writing: for variables whose values are different from their default, always set kHasDirtyFlag, even if they aren't dirty.
+        // Takes priority over kDontWriteDirtyFlag.
+        kDirtyNonDefaults = 1 << 9,
+
+        // When reading: if the blob uses the latest known version, perform an "update" anyway, as if it had an older version.
+        kForceConvert = 1 << 10,
     };
 
     enum BehaviorFlags

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDL.h
@@ -158,7 +158,7 @@ public:
     void SetHintString(ST::string c) { fHintString = std::move(c); }
     ST::string GetHintString() const { return fHintString; }
 
-    void Read(hsStream* s, uint32_t readOptions);
+    void Read(hsStream* s);
     void Write(hsStream* s) const;
 };
 

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateDataRecord.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateDataRecord.cpp
@@ -235,6 +235,7 @@ bool plStateDataRecord::IHasUsedVars(const VarsList& vars) const
 //
 // read state vars and indices, return true on success
 //
+// Options: kSkipNotificationInfo, kTimeStampOnRead, kKeepDirty, kMakeDirty, kDirtyNonDefaults, kForceConvert
 bool plStateDataRecord::Read(hsStream* s, float timeConvert, uint32_t readOptions)
 {
     fFlags = s->ReadLE16();
@@ -348,6 +349,7 @@ bool plStateDataRecord::Read(hsStream* s, float timeConvert, uint32_t readOption
 //
 // write out the state vars, along with their index
 //
+// Options: kDirtyOnly, kSkipNotificationInfo, kWriteTimeStamps, kTimeStampOnRead, kTimeStampOnWrite, kDontWriteDirtyFlag, kMakeDirty, kDirtyNonDefaults
 void plStateDataRecord::Write(hsStream* s, float timeConvert, uint32_t writeOptions) const
 {
 #ifdef HS_DEBUGGING
@@ -457,6 +459,7 @@ void plStateDataRecord::WriteStreamHeader(hsStream* s, plUoid* objUoid) const
 //
 // create and prepare a net msg with this data
 //
+// Options: kDirtyOnly, kSkipNotificationInfo, kBroadcast, kWriteTimeStamps, kTimeStampOnRead, kTimeStampOnWrite, kDontWriteDirtyFlag, kMakeDirty, kDirtyNonDefaults
 plNetMsgSDLState* plStateDataRecord::PrepNetMsg(float timeConvert, uint32_t writeOptions) const
 {
     // save to stream
@@ -478,6 +481,7 @@ plNetMsgSDLState* plStateDataRecord::PrepNetMsg(float timeConvert, uint32_t writ
 //
 // Destroys 'this' and makes a total copy of other
 //
+// Options: all except for kDirtyOnly, kBroadcast, kForceConvert
 void plStateDataRecord::CopyFrom(const plStateDataRecord& other, uint32_t writeOptions/*=0*/)
 {
     fFlags = other.GetFlags();
@@ -501,6 +505,7 @@ void plStateDataRecord::CopyFrom(const plStateDataRecord& other, uint32_t writeO
 // copy them to my corresponding item.
 // Requires that records have the same descriptor.
 //
+// Options: all except for kBroadcast, kForceConvert
 void plStateDataRecord::UpdateFrom(const plStateDataRecord& other, uint32_t writeOptions/*=0*/)
 {
     if ( GetDescriptor()->GetVersion()!=other.GetDescriptor()->GetVersion() )

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
@@ -2679,7 +2679,7 @@ bool plSDStateVariable::WriteData(hsStream* s, float timeConvert, uint32_t write
             if (!all)
                 plSDL::VariableLengthWrite(s, 
                     GetVarDescriptor()->IsVariableLength() ? 0xffffffff : GetVarDescriptor()->GetCount(), i);   // idx
-            fDataRecList[i]->Write(s, timeConvert, dirtyOnly);  // item
+            fDataRecList[i]->Write(s, timeConvert, dirtyOnly ? plSDL::kDirtyOnly : 0); // item
             written++;
         }
     }

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
@@ -101,6 +101,7 @@ public:
 // plStateVarNotificationInfo
 /////////////////////////////////////////////////////
 
+// Options: kSkipNotificationInfo
 void plStateVarNotificationInfo::Read(hsStream* s, uint32_t readOptions)
 {
     (void)s->ReadByte();  // unused: saveFlags
@@ -109,6 +110,7 @@ void plStateVarNotificationInfo::Read(hsStream* s, uint32_t readOptions)
         fHintString = hint;
 }
 
+// Options: (none)
 void plStateVarNotificationInfo::Write(hsStream* s, uint32_t writeOptions) const
 {
     (void)s->WriteByte(uint8_t(0));   // unused: saveFlags
@@ -118,6 +120,7 @@ void plStateVarNotificationInfo::Write(hsStream* s, uint32_t writeOptions) const
 /////////////////////////////////////////////////////
 // plStateVariable
 /////////////////////////////////////////////////////
+// Options: kSkipNotificationInfo, kTimeStampOnRead, kKeepDirty, kMakeDirty, kDirtyNonDefaults, [plSDStateVariable only: kForceConvert]
 bool plStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t readOptions)
 {
     uint8_t saveFlags = s->ReadByte();
@@ -128,6 +131,7 @@ bool plStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t readOpti
     return true;
 }
 
+// Options: kSkipNotificationInfo, [plSDStateVariable only: kDirtyOnly], [plSimpleStateVariable only: kWriteTimeStamps, kTimeStampOnRead, kTimeStampOnWrite, kDontWriteDirtyFlag, kMakeDirty, kDirtyNonDefaults]
 bool plStateVariable::WriteData(hsStream* s, float timeConvert, uint32_t writeOptions) const
 {
     bool writeNotificationInfo = ((writeOptions & plSDL::kSkipNotificationInfo)==0);
@@ -1771,6 +1775,7 @@ ST::string plSimpleStateVariable::GetKeyName(int idx) const
 #ifdef _MSC_VER
 #   pragma optimize( "g", off )    // disable float optimizations
 #endif
+// Options: (none)
 bool plSimpleStateVariable::IWriteData(hsStream* s, float timeConvert, int idx, uint32_t writeOptions) const
 {
 #ifdef HS_DEBUGGING
@@ -1854,6 +1859,7 @@ bool plSimpleStateVariable::IWriteData(hsStream* s, float timeConvert, int idx, 
     return true;
 }
 
+// Options: (none)
 bool plSimpleStateVariable::IReadData(hsStream* s, float timeConvert, int idx, uint32_t readOptions) 
 {   
     int j=idx*fVar.GetAtomicCount();
@@ -1941,6 +1947,7 @@ bool plSimpleStateVariable::IReadData(hsStream* s, float timeConvert, int idx, u
 #   pragma optimize( "", on )  // restore optimizations to their defaults
 #endif
 
+// Options: kSkipNotificationInfo, kWriteTimeStamps, kTimeStampOnRead, kTimeStampOnWrite, kDontWriteDirtyFlag, kMakeDirty, kDirtyNonDefaults
 bool plSimpleStateVariable::WriteData(hsStream* s, float timeConvert, uint32_t writeOptions) const
 {
 #ifdef HS_DEBUGGING
@@ -2012,6 +2019,7 @@ bool plSimpleStateVariable::WriteData(hsStream* s, float timeConvert, uint32_t w
 }
 
 // assumes var is created from the right type of descriptor (count, type, etc.)
+// Options: kSkipNotificationInfo, kTimeStampOnRead, kKeepDirty, kMakeDirty, kDirtyNonDefaults
 bool plSimpleStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t readOptions)
 {
     // read base class data
@@ -2083,6 +2091,7 @@ bool plSimpleStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t re
     return true;
 }
 
+// Options: all except for kDirtyOnly, kBroadcast, kForceConvert
 void plSimpleStateVariable::CopyData(const plSimpleStateVariable* other, uint32_t writeOptions/*=0*/)
 {
     // use stream as a medium
@@ -2478,6 +2487,7 @@ void plSDStateVariable::IDeInit()
 //
 // Make 'this' into a copy of 'other'.
 //
+// Options: all except for kDirtyOnly, kBroadcast, kForceConvert
 void plSDStateVariable::CopyFrom(plSDStateVariable* other, uint32_t writeOptions/*=0*/)
 {
     // IDeInit();
@@ -2492,6 +2502,7 @@ void plSDStateVariable::CopyFrom(plSDStateVariable* other, uint32_t writeOptions
 // copy them to my corresponding item.
 // Requires that records have the same descriptor.
 //
+// Options: all except for kBroadcast, kForceConvert
 void plSDStateVariable::UpdateFrom(plSDStateVariable* other, uint32_t writeOptions/*=0*/)
 {
     hsAssert(!other->GetSDVarDescriptor()->GetName().compare_i(fVarDescriptor->GetName()),
@@ -2593,6 +2604,7 @@ void plSDStateVariable::GetDirtyDataRecords(ConstDataRecList* recList) const
 //
 // read all SDVars
 //
+// Options: kSkipNotificationInfo, kTimeStampOnRead, kKeepDirty, kMakeDirty, kDirtyNonDefaults, kForceConvert
 bool plSDStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t readOptions)
 {
     plStateVariable::ReadData(s, timeConvert, readOptions);
@@ -2636,6 +2648,7 @@ bool plSDStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t readOp
 //
 // write all SDVars
 //
+// Options: kSkipNotificationInfo, kDirtyOnly
 bool plSDStateVariable::WriteData(hsStream* s, float timeConvert, uint32_t writeOptions) const
 {   
     plStateVariable::WriteData(s, timeConvert, writeOptions);

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
@@ -110,8 +110,7 @@ void plStateVarNotificationInfo::Read(hsStream* s, uint32_t readOptions)
         fHintString = hint;
 }
 
-// Options: (none)
-void plStateVarNotificationInfo::Write(hsStream* s, uint32_t writeOptions) const
+void plStateVarNotificationInfo::Write(hsStream* s) const
 {
     (void)s->WriteByte(uint8_t(0));   // unused: saveFlags
     s->WriteSafeString(fHintString);
@@ -143,7 +142,7 @@ bool plStateVariable::WriteData(hsStream* s, float timeConvert, uint32_t writeOp
     s->WriteByte(saveFlags);
     if (writeNotificationInfo)
     {
-        GetNotificationInfo().Write(s, writeOptions);
+        GetNotificationInfo().Write(s);
     }
     return true;
 }
@@ -1775,8 +1774,7 @@ ST::string plSimpleStateVariable::GetKeyName(int idx) const
 #ifdef _MSC_VER
 #   pragma optimize( "g", off )    // disable float optimizations
 #endif
-// Options: (none)
-bool plSimpleStateVariable::IWriteData(hsStream* s, float timeConvert, int idx, uint32_t writeOptions) const
+bool plSimpleStateVariable::IWriteData(hsStream* s, float timeConvert, int idx) const
 {
 #ifdef HS_DEBUGGING
     if (!IsUsed())
@@ -1859,8 +1857,7 @@ bool plSimpleStateVariable::IWriteData(hsStream* s, float timeConvert, int idx, 
     return true;
 }
 
-// Options: (none)
-bool plSimpleStateVariable::IReadData(hsStream* s, float timeConvert, int idx, uint32_t readOptions) 
+bool plSimpleStateVariable::IReadData(hsStream* s, float timeConvert, int idx) 
 {   
     int j=idx*fVar.GetAtomicCount();
     int i;
@@ -2011,7 +2008,7 @@ bool plSimpleStateVariable::WriteData(hsStream* s, float timeConvert, uint32_t w
         // list
         int i;
         for(i=0;i<fVar.GetCount();i++)
-            if (!IWriteData(s, timeConvert, i, writeOptions))
+            if (!IWriteData(s, timeConvert, i))
                 return false;
     }
 
@@ -2076,7 +2073,7 @@ bool plSimpleStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t re
     {
         int i;
         for(i=0;i<fVar.GetCount();i++)
-            if (!IReadData(s, timeConvert, i, readOptions))
+            if (!IReadData(s, timeConvert, i))
                 return false;
     }
     else

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
@@ -101,12 +101,11 @@ public:
 // plStateVarNotificationInfo
 /////////////////////////////////////////////////////
 
-// Options: kSkipNotificationInfo
-void plStateVarNotificationInfo::Read(hsStream* s, uint32_t readOptions)
+void plStateVarNotificationInfo::Read(hsStream* s)
 {
     (void)s->ReadByte();  // unused: saveFlags
     ST::string hint=s->ReadSafeString();
-    if (!hint.empty() && !(readOptions & plSDL::kSkipNotificationInfo))
+    if (!hint.empty())
         fHintString = hint;
 }
 
@@ -125,7 +124,11 @@ bool plStateVariable::ReadData(hsStream* s, float timeConvert, uint32_t readOpti
     uint8_t saveFlags = s->ReadByte();
     if (saveFlags & plSDL::kHasNotificationInfo)
     {
-        GetNotificationInfo().Read(s, readOptions);
+        if (readOptions & plSDL::kSkipNotificationInfo) {
+            plStateVarNotificationInfo().Read(s);
+        } else {
+            GetNotificationInfo().Read(s);
+        }
     }
     return true;
 }


### PR DESCRIPTION
The code that handles the SDL blob read/write options is quite tangled, so it's difficult to see which options do what exactly and where they even have any effect at all.

This PR adds detailed comments for all the options' meanings (for both reading and writing) and explicitly lists all the options understood by each method. Also some minor cleanup to the option passing, but not much - this is 90% a documentation change.