### PR TITLE
Refactor and add tests for console command parsing

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsoleCore/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/CMakeLists.txt
@@ -3,12 +3,14 @@ set(pfConsoleCore_SOURCES
     pfConsoleCommandsCore.cpp
     pfConsoleContext.cpp
     pfConsoleEngine.cpp
+    pfConsoleParser.cpp
 )
 
 set(pfConsoleCore_HEADERS
     pfConsoleCmd.h
     pfConsoleContext.h
     pfConsoleEngine.h
+    pfConsoleParser.h
 )
 
 plasma_library(pfConsoleCore SOURCES ${pfConsoleCore_SOURCES} ${pfConsoleCore_HEADERS})

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.cpp
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pfConsoleCmd.h"
 
+#include <string_theory/format>
 #include <string_theory/string_stream>
 
 //////////////////////////////////////////////////////////////////////////////
@@ -132,6 +133,15 @@ void    pfConsoleCmdGroup::AddSubGroup( pfConsoleCmdGroup *group )
 {
     group->Link( &fSubGroups );
     fBaseCmdGroupRef++;
+}
+
+ST::string pfConsoleCmdGroup::GetFullName()
+{
+    if (fParentGroup == nullptr || fParentGroup == GetBaseGroup()) {
+        return fName;
+    } else {
+        return ST::format("{}.{}", fParentGroup->GetFullName(), fName);
+    }
 }
 
 //// FindCommand /////////////////////////////////////////////////////////////
@@ -444,6 +454,15 @@ void    pfConsoleCmd::Unlink()
     if( fNext )
         fNext->fPrevPtr = fPrevPtr;
     *fPrevPtr = fNext;
+}
+
+ST::string pfConsoleCmd::GetFullName()
+{
+    if (fParentGroup == pfConsoleCmdGroup::GetBaseGroup()) {
+        return fName;
+    } else {
+        return ST::format("{}.{}", fParentGroup->GetFullName(), fName);
+    }
 }
 
 //// GetSigEntry /////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.h
@@ -95,6 +95,7 @@ class pfConsoleCmdGroup
 
         pfConsoleCmdGroup   *GetNext() { return fNext; }
         ST::string GetName() { return fName; }
+        ST::string GetFullName();
         pfConsoleCmdGroup   *GetParent() { return fParentGroup; }
 
         static pfConsoleCmdGroup    *GetBaseGroup();
@@ -262,6 +263,7 @@ class pfConsoleCmd
 
         pfConsoleCmd    *GetNext() { return fNext; }
         ST::string GetName() { return fName; }
+        ST::string GetFullName();
         ST::string GetHelp() { return fHelpString; }
         ST::string GetSignature();
 

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -123,15 +123,7 @@ ST::string pfConsoleEngine::GetCmdSignature(const ST::string& name)
     pfConsoleCmd        *cmd;
     
     pfConsoleParser parser(name);
