### PR TITLE
Resolve 2 clang warnings in pfCrashHandler

### DIFF
--- a/Sources/Plasma/FeatureLib/pfCrashHandler/plCrashSrv.cpp
+++ b/Sources/Plasma/FeatureLib/pfCrashHandler/plCrashSrv.cpp
@@ -83,7 +83,7 @@ plCrashSrv::~plCrashSrv()
 static inline bool IGetCrashedThreadContext(HANDLE process, const LPEXCEPTION_POINTERS ptrs, LPCONTEXT context)
 {
     if (process == GetCurrentProcess()) {
-        memcpy(context, ptrs->ContextRecord, sizeof(ptrs->ContextRecord));
+        memcpy(context, ptrs->ContextRecord, sizeof(CONTEXT));
         return true;
     }
 

--- a/Sources/Plasma/FeatureLib/pfCrashHandler/plWindowsStackWalker.cpp
+++ b/Sources/Plasma/FeatureLib/pfCrashHandler/plWindowsStackWalker.cpp
@@ -137,7 +137,7 @@ bool plStackWalker::iterator::next()
 class plStackWalkError : public std::runtime_error
 {
 public:
-    plStackWalkError() = default;
+    plStackWalkError() = delete;
     explicit plStackWalkError(const char* msg) : std::runtime_error(msg) { }
     explicit plStackWalkError(const ST::string& msg) : std::runtime_error(msg.c_str()) { }
 };


### PR DESCRIPTION
clang-cl was reporting 2 warnings when compiling pfCrashHandler:

```
Plasma/FeatureLib/pfCrashHandler/plCrashSrv.cpp(86,46): warning: argument to
'sizeof' in 'memcpy' call is the same pointer type 'PCONTEXT' (aka '_CONTEXT
*') as the destination; expected 'struct _CONTEXT' or an explicit length
[-Wsizeof-pointer-memaccess]
        memcpy(context, ptrs->ContextRecord, sizeof(ptrs->ContextRecord));
               ~~~~~~~                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
Plasma/FeatureLib/pfCrashHandler/plWindowsStackWalker.cpp(140,5): warning:
explicitly defaulted default constructor is implicitly deleted
[-Wdefaulted-function-deleted]
    plStackWalkError() = default;
    ^
Plasma/Sources/Plasma/FeatureLib/pfCrashHandler/plWindowsStackWalker.cpp(137,26):
note: default constructor of 'plStackWalkError' is implicitly deleted because
base class 'std::runtime_error' has no default constructor
class plStackWalkError : public std::runtime_error
                         ^
Plasma/Sources/Plasma/FeatureLib/pfCrashHandler/plWindowsStackWalker.cpp(140,26):
note: replace 'default' with 'delete'
    plStackWalkError() = default;
                         ^~~~~~~
                         delete

```

The memcpy one seems like an actual issue in terms of behaviour...