### PR TITLE
Close `hsStream`s automatically in destructors

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -820,7 +820,6 @@ bool plClient::MsgReceive(plMessage* msg)
             char buf[256];
             sprintf(buf, "%s %d\n", plAgeLoader::GetInstance()->GetCurrAgeFilename(), fNumPostLoadMsgs);
             s.WriteString(buf);
-            s.Close();
             #endif
 #endif
         }
@@ -2023,9 +2022,6 @@ void plClient::IDetectAudioVideoSettings()
 
     plPipeline::fDefaultPipeParams.VSync = false;
 
-    int val = 0;
-    hsStream *stream = nullptr;
-    hsUNIXStream s;
     plFileName audioIniFile = plFileName::Join(plFileSystem::GetInitPath(), "audio.ini");
     plFileName graphicsIniFile = plFileName::Join(plFileSystem::GetInitPath(), "graphics.ini");
 
@@ -2038,15 +2034,11 @@ void plClient::IDetectAudioVideoSettings()
 #endif
 
     //check to see if audio.ini exists
-    if (s.Open(audioIniFile))
-        s.Close();
-    else
+    if (!plFileInfo(audioIniFile).Exists())
         IWriteDefaultAudioSettings(audioIniFile);
 
     // check to see if graphics.ini exists
-    if (s.Open(graphicsIniFile))
-        s.Close();
-    else
+    if (!plFileInfo(graphicsIniFile).Exists())
         IWriteDefaultGraphicsSettings(graphicsIniFile);
 }
 
@@ -2063,9 +2055,7 @@ void plClient::IWriteDefaultAudioSettings(const plFileName& destFile)
     WriteInt(stream, "Audio.SetChannelVolume NPCVoice", 1);
     WriteInt(stream, "Audio.EnableVoiceRecording", 1);
     WriteInt(stream, "Audio.EnableSubtitles", true);
-    stream->Close();
     delete stream;
-    stream = nullptr;
 }
 
 void plClient::IWriteDefaultGraphicsSettings(const plFileName& destFile)
@@ -2083,9 +2073,7 @@ void plClient::IWriteDefaultGraphicsSettings(const plFileName& destFile)
     WriteInt(stream, "Graphics.Shadow.Enable", plPipeline::fDefaultPipeParams.Shadows);
     WriteInt(stream, "Graphics.EnablePlanarReflections", plPipeline::fDefaultPipeParams.PlanarReflections);
     WriteBool(stream, "Graphics.EnableVSync", plPipeline::fDefaultPipeParams.VSync);
-    stream->Close();
     delete stream;
-    stream = nullptr;
 }
 
 

--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -2044,36 +2044,34 @@ void plClient::IDetectAudioVideoSettings()
 
 void plClient::IWriteDefaultAudioSettings(const plFileName& destFile)
 {
-    hsStream *stream = plEncryptedStream::OpenEncryptedFileWrite(destFile);
-    WriteBool(stream, "Audio.Initialize",  true);
-    WriteBool(stream, "Audio.UseEAX", false);
-    WriteInt(stream, "Audio.SetPriorityCutoff", 6);
-    WriteInt(stream, "Audio.MuteAll", false);
-    WriteInt(stream, "Audio.SetChannelVolume SoundFX", 1);
-    WriteInt(stream, "Audio.SetChannelVolume BgndMusic", 1);
-    WriteInt(stream, "Audio.SetChannelVolume Ambience", 1);
-    WriteInt(stream, "Audio.SetChannelVolume NPCVoice", 1);
-    WriteInt(stream, "Audio.EnableVoiceRecording", 1);
-    WriteInt(stream, "Audio.EnableSubtitles", true);
-    delete stream;
+    std::unique_ptr<hsStream> stream = plEncryptedStream::OpenEncryptedFileWrite(destFile);
+    WriteBool(stream.get(), "Audio.Initialize",  true);
+    WriteBool(stream.get(), "Audio.UseEAX", false);
+    WriteInt(stream.get(), "Audio.SetPriorityCutoff", 6);
+    WriteInt(stream.get(), "Audio.MuteAll", false);
+    WriteInt(stream.get(), "Audio.SetChannelVolume SoundFX", 1);
+    WriteInt(stream.get(), "Audio.SetChannelVolume BgndMusic", 1);
+    WriteInt(stream.get(), "Audio.SetChannelVolume Ambience", 1);
+    WriteInt(stream.get(), "Audio.SetChannelVolume NPCVoice", 1);
+    WriteInt(stream.get(), "Audio.EnableVoiceRecording", 1);
+    WriteInt(stream.get(), "Audio.EnableSubtitles", true);
 }
 
 void plClient::IWriteDefaultGraphicsSettings(const plFileName& destFile)
 {
-    hsStream *stream = plEncryptedStream::OpenEncryptedFileWrite(destFile);
+    std::unique_ptr<hsStream> stream = plEncryptedStream::OpenEncryptedFileWrite(destFile);
 
-    WriteInt(stream, "Graphics.Width", plPipeline::fDefaultPipeParams.Width);
-    WriteInt(stream, "Graphics.Height", plPipeline::fDefaultPipeParams.Height);
-    WriteInt(stream, "Graphics.ColorDepth", plPipeline::fDefaultPipeParams.ColorDepth);
-    WriteBool(stream, "Graphics.Windowed", plPipeline::fDefaultPipeParams.Windowed);
-    WriteInt(stream, "Graphics.AntiAliasAmount", plPipeline::fDefaultPipeParams.AntiAliasingAmount);
-    WriteInt(stream, "Graphics.AnisotropicLevel", plPipeline::fDefaultPipeParams.AnisotropicLevel );
-    WriteInt(stream, "Graphics.TextureQuality", plPipeline::fDefaultPipeParams.TextureQuality);
-    WriteInt(stream, "Quality.Level", plPipeline::fDefaultPipeParams.VideoQuality);
-    WriteInt(stream, "Graphics.Shadow.Enable", plPipeline::fDefaultPipeParams.Shadows);
-    WriteInt(stream, "Graphics.EnablePlanarReflections", plPipeline::fDefaultPipeParams.PlanarReflections);
-    WriteBool(stream, "Graphics.EnableVSync", plPipeline::fDefaultPipeParams.VSync);
-    delete stream;
+    WriteInt(stream.get(), "Graphics.Width", plPipeline::fDefaultPipeParams.Width);
+    WriteInt(stream.get(), "Graphics.Height", plPipeline::fDefaultPipeParams.Height);
+    WriteInt(stream.get(), "Graphics.ColorDepth", plPipeline::fDefaultPipeParams.ColorDepth);
+    WriteBool(stream.get(), "Graphics.Windowed", plPipeline::fDefaultPipeParams.Windowed);
+    WriteInt(stream.get(), "Graphics.AntiAliasAmount", plPipeline::fDefaultPipeParams.AntiAliasingAmount);
+    WriteInt(stream.get(), "Graphics.AnisotropicLevel", plPipeline::fDefaultPipeParams.AnisotropicLevel );
+    WriteInt(stream.get(), "Graphics.TextureQuality", plPipeline::fDefaultPipeParams.TextureQuality);
+    WriteInt(stream.get(), "Quality.Level", plPipeline::fDefaultPipeParams.VideoQuality);
+    WriteInt(stream.get(), "Graphics.Shadow.Enable", plPipeline::fDefaultPipeParams.Shadows);
+    WriteInt(stream.get(), "Graphics.EnablePlanarReflections", plPipeline::fDefaultPipeParams.PlanarReflections);
+    WriteBool(stream.get(), "Graphics.EnableVSync", plPipeline::fDefaultPipeParams.VSync);
 }
 
 

--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -872,9 +872,8 @@ INT_PTR CALLBACK UruLoginDialogProc( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
                     {
                         plFileName gipath = plFileName::Join(plFileSystem::GetInitPath(), "general.ini");
                         ST::string ini_str = ST::format("App.SetLanguage {}\n", plLocalization::GetLanguageName(new_language));
-                        hsStream* gini = plEncryptedStream::OpenEncryptedFileWrite(gipath);
+                        std::unique_ptr<hsStream> gini = plEncryptedStream::OpenEncryptedFileWrite(gipath);
                         gini->WriteString(ini_str);
-                        delete gini;
                     }
 
                     memset(&pLoginParam->authError, 0, sizeof(pLoginParam->authError));

--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -874,7 +874,6 @@ INT_PTR CALLBACK UruLoginDialogProc( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
                         ST::string ini_str = ST::format("App.SetLanguage {}\n", plLocalization::GetLanguageName(new_language));
                         hsStream* gini = plEncryptedStream::OpenEncryptedFileWrite(gipath);
                         gini->WriteString(ini_str);
-                        gini->Close();
                         delete gini;
                     }
 

--- a/Sources/Plasma/Apps/plFileSecure/main.cpp
+++ b/Sources/Plasma/Apps/plFileSecure/main.cpp
@@ -104,7 +104,6 @@ void GenerateKey(bool useDefault)
     hsUNIXStream out;
     out.Open(plSecureStream::kKeyFilename, "wb");
     out.Write(sizeof(uint32_t) * std::size(key), (void*)key);
-    out.Close();
 }
 
 void SecureFiles(const plFileName& dir, const ST::string& ext, uint32_t* key)

--- a/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
+++ b/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
@@ -212,7 +212,7 @@ class plStatDumpIterator : public plRegistryPageIterator, public plRegistryKeyIt
 {
 protected:
     plFileName fOutputDir;
-    std::unique_ptr<hsStream> fStream;
+    std::unique_ptr<hsFileSystemStream> fStream;
 
 public:
     plStatDumpIterator(const plFileName& outputDir) : fOutputDir(outputDir) {}

--- a/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
+++ b/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
@@ -211,7 +211,7 @@ class plStatDumpIterator : public plRegistryPageIterator, public plRegistryKeyIt
 {
 protected:
     plFileName fOutputDir;
-    hsUNIXStream fStream;
+    hsUNIXStream* fStream;
 
 public:
     plStatDumpIterator(const plFileName& outputDir) : fOutputDir(outputDir) {}
@@ -220,16 +220,16 @@ public:
     {
         const plKeyImp* imp = plKeyImp::GetFromKey(key);
 
-        fStream.WriteString(key->GetName());
-        fStream.WriteString(",");
+        fStream->WriteString(key->GetName());
+        fStream->WriteString(",");
 
-        fStream.WriteString(plFactory::GetNameOfClass(key->GetUoid().GetClassType()));
-        fStream.WriteString(",");
+        fStream->WriteString(plFactory::GetNameOfClass(key->GetUoid().GetClassType()));
+        fStream->WriteString(",");
 
         char buf[30];
         sprintf(buf, "%u", imp->GetDataLen());
-        fStream.WriteString(buf);
-        fStream.WriteString("\n");
+        fStream->WriteString(buf);
+        fStream->WriteString("\n");
 
         return true;
     }
@@ -240,12 +240,13 @@ public:
 
         plFileName fileName = plFileName::Join(fOutputDir,
                 ST::format("{}_{}.csv", info.GetAge(), info.GetPage()));
-        fStream.Open(fileName, "wt");
+        fStream = new hsUNIXStream;
+        fStream->Open(fileName, "wt");
 
         page->LoadKeys();
         page->IterateKeys(this);
 
-        fStream.Close();
+        delete fStream;
 
         return true;
     }

--- a/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
+++ b/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
@@ -44,6 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsStream.h"
 #include "hsTimer.h"
 
+#include <memory>
 #include <string_theory/format>
 
 #include "pnKeyedObject/plKeyImp.h"
@@ -211,7 +212,7 @@ class plStatDumpIterator : public plRegistryPageIterator, public plRegistryKeyIt
 {
 protected:
     plFileName fOutputDir;
-    hsUNIXStream* fStream;
+    std::unique_ptr<hsStream> fStream;
 
 public:
     plStatDumpIterator(const plFileName& outputDir) : fOutputDir(outputDir) {}
@@ -240,13 +241,13 @@ public:
 
         plFileName fileName = plFileName::Join(fOutputDir,
                 ST::format("{}_{}.csv", info.GetAge(), info.GetPage()));
-        fStream = new hsUNIXStream;
+        fStream = std::make_unique<hsUNIXStream>();
         fStream->Open(fileName, "wt");
 
         page->LoadKeys();
         page->IterateKeys(this);
 
-        delete fStream;
+        fStream.reset();
 
         return true;
     }

--- a/Sources/Plasma/Apps/plPageOptimizer/plPageOptimizer.cpp
+++ b/Sources/Plasma/Apps/plPageOptimizer/plPageOptimizer.cpp
@@ -269,8 +269,5 @@ void plPageOptimizer::IRewritePage()
                 newPage.WriteLE32(dataLen);
             }
         }