-    auto [group, token] = parser.ParseGroupAndName();
-
-    if (!token) {
-        fErrorMsg = ST_LITERAL("Invalid command syntax");
-        return {};
-    }
-
-    /// OK, so what we found wasn't a group. Which means we need a command...
-    cmd = group->FindCommandNoCase(*token);
+    cmd = parser.ParseCommand();
     if (cmd == nullptr)
     {
         fErrorMsg = ST_LITERAL("Invalid syntax: command not found");
@@ -197,15 +189,7 @@ bool pfConsoleEngine::RunCommand(const ST::string& line, void (*PrintFn)(const S
     bool                valid = true;
 
     pfConsoleParser parser(line);
-    auto [group, token] = parser.ParseGroupAndName();
-
-    if (!token) {
-        fErrorMsg = ST_LITERAL("Invalid command syntax");
-        return false;
-    }
-
-    /// OK, so what we found wasn't a group. Which means we need a command next
-    cmd = group->FindCommandNoCase(*token);
+    cmd = parser.ParseCommand();
     if (cmd == nullptr)
     {
         fErrorMsg = ST_LITERAL("Invalid syntax: command not found");
@@ -216,6 +200,7 @@ bool pfConsoleEngine::RunCommand(const ST::string& line, void (*PrintFn)(const S
     /// tokenizing (with the new separators now, mind you) and turn them into
     /// params
 
+    std::optional<ST::string> token;
     for (numParams = 0; numParams < fMaxNumParams
                         && (token = parser.fTokenizer.NextArgument())
                         && valid; numParams++ )

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -298,7 +298,7 @@ bool pfConsoleEngine::RunCommand(const ST::string& line, void (*PrintFn)(const S
 {
     pfConsoleCmd        *cmd;
     pfConsoleCmdGroup   *group, *subGrp;
-    int32_t               numParams, i, numQuotedParams = 0;
+    int32_t               numParams, i;
     pfConsoleCmdParam   paramArray[ fMaxNumParams + 1 ];
     const char          *ptr;
     bool                valid = true;
@@ -339,7 +339,7 @@ bool pfConsoleEngine::RunCommand(const ST::string& line, void (*PrintFn)(const S
     /// tokenizing (with the new separators now, mind you) and turn them into
     /// params
 
-    for( numParams = numQuotedParams = 0; numParams < fMaxNumParams 
+    for (numParams = 0; numParams < fMaxNumParams
                         && (ptr = TokenizeArguments(linePtr)) != nullptr
                         && valid; numParams++ )
     {

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -79,7 +79,7 @@ bool pfConsoleEngine::PrintCmdHelp(const ST::string& name, void (*PrintFn)(const
     pfConsoleCmdGroup   *group, *subGrp;
 
     /// Scan for subgroups. This can be an empty loop
-    pfConsoleTokenizer tokenizer(name.c_str());
+    pfConsoleTokenizer tokenizer(name);
     group = pfConsoleCmdGroup::GetBaseGroup();
     auto token = tokenizer.NextNamePart();
     while (token) {
@@ -142,7 +142,7 @@ ST::string pfConsoleEngine::GetCmdSignature(const ST::string& name)
     pfConsoleCmdGroup   *group, *subGrp;
     
     /// Scan for subgroups. This can be an empty loop
-    pfConsoleTokenizer tokenizer(name.c_str());
+    pfConsoleTokenizer tokenizer(name);
     group = pfConsoleCmdGroup::GetBaseGroup();
     auto token = tokenizer.NextNamePart();
     while (token) {
@@ -228,7 +228,7 @@ bool pfConsoleEngine::RunCommand(const ST::string& line, void (*PrintFn)(const S
     bool                valid = true;
 
     /// Loop #1: Scan for subgroups. This can be an empty loop
-    pfConsoleTokenizer tokenizer(line.c_str());
+    pfConsoleTokenizer tokenizer(line);
     group = pfConsoleCmdGroup::GetBaseGroup();
     auto token = tokenizer.NextNamePart();
     while (token) {
@@ -381,7 +381,7 @@ ST::string pfConsoleEngine::FindPartialCmd(const ST::string& line, bool findAgai
     ST::string_stream newStr;
 
     /// Loop #1: Scan for subgroups. This can be an empty loop
-    pfConsoleTokenizer tokenizer(line.c_str());
+    pfConsoleTokenizer tokenizer(line);
     pfConsoleCmdGroup* group = pfConsoleCmdGroup::GetBaseGroup();
     auto token = tokenizer.NextNamePart();
     while (token) {
@@ -419,7 +419,7 @@ ST::string pfConsoleEngine::FindPartialCmd(const ST::string& line, bool findAgai
     if( preserveParams )
     {
         /// Preserve the rest of the string after the matched command
-        newStr << tokenizer.fPos;
+        newStr.append(tokenizer.fPos, tokenizer.fEnd - tokenizer.fPos);
     }
 
     return newStr.to_string();

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -84,7 +84,6 @@ const char* pfConsoleEngine::TokenizeCommandName(char*& line)
     if (begin == line)
         return nullptr;
 
-    line = line + strlen(line);
     return begin;
 }
 
@@ -121,7 +120,6 @@ const char* pfConsoleEngine::TokenizeArguments(char*& line)
     if (begin == line)
         return nullptr;
 
-    line = line + strlen(line);
     return begin;
 }
 

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -343,14 +343,8 @@ ST::string pfConsoleEngine::FindPartialCmd(const ST::string& line, bool findAgai
     auto [group, token] = parser.ParseGroupAndName();
 
     // Add group name to replacement line.
-    std::vector<ST::string> reverseParts;
-    pfConsoleCmdGroup* parent = group;
-    while (parent != nullptr && parent != pfConsoleCmdGroup::GetBaseGroup()) {
-        reverseParts.emplace_back(parent->GetName());
-        parent = parent->GetParent();
-    }
-    for (auto it = reverseParts.crbegin(); it != reverseParts.crend(); ++it) {
-        newStr << *it << '.';
+    if (group != pfConsoleCmdGroup::GetBaseGroup()) {
+        newStr << group->GetFullName() << '.';
     }
 
     if (token) {
@@ -395,23 +389,8 @@ ST::string pfConsoleEngine::FindNestedPartialCmd(const ST::string& line, uint32_
     if (cmd == nullptr)
         return {};
 
-    /// Recurse back up and get the group hierarchy
-    std::vector<ST::string> reverseParts {cmd->GetName()};
-    pfConsoleCmdGroup* group = cmd->GetParent();
-    while (group != nullptr && group != pfConsoleCmdGroup::GetBaseGroup()) {
-        reverseParts.emplace_back(group->GetName());
-        group = group->GetParent();
-    }
-
     ST::string_stream name;
-    for (auto it = reverseParts.crbegin(); it != reverseParts.crend(); ++it) {
-        name << *it;
-        if (it + 1 == reverseParts.crend()) {
-            name << ' ';
-        } else {
-            name << '.';
-        }
-    }
+    name << cmd->GetFullName() << ' ';
 
     if( preserveParams )
     {

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -71,8 +71,6 @@ pfConsoleEngine::~pfConsoleEngine()
 
 bool pfConsoleEngine::PrintCmdHelp(const ST::string& name, void (*PrintFn)(const ST::string&))
 {
-    pfConsoleCmd        *cmd;
-
     pfConsoleParser parser(name);
     auto [group, token] = parser.ParseGroupAndName();
 
@@ -88,7 +86,7 @@ bool pfConsoleEngine::PrintCmdHelp(const ST::string& name, void (*PrintFn)(const
             PrintFn(ST::format("    {}", subGrp->GetName()));
         }
         PrintFn(ST_LITERAL("  Commands:"));
-        for (cmd = group->GetFirstCommand(); cmd != nullptr; cmd = cmd->GetNext())
+        for (pfConsoleCmd* cmd = group->GetFirstCommand(); cmd != nullptr; cmd = cmd->GetNext())
         {
             PrintFn(ST::format("    {}: {}", cmd->GetName(), cmd->GetHelp().before_first('\n')));
         }
@@ -97,7 +95,7 @@ bool pfConsoleEngine::PrintCmdHelp(const ST::string& name, void (*PrintFn)(const
     }
 
     /// OK, so what we found wasn't a group. Which means we need a command...
-    cmd = group->FindCommandNoCase(*token);
+    pfConsoleCmd* cmd = group->FindCommandNoCase(*token);
     if (cmd == nullptr)
     {
         fErrorMsg = ST_LITERAL("Invalid syntax: command not found");
@@ -116,10 +114,8 @@ bool pfConsoleEngine::PrintCmdHelp(const ST::string& name, void (*PrintFn)(const
 
 ST::string pfConsoleEngine::GetCmdSignature(const ST::string& name)
 {
-    pfConsoleCmd        *cmd;
-    
     pfConsoleParser parser(name);
-    cmd = parser.ParseCommand();
+    pfConsoleCmd* cmd = parser.ParseCommand();
     if (cmd == nullptr)
     {
         fErrorMsg = ST_LITERAL("Invalid syntax: command not found");
@@ -140,8 +136,6 @@ void DummyPrintFn(const ST::string& line)
 
 bool pfConsoleEngine::ExecuteFile(const plFileName &fileName)
 {
-    int     line;
-
     std::unique_ptr<hsStream> stream = plEncryptedStream::OpenEncryptedFile(fileName);
 
     if( !stream )
@@ -156,7 +150,7 @@ bool pfConsoleEngine::ExecuteFile(const plFileName &fileName)
     }
 
     ST::string string;
-    for (line = 1; stream->ReadLn(string); line++)
+    for (int line = 1; stream->ReadLn(string); line++)
     {
         fLastErrorLine = string;
 
@@ -179,10 +173,8 @@ bool pfConsoleEngine::ExecuteFile(const plFileName &fileName)
 
 bool pfConsoleEngine::RunCommand(const ST::string& line, void (*PrintFn)(const ST::string&))
 {
-    pfConsoleCmd        *cmd;
-
     pfConsoleParser parser(line);
-    cmd = parser.ParseCommand();
+    pfConsoleCmd* cmd = parser.ParseCommand();
     if (cmd == nullptr)
     {
         fErrorMsg = ST_LITERAL("Invalid syntax: command not found");

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -63,7 +63,7 @@ static const char kTokenSeparators[] = " =\r\n\t,";
 static const char kTokenGrpSeps[] = " =\r\n._\t,";
 
 //WARNING: Potentially increments the pointer passed to it.
-static const char *console_strtok( char *&line, bool haveCommand )
+const char* pfConsoleEngine::Tokenize(char*& line, bool haveCommand)
 {
     char *begin = line;
 
@@ -129,13 +129,13 @@ bool pfConsoleEngine::PrintCmdHelp(const ST::string& name, void (*PrintFn)(const
     pfConsoleCmdGroup   *group, *subGrp;
     const char          *ptr;
 
-    // console_strtok requires a writable C string...
+    // Tokenize requires a writable C string...
     ST::char_buffer nameBuf = name.to_utf8();
     char* namePtr = nameBuf.data();
 
     /// Scan for subgroups. This can be an empty loop
     group = pfConsoleCmdGroup::GetBaseGroup();
-    ptr = console_strtok(namePtr, false);
+    ptr = Tokenize(namePtr, false);
     while (ptr != nullptr)
     {
         // Take this token and check to see if it's a group
@@ -144,7 +144,7 @@ bool pfConsoleEngine::PrintCmdHelp(const ST::string& name, void (*PrintFn)(const
         else
             break;
 
-        ptr = console_strtok(namePtr, false);
+        ptr = Tokenize(namePtr, false);
     }
 
     if (ptr == nullptr)
@@ -198,13 +198,13 @@ ST::string pfConsoleEngine::GetCmdSignature(const ST::string& name)
     pfConsoleCmdGroup   *group, *subGrp;
     const char          *ptr;
 
-    // console_strtok requires a writable C string...
+    // Tokenize requires a writable C string...
     ST::char_buffer nameBuf = name.to_utf8();
     char* namePtr = nameBuf.data();
     
     /// Scan for subgroups. This can be an empty loop
     group = pfConsoleCmdGroup::GetBaseGroup();
-    ptr = console_strtok(namePtr, false);
+    ptr = Tokenize(namePtr, false);
     while (ptr != nullptr)
     {
         // Take this token and check to see if it's a group
@@ -213,7 +213,7 @@ ST::string pfConsoleEngine::GetCmdSignature(const ST::string& name)
         else
             break;
 
-        ptr = console_strtok(namePtr, false);
+        ptr = Tokenize(namePtr, false);
     }
 
     if (ptr == nullptr)
@@ -290,13 +290,13 @@ bool pfConsoleEngine::RunCommand(const ST::string& line, void (*PrintFn)(const S
     const char          *ptr;
     bool                valid = true;
 
-    // console_strtok requires a writable C string...
+    // Tokenize requires a writable C string...
     ST::char_buffer lineBuf = line.to_utf8();
     char* linePtr = lineBuf.data();
 
     /// Loop #1: Scan for subgroups. This can be an empty loop
     group = pfConsoleCmdGroup::GetBaseGroup();
-    ptr = console_strtok(linePtr, false);
+    ptr = Tokenize(linePtr, false);
     while (ptr != nullptr)
     {
         // Take this token and check to see if it's a group
@@ -305,7 +305,7 @@ bool pfConsoleEngine::RunCommand(const ST::string& line, void (*PrintFn)(const S
         else
             break;
 
-        ptr = console_strtok(linePtr, false);
+        ptr = Tokenize(linePtr, false);
     }
 
     if (ptr == nullptr)
@@ -327,7 +327,7 @@ bool pfConsoleEngine::RunCommand(const ST::string& line, void (*PrintFn)(const S
     /// params
 
     for( numParams = numQuotedParams = 0; numParams < fMaxNumParams 
-                        && (ptr = console_strtok(linePtr, true)) != nullptr
+                        && (ptr = Tokenize(linePtr, true)) != nullptr
                         && valid; numParams++ )
     {
         if( ptr[ 0 ] == '\xFF' )
@@ -448,13 +448,13 @@ ST::string pfConsoleEngine::FindPartialCmd(const ST::string& line, bool findAgai
 
     /// New search
     ST::string_stream newStr;
-    // console_strtok requires a writable C string...
+    // Tokenize requires a writable C string...
     ST::char_buffer lineBuf = line.to_utf8();
     char* linePtr = lineBuf.data();
 
     /// Loop #1: Scan for subgroups. This can be an empty loop
     pfConsoleCmdGroup* group = pfConsoleCmdGroup::GetBaseGroup();
-    const char* ptr = console_strtok(linePtr, false);
+    const char* ptr = Tokenize(linePtr, false);
     while (ptr != nullptr)
     {
         // Take this token and check to see if it's a group
@@ -465,7 +465,7 @@ ST::string pfConsoleEngine::FindPartialCmd(const ST::string& line, bool findAgai
 
         group = subGrp;
         newStr << group->GetName() << '.';
-        ptr = console_strtok(linePtr, false);
+        ptr = Tokenize(linePtr, false);
     }
 
     if (ptr != nullptr)

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
-#include <optional>
 #include <string_theory/string>
 
 class plFileName;
@@ -81,19 +80,6 @@ class pfConsoleEngine
 
         pfConsoleEngine();
         ~pfConsoleEngine();
-
-        // Special value returned by the Tokenize methods (currently only TokenizeArguments) to indicate a syntax error.
-        static const ST::string kTokenizeError;
-
-        // Parse the next command name or argument token from the given input line.
-        // On success, returns the parsed token.
-        // (Note that a successfully parsed token may be an empty string, e. g. from an empty pair of quotes!)
-        // The line pointer is incremented to point after that token
-        // so that it can be passed into another call to continue tokenizing.
-        // If the next token couldn't be parsed (e. g. quote not closed), returns kTokenizeError.
-        // If there are no further tokens in the line, returns an empty std::optional.
-        static std::optional<ST::string> TokenizeCommandName(const char*& line);
-        static std::optional<ST::string> TokenizeArguments(const char*& line);
 
         // Gets the signature for the command given (NO groups!)
         ST::string GetCmdSignature(const ST::string& name);

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
@@ -81,7 +81,8 @@ class pfConsoleEngine
         pfConsoleEngine();
         ~pfConsoleEngine();
 
-        static const char* Tokenize(char*& line, bool haveCommand);
+        static const char* TokenizeCommandName(char*& line);
+        static const char* TokenizeArguments(char*& line);
 
         // Gets the signature for the command given (NO groups!)
         ST::string GetCmdSignature(const ST::string& name);

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
@@ -58,11 +58,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 
 #include <string_theory/string>
+#include <vector>
 
 class plFileName;
 
 //// pfConsoleEngine Class Definition ////////////////////////////////////////
 
+class pfConsoleCmd;
 class pfConsoleCmdParam;
 class pfConsoleCmdGroup;
 class pfConsoleEngine
@@ -72,6 +74,7 @@ class pfConsoleEngine
         static const int32_t      fMaxNumParams;
 
         bool IConvertToParam(uint8_t type, ST::string string, pfConsoleCmdParam *param);
+        hsSsize_t IResolveParams(pfConsoleCmd* cmd, std::vector<ST::string> argTokens, pfConsoleCmdParam* paramArray);
 
         ST::string fErrorMsg;
         ST::string fLastErrorLine;

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
@@ -57,6 +57,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
+#include <optional>
 #include <string_theory/string>
 #include <vector>
 
@@ -70,11 +71,8 @@ class pfConsoleCmdGroup;
 class pfConsoleEngine
 {
     private:
-
-        static const int32_t      fMaxNumParams;
-
-        bool IConvertToParam(uint8_t type, ST::string string, pfConsoleCmdParam *param);
-        hsSsize_t IResolveParams(pfConsoleCmd* cmd, std::vector<ST::string> argTokens, pfConsoleCmdParam* paramArray);
+        std::optional<pfConsoleCmdParam> IConvertToParam(uint8_t type, ST::string string);
+        std::optional<std::vector<pfConsoleCmdParam>> IResolveParams(pfConsoleCmd* cmd, std::vector<ST::string> argTokens);
 
         ST::string fErrorMsg;
         ST::string fLastErrorLine;

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
@@ -57,6 +57,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
+#include <optional>
 #include <string_theory/string>
 
 class plFileName;
@@ -81,8 +82,18 @@ class pfConsoleEngine
         pfConsoleEngine();
         ~pfConsoleEngine();
 
-        static const char* TokenizeCommandName(char*& line);
-        static const char* TokenizeArguments(char*& line);
+        // Special value returned by the Tokenize methods (currently only TokenizeArguments) to indicate a syntax error.
+        static const ST::string kTokenizeError;
+
+        // Parse the next command name or argument token from the given input line.
+        // On success, returns the parsed token.
+        // (Note that a successfully parsed token may be an empty string, e. g. from an empty pair of quotes!)
+        // The line pointer is incremented to point after that token
+        // so that it can be passed into another call to continue tokenizing.
+        // If the next token couldn't be parsed (e. g. quote not closed), returns kTokenizeError.
+        // If there are no further tokens in the line, returns an empty std::optional.
+        static std::optional<ST::string> TokenizeCommandName(const char*& line);
+        static std::optional<ST::string> TokenizeArguments(const char*& line);
 
         // Gets the signature for the command given (NO groups!)
         ST::string GetCmdSignature(const ST::string& name);

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
@@ -81,6 +81,8 @@ class pfConsoleEngine
         pfConsoleEngine();
         ~pfConsoleEngine();
 
+        static const char* Tokenize(char*& line, bool haveCommand);
+
         // Gets the signature for the command given (NO groups!)
         ST::string GetCmdSignature(const ST::string& name);
 

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.cpp
@@ -142,3 +142,16 @@ pfConsoleCmd* pfConsoleParser::ParseCommand()
     }
     return group->FindCommandNoCase(*token);
 }
+
+std::optional<std::vector<ST::string>> pfConsoleParser::ParseArguments()
+{
+    std::vector<ST::string> args;
+    while (auto token = fTokenizer.NextArgument()) {
+        args.emplace_back(std::move(*token));
+    }
+    if (!fTokenizer.fErrorMsg.empty()) {
+        // Parse error in argument
+        return {};
+    }
+    return args;
+}

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.cpp
@@ -42,6 +42,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pfConsoleParser.h"
 
+#include <utility>
+
 #include "pfConsoleCmd.h"
 
 static const char kTokenSeparators[] = " =\r\n\t,";
@@ -117,7 +119,7 @@ std::optional<ST::string> pfConsoleTokenizer::NextArgument()
     return begin;
 }
 
-std::pair<pfConsoleCmdGroup*, std::optional<ST::string>> pfConsoleParser::ParseGroupAndName()
+std::tuple<pfConsoleCmdGroup*, std::optional<ST::string>> pfConsoleParser::ParseGroupAndName()
 {
     pfConsoleCmdGroup* group = pfConsoleCmdGroup::GetBaseGroup();
     auto token = fTokenizer.NextNamePart();

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.cpp
@@ -133,3 +133,12 @@ std::pair<pfConsoleCmdGroup*, std::optional<ST::string>> pfConsoleParser::ParseG
 
     return {group, token};
 }
+
+pfConsoleCmd* pfConsoleParser::ParseCommand()
+{
+    auto [group, token] = ParseGroupAndName();
+    if (!token) {
+        return nullptr;
+    }
+    return group->FindCommandNoCase(*token);
+}

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.cpp
@@ -42,6 +42,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pfConsoleParser.h"
 
+#include "pfConsoleCmd.h"
+
 static const char kTokenSeparators[] = " =\r\n\t,";
 static const char kTokenGrpSeps[] = " =\r\n._\t,";
 
@@ -113,4 +115,21 @@ std::optional<ST::string> pfConsoleTokenizer::NextArgument()
     }
 
     return begin;
+}
+
+std::pair<pfConsoleCmdGroup*, std::optional<ST::string>> pfConsoleParser::ParseGroupAndName()
+{
+    pfConsoleCmdGroup* group = pfConsoleCmdGroup::GetBaseGroup();
+    auto token = fTokenizer.NextNamePart();
+    while (token) {
+        // Take this token and check to see if it's a group
+        pfConsoleCmdGroup* subGrp = group->FindSubGroupNoCase(*token);
+        if (subGrp == nullptr) {
+            return {group, token};
+        }
+        group = subGrp;
+        token = fTokenizer.NextNamePart();
+    }
+
+    return {group, token};
 }

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.cpp
@@ -1,0 +1,113 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "pfConsoleParser.h"
+
+#include <string_theory/string>
+
+// Yes, this is invalid UTF-8. Yes, this is awful.
+const ST::string pfConsoleTokenizer::kTokenizeError = ST_LITERAL("\xff");
+
+static const char kTokenSeparators[] = " =\r\n\t,";
+static const char kTokenGrpSeps[] = " =\r\n._\t,";
+
+//WARNING: Potentially increments the pointer passed to it.
+std::optional<ST::string> pfConsoleTokenizer::TokenizeCommandName(const char*& line)
+{
+    const char* begin = line;
+
+    while (*begin && isspace(static_cast<unsigned char>(*begin)))
+        ++begin;
+
+    for (line = begin; *line; ++line) {
+        for (const char *sep = kTokenGrpSeps; *sep; ++sep) {
+            if (*line == *sep) {
+                const char* end = line;
+                while (*++line && (*line == *sep))
+                    /* skip duplicate delimiters */;
+                return ST::string::from_utf8(begin, end - begin);
+            }
+        }
+    }
+
+    if (begin == line) {
+        return {};
+    }
+
+    return begin;
+}
+
+//WARNING: Potentially increments the pointer passed to it.
+std::optional<ST::string> pfConsoleTokenizer::TokenizeArguments(const char*& line)
+{
+    const char* begin = line;
+
+    while (*begin && isspace(static_cast<unsigned char>(*begin)))
+        ++begin;
+
+    for (line = begin; *line; ++line) {
+        if (*begin == '"' || *begin == '\'') {
+            // Handle strings as a single token
+            ++begin;
+            const char* end = strchr(begin, *line);
+            if (end == nullptr) {
+                return kTokenizeError;
+            }
+            line = end + 1;
+            return ST::string::from_utf8(begin, end - begin);
+        }
+        for (const char *sep = kTokenSeparators; *sep; ++sep) {
+            if (*line == *sep) {
+                const char* end = line;
+                while (*++line && (*line == *sep))
+                    /* skip duplicate delimiters */;
+                return ST::string::from_utf8(begin, end - begin);
+            }
+        }
+    }
+
+    if (begin == line) {
+        return {};
+    }
+
+    return begin;
+}

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
@@ -46,24 +46,25 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 
 #include <optional>
-
-namespace ST { class string; }
+#include <string_theory/string>
 
 class pfConsoleTokenizer
 {
 public:
-    // Special value returned by the Tokenize methods (currently only TokenizeArguments) to indicate a syntax error.
-    static const ST::string kTokenizeError;
+    const char* fPos;
+    ST::string fErrorMsg;
 
-    // Parse the next command name or argument token from the given input line.
+    pfConsoleTokenizer(const char* line) : fPos(line), fErrorMsg() {}
+
+    // Parse the next command name or argument token from the input line.
     // On success, returns the parsed token.
     // (Note that a successfully parsed token may be an empty string, e. g. from an empty pair of quotes!)
-    // The line pointer is incremented to point after that token
-    // so that it can be passed into another call to continue tokenizing.
-    // If the next token couldn't be parsed (e. g. quote not closed), returns kTokenizeError.
-    // If there are no further tokens in the line, returns an empty std::optional.
-    static std::optional<ST::string> TokenizeCommandName(const char*& line);
-    static std::optional<ST::string> TokenizeArguments(const char*& line);
+    // If the next token couldn't be parsed (e. g. quote not closed),
+    // returns an empty std::optional and sets fErrorMsg to a non-empty string.
+    // If there are no further tokens in the line,
+    // returns an empty std::optional and sets fErrorMsg to an empty string.
+    std::optional<ST::string> NextNamePart();
+    std::optional<ST::string> NextArgument();
 };
 
 #endif // _pfConsolePareser_h

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
@@ -51,10 +51,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class pfConsoleTokenizer
 {
 public:
-    const char* fPos;
+    ST::string::const_iterator fPos;
+    ST::string::const_iterator fEnd;
     ST::string fErrorMsg;
 
-    pfConsoleTokenizer(const char* line) : fPos(line), fErrorMsg() {}
+    pfConsoleTokenizer(ST::string::const_iterator begin, ST::string::const_iterator end) :
+        fPos(begin), fEnd(end), fErrorMsg()
+    {}
+    pfConsoleTokenizer(const ST::string& line) : pfConsoleTokenizer(line.begin(), line.end()) {}
 
     // Parse the next command name or argument token from the input line.
     // On success, returns the parsed token.

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
@@ -1,0 +1,69 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef _pfConsolePareser_h
+#define _pfConsolePareser_h
+
+#include "HeadSpin.h"
+
+#include <optional>
+
+namespace ST { class string; }
+
+class pfConsoleTokenizer
+{
+public:
+    // Special value returned by the Tokenize methods (currently only TokenizeArguments) to indicate a syntax error.
+    static const ST::string kTokenizeError;
+
+    // Parse the next command name or argument token from the given input line.
+    // On success, returns the parsed token.
+    // (Note that a successfully parsed token may be an empty string, e. g. from an empty pair of quotes!)
+    // The line pointer is incremented to point after that token
+    // so that it can be passed into another call to continue tokenizing.
+    // If the next token couldn't be parsed (e. g. quote not closed), returns kTokenizeError.
+    // If there are no further tokens in the line, returns an empty std::optional.
+    static std::optional<ST::string> TokenizeCommandName(const char*& line);
+    static std::optional<ST::string> TokenizeArguments(const char*& line);
+};
+
+#endif // _pfConsolePareser_h

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
@@ -84,6 +84,8 @@ public:
     pfConsoleParser(ST::string::const_iterator begin, ST::string::const_iterator end) : fTokenizer(begin, end) {}
     pfConsoleParser(const ST::string& line) : pfConsoleParser(line.begin(), line.end()) {}
 
+    ST::string GetErrorMsg() const { return fTokenizer.fErrorMsg; }
+
     // Parse the command name part of the line as far as possible.
     // This consumes name part tokens and uses them to look up a command group
     // until a token is encountered that isn't a known group name.
@@ -95,6 +97,12 @@ public:
     // Returns the command corresponding to that name,
     // or nullptr if no matching command was found.
     pfConsoleCmd* ParseCommand();
+
+    // Parse the remainder of the line as command arguments.
+    // On success, returns the parsed arguments with any surrounding quotes removed.
+    // If any of the arguments couldn't be parsed,
+    // returns an empty std::optional (call GetErrorMsg for an error message).
+    std::optional<std::vector<ST::string>> ParseArguments();
 };
 
 #endif // _pfConsolePareser_h

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
@@ -47,7 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <optional>
 #include <string_theory/string>
-#include <utility>
+#include <tuple>
 #include <vector>
 
 class pfConsoleCmd;
@@ -91,7 +91,7 @@ public:
     // until a token is encountered that isn't a known group name.
     // Returns the found group and the first non-group token
     // (which may be an empty std::optional if the end of the line was reached).
-    std::pair<pfConsoleCmdGroup*, std::optional<ST::string>> ParseGroupAndName();
+    std::tuple<pfConsoleCmdGroup*, std::optional<ST::string>> ParseGroupAndName();
 
     // Parse the command name part of the line.
     // Returns the command corresponding to that name,

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
@@ -47,6 +47,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <optional>
 #include <string_theory/string>
+#include <utility>
+#include <vector>
+
+class pfConsoleCmdGroup;
 
 class pfConsoleTokenizer
 {
@@ -69,6 +73,22 @@ public:
     // returns an empty std::optional and sets fErrorMsg to an empty string.
     std::optional<ST::string> NextNamePart();
     std::optional<ST::string> NextArgument();
+};
+
+class pfConsoleParser
+{
+public:
+    pfConsoleTokenizer fTokenizer;
+
+    pfConsoleParser(ST::string::const_iterator begin, ST::string::const_iterator end) : fTokenizer(begin, end) {}
+    pfConsoleParser(const ST::string& line) : pfConsoleParser(line.begin(), line.end()) {}
+
+    // Parse the command name part of the line as far as possible.
+    // This consumes name part tokens and uses them to look up a command group
+    // until a token is encountered that isn't a known group name.
+    // Returns the found group and the first non-group token
+    // (which may be an empty std::optional if the end of the line was reached).
+    std::pair<pfConsoleCmdGroup*, std::optional<ST::string>> ParseGroupAndName();
 };
 
 #endif // _pfConsolePareser_h

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleParser.h
@@ -50,6 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <utility>
 #include <vector>
 
+class pfConsoleCmd;
 class pfConsoleCmdGroup;
 
 class pfConsoleTokenizer
@@ -89,6 +90,11 @@ public:
     // Returns the found group and the first non-group token
     // (which may be an empty std::optional if the end of the line was reached).
     std::pair<pfConsoleCmdGroup*, std::optional<ST::string>> ParseGroupAndName();
+
+    // Parse the command name part of the line.
+    // Returns the command corresponding to that name,
+    // or nullptr if no matching command was found.
+    pfConsoleCmd* ParseCommand();
 };
 
 #endif // _pfConsolePareser_h

--- a/Sources/Tests/FeatureTests/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/CMakeLists.txt
@@ -6,4 +6,5 @@ include_directories("${PLASMA_SOURCE_ROOT}/PubUtilLib/inc")
 include_directories("${PLASMA_SOURCE_ROOT}/FeatureLib")
 include_directories("${PLASMA_SOURCE_ROOT}/FeatureLib/inc")
 
+add_subdirectory(pfConsoleCoreTest)
 add_subdirectory(pfPythonTest)

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(pfConsoleCore_SOURCES
-    test_pfConsoleCore.cpp
+    test_pfConsoleTokenizer.cpp
 )
 
 plasma_test(test_pfConsoleCore SOURCES ${pfConsoleCore_SOURCES})

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(pfConsoleCore_SOURCES
+    test_pfConsoleCore.cpp
+)
+
+plasma_test(test_pfConsoleCore SOURCES ${pfConsoleCore_SOURCES})
+target_link_libraries(
+    test_pfConsoleCore
+    PRIVATE
+        CoreLib
+        pfConsoleCore
+        gtest_main
+)

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(pfConsoleCore_SOURCES
+    test_pfConsoleParser.cpp
     test_pfConsoleTokenizer.cpp
 )
 

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleCore.cpp
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleCore.cpp
@@ -44,33 +44,35 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pfConsoleCore/pfConsoleEngine.h"
 
+using namespace ST::literals;
+
 // Tokenize command name, 1 token
 
 TEST(pfConsoleCore, TokenizeCommandNameSingle)
 {
-    char buf[] = "SampleCmd1";
-    char* line = buf;
+    const char buf[] = "SampleCmd1";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token1, "SampleCmd1");
+    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token1, "SampleCmd1"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_EQ(token2, nullptr);
+    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeCommandNameSingleWhitespace)
 {
-    char buf[] = "  SampleCmd1   ";
-    char* line = buf;
+    const char buf[] = "  SampleCmd1   ";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token1, "SampleCmd1");
+    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token1, "SampleCmd1"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_EQ(token2, nullptr);
+    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
@@ -78,55 +80,55 @@ TEST(pfConsoleCore, TokenizeCommandNameSingleWhitespace)
 
 TEST(pfConsoleCore, TokenizeCommandNameDot)
 {
-    char buf[] = "App.Quit";
-    char* line = buf;
+    const char buf[] = "App.Quit";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token1, "App");
+    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token1, "App"_st);
     EXPECT_EQ(line, buf + sizeof("App.") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token2, "Quit");
+    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token2, "Quit"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_EQ(token3, nullptr);
+    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeCommandNameUnderscore)
 {
-    char buf[] = "App_Quit";
-    char* line = buf;
+    const char buf[] = "App_Quit";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token1, "App");
+    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token1, "App"_st);
     EXPECT_EQ(line, buf + sizeof("App_") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token2, "Quit");
+    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token2, "Quit"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_EQ(token3, nullptr);
+    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeCommandNameSpace)
 {
-    char buf[] = "App  Quit";
-    char* line = buf;
+    const char buf[] = "App  Quit";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token1, "App");
+    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token1, "App"_st);
     EXPECT_EQ(line, buf + sizeof("App  ") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token2, "Quit");
+    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token2, "Quit"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_EQ(token3, nullptr);
+    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
@@ -134,67 +136,67 @@ TEST(pfConsoleCore, TokenizeCommandNameSpace)
 
 TEST(pfConsoleCore, TokenizeCommandNameDots)
 {
-    char buf[] = "Graphics.Renderer.SetYon";
-    char* line = buf;
+    const char buf[] = "Graphics.Renderer.SetYon";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token1, "Graphics");
+    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token1, "Graphics"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics.") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token2, "Renderer");
+    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token2, "Renderer"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics.Renderer.") - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token3, "SetYon");
+    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token3, "SetYon"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token4 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_EQ(token4, nullptr);
+    auto token4 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeCommandNameUnderscores)
 {
-    char buf[] = "Graphics_Renderer_SetYon";
-    char* line = buf;
+    const char buf[] = "Graphics_Renderer_SetYon";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token1, "Graphics");
+    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token1, "Graphics"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics_") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token2, "Renderer");
+    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token2, "Renderer"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics_Renderer_") - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token3, "SetYon");
+    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token3, "SetYon"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token4 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_EQ(token4, nullptr);
+    auto token4 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeCommandNameSpaces)
 {
-    char buf[] = "Graphics Renderer   SetYon";
-    char* line = buf;
+    const char buf[] = "Graphics Renderer   SetYon";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token1, "Graphics");
+    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token1, "Graphics"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics ") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token2, "Renderer");
+    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token2, "Renderer"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics Renderer   ") - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_STREQ(token3, "SetYon");
+    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_EQ(token3, "SetYon"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token4 = pfConsoleEngine::TokenizeCommandName(line);
-    EXPECT_EQ(token4, nullptr);
+    auto token4 = pfConsoleEngine::TokenizeCommandName(line);
+    EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
@@ -202,163 +204,163 @@ TEST(pfConsoleCore, TokenizeCommandNameSpaces)
 
 TEST(pfConsoleCore, TokenizeArgumentsSingle)
 {
-    char buf[] = "arg";
-    char* line = buf;
+    const char buf[] = "arg";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "arg");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "arg"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token2, nullptr);
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeArgumentsSingleWhitespace)
 {
-    char buf[] = "  arg   ";
-    char* line = buf;
+    const char buf[] = "  arg   ";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "arg");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "arg"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token2, nullptr);
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeArgumentsSingleUnderscore)
 {
-    char buf[] = "arg_test";
-    char* line = buf;
+    const char buf[] = "arg_test";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "arg_test");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "arg_test"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token2, nullptr);
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeArgumentsSingleDoubleQuote)
 {
-    char buf[] = "\"(Default Device)\"";
-    char* line = buf;
+    const char buf[] = "\"(Default Device)\"";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "(Default Device)");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "(Default Device)"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token2, nullptr);
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeArgumentsSingleSingleQuote)
 {
-    char buf[] = "'(Default Device)'";
-    char* line = buf;
+    const char buf[] = "'(Default Device)'";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "(Default Device)");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "(Default Device)"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token2, nullptr);
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeArgumentsSingleDoubleQuoteUnclosed)
 {
-    char buf[] = "\"(Default Device)";
-    char* line = buf;
+    const char buf[] = "\"(Default Device)";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "\xff");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "\xff"_st);
 }
 
 TEST(pfConsoleCore, TokenizeArgumentsSingleSingleQuoteUnclosed)
 {
-    char buf[] = "'(Default Device)";
-    char* line = buf;
+    const char buf[] = "'(Default Device)";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "\xff");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "\xff"_st);
 }
 
 // Tokenize arguments, 2 tokens
 
 TEST(pfConsoleCore, TokenizeArgumentsPair)
 {
-    char buf[] = "arg1 arg2";
-    char* line = buf;
+    const char buf[] = "arg1 arg2";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "arg1");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "arg1"_st);
     EXPECT_EQ(line, buf + sizeof("arg1 ") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token2, "arg2");
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token2, "arg2"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token3, nullptr);
+    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeArgumentsPairWhitespace)
 {
-    char buf[] = " arg1  arg2   ";
-    char* line = buf;
+    const char buf[] = " arg1  arg2   ";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "arg1");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "arg1"_st);
     EXPECT_EQ(line, buf + sizeof(" arg1  ") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token2, "arg2");
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token2, "arg2"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token3, nullptr);
+    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeArgumentsPairComma)
 {
-    char buf[] = "arg1, arg2";
-    char* line = buf;
+    const char buf[] = "arg1, arg2";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "arg1");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "arg1"_st);
     EXPECT_EQ(line, buf + sizeof("arg1,") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token2, "arg2");
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token2, "arg2"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token3, nullptr);
+    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeArgumentsPairMixedQuotes)
 {
-    char buf[] = "\"argument '1'\" 'argument \"2\"'";
-    char* line = buf;
+    const char buf[] = "\"argument '1'\" 'argument \"2\"'";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "argument '1'");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "argument '1'"_st);
     EXPECT_EQ(line, buf + sizeof("\"argument '1'\"") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token2, "argument \"2\"");
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token2, "argument \"2\""_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token3, nullptr);
+    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
@@ -366,44 +368,44 @@ TEST(pfConsoleCore, TokenizeArgumentsPairMixedQuotes)
 
 TEST(pfConsoleCore, TokenizeArgumentsTriple)
 {
-    char buf[] = "1.2 3.4 5.6";
-    char* line = buf;
+    const char buf[] = "1.2 3.4 5.6";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "1.2");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "1.2"_st);
     EXPECT_EQ(line, buf + sizeof("1.2 ") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token2, "3.4");
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token2, "3.4"_st);
     EXPECT_EQ(line, buf + sizeof("1.2 3.4 ") - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token3, "5.6");
+    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token3, "5.6"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token4 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token4, nullptr);
+    auto token4 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleCore, TokenizeArgumentsTripleCommas)
 {
-    char buf[] = "1.2, 3.4, 5.6";
-    char* line = buf;
+    const char buf[] = "1.2, 3.4, 5.6";
+    const char* line = buf;
 
-    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token1, "1.2");
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, "1.2"_st);
     EXPECT_EQ(line, buf + sizeof("1.2,") - 1);
 
-    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token2, "3.4");
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token2, "3.4"_st);
     EXPECT_EQ(line, buf + sizeof("1.2, 3.4,") - 1);
 
-    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_STREQ(token3, "5.6");
+    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token3, "5.6"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token4 = pfConsoleEngine::TokenizeArguments(line);
-    EXPECT_EQ(token4, nullptr);
+    auto token4 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleCore.cpp
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleCore.cpp
@@ -409,3 +409,25 @@ TEST(pfConsoleCore, TokenizeArgumentsTripleCommas)
     EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
+
+TEST(pfConsoleCore, TokenizeArgumentsTripleEmptyQuotes)
+{
+    const char buf[] = "'' \"\" ''";
+    const char* line = buf;
+
+    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token1, ""_st);
+    EXPECT_EQ(line, buf + sizeof("''") - 1);
+
+    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token2, ""_st);
+    EXPECT_EQ(line, buf + sizeof("'' \"\"") - 1);
+
+    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_EQ(token3, ""_st);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    auto token4 = pfConsoleEngine::TokenizeArguments(line);
+    EXPECT_FALSE(token4);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleCore.cpp
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleCore.cpp
@@ -1,0 +1,409 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <gtest/gtest.h>
+
+#include "pfConsoleCore/pfConsoleEngine.h"
+
+// Tokenize command name, 1 token
+
+TEST(pfConsoleCore, TokenizeCommandNameSingle)
+{
+    char buf[] = "SampleCmd1";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token1, "SampleCmd1");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_EQ(token2, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeCommandNameSingleWhitespace)
+{
+    char buf[] = "  SampleCmd1   ";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token1, "SampleCmd1");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_EQ(token2, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+// Tokenize command name, 2 tokens
+
+TEST(pfConsoleCore, TokenizeCommandNameDot)
+{
+    char buf[] = "App.Quit";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token1, "App");
+    EXPECT_EQ(line, buf + sizeof("App.") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token2, "Quit");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_EQ(token3, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeCommandNameUnderscore)
+{
+    char buf[] = "App_Quit";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token1, "App");
+    EXPECT_EQ(line, buf + sizeof("App_") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token2, "Quit");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_EQ(token3, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeCommandNameSpace)
+{
+    char buf[] = "App  Quit";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token1, "App");
+    EXPECT_EQ(line, buf + sizeof("App  ") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token2, "Quit");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_EQ(token3, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+// Tokenize command name, 3 tokens
+
+TEST(pfConsoleCore, TokenizeCommandNameDots)
+{
+    char buf[] = "Graphics.Renderer.SetYon";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token1, "Graphics");
+    EXPECT_EQ(line, buf + sizeof("Graphics.") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token2, "Renderer");
+    EXPECT_EQ(line, buf + sizeof("Graphics.Renderer.") - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token3, "SetYon");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token4 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_EQ(token4, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeCommandNameUnderscores)
+{
+    char buf[] = "Graphics_Renderer_SetYon";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token1, "Graphics");
+    EXPECT_EQ(line, buf + sizeof("Graphics_") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token2, "Renderer");
+    EXPECT_EQ(line, buf + sizeof("Graphics_Renderer_") - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token3, "SetYon");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token4 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_EQ(token4, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeCommandNameSpaces)
+{
+    char buf[] = "Graphics Renderer   SetYon";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token1, "Graphics");
+    EXPECT_EQ(line, buf + sizeof("Graphics ") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token2, "Renderer");
+    EXPECT_EQ(line, buf + sizeof("Graphics Renderer   ") - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_STREQ(token3, "SetYon");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token4 = pfConsoleEngine::Tokenize(line, false);
+    EXPECT_EQ(token4, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+// Tokenize arguments, 1 token
+
+TEST(pfConsoleCore, TokenizeArgumentsSingle)
+{
+    char buf[] = "arg";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "arg");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token2, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeArgumentsSingleWhitespace)
+{
+    char buf[] = "  arg   ";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "arg");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token2, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeArgumentsSingleUnderscore)
+{
+    char buf[] = "arg_test";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "arg_test");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token2, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeArgumentsSingleDoubleQuote)
+{
+    char buf[] = "\"(Default Device)\"";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "(Default Device)");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token2, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeArgumentsSingleSingleQuote)
+{
+    char buf[] = "'(Default Device)'";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "(Default Device)");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token2, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeArgumentsSingleDoubleQuoteUnclosed)
+{
+    char buf[] = "\"(Default Device)";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "\xff");
+}
+
+TEST(pfConsoleCore, TokenizeArgumentsSingleSingleQuoteUnclosed)
+{
+    char buf[] = "'(Default Device)";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "\xff");
+}
+
+// Tokenize arguments, 2 tokens
+
+TEST(pfConsoleCore, TokenizeArgumentsPair)
+{
+    char buf[] = "arg1 arg2";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "arg1");
+    EXPECT_EQ(line, buf + sizeof("arg1 ") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token2, "arg2");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token3, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeArgumentsPairWhitespace)
+{
+    char buf[] = " arg1  arg2   ";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "arg1");
+    EXPECT_EQ(line, buf + sizeof(" arg1  ") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token2, "arg2");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token3, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeArgumentsPairComma)
+{
+    char buf[] = "arg1, arg2";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "arg1");
+    EXPECT_EQ(line, buf + sizeof("arg1,") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token2, "arg2");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token3, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeArgumentsPairMixedQuotes)
+{
+    char buf[] = "\"argument '1'\" 'argument \"2\"'";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "argument '1'");
+    EXPECT_EQ(line, buf + sizeof("\"argument '1'\"") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token2, "argument \"2\"");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token3, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+// Tokenize arguments, 3 tokens
+
+TEST(pfConsoleCore, TokenizeArgumentsTriple)
+{
+    char buf[] = "1.2 3.4 5.6";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "1.2");
+    EXPECT_EQ(line, buf + sizeof("1.2 ") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token2, "3.4");
+    EXPECT_EQ(line, buf + sizeof("1.2 3.4 ") - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token3, "5.6");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token4 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token4, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}
+
+TEST(pfConsoleCore, TokenizeArgumentsTripleCommas)
+{
+    char buf[] = "1.2, 3.4, 5.6";
+    char* line = buf;
+
+    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token1, "1.2");
+    EXPECT_EQ(line, buf + sizeof("1.2,") - 1);
+
+    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token2, "3.4");
+    EXPECT_EQ(line, buf + sizeof("1.2, 3.4,") - 1);
+
+    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_STREQ(token3, "5.6");
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+
+    const char* token4 = pfConsoleEngine::Tokenize(line, true);
+    EXPECT_EQ(token4, nullptr);
+    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+}

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleCore.cpp
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleCore.cpp
@@ -51,11 +51,11 @@ TEST(pfConsoleCore, TokenizeCommandNameSingle)
     char buf[] = "SampleCmd1";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token1, "SampleCmd1");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_EQ(token2, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -65,11 +65,11 @@ TEST(pfConsoleCore, TokenizeCommandNameSingleWhitespace)
     char buf[] = "  SampleCmd1   ";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token1, "SampleCmd1");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_EQ(token2, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -81,15 +81,15 @@ TEST(pfConsoleCore, TokenizeCommandNameDot)
     char buf[] = "App.Quit";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token1, "App");
     EXPECT_EQ(line, buf + sizeof("App.") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token2, "Quit");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_EQ(token3, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -99,15 +99,15 @@ TEST(pfConsoleCore, TokenizeCommandNameUnderscore)
     char buf[] = "App_Quit";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token1, "App");
     EXPECT_EQ(line, buf + sizeof("App_") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token2, "Quit");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_EQ(token3, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -117,15 +117,15 @@ TEST(pfConsoleCore, TokenizeCommandNameSpace)
     char buf[] = "App  Quit";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token1, "App");
     EXPECT_EQ(line, buf + sizeof("App  ") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token2, "Quit");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_EQ(token3, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -137,19 +137,19 @@ TEST(pfConsoleCore, TokenizeCommandNameDots)
     char buf[] = "Graphics.Renderer.SetYon";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token1, "Graphics");
     EXPECT_EQ(line, buf + sizeof("Graphics.") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token2, "Renderer");
     EXPECT_EQ(line, buf + sizeof("Graphics.Renderer.") - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token3, "SetYon");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token4 = pfConsoleEngine::Tokenize(line, false);
