### PR TITLE
make xHighLevelStarTrekDoor.py to be less bad

### DIFF
--- a/Scripts/Python/xHighLevelStarTrekDoor.py
+++ b/Scripts/Python/xHighLevelStarTrekDoor.py
@@ -80,7 +80,6 @@ class xHighLevelStarTrekDoor(ptModifier):
         PtDebugPrint("DEBUG: xHighLevelStarTrekDoor.__init__: v. %d" % self.version)
 
         self.DoorEnabled = 1
-        rgnSensor.volumeSensorNoArbitration(True)
 
     ##########################################
     def OnServerInitComplete(self):
@@ -122,6 +121,8 @@ class xHighLevelStarTrekDoor(ptModifier):
             # the door is really shut, someone left it open
             self.SDL['DoorState'] = (doorSDLstates.closed,)
             ageSDL[strDoorClosedVar.value] = (1,)
+
+        rgnSensor.volumeSensorNoArbitration(True)
 
     ##########################################
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):

--- a/Scripts/Python/xHighLevelStarTrekDoor.py
+++ b/Scripts/Python/xHighLevelStarTrekDoor.py
@@ -68,12 +68,12 @@ class xHighLevelStarTrekDoor(ptModifier):
         self.version = 3
 
         PtDebugPrint("DEBUG: xHighLevelStarTrekDoor.__init__: v. %d" % self.version)
-        
+
         self.PrevDoorState = 0
         self.DoorState = 0
-        self.DoorStack = []
         self.DoorEnabled = 1
         self.respondertime = 30
+        self.lastTriggered = -1
 
     ##########################################
     def OnServerInitComplete(self):
@@ -94,46 +94,31 @@ class xHighLevelStarTrekDoor(ptModifier):
                 PtDebugPrint("ERROR: xHighLevelStarTrekDoor.OnServerInitComplete():\tERROR: age sdl read failed, defaulting door enabled value")
         else:
             self.DoorEnabled = 1
-        
+
         try:
             self.DoorState = self.SDL['DoorState'][0]
         except:
             self.SDL['DoorState'] = (0,)
             self.DoorState = self.SDL['DoorState'][0]
-         
+
         PtDebugPrint("xHighLevelStarTrekDoor: self.SDL = %d" % self.DoorState)
 
         if not PtIsSolo():
-            
+
             PtDebugPrint("xHighLevelStarTrekDoor: Somebody is already in the age. Attempting to sync states.")
 
             if self.DoorState == doorSDLstates['opening'] or self.DoorState == doorSDLstates['movingopen'] or self.DoorState == doorSDLstates['opentoclose']:
                 respOpenDoor.run(self.key,netPropagate=0)
-                self.DoorStack.append("respOpenDoor.run(self.key,netPropagate=0)")
-
-                '''
-                respOpenDoor.run(self.key,fastforward=1)
-                self.DoorState = doorSDLstates['open']
-                PtDebugPrint("xHighLevelStarTrekDoor: Door is open.")
-                '''
-            
             elif self.DoorState == doorSDLstates['closing'] or self.DoorState == doorSDLstates['movingclosed'] or self.DoorState == doorSDLstates['closetoopen']:
                 respCloseDoor.run(self.key,netPropagate=0)
-                self.DoorStack.append("respCloseDoor.run(self.key,netPropagate=0)")
-                '''
-                respCloseDoor.run(self.key,fastforward=1)
-                self.DoorState = doorSDLstates['closed']
-                PtDebugPrint("xHighLevelStarTrekDoor: Door is closed.")
-                '''
-            
             elif self.DoorState == doorSDLstates['open']:
                 respOpenDoor.run(self.key,fastforward=1)
-                
 
         else:
             # the door is really shut, someone left it open
             self.SDL['DoorState'] = (doorSDLstates['closed'],)
             self.DoorState = self.SDL['DoorState'][0]
