### PR TITLE
Adds SDL based upload check for imagers

### DIFF
--- a/Scripts/Python/xSimpleImager.py
+++ b/Scripts/Python/xSimpleImager.py
@@ -77,7 +77,7 @@ ImagerPelletUpload = ptAttribBoolean(10, "Pellet Score Imager?", 0)
 ImagerClueObject = ptAttribSceneobject(11, "Imager Object (for puzzle clue)")
 ImagerClueTime = ptAttribInt(12, "Number of seconds until clue image shows",default=870)
 ImagerRandomTime = ptAttribInt(13, "Random number added to make timer more variable",default=0)
-ImagerPermissionCheck = ptAttribString(14,"Imager upload SDL variable (optional)")
+ImagerPermissionCheck = ptAttribString(14, "Imager upload SDL variable (optional)")
 #----------
 # globals
 #----------
@@ -531,7 +531,7 @@ class xSimpleImager(ptModifier):
                 ageVault.setDeviceInbox(ImagerName.value, ageSDL[ImagerInboxVariable.value][0], self, kSettingDeviceInbox)
 
     def PermissionCheck(self):
-        #Age SDL Check to prevent unwanted access to imager
+        # Age SDL Check to prevent unwanted access to imager
         ageSDL = PtGetAgeSDL()
         permissionCheck = kPermissionEveryone
         if ImagerPermissionCheck.value:

--- a/Scripts/Python/xSimpleImager.py
+++ b/Scripts/Python/xSimpleImager.py
@@ -77,6 +77,7 @@ ImagerPelletUpload = ptAttribBoolean(10, "Pellet Score Imager?", 0)
 ImagerClueObject = ptAttribSceneobject(11, "Imager Object (for puzzle clue)")
 ImagerClueTime = ptAttribInt(12, "Number of seconds until clue image shows",default=870)
 ImagerRandomTime = ptAttribInt(13, "Random number added to make timer more variable",default=0)
+ImagerPelletCheckVariable = ptAttribString(14,"Pellet upload SDL variable (optional)")
 #----------
 # globals
 #----------
@@ -298,7 +299,7 @@ class xSimpleImager(ptModifier):
                         for event in events:
                             if event[0] == kCollisionEvent:
                                 kiLevel = PtDetermineKILevel()
-                                if (kiLevel < kNormalKI):
+                                if (kiLevel < kNormalKI or not self.PelletUploadCheck()):
                                     return
                                 if ImagerPelletUpload.value:
                                     messagetoki = str(ImagerName.value) + "<p>"
@@ -521,6 +522,19 @@ class xSimpleImager(ptModifier):
                 ageVault.setDeviceInbox(ImagerName.value, ImagerName.value, self, kSettingDeviceInbox)
             else:
                 ageVault.setDeviceInbox(ImagerName.value, ageSDL[ImagerInboxVariable.value][0], self, kSettingDeviceInbox)
+
+    def PelletUploadCheck(self):
+        """Age SDL Check to prevent unwanted pellet drops"""
+        ageSDL = PtGetAgeSDL()
+        pelletCheck = 0
+        if ImagerPelletCheckVariable.value:
+            pelletCheck = ageSDL[ImagerPelletCheckVariable.value][0]
+        if pelletCheck >= 2: # Locked for everyone
+            return False
+        elif pelletCheck == 1 and ptVault().amOwnerOfCurrentAge(): #Hood members only
+            return True
+        elif pelletCheck <= 0: # Anyone
+            return True
 
     def OnBackdoorMsg(self, target, param):
         if target == "imager" and param == "refresh" and ImagerName.value == "D'ni  Imager Right":

--- a/Scripts/Python/xSimpleImager.py
+++ b/Scripts/Python/xSimpleImager.py
@@ -103,6 +103,13 @@ AgeStartedIn = None
 kFlipImagesTimerStates = 5
 kFlipImagesTimerCurrent = 0
 
+#----------
+# Permission Check
+#----------
+kPermissionEveryone = 0
+kPermissionMembers = 1
+kPermissionNoOne = 2
+
 #====================================
 
 Instance = None
