### PR TITLE
Fix 3 problems with `plSubWorldMsg`.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -1379,7 +1379,7 @@ bool plArmatureMod::MsgReceive(plMessage* msg)
         if (fController)
         {
             fController->SetSubworld(subMsg->fWorldKey);
-            DirtySynchState(kSDLAvatar, plSynchedObject::kBCastToClients);
+            DirtyPhysicalSynchState(plSynchedObject::kBCastToClients);
         }
         return true;
     }

--- a/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
@@ -208,6 +208,8 @@ bool plResponderModifier::IIsLocalOnlyCmd(plMessage* cmd)
         return true;
     if (plCameraMsg::ConvertNoRef(cmd))     // don't want to change our camera
         return true;
+    if (plSubWorldMsg::ConvertNoRef(cmd))   // don't want to enter a subworld (changes the avatar SDL)
+        return true;
 
     plSoundMsg *snd = plSoundMsg::ConvertNoRef( cmd );
     if (snd != nullptr && snd->Cmd(plSoundMsg::kIsLocalOnly))

--- a/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
@@ -351,6 +351,7 @@ bool plResponderModifier::IContinueSending()
                     plArmatureMod *avatar = plAvatarMgr::GetInstance()->GetLocalAvatar();
                     if(avatar)
                     {
+                        swMsg->ClearReceivers();
                         swMsg->AddReceiver(avatar->GetKey());
                     }
                 }


### PR DESCRIPTION
The impetus for this change is that Korman's new `Change Subworld` message node can cause all players in the Age to change to that subworld. The rationale here is that changing subworlds modifies a player's avatarPhysical SDL. So, really, we probably only want to be sending `plSubWorldMsg` to the local player from a Responder. Responders are primarily a zero-code artist logic tool, so they shouldn't have to care about that level of SDL detail. Further, there is precedent for major avatar/player related actions to be rejected from non-local sources. Namely, all camera messages are restricted in the same way in Responders.

As a bonus, I fixed a memory leak that wouldn't be detected by asan and fixed a logic error with the subworld SDL synch.