-
-        newPage.Close();
-        oldPage.Close();
     }
 }

--- a/Sources/Plasma/Apps/plPythonPack/main.cpp
+++ b/Sources/Plasma/Apps/plPythonPack/main.cpp
@@ -302,8 +302,7 @@ void PackDirectory(const plFileName& dir, const plFileName& rootPath, const plFi
 
         PythonInterface::initPython(rootPath, extraDirs, out, stderr);
     
-        std::vector<uint32_t> filePositions;
-        filePositions.resize(fileNames.size());
+        std::vector<uint32_t> filePositions(fileNames.size());
 
         for (size_t i = 0; i < fileNames.size(); i++)
         {

--- a/Sources/Plasma/Apps/plPythonPack/main.cpp
+++ b/Sources/Plasma/Apps/plPythonPack/main.cpp
@@ -206,9 +206,6 @@ void WritePythonFile(const plFileName &fileName, const plFileName &path, hsStrea
     delete [] code;
     Py_XDECREF(pythonCode);
     Py_XDECREF(fModule);
-
-    pyStream.Close();
-    glueStream.Close();
 }
 
 void FindFiles(std::vector<plFileName> &filenames, std::vector<plFileName> &pathnames, const plFileName& path)
@@ -291,40 +288,41 @@ void PackDirectory(const plFileName& dir, const plFileName& rootPath, const plFi
 
 
     // ok, we know how many files we're gonna pack, so make a fake index (we'll fill in later)
-    hsUNIXStream s;
-    if (!s.Open(pakName, "wb"))
-        return;
-
-    s.WriteLE32((uint32_t)fileNames.size());
-    for (const plFileName& fn : fileNames)
     {
-        s.WriteSafeString(fn.AsString());
-        s.WriteLE32(0);
+        hsUNIXStream s;
+        if (!s.Open(pakName, "wb"))
+            return;
+
+        s.WriteLE32((uint32_t)fileNames.size());
+        for (const plFileName& fn : fileNames)
+        {
+            s.WriteSafeString(fn.AsString());
+            s.WriteLE32(0);
+        }
+
+        PythonInterface::initPython(rootPath, extraDirs, out, stderr);
+    
+        std::vector<uint32_t> filePositions;
+        filePositions.resize(fileNames.size());
+
+        for (size_t i = 0; i < fileNames.size(); i++)
+        {
+            // strip '.py' from the file name
+            plFileName properFileName = fileNames[i].StripFileExt();
+            uint32_t initialPos = s.GetPosition();
+            WritePythonFile(properFileName, pathNames[i], &s);
+    
+            filePositions[i] = initialPos;
+        }
+
+        s.SetPosition(sizeof(uint32_t));
+        for (size_t i = 0; i < fileNames.size(); i++)
+        {
+            s.WriteSafeString(fileNames[i].AsString());
+            s.WriteLE32(filePositions[i]);
+        }
     }
 
-    PythonInterface::initPython(rootPath, extraDirs, out, stderr);
-
-    std::vector<uint32_t> filePositions;
-    filePositions.resize(fileNames.size());
-
-    for (size_t i = 0; i < fileNames.size(); i++)
-    {
-        // strip '.py' from the file name
-        plFileName properFileName = fileNames[i].StripFileExt();
-        uint32_t initialPos = s.GetPosition();
-        WritePythonFile(properFileName, pathNames[i], &s);
-
-        filePositions[i] = initialPos;
-    }
-
-    s.SetPosition(sizeof(uint32_t));
-    for (size_t i = 0; i < fileNames.size(); i++)
-    {
-        s.WriteSafeString(fileNames[i].AsString());
-        s.WriteLE32(filePositions[i]);
-    }
-
-    s.Close();
     ST::printf(out, "\nPython Package written to {}\n", pakName);
 
     PythonInterface::finiPython();

--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -541,12 +541,9 @@ void hsUNIXStream::Flush()
 
 //////////////////////////////////////////////////////////////////////////////////////
 
-void    plReadOnlySubStream::Open( hsStream *base, uint32_t offset, uint32_t length )
+plReadOnlySubStream::plReadOnlySubStream(hsStream* base, uint32_t offset, uint32_t length)
+    : fBase(base), fOffset(offset), fLength(length)
 {
-    fBase = base;
-    fOffset = offset;
-    fLength = length;
-
     fBase->SetPosition( fOffset );
     IFixPosition();
 }

--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -833,7 +833,7 @@ void hsWriteOnlyStream::FastFwd()
 
 void hsWriteOnlyStream::Truncate()
 {
-    hsThrow("can't write to a readonly stream");
+    hsThrow("can't change size of hsWriteOnlyStream");
 }
 
 void hsWriteOnlyStream::CopyToMem(void* mem)

--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -788,6 +788,12 @@ void hsReadOnlyStream::CopyToMem(void* mem)
 
 
 ////////////////////////////////////////////////////////////////////////////////////
+
+bool hsWriteOnlyStream::AtEnd()
+{
+    return fData >= fStop;
+}
+
 uint32_t hsWriteOnlyStream::Read(uint32_t byteCount, void* buffer)
 {
     hsThrow( "can't read to a writeonly stream");
@@ -802,6 +808,39 @@ uint32_t hsWriteOnlyStream::Write(uint32_t byteCount, const void* buffer)
     fData += byteCount;
     fPosition += byteCount;
     return byteCount;
+}
+
+void hsWriteOnlyStream::Skip(uint32_t deltaByteCount)
+{
+    fPosition += deltaByteCount;
+    fData += deltaByteCount;
+    if (fData > fStop) {
+        hsThrow("Skip went past end of stream");
+    }
+}
+
+void hsWriteOnlyStream::Rewind()
+{
+    fPosition = 0;
+    fData = fStart;
+}
+
+void hsWriteOnlyStream::FastFwd()
+{
+    fPosition = GetEOF();
+    fData = fStop;
+}
+
+void hsWriteOnlyStream::Truncate()
+{
+    hsThrow("can't write to a readonly stream");
+}
+
+void hsWriteOnlyStream::CopyToMem(void* mem)
+{
+    if (fData < fStop) {
+        memmove(mem, fData, fStop - fData);
+    }
 }
 
 

--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -196,9 +196,8 @@ class plReadOnlySubStream: public hsStream
     void    IFixPosition();
 
 public:
-    plReadOnlySubStream() : fBase(), fOffset(), fLength() { }
+    plReadOnlySubStream(hsStream* base, uint32_t offset, uint32_t length);
 
-    void      Open( hsStream *base, uint32_t offset, uint32_t length );
     bool      AtEnd() override;
     uint32_t  Read(uint32_t byteCount, void* buffer) override;
     uint32_t  Write(uint32_t byteCount, const void* buffer) override;
@@ -265,10 +264,10 @@ protected:
     char*   fData;
     char*   fStop;
 public:
-    hsReadOnlyStream(int size, const void* data) { Init(size, data); }
-    hsReadOnlyStream() : fStart(), fData(), fStop() { }
+    hsReadOnlyStream(int size, const void* data)
+        : fStart((char*)data), fData((char*)data), fStop((char*)data + size)
+    {}
 
-    virtual void      Init(int size, const void* data) { fStart=((char*)data); fData=((char*)data); fStop=((char*)data + size); }
     bool      AtEnd() override;
     uint32_t  Read(uint32_t byteCount, void * buffer) override;
     uint32_t  Write(uint32_t byteCount, const void* buffer) override;    // throws exception
@@ -284,7 +283,6 @@ public:
 class hsWriteOnlyStream : public hsReadOnlyStream {
 public:
     hsWriteOnlyStream(int size, const void* data) : hsReadOnlyStream(size, data) {}
-    hsWriteOnlyStream() {}
     hsWriteOnlyStream(const hsWriteOnlyStream& other) = delete;
     hsWriteOnlyStream(hsWriteOnlyStream&& other) = delete;
 

--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -156,7 +156,13 @@ class hsUNIXStream: public hsStream
 
 public:
     hsUNIXStream() : fRef() {}
+    hsUNIXStream(const hsUNIXStream& other) = delete;
+    hsUNIXStream(hsUNIXStream&& other) = delete;
     ~hsUNIXStream();
+
+    const hsUNIXStream& operator=(const hsUNIXStream& other) = delete;
+    hsUNIXStream& operator=(hsUNIXStream&& other) = delete;
+
     bool  Open(const plFileName& name, const char* mode = "rb") override;
     bool  Close() override;
 
@@ -290,6 +296,11 @@ class hsWriteOnlyStream : public hsReadOnlyStream {
 public:
     hsWriteOnlyStream(int size, const void* data) : hsReadOnlyStream(size, data) {}
     hsWriteOnlyStream() {}
+    hsWriteOnlyStream(const hsWriteOnlyStream& other) = delete;
+    hsWriteOnlyStream(hsWriteOnlyStream&& other) = delete;
+
+    const hsWriteOnlyStream& operator=(const hsWriteOnlyStream& other) = delete;
+    hsWriteOnlyStream& operator=(hsWriteOnlyStream&& other) = delete;
 
     bool      Open(const plFileName &, const char *) override { hsAssert(0, "hsWriteOnlyStream::Open  NotImplemented"); return false; }
     bool      Close() override { hsAssert(0, "hsWriteOnlyStream::Close  NotImplemented"); return false; }
@@ -307,7 +318,12 @@ private:
     
 public:
     hsQueueStream(int32_t size);
+    hsQueueStream(const hsQueueStream& other) = delete;
+    hsQueueStream(hsQueueStream&& other) = delete;
     ~hsQueueStream();
+
+    const hsQueueStream& operator=(const hsQueueStream& other) = delete;
+    hsQueueStream& operator=(hsQueueStream&& other) = delete;
 
     bool  Open(const plFileName &, const char *) override { hsAssert(0, "hsQueueStream::Open  NotImplemented"); return false; }
     bool  Close() override { hsAssert(0, "hsQueueStream::Close  NotImplemented"); return false; }
@@ -351,7 +367,12 @@ class hsBufferedStream : public hsStream
 
 public:
     hsBufferedStream();
+    hsBufferedStream(const hsBufferedStream& other) = delete;
+    hsBufferedStream(hsBufferedStream&& other) = delete;
     virtual ~hsBufferedStream() { }
+
+    const hsBufferedStream& operator=(const hsBufferedStream& other) = delete;
+    hsBufferedStream& operator=(hsBufferedStream&& other) = delete;
 
     bool  Open(const plFileName& name, const char* mode = "rb") override;
     bool  Close() override;

--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -63,7 +63,6 @@ public:
     virtual     ~hsStream() { }
 
     virtual bool      Open(const plFileName &, const char * = "rb") = 0;
-    virtual bool      Close()=0;
     virtual bool      AtEnd() = 0;
     virtual uint32_t  Read(uint32_t byteCount, void * buffer) = 0;
     virtual uint32_t  Write(uint32_t byteCount, const void* buffer) = 0;
@@ -164,7 +163,6 @@ public:
     hsUNIXStream& operator=(hsUNIXStream&& other) = delete;
 
     bool  Open(const plFileName& name, const char* mode = "rb") override;
-    bool  Close() override;
 
     bool      AtEnd() override;
     uint32_t  Read(uint32_t byteCount, void* buffer) override;
@@ -195,11 +193,9 @@ class plReadOnlySubStream: public hsStream
 
 public:
     plReadOnlySubStream() : fBase(), fOffset(), fLength() { }
-    ~plReadOnlySubStream();
 
     bool      Open(const plFileName &, const char *) override { hsAssert(0, "plReadOnlySubStream::Open  NotImplemented"); return false; }
     void      Open( hsStream *base, uint32_t offset, uint32_t length );
-    bool      Close() override { fBase = nullptr; fOffset = 0; fLength = 0; return true; }
     bool      AtEnd() override;
     uint32_t  Read(uint32_t byteCount, void* buffer) override;
     uint32_t  Write(uint32_t byteCount, const void* buffer) override;
@@ -224,9 +220,7 @@ public:
     hsRAMStream(uint32_t chunkSize) { fVector.reserve(chunkSize); }
 
     bool  Open(const plFileName &, const char *) override { hsAssert(0, "hsRAMStream::Open  NotImplemented"); return false; }
-    bool  Close() override { return false; }
 
-    
     bool      AtEnd() override;
     uint32_t  Read(uint32_t byteCount, void * buffer) override;
     uint32_t  Write(uint32_t byteCount, const void* buffer) override;
@@ -253,7 +247,6 @@ class hsNullStream : public hsStream {
 public:
 
     bool      Open(const plFileName &, const char *) override { return true; }
-    bool      Close() override { return true; }
 
     bool AtEnd() override;
     uint32_t  Read(uint32_t byteCount, void * buffer) override;  // throws exception
@@ -279,7 +272,6 @@ public:
 
     virtual void      Init(int size, const void* data) { fStart=((char*)data); fData=((char*)data); fStop=((char*)data + size); }
     bool      Open(const plFileName &, const char *) override { hsAssert(0, "hsReadOnlyStream::Open  NotImplemented"); return false; }
-    bool      Close() override { hsAssert(0, "hsReadOnlyStream::Close  NotImplemented"); return false; }
     bool      AtEnd() override;
     uint32_t  Read(uint32_t byteCount, void * buffer) override;
     uint32_t  Write(uint32_t byteCount, const void* buffer) override;    // throws exception
@@ -303,7 +295,6 @@ public:
     hsWriteOnlyStream& operator=(hsWriteOnlyStream&& other) = delete;
 
     bool      Open(const plFileName &, const char *) override { hsAssert(0, "hsWriteOnlyStream::Open  NotImplemented"); return false; }
-    bool      Close() override { hsAssert(0, "hsWriteOnlyStream::Close  NotImplemented"); return false; }
     uint32_t  Read(uint32_t byteCount, void * buffer) override;  // throws exception
     uint32_t  Write(uint32_t byteCount, const void* buffer) override;
 };
@@ -326,7 +317,6 @@ public:
     hsQueueStream& operator=(hsQueueStream&& other) = delete;
 
     bool  Open(const plFileName &, const char *) override { hsAssert(0, "hsQueueStream::Open  NotImplemented"); return false; }
-    bool  Close() override { hsAssert(0, "hsQueueStream::Close  NotImplemented"); return false; }
 
     uint32_t  Read(uint32_t byteCount, void * buffer) override;
     uint32_t  Write(uint32_t byteCount, const void* buffer) override;
@@ -369,13 +359,12 @@ public:
     hsBufferedStream();
     hsBufferedStream(const hsBufferedStream& other) = delete;
     hsBufferedStream(hsBufferedStream&& other) = delete;
-    virtual ~hsBufferedStream() { }
+    ~hsBufferedStream();
 
     const hsBufferedStream& operator=(const hsBufferedStream& other) = delete;
     hsBufferedStream& operator=(hsBufferedStream&& other) = delete;
 
     bool  Open(const plFileName& name, const char* mode = "rb") override;
-    bool  Close() override;
 
     bool      AtEnd() override;
     uint32_t  Read(uint32_t byteCount, void* buffer) override;

--- a/Sources/Plasma/CoreLib/hsSystemInfo.cpp
+++ b/Sources/Plasma/CoreLib/hsSystemInfo.cpp
@@ -181,12 +181,10 @@ static inline bool IGetLinuxVersion(const plFileName& osVersionPath, ST::string&
                         system = ST::string::from_utf8(token);
                         // chop off the quotes
                         system = system.substr(1, system.size() - 2);
-                        s.Close();
                         return true;
                     }
                 }
             }
-            s.Close();
         }
     }
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -5297,8 +5297,6 @@ PF_CONSOLE_CMD( Age, GetElapsedDays, "string agedefnfile", "Gets the elapsed day
     age.Read(&s);
 
     PrintString(ST::format("ElapsedTime: {f} Days", age.GetAgeElapsedDays(plUnifiedTime::GetCurrent())));
-
-    s.Close();
 }
 
 PF_CONSOLE_CMD( Age, GetTimeOfDay, "string agedefnfile", "Gets the elapsed days and fractions" )
@@ -5314,8 +5312,6 @@ PF_CONSOLE_CMD( Age, GetTimeOfDay, "string agedefnfile", "Gets the elapsed days 
     age.Read(&s);
 
     PrintString(ST::format("TimeOfDay: {f} percent", age.GetAgeTimeOfDayPercent(plUnifiedTime::GetCurrent())));
-
-    s.Close();
 }
 
 PF_CONSOLE_CMD( Age, SetSDLFloat, "string varName, float value, int index", "Set the value of an age global variable" )

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -246,7 +246,7 @@ bool pfConsoleEngine::ExecuteFile(const plFileName &fileName)
 {
     int     line;
 
-    hsStream* stream = plEncryptedStream::OpenEncryptedFile(fileName);
+    std::unique_ptr<hsStream> stream = plEncryptedStream::OpenEncryptedFile(fileName);
 
     if( !stream )
     {
@@ -268,11 +268,9 @@ bool pfConsoleEngine::ExecuteFile(const plFileName &fileName)
         {
             fErrorMsg = ST::format("Error in console file {}, command line {}: {}",
                      fileName.AsString(), line, fErrorMsg);
-            delete stream;
             return false;
         }
     }
-    delete stream;
     fLastErrorLine.clear();
 
     return true;

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -268,12 +268,10 @@ bool pfConsoleEngine::ExecuteFile(const plFileName &fileName)
         {
             fErrorMsg = ST::format("Error in console file {}, command line {}: {}",
                      fileName.AsString(), line, fErrorMsg);
-            stream->Close();
             delete stream;
             return false;
         }
     }
-    stream->Close();
     delete stream;
     fLastErrorLine.clear();
 

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
@@ -393,7 +393,6 @@ bool LocalizationXMLFile::Parse(const plFileName& fileName)
 
     XML_ParserFree(fParser);
     fParser = nullptr;
-    xmlStream->Close();
     delete xmlStream;
     return true;
 }