@@ -524,16 +531,16 @@ class xSimpleImager(ptModifier):
                 ageVault.setDeviceInbox(ImagerName.value, ageSDL[ImagerInboxVariable.value][0], self, kSettingDeviceInbox)
 
     def PermissionCheck(self):
-        """Age SDL Check to prevent unwanted access to imager"""
+        #Age SDL Check to prevent unwanted access to imager
         ageSDL = PtGetAgeSDL()
-        permissionCheck = 0
+        permissionCheck = kPermissionEveryone
         if ImagerPermissionCheck.value:
             permissionCheck = ageSDL[ImagerPermissionCheck.value][0]
-        if permissionCheck >= 2: # Locked for everyone
+        if permissionCheck >= kPermissionNoOne:
             return False
-        elif permissionCheck == 1 and ptVault().amOwnerOfCurrentAge(): #Hood members only
+        elif permissionCheck == kPermissionMembers and ptVault().amOwnerOfCurrentAge():
             return True
-        elif permissionCheck <= 0: # Anyone
+        elif permissionCheck <= kPermissionEveryone:
             return True
 
     def OnBackdoorMsg(self, target, param):

--- a/Scripts/Python/xSimpleImager.py
+++ b/Scripts/Python/xSimpleImager.py
@@ -77,7 +77,7 @@ ImagerPelletUpload = ptAttribBoolean(10, "Pellet Score Imager?", 0)
 ImagerClueObject = ptAttribSceneobject(11, "Imager Object (for puzzle clue)")
 ImagerClueTime = ptAttribInt(12, "Number of seconds until clue image shows",default=870)
 ImagerRandomTime = ptAttribInt(13, "Random number added to make timer more variable",default=0)
-ImagerPelletCheckVariable = ptAttribString(14,"Pellet upload SDL variable (optional)")
+ImagerPermissionCheck = ptAttribString(14,"Imager upload SDL variable (optional)")
 #----------
 # globals
 #----------
@@ -299,7 +299,7 @@ class xSimpleImager(ptModifier):
                         for event in events:
                             if event[0] == kCollisionEvent:
                                 kiLevel = PtDetermineKILevel()
-                                if (kiLevel < kNormalKI or not self.PelletUploadCheck()):
+                                if (kiLevel < kNormalKI or not self.PermissionCheck()):
                                     return
                                 if ImagerPelletUpload.value:
                                     messagetoki = str(ImagerName.value) + "<p>"
@@ -523,17 +523,17 @@ class xSimpleImager(ptModifier):
             else:
                 ageVault.setDeviceInbox(ImagerName.value, ageSDL[ImagerInboxVariable.value][0], self, kSettingDeviceInbox)
 
-    def PelletUploadCheck(self):
-        """Age SDL Check to prevent unwanted pellet drops"""
+    def PermissionCheck(self):
+        """Age SDL Check to prevent unwanted access to imager"""
         ageSDL = PtGetAgeSDL()
-        pelletCheck = 0
-        if ImagerPelletCheckVariable.value:
-            pelletCheck = ageSDL[ImagerPelletCheckVariable.value][0]
-        if pelletCheck >= 2: # Locked for everyone
+        permissionCheck = 0
+        if ImagerPermissionCheck.value:
+            permissionCheck = ageSDL[ImagerPermissionCheck.value][0]
+        if permissionCheck >= 2: # Locked for everyone
             return False
-        elif pelletCheck == 1 and ptVault().amOwnerOfCurrentAge(): #Hood members only
+        elif permissionCheck == 1 and ptVault().amOwnerOfCurrentAge(): #Hood members only
             return True
-        elif pelletCheck <= 0: # Anyone
+        elif permissionCheck <= 0: # Anyone
             return True
 
     def OnBackdoorMsg(self, target, param):