+    const char* token4 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_EQ(token4, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -159,19 +159,19 @@ TEST(pfConsoleCore, TokenizeCommandNameUnderscores)
     char buf[] = "Graphics_Renderer_SetYon";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token1, "Graphics");
     EXPECT_EQ(line, buf + sizeof("Graphics_") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token2, "Renderer");
     EXPECT_EQ(line, buf + sizeof("Graphics_Renderer_") - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token3, "SetYon");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token4 = pfConsoleEngine::Tokenize(line, false);
+    const char* token4 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_EQ(token4, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -181,19 +181,19 @@ TEST(pfConsoleCore, TokenizeCommandNameSpaces)
     char buf[] = "Graphics Renderer   SetYon";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, false);
+    const char* token1 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token1, "Graphics");
     EXPECT_EQ(line, buf + sizeof("Graphics ") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, false);
+    const char* token2 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token2, "Renderer");
     EXPECT_EQ(line, buf + sizeof("Graphics Renderer   ") - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, false);
+    const char* token3 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_STREQ(token3, "SetYon");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token4 = pfConsoleEngine::Tokenize(line, false);
+    const char* token4 = pfConsoleEngine::TokenizeCommandName(line);
     EXPECT_EQ(token4, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -205,11 +205,11 @@ TEST(pfConsoleCore, TokenizeArgumentsSingle)
     char buf[] = "arg";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "arg");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token2, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -219,11 +219,11 @@ TEST(pfConsoleCore, TokenizeArgumentsSingleWhitespace)
     char buf[] = "  arg   ";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "arg");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token2, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -233,11 +233,11 @@ TEST(pfConsoleCore, TokenizeArgumentsSingleUnderscore)
     char buf[] = "arg_test";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "arg_test");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token2, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -247,11 +247,11 @@ TEST(pfConsoleCore, TokenizeArgumentsSingleDoubleQuote)
     char buf[] = "\"(Default Device)\"";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "(Default Device)");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token2, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -261,11 +261,11 @@ TEST(pfConsoleCore, TokenizeArgumentsSingleSingleQuote)
     char buf[] = "'(Default Device)'";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "(Default Device)");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token2, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -275,7 +275,7 @@ TEST(pfConsoleCore, TokenizeArgumentsSingleDoubleQuoteUnclosed)
     char buf[] = "\"(Default Device)";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "\xff");
 }
 