@@ -903,7 +902,6 @@ void pfLocalizationDataMgr::IWriteText(const plFileName & filename, const ST::st
         // now spit the results out to the file
         hsStream *xmlStream = plEncryptedStream::OpenEncryptedFileWrite(filename);
         xmlStream->Write(fileData.size(), fileData.raw_buffer());
-        xmlStream->Close();
         delete xmlStream;
     }
 }

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationDataMgr.cpp
@@ -365,7 +365,7 @@ bool LocalizationXMLFile::Parse(const plFileName& fileName)
     XML_SetCharacterDataHandler(fParser, HandleData);
     XML_SetUserData(fParser, (void*)this);
 
-    hsStream *xmlStream = plEncryptedStream::OpenEncryptedFile(fileName);
+    std::unique_ptr<hsStream> xmlStream = plEncryptedStream::OpenEncryptedFile(fileName);
     if (!xmlStream)
     {
         pfLocalizationDataMgr::GetLog()->AddLineF("ERROR: Can't open file stream for {}", fileName);
@@ -393,7 +393,6 @@ bool LocalizationXMLFile::Parse(const plFileName& fileName)
 
     XML_ParserFree(fParser);
     fParser = nullptr;
-    delete xmlStream;
     return true;
 }
 
@@ -900,9 +899,8 @@ void pfLocalizationDataMgr::IWriteText(const plFileName & filename, const ST::st
     if (weWroteData)
     {
         // now spit the results out to the file
-        hsStream *xmlStream = plEncryptedStream::OpenEncryptedFileWrite(filename);
+        std::unique_ptr<hsStream> xmlStream = plEncryptedStream::OpenEncryptedFileWrite(filename);
         xmlStream->Write(fileData.size(), fileData.raw_buffer());
-        delete xmlStream;
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
@@ -104,7 +104,6 @@ ST::string pfFilePasswordStore::GetPassword(const ST::string& username)
             }
         }
 
-        stream->Close();
         delete stream;
     }
 
@@ -130,7 +129,6 @@ bool pfFilePasswordStore::SetPassword(const ST::string& username, const ST::stri
         stream->WriteSafeString(username);
         stream->WriteSafeString(password);
 
-        stream->Close();
         delete stream;
 
         return true;

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.cpp
@@ -90,7 +90,7 @@ ST::string pfFilePasswordStore::GetPassword(const ST::string& username)
         loginDat = local;
 #endif
 
-    hsStream* stream = plEncryptedStream::OpenEncryptedFile(loginDat, fCryptKey);
+    std::unique_ptr<hsStream> stream = plEncryptedStream::OpenEncryptedFile(loginDat, fCryptKey);
     if (stream && !stream->AtEnd())
     {
         uint32_t savedKey[4];
@@ -103,8 +103,6 @@ ST::string pfFilePasswordStore::GetPassword(const ST::string& username)
                 password = stream->ReadSafeString();
             }
         }
-
-        delete stream;
     }
 
     return password;
