### PR TITLE
Fix #1474.

### DIFF
--- a/Scripts/Python/xAvatarCustomization.py
+++ b/Scripts/Python/xAvatarCustomization.py
@@ -758,7 +758,7 @@ class xAvatarCustomization(ptModifier):
                             descbox = AvCustGUI.dialog.getControlModFromTag(kClothingDesc)
                             descbox.setString(newitem.description)
                             # set up the color pickers
-                            colorbar1 = pAvCustGUI.dialog.getControlModFromTag(kColorbarName1)
+                            colorbar1 = AvCustGUI.dialog.getControlModFromTag(kColorbarName1)
                             if newitem.colorlabel1 == "":
                                 self.IHideColorPicker(kColor1ClickMap)
                             else:


### PR DESCRIPTION
Fixes typo causing issue reported in discord where the avatar customization GUI can persist into Relto.

Fixes #1474.