### PR TITLE
Adding missing rpath to Python on Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,6 @@ jobs:
           brew install \
               autoconf \
               automake \
-              cairo \
               libtool \
               nasm \
               qt@5

--- a/Scripts/Ports/python3-cairosvg/vcpkg.json
+++ b/Scripts/Ports/python3-cairosvg/vcpkg.json
@@ -6,7 +6,6 @@
   "dependencies": [
     {
       "name": "cairo",
-      "platform": "windows",
       "default-features": false
     },
     "python3"

--- a/Scripts/Triplets/arm64-macos-plasma.cmake
+++ b/Scripts/Triplets/arm64-macos-plasma.cmake
@@ -12,3 +12,7 @@ if(PORT STREQUAL cairo)
     set(VCPKG_LIBRARY_LINKAGE dynamic)
     set(VCPKG_BUILD_TYPE release)
 endif()
+
+if(PORT STREQUAL python3)
+    set(VCPKG_CONFIGURE_MAKE_OPTIONS "LDFLAGS_NODIST=-rpath ${CURRENT_INSTALLED_DIR}/lib")
+endif()

--- a/Scripts/Triplets/universal-macos-plasma.cmake
+++ b/Scripts/Triplets/universal-macos-plasma.cmake
@@ -13,3 +13,7 @@ if(PORT STREQUAL cairo)
     set(VCPKG_BUILD_TYPE release)
 endif()
 
+if(PORT STREQUAL python3)
+    set(VCPKG_CONFIGURE_MAKE_OPTIONS "LDFLAGS_NODIST=-rpath ${CURRENT_INSTALLED_DIR}/lib")
+endif()
+

--- a/Scripts/Triplets/x64-macos-plasma.cmake
+++ b/Scripts/Triplets/x64-macos-plasma.cmake
@@ -12,3 +12,7 @@ if(PORT STREQUAL cairo)
     set(VCPKG_LIBRARY_LINKAGE dynamic)
     set(VCPKG_BUILD_TYPE release)
 endif()
+
+if(PORT STREQUAL python3)
+    set(VCPKG_CONFIGURE_MAKE_OPTIONS "LDFLAGS_NODIST=-rpath ${CURRENT_INSTALLED_DIR}/lib")
+endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -54,8 +54,8 @@
         "dependencies": [
           {
             "name": "cairo",
-            "platform": "windows",
-            "default-features": false
+            "default-features": false,
+            "host": true
           },
           {
             "name": "python3-cairosvg",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -53,11 +53,6 @@
         "description": "Installs a functional cairosvg Python module for the resource.dat generator.",
         "dependencies": [
           {
-            "name": "cairo",
-            "default-features": false,
-            "host": true
-          },
-          {
             "name": "python3-cairosvg",
             "host": true
           }


### PR DESCRIPTION
On Apple Silicon, Homebrew has moved the location its installed its libraries. That means if you are installing a version of Cairo from Homebrew, Python/python3-cairosvg cannot find Cairo, and vcpkg will fail to build python3-cairosvg.

Homebrew's version of Python passes an additional rpath to the configuration phase of the Python build to fix this:
https://github.com/carlocab/homebrew-core/blob/d83d8d4665518494ef7fc3e5a64ba937e69cb06c/Formula/python%403.9.rb#L150

This patch to our Python port also introduces the same patch. I'm still pretty new with vcpkg so I possibly haven't defined this correctly from a maintainable vcpkg perspective. But this fix does block Apple Silicon builds out of the box. I've had to do some manual patching each vcpkg update to work around it.