@@ -284,7 +284,7 @@ TEST(pfConsoleCore, TokenizeArgumentsSingleSingleQuoteUnclosed)
     char buf[] = "'(Default Device)";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "\xff");
 }
 
@@ -295,15 +295,15 @@ TEST(pfConsoleCore, TokenizeArgumentsPair)
     char buf[] = "arg1 arg2";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "arg1");
     EXPECT_EQ(line, buf + sizeof("arg1 ") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token2, "arg2");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token3, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -313,15 +313,15 @@ TEST(pfConsoleCore, TokenizeArgumentsPairWhitespace)
     char buf[] = " arg1  arg2   ";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "arg1");
     EXPECT_EQ(line, buf + sizeof(" arg1  ") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token2, "arg2");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token3, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -331,15 +331,15 @@ TEST(pfConsoleCore, TokenizeArgumentsPairComma)
     char buf[] = "arg1, arg2";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "arg1");
     EXPECT_EQ(line, buf + sizeof("arg1,") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token2, "arg2");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token3, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -349,15 +349,15 @@ TEST(pfConsoleCore, TokenizeArgumentsPairMixedQuotes)
     char buf[] = "\"argument '1'\" 'argument \"2\"'";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "argument '1'");
     EXPECT_EQ(line, buf + sizeof("\"argument '1'\"") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token2, "argument \"2\"");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token3, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -369,19 +369,19 @@ TEST(pfConsoleCore, TokenizeArgumentsTriple)
     char buf[] = "1.2 3.4 5.6";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "1.2");
     EXPECT_EQ(line, buf + sizeof("1.2 ") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token2, "3.4");
     EXPECT_EQ(line, buf + sizeof("1.2 3.4 ") - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token3, "5.6");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token4 = pfConsoleEngine::Tokenize(line, true);
