### PR TITLE
pnNcCli should consistently convert to little endian

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -613,6 +613,8 @@ static bool DispatchData (NetCli * cli, void * param) {
                     cli->recvFieldBytes = 0;
                 }
                 break;
+
+                default: break;
             }
         }
 

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2File/pnNpCli2File.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2File/pnNpCli2File.h
@@ -109,7 +109,7 @@ static const unsigned   kFileSrvBuildId = 0;
 struct Cli2File_ConnData {
     uint32_t       dataBytes;
     uint32_t       buildId;
-    unsigned    serverType;
+    uint32_t       serverType;
 };
 struct Cli2File_Connect {
     AsyncSocketConnectPacket    hdr;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -1536,13 +1536,13 @@ static void Connect (
     
     Cli2Auth_Connect connect;
     connect.hdr.connType        = kConnTypeCliToAuth;
-    connect.hdr.hdrBytes        = sizeof(connect.hdr);
-    connect.hdr.buildId         = plProduct::BuildId();
-    connect.hdr.buildType       = plProduct::BuildType();
-    connect.hdr.branchId        = plProduct::BranchId();
+    connect.hdr.hdrBytes        = hsToLE16(sizeof(connect.hdr));
+    connect.hdr.buildId         = hsToLE32(plProduct::BuildId());
+    connect.hdr.buildType       = hsToLE32(plProduct::BuildType());
+    connect.hdr.branchId        = hsToLE32(plProduct::BranchId());
     connect.hdr.productId       = plProduct::UUID();
     connect.data.token          = conn->token;
-    connect.data.dataBytes      = sizeof(connect.data);
+    connect.data.dataBytes      = hsToLE32(sizeof(connect.data));
 
     AsyncSocketConnect(
         &conn->cancelId,

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -495,14 +495,14 @@ static void Connect (CliFileConn * conn) {
 
     Cli2File_Connect connect;
     connect.hdr.connType    = kConnTypeCliToFile;
-    connect.hdr.hdrBytes    = sizeof(connect.hdr);
-    connect.hdr.buildId     = kFileSrvBuildId;
-    connect.hdr.buildType   = plProduct::BuildType();
-    connect.hdr.branchId    = plProduct::BranchId();
+    connect.hdr.hdrBytes    = hsToLE16(sizeof(connect.hdr));
+    connect.hdr.buildId     = hsToLE32(kFileSrvBuildId);
+    connect.hdr.buildType   = hsToLE32(plProduct::BuildType());
+    connect.hdr.branchId    = hsToLE32(plProduct::BranchId());
     connect.hdr.productId   = plProduct::UUID();
-    connect.data.buildId    = conn->buildId;
-    connect.data.serverType = conn->serverType;
-    connect.data.dataBytes  = sizeof(connect.data);
+    connect.data.buildId    = hsToLE32(conn->buildId);
+    connect.data.serverType = hsToLE32(conn->serverType);
+    connect.data.dataBytes  = hsToLE32(sizeof(connect.data));
 
     AsyncSocketConnect(
         &conn->cancelId,

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -51,6 +51,15 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // It changes the logic by which the decision to attempt a reconnect is made.
 #define LOAD_BALANCER_HARDWARE
 
+static void StrCopyLE16(char16_t* dest, const char16_t source[], size_t chars) {
+    while ((chars > 1) && ((*dest = hsToLE16(*source++)) != 0)) {
+        --chars;
+        ++dest;
+    }
+    if (chars)
+        *dest = 0;
+}
+
 
 namespace Ngl { namespace File {
 /*****************************************************************************
@@ -107,12 +116,12 @@ struct CliFileConn : hsRefCnt {
 
     void Destroy(); // cleans up the socket and buffer
 
-    void Dispatch (const Cli2File_MsgHeader * msg);
-    bool Recv_PingReply (const File2Cli_PingReply * msg);
-    bool Recv_BuildIdReply (const File2Cli_BuildIdReply * msg);
-    bool Recv_BuildIdUpdate (const File2Cli_BuildIdUpdate * msg);
-    bool Recv_ManifestReply (const File2Cli_ManifestReply * msg);
-    bool Recv_FileDownloadReply (const File2Cli_FileDownloadReply * msg);
+    void Dispatch (Cli2File_MsgHeader * msg);
+    bool Recv_PingReply (File2Cli_PingReply * msg);
+    bool Recv_BuildIdReply (File2Cli_BuildIdReply * msg);
+    bool Recv_BuildIdUpdate (File2Cli_BuildIdUpdate * msg);
+    bool Recv_ManifestReply (File2Cli_ManifestReply * msg);
+    bool Recv_FileDownloadReply (File2Cli_FileDownloadReply * msg);
 };
 
 
@@ -419,11 +428,11 @@ static bool NotifyConnSocketRead (CliFileConn * conn, AsyncNotifySocketRead * re
         if (conn->recvBuffer.size() < sizeof(uint32_t))
             return true;
 
-        uint32_t msgSize = *(uint32_t *)conn->recvBuffer.data();
+        uint32_t msgSize = hsToLE32(*(uint32_t *)conn->recvBuffer.data());
         if (conn->recvBuffer.size() < msgSize)
             return true;
 
-        const Cli2File_MsgHeader * msg = (const Cli2File_MsgHeader *) conn->recvBuffer.data();
+        Cli2File_MsgHeader * msg = (Cli2File_MsgHeader *) conn->recvBuffer.data();
         conn->Dispatch(msg);
 
         conn->recvBuffer.erase(conn->recvBuffer.begin(), conn->recvBuffer.begin() + msgSize);
@@ -702,12 +711,12 @@ void CliFileConn::TimerPing () {
             pingSendTimeMs = GetNonZeroTimeMs();
 
             Cli2File_PingRequest msg;
-            msg.messageId = kCli2File_PingRequest;
-            msg.messageBytes = sizeof(msg);
-            msg.pingTimeMs = pingSendTimeMs;
+            msg.messageId = hsToLE32(kCli2File_PingRequest);
+            msg.messageBytes = hsToLE32(sizeof(msg));
+            msg.pingTimeMs = hsToLE32(pingSendTimeMs);
 
             // read locks are reentrant, so calling Send is ok here within the read lock
-            Send(&msg, msg.messageBytes);
+            Send(&msg, sizeof(msg));
         }
         break;
     }
@@ -737,10 +746,10 @@ void CliFileConn::Send (const void * data, unsigned bytes) {
 }
 
 //============================================================================
-void CliFileConn::Dispatch (const Cli2File_MsgHeader * msg) {
+void CliFileConn::Dispatch (Cli2File_MsgHeader * msg) {
 
-#define DISPATCH(a) case kFile2Cli_##a: Recv_##a((const File2Cli_##a *) msg); break
-    switch (msg->messageId) {
+#define DISPATCH(a) case kFile2Cli_##a: Recv_##a((File2Cli_##a *) msg); break
+    switch (hsToLE32(msg->messageId)) {
         DISPATCH(PingReply);
         DISPATCH(BuildIdReply);
         DISPATCH(BuildIdUpdate);
@@ -753,15 +762,21 @@ void CliFileConn::Dispatch (const Cli2File_MsgHeader * msg) {
 
 //============================================================================
 bool CliFileConn::Recv_PingReply (
-    const File2Cli_PingReply * msg
+    File2Cli_PingReply* msg
 ) {
     return true;
 }
 
 //============================================================================
 bool CliFileConn::Recv_BuildIdReply (
-    const File2Cli_BuildIdReply * msg
+    File2Cli_BuildIdReply* msg
 ) {
+    msg->messageId = hsToLE32(msg->messageId);
+    msg->messageBytes = hsToLE32(msg->messageBytes);
+    msg->transId = hsToLE32(msg->transId);
+    msg->result = (ENetError)hsToLE32(msg->result);
+    msg->buildId = hsToLE32(msg->buildId);
+
     NetTransRecv(msg->transId, (const uint8_t *)msg, msg->messageBytes);
 
     return true;
@@ -769,17 +784,30 @@ bool CliFileConn::Recv_BuildIdReply (
 
 //============================================================================
 bool CliFileConn::Recv_BuildIdUpdate (
-    const File2Cli_BuildIdUpdate * msg
+    File2Cli_BuildIdUpdate* msg
 ) {
     if (s_buildIdCallback)
-        s_buildIdCallback(msg->buildId);
+        s_buildIdCallback(hsToLE32(msg->buildId));
     return true;
 }
 
 //============================================================================
 bool CliFileConn::Recv_ManifestReply (
-    const File2Cli_ManifestReply * msg
+    File2Cli_ManifestReply* msg
 ) {
+    msg->messageId = hsToLE32(msg->messageId);
+    msg->messageBytes = hsToLE32(msg->messageBytes);
+    msg->transId = hsToLE32(msg->transId);
+    msg->result = (ENetError)hsToLE32(msg->result);
+    msg->readerId = hsToLE32(msg->readerId);
+    msg->numFiles = hsToLE32(msg->numFiles);
+    msg->wcharCount = hsToLE32(msg->wcharCount);
+
+    // The manifest format includes \0 characters, so we can't just StrCopy
+    for (size_t i = 0; i < msg->wcharCount; i++) {
+        msg->manifestData[i] = hsToLE16(msg->manifestData[i]);
+    }
+
     NetTransRecv(msg->transId, (const uint8_t *)msg, msg->messageBytes);
 
     return true;
@@ -787,8 +815,16 @@ bool CliFileConn::Recv_ManifestReply (
 
 //============================================================================
 bool CliFileConn::Recv_FileDownloadReply (
-    const File2Cli_FileDownloadReply * msg
+    File2Cli_FileDownloadReply* msg
 ) {
+    msg->messageId = hsToLE32(msg->messageId);
+    msg->messageBytes = hsToLE32(msg->messageBytes);
+    msg->transId = hsToLE32(msg->transId);
+    msg->result = (ENetError)hsToLE32(msg->result);
+    msg->readerId = hsToLE32(msg->readerId);
+    msg->totalFileSize = hsToLE32(msg->totalFileSize);
+    msg->byteCount = hsToLE32(msg->byteCount);
+
     NetTransRecv(msg->transId, (const uint8_t *)msg, msg->messageBytes);
 
     return true;
@@ -814,12 +850,12 @@ bool BuildIdRequestTrans::Send () {
         return false;
 
     Cli2File_BuildIdRequest buildIdReq;
-    buildIdReq.messageId = kCli2File_BuildIdRequest;
-    buildIdReq.transId = m_transId;
-    buildIdReq.messageBytes = sizeof(buildIdReq);
+    buildIdReq.messageId = hsToLE32(kCli2File_BuildIdRequest);
+    buildIdReq.transId = hsToLE32(m_transId);
+    buildIdReq.messageBytes = hsToLE32(sizeof(buildIdReq));
 
-    m_conn->Send(&buildIdReq, buildIdReq.messageBytes); 
-    
+    m_conn->Send(&buildIdReq, sizeof(buildIdReq));
+
     return true;
 }
 
@@ -882,13 +918,13 @@ bool ManifestRequestTrans::Send () {
         return false;
 
     Cli2File_ManifestRequest manifestReq;
-    StrCopy(manifestReq.group, m_group, std::size(manifestReq.group));
-    manifestReq.messageId = kCli2File_ManifestRequest;
-    manifestReq.transId = m_transId;
-    manifestReq.messageBytes = sizeof(manifestReq);
-    manifestReq.buildId = m_buildId;
+    StrCopyLE16(manifestReq.group, m_group, std::size(manifestReq.group));
+    manifestReq.messageId = hsToLE32(kCli2File_ManifestRequest);
+    manifestReq.transId = hsToLE32(m_transId);
+    manifestReq.messageBytes = hsToLE32(sizeof(manifestReq));
+    manifestReq.buildId = hsToLE32(m_buildId);
 
-    m_conn->Send(&manifestReq, manifestReq.messageBytes);   
+    m_conn->Send(&manifestReq, sizeof(manifestReq));
 
     return true;
 }
@@ -936,12 +972,12 @@ bool ManifestRequestTrans::Recv (
 
     // tell the server we got the data
     Cli2File_ManifestEntryAck manifestAck;
-    manifestAck.messageId = kCli2File_ManifestEntryAck;
-    manifestAck.transId = reply.transId;
-    manifestAck.messageBytes = sizeof(manifestAck);
-    manifestAck.readerId = reply.readerId;
+    manifestAck.messageId = hsToLE32(kCli2File_ManifestEntryAck);
+    manifestAck.transId = hsToLE32(reply.transId);
+    manifestAck.messageBytes = hsToLE32(sizeof(manifestAck));
+    manifestAck.readerId = hsToLE32(reply.readerId);
 
-    m_conn->Send(&manifestAck, manifestAck.messageBytes);   
+    m_conn->Send(&manifestAck, sizeof(manifestAck));
 
     // if wcharCount is 2 or less, the data only contains the terminator "\0\0" and we
     // don't need to convert anything (and we are done)
@@ -1121,11 +1157,11 @@ bool DownloadRequestTrans::Send () {
 
     Cli2File_FileDownloadRequest filedownloadReq;
     const ST::utf16_buffer buffer = m_filename.AsString().to_utf16();
-    StrCopy(filedownloadReq.filename, buffer.data(), std::size(filedownloadReq.filename));
-    filedownloadReq.messageId = kCli2File_FileDownloadRequest;
-    filedownloadReq.transId = m_transId;
-    filedownloadReq.messageBytes = sizeof(filedownloadReq);
-    filedownloadReq.buildId = m_buildId;
+    StrCopyLE16(filedownloadReq.filename, buffer.data(), std::size(filedownloadReq.filename));
+    filedownloadReq.messageId = hsToLE32(kCli2File_FileDownloadRequest);
+    filedownloadReq.transId = hsToLE32(m_transId);
+    filedownloadReq.messageBytes = hsToLE32(sizeof(filedownloadReq));
+    filedownloadReq.buildId = hsToLE32(m_buildId);
 
     m_conn->Send(&filedownloadReq, sizeof(filedownloadReq));
     
@@ -1151,12 +1187,12 @@ bool DownloadRequestTrans::Recv (
 
     // tell the server we got the data
     Cli2File_FileDownloadChunkAck fileAck;
-    fileAck.messageId = kCli2File_FileDownloadChunkAck;
-    fileAck.transId = reply.transId;
-    fileAck.messageBytes = sizeof(fileAck);
-    fileAck.readerId = reply.readerId;
+    fileAck.messageId = hsToLE32(kCli2File_FileDownloadChunkAck);
+    fileAck.transId = hsToLE32(reply.transId);
+    fileAck.messageBytes = hsToLE32(sizeof(fileAck));
+    fileAck.readerId = hsToLE32(reply.readerId);
 
-    m_conn->Send(&fileAck, fileAck.messageBytes);
+    m_conn->Send(&fileAck, sizeof(fileAck));
 
     if (IS_NET_ERROR(reply.result)) {
         // we have a problem... indicate we are done and abort

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
@@ -384,12 +384,12 @@ static void Connect (
 
     Cli2Game_Connect connect;
     connect.hdr.connType    = kConnTypeCliToGame;
-    connect.hdr.hdrBytes    = sizeof(connect.hdr);
-    connect.hdr.buildId     = plProduct::BuildId();
-    connect.hdr.buildType   = plProduct::BuildType();
-    connect.hdr.branchId    = plProduct::BranchId();
+    connect.hdr.hdrBytes    = hsToLE16(sizeof(connect.hdr));
+    connect.hdr.buildId     = hsToLE32(plProduct::BuildId());
+    connect.hdr.buildType   = hsToLE32(plProduct::BuildType());
+    connect.hdr.branchId    = hsToLE32(plProduct::BranchId());
     connect.hdr.productId   = plProduct::UUID();
-    connect.data.dataBytes  = sizeof(connect.data);
+    connect.data.dataBytes  = hsToLE32(sizeof(connect.data));
 
     AsyncSocketConnect(
         &conn->cancelId,

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -423,13 +423,13 @@ static void Connect (
     
     Cli2GateKeeper_Connect connect;
     connect.hdr.connType        = kConnTypeCliToGateKeeper;
-    connect.hdr.hdrBytes        = sizeof(connect.hdr);
-    connect.hdr.buildId         = plProduct::BuildId();
-    connect.hdr.buildType       = plProduct::BuildType();
-    connect.hdr.branchId        = plProduct::BranchId();
+    connect.hdr.hdrBytes        = hsToLE16(sizeof(connect.hdr));
+    connect.hdr.buildId         = hsToLE32(plProduct::BuildId());
+    connect.hdr.buildType       = hsToLE32(plProduct::BuildType());
+    connect.hdr.branchId        = hsToLE32(plProduct::BranchId());
     connect.hdr.productId       = plProduct::UUID();
     connect.data.token          = conn->token;
-    connect.data.dataBytes      = sizeof(connect.data);
+    connect.data.dataBytes      = hsToLE32(sizeof(connect.data));
 
     AsyncSocketConnect(
         &conn->cancelId,


### PR DESCRIPTION
There are 3 special cases that are not handled here:

- UUIDs are handled as "data", but those should already be stored in the weird mixed endian mode that Windows uses (we had to fix this for macOS a while back)

- SHA digests are handled as "raw data", and I'm not sure of the endianness on these. I think this might have been fixed in my first batch of PowerPC fixes? This might need further tweaking.

- Plasma Net Messages are "variable pointers" but those should have all their data stored in little endian by the `Read()`/`Write()` methods on the classes, so we should be okay here.