### PR TITLE
Fix ODR violation for `plFactory` and avoid including it everywhere

### DIFF
--- a/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
+++ b/Sources/Plasma/Apps/plPageInfo/plPageInfo.cpp
@@ -46,6 +46,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <string_theory/format>
 
+#include "pnFactory/plFactory.h"
 #include "pnKeyedObject/plKeyImp.h"
 
 #include "plAgeDescription/plAgeManifest.h"

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -64,6 +64,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfConsole.h"
 #include "pfDispatchLog.h"
 
+#include "pnFactory/plFactory.h"
 #include "pnInputCore/plKeyMap.h"
 #include "pnKeyedObject/plFixedKey.h"
 #include "pnKeyedObject/plKey.h"

--- a/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.cpp
@@ -48,6 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <string_theory/format>
 #include <string_theory/string>
 
+#include "pnFactory/plFactory.h"
 #include "pnKeyedObject/plKey.h"
 #include "pnKeyedObject/hsKeyedObject.h"
 #include "pnMessage/plClientMsg.h"

--- a/Sources/Plasma/NucleusLib/pnDispatch/plDispatch.cpp
+++ b/Sources/Plasma/NucleusLib/pnDispatch/plDispatch.cpp
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "hsResMgr.h"
 #include "plDispatch.h"
+#include "pnFactory/plFactory.h"
 #define PLMESSAGE_PRIVATE
 #include "pnMessage/plMessage.h"
 #include "pnKeyedObject/hsKeyedObject.h"

--- a/Sources/Plasma/NucleusLib/pnFactory/plCreatable.h
+++ b/Sources/Plasma/NucleusLib/pnFactory/plCreatable.h
@@ -43,8 +43,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plCreatable_inc
 #define plCreatable_inc
 
+#include "HeadSpin.h"
+
 #include "hsRefCnt.h"
-#include "plFactory.h"
 
 class plCreator;
 class hsStream;
@@ -97,7 +98,6 @@ public:
 //          as plClassName, return that, else nullptr. Incs the ref count of the object.
 //      static plClassName* ConvertNoRef(plCreatable* c) - Same as Convert(), but
 //          doesn't inc the ref count.
-//      static plClassName* Create() - returns a new object of type plClassName
 //  Insert into public section of class definition.
 //
 //  Normally one of the next 3 macros should follow CLASSNAME_REGISTER
@@ -124,13 +124,13 @@ public:
 //
 //  USAGE:
 //  There is a method of identifying an object's type. You should rarely need it,
-//  using Create() and Convert() instead.
+//  using Convert() instead.
 //  ClassIndex() the class handle is an immutable index to this class. It provides an 
 //      instantaneous lookup. It may be stored, loaded, sent over the wire, etc.
 //
 //  Create()
 //  If you know what type object you want to create at compile time, use
-//      <ObjectType>::Create()
+//      new <ObjectType>()
 //  But if you have a class index at run-time (e.g. loaded from file), use
 //      plCreatable* plFactory::Create(hClass); 
 //  The ultra-safe way to do this is:
@@ -139,7 +139,7 @@ public:
 //      hsRefCnt_SafeUnRef(tmp);
 //
 //  If you have a fred interface to an object f, and want a wilma interface, use
-//      fred* f = fred::Create();  more likely f was passed in.
+//      fred* f = new fred();  more likely f was passed in.
 //      wilma* w = wilma::Convert(f)
 //  NOTE that two strange things may be true here:
 //      1) f != nullptr, w == nullptr
@@ -178,10 +178,6 @@ public:                                                                     \
     static uint16_t Index() {                                               \
         return plClassName##ClassIndex;                                     \
     }                                                                       \
