### PR TITLE
Prefer to grab the server's SDL descriptors.

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -1341,8 +1341,6 @@ void    plClient::IStopProgress()
 *
 ***/
 
-extern  bool    gDataServerLocal;
-
 //============================================================================
 bool plClient::StartInit()
 {

--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -97,14 +97,16 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 ITaskbarList3* gTaskbarList = nullptr; // NT 6.1+ taskbar stuff
 
 extern bool gDataServerLocal;
-extern bool gSkipPreload;
+extern bool gPythonLocal;
+extern bool gSDLLocal;
 
 enum
 {
     kArgSkipLoginDialog,
     kArgServerIni,
     kArgLocalData,
-    kArgSkipPreload,
+    kArgLocalPython,
+    kArgLocalSDL,
     kArgPlayerId,
     kArgStartUpAgeName,
     kArgPvdFile,
@@ -116,7 +118,8 @@ static const plCmdArgDef s_cmdLineArgs[] = {
     { kCmdArgFlagged  | kCmdTypeBool,       "SkipLoginDialog", kArgSkipLoginDialog },
     { kCmdArgFlagged  | kCmdTypeString,     "ServerIni",       kArgServerIni },
     { kCmdArgFlagged  | kCmdTypeBool,       "LocalData",       kArgLocalData   },
-    { kCmdArgFlagged  | kCmdTypeBool,       "SkipPreload",     kArgSkipPreload },
+    { kCmdArgFlagged  | kCmdTypeBool,       "LocalPython",     kArgLocalPython },
+    { kCmdArgFlagged  | kCmdTypeBool,       "LocalSDL",        kArgLocalSDL },
     { kCmdArgFlagged  | kCmdTypeInt,        "PlayerId",        kArgPlayerId },
     { kCmdArgFlagged  | kCmdTypeString,     "Age",             kArgStartUpAgeName },
     { kCmdArgFlagged  | kCmdTypeString,     "PvdFile",         kArgPvdFile },
@@ -1090,13 +1093,14 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
 #ifndef PLASMA_EXTERNAL_RELEASE
     if (cmdParser.IsSpecified(kArgSkipLoginDialog))
         doIntroDialogs = false;
-    if (cmdParser.IsSpecified(kArgLocalData))
-    {
+    if (cmdParser.IsSpecified(kArgLocalData)) {
         gDataServerLocal = true;
-        gSkipPreload = true;
+        gPythonLocal = true;
     }
-    if (cmdParser.IsSpecified(kArgSkipPreload))
-        gSkipPreload = true;
+    if (cmdParser.IsSpecified(kArgLocalPython))
+        gPythonLocal = true;
+    if (cmdParser.IsSpecified(kArgLocalSDL))
+        gSDLLocal = true;
     if (cmdParser.IsSpecified(kArgPlayerId))
         NetCommSetIniPlayerId(cmdParser.GetInt(kArgPlayerId));
     if (cmdParser.IsSpecified(kArgStartUpAgeName))

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.h
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.h
@@ -131,7 +131,7 @@ public:
     /** This is called when the current application has been updated. */
     void OnSelfPatch(FileDownloadFunc cb);
 
-    void RequestGameCode();
+    void RequestGameCode(bool python = true, bool sdl = true);
     void RequestManifest(const ST::string& mfs);
     void RequestManifest(const std::vector<ST::string>& mfs);
 

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plResPatcher.cpp
@@ -151,7 +151,7 @@ pfPatcher* plResPatcher::CreatePatcher()
         // There is a very special case for local data, and that is the SDL. The SDL is a contract that we have with the
         // server. If the client and server have different ideas about what the SDL is, then we're really up poop creek.
         // So, we *always* ask for the server's SDL unless we really, really, really don't want it.
-        patcher->RequestGameCode(!(gDataServerLocal || gPythonLocal), !gSDLLocal);
+        patcher->RequestGameCode(!gPythonLocal, !gSDLLocal);
         fRequestedGameCode = true;
     }
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -1336,6 +1336,11 @@ void NetCliFileStartConnect (
 }
 
 //============================================================================
+bool NetCliFileQueryConnected () {
+    return FileQueryConnected();
+}
+
+//============================================================================
 void NetCliFileDisconnect () {
     hsLockGuard(s_critsect);
     while (CliFileConn * conn = s_conns.Head())

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
@@ -66,6 +66,7 @@ void NetCliFileStartConnect (
     unsigned        fileAddrCount,
     bool            isPatcher = false
 );
+bool NetCliFileQueryConnected ();
 
 //============================================================================
 // Disconnect


### PR DESCRIPTION
The impetus for this change is the SDL on MOULa is now progressing, sometimes faster than we can update it due to limited reviewer manpower and the lack of proper reviews taking place on the OU side. This results in SDL DESC PROBLEM for people using our clients. Further, it is known that the MOULa game server does not inspect SDL blobs before propagating them to other players, so it is fairly trivial to make clients error out on MOULa with cryptic messages by taking specially crafted SDLs on that shard. Therefore, we now prefer to use the server's SDL, even in /LocalData.

This removes the singlular `/SkipPreload` command line argument in favor of two arguments: `/LocalPython` and `/LocalSDL`. `/LocalData` now implies the former but not the latter. The reason for this change is that the SDL is a contract between the server and the client about how exactly an SDL blob is formatted. If SDL blobs don't have the same format between the client and server, this can have fairly bad implications, ranging from remote players being disconnected with an error, the player with the wrong SDL getting an error, or the server crashing.