### PR TITLE
Add ServerCaps message support to plNetLog.

### DIFF
--- a/Sources/Tools/plNetLog/Auth.h
+++ b/Sources/Tools/plNetLog/Auth.h
@@ -121,6 +121,10 @@ enum
 
     kCli2Auth_AccountExistsRequest,
 
+    // Extended (DirtSand) messages
+    kCli2Auth_AgeRequestEx = 0x1000,
+    kCli2Auth_ScoreGetHighScores,
+
     // -------------------------------------------------------------- //
 
     // Global
@@ -196,6 +200,11 @@ enum
     kAuth2Cli_ScoreGetRanksReply,
 
     kAuth2Cli_AccountExistsReply,
+
+    // Extended (DirtSand) messages
+    kAuth2Cli_AgeReplyEx = 0x1000,
+    kAuth2Cli_ScoreGetHighScoresReply,
+    kAuth2Cli_ServerCaps,
 };
 
 bool Auth_Factory(QTreeWidget* logger, const QString& timeFmt, int direction,


### PR DESCRIPTION
This fixes compatibility with DirtSand and comaptible servers for the early Auth server connection messages.