@@ -122,14 +120,12 @@ bool pfFilePasswordStore::SetPassword(const ST::string& username, const ST::stri
         loginDat = local;
 #endif
 
-    hsStream* stream = plEncryptedStream::OpenEncryptedFileWrite(loginDat, fCryptKey);
+    std::unique_ptr<hsStream> stream = plEncryptedStream::OpenEncryptedFileWrite(loginDat, fCryptKey);
     if (stream)
     {
         stream->Write(sizeof(fCryptKey), fCryptKey);
         stream->WriteSafeString(username);
         stream->WriteSafeString(password);
-
-        delete stream;
 
         return true;
     }

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -230,7 +230,7 @@ public:
         : fParent(parent), fFilename(filename), fFlags(), fBytesWritten(), fDLStartTime(), plZlibStream()
     {
         fParent->fTotalBytes += size;
-        fOutput = new hsRAMStream;
+        fOutput = std::make_unique<hsRAMStream>();
     }
 
     pfPatcherStream(pfPatcherWorker* parent, const pfPatcherQueuedFile& file)

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -388,7 +388,6 @@ static void IFileThingDownloadCB(ENetError result, void* param, const plFileName
 {
     pfPatcherWorker* patcher = static_cast<pfPatcherWorker*>(param);
     pfPatcherStream* stream = static_cast<pfPatcherStream*>(writer);
-    stream->Close();
 
     if (IS_NET_SUCCESS(result)) {
         PatcherLogGreen("\tDownloaded File '{}'", stream->GetFileName());
@@ -427,7 +426,6 @@ pfPatcherWorker::~pfPatcherWorker()
         hsLockGuard(fRequestMut);
         std::for_each(fRequests.begin(), fRequests.end(),
             [] (const Request& req) {
-                if (req.fStream) req.fStream->Close();
                 delete req.fStream;
             }
         );
@@ -636,9 +634,8 @@ void pfPatcherWorker::WhitelistFile(const plFileName& file, bool justDownloaded,
             if (!fGameCodeDiscovered(file, stream))
                 EndPatch(kNetErrInternalError, "SecurePreloader failed.");
         }
-    } else if (stream) {
+    } else {
         // no dad gum memory leaks, m'kay?
-        stream->Close();
         delete stream;
     }
 }

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -625,8 +625,9 @@ void pfPatcherWorker::WhitelistFile(const plFileName& file, bool justDownloaded,
         ST::string ext = file.GetFileExt();
         if (ext.compare_i("pak") == 0 || ext.compare_i("sdl") == 0) {
             if (!stream) {
-                stream = new hsUNIXStream;
-                stream->Open(file, "rb");
+                hsUNIXStream* newStream = new hsUNIXStream;
+                newStream->Open(file, "rb");
+                stream = newStream;
             }
 
             // if something terrible goes wrong (eg bad encryption), we can exit sanely

--- a/Sources/Plasma/FeatureLib/pfPython/pyStream.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyStream.cpp
@@ -59,12 +59,6 @@ pyStream::pyStream()
 {
 }
 
-pyStream::~pyStream()
-{
-    Close();
-}
-
-
 bool pyStream::Open(const plFileName& fileName, const ST::string& flags)
 {
     // make sure its closed first
@@ -92,7 +86,7 @@ bool pyStream::Open(const plFileName& fileName, const ST::string& flags)
                 // force encryption?
                 if (encryptflag)
                 {
-                    fStream = new plEncryptedStream;
+                    fStream = std::make_unique<plEncryptedStream>();
                     fStream->Open(fileName, "wb");
                 }
                 else
@@ -145,6 +139,5 @@ bool pyStream::WriteLines(const std::vector<ST::string> & lines)
 
 void pyStream::Close()
 {
-    delete fStream;
-    fStream = nullptr;
+    fStream.reset();
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyStream.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyStream.cpp
@@ -86,8 +86,9 @@ bool pyStream::Open(const plFileName& fileName, const ST::string& flags)
                 // force encryption?
                 if (encryptflag)
                 {
-                    fStream = std::make_unique<plEncryptedStream>();
-                    fStream->Open(fileName, "wb");
+                    auto stream = std::make_unique<plEncryptedStream>();
+                    stream->Open(fileName, "wb");
+                    fStream = std::move(stream);
                 }
                 else
                     fStream = plEncryptedStream::OpenEncryptedFileWrite(fileName);

--- a/Sources/Plasma/FeatureLib/pfPython/pyStream.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyStream.cpp
@@ -145,10 +145,6 @@ bool pyStream::WriteLines(const std::vector<ST::string> & lines)
 
 void pyStream::Close()
 {
-    if (fStream)
-    {
-        fStream->Close();
-        delete fStream;
-    }
+    delete fStream;
     fStream = nullptr;
 }

--- a/Sources/Plasma/FeatureLib/pfPython/pyStream.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyStream.h
@@ -52,6 +52,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "pyGlueHelpers.h"
 
+#include <memory>
 #include <vector>
 
 class hsStream;
@@ -61,14 +62,12 @@ namespace ST { class string; }
 class pyStream
 {
 private:
-    hsStream*   fStream;
+    std::unique_ptr<hsStream> fStream;
 
 protected:
     pyStream();
 
 public:
-    ~pyStream();
-
     // required functions for PyObject interoperability
     PYTHON_CLASS_NEW_FRIEND(ptStream);
     PYTHON_CLASS_NEW_DEFINITION;

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -168,7 +168,6 @@ void plMD5Checksum::CalcFromFile(const plFileName& fileName)
     if (s.Open(fileName))
     {
         CalcFromStream(&s);
-        s.Close();
     }
 }
 
@@ -310,7 +309,6 @@ void plSHAChecksum::CalcFromFile(const plFileName& fileName)
     if (s.Open(fileName))
     {
         CalcFromStream(&s);
-        s.Close();
     }
 }
 
@@ -463,7 +461,6 @@ void plSHA1Checksum::CalcFromFile(const plFileName& fileName)
     if (s.Open(fileName))
     {
         CalcFromStream(&s);
-        s.Close();
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.cpp
@@ -171,7 +171,6 @@ bool plAgeDescription::ReadFromFile( const plFileName &fileNameToReadFrom )
         return false;
 
     Read( stream );
-    stream->Close();
     delete stream;
 
     SetAgeNameFromPath( fileNameToReadFrom );

--- a/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeDescription/plAgeDescription.cpp
@@ -166,12 +166,11 @@ bool plAgeDescription::ReadFromFile( const plFileName &fileNameToReadFrom )
 {
     IInit();
 
-    hsStream* stream = plEncryptedStream::OpenEncryptedFile(fileNameToReadFrom);
+    std::unique_ptr<hsStream> stream = plEncryptedStream::OpenEncryptedFile(fileNameToReadFrom);
     if( !stream )
         return false;
 
-    Read( stream );
-    delete stream;
+    Read(stream.get());
 
     SetAgeNameFromPath( fileNameToReadFrom );
     return true;
@@ -401,7 +400,6 @@ void plAgeDescription::Read(hsStream* stream)
     }
     
     reader.Parse();
-    reader.Close();
 }
 
 //

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
@@ -241,7 +241,6 @@ bool plAgeLoader::ILoadAge(const ST::string& ageName)
     plAgeDescription ad;
     ad.Read(stream);
     ad.SetAgeName(fAgeName);
-    stream->Close();
     delete stream;
     ad.SeekFirstPage();
     
@@ -418,7 +417,6 @@ void plAgeLoader::ExecPendingAgeCsvFiles()
         if (stream)
         {
             plRelevanceMgr::Instance()->ParseCsvInput(stream);
-            stream->Close();
             delete stream;
         }
     }

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.h
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.h
@@ -44,6 +44,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
+#include <memory>
+
 #include "pnKeyedObject/hsKeyedObject.h"
 #include "plAgeDescription/plAgeDescription.h"
 
@@ -97,7 +99,7 @@ public:
 
     static plAgeLoader* GetInstance();
     static void SetInstance(plAgeLoader* inst);
-    static hsStream* GetAgeDescFileStream(const ST::string& ageName);
+    static std::unique_ptr<hsStream> GetAgeDescFileStream(const ST::string& ageName);
 
     void Init();
     void Shutdown();

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
@@ -106,14 +106,14 @@ void plResPatcher::OnFileDownloaded(const plFileName& file)
 
 bool plResPatcher::OnGameCodeDiscovered(const plFileName& file, hsStream* stream)
 {
-    plSecureStream* ss = new plSecureStream(false, plStreamSource::GetInstance()->GetEncryptionKey());
+    auto ss = std::make_unique<plSecureStream>(false, plStreamSource::GetInstance()->GetEncryptionKey());
     if (ss->Open(stream)) {
-        plStreamSource::GetInstance()->InsertFile(file, ss);
+        plStreamSource::GetInstance()->InsertFile(file, std::move(ss));
 
         // SecureStream will hold a decrypted buffer...
         delete stream;
     } else
-        plStreamSource::GetInstance()->InsertFile(file, stream);
+        plStreamSource::GetInstance()->InsertFile(file, std::unique_ptr<hsStream>(stream));
 
     return true; // ASSume success for now...
 }

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
@@ -111,7 +111,6 @@ bool plResPatcher::OnGameCodeDiscovered(const plFileName& file, hsStream* stream
         plStreamSource::GetInstance()->InsertFile(file, ss);
 
         // SecureStream will hold a decrypted buffer...
-        stream->Close();
         delete stream;
     } else
         plStreamSource::GetInstance()->InsertFile(file, stream);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarClothing.cpp
@@ -1468,7 +1468,6 @@ bool plClothingOutfit::WriteToFile(const plFileName &filename)
             S.Write(sdl.GetSDLData().size(), sdl.GetSDLData().data());
     }
 
-    S.Close();
     return true;
 }
 
@@ -1491,7 +1490,6 @@ bool plClothingOutfit::IReadFromFile(const plFileName &filename)
             else if (gender == plClothingMgr::kClothingBaseFemale)
                 plClothingMgr::ChangeAvatar("Female", filename);
         }
-        S.Close();
         return true;
     }
 
@@ -1517,7 +1515,6 @@ bool plClothingOutfit::IReadFromFile(const plFileName &filename)
         }
     }
 
-    S.Close();
     fSynchClients = true;
     ForceUpdate(true);
     SaveCustomizations(); // Sync with the vault

--- a/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plClientResMgr/plClientResMgr.cpp
@@ -119,8 +119,6 @@ void plClientResMgr::ILoadResources(const plFileName& resfile)
             default:
                 break;
         }
-
-        in.Close();
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.cpp
@@ -62,17 +62,13 @@ bool plZlibStream::Open(const plFileName& filename, const char* mode)
     fFilename = filename;
     fMode = mode;
 
-    fOutput = new hsUNIXStream;
+    fOutput = std::make_unique<hsUNIXStream>();
     return fOutput->Open(filename, "wb");
 }
 
 void plZlibStream::Close()
 {
-    if (fOutput)
-    {
-        delete fOutput;
-        fOutput = nullptr;
-    }
+    fOutput.reset();
     if (fZStream)
     {
         z_streamp zstream = (z_streamp)fZStream;

--- a/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.cpp
@@ -62,8 +62,13 @@ bool plZlibStream::Open(const plFileName& filename, const char* mode)
     fFilename = filename;
     fMode = mode;
 
-    fOutput = std::make_unique<hsUNIXStream>();
-    return fOutput->Open(filename, "wb");
+    auto output = std::make_unique<hsUNIXStream>();
+    if (output->Open(filename, "wb")) {
+        fOutput = std::move(output);
+        return true;
+    } else {
+        return false;
+    }
 }
 
 void plZlibStream::Close()

--- a/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.cpp
@@ -54,7 +54,7 @@ void ZlibFree(voidpf opaque, voidpf address)
 
 plZlibStream::~plZlibStream()
 {
-    hsAssert(!fOutput && !fZStream, "plZlibStream not closed");
+    Close();
 }
 
 bool plZlibStream::Open(const plFileName& filename, const char* mode)
@@ -66,11 +66,10 @@ bool plZlibStream::Open(const plFileName& filename, const char* mode)
     return fOutput->Open(filename, "wb");
 }
 
