### PR TITLE
Add popup quit when sitting at heek table

### DIFF
--- a/Scripts/Python/nb01RPSGame.py
+++ b/Scripts/Python/nb01RPSGame.py
@@ -383,7 +383,7 @@ class nb01RPSGame(ptResponder, object):
 
     def OnControlKeyEvent(self,controlKey,activeFlag):
         if controlKey in [PlasmaControlKeys.kKeyMoveBackward, PlasmaControlKeys.kKeyRotateLeft, PlasmaControlKeys.kKeyRotateRight, PlasmaControlKeys.kKeyExitMode] and activeFlag:
-            PtYesNoDialog(self.key, "Do you want to leave the Ahyoheek game?")
+            PtYesNoDialog(self.key, PtGetLocalizedString("Heek.Messages.Quit"))
 
     def OnNotify(self, state, id, events):
         """Handle Plasma Notification Messages"""
@@ -951,7 +951,6 @@ class nb01RPSGame(ptResponder, object):
             args[event[1]] = event[3]
 
         if "YesNo" in args:
-            PtDebugPrint("YesNo is",args["YesNo"])
             if args["YesNo"]:
                 PtDisableControlKeyEvents(self.key)
                 PtEnableMovementKeys()
@@ -959,7 +958,7 @@ class nb01RPSGame(ptResponder, object):
                 return True
             else:
                 return False
-        elif "type" in args:
+        else:
             # Now, let's fire it off!
             type = args["type"]
             del args["type"]

--- a/Scripts/Python/nb01RPSGame.py
+++ b/Scripts/Python/nb01RPSGame.py
@@ -384,7 +384,7 @@ class nb01RPSGame(ptResponder, object):
             raise RuntimeError("Got an SDL notify for {}, but no CB".format(VARname))
 
     def OnControlKeyEvent(self, controlKey, activeFlag):
-        """Captures movement keys and prompt a yes/no dialog during a game or standup animation otherwise"""
+        #Captures movement keys and prompt a yes/no dialog during a game or standup animation otherwise
         if controlKey in [PlasmaControlKeys.kKeyMoveBackward, PlasmaControlKeys.kKeyRotateLeft, PlasmaControlKeys.kKeyRotateRight, PlasmaControlKeys.kKeyExitMode] and activeFlag:
             if self._round_played:
                 PtLocalizedYesNoDialog(self.key, "Heek.Messages.Quit")
@@ -456,10 +456,10 @@ class nb01RPSGame(ptResponder, object):
         # Manage game state if standing up
         if state:
             if PtWasLocallyNotified(self.key):
-                """Disable Yeesha Book to prevent linking out
-                   Enable control keys to capture button presses or mouse movements
-                   Disable all movement keys so sit modifier wont trigger before we want it to
-                   Enable the mouse movement so we can move the camera and use the sides of the screen to trigger a movement"""
+                #Disable Yeesha Book to prevent linking out
+                #Enable control keys to capture button presses or mouse movements
+                #Disable all movement keys so sit modifier wont trigger before we want it to
+                #Enable the mouse movement so we can move the camera and use the sides of the screen to trigger a movement
                 PtSendKIMessage(kDisableEntireYeeshaBook, 0)
                 PtEnableControlKeyEvents(self.key)
                 PtDisableMovementKeys()
@@ -733,10 +733,10 @@ class nb01RPSGame(ptResponder, object):
         PtSendKIMessage(kKILocalChatStatusMsg, msg)
 
     def _QuitGame(self, YesNo):
-        """Performs the standup animation when sitting down
-           Disable control key events
-           Enables the disabled movement keys
-           PtAvatarExitAFK() is actually just performing a GoToStage 2 which for the sit brain is the standup animation - https://github.com/H-uru/Plasma/blob/9956967363f383d91f43162d116ad3477148adb2/Sources/Plasma/FeatureLib/pfPython/cyAvatar.cpp#L1970"""
+        #Performs the standup animation when sitting down
+        #Disable control key events
+        #Enables the disabled movement keys
+        #PtAvatarExitAFK() is just doing IExitTopmostGenericMode()
         if YesNo:
             PtDisableControlKeyEvents(self.key)
             PtEnableMovementKeys()