+            ageSDL[strDoorClosedVar.value] = (1,)
 
     ##########################################
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
@@ -144,219 +129,85 @@ class xHighLevelStarTrekDoor(ptModifier):
         elif VARname == strDoorClosedVar.value:
             doorClosed = ageSDL[strDoorClosedVar.value][0]
             PtDebugPrint("HighLevelStarTrekDoor.OnSDLNotify: Door Closed SDL Updated to: %d" % doorClosed)
-            PtDebugPrint("HighLevelStarTrekDoor.OnSDLNotify: Player who updated SDL: ", playerID)
-            if playerID == 0 and self.sceneobject.isLocallyOwned():
-                if doorClosed == 0:
-                    self.SendNote("respOpenDoor;1")
-                    self.UpdateDoorState(doorSDLstates['open'])
-                elif doorClosed == 1:
-                    self.SendNote("respCloseDoor;1")
-                    self.UpdateDoorState(doorSDLstates['closed'])
+            if doorClosed:
+                respCloseDoor.run(self.key,netPropagate=0)
+            else:
+                respOpenDoor.run(self.key,netPropagate=0)
 
     ##########################################
     def OnNotify(self,state,id,events):
-        
         ageSDL = PtGetAgeSDL()
         #Notify Section
-        if id == (-1):
-            if events[0][1].find('rgnTriggerEnter') != -1 and self.sceneobject.isLocallyOwned():
-                PtDebugPrint("xHighLevelStarTrekDoor: Avatar who entered the region. ",events[0][1].lstrip("rgnTriggerEnter"))
-                if self.DoorState == doorSDLstates['closed']:            
-                    self.UpdateDoorState(doorSDLstates['opening'])
-                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to opening.")
-
-                elif self.DoorState == doorSDLstates['movingclosed'] or self.DoorState == doorSDLstates['closing']:
-                    self.UpdateDoorState(doorSDLstates['closetoopen'])
-                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to closetoopen.")
-
-                elif self.DoorState == doorSDLstates['opentoclose']:
-                    self.UpdateDoorState(doorSDLstates['movingopen'])
-                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to movingopen.")
-                return
-
-            elif events[0][1].find('rgnTriggerExit') != -1 and self.sceneobject.isLocallyOwned():
-                PtDebugPrint("xHighLevelStarTrekDoor: Avatar who exited the region. ",events[0][1].lstrip("rgnTriggerExit"))
-                if self.DoorState == doorSDLstates['open']:
-                    self.UpdateDoorState(doorSDLstates['closing'])
-                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to closing.")
-
-                elif self.DoorState == doorSDLstates['movingopen'] or self.DoorState == doorSDLstates['opening']:
-                    self.UpdateDoorState(doorSDLstates['opentoclose'])
-                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to opentoclose.")
-
-                elif self.DoorState == doorSDLstates['closetoopen']:
-                    self.UpdateDoorState(doorSDLstates['movingclosed'])
-                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to movingclosed.")
-                return
-
-            
-            elif events[0][1].find('respOpenDoor') != -1 or events[0][1].find('respCloseDoor') != -1:
-                self.DoorStack.append(events[0][1])
-                PtDebugPrint("xHighLevelStarTrekDoor: New list is: %s" % (str(self.DoorStack)))
-                
-                if len(self.DoorStack) == 1:
-                    PtDebugPrint("xHighLevelStarTrekDoor: List is only one command long, so I'm playing it")
-                    code = self.DoorStack[0]
-                    #PtDebugPrint("xHighLevelStarTrekDoor: Timer set to : %d" % self.respondertime)
-                    #PtAtTimeCallback(self.key,self.respondertime,1)
-                    PtDebugPrint("xHighLevelStarTrekDoor: Playing command: %s" % (code))
-                    self.ExecCode(code)
-                    if self.DoorStack[0].find('fastforward=1') != -1:
-                        self.UpdateRespStack()
-                return
-
-
-            elif events[0][1].find('DoorState') != -1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1 and events[0][1].find('Responder') == -1:
-                #PtDebugPrint("xHighLevelStarTrekDoor: Events = ", events[0][1].lstrip('DoorState='))
-                curState = int(events[0][1].lstrip('DoorState='))
-                PtDebugPrint("xHighLevelStarTrekDoor: Door State Updated to %d" % curState)
-                #PtDebugPrint("xHighLevelStarTrekDoor: Door State SDL Set to %d" % self.SDL['DoorState'][0])
-                if curState != self.DoorState:
-                    self.DoorState = curState
-                    PtDebugPrint("xHighLevelStarTrekDoor: Door state is now %d" % self.DoorState)
-                return
-
-                    
-        ##########################################                
-        elif id == rgnSensor.id:
+        if id == rgnSensor.id:
             if self.DoorEnabled == 0:
                 return
             #Region Triggered
             for event in events:
+                if PtFindAvatar(events) == PtGetLocalAvatar():
+                    self.lastTriggered = PtGetLocalPlayer().getPlayerID()
+                else:
+                    self.lastTriggered = -1
                 #true when you enter the region
-                
-                if event[0] == 1 and event[1] == 1 and PtFindAvatar(events) == PtGetLocalAvatar():
-                    playerID = PtGetLocalPlayer().getPlayerID()
-                    triggerstr = "rgnTriggerEnter%d" % playerID
-                    self.SendNote(triggerstr)
+                if event[0] == 1 and event[1] == 1:
                     PtDebugPrint("xHighLevelStarTrekDoor: Door region entered.")
-                            
+                    PtDebugPrint("xHighLevelStarTrekDoor: Avatar who entered the region. ",self.lastTriggered)
+                    if self.DoorState == doorSDLstates['closed']:
+                        self.UpdateDoorState(doorSDLstates['opening'], self.lastTriggered)
+                        PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to opening.")
+
+                    elif self.DoorState == doorSDLstates['movingclosed'] or self.DoorState == doorSDLstates['closing']:
+                        self.UpdateDoorState(doorSDLstates['closetoopen'])
+                        PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to closetoopen.")
+
+                    elif self.DoorState == doorSDLstates['opentoclose']:
+                        self.UpdateDoorState(doorSDLstates['movingopen'])
+                        PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to movingopen.")
+                    return
 
                 #true when you leave the region
-                elif event[0] == 1 and event[1] == 0 and PtFindAvatar(events) == PtGetLocalAvatar():
-                    playerID = PtGetLocalPlayer().getPlayerID()
-                    triggerstr = "rgnTriggerExit%d" % playerID
-                    self.SendNote(triggerstr)
-                    PtDebugPrint("xHighLevelStarTrekDoor: Door region clear.")
+                elif event[0] == 1 and event[1] == 0:
+                    PtDebugPrint("xHighLevelStarTrekDoor: Avatar who exited the region. ",self.lastTriggered)
+                    if self.DoorState == doorSDLstates['open']:
+                        self.UpdateDoorState(doorSDLstates['closing'], self.lastTriggered)
+                        PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to closing.")
 
-                        
+                    elif self.DoorState == doorSDLstates['movingopen'] or self.DoorState == doorSDLstates['opening']:
+                        self.UpdateDoorState(doorSDLstates['opentoclose'])
+                        PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to opentoclose.")
+
+                    elif self.DoorState == doorSDLstates['closetoopen']:
+                        self.UpdateDoorState(doorSDLstates['movingclosed'])
+                        PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to movingclosed.")
+                    return
+
         elif id == respOpenDoor.id:
-            
-            self.UpdateRespStack()
-            
             PtDebugPrint("xHighLevelStarTrekDoor: Door is now open.")