-bool plZlibStream::Close()
+void plZlibStream::Close()
 {
     if (fOutput)
     {
-        fOutput->Close();
         delete fOutput;
         fOutput = nullptr;
     }
@@ -81,8 +80,6 @@ bool plZlibStream::Close()
         delete zstream;
         fZStream = nullptr;
     }
-
-    return true;
 }
 
 uint32_t plZlibStream::Write(uint32_t byteCount, const void* buffer)

--- a/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.h
+++ b/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.h
@@ -60,6 +60,8 @@ protected:
     plFileName fFilename;
     const char* fMode;
 
+    void Close();
+
 public:
     plZlibStream() : fOutput(), fZStream(), fErrorOccurred(), fDecompressedOk(), fMode() { }
     plZlibStream(const plZlibStream& other) = delete;
@@ -70,7 +72,6 @@ public:
     plZlibStream& operator=(plZlibStream&& other) = delete;
 
     bool     Open(const plFileName& filename, const char* mode) override;
-    bool     Close() override;
     uint32_t Write(uint32_t byteCount, const void* buffer) override;
 
     // Since most functions don't check the return value from Write, you can

--- a/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.h
+++ b/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.h
@@ -62,7 +62,12 @@ protected:
 
 public:
     plZlibStream() : fOutput(), fZStream(), fErrorOccurred(), fDecompressedOk(), fMode() { }
+    plZlibStream(const plZlibStream& other) = delete;
+    plZlibStream(plZlibStream&& other) = delete;
     virtual ~plZlibStream();
+
+    const plZlibStream& operator=(const plZlibStream& other) = delete;
+    plZlibStream& operator=(plZlibStream&& other) = delete;
 
     bool     Open(const plFileName& filename, const char* mode) override;
     bool     Close() override;

--- a/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.h
+++ b/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.h
@@ -44,6 +44,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsStream.h"
 
+#include <memory>
+
 //
 // This is for reading a .gz file from a buffer, and writing the uncompressed data to a file.
 // Call open with the name of the uncompressed file, then call write with the compressed data.
@@ -51,7 +53,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plZlibStream : public hsStream
 {
 protected:
-    hsStream* fOutput;
+    std::unique_ptr<hsStream> fOutput;
     void* fZStream;
     bool fErrorOccurred;
     bool fDecompressedOk;

--- a/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.h
+++ b/Sources/Plasma/PubUtilLib/plCompression/plZlibStream.h
@@ -50,7 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // This is for reading a .gz file from a buffer, and writing the uncompressed data to a file.
 // Call open with the name of the uncompressed file, then call write with the compressed data.
 //
-class plZlibStream : public hsStream
+class plZlibStream : public hsFileSystemStream
 {
 protected:
     std::unique_ptr<hsStream> fOutput;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpansExport.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpansExport.cpp
@@ -184,7 +184,6 @@ void    plDrawableSpans::Write( hsStream* s, hsResMgr* mgr )
         char buf[256];
         sprintf(buf, "Drawable Span: %s, GroupNum: %u\r\n", GetKeyName().c_str(), i);
         log.WriteString(buf);
-        log.Close();
 #endif
         fGroups[ i ]->Write( s );
     }

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
@@ -528,11 +528,6 @@ void    plGBufferGroup::Write( hsStream *s )
         for (const plGBufferCell& cell : fCells[i])
             cell.Write(s);
     }