+    const char* token4 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token4, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
@@ -391,19 +391,19 @@ TEST(pfConsoleCore, TokenizeArgumentsTripleCommas)
     char buf[] = "1.2, 3.4, 5.6";
     char* line = buf;
 
-    const char* token1 = pfConsoleEngine::Tokenize(line, true);
+    const char* token1 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token1, "1.2");
     EXPECT_EQ(line, buf + sizeof("1.2,") - 1);
 
-    const char* token2 = pfConsoleEngine::Tokenize(line, true);
+    const char* token2 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token2, "3.4");
     EXPECT_EQ(line, buf + sizeof("1.2, 3.4,") - 1);
 
-    const char* token3 = pfConsoleEngine::Tokenize(line, true);
+    const char* token3 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_STREQ(token3, "5.6");
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    const char* token4 = pfConsoleEngine::Tokenize(line, true);
+    const char* token4 = pfConsoleEngine::TokenizeArguments(line);
     EXPECT_EQ(token4, nullptr);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleParser.cpp
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleParser.cpp
@@ -79,6 +79,9 @@ TEST(pfConsoleParser, ParseBaseCommand)
     pfConsoleParser parser2(string);
     auto cmd = parser2.ParseCommand();
     EXPECT_EQ(cmd, &conCmd_TestBaseCmd);
+    auto args = parser2.ParseArguments();
+    EXPECT_TRUE(args);
+    EXPECT_TRUE(args->empty());
 }
 
 TEST(pfConsoleParser, ParseBaseCommandArgs)
@@ -94,6 +97,11 @@ TEST(pfConsoleParser, ParseBaseCommandArgs)
     pfConsoleParser parser2(string);
     auto cmd = parser2.ParseCommand();
     EXPECT_EQ(cmd, &conCmd_TestBaseCmd);
+    auto args = parser2.ParseArguments();
+    EXPECT_TRUE(args);
+    EXPECT_EQ(args->size(), 2);
+    EXPECT_EQ((*args)[0], "arg1"_st);
+    EXPECT_EQ((*args)[1], "arg2"_st);
 }
 
 // Top-level group
@@ -128,6 +136,9 @@ TEST(pfConsoleParser, ParseSubCommand)
     pfConsoleParser parser2(string);
     auto cmd = parser2.ParseCommand();
     EXPECT_EQ(cmd, &conCmd_TestGroup_SubCmd);
+    auto args = parser2.ParseArguments();
+    EXPECT_TRUE(args);
+    EXPECT_TRUE(args->empty());
 }
 
 TEST(pfConsoleParser, ParseSubCommandArgs)
@@ -143,6 +154,11 @@ TEST(pfConsoleParser, ParseSubCommandArgs)
     pfConsoleParser parser2(string);
     auto cmd = parser2.ParseCommand();
     EXPECT_EQ(cmd, &conCmd_TestGroup_SubCmd);
+    auto args = parser2.ParseArguments();
+    EXPECT_TRUE(args);
+    EXPECT_EQ(args->size(), 2);
+    EXPECT_EQ((*args)[0], "arg1"_st);
+    EXPECT_EQ((*args)[1], "arg2"_st);
 }
 
 TEST(pfConsoleParser, ParseSubCommandSpace)
@@ -158,6 +174,9 @@ TEST(pfConsoleParser, ParseSubCommandSpace)
     pfConsoleParser parser2(string);
     auto cmd = parser2.ParseCommand();
     EXPECT_EQ(cmd, &conCmd_TestGroup_SubCmd);
+    auto args = parser2.ParseArguments();
+    EXPECT_TRUE(args);
+    EXPECT_TRUE(args->empty());
 }
 
 TEST(pfConsoleParser, ParseSubCommandSpaceArgs)
@@ -173,6 +192,11 @@ TEST(pfConsoleParser, ParseSubCommandSpaceArgs)
     pfConsoleParser parser2(string);
     auto cmd = parser2.ParseCommand();
     EXPECT_EQ(cmd, &conCmd_TestGroup_SubCmd);
