### PR TITLE
Fix an unlikely corner case of backwards compatibility with older clients

### DIFF
--- a/Sources/Plasma/NucleusLib/pnEncryption/plChallengeHash.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChallengeHash.cpp
@@ -96,8 +96,10 @@ void CryptCreateRandomSeed(size_t length, uint8_t* data)
 void CryptHashPassword(const ST::string& username, const ST::string& password, ShaDigest dest)
 {
     ST::string_stream buf;
-    buf << password.left(password.size() - 1) << '\0';
-    buf << username.to_lower().left(username.size() - 1) << '\0';
+    if (!password.empty())
+        buf << password.left(password.size() - 1) << '\0';
+    if (!username.empty())
+        buf << username.to_lower().left(username.size() - 1) << '\0';
     ST::utf16_buffer result = buf.to_string().to_utf16();
     plSHAChecksum sum(result.size() * sizeof(char16_t), (uint8_t*)result.data());
 


### PR DESCRIPTION
The previous broken `StrCopy` used in the older implementation of `CryptHashPassword` would only write the trailing '\0' character if the copied string had a size greater than zero.  This change ONLY affects empty usernames and passwords, which is basically useless for anything other than testing (however, it can get DirtSand into a bad state -- see the PR there for details).