-
-#ifdef VERT_LOG
-    log.Close();
-#endif
-    // All done!
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
@@ -486,7 +486,7 @@ std::unique_ptr<hsStream> plEncryptedStream::OpenEncryptedFile(const plFileName&
 
     bool isEncrypted = IsEncryptedFile(fileName);
 
-    std::unique_ptr<hsStream> s;
+    std::unique_ptr<hsFileSystemStream> s;
     if (isEncrypted)
         s = std::make_unique<plEncryptedStream>(cryptKey);
     else
@@ -498,7 +498,7 @@ std::unique_ptr<hsStream> plEncryptedStream::OpenEncryptedFile(const plFileName&
 
 std::unique_ptr<hsStream> plEncryptedStream::OpenEncryptedFileWrite(const plFileName& fileName, uint32_t* cryptKey)
 {
-    std::unique_ptr<hsStream> s;
+    std::unique_ptr<hsFileSystemStream> s;
     if (IsEncryptedFile(fileName))
         s = std::make_unique<plEncryptedStream>(cryptKey);
     else

--- a/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.h
@@ -80,7 +80,12 @@ protected:
 public:
     // If you don't pass in a key (4 uint32_t's), the default one will be used
     plEncryptedStream(uint32_t* key=nullptr);
+    plEncryptedStream(const plEncryptedStream& other) = delete;
+    plEncryptedStream(plEncryptedStream&& other) = delete;
     ~plEncryptedStream();
+
+    const plEncryptedStream& operator=(const plEncryptedStream& other) = delete;
+    plEncryptedStream& operator=(plEncryptedStream&& other) = delete;
 
     bool    Open(const plFileName& name, const char* mode = "rb") override;
     bool    Close() override;

--- a/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.h
@@ -88,7 +88,6 @@ public:
     plEncryptedStream& operator=(plEncryptedStream&& other) = delete;
 
     bool    Open(const plFileName& name, const char* mode = "rb") override;
-    bool    Close() override;
 
     uint32_t  Read(uint32_t byteCount, void* buffer) override;
     uint32_t  Write(uint32_t byteCount, const void* buffer) override;

--- a/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.h
@@ -44,6 +44,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsStream.h"
 
+#include <memory>
+
 //
 // Encrypt a large file by running FileEncrypt on it.  Small files can be done
 // in the usual way, but they will be in memory until Close is called.  Files
@@ -59,7 +61,7 @@ protected:
 
     bool fBufferedStream;
 
-    hsStream* fRAMStream;
+    std::unique_ptr<hsStream> fRAMStream;
 
     plFileName fWriteFileName;
 
@@ -106,10 +108,9 @@ public:
     static bool IsEncryptedFile(const plFileName& fileName);
 
     // Attempts to create a read-binary stream for the requested file.  If it's
-    // encrypted, you'll get a plEncryptedStream, otherwise just a standard
-    // hsUNIXStream.  Remember to delete the stream when you're done with it.
-    static hsStream* OpenEncryptedFile(const plFileName& fileName, uint32_t* cryptKey = nullptr);
-    static hsStream* OpenEncryptedFileWrite(const plFileName& fileName, uint32_t* cryptKey = nullptr);
+    // encrypted, you'll get a plEncryptedStream, otherwise just a standard hsUNIXStream.
+    static std::unique_ptr<hsStream> OpenEncryptedFile(const plFileName& fileName, uint32_t* cryptKey = nullptr);
+    static std::unique_ptr<hsStream> OpenEncryptedFileWrite(const plFileName& fileName, uint32_t* cryptKey = nullptr);
 };
 
 #endif // plEncryptedStream_h_inc

--- a/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.h
@@ -51,7 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // in the usual way, but they will be in memory until Close is called.  Files
 // will be decrypted on the fly during read.operations
 //
-class plEncryptedStream : public hsStream
+class plEncryptedStream : public hsFileSystemStream
 {
 protected:
     FILE* fRef;

--- a/Sources/Plasma/PubUtilLib/plFile/plInitFileReader.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plInitFileReader.cpp
@@ -200,7 +200,6 @@ void    plInitFileReader::Close()
 
     if( fStream == fOurStream )
     {
-        fStream->Close();
         delete fOurStream;
         fOurStream = nullptr;
     }

--- a/Sources/Plasma/PubUtilLib/plFile/plInitFileReader.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plInitFileReader.cpp
@@ -79,19 +79,21 @@ void    plInitFileReader::IInitReaders( plInitSectionReader **readerArray )
 }
 
 plInitFileReader::plInitFileReader( plInitSectionReader **readerArray, uint16_t lineSize )
+    : fOurStream()
 {
     fCurrLine = nullptr;
     fLineSize = lineSize;
-    fStream = fOurStream = nullptr;
+    fStream = nullptr;
     IInitReaders( readerArray );
     fUnhandledSection = nullptr;
 }
 
 plInitFileReader::plInitFileReader( const char *fileName, plInitSectionReader **readerArray, uint16_t lineSize )
+    : fOurStream()
 {
     fCurrLine = nullptr;
     fLineSize = lineSize;
-    fStream = fOurStream = nullptr;
+    fStream = nullptr;
     IInitReaders( readerArray );
     if( !Open( fileName ) )
         hsAssert( false, "Constructor open for plInitFileReader failed!" );
@@ -99,10 +101,11 @@ plInitFileReader::plInitFileReader( const char *fileName, plInitSectionReader **
 }
 
 plInitFileReader::plInitFileReader( hsStream *stream, plInitSectionReader **readerArray, uint16_t lineSize )
+    : fOurStream()
 {
     fCurrLine = nullptr;
     fLineSize = lineSize;
-    fStream = fOurStream = nullptr;
+    fStream = nullptr;
     IInitReaders( readerArray );
     if( !Open( stream ) )
         hsAssert( false, "Constructor open for plInitFileReader failed!" );
@@ -111,7 +114,6 @@ plInitFileReader::plInitFileReader( hsStream *stream, plInitSectionReader **read
 
 plInitFileReader::~plInitFileReader()
 {
-    Close();
     delete [] fCurrLine;
 }
 
@@ -128,7 +130,7 @@ bool    plInitFileReader::Open( const char *fileName )
     if (fOurStream == nullptr)
         return false;
 
-    fStream = fOurStream;
+    fStream = fOurStream.get();
 
     return true;
 }
@@ -192,18 +194,3 @@ bool    plInitFileReader::Parse( uint32_t userData )
 
     return true;
 }
-
-void    plInitFileReader::Close()
-{
-    if (fStream == nullptr)
-        return;
-
-    if( fStream == fOurStream )
-    {
-        delete fOurStream;
-        fOurStream = nullptr;
-    }
-
-    fStream = nullptr;
-}
-

--- a/Sources/Plasma/PubUtilLib/plFile/plInitFileReader.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plInitFileReader.h
@@ -64,6 +64,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include "hsStream.h"
+
+#include <memory>
 #include <vector>
 
 //// Base Section Class //////////////////////////////////////////////////////
@@ -115,7 +117,7 @@ class plInitFileReader
     protected:
 
         hsStream            *fStream;
-        hsStream            *fOurStream;
+        std::unique_ptr<hsStream> fOurStream;
         char                *fCurrLine;
         uint32_t              fLineSize;
 
@@ -142,7 +144,6 @@ class plInitFileReader
         bool    Open( const char *fileName );
         bool    Open( hsStream *stream );
         bool    Parse( uint32_t userData = 0 );
-        void    Close();
 
         bool    IsOpen() const { return fStream != nullptr; }
 };

--- a/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
@@ -654,7 +654,7 @@ std::unique_ptr<hsStream> plSecureStream::OpenSecureFile(const plFileName& fileN
     bool deleteOnExit = flags & kDeleteOnExit;
     bool isEncrypted = IsSecureFile(fileName);
 
-    std::unique_ptr<hsStream> s;
+    std::unique_ptr<hsFileSystemStream> s;
     if (isEncrypted)
         s = std::make_unique<plSecureStream>(deleteOnExit, key);
     else if (!requireEncryption)
@@ -667,7 +667,7 @@ std::unique_ptr<hsStream> plSecureStream::OpenSecureFile(const plFileName& fileN
 
 std::unique_ptr<hsStream> plSecureStream::OpenSecureFileWrite(const plFileName& fileName, uint32_t* key /* = nullptr */)
 {
-    std::unique_ptr<hsStream> s;
+    std::unique_ptr<hsFileSystemStream> s;
 #ifdef PLASMA_EXTERNAL_RELEASE
     s = std::make_unique<plSecureStream>(false, key);
 #else

--- a/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
@@ -101,9 +101,9 @@ plSecureStream::~plSecureStream()
     }
 
     if (fRef != INVALID_HANDLE_VALUE) {
-#if HS_BUILD_FOR_WIN32
+#if defined(HS_BUILD_FOR_WIN32)
         CloseHandle(fRef);
-#elif HS_BUILD_FOR_UNIX
+#elif defined(HS_BUILD_FOR_UNIX)
         fclose(fRef);
 #endif
     }

--- a/Sources/Plasma/PubUtilLib/plFile/plSecureStream.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plSecureStream.h
@@ -100,7 +100,6 @@ public:
 
     bool Open(const plFileName& name, const char* mode = "rb") override;
     bool Open(hsStream* stream);
-    bool Close() override;
 
     uint32_t Read(uint32_t byteCount, void* buffer) override;
     uint32_t Write(uint32_t byteCount, const void* buffer) override;

--- a/Sources/Plasma/PubUtilLib/plFile/plSecureStream.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plSecureStream.h
@@ -59,7 +59,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // to download the file from a server into a temporary directory (with a mangled name) and
 // delete that file on close, thereby minimizing the chance of having that file examined or
 // edited.
-class plSecureStream: public hsStream
+class plSecureStream : public hsFileSystemStream
 {
 protected:
     hsFD fRef;

--- a/Sources/Plasma/PubUtilLib/plFile/plSecureStream.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plSecureStream.h
@@ -45,6 +45,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "hsStream.h"
 
+#include <memory>
+
 #if HS_BUILD_FOR_WIN32
     typedef void* HANDLE;
 #   define hsFD HANDLE
@@ -67,7 +69,7 @@ protected:
 
     bool fBufferedStream;
 
-    hsStream* fRAMStream;
+    std::unique_ptr<hsStream> fRAMStream;
 
     plFileName fWriteFileName;
 
@@ -123,12 +125,10 @@ public:
 
     static bool IsSecureFile(const plFileName& fileName);
 
-    // Attempts to create a read-binary stream for the requested file (delete the stream
-    // when you are done with it!)
-    static hsStream* OpenSecureFile(const plFileName& fileName, const uint32_t flags = kRequireEncryption, uint32_t* key = nullptr);
-    // Attempts to create a write-binary stream for the requested file (delete the stream
-    // when you are done with it!)
-    static hsStream* OpenSecureFileWrite(const plFileName& fileName, uint32_t* key = nullptr);
+    // Attempts to create a read-binary stream for the requested file
+    static std::unique_ptr<hsStream> OpenSecureFile(const plFileName& fileName, const uint32_t flags = kRequireEncryption, uint32_t* key = nullptr);
+    // Attempts to create a write-binary stream for the requested file
+    static std::unique_ptr<hsStream> OpenSecureFileWrite(const plFileName& fileName, uint32_t* key = nullptr);
 
     static const uint32_t kDefaultKey[4]; // our default encryption key
 

--- a/Sources/Plasma/PubUtilLib/plFile/plSecureStream.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plSecureStream.h
@@ -91,7 +91,12 @@ protected:
 public:
     plSecureStream(bool deleteOnExit = false, uint32_t* key = nullptr); // uses default key if you don't pass one in
     plSecureStream(hsStream* base, uint32_t* key = nullptr);
+    plSecureStream(const plSecureStream& other) = delete;
+    plSecureStream(plSecureStream&& other) = delete;
     ~plSecureStream();
+
+    const plSecureStream& operator=(const plSecureStream& other) = delete;
+    plSecureStream& operator=(plSecureStream&& other) = delete;
 
     bool Open(const plFileName& name, const char* mode = "rb") override;
     bool Open(hsStream* stream);

--- a/Sources/Plasma/PubUtilLib/plFile/plStreamSource.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plStreamSource.cpp
@@ -63,7 +63,6 @@ void plStreamSource::ICleanup()
     decltype(fFileData.begin()) curData;
     for (curData = fFileData.begin(); curData != fFileData.end(); curData++)
     {
-        curData->second.fStream->Close();
         delete curData->second.fStream;
         curData->second.fStream = nullptr;
     }

--- a/Sources/Plasma/PubUtilLib/plFile/plStreamSource.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plStreamSource.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plStreamSource_h_inc
 
 #include <map>
+#include <memory>
 #include <mutex>
 #include "hsStream.h"
 
@@ -57,7 +58,7 @@ private:
         plFileName      fFilename; // includes path
         plFileName      fDir; // parent directory
         ST::string      fExt;
-        hsStream*       fStream; // we own this pointer, so clean it up
+        std::unique_ptr<hsStream> fStream;
     };
     std::map<plFileName, fileData, plFileName::less_i> fFileData; // key is filename
     std::mutex fMutex;
@@ -77,7 +78,7 @@ public:
     std::vector<plFileName> GetListOfNames(const plFileName& dir, const ST::string& ext); // internal builds merge from disk
 
     // For other classes to insert files (takes ownership of the stream if successful)
-    bool InsertFile(const plFileName& filename, hsStream* stream);
+    bool InsertFile(const plFileName& filename, std::unique_ptr<hsStream>&& stream);
 
     /** Gets a pointer to our encryption key */
     uint32_t* GetEncryptionKey() { return fServerKey; }

--- a/Sources/Plasma/PubUtilLib/plGImage/plJPEG.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plJPEG.cpp
@@ -242,9 +242,7 @@ plMipmap*   plJPEG::ReadFromFile( const plFileName &fileName )
     delete [] tempbuffer;
     tempstream.Rewind();
 
-    plMipmap* ret = IRead(&tempstream);
-    in.Close();
-    return ret;
+    return IRead(&tempstream);
 }
 
 //// IWrite ///////////////////////////////////////////////////////////////////
@@ -360,7 +358,6 @@ bool    plJPEG::WriteToFile( const plFileName &fileName, plMipmap *sourceData )
 
         delete [] tempbuffer;
     }
-    out.Close();
     return ret;
 }
 

--- a/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
@@ -559,16 +559,20 @@ void plMipmap::IWriteJPEGImage( hsStream *stream )
     plMipmap *alpha = ISplitAlpha();
     uint8_t flags = 0;
 
-    hsNullStream *nullStream = new hsNullStream();
-    IWriteRLEImage(nullStream,this);
-    if (nullStream->GetPosition() < 5120) // we use RLE if it can get the image size under 5k, otherwise we use JPEG
-        flags |= kColorDataRLE;
-    delete nullStream;
-    nullStream = new hsNullStream();
-    IWriteRLEImage(nullStream,alpha);
-    if (nullStream->GetPosition() < 5120)
-        flags |= kAlphaDataRLE;
-    delete nullStream;
+    {
+        hsNullStream nullStream;
+        IWriteRLEImage(&nullStream, this);
+        if (nullStream.GetPosition() < 5120) // we use RLE if it can get the image size under 5k, otherwise we use JPEG
+            flags |= kColorDataRLE;
+    }
+
+    {
+        hsNullStream nullStream;
+        IWriteRLEImage(&nullStream, alpha);
+        if (nullStream.GetPosition() < 5120)
+            flags |= kAlphaDataRLE;
+    }
+
     stream->WriteByte(flags);
 
     if (flags & kColorDataRLE)

--- a/Sources/Plasma/PubUtilLib/plGImage/plPNG.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plPNG.cpp
@@ -187,9 +187,7 @@ plMipmap* plPNG::ReadFromFile(const plFileName& fileName)
         return nullptr;
     }
 
-    plMipmap* ret = IRead(&in);
-    in.Close();
-    return ret;
+    return IRead(&in);
 }
 
 bool plPNG::IWrite(plMipmap* source, hsStream* outStream, const std::multimap<ST::string, ST::string>& textFields)
@@ -293,7 +291,5 @@ bool plPNG::WriteToFile(const plFileName& fileName, plMipmap* sourceData, const 
         return false;
     }
 
-    bool ret = IWrite(sourceData, &out, textFields);
-    out.Close();
-    return ret;
+    return IWrite(sourceData, &out, textFields);
 }

--- a/Sources/Plasma/PubUtilLib/plGImage/plTGAWriter.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plTGAWriter.cpp
@@ -105,8 +105,5 @@ void    plTGAWriter::WriteMipmap( const char *fileName, plMipmap *mipmap )
             stream.WriteByte( pixel.r );
         }
     }
-
-    /// All done!
-    stream.Close();
 }
 

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -1347,7 +1347,6 @@ plUoid plNetClientMgr::GetAgeSDLObjectUoid(const ST::string& ageName) const
                 plAgeDescription ad;
                 ad.Read(stream);
                 loc=ad.CalcPageLocation("BuiltIn");
-                stream->Close();
             }           
             delete stream;
         }

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -1341,14 +1341,13 @@ plUoid plNetClientMgr::GetAgeSDLObjectUoid(const ST::string& ageName) const
         if (!loc.IsValid())
         {
             // try to load age desc
-            hsStream* stream=plAgeLoader::GetAgeDescFileStream(ageName);
+            std::unique_ptr<hsStream> stream = plAgeLoader::GetAgeDescFileStream(ageName);
             if (stream)
             {
                 plAgeDescription ad;
-                ad.Read(stream);
+                ad.Read(stream.get());
                 loc=ad.CalcPageLocation("BuiltIn");
-            }           
-            delete stream;
+            }
         }
     }
 

--- a/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientRecorder.h
+++ b/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientRecorder.h
@@ -44,6 +44,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
+#include <memory>
+
 class hsStream;
 class plNetMessage;
 class plStatusLog;
