### PR TITLE
Avoid runtime indirection when initializing `plCreatable` class indices

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.h
@@ -80,8 +80,6 @@ protected:
     SDLMap fMap;
     plPythonFileMod* fOwner;
 
-    plPythonSDLModifier() : fOwner() { }
-
     PyObject* ISDLVarToPython(plSimpleStateVariable* var);
     PyObject* ISDLVarIdxToPython(plSimpleStateVariable* var, int type, int idx);
 
@@ -94,6 +92,7 @@ protected:
     void IPutCurrentStateIn(plStateDataRecord* dstState) override;
     void ISetCurrentStateFrom(const plStateDataRecord* srcState) override;
 public:
+    plPythonSDLModifier() : fOwner() {}
     plPythonSDLModifier(plPythonFileMod* owner);
     ~plPythonSDLModifier();
 

--- a/Sources/Plasma/NucleusLib/pnFactory/plCreatable.h
+++ b/Sources/Plasma/NucleusLib/pnFactory/plCreatable.h
@@ -170,10 +170,7 @@ public:                                                                     \
         return #plClassName;                                                \
     }                                                                       \
 private:                                                                    \
-    static uint16_t plClassName##ClassIndex;                                \
-    static void SetClassIndex(uint16_t hClass) {                            \
-        plClassName##ClassIndex = hClass;                                   \
-    }                                                                       \
+    static const uint16_t plClassName##ClassIndex;                          \
 public:                                                                     \
     uint16_t ClassIndex() const override {                                  \
         return plClassName::Index();                                        \
@@ -206,8 +203,7 @@ public:                                                                     \
     }                                                                       \
     static bool HasDerivedClass(uint16_t hDer) {                            \
         return plFactory::DerivesFrom(plClassName##ClassIndex, hDer);       \
-    }                                                                       \
-    friend class plClassName##__Creator;
+    }
 
 
 

--- a/Sources/Plasma/NucleusLib/pnFactory/plCreator.h
+++ b/Sources/Plasma/NucleusLib/pnFactory/plCreator.h
@@ -115,8 +115,7 @@ class plClassName##__Creator : public plCreator                                 
 public:                                                                             \
     plClassName##__Creator()                                                        \
     {                                                                               \
-        plFactory::Register( CLASS_INDEX_SCOPED(plClassName), this);                \
-        plClassName::SetClassIndex(ClassIndex());                                   \
+        plFactory::Register(CLASS_INDEX_SCOPED(plClassName), this);                 \
     }                                                                               \
     virtual ~plClassName##__Creator()                                               \
     {                                                                               \
@@ -132,7 +131,7 @@ public:                                                                         
                                                                                     \
 };                                                                                  \
 static plClassName##__Creator   static##plClassName##__Creator;                     \
-uint16_t plClassName::plClassName##ClassIndex = 0;                                  \
+const uint16_t plClassName::plClassName##ClassIndex = CLASS_INDEX_SCOPED(plClassName);  \
 VERIFY_CREATABLE(plClassName);                                                        //
 
 
@@ -143,8 +142,7 @@ class plClassName##__Creator : public plCreator                                 
 public:                                                                             \
     plClassName##__Creator()                                                        \
     {                                                                               \
-        plFactory::Register( CLASS_INDEX_SCOPED(plClassName), this);                \
-        plClassName::SetClassIndex(ClassIndex());                                   \
+        plFactory::Register(CLASS_INDEX_SCOPED(plClassName), this);                 \
     }                                                                               \
     virtual ~plClassName##__Creator()                                               \
     {                                                                               \
@@ -160,7 +158,7 @@ public:                                                                         
                                                                                     \
 };                                                                                  \
 static plClassName##__Creator   static##plClassName##__Creator;                     \
-uint16_t plClassName::plClassName##ClassIndex = 0;                                  \
+const uint16_t plClassName::plClassName##ClassIndex = CLASS_INDEX_SCOPED(plClassName);  \
 VERIFY_CREATABLE(plClassName);                                                        //
 
 
