### PR TITLE
Fix regression from #1428.

### DIFF
--- a/Scripts/Python/plasma/PlasmaTypes.py
+++ b/Scripts/Python/plasma/PlasmaTypes.py
@@ -93,6 +93,9 @@ kCheckBox=10
 kRadioGroup=11
 kDynamicTextControl=12
 kMultiLineEdit=13
+kPopUpMenu=14
+kClickMap=15
+kProgress=16
 # GUIControlListBox String Justify Types
 kLeftJustify=1
 kRightJustify=2

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.cpp
@@ -67,6 +67,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 // specific value controls
 #include "pfGameGUIMgr/pfGUIKnobCtrl.h"
+#include "pfGameGUIMgr/pfGUIProgressCtrl.h"
 #include "pfGameGUIMgr/pfGUIUpDownPairMod.h"
 
 pyGUIDialog::pyGUIDialog(pyKey& gckey)
@@ -117,6 +118,8 @@ PyObject* pyGUIDialog::ConvertControl(const plKey& key)
         return pyGUIControlMultiLineEdit::New(key);
     case kClickMap:
         return pyGUIControlClickMap::New(key);
+    case kProgress:
+        return pyGUIControlProgress::New(key);
     default:
         return nullptr;
     }
@@ -156,6 +159,8 @@ uint32_t pyGUIDialog::WhatControlType(const plKey& key)
             return kKnob;
         else if ( pfGUIUpDownPairMod::ConvertNoRef(key->GetObjectPtr()) )
             return kUpDownPair;
+        else if ( pfGUIProgressCtrl::ConvertNoRef(key->GetObjectPtr()) )
+            return kProgress;
         else
             return 0;
     }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.h
@@ -101,6 +101,7 @@ public:
         kMultiLineEdit=13,
         kPopUpMenu=14,
         kClickMap=15,
+        kProgress=16,
     };
     static PyObject* ConvertControl(const plKey& key);
     static uint32_t WhatControlType(const plKey& key);


### PR DESCRIPTION
Fixes:
```
(08/06 18:14:26) cPythScope1 - Traceback (most recent call last):
(08/06 18:14:26)   File ".\python\ercaOvenScope.py", line 419, in OnGUINotify
(08/06 18:14:26)     timerWheel = control.getControlModFromTag(kTimerWheel)
(08/06 18:14:26) KeyError: 'TagID 500 not found in GUIDialog BakingRmGUI'
```

It looks like `pfGUIProgressCtrl` was never added to `WhatControlType()`, so any attempts to grab those kinds of value controls resulted in an error (eg in the Er'cana bakery). This fixes that problem and updates the "enum" in PlasmaTypes.py, which was even further behind than the C++.