### PR TITLE
Include Winsock header only where it's actually used

### DIFF
--- a/Sources/Plasma/CoreLib/hsWindows.h
+++ b/Sources/Plasma/CoreLib/hsWindows.h
@@ -49,8 +49,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 /** \file hsWindows.h
  *  \brief Pulls in Windows core headers
  *
- *  This file pulls in the core Windows headers and Winsock2. It is separate from
- *  HeadSpin.h to improve build times and to facillitate adding precompiled headers.
+ *  This file pulls in the core Windows headers. It is separate from HeadSpin.h
+ *  to improve build times and to facilitate adding precompiled headers.
  *  You should avoid including this header from other headers!
  */
 
@@ -75,7 +75,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #   define WIN32_LEAN_AND_MEAN
 #   include <windows.h>
-#   include <ws2tcpip.h> // Pulls in WinSock 2 for us
 
     // This needs to be after #include <windows.h>, since it also includes windows.h
 #   ifdef USE_VLD

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
@@ -91,7 +91,7 @@ void plNetAddress::Read(hsStream * s)
     fHost = s->ReadLE32();
     fPort = s->ReadLE16();
 
-    // Family is always AF_INET
+    // Family is always kInet
     (void) s->ReadLE16();
 }
 
@@ -100,6 +100,5 @@ void plNetAddress::Write(hsStream * s)
     s->WriteLE32(fHost);
     s->WriteLE16(fPort);
 
-    // Family is always AF_INET
-    s->WriteLE16(static_cast<uint16_t>(2));
+    s->WriteLE16(static_cast<uint16_t>(Family::kInet));
 }

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
@@ -46,10 +46,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plNetAddress.h"
 #include "pnNetCommon.h"
 
-#ifndef AF_INET
-#   define AF_INET 2
-#endif
-
 ST::string plNetAddress::GetHostString() const
 {
     return pnNetCommon::GetTextAddr(fHost);
@@ -105,5 +101,5 @@ void plNetAddress::Write(hsStream * s)
     s->WriteLE16(fPort);
 
     // Family is always AF_INET
-    s->WriteLE16((uint16_t)AF_INET);
+    s->WriteLE16(static_cast<uint16_t>(2));
 }

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.h
@@ -61,6 +61,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
  */
 class plNetAddress
 {
+    // This is used in the Read/Write format and so must not use the potentially OS-dependent AF_* constants.
+    enum class Family : uint16_t
+    {
+        kInet = 2, // matches AF_INET from Winsock <ws2def.h>
+    };
+
     uint32_t    fHost;
     uint16_t    fPort;
 

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
@@ -41,14 +41,16 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 #include <string>
 #include "pnNetCommon.h"
-#include "hsWindows.h"
 
-#if HS_BUILD_FOR_UNIX
+#if defined(HS_BUILD_FOR_UNIX)
 # include <sys/socket.h>
 # include <netinet/in.h>
 # include <arpa/inet.h>
 # include <netdb.h>
-#elif !defined(HS_BUILD_FOR_WIN32)
+#elif defined(HS_BUILD_FOR_WIN32)
+#include "hsWindows.h"
+#include <ws2tcpip.h>
+#else
 #error "Not implemented for this platform"
 #endif
 


### PR DESCRIPTION
pnNetCommon is also the only library that actually links with Winsock, so including the header elsewhere doesn't make much sense.