@@ -178,8 +176,7 @@ public:                                                                         
     }                                                                               \
     void Register()                                                                 \
     {                                                                               \
-        plFactory::Register( EXTERN_CLASS_INDEX_SCOPED(plClassName), this);         \
-        plClassName::SetClassIndex(ClassIndex());                                   \
+        plFactory::Register(EXTERN_CLASS_INDEX_SCOPED(plClassName), this);          \
     }                                                                               \
     void UnRegister()                                                               \
     {                                                                               \
@@ -195,7 +192,7 @@ public:                                                                         
                                                                                     \
 };                                                                                  \
 static plClassName##__Creator   static##plClassName##__Creator;                     \
-uint16_t plClassName::plClassName##ClassIndex = 0;                                  \
+const uint16_t plClassName::plClassName##ClassIndex = EXTERN_CLASS_INDEX_SCOPED(plClassName);  \
 VERIFY_EXTERNAL_CREATABLE(plClassName);                                             //
 
 
@@ -214,8 +211,7 @@ class plClassName##__Creator : public plCreator                                 
 public:                                                                             \
     plClassName##__Creator()                                                        \
     {                                                                               \
-        plFactory::Register( EXTERN_CLASS_INDEX_SCOPED(plClassName), this);         \
-        plClassName::SetClassIndex(ClassIndex());                                   \
+        plFactory::Register(EXTERN_CLASS_INDEX_SCOPED(plClassName), this);          \
     }                                                                               \
     virtual ~plClassName##__Creator()                                               \
     {                                                                               \
@@ -231,7 +227,7 @@ public:                                                                         
                                                                                     \
 };                                                                                  \
 static plClassName##__Creator   static##plClassName##__Creator;                     \
-uint16_t plClassName::plClassName##ClassIndex = 0;                                  \
+const uint16_t plClassName::plClassName##ClassIndex = EXTERN_CLASS_INDEX_SCOPED(plClassName);  \
 VERIFY_EXTERNAL_CREATABLE(plClassName);                                             //
 
 

--- a/Sources/Plasma/NucleusLib/pnFactory/plCreator.h
+++ b/Sources/Plasma/NucleusLib/pnFactory/plCreator.h
@@ -93,7 +93,7 @@ static_assert(plCreator::VerifyKeyedIndex<plClassName, CLASS_INDEX_SCOPED(plClas
                                                                                               \
 static_assert(plCreator::VerifyNonKeyedIndex<plClassName, CLASS_INDEX_SCOPED(plClassName)>(), \
               #plClassName " is in the non-KeyedObject section of plCreatableIndex but "      \
-              "derives from hsKeyedObject.");                                                   //
+              "derives from hsKeyedObject.")                                                  //
 
 
 #define VERIFY_EXTERNAL_CREATABLE(plClassName)                                               \
@@ -104,7 +104,7 @@ static_assert(plCreator::VerifyKeyedIndex<plClassName, EXTERN_CLASS_INDEX_SCOPED
                                                                                               \
 static_assert(plCreator::VerifyNonKeyedIndex<plClassName, EXTERN_CLASS_INDEX_SCOPED(plClassName)>(), \
               #plClassName " is in the non-KeyedObject section of plCreatableIndex but "      \
-              "derives from hsKeyedObject.");                                                 //
+              "derives from hsKeyedObject.")                                                  //
 
 
 #define REGISTER_CREATABLE( plClassName )                                           \
@@ -132,7 +132,7 @@ public:                                                                         
 };                                                                                  \
 static plClassName##__Creator   static##plClassName##__Creator;                     \
 const uint16_t plClassName::plClassName##ClassIndex = CLASS_INDEX_SCOPED(plClassName);  \
-VERIFY_CREATABLE(plClassName);                                                        //
+VERIFY_CREATABLE(plClassName)                                                       //
 
 
 #define REGISTER_NONCREATABLE( plClassName )                                        \
@@ -159,7 +159,7 @@ public:                                                                         
 };                                                                                  \
 static plClassName##__Creator   static##plClassName##__Creator;                     \
 const uint16_t plClassName::plClassName##ClassIndex = CLASS_INDEX_SCOPED(plClassName);  \
-VERIFY_CREATABLE(plClassName);                                                        //
+VERIFY_CREATABLE(plClassName)                                                       //
 
 
 #define DECLARE_EXTERNAL_CREATABLE( plClassName )                                   \