@@ -114,7 +116,7 @@ public:
 class plNetClientStreamRecorder : public plNetClientLoggingRecorder
 {
 protected:
-    hsStream* fRecordStream;
+    std::unique_ptr<hsStream> fRecordStream;
 
     hsResMgr* fResMgr;
 

--- a/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientStreamRecorder.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientStreamRecorder.cpp
@@ -70,11 +70,7 @@ plNetClientStreamRecorder::plNetClientStreamRecorder(TimeWrapper* timeWrapper) :
 
 plNetClientStreamRecorder::~plNetClientStreamRecorder()
 {
-    if (fRecordStream)
-    {
-        fRecordStream->Close();
-        delete fRecordStream;
-    }
+    delete fRecordStream;
 }
 
 hsResMgr* plNetClientStreamRecorder::GetResMgr()
@@ -238,7 +234,6 @@ plNetMessage* plNetClientStreamRecorder::IGetNextMessage()
         // If this was the last message, stop playing back
         if (fRecordStream->AtEnd())
         {
-            fRecordStream->Close();
             delete fRecordStream;
             fRecordStream = nullptr;
         }

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.cpp
@@ -139,9 +139,8 @@ plNetMessage* plNetMessage::Create(const plNetCommonMessage* msg)
 {
     if (msg)
     {
-        hsReadOnlyStream readStream;
         ClassIndexType classIndex;
-        readStream.Init(sizeof(classIndex), msg->GetData());
+        hsReadOnlyStream readStream(sizeof(classIndex), msg->GetData());
         readStream.ReadLE16(&classIndex);
         if (!plFactory::IsValidClassIndex(classIndex))
             return nullptr;
@@ -170,8 +169,7 @@ int plNetMessage::PokeBuffer(char* bufIn, int bufLen, uint32_t peekOptions)
         memset(bufIn, 0, bufLen);
     
     ValidatePoke();
-    hsWriteOnlyStream writeStream;
-    writeStream.Init(bufLen, bufIn);
+    hsWriteOnlyStream writeStream(bufLen, bufIn);
     int ret;
     if (peekOptions & kBaseClassOnly)
     {
@@ -199,8 +197,7 @@ int plNetMessage::PeekBuffer(const char* bufIn, int bufLen, uint32_t peekOptions
     // set peek status based on peekOptions
     fPeekStatus = partialPeekOptions ? partialPeekOptions : kFullyPeeked;
     
-    hsReadOnlyStream readStream;
-    readStream.Init(bufLen, bufIn);
+    hsReadOnlyStream readStream(bufLen, bufIn);
     int ret;
     if (peekOptions & kBaseClassOnly)
     {

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
@@ -132,15 +132,14 @@ hsStream* plRegistryPageNode::OpenStream()
     if (fOpenRequests == 0)
     {
         hsAssert(fStream == nullptr, "plRegistryPageNode::fStream should be nullptr when not open!");
-        hsBufferedStream* stream = new hsBufferedStream;
+        auto stream = std::make_unique<hsBufferedStream>();
         if (!stream->Open(fPath, "rb")) {
-            delete stream;
             return nullptr;
         }
-        fStream = stream;
+        fStream = std::move(stream);
     }
     fOpenRequests++;
-    return fStream;
+    return fStream.get();
 }
 
 void plRegistryPageNode::CloseStream()
@@ -149,8 +148,7 @@ void plRegistryPageNode::CloseStream()
         fOpenRequests--;
 
     if (fOpenRequests == 0) {
-        delete fStream;
-        fStream = nullptr;
+        fStream.reset();
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
@@ -42,6 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plRegistryNode.h"
 
+#include "hsStream.h"
 #include "plRegistryHelpers.h"
 #include "plRegistryKeyList.h"
 #include "plVersion.h"
@@ -49,17 +50,21 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnFactory/plFactory.h"
 #include "pnKeyedObject/plKeyImp.h"
 
+plRegistryPageNode::plRegistryPageNode()
+{}
+
 plRegistryPageNode::plRegistryPageNode(const plFileName& path)
     : fValid(kPageCorrupt)
     , fPath(path)
     , fLoadedTypes(0)
+    , fStream(nullptr)
     , fOpenRequests(0)
     , fIsNewPage(false)
 {
     hsStream* stream = OpenStream();
     if (stream)
     {
-        fPageInfo.Read(&fStream);
+        fPageInfo.Read(stream);
         fValid = IVerify();
         CloseStream();
     }
@@ -70,6 +75,7 @@ plRegistryPageNode::plRegistryPageNode(const plLocation& location, const ST::str
     : fValid(kPageOk)
     , fPageInfo(location)
     , fLoadedTypes(0)
+    , fStream(nullptr)
     , fOpenRequests(0)
     , fIsNewPage(true)
 {
@@ -125,11 +131,16 @@ hsStream* plRegistryPageNode::OpenStream()
 {
     if (fOpenRequests == 0)
     {
-        if (!fStream.Open(fPath, "rb"))
+        hsAssert(fStream == nullptr, "plRegistryPageNode::fStream should be nullptr when not open!");
+        hsBufferedStream* stream = new hsBufferedStream;
+        if (!stream->Open(fPath, "rb")) {
+            delete stream;
             return nullptr;
+        }
+        fStream = stream;
     }
     fOpenRequests++;
-    return &fStream;
+    return fStream;
 }
 
 void plRegistryPageNode::CloseStream()
@@ -137,8 +148,10 @@ void plRegistryPageNode::CloseStream()
     if (fOpenRequests > 0)
         fOpenRequests--;
 
-    if (fOpenRequests == 0)
-        fStream.Close();
+    if (fOpenRequests == 0) {
+        delete fStream;
+        fStream = nullptr;
+    }
 }
 
 void plRegistryPageNode::LoadKeys()
@@ -213,9 +226,11 @@ public:
 
 void plRegistryPageNode::Write()
 {
+    hsAssert(fStream == nullptr, "Trying to write while the page is open for reading");
     hsAssert(fOpenRequests == 0, "Trying to write while the page is open for reading");
 
-    if (!fStream.Open(fPath, "wb"))
+    hsBufferedStream stream;
+    if (!stream.Open(fPath, "wb"))
     {
         hsAssert(0, "Couldn't open file for writing");
         return;
@@ -234,31 +249,29 @@ void plRegistryPageNode::Write()
     }
 
     // First thing we write is the pageinfo.  Later we'll rewind and overwrite this with the final values
-    fPageInfo.Write(&fStream);
+    fPageInfo.Write(&stream);
 
-    fPageInfo.SetDataStart(fStream.GetPosition());
+    fPageInfo.SetDataStart(stream.GetPosition());
 
     // Write all our objects
-    plWriteIterator writer(&fStream);
+    plWriteIterator writer(&stream);
     IterateKeys(&writer);
 
-    fPageInfo.SetIndexStart(fStream.GetPosition());
+    fPageInfo.SetIndexStart(stream.GetPosition());
 
     // Write our keys
-    fStream.WriteLE32((uint32_t)fKeyLists.size());
+    stream.WriteLE32((uint32_t)fKeyLists.size());
     for (it = fKeyLists.begin(); it != fKeyLists.end(); it++)
     {
         plRegistryKeyList* keyList = it->second;
-        fStream.WriteLE16(keyList->GetClassType());
-        keyList->Write(&fStream);
+        stream.WriteLE16(keyList->GetClassType());
+        keyList->Write(&stream);
     }
 
     // Rewind and write the pageinfo with the correct data and index offsets
-    fStream.Rewind();
-    fPageInfo.SetChecksum(fStream.GetEOF() - fPageInfo.GetDataStart());
-    fPageInfo.Write(&fStream);
-
-    fStream.Close();
+    stream.Rewind();
+    fPageInfo.SetChecksum(stream.GetEOF() - fPageInfo.GetDataStart());
+    fPageInfo.Write(&stream);
 }
 
 //// IterateKeys /////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.h
@@ -43,11 +43,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plRegistryNode_h_inc
 
 #include "HeadSpin.h"
-#include "hsStream.h"
+#include "plFileSystem.h"
 #include "plPageInfo.h"
 
 #include <map>
 
+class hsStream;
 class plRegistryKeyList;
 class plKeyImp;
 class plRegistryKeyIterator;
@@ -78,12 +79,12 @@ protected:
     plFileName  fPath;          // Path to the page file
     plPageInfo  fPageInfo;      // Info about this page
 
-    hsBufferedStream fStream;   // Stream for reading/writing our page
+    hsBufferedStream* fStream; // Stream for reading/writing our page
     uint8_t fOpenRequests;        // How many handles there are to fStream (or
                                 // zero if it's closed)
     bool fIsNewPage;          // True if this page is new (not read off disk)
 
-    plRegistryPageNode() {}
+    plRegistryPageNode();
 
     plRegistryKeyList* IGetKeyList(uint16_t classType) const;
     PageCond IVerify();

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.h
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plPageInfo.h"
 
 #include <map>
+#include <memory>
 
 class hsStream;
 class plRegistryKeyList;
@@ -79,7 +80,7 @@ protected:
     plFileName  fPath;          // Path to the page file
     plPageInfo  fPageInfo;      // Info about this page
 
-    hsBufferedStream* fStream; // Stream for reading/writing our page
+    std::unique_ptr<hsStream> fStream; // Stream for reading/writing our page
     uint8_t fOpenRequests;        // How many handles there are to fStream (or
                                 // zero if it's closed)
     bool fIsNewPage;          // True if this page is new (not read off disk)

--- a/Sources/Plasma/PubUtilLib/plStatGather/plProfileManagerFull.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plProfileManagerFull.cpp
@@ -483,8 +483,6 @@ void plProfileManagerFull::ILogStats()
         }
         s.WriteByte((uint8_t)'\r');
         s.WriteByte((uint8_t)'\n');
-
-        s.Close();
     }
 
     fLogStats = false;

--- a/Sources/Tools/MaxComponent/plAudioComponents.cpp
+++ b/Sources/Tools/MaxComponent/plAudioComponents.cpp
@@ -3043,9 +3043,6 @@ void    plEAXListenerComponent::SetCustFile( const MCHAR* path )
         hsAssert( false, "Couldn't find all of the keywords in the settings file. Oh well" );
     }
 
-    // All done!
-    presetFile.Close();
-
     // Update our helper reminder string
     _tsplitpath(path, nullptr, nullptr, file, nullptr);
     fCompPB->SetValue( (ParamID)kRefCustFile, 0, file );

--- a/Sources/Tools/MaxComponent/plMultistageBehComponent.cpp
+++ b/Sources/Tools/MaxComponent/plMultistageBehComponent.cpp
@@ -485,6 +485,10 @@ protected:
 public:
     MaxStream(ISave* isave) : fSave(isave), fLoad() { }
     MaxStream(ILoad* iload) : fSave(), fLoad(iload) { }
+    MaxStream(const MaxStream& other) = delete;
+    MaxStream(MaxStream&& other) = delete;
+    const MaxStream& operator=(const MaxStream& other) = delete;
+    MaxStream& operator=(MaxStream&& other) = delete;
 
     // Don't support any of this
     bool Open(const plFileName &, const char * = "rb") override { hsAssert(0, "Not supported"); return false; }

--- a/Sources/Tools/MaxComponent/plMultistageBehComponent.cpp
+++ b/Sources/Tools/MaxComponent/plMultistageBehComponent.cpp
@@ -492,7 +492,6 @@ public:
 
     // Don't support any of this
     bool Open(const plFileName &, const char * = "rb") override { hsAssert(0, "Not supported"); return false; }
-    bool Close() override { hsAssert(0, "Not supported"); return false; }
     bool AtEnd() override { hsAssert(false, "Not supported"); return false; }
     void Skip(uint32_t deltaByteCount) override { hsAssert(0, "Not supported"); }
     void Rewind() override { hsAssert(0, "Not supported"); }

--- a/Sources/Tools/MaxComponent/plMultistageBehComponent.cpp
+++ b/Sources/Tools/MaxComponent/plMultistageBehComponent.cpp
@@ -491,7 +491,6 @@ public:
     MaxStream& operator=(MaxStream&& other) = delete;
 
     // Don't support any of this
-    bool Open(const plFileName &, const char * = "rb") override { hsAssert(0, "Not supported"); return false; }
     bool AtEnd() override { hsAssert(false, "Not supported"); return false; }
     void Skip(uint32_t deltaByteCount) override { hsAssert(0, "Not supported"); }
     void Rewind() override { hsAssert(0, "Not supported"); }

--- a/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
+++ b/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
@@ -5008,7 +5008,6 @@ void hsMaterialConverter::IPrintDoneMaterials(const char* path, const std::vecto
         char buff[256];
         sprintf(buff, "");
         stream.WriteString("No Materials Generated\n");
-        stream.Close();
         return;
     }
 
@@ -5065,8 +5064,6 @@ void hsMaterialConverter::IPrintDoneMaterials(const char* path, const std::vecto
 
     sprintf(buff, "\nThank you, and have a lovely day.\n");
     stream.WriteString(buff);
-
-    stream.Close();
 }
 
 hsMaterialConverter::DoneMaterialData* hsMaterialConverter::IFindDoneMaterial(DoneMaterialData& done)

--- a/Sources/Tools/MaxConvert/plLightMapGen.cpp
+++ b/Sources/Tools/MaxConvert/plLightMapGen.cpp
@@ -329,8 +329,6 @@ void DumpMipmap(plMipmap* mipmap, const char* prefix)
             dump.WriteString("\n");
         }
     }
-
-    dump.Close();
 }
 #endif // MIPMAP_LOG
 

--- a/Sources/Tools/MaxExport/SimpleExport.cpp
+++ b/Sources/Tools/MaxExport/SimpleExport.cpp
@@ -369,7 +369,6 @@ int HSExport2::DoExport(const MCHAR *name,ExpInterface *ei,Interface *gi, BOOL s
             out_name, tm.wMonth, tm.wDay, tm.wYear, exportTime / 60, exportTime % 60
         )
     );
-    dbLog.Close();
 
     // Allow plugins to clean up after export
     BroadcastNotification(NOTIFY_POST_EXPORT);

--- a/Sources/Tools/MaxExport/plExportDlg.cpp
+++ b/Sources/Tools/MaxExport/plExportDlg.cpp
@@ -414,7 +414,6 @@ static bool AutoExportDir(const plFileName& inputDir, const plFileName& outputDi
         if (log.Open(outputLog, "ab"))
         {
             log.WriteString(ST::format("{}\r\n", iter->GetFileName()));
-            log.Close();
         }
 
         if (GetCOREInterface()->LoadFromFile(ST2M(iter->AsString())))
@@ -442,7 +441,6 @@ static void ShutdownMax()
     {
         hsUNIXStream s;
         s.Open("log\\AutoExportDone.txt", "wb");
-        s.Close();
     }
     GetCOREInterface()->FlushUndoBuffer();
     SetSaveRequiredFlag(FALSE);

--- a/Sources/Tools/MaxExport/plExportLogErrorMsg.cpp
+++ b/Sources/Tools/MaxExport/plExportLogErrorMsg.cpp
@@ -64,7 +64,6 @@ plExportLogErrorMsg::~plExportLogErrorMsg()
                     fErrfile->WriteString("(which is a disaster!)");
             else
                 fErrfile->WriteString("(which is way too many!)");
-        fErrfile->Close();
     }
 #ifdef ERRORLOG_ALWAYS_WRITE_SOMETHING
     else
@@ -73,7 +72,6 @@ plExportLogErrorMsg::~plExportLogErrorMsg()
         fErrfile->Open(fErrfile_name, "wt");
         setbuf(fErrfile->GetFILE(), nullptr);
         fErrfile->WriteString("No errors found! Good job.");
-        fErrfile->Close();
     }
 #endif // ERRORLOG_ALWAYS_WRITE_SOMETHING
 }

