### PR TITLE
Fix file extension case on plCrashHandler icon

### DIFF
--- a/Sources/Plasma/Apps/plCrashHandler/plCrashHandler.rc
+++ b/Sources/Plasma/Apps/plCrashHandler/plCrashHandler.rc
@@ -102,7 +102,7 @@ IDB_BITMAP              BITMAP                  "banner.bmp"
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-IDI_ICON1               ICON                    "Dirt.ICO"
+IDI_ICON1               ICON                    "Dirt.ico"
 
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This was causing issues cross-compiling on Linux with clang-cl.