-            if self.sceneobject.isLocallyOwned():
-                if self.DoorState == doorSDLstates['opentoclose']:
-                    self.UpdateDoorState(doorSDLstates['closing'])
-                
-                elif self.DoorState == doorSDLstates['movingopen'] or self.DoorState == doorSDLstates['opening']:
-                    self.UpdateDoorState(doorSDLstates['open'])
-
-        elif id == respCloseDoor.id:
-
-            self.UpdateRespStack()
-            
-            PtDebugPrint("xHighLevelStarTrekDoor: Door is now closed.")
-            if self.sceneobject.isLocallyOwned():
-                if self.DoorState == doorSDLstates['closetoopen']:
-                    self.UpdateDoorState(doorSDLstates['opening'])
-                
-                elif self.DoorState == doorSDLstates['movingclosed'] or self.DoorState == doorSDLstates['closing']:
-                    self.UpdateDoorState(doorSDLstates['closed'])
-
-    ##########################################
-    def SendNote(self, ExtraInfo):
-        notify = ptNotify(self.key)
-        notify.clearReceivers()                
-        notify.addReceiver(self.key)        
-        notify.netPropagate(1)
-        notify.netForce(1)
-        notify.setActivate(1.0)
-        notify.addVarNumber(str(ExtraInfo),1.0)
-        notify.send()
-
-    ##########################################
-    def UpdateRespStack (self):
-        #PtClearTimerCallbacks(self.key)
-        #Updates the Responder List
-        old = self.DoorStack.pop(0)
-        PtDebugPrint("xHighLevelStarTrekDoor: Getting rid of Resp: %s" % (old))
-        if len(self.DoorStack):
-            PtDebugPrint("xHighLevelStarTrekDoor: There's at lest one more Resp to play.")
-            code = self.DoorStack[0]            
-            PtDebugPrint("Playing command: %s" % (code))
-            #PtDebugPrint("xHighLevelStarTrekDoor: Timer set to : %d" % self.respondertime)
-            #PtAtTimeCallback(self.key,self.respondertime,1)
-            self.ExecCode(code)
-            if self.DoorStack[0].find('fastforward=1') != -1:
-                self.DoorStack.pop(0)
-
-    ##########################################
-    def UpdateDoorState (self, StateNum):
-        if StateNum != self.DoorState:
-            ageSDL = PtGetAgeSDL()
-            self.DoorState = StateNum
-            self.SDL['DoorState'] = (StateNum,)
-            self.SendNote('DoorState='+str(StateNum))
-            PtClearTimerCallbacks(self.key)
-            PtAtTimeCallback(self.key, 30, 1)
-            if self.DoorEnabled == 0:
-                return            
-
-            if self.DoorState == doorSDLstates['opening']:
-                self.SendNote("respOpenDoor;0")
-                PtDebugPrint("xHighLevelStarTrekDoor: Notifying Clients to play Open Door Responder")
-
-            elif self.DoorState == doorSDLstates['closing']:
-                self.SendNote("respCloseDoor;0")
-                PtDebugPrint("xHighLevelStarTrekDoor: Notifying Clients to play Close Door Responder")
-
-            elif self.DoorState == doorSDLstates['open']:
-                PtDebugPrint("xHighLevelStarTrekDoor: Updating Age SDL to Open")
-                ageSDL[strDoorClosedVar.value] = (0,)
-
-            elif self.DoorState == doorSDLstates['closed']:
-                PtDebugPrint("xHighLevelStarTrekDoor: Updating Age SDL to Closed")
-                ageSDL[strDoorClosedVar.value] = (1,)
-
-    ##########################################
-    # This is a cheap hack to attempt to get 
-    # the doors reset, should the age owner 
-    # screw up and not update the door states
-    ##########################################
-    def OnTimer(self,TimerID):
-        if self.sceneobject.isLocallyOwned():
-            PtDebugPrint("xHighLevelStarTrekDoor: Timer Came Back")
             if self.DoorState == doorSDLstates['opentoclose']:
-                self.UpdateDoorState(doorSDLstates['closing'])
+                self.UpdateDoorState(doorSDLstates['closing'], self.lastTriggered)
 
             elif self.DoorState == doorSDLstates['movingopen'] or self.DoorState == doorSDLstates['opening']:
                 self.UpdateDoorState(doorSDLstates['open'])
 
-            elif self.DoorState == doorSDLstates['closetoopen']:
-                self.UpdateDoorState(doorSDLstates['opening'])
+        elif id == respCloseDoor.id:
+            PtDebugPrint("xHighLevelStarTrekDoor: Door is now closed.")
+            if self.DoorState == doorSDLstates['closetoopen']:
+                self.UpdateDoorState(doorSDLstates['opening'], self.lastTriggered)
 
             elif self.DoorState == doorSDLstates['movingclosed'] or self.DoorState == doorSDLstates['closing']:
                 self.UpdateDoorState(doorSDLstates['closed'])
 