@@ -193,15 +193,15 @@ public:                                                                         
 };                                                                                  \
 static plClassName##__Creator   static##plClassName##__Creator;                     \
 const uint16_t plClassName::plClassName##ClassIndex = EXTERN_CLASS_INDEX_SCOPED(plClassName);  \
-VERIFY_EXTERNAL_CREATABLE(plClassName);                                             //
+VERIFY_EXTERNAL_CREATABLE(plClassName)                                              //
 
 
 #define REGISTER_EXTERNAL_CREATABLE(plClassName)                                    \
-static##plClassName##__Creator.Register();                                          //
+static##plClassName##__Creator.Register()                                           //
 
 
 #define UNREGISTER_EXTERNAL_CREATABLE(plClassName)                                  \
-plFactory::UnRegister(EXTERN_CLASS_INDEX_SCOPED(plClassName), &static##plClassName##__Creator);
+plFactory::UnRegister(EXTERN_CLASS_INDEX_SCOPED(plClassName), &static##plClassName##__Creator)
 
 
 #define REGISTER_EXTERNAL_NONCREATABLE( plClassName )                               \
@@ -228,7 +228,7 @@ public:                                                                         
 };                                                                                  \
 static plClassName##__Creator   static##plClassName##__Creator;                     \
 const uint16_t plClassName::plClassName##ClassIndex = EXTERN_CLASS_INDEX_SCOPED(plClassName);  \
-VERIFY_EXTERNAL_CREATABLE(plClassName);                                             //
+VERIFY_EXTERNAL_CREATABLE(plClassName)                                              //
 
 
 #endif // plCreator_inc

--- a/Sources/Plasma/NucleusLib/pnFactory/plFactory.cpp
+++ b/Sources/Plasma/NucleusLib/pnFactory/plFactory.cpp
@@ -200,11 +200,13 @@ uint16_t plFactory::FindClassIndex(const char* className)
 
     if (className && theFactory)
     {
-        for (plCreator* creator : theFactory->fCreators)
+        for (size_t i = 0; i < theFactory->fCreators.size(); i++)
         {
+            plCreator* creator = theFactory->fCreators[i];
             if (creator && stricmp(className, creator->ClassName()) == 0)
             {
-                return creator->ClassIndex();
+                hsAssert(i < numClasses, "Class index out of range??");
+                return static_cast<uint16_t>(i);
             }
         }
     }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarCreatable.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarCreatable.h
@@ -76,7 +76,7 @@ REGISTER_NONCREATABLE(plAvTask);
 REGISTER_CREATABLE(plAvAnimTask);
 REGISTER_CREATABLE(plAvOneShotTask);
 REGISTER_CREATABLE(plAvOneShotLinkTask);
-REGISTER_CREATABLE(plAvSeekTask)
+REGISTER_CREATABLE(plAvSeekTask);
 
 #include "plAvBrain.h"
 REGISTER_NONCREATABLE(plArmatureBrain);
@@ -100,7 +100,7 @@ REGISTER_CREATABLE(plAvBrainGeneric);
 REGISTER_CREATABLE(plAvBrainHuman);
 
 #include "plAvBrainRideAnimatedPhysical.h"
-REGISTER_CREATABLE(plAvBrainRideAnimatedPhysical)
+REGISTER_CREATABLE(plAvBrainRideAnimatedPhysical);
 
 #include "plAvBrainSwim.h"
 REGISTER_CREATABLE(plAvBrainSwim);

--- a/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
@@ -186,7 +186,7 @@ REGISTER_CREATABLE(plSetListenerMsg);
 
 #include "plLoadAgeMsg.h"
 REGISTER_CREATABLE(plLoadAgeMsg);
-REGISTER_CREATABLE(plLinkInDoneMsg)
+REGISTER_CREATABLE(plLinkInDoneMsg);
 REGISTER_CREATABLE(plLinkOutUnloadMsg);
 
 #include "plLOSHitMsg.h"


### PR DESCRIPTION
The initialization went through a couple of getter/setter methods (one of them virtual), but the field can easily be made a constant initialized at compile time with no dynamic lookup.

I'm actually fixing a couple of IDE warnings here: one about virtual calls in constructors (`ClassIndex()`) and one about "unnecessary" semicolons after the plCreator.h `REGISTER_*` macros.