-    static plClassName* Create() {                                          \
-        return static_cast<plClassName*>(                                   \
-                plFactory::Create(plClassName##ClassIndex));                \
-    }                                                                       \
     static plClassName* ConvertNoRef(plCreatable* c) {                      \
         plClassName* retVal = c                                             \
             ? static_cast<plClassName*>(                                    \
@@ -200,9 +196,6 @@ public:                                                                     \
         plClassName* retVal = ConvertNoRef(c);                              \
         hsRefCnt_SafeRef(retVal);                                           \
         return retVal;                                                      \
-    }                                                                       \
-    static bool HasDerivedClass(uint16_t hDer) {                            \
-        return plFactory::DerivesFrom(plClassName##ClassIndex, hDer);       \
     }
 
 

--- a/Sources/Plasma/NucleusLib/pnFactory/plCreator.h
+++ b/Sources/Plasma/NucleusLib/pnFactory/plCreator.h
@@ -81,8 +81,6 @@ public:
             return !(std::is_base_of_v<hsKeyedObject, _CreatableT>);
         return true;
     }
-
-    friend class plFactory;
 };
 
 #define VERIFY_CREATABLE(plClassName)                                                         \

--- a/Sources/Plasma/NucleusLib/pnFactory/plFactory.cpp
+++ b/Sources/Plasma/NucleusLib/pnFactory/plFactory.cpp
@@ -40,8 +40,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#define PLFACTORY_PRIVATE
 #include "plFactory.h"
+
 #include "hsStream.h"
 #include "plCreatable.h"
 #include "plCreator.h"

--- a/Sources/Plasma/NucleusLib/pnFactory/plFactory.h
+++ b/Sources/Plasma/NucleusLib/pnFactory/plFactory.h
@@ -75,7 +75,6 @@ private:
 
 public:
     // Don't use this unless you're initializing a DLL
-    friend class plClient;
     static plFactory*   GetTheFactory();
 
 

--- a/Sources/Plasma/NucleusLib/pnFactory/plFactory.h
+++ b/Sources/Plasma/NucleusLib/pnFactory/plFactory.h
@@ -45,9 +45,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsRefCnt.h"
 #include "HeadSpin.h"
-#ifdef PLFACTORY_PRIVATE
-    #include <vector>
-#endif
+
+#include <vector>
 
 class plCreator;
 class plCreatable;
@@ -56,7 +55,6 @@ class hsResMgr;
 
 class plFactory : public hsRefCnt
 {
-#ifdef PLFACTORY_PRIVATE
 private:
     std::vector<plCreator*> fCreators;
 
@@ -74,7 +72,6 @@ private:
 
     plFactory();
     ~plFactory();
-#endif
 
 public:
     // Don't use this unless you're initializing a DLL

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
@@ -50,6 +50,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plProfile.h"
 #include "plgDispatch.h"
 
+#if defined(HS_DEBUGGING) || defined(LOG_ACTIVE_REFS)
+#include "pnFactory/plFactory.h"
+#endif
+
 plProfile_CreateMemCounter("Keys", "Memory", KeyMem);
 
 static uint32_t CalcKeySize(plKeyImp* key)

--- a/Sources/Plasma/NucleusLib/pnSceneObject/plSceneObject.cpp
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/plSceneObject.cpp
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plCoordinateInterface.h"
 #include "plAudioInterface.h"
 #include "pnDispatch/plDispatch.h"
+#include "pnFactory/plFactory.h"
 #include "pnModifier/plModifier.h"
 #include "pnMessage/plMessage.h"
 #include "pnMessage/plRefMsg.h"

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -59,6 +59,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsTimer.h"        // just when debugging for GetSysSeconds
 
 // other
+#include "pnFactory/plFactory.h"
 #include "plInterp/plAnimTimeConvert.h"
 #include "pnNetCommon/plSDLTypes.h"
 #include "plMessage/plAnimCmdMsg.h"

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGApplicator.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGApplicator.cpp
@@ -45,6 +45,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsResMgr.h"
 #include "hsStream.h"
 
+#include "pnFactory/plFactory.h"
+
 #include "plAGChannel.h"
 #include "plAGModifier.h"
 

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -51,6 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsSystemInfo.h"
 #include "hsTimer.h"
 
+#include "pnFactory/plFactory.h"
 #include "pnMessage/plClientMsg.h"
 #include "pnMessage/plPlayerPageMsg.h"
 #include "pnMessage/plTimeMsg.h"

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgScreener.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgScreener.cpp
@@ -44,6 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plCreatableIndex.h"
 #include "plNetLinkingMgr.h"
 
+#include "pnFactory/plFactory.h"
 #include "pnMessage/plMessage.h"
 #include "pnNetCommon/plNetApp.h"
 

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -57,6 +57,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnAsyncCore/pnAsyncCore.h"
 #include "pnEncryption/plChallengeHash.h"
+#include "pnFactory/plFactory.h"
 #include "pnNetBase/pnNbConst.h"
 #include "pnNetCli/pnNetCli.h"
 #include "pnNetCommon/plNetApp.h"

--- a/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientStatsRecorder.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientStatsRecorder.cpp
@@ -45,6 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plgDispatch.h"
 #include "hsStream.h"
 
+#include "pnFactory/plFactory.h"
 #include "pnMessage/plNotifyMsg.h"
 
 #include "plNetMessage/plNetMessage.h"

--- a/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientStreamRecorder.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientStreamRecorder.cpp
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsResMgr.h"
 #include "hsStream.h"
 
+#include "pnFactory/plFactory.h"
 #include "pnMessage/plNotifyMsg.h"
 #include "pnNetCommon/plNetApp.h"
 

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.cpp
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <iterator>
 #include <string_theory/string>
 
+#include "pnFactory/plFactory.h"
 #include "pnNetCommon/plGenericVar.h"
 #include "pnNetCommon/plNetApp.h"
 #include "pnNetCommon/pnNetCommon.h"

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetMsgScreener.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetMsgScreener.cpp
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plNetMsgScreener.h"
 #include "plCreatableIndex.h"
 
+#include "pnFactory/plFactory.h"
 #include "pnNetCommon/plNetApp.h"
 #include "pnKeyedObject/plKey.h"
 

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.cpp
@@ -546,7 +546,7 @@ void plNetMsgGameMessage::WriteVersion(hsStream* s, hsResMgr* mgr)
 
 ST::string plNetMsgGameMessage::AsString() const
 {
-    const char* noc = plFactory::GetTheFactory()->GetNameOfClass(StreamInfo()->GetStreamType());
+    const char* noc = plFactory::GetNameOfClass(StreamInfo()->GetStreamType());
     return ST::format("{} {}", plNetMsgStream::AsString(), noc ? noc : "?");
 }
 

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMsgHelpers.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMsgHelpers.cpp
@@ -45,6 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsStream.h"
 
+#include "pnFactory/plFactory.h"
 #include "pnKeyedObject/plKey.h"
 #include "pnNetCommon/plNetApp.h"
 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
@@ -46,7 +46,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plRegistryKeyList.h"
 #include "plVersion.h"
 
-#include "pnFactory/plFactory.h"
 #include "pnKeyedObject/plKeyImp.h"
 
 plRegistryPageNode::plRegistryPageNode(const plFileName& path)

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
@@ -51,6 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnDispatch/plDispatch.h"
 #include "pnFactory/plCreator.h"
+#include "pnFactory/plFactory.h"
 #include "pnKeyedObject/hsKeyedObject.h"
 #include "pnKeyedObject/plFixedKey.h"
 #include "pnKeyedObject/plKeyImp.h"

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsStream.h"
 
 #include "pnFactory/plCreatable.h"
+#include "pnFactory/plFactory.h"
 #include "pnNetCommon/plNetApp.h"
 #include "pnNetCommon/pnNetCommon.h"
 

--- a/Sources/Tools/MaxMain/plMaxUtils.cpp
+++ b/Sources/Tools/MaxMain/plMaxUtils.cpp
@@ -52,7 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plMaxUtils.h"
 #include "plResMgr/plPageInfo.h"
 #include "pnKeyedObject/plUoid.h"
-#include "pnFactory/plFactory.h"
 
 class MaxUtilsClassDesc : public plMaxClassDesc<ClassDesc>
 {

--- a/Sources/Tools/plResBrowser/plResBrowser.cpp
+++ b/Sources/Tools/plResBrowser/plResBrowser.cpp
@@ -49,6 +49,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnAllCreatables.h"
 
+#include "pnFactory/plFactory.h"
 #include "pnKeyedObject/plKey.h"
 #include "pnKeyedObject/plKeyImp.h"
 #include "pnKeyedObject/plUoid.h"


### PR DESCRIPTION
Touching the core plCreatable headers, part two.

The private members of `plFactory` were only conditionally defined in plFactory.h, which is an ODR violation and gives warnings with GCC for example (although apparently it has never caused any issues in practice). I'm not sure why it was done that way (perhaps to reduce header pollution very slightly?), but it seems safe to define everything unconditionally.

Regardless, to avoid pulling in `plFactory` in many places where it's not needed, I also adjusted plCreatable.h to not automatically include plFactory.h anymore. This required removing a couple of `plCreatable` methods, but they weren't used anywhere and are trivial to replace.