-    def ExecCode(self,code):
-        try:
-            chunks = code.split(';')
-            tag = chunks[0];
-            fastForward = int(chunks[1])
-            if tag == "respOpenDoor":
-                if fastForward == 1:
-                    respOpenDoor.run(self.key,fastforward=1)
-                else:
-                    respOpenDoor.run(self.key,netPropagate=0)
-            elif tag == "respCloseDoor":
-                if fastForward == 1:
-                    respCloseDoor.run(self.key,fastforward=1)
-                else:
-                    respCloseDoor.run(self.key,netPropagate=0)
-            else:
-                PtDebugPrint("xHighLevelStarTrekDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag))
-                self.DoorStack.pop(0)
-        except:
-            PtDebugPrint("xStandardDoor.ExecCode(): ERROR! Invalid code '%s'." % (code))
-            self.DoorStack.pop(0)
+    ##########################################
+    def UpdateDoorState (self, StateNum, playerID = -1):
+        if StateNum != self.DoorState:
+            ageSDL = PtGetAgeSDL()
+            self.DoorState = StateNum
+            self.SDL['DoorState'] = (StateNum,)
+            localPlayerID = PtGetLocalPlayer().getPlayerID()
+            if self.DoorEnabled == 0:
+                return
+            if int(playerID) == int(localPlayerID):
+                if self.DoorState == doorSDLstates['opening']:
+                    ageSDL[strDoorClosedVar.value] = (0,)
+
+                elif self.DoorState == doorSDLstates['closing']:
+                    ageSDL[strDoorClosedVar.value] = (1,)

--- a/Scripts/Python/xHighLevelStarTrekDoor.py
+++ b/Scripts/Python/xHighLevelStarTrekDoor.py
@@ -111,16 +111,16 @@ class xHighLevelStarTrekDoor(ptModifier):
 
             PtDebugPrint("xHighLevelStarTrekDoor: Somebody is already in the age. Attempting to sync states.")
 
-            if self.SDL['DoorState'][0] in (doorSDLstates['opening'], doorSDLstates['movingopen'], doorSDLstates['opentoclose']):
+            if self.SDL['DoorState'][0] in (doorSDLstates.opening, doorSDLstates.movingopen, doorSDLstates.opentoclose):
                 respOpenDoor.run(self.key)
-            elif self.SDL['DoorState'][0] in (doorSDLstates['closing'], doorSDLstates['movingclosed'], doorSDLstates['closetoopen']):
+            elif self.SDL['DoorState'][0] in (doorSDLstates.closing, doorSDLstates.movingclosed, doorSDLstates.closetoopen):
                 respCloseDoor.run(self.key)
-            elif self.SDL['DoorState'][0] == doorSDLstates['open']:
+            elif self.SDL['DoorState'][0] == doorSDLstates.open:
                 respOpenDoor.run(self.key,fastforward=True)
 
         else:
             # the door is really shut, someone left it open
-            self.SDL['DoorState'] = (doorSDLstates['closed'],)
+            self.SDL['DoorState'] = (doorSDLstates.closed,)
             ageSDL[strDoorClosedVar.value] = (1,)
 
     ##########################################
@@ -149,49 +149,49 @@ class xHighLevelStarTrekDoor(ptModifier):
             for event in events:
                 #true when you enter the region
                 if event[0] == 1 and event[1] == 1:
-                    if doorState == doorSDLstates['closed']:
-                        self.UpdateDoorState(doorSDLstates['opening'])
+                    if doorState == doorSDLstates.closed:
+                        self.UpdateDoorState(doorSDLstates.opening)
                         PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to opening.")
 
-                    elif doorState in (doorSDLstates['movingclosed'], doorSDLstates['closing']):
-                        self.UpdateDoorState(doorSDLstates['closetoopen'])
+                    elif doorState in (doorSDLstates.movingclosed, doorSDLstates.closing):
+                        self.UpdateDoorState(doorSDLstates.closetoopen)
                         PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to closetoopen.")
 
-                    elif doorState == doorSDLstates['opentoclose']:
-                        self.UpdateDoorState(doorSDLstates['movingopen'])
+                    elif doorState == doorSDLstates.opentoclose:
+                        self.UpdateDoorState(doorSDLstates.movingopen)
                         PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to movingopen.")
                     return
 
                 #true when you leave the region
                 elif event[0] == 1 and event[1] == 0:
-                    if doorState == doorSDLstates['open']:
-                        self.UpdateDoorState(doorSDLstates['closing'])
+                    if doorState == doorSDLstates.open:
+                        self.UpdateDoorState(doorSDLstates.closing)
                         PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to closing.")
 
-                    elif doorState in (doorSDLstates['movingopen'], doorSDLstates['opening']):
-                        self.UpdateDoorState(doorSDLstates['opentoclose'])
+                    elif doorState in (doorSDLstates.movingopen, doorSDLstates.opening):
+                        self.UpdateDoorState(doorSDLstates.opentoclose)
                         PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to opentoclose.")
 
-                    elif doorState == doorSDLstates['closetoopen']:
-                        self.UpdateDoorState(doorSDLstates['movingclosed'])
+                    elif doorState == doorSDLstates.closetoopen:
+                        self.UpdateDoorState(doorSDLstates.movingclosed)
                         PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to movingclosed.")
                     return
 
         elif id == respOpenDoor.id:
             PtDebugPrint("xHighLevelStarTrekDoor: Door is now open.")
-            if doorState == doorSDLstates['opentoclose']:
-                self.UpdateDoorState(doorSDLstates['closing'])
+            if doorState == doorSDLstates.opentoclose:
+                self.UpdateDoorState(doorSDLstates.closing)
 
-            elif doorState in (doorSDLstates['movingopen'], doorSDLstates['opening']):
-                self.UpdateDoorState(doorSDLstates['open'])
+            elif doorState in (doorSDLstates.movingopen, doorSDLstates.opening):
+                self.UpdateDoorState(doorSDLstates.open)
 
         elif id == respCloseDoor.id:
             PtDebugPrint("xHighLevelStarTrekDoor: Door is now closed.")
-            if doorState == doorSDLstates['closetoopen']:
-                self.UpdateDoorState(doorSDLstates['opening'])
+            if doorState == doorSDLstates.closetoopen:
+                self.UpdateDoorState(doorSDLstates.opening)
 
-            elif doorState in (doorSDLstates['movingclosed'], doorSDLstates['closing']):
-                self.UpdateDoorState(doorSDLstates['closed'])
+            elif doorState in (doorSDLstates.movingclosed, doorSDLstates.closing):
+                self.UpdateDoorState(doorSDLstates.closed)
 
     ##########################################
     def UpdateDoorState (self, StateNum):
@@ -200,8 +200,8 @@ class xHighLevelStarTrekDoor(ptModifier):
             self.SDL['DoorState'] = (StateNum,)
             if self.DoorEnabled == 0:
                 return
-            if self.SDL['DoorState'][0] == doorSDLstates['opening']:
+            if self.SDL['DoorState'][0] == doorSDLstates.opening:
                 ageSDL[strDoorClosedVar.value] = (0,)
-            elif self.SDL['DoorState'][0] == doorSDLstates['closing']:
+            elif self.SDL['DoorState'][0] == doorSDLstates.closing:
                 ageSDL[strDoorClosedVar.value] = (1,)
 


### PR DESCRIPTION
Not saying this is better but its less bad

Removes age owner from controlling the triggering of the doors
Removes the SendNote() stuff it was doing
Removes the doorstack tracking
Makes the door opening and closing rely on the SDL triggering
Makes the SDL trigger only happen by the person who set off the door sensor

I think ive fixed some of the race conditions but this is a multiplayer script and those are hard to troubleshoot