### PR TITLE
Fix starting video failing to play

### DIFF
--- a/Scripts/Python/xOpeningSequence.py
+++ b/Scripts/Python/xOpeningSequence.py
@@ -446,7 +446,7 @@ class xOpeningSequence(ptModifier):
             ageSDL = PtGetAgeSDL()
             if StartInCleft():
                 gMovieFilePath = kAtrusIntroMovie
-            elif ageSDL["psnlIntroMovie"][0]:
+            elif ageSDL["psnlIntroMovie"] and ageSDL["psnlIntroMovie"][0]:
                 gMovieFilePath = ageSDL["psnlIntroMovie"][0]
             else:
                 gMovieFilePath = kReltoIntroMovie

--- a/Scripts/Python/xOpeningSequence.py
+++ b/Scripts/Python/xOpeningSequence.py
@@ -446,7 +446,7 @@ class xOpeningSequence(ptModifier):
             ageSDL = PtGetAgeSDL()
             if StartInCleft():
                 gMovieFilePath = kAtrusIntroMovie
-            elif ageSDL["psnlIntroMovie"] and ageSDL["psnlIntroMovie"][0]:
+            elif any(ageSDL["psnlIntroMovie"]):
                 gMovieFilePath = ageSDL["psnlIntroMovie"][0]
             else:
                 gMovieFilePath = kReltoIntroMovie


### PR DESCRIPTION
The starting video will fail to play with the default SDL due to "IndexError: tuple index out of range"
Adding this check catches that before we get an error.