--- a/Scripts/SDL/Neighborhood.sdl
+++ b/Scripts/SDL/Neighborhood.sdl
@@ -2038,7 +2038,7 @@ STATEDESC Neighborhood
     VAR BYTE            nb01LakeLightState[1]                   DEFAULT=0   DEFAULTOPTION=VAULT
     VAR BYTE            nb01PrivateRoomsState[1]                DEFAULT=0   DEFAULTOPTION=VAULT
     VAR BYTE            nb01PuzzleWallState[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
-    VAR BYTE            nb01PelletUploadState[1]                DEFAULT=0
+    VAR BYTE            nb01PelletUploadState[1]                DEFAULT=0   DEFAULTOPTION=VAULT
     VAR BYTE            nb01CmnRmSpeech[1]                      DEFAULT=0
 
 ## Age Mechanisms   ##

--- a/Scripts/SDL/Neighborhood.sdl
+++ b/Scripts/SDL/Neighborhood.sdl
@@ -1966,3 +1966,133 @@ STATEDESC Neighborhood
     VAR BOOL            nb01BahroBoatsProximity[1]              DEFAULT=0   DEFAULTOPTION=VAULT
 
 }
+
+STATEDESC Neighborhood
+{
+    VERSION 35
+
+## DEFAULTOPTION=VAULT Content ##
+
+    VAR AGETIMEOFDAY    nb01TimeOfDay[1]
+
+# Boolean variables
+    VAR BOOL            nb01AyhoheekAccountingFunc[1]           DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01BulletinBoardVis[1]                 DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CityLightsBlueVis[1]                DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CityLightsConstruction01Vis[1]      DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CityLightsConstruction02Vis[1]      DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CityLightsConstruction03Vis[1]      DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CityLightsConstruction04Vis[1]      DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CityLightsGreatZeroVis[1]           DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CityLightsHarborVis[1]              DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CityLightsMoving01Vis[1]            DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CityLightsMoving02Vis[1]            DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CityLightsMoving03Vis[1]            DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01ClockFunc[1]                        DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01CommunityAreaConstructionVis[1]     DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01ConesVis[1]                         DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01DniPaperVis[1]                      DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01FansFunc[1]                         DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01FireMarbles1Vis[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01FireMarbles2Vis[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01FountainWaterVis[1]                 DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01GardenBugsVis[1]                    DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01GardenLightsFunc[1]                 DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01JourneyCloth1Vis[1]                 DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01JourneyCloth2Vis[1]                 DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01LinkBookEderVis[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01LinkBookEderToggle[1]               DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01LinkBookGarrisonVis[1]              DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01LinkBookTeledahnVis[1]              DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01LinkBookGZVis[1]                    DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01LinkRoomDoorFunc[1]                 DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01RatCreatureVis[1]                   DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01TelescopeVis[1]                     DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01WaterfallVis[1]                     DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01DRCInfoBoardsVis[1]                 DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01YeeshaPage07Vis[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01PlayerImagerVis[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01DRCImagerVis[1]                     DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01HappyNewYearVis[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01WebCamVis[1]                        DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01HoodInfoImagerVis[1]                DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01ThanksgivingVis[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01LinkBookNexusVis[1]                 DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01Poetry1JournalVis[1]                DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01KiNexusJournalVis[1]                DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01BahroStonePedestalVis[1]            DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01BahroPedestalShoutRun[1]            DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01ReaderBoardVis[1]                   DEFAULT=0   DEFAULTOPTION=VAULT
+
+    VAR STRING32        nb01DRCImagerInbox[1]                               DEFAULTOPTION=VAULT
+
+# Performance variables
+    VAR BOOL            nb01BahroBoatsRun[1]                    DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01CallSoundChance[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01DarkShapeSwimsRun[1]                DEFAULT=0   DEFAULTOPTION=VAULT
+
+# State variables
+    VAR BYTE            nb01Ayhoheek5Man1State[1]               DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01CommunityAreaState[1]               DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01CityLightsArchState[1]              DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01LakeLightState[1]                   DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01PrivateRoomsState[1]                DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01PuzzleWallState[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01PelletUploadState[1]                DEFAULT=0
+    VAR BYTE            nb01CmnRmSpeech[1]                      DEFAULT=0
+
+## Age Mechanisms   ##
+
+    VAR BOOL            nb01BlueLightOn[1]                      DEFAULT=0
+    VAR BOOL            nb01GreenLightOn[1]                     DEFAULT=0
+    VAR BOOL            nb01OrangeLightOn[1]                    DEFAULT=0
+    VAR BOOL            nb01LinkRoomDoor01Closed[1]             DEFAULT=1
+    VAR BOOL            nb01LinkRoomDoor02Closed[1]             DEFAULT=1
+    VAR BOOL            nb01ClassroomDoorClosed[1]              DEFAULT=1
+    VAR BOOL            nb01PrivateRoomsOuterDoorClosed[1]      DEFAULT=1
+    VAR BOOL            nb01PrivateRoomsOuterDoorEnabled[1]     DEFAULT=0
+    VAR BOOL            nb01PrivateRoom01Closed[1]              DEFAULT=0
+    VAR BOOL            nb01PrivateRoom02Closed[1]              DEFAULT=0
+    VAR BOOL            nb01PrivateRoom03Closed[1]              DEFAULT=0
+    VAR BOOL            nb01PrivateRoom04Closed[1]              DEFAULT=0
+    VAR BOOL            nb01PrivateRoom05Closed[1]              DEFAULT=0
+    VAR BOOL            nb01FireworksOnBalcony[1]               DEFAULT=0
+    VAR BOOL            nb01FireworksOnBanner[1]                DEFAULT=0
+    VAR BOOL            nb01FireworksOnFountain[1]              DEFAULT=0
+    VAR STRING32        nb01PelletImagerScores[50]              DEFAULT=""
+
+# Neighborhood Customization options #
+
+    VAR BOOL            nb01BeachBallVis[1]                     DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01ClockVis[1]                         DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01GardenFungusVis[1]                  DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01GardenLightsVis[1]                  DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01DestructionCracksVis[1]             DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01LanternsVis[1]                      DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01LampOption01Vis[1]                  DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01OldImager01Vis[1]                   DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01OldImager02Vis[1]                   DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01WaterfallTorchesVis[1]              DEFAULT=1   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01ResidenceAdditionsVis[1]            DEFAULT=1   DEFAULTOPTION=VAULT
+
+    VAR BYTE            nb01StainedWindowOption[1]              DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01StainedGlassEders[1]                DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01StainedGlassGZ[1]                   DEFAULT=0   DEFAULTOPTION=VAULT
+
+#GZ Marker visibility
+    VAR BOOL            nb01GZMarkerVis[1]                      DEFAULT=0   DEFAULTOPTION=VAULT
+
+# Randomized object appear/disappear
+    VAR BOOL            nb01YeeshaPage07Enabled[1]              DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01YeeshaPage07Chance[1]               DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01YeeshaPage07Proximity[1]            DEFAULT=0   DEFAULTOPTION=VAULT
+
+    VAR BOOL            nb01DarkShapeSwimsEnabled[1]            DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01DarkShapeSwimsChance[1]             DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01DarkShapeSwimsProximity[1]          DEFAULT=0   DEFAULTOPTION=VAULT
+
+    VAR BOOL            nb01BahroBoatsEnabled[1]                DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BYTE            nb01BahroBoatsChance[1]                 DEFAULT=0   DEFAULTOPTION=VAULT
+    VAR BOOL            nb01BahroBoatsProximity[1]              DEFAULT=0   DEFAULTOPTION=VAULT
+
+}


### PR DESCRIPTION
Assets - https://github.com/H-uru/moul-assets/pull/241
Sets up the an SDL variable so you can set individual permissions for upload/pellet drops to everyone/member only/off

Requested by Cyan Shard operator to prevent pellet uploads in individual hoods

Adds new SDL variable to Neighborhood.sdl
nb01PelletUploadState

0 <= Everyone can upload (Default)
1 = Members only upload
2 >= No one can upload