### PR TITLE
Remove no longer used check for `pthread_timedjoin_np`

### DIFF
--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceThread.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceThread.cpp
@@ -47,11 +47,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "Pch.h"
 
-#if defined(HAVE_PTHREAD_TIMEDJOIN_NP)
-#include <pthread.h>
-#include <time.h>
-#endif
-
 static void CreateThreadProc(AsyncThreadRef thread)
 {
 #ifdef USE_VLD

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -11,10 +11,6 @@ if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
     endif()
 endif()
 
-try_compile(HAVE_PTHREAD_TIMEDJOIN_NP ${PROJECT_BINARY_DIR}
-            ${PROJECT_SOURCE_DIR}/cmake/check_pthread_timedjoin_np.cpp
-            LINK_LIBRARIES Threads::Threads)
-
 # Check for Linux sysinfo.
 include(CheckCXXSymbolExists)
 check_cxx_symbol_exists("sysinfo" "sys/sysinfo.h" HAVE_SYSINFO)

--- a/cmake/check_pthread_timedjoin_np.cpp
+++ b/cmake/check_pthread_timedjoin_np.cpp
@@ -1,9 +1,0 @@
-#include <pthread.h>
-#include <time.h>
-
-int main()
-{
-    pthread_t thread;
-    struct timespec ts{};
-    return pthread_timedjoin_np(thread, nullptr, &ts);
-}

--- a/cmake/hsConfig.h.cmake
+++ b/cmake/hsConfig.h.cmake
@@ -63,7 +63,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #cmakedefine USE_VPX
 #cmakedefine USE_WEBM
 
-#cmakedefine HAVE_PTHREAD_TIMEDJOIN_NP
 #cmakedefine HAVE_SYSCTL
 #cmakedefine HAVE_SYSDIR
 #cmakedefine HAVE_SYSINFO


### PR DESCRIPTION
No longer needed as of c70211a327682fbe11c73f8241dcd361ef2e6224 (#1205).