### PR TITLE
Don't trust the local machine's system time.

### DIFF
--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -207,14 +207,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
     // Handle messages
     switch (message) {
-        case WM_TIMECHANGE:
-            // To prevent cheating and keep things better synchronized,
-            // we will completely re-eval the offsets on the next NetMsg we
-            // get from the server
-            if (plNetClientMgr* nc = plNetClientMgr::GetInstance())
-                nc->ResetServerTimeOffset(true);
-            break;
-
         case WM_LBUTTONDOWN:
         case WM_RBUTTONDOWN:
         case WM_LBUTTONDBLCLK:

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
@@ -212,7 +212,7 @@ void plNCAgeJoiner::Start () {
 
     plNetClientMgr * nc = plNetClientMgr::GetInstance();
     nc->SetFlagsBit(plNetClientMgr::kPlayingGame, false);
-    nc->fServerTimeOffset               = 0;    // reset since we're connecting to a new server
+    nc->ResetServerTimeOffset();
     nc->fRequiredNumInitialSDLStates    = 0;
     nc->fNumInitialSDLStates            = 0;
     nc->SetFlagsBit(plNetClientApp::kNeedInitialAgeStateCount);

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -428,7 +428,7 @@ void plNetClientMgr::ResetServerTimeOffset()
 plUnifiedTime plNetClientMgr::GetServerTime() const 
 {
     if (fLastServerTime.AtEpoch()) {
-        WarningMsg("WARNING: Someone asked for the server time, but we don't know it yet!");
+        WarningMsg("Someone asked for the server time, but we don't know it yet!");
         return plUnifiedTime::GetCurrent();
     }
 

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
@@ -161,9 +161,8 @@ private:
     std::string         fSPDesiredPlayerName;   // SP: the player we want to load from vault.
     
     // server info
-    double              fServerTimeOffset;      // diff between our unified time and server's unified time
-    uint32_t              fTimeSamples;
-    double              fLastTimeUpdate;
+    plUnifiedTime       fLastServerTime;       // Last received time update from the server
+    double              fLastLocalTime;        // Last monotonic time (in seconds) when the above update was received
 
     uint8_t               fJoinOrder;         // returned by the server
     
@@ -379,7 +378,7 @@ public:
     void StoreSDLState(const plStateDataRecord* sdRec, const plUoid& uoid, uint32_t sendFlags, uint32_t writeOptions);
 
     void UpdateServerTimeOffset(plNetMessage* msg);
-    void ResetServerTimeOffset(bool delayed=false);
+    void ResetServerTimeOffset();
 
 private:
     plNetClientComm             fNetClientComm;


### PR DESCRIPTION
Previously, when asking for the server's time, the calculation was done by basically offsetting the local system time by some previously calculated delta. This was basically useless because the user can easily change the system time out from under us and cause huge deltas. The attempt to fix things in #173 by using `WM_TIMECHANGE` was a good idea but ultimately incorrect because `hsTimer` is a monotonic timer. At this point, it uses `std::chrono::steady_clock` as its backend, so attempting to use `hsTimer` to recalculate the server/client time offset is useless.

Therefore, this changes us to simply save the last time value that we received from the game server and the monotonic time that we received that update. This is definitely not perfect because we don't consider things like round trip time for the message and time spent in the update loop. However, it *is* a clear improvement in that now the KI will always display what the server thinks Mountain time is, and it should be impossible to perform system clock based exploits (such as instantly baking pellets)... without any platform specific code!

Future work: currently, we are implicitly depending on the server to send us periodic `plNetMessage`s with the time sent value to synchronize the time. If that's never done, then we simply return the client's time (yikes!). This is a decent assumption in all current content because we will receive `plNetMsgGameMessage` with `plServerReply` for region enters on spawn and `plNetSDLMsg` for the Age state (when an Age has any non-excluded SDL states), however, there is little guarantee that the server will continue to send us these messages if we are in an Age by ourselves doing nothing. One option would be to send an innocuous message such as `plNetMsgGetSharedState` periodically. I have not implemented that here because it is not immediately apparent whether or not the various server types implement this message.