+    auto args = parser2.ParseArguments();
+    EXPECT_TRUE(args);
+    EXPECT_EQ(args->size(), 2);
+    EXPECT_EQ((*args)[0], "arg1"_st);
+    EXPECT_EQ((*args)[1], "arg2"_st);
 }
 
 // Subgroup inside other group
@@ -222,6 +246,9 @@ TEST(pfConsoleParser, ParseSubSubCommand)
     pfConsoleParser parser2(string);
     auto cmd = parser2.ParseCommand();
     EXPECT_EQ(cmd, &conCmd_TestGroup_SubGroup_SubSubCmd);
+    auto args = parser2.ParseArguments();
+    EXPECT_TRUE(args);
+    EXPECT_TRUE(args->empty());
 }
 
 TEST(pfConsoleParser, ParseSubSubCommandArgs)
@@ -237,6 +264,11 @@ TEST(pfConsoleParser, ParseSubSubCommandArgs)
     pfConsoleParser parser2(string);
     auto cmd = parser2.ParseCommand();
     EXPECT_EQ(cmd, &conCmd_TestGroup_SubGroup_SubSubCmd);
+    auto args = parser2.ParseArguments();
+    EXPECT_TRUE(args);
+    EXPECT_EQ(args->size(), 2);
+    EXPECT_EQ((*args)[0], "arg1"_st);
+    EXPECT_EQ((*args)[1], "arg2"_st);
 }
 
 TEST(pfConsoleParser, ParseSubSubCommandSpaces)
@@ -252,6 +284,9 @@ TEST(pfConsoleParser, ParseSubSubCommandSpaces)
     pfConsoleParser parser2(string);
     auto cmd = parser2.ParseCommand();
     EXPECT_EQ(cmd, &conCmd_TestGroup_SubGroup_SubSubCmd);
+    auto args = parser2.ParseArguments();
+    EXPECT_TRUE(args);
+    EXPECT_TRUE(args->empty());
 }
 
 TEST(pfConsoleParser, ParseSubSubCommandSpacesArgs)
@@ -267,4 +302,9 @@ TEST(pfConsoleParser, ParseSubSubCommandSpacesArgs)
     pfConsoleParser parser2(string);
     auto cmd = parser2.ParseCommand();
     EXPECT_EQ(cmd, &conCmd_TestGroup_SubGroup_SubSubCmd);
+    auto args = parser2.ParseArguments();
+    EXPECT_TRUE(args);
+    EXPECT_EQ(args->size(), 2);
+    EXPECT_EQ((*args)[0], "arg1"_st);
+    EXPECT_EQ((*args)[1], "arg2"_st);
 }

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleParser.cpp
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleParser.cpp
@@ -75,6 +75,10 @@ TEST(pfConsoleParser, ParseBaseCommand)
     EXPECT_EQ(group, pfConsoleCmdGroup::GetBaseGroup());
     EXPECT_EQ(token, "TestBaseCmd"_st);
     EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, &conCmd_TestBaseCmd);
 }
 
 TEST(pfConsoleParser, ParseBaseCommandArgs)
@@ -86,6 +90,10 @@ TEST(pfConsoleParser, ParseBaseCommandArgs)
     EXPECT_EQ(group, pfConsoleCmdGroup::GetBaseGroup());
     EXPECT_EQ(token, "TestBaseCmd"_st);
     EXPECT_EQ(parser.fTokenizer.fPos, string.begin() + sizeof("TestBaseCmd ") - 1);
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, &conCmd_TestBaseCmd);
 }
 
 // Top-level group
@@ -99,6 +107,10 @@ TEST(pfConsoleParser, ParseBaseGroup)
     EXPECT_EQ(group, &conGroup_TestGroup);
     EXPECT_FALSE(token);
     EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, nullptr);
 }
 
 // Command inside top-level group
@@ -112,6 +124,10 @@ TEST(pfConsoleParser, ParseSubCommand)
     EXPECT_EQ(group, &conGroup_TestGroup);
     EXPECT_EQ(token, "SubCmd"_st);
     EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, &conCmd_TestGroup_SubCmd);
 }
 
 TEST(pfConsoleParser, ParseSubCommandArgs)
@@ -123,6 +139,10 @@ TEST(pfConsoleParser, ParseSubCommandArgs)
     EXPECT_EQ(group, &conGroup_TestGroup);
     EXPECT_EQ(token, "SubCmd"_st);
     EXPECT_EQ(parser.fTokenizer.fPos, string.begin() + sizeof("TestGroup.SubCmd ") - 1);
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, &conCmd_TestGroup_SubCmd);
 }
 
 TEST(pfConsoleParser, ParseSubCommandSpace)
@@ -134,6 +154,10 @@ TEST(pfConsoleParser, ParseSubCommandSpace)
     EXPECT_EQ(group, &conGroup_TestGroup);
     EXPECT_EQ(token, "SubCmd"_st);
     EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, &conCmd_TestGroup_SubCmd);
 }
 
 TEST(pfConsoleParser, ParseSubCommandSpaceArgs)
@@ -145,6 +169,10 @@ TEST(pfConsoleParser, ParseSubCommandSpaceArgs)
     EXPECT_EQ(group, &conGroup_TestGroup);
     EXPECT_EQ(token, "SubCmd"_st);
     EXPECT_EQ(parser.fTokenizer.fPos, string.begin() + sizeof("TestGroup SubCmd ") - 1);
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, &conCmd_TestGroup_SubCmd);
 }
 
 // Subgroup inside other group
@@ -158,6 +186,10 @@ TEST(pfConsoleParser, ParseSubGroup)
     EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
     EXPECT_FALSE(token);
     EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, nullptr);
 }
 
 TEST(pfConsoleParser, ParseSubGroupSpace)
@@ -169,6 +201,10 @@ TEST(pfConsoleParser, ParseSubGroupSpace)
     EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
     EXPECT_FALSE(token);
     EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, nullptr);
 }
 
 // Command inside subgroup
@@ -182,6 +218,10 @@ TEST(pfConsoleParser, ParseSubSubCommand)
     EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
     EXPECT_EQ(token, "SubSubCmd"_st);
     EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, &conCmd_TestGroup_SubGroup_SubSubCmd);
 }
 
 TEST(pfConsoleParser, ParseSubSubCommandArgs)
@@ -193,6 +233,10 @@ TEST(pfConsoleParser, ParseSubSubCommandArgs)
     EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
     EXPECT_EQ(token, "SubSubCmd"_st);
     EXPECT_EQ(parser.fTokenizer.fPos, string.begin() + sizeof("TestGroup.SubGroup.SubSubCmd ") - 1);
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, &conCmd_TestGroup_SubGroup_SubSubCmd);
 }
 
 TEST(pfConsoleParser, ParseSubSubCommandSpaces)
@@ -204,6 +248,10 @@ TEST(pfConsoleParser, ParseSubSubCommandSpaces)
     EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
     EXPECT_EQ(token, "SubSubCmd"_st);
     EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, &conCmd_TestGroup_SubGroup_SubSubCmd);
 }
 
 TEST(pfConsoleParser, ParseSubSubCommandSpacesArgs)
@@ -215,4 +263,8 @@ TEST(pfConsoleParser, ParseSubSubCommandSpacesArgs)
     EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
     EXPECT_EQ(token, "SubSubCmd"_st);
     EXPECT_EQ(parser.fTokenizer.fPos, string.begin() + sizeof("TestGroup SubGroup SubSubCmd ") - 1);
