### PR TITLE
Fixes for finding png crush executable

### DIFF
--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -29,7 +29,7 @@ cmake_dependent_option(RESOURCE_BRUTE "Allow pngcrush brute-force optimization" 
 if(PLASMA_BUILD_RESOURCE_DAT)
     set(external_DAT "${CMAKE_CURRENT_BINARY_DIR}/resource.dat")
     if(RESOURCE_OPTIMIZE)
-        string(APPEND OPTIMIZE_ARGUMENT "--pngcrush \"${PNGCRUSH_EXECUTABLE}\" ")
+        string(APPEND OPTIMIZE_ARGUMENT "--pngcrush=\"${PNGCRUSH_EXECUTABLE}\" ")
     endif()
     if(RESOURCE_BRUTE)
         string(APPEND OPTIMIZE_ARGUMENT "--brute ")

--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -29,10 +29,10 @@ cmake_dependent_option(RESOURCE_BRUTE "Allow pngcrush brute-force optimization" 
 if(PLASMA_BUILD_RESOURCE_DAT)
     set(external_DAT "${CMAKE_CURRENT_BINARY_DIR}/resource.dat")
     if(RESOURCE_OPTIMIZE)
-        string(APPEND OPTIMIZE_ARGUMENT "--pngcrush=\"${PNGCRUSH_EXECUTABLE}\" ")
+        list(APPEND OPTIMIZE_ARGUMENT --pngcrush "${PNGCRUSH_EXECUTABLE}")
     endif()
     if(RESOURCE_BRUTE)
-        string(APPEND OPTIMIZE_ARGUMENT "--brute ")
+        list(APPEND OPTIMIZE_ARGUMENT "--brute")
     endif()
 
     add_custom_command(


### PR DESCRIPTION
I'm not sure why this is required or how the fix improves things - but the part of the CMake script that finds pngcrush has been failing on _some_ of my Macs. I'm not sure why - the Mac that I am seeing this on is running the latest version of CMake.

These changes to the script seem to make things work.

If anyone has a CMake perspective on why this is going on or why the fix works - that would be appreciated.