### PR TITLE
Fix hsMaterialConverter format stuff.

### DIFF
--- a/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
+++ b/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
@@ -135,13 +135,6 @@ namespace {
 */
         }
     }
-
-    const char  sWarnBaseTextureMissing[] = "The object \"%s\"'s material has a base layer that is assigned texture \"%s\", but the texture file is missing. "
-                                        "This can cause unwanted effects during runtime."; 
-    const char  sWarnUpperTextureMissing[] = "The object \"%s\"'s material has an upper layer that is assigned texture \"%s\", but the texture file is missing. "
-                                        "This is not supported in the engine, so the upper layer will be ignored."; 
-    const char  sWarnNoUpperTexture[] = "The object \"%s\"'s material has an uppper layer that is not assigned a texture. "
-                                        "This is not supported in the engine, so the upper layer will be disabled."; 
 }
 
 static uint32_t MakeUInt32Color(float r, float g, float b, float a)

--- a/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
+++ b/Sources/Tools/MaxConvert/hsMaterialConverter.cpp
@@ -1607,7 +1607,7 @@ hsGMaterial *hsMaterialConverter::IProcessCompositeMtl(Mtl *mtl, plMaxNode *node
                     {
                         bool ignore = fErrorMsg->Set(!(fWarned & kWarnedCompMtlBadBlend), node->GetName(),
                             ST::format(
-                                "Composite material %s has a submaterial, %s, that requires too many textures in a single pass "
+                                "Composite material {} has a submaterial, {}, that requires too many textures in a single pass "
                                 "(for blending effects). To cut this down, try some of the following:\n"
                                 "1. Make sure all multi-layered submaterials (except the base)"
                                 " choose 'alpha' for 'layer blending', and 'base alpha only' for 'layer alpha blending'\n"


### PR DESCRIPTION
This fixes an incorrect format specifier in use in the wild (crashes). As a bonus, I have also fixed a potential ODR violation in our unity builds. The deleted strings were also present in plLayerConverter but never used in hsMaterialConverter.