+
+    pfConsoleParser parser2(string);
+    auto cmd = parser2.ParseCommand();
+    EXPECT_EQ(cmd, &conCmd_TestGroup_SubGroup_SubSubCmd);
 }

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleParser.cpp
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleParser.cpp
@@ -1,0 +1,218 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <gtest/gtest.h>
+#include <string_theory/string>
+
+#include "pfConsoleCore/pfConsoleCmd.h"
+#include "pfConsoleCore/pfConsoleParser.h"
+
+using namespace ST::literals;
+
+// Define a few test groups and commands so that we don't have to pull in
+// all the real console commands just to test the parsing.
+
+PF_CONSOLE_BASE_CMD(TestBaseCmd, "", "")
+{}
+
+PF_CONSOLE_GROUP(TestGroup)
+
+PF_CONSOLE_CMD(TestGroup, SubCmd, "", "")
+{}
+
+PF_CONSOLE_SUBGROUP(TestGroup, SubGroup)
+
+PF_CONSOLE_CMD(TestGroup_SubGroup, SubSubCmd, "", "")
+{}
+
+// Top-level command outside of any group
+
+TEST(pfConsoleParser, ParseBaseCommand)
+{
+    ST::string string = "TestBaseCmd"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, pfConsoleCmdGroup::GetBaseGroup());
+    EXPECT_EQ(token, "TestBaseCmd"_st);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+}
+
+TEST(pfConsoleParser, ParseBaseCommandArgs)
+{
+    ST::string string = "TestBaseCmd arg1 arg2"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, pfConsoleCmdGroup::GetBaseGroup());
+    EXPECT_EQ(token, "TestBaseCmd"_st);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.begin() + sizeof("TestBaseCmd ") - 1);
+}
+
+// Top-level group
+
+TEST(pfConsoleParser, ParseBaseGroup)
+{
+    ST::string string = "TestGroup"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup);
+    EXPECT_FALSE(token);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+}
+
+// Command inside top-level group
+
+TEST(pfConsoleParser, ParseSubCommand)
+{
+    ST::string string = "TestGroup.SubCmd"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup);
+    EXPECT_EQ(token, "SubCmd"_st);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+}
+
+TEST(pfConsoleParser, ParseSubCommandArgs)
+{
+    ST::string string = "TestGroup.SubCmd arg1 arg2"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup);
+    EXPECT_EQ(token, "SubCmd"_st);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.begin() + sizeof("TestGroup.SubCmd ") - 1);
+}
+
+TEST(pfConsoleParser, ParseSubCommandSpace)
+{
+    ST::string string = "TestGroup SubCmd"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup);
+    EXPECT_EQ(token, "SubCmd"_st);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+}
+
+TEST(pfConsoleParser, ParseSubCommandSpaceArgs)
+{
+    ST::string string = "TestGroup SubCmd arg1 arg2"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup);
+    EXPECT_EQ(token, "SubCmd"_st);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.begin() + sizeof("TestGroup SubCmd ") - 1);
+}
+
+// Subgroup inside other group
+
+TEST(pfConsoleParser, ParseSubGroup)
+{
+    ST::string string = "TestGroup.SubGroup"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
+    EXPECT_FALSE(token);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+}
+
+TEST(pfConsoleParser, ParseSubGroupSpace)
+{
+    ST::string string = "TestGroup SubGroup"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
+    EXPECT_FALSE(token);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+}
+
+// Command inside subgroup
+
+TEST(pfConsoleParser, ParseSubSubCommand)
+{
+    ST::string string = "TestGroup.SubGroup.SubSubCmd"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
+    EXPECT_EQ(token, "SubSubCmd"_st);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+}
+
+TEST(pfConsoleParser, ParseSubSubCommandArgs)
+{
+    ST::string string = "TestGroup.SubGroup.SubSubCmd arg1 arg2"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
+    EXPECT_EQ(token, "SubSubCmd"_st);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.begin() + sizeof("TestGroup.SubGroup.SubSubCmd ") - 1);
+}
+
+TEST(pfConsoleParser, ParseSubSubCommandSpaces)
+{
+    ST::string string = "TestGroup SubGroup SubSubCmd"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
+    EXPECT_EQ(token, "SubSubCmd"_st);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.end());
+}
+
+TEST(pfConsoleParser, ParseSubSubCommandSpacesArgs)
+{
+    ST::string string = "TestGroup SubGroup SubSubCmd arg1 arg2"_st;
+    pfConsoleParser parser(string);
+
+    auto [group, token] = parser.ParseGroupAndName();
+    EXPECT_EQ(group, &conGroup_TestGroup_SubGroup);
+    EXPECT_EQ(token, "SubSubCmd"_st);
+    EXPECT_EQ(parser.fTokenizer.fPos, string.begin() + sizeof("TestGroup SubGroup SubSubCmd ") - 1);
+}

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleTokenizer.cpp
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleTokenizer.cpp
@@ -51,245 +51,245 @@ using namespace ST::literals;
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameSingle)
 {
-    const char buf[] = "SampleCmd1";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "SampleCmd1"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "SampleCmd1"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token2 = tokenizer.NextNamePart();
     EXPECT_FALSE(token2);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameSingleWhitespace)
 {
-    const char buf[] = "  SampleCmd1   ";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "  SampleCmd1   "_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "SampleCmd1"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token2 = tokenizer.NextNamePart();
     EXPECT_FALSE(token2);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 // Tokenize command name, 2 tokens
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameDot)
 {
-    const char buf[] = "App.Quit";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "App.Quit"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "App"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("App.") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("App.") - 1);
 
     auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Quit"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token3 = tokenizer.NextNamePart();
     EXPECT_FALSE(token3);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameUnderscore)
 {
-    const char buf[] = "App_Quit";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "App_Quit"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "App"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("App_") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("App_") - 1);
 
     auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Quit"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token3 = tokenizer.NextNamePart();
     EXPECT_FALSE(token3);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameSpace)
 {
-    const char buf[] = "App  Quit";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "App  Quit"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "App"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("App  ") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("App  ") - 1);
 
     auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Quit"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token3 = tokenizer.NextNamePart();
     EXPECT_FALSE(token3);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 // Tokenize command name, 3 tokens
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameDots)
 {
-    const char buf[] = "Graphics.Renderer.SetYon";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "Graphics.Renderer.SetYon"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "Graphics"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics.") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("Graphics.") - 1);
 
     auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Renderer"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics.Renderer.") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("Graphics.Renderer.") - 1);
 
     auto token3 = tokenizer.NextNamePart();
     EXPECT_EQ(token3, "SetYon"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token4 = tokenizer.NextNamePart();
     EXPECT_FALSE(token4);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameUnderscores)
 {
-    const char buf[] = "Graphics_Renderer_SetYon";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "Graphics_Renderer_SetYon"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "Graphics"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics_") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("Graphics_") - 1);
 
     auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Renderer"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics_Renderer_") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("Graphics_Renderer_") - 1);
 
     auto token3 = tokenizer.NextNamePart();
     EXPECT_EQ(token3, "SetYon"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token4 = tokenizer.NextNamePart();
     EXPECT_FALSE(token4);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameSpaces)
 {
-    const char buf[] = "Graphics Renderer   SetYon";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "Graphics Renderer   SetYon"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "Graphics"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics ") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("Graphics ") - 1);
 
     auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Renderer"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics Renderer   ") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("Graphics Renderer   ") - 1);
 
     auto token3 = tokenizer.NextNamePart();
     EXPECT_EQ(token3, "SetYon"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token4 = tokenizer.NextNamePart();
     EXPECT_FALSE(token4);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 // Tokenize arguments, 1 token
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingle)
 {
-    const char buf[] = "arg";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "arg"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_FALSE(token2);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleWhitespace)
 {
-    const char buf[] = "  arg   ";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "  arg   "_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_FALSE(token2);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleUnderscore)
 {
-    const char buf[] = "arg_test";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "arg_test"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg_test"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_FALSE(token2);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleDoubleQuote)
 {
-    const char buf[] = "\"(Default Device)\"";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "\"(Default Device)\""_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "(Default Device)"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_FALSE(token2);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleSingleQuote)
 {
-    const char buf[] = "'(Default Device)'";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "'(Default Device)'"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "(Default Device)"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_FALSE(token2);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleDoubleQuoteUnclosed)
 {
-    const char buf[] = "\"(Default Device)";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "\"(Default Device)"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_FALSE(token1);
@@ -298,8 +298,8 @@ TEST(pfConsoleTokenizer, TokenizeArgumentsSingleDoubleQuoteUnclosed)
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleSingleQuoteUnclosed)
 {
-    const char buf[] = "'(Default Device)";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "'(Default Device)"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_FALSE(token1);
@@ -310,147 +310,147 @@ TEST(pfConsoleTokenizer, TokenizeArgumentsSingleSingleQuoteUnclosed)
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsPair)
 {
-    const char buf[] = "arg1 arg2";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "arg1 arg2"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg1"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("arg1 ") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("arg1 ") - 1);
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "arg2"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token3 = tokenizer.NextArgument();
     EXPECT_FALSE(token3);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsPairWhitespace)
 {
-    const char buf[] = " arg1  arg2   ";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = " arg1  arg2   "_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg1"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(" arg1  ") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof(" arg1  ") - 1);
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "arg2"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token3 = tokenizer.NextArgument();
     EXPECT_FALSE(token3);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsPairComma)
 {
-    const char buf[] = "arg1, arg2";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "arg1, arg2"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg1"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("arg1,") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("arg1,") - 1);
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "arg2"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token3 = tokenizer.NextArgument();
     EXPECT_FALSE(token3);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsPairMixedQuotes)
 {
-    const char buf[] = "\"argument '1'\" 'argument \"2\"'";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "\"argument '1'\" 'argument \"2\"'"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "argument '1'"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("\"argument '1'\"") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("\"argument '1'\"") - 1);
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "argument \"2\""_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token3 = tokenizer.NextArgument();
     EXPECT_FALSE(token3);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 // Tokenize arguments, 3 tokens
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsTriple)
 {
-    const char buf[] = "1.2 3.4 5.6";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "1.2 3.4 5.6"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "1.2"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("1.2 ") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("1.2 ") - 1);
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "3.4"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("1.2 3.4 ") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("1.2 3.4 ") - 1);
 
     auto token3 = tokenizer.NextArgument();
     EXPECT_EQ(token3, "5.6"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token4 = tokenizer.NextArgument();
     EXPECT_FALSE(token4);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsTripleCommas)
 {
-    const char buf[] = "1.2, 3.4, 5.6";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "1.2, 3.4, 5.6"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "1.2"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("1.2,") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("1.2,") - 1);
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "3.4"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("1.2, 3.4,") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("1.2, 3.4,") - 1);
 
     auto token3 = tokenizer.NextArgument();
     EXPECT_EQ(token3, "5.6"_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token4 = tokenizer.NextArgument();
     EXPECT_FALSE(token4);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsTripleEmptyQuotes)
 {
-    const char buf[] = "'' \"\" ''";
-    pfConsoleTokenizer tokenizer(buf);
+    ST::string string = "'' \"\" ''"_st;
+    pfConsoleTokenizer tokenizer(string);
 
     auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, ""_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("''") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("''") - 1);
 
     auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, ""_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof("'' \"\"") - 1);
+    EXPECT_EQ(tokenizer.fPos, string.begin() + sizeof("'' \"\"") - 1);
 
     auto token3 = tokenizer.NextArgument();
     EXPECT_EQ(token3, ""_st);
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 
     auto token4 = tokenizer.NextArgument();
     EXPECT_FALSE(token4);
     EXPECT_TRUE(tokenizer.fErrorMsg.empty());