--- a/Sources/Tools/MaxMain/plAgeDescInterface.cpp
+++ b/Sources/Tools/MaxMain/plAgeDescInterface.cpp
@@ -1183,7 +1183,6 @@ void plAgeDescInterface::ISaveCurAge( const plFileName &path, bool checkSeqNum )
 
     // write it all out
     aged.Write(&s);
-    s.Close();
 }
 
 //// ICheckSequenceNumber /////////////////////////////////////////////////////
@@ -1310,7 +1309,6 @@ uint32_t  plAgeDescInterface::IGetNextFreeSequencePrefix( bool getReservedPrefix
         if( stream.Open( fAgeFiles[ i ]->fPath, "rt" ) )
         {
             ages[ i ].Read( &stream );
-            stream.Close();
         }
     }
 

--- a/Sources/Tools/MaxMain/plTextureExportLog.cpp
+++ b/Sources/Tools/MaxMain/plTextureExportLog.cpp
@@ -232,7 +232,6 @@ void    plTextureExportLog::Write()
         stream->WriteString( "\n" );
     }
 
-    stream->Close();
     delete stream;
 
     // HACK: Prevent the destructor from writing out now

--- a/Sources/Tools/MaxMain/plTextureExportLog.cpp
+++ b/Sources/Tools/MaxMain/plTextureExportLog.cpp
@@ -111,21 +111,21 @@ void    plTextureExportLog::AddTexture( plBitmap *texture )
 void    plTextureExportLog::Write()
 {
     plBMapNode      *node;
-    hsUNIXStream    *stream = new hsUNIXStream;
+    hsUNIXStream stream;
     char            str[ 128 ];
     uint32_t          size;
 
 
-    stream->Open( fFileName, "wt" );
-    stream->WriteString( "------------------------------------------------------------\n" );
-    stream->WriteString( "- Texture Export Data Log                                  -\n" );
-    stream->WriteString( "------------------------------------------------------------\n" );
-    stream->WriteString( "\n" );
+    stream.Open(fFileName, "wt");
+    stream.WriteString("------------------------------------------------------------\n");
+    stream.WriteString("- Texture Export Data Log                                  -\n");
+    stream.WriteString("------------------------------------------------------------\n");
+    stream.WriteString("\n");
     IWriteTabbedString( stream, "Name", 4 );
     IWriteTabbedString( stream, "Size", 3 );
     IWriteTabbedString( stream, "Type", 4 );
-    stream->WriteString( "\n" );
-    stream->WriteString( "------------------------------------------------------------\n" );
+    stream.WriteString("\n");
+    stream.WriteString("------------------------------------------------------------\n");
 
     for (node = fNodeList; node != nullptr; node = node->fNextNode)
     {
@@ -229,22 +229,20 @@ void    plTextureExportLog::Write()
         {
             IWriteTabbedString( stream, "Unknown", 3 );
         }
-        stream->WriteString( "\n" );
+        stream.WriteString("\n");
     }
-
-    delete stream;
 
     // HACK: Prevent the destructor from writing out now
     fFileName = plFileName();
 }
 
-void    plTextureExportLog::IWriteTabbedString( hsStream *stream, const char *string, int numTabs )
+void plTextureExportLog::IWriteTabbedString(hsStream& stream, const char *string, int numTabs)
 {
     static char tabs[ 64 ];
     int         i;
 
 
-    stream->WriteString( string );
+    stream.WriteString(string);
 
     // Assumes 8 spaces per tab
     numTabs -= strlen( string ) / 8;
@@ -255,5 +253,5 @@ void    plTextureExportLog::IWriteTabbedString( hsStream *stream, const char *st
         tabs[ i ] = '\t';
     tabs[ i ] = 0;
 
-    stream->WriteString( tabs );
+    stream.WriteString(tabs);
 }

--- a/Sources/Tools/MaxMain/plTextureExportLog.h
+++ b/Sources/Tools/MaxMain/plTextureExportLog.h
@@ -77,7 +77,7 @@ class plTextureExportLog
 
 
         void    IAddBMapNode( uint32_t rank, plBitmap *bMap );
-        void    IWriteTabbedString( hsStream *stream, const char *string, int numTabs );
+        void IWriteTabbedString(hsStream& stream, const char *string, int numTabs);
 
     public: 
 

--- a/Sources/Tools/plFontConverter/plFontConverter.cpp
+++ b/Sources/Tools/plFontConverter/plFontConverter.cpp
@@ -251,7 +251,6 @@ void plFontConverter::ExportP2F()
                 hsgResMgr::ResMgr()->NewKey( fileName, gFont, plLocation::kGlobalFixedLoc );
             */
             fFont->WriteRaw(&stream);
-            stream.Close();
         }
     }
 }
@@ -582,7 +581,6 @@ void plFontConverter::IBatchFreeType(const plFileName &path, void *init)
         else
         {
             fFont->WriteRaw(&stream);
-            stream.Close();
         }
 
         callback.CharDone();

--- a/Sources/Tools/plResBrowser/plResBrowser.cpp
+++ b/Sources/Tools/plResBrowser/plResBrowser.cpp
@@ -253,6 +253,7 @@ void plResBrowser::SaveSelectedObject()
             stream->SetPosition(keyImp->GetStartPos());
             stream->Read(keyImp->GetDataLen(), buffer);
         }
+        pageNode->CloseStream();
 
         if (!buffer)
             return;
@@ -260,7 +261,6 @@ void plResBrowser::SaveSelectedObject()
         hsUNIXStream outStream;
         outStream.Open(fileName.toUtf8().constData(), "wb");
         outStream.Write(keyImp->GetDataLen(), buffer);
-        outStream.Close();
 
         delete[] buffer;
     }

--- a/Sources/Tools/plShaderAssembler/main.cpp
+++ b/Sources/Tools/plShaderAssembler/main.cpp
@@ -143,7 +143,6 @@ static void IAssShader(const plDXShaderAssembler& ass, const char* name)
 
     hsUNIXStream inFp;
     if (!inFp.Open(inFile, "r")) {
-        outFp.Close();
         fputs("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n", stderr);
         ST::printf(stderr, "Error opening file {} for input\n", inFile);
         fputs("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n", stderr);
@@ -153,7 +152,6 @@ static void IAssShader(const plDXShaderAssembler& ass, const char* name)
     uint32_t shaderCodeLen = inFp.GetEOF();
     auto shaderCode = std::make_unique<char[]>(shaderCodeLen);
     inFp.Read(shaderCodeLen, shaderCode.get());
-    inFp.Close();
 
     try {
         auto compiledShader = ass.AssShader(shaderCode.get(), shaderCodeLen);
@@ -163,8 +161,6 @@ static void IAssShader(const plDXShaderAssembler& ass, const char* name)
         fputs(error.c_str(), stderr);
         fputs("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n", stderr);
     }
-
-    outFp.Close();
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
A step towards RAII for `hsStream`. This makes streams much easier to manage correctly, especially when using `std::unique_ptr`, collections and such.

In fact, I removed `hsStream::Close` entirely, because almost nothing closed a stream *without* destroying it soon afterwards. Sometimes this was done to reuse a single stream object for multiple files, but it's not hard to recreate the stream for each file instead.

This isn't "proper full RAII", because *opening* a stream is still its own method call and not part of the constructor. I wasn't sure how to handle error reporting and virtual `Open` calls if the constructor does the opening. This isn't a big problem though I think - the automatic closing is the important part.

The diff is long, but it's mostly boring deleting of all the manual `Close` calls. The actually interesting changes are in `hsStream` and its implementations. The updated logic in plRegistryNode, plStreamSource, and pfPatcher could use some extra eyes perhaps.