--- a/Scripts/Python/nb01RPSGame.py
+++ b/Scripts/Python/nb01RPSGame.py
@@ -384,9 +384,10 @@ class nb01RPSGame(ptResponder, object):
             raise RuntimeError("Got an SDL notify for {}, but no CB".format(VARname))
 
     def OnControlKeyEvent(self, controlKey, activeFlag):
+        """Captures movement keys and prompt a yes/no dialog during a game or standup animation otherwise"""
         if controlKey in [PlasmaControlKeys.kKeyMoveBackward, PlasmaControlKeys.kKeyRotateLeft, PlasmaControlKeys.kKeyRotateRight, PlasmaControlKeys.kKeyExitMode] and activeFlag:
             if self._round_played:
-                PtYesNoDialog(self.key, PtGetLocalizedString("Heek.Messages.Quit"))
+                PtLocalizedYesNoDialog(self.key, "Heek.Messages.Quit")
             else:
                 quit = {
                     "type": NOTIFY_YESNO_QUIT,
@@ -455,6 +456,10 @@ class nb01RPSGame(ptResponder, object):
         # Manage game state if standing up
         if state:
             if PtWasLocallyNotified(self.key):
+                """Disable Yeesha Book to prevent linking out
+                   Enable control keys to capture button presses or mouse movements
+                   Disable all movement keys so sit modifier wont trigger before we want it to
+                   Enable the mouse movement so we can move the camera and use the sides of the screen to trigger a movement"""
                 PtSendKIMessage(kDisableEntireYeeshaBook, 0)
                 PtEnableControlKeyEvents(self.key)
                 PtDisableMovementKeys()
@@ -728,6 +733,10 @@ class nb01RPSGame(ptResponder, object):
         PtSendKIMessage(kKILocalChatStatusMsg, msg)
 
     def _QuitGame(self, YesNo):
+        """Performs the standup animation when sitting down
+           Disable control key events
+           Enables the disabled movement keys
+           PtAvatarExitAFK() is actually just performing a GoToStage 2 which for the sit brain is the standup animation - https://github.com/H-uru/Plasma/blob/9956967363f383d91f43162d116ad3477148adb2/Sources/Plasma/FeatureLib/pfPython/cyAvatar.cpp#L1970"""
         if YesNo:
             PtDisableControlKeyEvents(self.key)
             PtEnableMovementKeys()

--- a/Scripts/Python/nb01RPSGame.py
+++ b/Scripts/Python/nb01RPSGame.py
@@ -382,10 +382,7 @@ class nb01RPSGame(ptResponder, object):
             raise RuntimeError("Got an SDL notify for {}, but no CB".format(VARname))
 
     def OnControlKeyEvent(self,controlKey,activeFlag):
-        PtDebugPrint(controlKey, activeFlag)
-        if controlKey == PlasmaControlKeys.kKeyExitMode:
-            PtYesNoDialog(self.key, "Do you want to leave the Ahyoheek game?")
-        elif controlKey == PlasmaControlKeys.kKeyMoveBackward or controlKey == PlasmaControlKeys.kKeyRotateLeft or controlKey == PlasmaControlKeys.kKeyRotateRight:
+        if controlKey in [PlasmaControlKeys.kKeyMoveBackward, PlasmaControlKeys.kKeyRotateLeft, PlasmaControlKeys.kKeyRotateRight, PlasmaControlKeys.kKeyExitMode] and activeFlag:
             PtYesNoDialog(self.key, "Do you want to leave the Ahyoheek game?")
 
     def OnNotify(self, state, id, events):
@@ -399,8 +396,8 @@ class nb01RPSGame(ptResponder, object):
         if self._HandleNotify(state, id, events, self._sitting, self._OnSitDown):
             if not self.playing:
                 PtEnableControlKeyEvents(self.key)
-                #PtDisableMouseMovement()
                 PtDisableMovementKeys()
+                PtEnableMouseMovement()
             return
 
         # A rock/paper/sics button was mashed
@@ -958,6 +955,7 @@ class nb01RPSGame(ptResponder, object):
             if args["YesNo"]:
                 PtDisableControlKeyEvents(self.key)
                 PtEnableMovementKeys()
+                PtAvatarExitAFK()
                 return True
             else:
                 return False

--- a/Scripts/Python/nb01RPSGame.py
+++ b/Scripts/Python/nb01RPSGame.py
@@ -384,7 +384,7 @@ class nb01RPSGame(ptResponder, object):
             raise RuntimeError("Got an SDL notify for {}, but no CB".format(VARname))
 
     def OnControlKeyEvent(self, controlKey, activeFlag):
-        #Captures movement keys and prompt a yes/no dialog during a game or standup animation otherwise
+        # Captures movement keys and prompt a yes/no dialog during a game or standup animation otherwise
         if controlKey in [PlasmaControlKeys.kKeyMoveBackward, PlasmaControlKeys.kKeyRotateLeft, PlasmaControlKeys.kKeyRotateRight, PlasmaControlKeys.kKeyExitMode] and activeFlag:
             if self._round_played:
                 PtLocalizedYesNoDialog(self.key, "Heek.Messages.Quit")
@@ -456,10 +456,10 @@ class nb01RPSGame(ptResponder, object):
         # Manage game state if standing up
         if state:
             if PtWasLocallyNotified(self.key):
-                #Disable Yeesha Book to prevent linking out
-                #Enable control keys to capture button presses or mouse movements
-                #Disable all movement keys so sit modifier wont trigger before we want it to
-                #Enable the mouse movement so we can move the camera and use the sides of the screen to trigger a movement
+                # Disable Yeesha Book to prevent linking out
+                # Enable control keys to capture button presses or mouse movements
+                # Disable all movement keys so sit modifier wont trigger before we want it to
+                # Enable the mouse movement so we can move the camera and use the sides of the screen to trigger a movement
                 PtSendKIMessage(kDisableEntireYeeshaBook, 0)
                 PtEnableControlKeyEvents(self.key)
                 PtDisableMovementKeys()
@@ -733,10 +733,10 @@ class nb01RPSGame(ptResponder, object):
         PtSendKIMessage(kKILocalChatStatusMsg, msg)
 
     def _QuitGame(self, YesNo):
-        #Performs the standup animation when sitting down
-        #Disable control key events
-        #Enables the disabled movement keys
-        #PtAvatarExitAFK() is just doing IExitTopmostGenericMode()
+        # Performs the standup animation when sitting down
+        # Disable control key events
+        # Enables the disabled movement keys
+        # PtAvatarExitAFK() is just doing IExitTopmostGenericMode()
         if YesNo:
             PtDisableControlKeyEvents(self.key)
             PtEnableMovementKeys()

--- a/Scripts/Python/nb01RPSGame.py
+++ b/Scripts/Python/nb01RPSGame.py
@@ -389,6 +389,10 @@ class nb01RPSGame(ptResponder, object):
 
         # Finished sitting down.
         if self._HandleNotify(state, id, events, self._sitting, self._OnSitDown):
+            if self.playing:
+                PtEnableMouseMovement()
+            else:
+                PtDisableMouseMovement()
             return
 
         # A rock/paper/sics button was mashed


### PR DESCRIPTION
Stops the mouse movement keys when sitting at the heek table to prevent misclicking and leaving the game unintentionally.

Keyboard movement still works and allows you to leave the game still.
Closing the KI will also re-enable mouse movement keys.
Mouse movement key is re-enabled after standing back up.