-    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, string.end());
 }

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleTokenizer.cpp
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleTokenizer.cpp
@@ -52,29 +52,31 @@ using namespace ST::literals;
 TEST(pfConsoleTokenizer, TokenizeCommandNameSingle)
 {
     const char buf[] = "SampleCmd1";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "SampleCmd1"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token2 = tokenizer.NextNamePart();
     EXPECT_FALSE(token2);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameSingleWhitespace)
 {
     const char buf[] = "  SampleCmd1   ";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "SampleCmd1"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token2 = tokenizer.NextNamePart();
     EXPECT_FALSE(token2);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 // Tokenize command name, 2 tokens
@@ -82,55 +84,58 @@ TEST(pfConsoleTokenizer, TokenizeCommandNameSingleWhitespace)
 TEST(pfConsoleTokenizer, TokenizeCommandNameDot)
 {
     const char buf[] = "App.Quit";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "App"_st);
-    EXPECT_EQ(line, buf + sizeof("App.") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("App.") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Quit"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token3 = tokenizer.NextNamePart();
     EXPECT_FALSE(token3);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameUnderscore)
 {
     const char buf[] = "App_Quit";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "App"_st);
-    EXPECT_EQ(line, buf + sizeof("App_") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("App_") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Quit"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token3 = tokenizer.NextNamePart();
     EXPECT_FALSE(token3);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameSpace)
 {
     const char buf[] = "App  Quit";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "App"_st);
-    EXPECT_EQ(line, buf + sizeof("App  ") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("App  ") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Quit"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token3 = tokenizer.NextNamePart();
     EXPECT_FALSE(token3);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 // Tokenize command name, 3 tokens
@@ -138,67 +143,70 @@ TEST(pfConsoleTokenizer, TokenizeCommandNameSpace)
 TEST(pfConsoleTokenizer, TokenizeCommandNameDots)
 {
     const char buf[] = "Graphics.Renderer.SetYon";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "Graphics"_st);
-    EXPECT_EQ(line, buf + sizeof("Graphics.") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics.") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Renderer"_st);
-    EXPECT_EQ(line, buf + sizeof("Graphics.Renderer.") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics.Renderer.") - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token3 = tokenizer.NextNamePart();
     EXPECT_EQ(token3, "SetYon"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token4 = tokenizer.NextNamePart();
     EXPECT_FALSE(token4);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameUnderscores)
 {
     const char buf[] = "Graphics_Renderer_SetYon";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "Graphics"_st);
-    EXPECT_EQ(line, buf + sizeof("Graphics_") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics_") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Renderer"_st);
-    EXPECT_EQ(line, buf + sizeof("Graphics_Renderer_") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics_Renderer_") - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token3 = tokenizer.NextNamePart();
     EXPECT_EQ(token3, "SetYon"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token4 = tokenizer.NextNamePart();
     EXPECT_FALSE(token4);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeCommandNameSpaces)
 {
     const char buf[] = "Graphics Renderer   SetYon";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token1 = tokenizer.NextNamePart();
     EXPECT_EQ(token1, "Graphics"_st);
-    EXPECT_EQ(line, buf + sizeof("Graphics ") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics ") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token2 = tokenizer.NextNamePart();
     EXPECT_EQ(token2, "Renderer"_st);
-    EXPECT_EQ(line, buf + sizeof("Graphics Renderer   ") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("Graphics Renderer   ") - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token3 = tokenizer.NextNamePart();
     EXPECT_EQ(token3, "SetYon"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleTokenizer::TokenizeCommandName(line);
+    auto token4 = tokenizer.NextNamePart();
     EXPECT_FALSE(token4);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 // Tokenize arguments, 1 token
@@ -206,89 +214,96 @@ TEST(pfConsoleTokenizer, TokenizeCommandNameSpaces)
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingle)
 {
     const char buf[] = "arg";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_FALSE(token2);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleWhitespace)
 {
     const char buf[] = "  arg   ";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_FALSE(token2);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleUnderscore)
 {
     const char buf[] = "arg_test";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg_test"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_FALSE(token2);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleDoubleQuote)
 {
     const char buf[] = "\"(Default Device)\"";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "(Default Device)"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_FALSE(token2);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleSingleQuote)
 {
     const char buf[] = "'(Default Device)'";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "(Default Device)"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_FALSE(token2);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleDoubleQuoteUnclosed)
 {
     const char buf[] = "\"(Default Device)";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
-    EXPECT_EQ(token1, "\xff"_st);
+    auto token1 = tokenizer.NextArgument();
+    EXPECT_FALSE(token1);
+    EXPECT_FALSE(tokenizer.fErrorMsg.empty());
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsSingleSingleQuoteUnclosed)
 {
     const char buf[] = "'(Default Device)";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
-    EXPECT_EQ(token1, "\xff"_st);
+    auto token1 = tokenizer.NextArgument();
+    EXPECT_FALSE(token1);
+    EXPECT_FALSE(tokenizer.fErrorMsg.empty());
 }
 
 // Tokenize arguments, 2 tokens
@@ -296,73 +311,77 @@ TEST(pfConsoleTokenizer, TokenizeArgumentsSingleSingleQuoteUnclosed)
 TEST(pfConsoleTokenizer, TokenizeArgumentsPair)
 {
     const char buf[] = "arg1 arg2";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg1"_st);
-    EXPECT_EQ(line, buf + sizeof("arg1 ") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("arg1 ") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "arg2"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token3 = tokenizer.NextArgument();
     EXPECT_FALSE(token3);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsPairWhitespace)
 {
     const char buf[] = " arg1  arg2   ";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg1"_st);
-    EXPECT_EQ(line, buf + sizeof(" arg1  ") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(" arg1  ") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "arg2"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token3 = tokenizer.NextArgument();
     EXPECT_FALSE(token3);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsPairComma)
 {
     const char buf[] = "arg1, arg2";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "arg1"_st);
-    EXPECT_EQ(line, buf + sizeof("arg1,") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("arg1,") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "arg2"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token3 = tokenizer.NextArgument();
     EXPECT_FALSE(token3);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsPairMixedQuotes)
 {
     const char buf[] = "\"argument '1'\" 'argument \"2\"'";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "argument '1'"_st);
-    EXPECT_EQ(line, buf + sizeof("\"argument '1'\"") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("\"argument '1'\"") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "argument \"2\""_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token3 = tokenizer.NextArgument();
     EXPECT_FALSE(token3);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 // Tokenize arguments, 3 tokens
@@ -370,65 +389,68 @@ TEST(pfConsoleTokenizer, TokenizeArgumentsPairMixedQuotes)
 TEST(pfConsoleTokenizer, TokenizeArgumentsTriple)
 {
     const char buf[] = "1.2 3.4 5.6";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "1.2"_st);
-    EXPECT_EQ(line, buf + sizeof("1.2 ") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("1.2 ") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "3.4"_st);
-    EXPECT_EQ(line, buf + sizeof("1.2 3.4 ") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("1.2 3.4 ") - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token3 = tokenizer.NextArgument();
     EXPECT_EQ(token3, "5.6"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token4 = tokenizer.NextArgument();
     EXPECT_FALSE(token4);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsTripleCommas)
 {
     const char buf[] = "1.2, 3.4, 5.6";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, "1.2"_st);
-    EXPECT_EQ(line, buf + sizeof("1.2,") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("1.2,") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, "3.4"_st);
-    EXPECT_EQ(line, buf + sizeof("1.2, 3.4,") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("1.2, 3.4,") - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token3 = tokenizer.NextArgument();
     EXPECT_EQ(token3, "5.6"_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token4 = tokenizer.NextArgument();
     EXPECT_FALSE(token4);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }
 
 TEST(pfConsoleTokenizer, TokenizeArgumentsTripleEmptyQuotes)
 {
     const char buf[] = "'' \"\" ''";
-    const char* line = buf;
+    pfConsoleTokenizer tokenizer(buf);
 
-    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token1 = tokenizer.NextArgument();
     EXPECT_EQ(token1, ""_st);
-    EXPECT_EQ(line, buf + sizeof("''") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("''") - 1);
 
-    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token2 = tokenizer.NextArgument();
     EXPECT_EQ(token2, ""_st);
-    EXPECT_EQ(line, buf + sizeof("'' \"\"") - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof("'' \"\"") - 1);
 
-    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token3 = tokenizer.NextArgument();
     EXPECT_EQ(token3, ""_st);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleTokenizer::TokenizeArguments(line);
+    auto token4 = tokenizer.NextArgument();
     EXPECT_FALSE(token4);
-    EXPECT_EQ(line, buf + sizeof(buf) - 1);
+    EXPECT_TRUE(tokenizer.fErrorMsg.empty());
+    EXPECT_EQ(tokenizer.fPos, buf + sizeof(buf) - 1);
 }

--- a/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleTokenizer.cpp
+++ b/Sources/Tests/FeatureTests/pfConsoleCoreTest/test_pfConsoleTokenizer.cpp
@@ -41,393 +41,394 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <gtest/gtest.h>
+#include <string_theory/string>
 
-#include "pfConsoleCore/pfConsoleEngine.h"
+#include "pfConsoleCore/pfConsoleParser.h"
 
 using namespace ST::literals;
 
 // Tokenize command name, 1 token
 
-TEST(pfConsoleCore, TokenizeCommandNameSingle)
+TEST(pfConsoleTokenizer, TokenizeCommandNameSingle)
 {
     const char buf[] = "SampleCmd1";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token1, "SampleCmd1"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeCommandNameSingleWhitespace)
+TEST(pfConsoleTokenizer, TokenizeCommandNameSingleWhitespace)
 {
     const char buf[] = "  SampleCmd1   ";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token1, "SampleCmd1"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 // Tokenize command name, 2 tokens
 
-TEST(pfConsoleCore, TokenizeCommandNameDot)
+TEST(pfConsoleTokenizer, TokenizeCommandNameDot)
 {
     const char buf[] = "App.Quit";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token1, "App"_st);
     EXPECT_EQ(line, buf + sizeof("App.") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token2, "Quit"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeCommandNameUnderscore)
+TEST(pfConsoleTokenizer, TokenizeCommandNameUnderscore)
 {
     const char buf[] = "App_Quit";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token1, "App"_st);
     EXPECT_EQ(line, buf + sizeof("App_") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token2, "Quit"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeCommandNameSpace)
+TEST(pfConsoleTokenizer, TokenizeCommandNameSpace)
 {
     const char buf[] = "App  Quit";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token1, "App"_st);
     EXPECT_EQ(line, buf + sizeof("App  ") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token2, "Quit"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 // Tokenize command name, 3 tokens
 
-TEST(pfConsoleCore, TokenizeCommandNameDots)
+TEST(pfConsoleTokenizer, TokenizeCommandNameDots)
 {
     const char buf[] = "Graphics.Renderer.SetYon";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token1, "Graphics"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics.") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token2, "Renderer"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics.Renderer.") - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token3, "SetYon"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token4 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeCommandNameUnderscores)
+TEST(pfConsoleTokenizer, TokenizeCommandNameUnderscores)
 {
     const char buf[] = "Graphics_Renderer_SetYon";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token1, "Graphics"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics_") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token2, "Renderer"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics_Renderer_") - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token3, "SetYon"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token4 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeCommandNameSpaces)
+TEST(pfConsoleTokenizer, TokenizeCommandNameSpaces)
 {
     const char buf[] = "Graphics Renderer   SetYon";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token1 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token1, "Graphics"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics ") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token2 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token2, "Renderer"_st);
     EXPECT_EQ(line, buf + sizeof("Graphics Renderer   ") - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token3 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_EQ(token3, "SetYon"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleEngine::TokenizeCommandName(line);
+    auto token4 = pfConsoleTokenizer::TokenizeCommandName(line);
     EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 // Tokenize arguments, 1 token
 
-TEST(pfConsoleCore, TokenizeArgumentsSingle)
+TEST(pfConsoleTokenizer, TokenizeArgumentsSingle)
 {
     const char buf[] = "arg";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "arg"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsSingleWhitespace)
+TEST(pfConsoleTokenizer, TokenizeArgumentsSingleWhitespace)
 {
     const char buf[] = "  arg   ";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "arg"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsSingleUnderscore)
+TEST(pfConsoleTokenizer, TokenizeArgumentsSingleUnderscore)
 {
     const char buf[] = "arg_test";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "arg_test"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsSingleDoubleQuote)
+TEST(pfConsoleTokenizer, TokenizeArgumentsSingleDoubleQuote)
 {
     const char buf[] = "\"(Default Device)\"";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "(Default Device)"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsSingleSingleQuote)
+TEST(pfConsoleTokenizer, TokenizeArgumentsSingleSingleQuote)
 {
     const char buf[] = "'(Default Device)'";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "(Default Device)"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token2);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsSingleDoubleQuoteUnclosed)
+TEST(pfConsoleTokenizer, TokenizeArgumentsSingleDoubleQuoteUnclosed)
 {
     const char buf[] = "\"(Default Device)";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "\xff"_st);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsSingleSingleQuoteUnclosed)
+TEST(pfConsoleTokenizer, TokenizeArgumentsSingleSingleQuoteUnclosed)
 {
     const char buf[] = "'(Default Device)";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "\xff"_st);
 }
 
 // Tokenize arguments, 2 tokens
 
-TEST(pfConsoleCore, TokenizeArgumentsPair)
+TEST(pfConsoleTokenizer, TokenizeArgumentsPair)
 {
     const char buf[] = "arg1 arg2";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "arg1"_st);
     EXPECT_EQ(line, buf + sizeof("arg1 ") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token2, "arg2"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsPairWhitespace)
+TEST(pfConsoleTokenizer, TokenizeArgumentsPairWhitespace)
 {
     const char buf[] = " arg1  arg2   ";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "arg1"_st);
     EXPECT_EQ(line, buf + sizeof(" arg1  ") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token2, "arg2"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsPairComma)
+TEST(pfConsoleTokenizer, TokenizeArgumentsPairComma)
 {
     const char buf[] = "arg1, arg2";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "arg1"_st);
     EXPECT_EQ(line, buf + sizeof("arg1,") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token2, "arg2"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsPairMixedQuotes)
+TEST(pfConsoleTokenizer, TokenizeArgumentsPairMixedQuotes)
 {
     const char buf[] = "\"argument '1'\" 'argument \"2\"'";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "argument '1'"_st);
     EXPECT_EQ(line, buf + sizeof("\"argument '1'\"") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token2, "argument \"2\""_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token3);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
 // Tokenize arguments, 3 tokens
 
-TEST(pfConsoleCore, TokenizeArgumentsTriple)
+TEST(pfConsoleTokenizer, TokenizeArgumentsTriple)
 {
     const char buf[] = "1.2 3.4 5.6";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "1.2"_st);
     EXPECT_EQ(line, buf + sizeof("1.2 ") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token2, "3.4"_st);
     EXPECT_EQ(line, buf + sizeof("1.2 3.4 ") - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token3, "5.6"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleEngine::TokenizeArguments(line);
+    auto token4 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsTripleCommas)
+TEST(pfConsoleTokenizer, TokenizeArgumentsTripleCommas)
 {
     const char buf[] = "1.2, 3.4, 5.6";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, "1.2"_st);
     EXPECT_EQ(line, buf + sizeof("1.2,") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token2, "3.4"_st);
     EXPECT_EQ(line, buf + sizeof("1.2, 3.4,") - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token3, "5.6"_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleEngine::TokenizeArguments(line);
+    auto token4 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }
 
-TEST(pfConsoleCore, TokenizeArgumentsTripleEmptyQuotes)
+TEST(pfConsoleTokenizer, TokenizeArgumentsTripleEmptyQuotes)
 {
     const char buf[] = "'' \"\" ''";
     const char* line = buf;
 
-    auto token1 = pfConsoleEngine::TokenizeArguments(line);
+    auto token1 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token1, ""_st);
     EXPECT_EQ(line, buf + sizeof("''") - 1);
 
-    auto token2 = pfConsoleEngine::TokenizeArguments(line);
+    auto token2 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token2, ""_st);
     EXPECT_EQ(line, buf + sizeof("'' \"\"") - 1);
 
-    auto token3 = pfConsoleEngine::TokenizeArguments(line);
+    auto token3 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_EQ(token3, ""_st);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 
-    auto token4 = pfConsoleEngine::TokenizeArguments(line);
+    auto token4 = pfConsoleTokenizer::TokenizeArguments(line);
     EXPECT_FALSE(token4);
     EXPECT_EQ(line, buf + sizeof(buf) - 1);
 }


### PR DESCRIPTION
Converts the very "old C-like" console command parsing code into its own class that has a bit more structure and uses modern C++ data types. Also, unit tests!

Aside from cleaning up the code, my motivation here is to allow parsing console commands *without* actually executing them. This would be especially useful for parsing .ini files - thinking of server.ini or cases like in #1244.

Suggestions for improving the parsing API are welcome. It has to be a bit complex unfortunately, to support situations where the input should only be partially parsed (e. g. tab completion), and because of the wacky command name syntax where parsing depends on which commands are defined...