### PR TITLE
Support Unicode in `plTextFont` (avatar tooltips, console, etc.)

### DIFF
--- a/Sources/Plasma/FeatureLib/pfAnimation/plAnimDebugList.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plAnimDebugList.cpp
@@ -114,7 +114,7 @@ void plAnimDebugList::ShowReport()
 
     x = startX;
     y = startY;
-    txt.DrawString(x, y, "Material Animations:", 255, 255, 255, 255, plDebugText::kStyleBold);
+    txt.DrawString(x, y, ST_LITERAL("Material Animations:"), 255, 255, 255, 255, plDebugText::kStyleBold);
     y += yOff;
     for (const plKey& matKey : fMaterialKeys)
     {
@@ -141,7 +141,7 @@ void plAnimDebugList::ShowReport()
         }
     }
     y += yOff;
-    txt.DrawString(x, y, "AGMaster Anims", 255, 255, 255, 255, plDebugText::kStyleBold);
+    txt.DrawString(x, y, ST_LITERAL("AGMaster Anims"), 255, 255, 255, 255, plDebugText::kStyleBold);
     y += yOff;
 
     for (const plKey& soKey : fSOKeys)

--- a/Sources/Plasma/FeatureLib/pfAudio/plListener.cpp
+++ b/Sources/Plasma/FeatureLib/pfAudio/plListener.cpp
@@ -75,7 +75,7 @@ bool plListener::IEval(double secs, float del, uint32_t dirty)
 
     int y = 16 + 12, x = 400;
     if( fPrintDbgInfo ) 
-        plDebugText::Instance().DrawString( x, 16, "Listener:", (uint32_t)0xffffffff, plDebugText::kStyleBold );
+        plDebugText::Instance().DrawString(x, 16, ST_LITERAL("Listener:"), (uint32_t)0xffffffff, plDebugText::kStyleBold);
 
     // Get the avatar's SceneObject
     plKey key = plNetClientApp::GetInstance()->GetLocalPlayerKey();
@@ -86,7 +86,7 @@ bool plListener::IEval(double secs, float del, uint32_t dirty)
     {
         // We don't have a position to init by, so do NOT eval yet!!!
         if( fPrintDbgInfo ) 
-            plDebugText::Instance().DrawString( x, y, "Not eval-ing yet", (uint32_t)0xffffffff );
+            plDebugText::Instance().DrawString(x, y, ST_LITERAL("Not eval-ing yet"), (uint32_t)0xffffffff);
         return true;
     }
 
@@ -171,7 +171,7 @@ bool plListener::IEval(double secs, float del, uint32_t dirty)
     if( facingType == kInvalid || posType == kInvalid || velType == kInvalid )
     {
         if( fPrintDbgInfo ) 
-            plDebugText::Instance().DrawString( x, y, "Not eval-ing: missing one or more parameter bases", (uint32_t)0xff0000ff );
+            plDebugText::Instance().DrawString(x, y, ST_LITERAL("Not eval-ing: missing one or more parameter bases"), (uint32_t)0xff0000ff);
         return true;
     }
 
@@ -191,22 +191,22 @@ bool plListener::IEval(double secs, float del, uint32_t dirty)
         ST::string str;
         str = ST::format("Direction: ({3.2f},{3.2f},{3.2f}) from {}", dir.fX, dir.fY, dir.fZ,
                          (facingType == kObject) ? pRefObject->GetKeyName() : "VCam");
-        plDebugText::Instance().DrawString( x, y, str.c_str(), (uint32_t)0xffffffff );
+        plDebugText::Instance().DrawString(x, y, str, (uint32_t)0xffffffff);
         y += 12;
 
         str = ST::format("Up: ({3.2f},{3.2f},{3.2f}) from {}", up.fX, up.fY, up.fZ,
                          (facingType == kObject) ? pRefObject->GetKeyName() : "VCam");
-        plDebugText::Instance().DrawString( x, y, str.c_str(), (uint32_t)0xffffffff );
+        plDebugText::Instance().DrawString(x, y, str, (uint32_t)0xffffffff);
         y += 12;
 
         str = ST::format("Position: ({3.2f},{3.2f},{3.2f}) from {}", position.fX, position.fY, position.fZ,
                          (posType == kObject) ? pRefObject->GetKeyName() : "VCam");
-        plDebugText::Instance().DrawString( x, y, str.c_str(), (uint32_t)0xffffffff );
+        plDebugText::Instance().DrawString(x, y, str, (uint32_t)0xffffffff);
         y += 12;
 
         str = ST::format("Velocity: ({3.2f},{3.2f},{3.2f}) from {}", velocity.fX, velocity.fY, velocity.fZ,
                          (velType == kObject) ? pRefObject->GetKeyName() : "VCam");
-        plDebugText::Instance().DrawString( x, y, str.c_str(), (uint32_t)0xffffffff );
+        plDebugText::Instance().DrawString(x, y, str, (uint32_t)0xffffffff);
         y += 12;
     }
     plgDispatch::MsgSend( msg );

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -1247,8 +1247,7 @@ PF_CONSOLE_CMD( Graphics_DebugText,         // Group name
                 "string face, int size",    // Params
                 "Sets the font face and size used for drawing debug text" ) // Help string
 {
-    const ST::string& face = params[0];
-    plDebugText::Instance().SetFont(face.c_str(), (uint16_t)(int)params[1]);
+    plDebugText::Instance().SetFont(params[0], (uint16_t)(int)params[1]);
 }
 
 PF_CONSOLE_CMD( Graphics_DebugText,         // Group name

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
@@ -128,6 +128,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <algorithm>
 #include <string_theory/string>
+#include <utility>
 
 //#define MF_TOSSER
 
@@ -2280,7 +2281,7 @@ void    plDXPipeline::Resize( uint32_t width, uint32_t height )
 
 //// MakeTextFont /////////////////////////////////////////////////////////////
 
-plTextFont  *plDXPipeline::MakeTextFont( char *face, uint16_t size )
+plTextFont* plDXPipeline::MakeTextFont(ST::string face, uint16_t size)
 {
     plTextFont  *font;
 
@@ -2288,7 +2289,7 @@ plTextFont  *plDXPipeline::MakeTextFont( char *face, uint16_t size )
     font = new plDXTextFont( this, fD3DDevice );
     if (font == nullptr)
         return nullptr;
-    font->Create( face, size );
+    font->Create(std::move(face), size);
     font->Link( &fTextFontRefList );
 
     return font;

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
@@ -9812,9 +9812,8 @@ void    plDXPlateManager::IDrawToDevice( plPipeline *pipe )
         {
             dxPipe->IDrawPlate( plate );
 
-            const char *title = plate->GetTitle();
-            if( plDebugText::Instance().IsEnabled() && title[ 0 ] != 0 )
-            {
+            ST::string title = plate->GetTitle();
+            if (plDebugText::Instance().IsEnabled() && !title.empty()) {
                 hsPoint3 pt;
                 pt.Set( 0, -0.5, 0 );
                 pt = plate->GetTransform() * pt;
@@ -9830,26 +9829,21 @@ void    plDXPlateManager::IDrawToDevice( plPipeline *pipe )
                 hsPoint3        pt, pt2;
                 int             i;
 
-                if( graph->GetLabelText( 0 )[ 0 ] != 0 )
-                {
+                uint32_t numLabels = graph->GetNumLabels();
+                if (numLabels > 0) {
                     /// Draw key
-                    const char *str;
-
                     pt.Set( -0.5, -0.5, 0 );
                     pt = plate->GetTransform() * pt;
                     pt.fX = pt.fX * scrnWidthDiv2 + scrnWidthDiv2;
                     pt.fY = pt.fY * scrnHeightDiv2 + scrnHeightDiv2;
                     pt.fY += plDebugText::Instance().GetFontHeight();
 
-                    uint32_t numLabels = graph->GetNumLabels();
                     if (numLabels > graph->GetNumColors())
                         numLabels = graph->GetNumColors();
 
                     for( i = 0; i < numLabels; i++ )
                     {
-                        str = graph->GetLabelText( i );
-                        if( str[ 0 ] == 0 )
-                            break;
+                        ST::string str = graph->GetLabelText(i);
 
                         pt2 = pt;
                         pt2.fX -= plDebugText::Instance().CalcStringWidth( str );

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.h
@@ -557,7 +557,7 @@ public:
     void                        LoadResources() override;    // Tells us where it's a good time to load in unmanaged resources.
 
     // Create a debug text font object
-    plTextFont      *MakeTextFont(char *face, uint16_t size) override;
+    plTextFont* MakeTextFont(ST::string face, uint16_t size) override;
 
     // Create and/or Refresh geometry buffers
     void            CheckVertexBufferRef(plGBufferGroup* owner, uint32_t idx) override;

--- a/Sources/Plasma/FeatureLib/pfGLPipeline/plGLPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfGLPipeline/plGLPipeline.cpp
@@ -49,6 +49,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "hsWindows.h"
 
+#include <string_theory/string>
+
 #include "plPipeline/hsWinRef.h"
 
 #include "plGLPipeline.h"
@@ -79,7 +81,7 @@ bool plGLPipeline::PrepForRender(plDrawable* drawable, std::vector<int16_t>& vis
 void plGLPipeline::Render(plDrawable* d, const std::vector<int16_t>& visList)
 {}
 
-plTextFont* plGLPipeline::MakeTextFont(char* face, uint16_t size)
+plTextFont* plGLPipeline::MakeTextFont(ST::string face, uint16_t size)
 {
     return nullptr;
 }

--- a/Sources/Plasma/FeatureLib/pfGLPipeline/plGLPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfGLPipeline/plGLPipeline.h
@@ -77,7 +77,7 @@ public:
     bool PreRender(plDrawable* drawable, std::vector<int16_t>& visList, plVisMgr* visMgr=nullptr) override;
     bool PrepForRender(plDrawable* drawable, std::vector<int16_t>& visList, plVisMgr* visMgr=nullptr) override;
     void Render(plDrawable* d, const std::vector<int16_t>& visList) override;
-    plTextFont* MakeTextFont(char* face, uint16_t size) override;
+    plTextFont* MakeTextFont(ST::string face, uint16_t size) override;
     void CheckVertexBufferRef(plGBufferGroup* owner, uint32_t idx) override;
     void CheckIndexBufferRef(plGBufferGroup* owner, uint32_t idx) override;
     bool OpenAccess(plAccessSpan& dst, plDrawableSpans* d, const plVertexSpan* span, bool readOnly) override;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
@@ -426,9 +426,7 @@ static bool     showBounds = false;
                     float x = sW * ctrl->fBoundsPoints[j].fX;
                     float y = sH * ctrl->fBoundsPoints[j].fY;
                     plDebugText::Instance().DrawRect( (uint16_t)(x - 2), (uint16_t)(y - 2), (uint16_t)(x + 2), (uint16_t)(y + 2), color );
-                    char str[24];
-                    snprintf(str, std::size(str), "%zu", j);
-                    plDebugText::Instance().DrawString( (uint16_t)(x + 8), (uint16_t)(y - 8), str, color );
+                    plDebugText::Instance().DrawString((uint16_t)(x + 8), (uint16_t)(y - 8), ST::string::from_uint(j), color);
                 }
             }
             else
@@ -484,7 +482,7 @@ static bool     showBounds = false;
         {
             const hsBounds3 &bnds = fMousedCtrl->GetBounds();
             plDebugText::Instance().DrawString((uint16_t)(bnds.GetMins().fX), (uint16_t)(bnds.GetMins().fY),
-                                               fMousedCtrl->GetKeyName().c_str(), (uint32_t)0xffffff00);
+                                               fMousedCtrl->GetKeyName(), (uint32_t)0xffffff00);
         }
 #endif
 

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -92,6 +92,7 @@ class plVisMgr;
 
 class plViewTransform;
 
+namespace ST { class string; }
 
 struct PipelineParams
 {
@@ -169,7 +170,7 @@ public:
     virtual void                        Draw(plDrawable* d) = 0;
     
     // Device-specific ref creation. Includes buffers and fonts
-    virtual plTextFont                  *MakeTextFont( char *face, uint16_t size ) = 0;
+    virtual plTextFont* MakeTextFont(ST::string face, uint16_t size) = 0;
 
     // Create and/or Refresh geometry buffers
     virtual void            CheckVertexBufferRef(plGBufferGroup* owner, uint32_t idx) = 0;

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.cpp
@@ -125,10 +125,10 @@ void plSound::IUpdateDebugPlate()
             fDebugPlate->SetPosition( -0.5, 0 );
             fDebugPlate->SetDataRange( 0, 100, 100 );
             fDebugPlate->SetColors( 0x80202000 );
-            fDebugPlate->SetLabelText( "Desired", "Curr", "Soft", "Dist" );
+            fDebugPlate->SetLabelText({ST_LITERAL("Desired"), ST_LITERAL("Curr"), ST_LITERAL("Soft"), ST_LITERAL("Dist")});
         }
 
-        fDebugPlate->SetTitle(GetKeyName().c_str());      // Bleah
+        fDebugPlate->SetTitle(GetKeyName()); // Bleah
         fDebugPlate->SetVisible( true );
         fDebugPlate->AddData( (int32_t)( fDesiredVol * 100.f ), 
                               (int32_t)( fCurrVolume * 100.f ),

--- a/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.cpp
@@ -131,11 +131,8 @@ void plVoiceRecorder::IncreaseRecordingThreshhold()
     fRecordThreshhold += (100 * hsTimer::GetDelSysSeconds());
     if (fRecordThreshhold >= 10000.0f)
         fRecordThreshhold = 10000.0f;
-    
-    plDebugText &txt = plDebugText::Instance();
-    char str[256];
-    sprintf(str, "RecordThreshhold %f\n", fRecordThreshhold);
-    txt.DrawString(400,300,str);
+
+    plDebugText::Instance().DrawString(400, 300, ST::format("RecordThreshhold {}\n", fRecordThreshhold));
 }
 
 void plVoiceRecorder::DecreaseRecordingThreshhold()
@@ -143,11 +140,8 @@ void plVoiceRecorder::DecreaseRecordingThreshhold()
     fRecordThreshhold -= (100 * hsTimer::GetDelSysSeconds());
     if (fRecordThreshhold <= 50.0f)
         fRecordThreshhold = 50.0f;
-    
-    plDebugText &txt = plDebugText::Instance();
-    char str[256];
-    sprintf(str, "RecordThreshhold %f\n", fRecordThreshhold);
-    txt.DrawString(400,300,str);
+
+    plDebugText::Instance().DrawString(400, 300, ST::format("RecordThreshhold {}\n", fRecordThreshhold));
 }
 
 void plVoiceRecorder::SetSampleRate(uint32_t rate)

--- a/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plVoiceChat.cpp
@@ -117,8 +117,8 @@ void plVoiceRecorder::ShowGraph(bool b)
     if (!fGraph) {
         plPlateManager::Instance().CreateGraphPlate(&fGraph);
         fGraph->SetDataRange(0, 100, 100);
-        fGraph->SetLabelText("Voice Send Rate");
-        fGraph->SetTitle("Voice Recorder");
+        fGraph->SetLabelText({ST_LITERAL("Voice Send Rate")});
+        fGraph->SetTitle(ST_LITERAL("Voice Recorder"));
     }
 
     fGraph->SetSize(.4f, .25f);
@@ -205,8 +205,9 @@ void plVoiceRecorder::SetMicOpen(bool b)
             fCaptureOpenSecs = hsTimer::GetSeconds<float>();
         } else {
             plgAudioSys::EndCapture();
-            if (fGraph)
-                fGraph->SetTitle("Voice Recorder");
+            if (fGraph) {
+                fGraph->SetTitle(ST_LITERAL("Voice Recorder"));
+            }
         }
         DrawTalkIcon(b);
         fMicOpen = b;
@@ -317,7 +318,7 @@ void plVoiceRecorder::Update(double time)
                 float sendRate = ((float)bytesSent / (now - fCaptureOpenSecs)) / 1024.f;
                 // Scale the graph such that 8 KiB/s is the max
                 fGraph->AddData((int32_t)((100.f * sendRate) / 8.f));
-                fGraph->SetTitle(ST::format("{.2f} KiB/s", sendRate).c_str());
+                fGraph->SetTitle(ST::format("{.2f} KiB/s", sendRate));
             }
             fCaptureOpenSecs = now;
         }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -2661,7 +2661,7 @@ void plArmatureMod::DumpToDebugDisplay(int &x, int &y, int lineHeight, plDebugTe
     {
         y += lineHeight;
 
-        debugTxt.DrawString(x, y, "ItemsWorn:");
+        debugTxt.DrawString(x, y, ST_LITERAL("ItemsWorn:"));
         y += lineHeight;
         ST::string_stream outfit;
         int itemCount = 0; 
@@ -2695,7 +2695,7 @@ void plArmatureMod::DumpToDebugDisplay(int &x, int &y, int lineHeight, plDebugTe
     {
         y += lineHeight;
 
-        debugTxt.DrawString(x, y, "Relevance Regions:");
+        debugTxt.DrawString(x, y, ST_LITERAL("Relevance Regions:"));
         y += lineHeight;
         debugTxt.DrawString(x, y, ST::format("          In: {}",
                 plRelevanceMgr::Instance()->GetRegionNames(fRegionsImIn)));

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainClimb.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainClimb.cpp
@@ -890,14 +890,12 @@ void plAvBrainClimb::LoadFromSDL(const plStateDataRecord *sdl)
 // ------------------
 void plAvBrainClimb::DumpToDebugDisplay(int &x, int &y, int lineHeight, plDebugText &debugTxt)
 {
-    debugTxt.DrawString(x, y, "Brain type: Climb");
+    debugTxt.DrawString(x, y, ST_LITERAL("Brain type: Climb"));
     y += lineHeight;
     const char * worldDir = WorldDirStr(fDesiredDirection);
     const char * modeStr = ModeStr(fCurMode);
 
-    char buffy[256];
-    sprintf(buffy, "direction: %s mode: %s controlDir: %f", worldDir, modeStr, fControlDir);
-    debugTxt.DrawString(x,y, buffy);
+    debugTxt.DrawString(x, y, ST::format("direction: {} mode: {} controlDir: {}", worldDir, modeStr, fControlDir));
     y += lineHeight;
     
     IDumpClimbDirections(x, y, lineHeight, debugTxt);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
@@ -447,7 +447,7 @@ void plAvBrainCritter::RemoveReceiver(const plKey& key)
 
 void plAvBrainCritter::DumpToDebugDisplay(int& x, int& y, int lineHeight, plDebugText& debugTxt)
 {
-    debugTxt.DrawString(x, y, "Brain type: Critter", 0, 255, 255);
+    debugTxt.DrawString(x, y, ST_LITERAL("Brain type: Critter"), 0, 255, 255);
     y += lineHeight;
 
     // extract the name from the behavior running

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainGeneric.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainGeneric.cpp
@@ -937,7 +937,7 @@ void plAvBrainGeneric::SetBodyUsage(plAGAnim::BodyUsage bodyUsage)
 // -------------------
 void plAvBrainGeneric::DumpToDebugDisplay(int &x, int &y, int lineHeight, plDebugText &debugTxt)
 {
-    debugTxt.DrawString(x, y, "Brain type: Generic AKA Multistage");
+    debugTxt.DrawString(x, y, ST_LITERAL("Brain type: Generic AKA Multistage"));
     y += lineHeight;
 
     int stageCount = fStages->size();

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
@@ -879,7 +879,7 @@ bool plAvBrainHuman::LeaveAge()
 
 void plAvBrainHuman::DumpToDebugDisplay(int &x, int &y, int lineHeight, plDebugText &debugTxt)
 {
-    debugTxt.DrawString(x, y, "Brain type: Human");
+    debugTxt.DrawString(x, y, ST_LITERAL("Brain type: Human"));
     y += lineHeight;
     
     const char *grounded = fWalkingStrategy->IsOnGround() ? "yes" : "no";
@@ -891,12 +891,12 @@ void plAvBrainHuman::DumpToDebugDisplay(int &x, int &y, int lineHeight, plDebugT
     for (plArmatureBehavior* behavior : fBehaviors)
         behavior->DumpDebug(x, y, lineHeight, debugTxt);
 
-    debugTxt.DrawString(x, y, "Tasks:");
+    debugTxt.DrawString(x, y, ST_LITERAL("Tasks:"));
     y += lineHeight;
 
     if(fCurTask)
     {
-        debugTxt.DrawString(x, y, "Current task:");
+        debugTxt.DrawString(x, y, ST_LITERAL("Current task:"));
         y += lineHeight;
 
         int indentedX = x + 4;
@@ -905,7 +905,7 @@ void plAvBrainHuman::DumpToDebugDisplay(int &x, int &y, int lineHeight, plDebugT
     int tasks = fTaskQueue.size();
     if(tasks > 0)
     {
-        debugTxt.DrawString(x, y, "Tasks in the Queue:");
+        debugTxt.DrawString(x, y, ST_LITERAL("Tasks in the Queue:"));
         y += lineHeight;
 
         int indentedX = x + 4;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainSwim.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainSwim.cpp
@@ -604,21 +604,21 @@ bool plAvBrainSwim::IHandleControlMsg(plControlEventMsg* msg)
 
 void plAvBrainSwim::DumpToDebugDisplay(int &x, int &y, int lineHeight, plDebugText &debugTxt)
 {
-    debugTxt.DrawString(x, y, "Brain type: Swim", 0, 255, 255);
+    debugTxt.DrawString(x, y, ST_LITERAL("Brain type: Swim"), 0, 255, 255);
     y += lineHeight;
     
     switch(fMode) {
         case kWading:
-            debugTxt.DrawString(x, y, "Mode: Wading");
+            debugTxt.DrawString(x, y, ST_LITERAL("Mode: Wading"));
             break;
         case kSwimming2D:
-            debugTxt.DrawString(x, y, "Mode: Swimming2D");
+            debugTxt.DrawString(x, y, ST_LITERAL("Mode: Swimming2D"));
             break;
         case kSwimming3D:
-            debugTxt.DrawString(x, y, "Mode: Swimming3D");
+            debugTxt.DrawString(x, y, ST_LITERAL("Mode: Swimming3D"));
             break;
         case kAbort:
-            debugTxt.DrawString(x, y, "Mode: Abort (you should never see this)");
+            debugTxt.DrawString(x, y, ST_LITERAL("Mode: Abort (you should never see this)"));
             break;
         default:
             break;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvTaskBrain.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvTaskBrain.cpp
@@ -96,11 +96,10 @@ void plAvTaskBrain::Finish(plArmatureMod *avatar, plArmatureBrain *brain, double
 // ----------
 void plAvTaskBrain::DumpDebug(const char *name, int &x, int&y, int lineHeight, plDebugText &debugTxt)
 {
-    if(fBrain)
-    {
-        debugTxt.DrawString(x, y, "Brain task -- Push New Brain.");
+    if (fBrain) {
+        debugTxt.DrawString(x, y, ST_LITERAL("Brain task -- Push New Brain."));
     } else {
-        debugTxt.DrawString(x, y, "Brain task -- Pop Current Brain.");
+        debugTxt.DrawString(x, y, ST_LITERAL("Brain task -- Pop Current Brain."));
     }
     y += lineHeight;
 }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
@@ -111,7 +111,7 @@ void plAvTask::Finish(plArmatureMod *avatar, plArmatureBrain *brain, double time
 // DUMPDEBUG
 void plAvTask::DumpDebug(const char *name, int &x, int&y, int lineHeight, plDebugText &debugTxt)
 {
-    debugTxt.DrawString(x, y, "<anonymous task>");
+    debugTxt.DrawString(x, y, ST_LITERAL("<anonymous task>"));
     y += lineHeight;
 }
 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
@@ -304,7 +304,7 @@ void plMouseDevice::AddCCRToCursor()
     if (fInstance)
     {
         plDebugText     &txt = plDebugText::Instance();
-        txt.DrawString(fInstance->fWXPos + 12 * fScale, fInstance->fWYPos - 17, "CCR");
+        txt.DrawString(fInstance->fWXPos + 12 * fScale, fInstance->fWYPos - 17, ST_LITERAL("CCR"));
     }
 }
 void plMouseDevice::AddIDNumToCursor(uint32_t idNum)
@@ -326,10 +326,6 @@ void plMouseDevice::SetCursorX(float x)
     if (fCursor)
         fCursor->SetPosition( ( x * 2.0f ) - 1.0f, 
                           ( fYPos * 2.0f ) - 1.0f );
-
-//  plDebugText     &txt = plDebugText::Instance();
-//  txt.DrawString(fWXPos + 20,fWYPos - 5,"test");
-
 }
 void plMouseDevice::SetCursorY(float y)
 {
@@ -340,10 +336,6 @@ void plMouseDevice::SetCursorY(float y)
     if (fCursor)
         fCursor->SetPosition( ( fXPos * 2.0f ) - 1.0f, 
                           ( y * 2.0f ) - 1.0f );
-
-//  plDebugText     &txt = plDebugText::Instance();
-//  txt.DrawString(fWXPos + 20,fWYPos - 10,"test");
-
 }
 
 

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrShow.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrShow.cpp
@@ -67,32 +67,28 @@ void plNetClientMgr::IShowLists()
 
     int y,x,i;
     const int yOff=10, xOff=300, startY=70, startX=10;
-    char str[256];
+    ST::string str;
 
     // My player info
     x=startX;
     y=startY;
     plSceneObject *player = plSceneObject::ConvertNoRef(GetLocalPlayer());
     hsPoint3 pos = (player ? player->GetLocalToWorld() * hsPoint3(0, 0, 0) : hsPoint3(0, 0, 0));
-    sprintf(str, "%s%s PlyrName=%s PlyrID=%d Join#=%d %.1f,%.1f,%.1f",
+    str = ST::format("{}{} PlyrName={} PlyrID={} Join#={} ILIAS={} {.1f},{.1f},{.1f}",
         GetFlagsBit(kSendingVoice) ? "V" : " ",
         GetFlagsBit(kSendingActions) ? "A" : " ",
         GetPlayerName().c_str(), GetPlayerID(),
         GetJoinOrder(),
+        IsLoadingInitialAgeState(),
         pos.fX, pos.fY, pos.fZ);
     txt.DrawString(x,y,str,255,255,255,255);
     SetFlagsBit(kSendingVoice, 0);
     SetFlagsBit(kSendingActions, 0);
 
-    y+=yOff;
-    sprintf(str, "   Server=%s ILIAS=%d", "foo",
-        IsLoadingInitialAgeState());
-    txt.DrawString(x,y,str,255,255,255,255);
-    
     // MEMBERS
     y+=yOff;
     int baseY=y;
-    txt.DrawString(x,y,"   Members",255,255,255,255,plDebugText::kStyleBold);
+    txt.DrawString(x, y, ST_LITERAL("   Members"), 255, 255, 255, 255, plDebugText::kStyleBold);
     y+=yOff;
     std::vector<plNetTransportMember*> members = fTransport.GetMemberListDistSorted();
     for (plNetTransportMember* mbr : members)
@@ -101,7 +97,7 @@ void plNetClientMgr::IShowLists()
         if (mbr->IsServer())
             continue;
         player = (mbr->GetAvatarKey() ? plSceneObject::ConvertNoRef(mbr->GetAvatarKey()->ObjectIsLoaded()) : nullptr);
-        sprintf(str, "%s%s %s dist=%.1f",
+        str = ST::format("{}{} {} dist={.1f}",
             mbr->GetTransportFlags() & plNetTransportMember::kSendingVoice ? "V" : " ",
             mbr->GetTransportFlags() & plNetTransportMember::kSendingActions ? "A" : " ",
             mbr->AsString().c_str(),
@@ -115,24 +111,22 @@ void plNetClientMgr::IShowLists()
     // LISTENLIST
     x+=xOff;
     y=baseY;
-    txt.DrawString(x,y,"ListenList",255,255,255,255,plDebugText::kStyleBold);
+    txt.DrawString(x, y, ST_LITERAL("ListenList"), 255, 255, 255, 255, plDebugText::kStyleBold);
     y+=yOff;
     for(i=0;i<GetListenList()->GetNumMembers();i++)
     {
-        sprintf(str, "name=%s", GetListenList()->GetMember(i)->AsString().c_str());
-        txt.DrawString(x,y,str);
+        txt.DrawString(x, y, ST::format("name={}", GetListenList()->GetMember(i)->AsString()));
         y+=yOff;
     }
 
     // TALKLIST
     x+=xOff;
     y=baseY;
-    txt.DrawString(x,y,"TalkList",255,255,255,255,plDebugText::kStyleBold);
+    txt.DrawString(x, y, ST_LITERAL("TalkList"), 255, 255, 255, 255, plDebugText::kStyleBold);
     y+=yOff;
     for(i=0;i<GetTalkList()->GetNumMembers();i++)
     {
-        sprintf(str, "name=%s", GetTalkList()->GetMember(i)->AsString().c_str());
-        txt.DrawString(x,y,str);
+        txt.DrawString(x, y, ST::format("name={}", GetTalkList()->GetMember(i)->AsString()));
         y+=yOff;
     }
 }
@@ -151,7 +145,7 @@ void plNetClientMgr::IShowRooms()
     // OWNEDLIST
     x=startX;
     y=startY;
-    txt.DrawString(x,y,"RoomsOwned",255,255,255,255,plDebugText::kStyleBold);
+    txt.DrawString(x, y, ST_LITERAL("RoomsOwned"), 255, 255, 255, 255, plDebugText::kStyleBold);
     y+=yOff;
     std::set<plNetClientGroups::OwnedGroup>::iterator it=GetNetGroups()->fGroups.begin();
     for(;it != GetNetGroups()->fGroups.end(); it++)
@@ -166,7 +160,7 @@ void plNetClientMgr::IShowRooms()
     // NOTOWNEDLIST
     x+=xOff;
     y=startY;
-    txt.DrawString(x,y,"RoomsNotOwned",255,255,255,255,plDebugText::kStyleBold);
+    txt.DrawString(x, y, ST_LITERAL("RoomsNotOwned"), 255, 255, 255, 255, plDebugText::kStyleBold);
     y+=yOff;
     it=GetNetGroups()->fGroups.begin();
     for(;it != GetNetGroups()->fGroups.end(); it++)
@@ -181,31 +175,27 @@ void plNetClientMgr::IShowRooms()
 
 uint32_t IPrintRelRegion(const hsBitVector& region, int x, int y, const hsBitVector* cmpRegion)
 {
-    char buf[256];
-    int maxBits = 255;
-
     uint32_t num = plRelevanceMgr::Instance()->GetNumRegions();
-    if (num > maxBits)
-        num = maxBits;
 
     bool orTrue = false;
 
+    ST::string_stream buf;
     int i;
     for (i = 0; i < num; i++)
     {
-        buf[i] = (region.IsBitSet(i) ? '1' : '0');
+        buf << (region.IsBitSet(i) ? '1' : '0');
         if (cmpRegion && cmpRegion->IsBitSet(i) && region.IsBitSet(i))
             orTrue = true;
     }
-    buf[i] = '\0';
+    ST::string str = buf.to_string();
 
     plDebugText& txt = plDebugText::Instance()  ;
     if (orTrue)
-        txt.DrawString(x, y, buf, 0, 255, 0);
+        txt.DrawString(x, y, str, 0, 255, 0);
     else
-        txt.DrawString(x, y, buf);
+        txt.DrawString(x, y, str);
 
-    return txt.CalcStringWidth(buf);
+    return txt.CalcStringWidth(str);
 }
 
 void plNetClientMgr::IShowRelevanceRegions()
@@ -215,8 +205,7 @@ void plNetClientMgr::IShowRelevanceRegions()
     const int yOff = 12, xOff = 20, startY=70, startX=10;
     int x = startX, y = startY;
 
-    const char* title = "Name / In / Care";
-    txt.DrawString(x, y - yOff, title, 255, 255, 255, 255, plDebugText::kStyleBold);
+    txt.DrawString(x, y - yOff, ST_LITERAL("Name / In / Care"), 255, 255, 255, 255, plDebugText::kStyleBold);
 
     std::vector<plNetTransportMember*> members =  fTransport.GetMemberListDistSorted();
 
@@ -225,8 +214,8 @@ void plNetClientMgr::IShowRelevanceRegions()
     //
     uint32_t maxPlayerName = 0;
 
-    txt.DrawString(x, y, GetPlayerName().c_str());
-    maxPlayerName = std::max(maxPlayerName, txt.CalcStringWidth(GetPlayerName().c_str()));
+    txt.DrawString(x, y, GetPlayerName());
+    maxPlayerName = std::max(maxPlayerName, txt.CalcStringWidth(GetPlayerName()));
     y += yOff;
 
     for (plNetTransportMember* mbr : members)
@@ -236,8 +225,8 @@ void plNetClientMgr::IShowRelevanceRegions()
             continue;
 
         ST::string name = mbr->GetPlayerName();
-        txt.DrawString(x, y, name.c_str());
-        maxPlayerName = std::max(maxPlayerName, txt.CalcStringWidth(name.c_str()));
+        txt.DrawString(x, y, name);
+        maxPlayerName = std::max(maxPlayerName, txt.CalcStringWidth(name));
         y += yOff;
     }
 
@@ -296,7 +285,7 @@ void plNetClientMgr::IShowAvatars()
 
     int y, x;
     const int yOff=10, xOff=285, startY=100, startX=10;
-    char str[256];
+    ST::string str;
 
     // Me
     x=startX;
@@ -304,8 +293,8 @@ void plNetClientMgr::IShowAvatars()
     plSceneObject *player = plSceneObject::ConvertNoRef(GetLocalPlayer());
     hsPoint3 pos = (player ? player->GetLocalToWorld() * hsPoint3() : hsPoint3());
     hsVector3 ori = (player ? player->GetLocalToWorld() * hsVector3(0.f, -1.f, 0.f) : hsVector3());
-    sprintf(str, "%s: pos(%.2f, %.2f, %.2f) ori(%.2f, %.2f, %.2f)",
-            GetPlayerName().c_str(), pos.fX, pos.fY, pos.fZ, ori.fX, ori.fY, ori.fZ);
+    str = ST::format("{}: pos({.2f}, {.2f}, {.2f}) ori({.2f}, {.2f}, {.2f})",
+        GetPlayerName(), pos.fX, pos.fY, pos.fZ, ori.fX, ori.fY, ori.fZ);
     txt.DrawString(x,y,str,255,255,255,255);
 
 
@@ -322,8 +311,8 @@ void plNetClientMgr::IShowAvatars()
                 y+=yOff;
                 hsPoint3 pos = (pObj ? pObj->GetLocalToWorld() * hsPoint3() : hsPoint3());
                 hsVector3 ori = (pObj ? pObj->GetLocalToWorld() * hsVector3(0.f, -1.f, 0.f) : hsVector3());
-                sprintf(str, "%s: pos(%.2f, %.2f, %.2f) ori(%.2f, %.2f, %.2f)",
-                        pObj->GetKeyName().c_str(), pos.fX, pos.fY, pos.fZ, ori.fX, ori.fY, ori.fZ);
+                str = ST::format("{}: pos({.2f}, {.2f}, {.2f}) ori({.2f}, {.2f}, {.2f})",
+                    pObj->GetKeyName(), pos.fX, pos.fY, pos.fZ, ori.fX, ori.fY, ori.fZ);
                 txt.DrawString(x,y,str,255,255,255,255);
             }
         }
@@ -345,8 +334,8 @@ void plNetClientMgr::IShowAvatars()
         pos = (player ? player->GetLocalToWorld() * hsPoint3() : hsPoint3());
         ori = (player ? player->GetLocalToWorld() * hsVector3(0.f, -1.f, 0.f) : hsVector3());
 
-        sprintf(str, "%s: pos(%.2f, %.2f, %.2f) ori(%.2f, %.2f, %.2f)",
-                mbr->AsString().c_str(), pos.fX, pos.fY, pos.fZ, ori.fX, ori.fY, ori.fZ);
+        str = ST::format("{}: pos({.2f}, {.2f}, {.2f}) ori({.2f}, {.2f}, {.2f})",
+            mbr->AsString(), pos.fX, pos.fY, pos.fZ, ori.fX, ori.fY, ori.fZ);
         txt.DrawString(x,y,str);
         y+=yOff;
 
@@ -363,8 +352,8 @@ void plNetClientMgr::IShowAvatars()
                     y+=yOff;
                     hsPoint3 pos = (pObj ? pObj->GetLocalToWorld() * hsPoint3() : hsPoint3());
                     hsVector3 ori = (pObj ? pObj->GetLocalToWorld() * hsVector3(0.f, -1.f, 0.f) : hsVector3());
-                    sprintf(str, "%s: pos(%.2f, %.2f, %.2f) ori(%.2f, %.2f, %.2f)",
-                            pObj->GetKeyName().c_str(), pos.fX, pos.fY, pos.fZ, ori.fX, ori.fY, ori.fZ);
+                    str = ST::format("{}: pos({.2f}, {.2f}, {.2f}) ori({.2f}, {.2f}, {.2f})",
+                        pObj->GetKeyName(), pos.fX, pos.fY, pos.fZ, ori.fX, ori.fY, ori.fZ);
                     txt.DrawString(x,y,str,255,255,255,255);
                 }
             }

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrShow.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgrShow.cpp
@@ -292,7 +292,7 @@ void plNetClientMgr::IShowRelevanceRegions()
 void plNetClientMgr::IShowAvatars()
 {
     plDebugText     &txt = plDebugText::Instance();
-    txt.SetFont( "Courier New", 6 );
+    txt.SetFont(ST_LITERAL("Courier New"), 6);
 
     int y, x;
     const int yOff=10, xOff=285, startY=100, startX=10;
@@ -372,5 +372,5 @@ void plNetClientMgr::IShowAvatars()
 
     }
 
-    txt.SetFont( "Courier New", 8 );
+    txt.SetFont(ST_LITERAL("Courier New"), 8);
 }

--- a/Sources/Plasma/PubUtilLib/plPipeline/pl3DPipeline.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/pl3DPipeline.h
@@ -240,7 +240,7 @@ public:
     void Draw(plDrawable* d) override;
 
 
-    //virtual plTextFont* MakeTextFont(char* face, uint16_t size) = 0;
+    //virtual plTextFont* MakeTextFont(ST::string face, uint16_t size) = 0;
     //virtual void CheckVertexBufferRef(plGBufferGroup* owner, uint32_t idx) = 0;
     //virtual void CheckIndexBufferRef(plGBufferGroup* owner, uint32_t idx) = 0;
     //virtual bool OpenAccess(plAccessSpan& dst, plDrawableSpans* d, const plVertexSpan* span, bool readOnly) = 0;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDTProgressMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDTProgressMgr.cpp
@@ -201,7 +201,7 @@ bool    plDTProgressMgr::IDrawTheStupidThing(plPipeline *p, plOperationProgress 
     // draw the title
     if (!prog->GetTitle().empty()) {
         y -= downsz;
-        text.DrawString_TEMP(x, y, prog->GetTitle(), kTitleColor);
+        text.DrawString(x, y, prog->GetTitle(), kTitleColor);
         y += downsz;
         drew_something = true;
     }
@@ -232,14 +232,14 @@ bool    plDTProgressMgr::IDrawTheStupidThing(plPipeline *p, plOperationProgress 
 
     // draw the left justified status text
     if (!prog->GetStatusText().empty()) {
-        text.DrawString_TEMP(x, y, prog->GetStatusText(), kInfoColor);
+        text.DrawString(x, y, prog->GetStatusText(), kInfoColor);
         drew_something = true;
     }
 
     // draw the right justified info text
     if (!prog->GetInfoText().empty()) {
-        uint16_t right_x = 2 + x + width - text.CalcStringWidth_TEMP(prog->GetInfoText());
-        text.DrawString_TEMP(right_x, y, prog->GetInfoText(), kInfoColor);
+        uint16_t right_x = 2 + x + width - text.CalcStringWidth(prog->GetInfoText());
+        text.DrawString(right_x, y, prog->GetInfoText(), kInfoColor);
         drew_something = true;
     }
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.cpp
@@ -200,8 +200,7 @@ void    plDebugTextManager::DrawToDevice( plPipeline *pipe )
     if (fFont == nullptr)
     {
         // Create font first time around
-        fFont = pipe->MakeTextFont( (char *)plDebugText::Instance().GetFontFace(), 
-                                        plDebugText::Instance().GetFontSize() );
+        fFont = pipe->MakeTextFont(plDebugText::Instance().GetFontFace(), plDebugText::Instance().GetFontSize());
 
         if (fFont == nullptr)
         {

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.cpp
@@ -58,18 +58,20 @@ plDebugText plDebugText::fInstance;
 
 //// DrawString //////////////////////////////////////////////////////////////
 
-void    plDebugText::DrawString( uint16_t x, uint16_t y, const char *string, uint32_t hexColor, uint8_t style )
+void plDebugText::DrawString(uint16_t x, uint16_t y, ST::string string, uint32_t hexColor, uint8_t style)
 {
-    if (IsEnabled() && fManager && string != nullptr && string[0] != 0)
-        fManager->AddString( x, y, string, hexColor, style, fDrawOnTopMode );
+    if (IsEnabled() && fManager && !string.empty()) {
+        fManager->AddString(x, y, std::move(string), hexColor, style, fDrawOnTopMode);
+    }
 }
 
 //// CalcStringWidth /////////////////////////////////////////////////////////
 
-uint32_t  plDebugText::CalcStringWidth( const char *string )
+uint32_t plDebugText::CalcStringWidth(const ST::string& string)
 {
-    if( IsEnabled() && fManager && string )
-        return fManager->CalcStringWidth( string );
+    if (IsEnabled() && fManager) {
+        return fManager->CalcStringWidth(string);
+    }
 
     return 0;
 }
@@ -114,10 +116,9 @@ uint16_t plDebugText::GetFontHeight()
 
 //// plDebugTextNode Constructor /////////////////////////////////////////////
 
-plDebugTextManager::plDebugTextNode::plDebugTextNode( const char *s, uint32_t c, uint16_t x, uint16_t y, uint8_t style )
+plDebugTextManager::plDebugTextNode::plDebugTextNode(ST::string s, uint32_t c, uint16_t x, uint16_t y, uint8_t style) :
+    fText(std::move(s))
 {
-    memset( fText, 0, sizeof( fText ) );
-    strncpy( fText, s, sizeof( fText ) - 1 );
     fColor = c;
     fX = x;
     fY = y;
@@ -126,7 +127,6 @@ plDebugTextManager::plDebugTextNode::plDebugTextNode( const char *s, uint32_t c,
 
 plDebugTextManager::plDebugTextNode::plDebugTextNode( uint16_t left, uint16_t top, uint16_t right, uint16_t bottom, uint32_t c )
 {
-    memset( fText, 0, sizeof( fText ) );
     fColor = c;
     fX = left;
     fY = top;
@@ -137,7 +137,6 @@ plDebugTextManager::plDebugTextNode::plDebugTextNode( uint16_t left, uint16_t to
 
 plDebugTextManager::plDebugTextNode::plDebugTextNode( uint16_t left, uint16_t top, uint16_t right, uint16_t bottom, uint32_t c1, uint32_t c2 )
 {
-    memset( fText, 0, sizeof( fText ) );
     fColor = c1;
     fDarkColor = c2;
     fX = left;
@@ -157,12 +156,12 @@ plDebugTextManager::~plDebugTextManager()
 
 //// AddString ///////////////////////////////////////////////////////////////
 
-void    plDebugTextManager::AddString( uint16_t x, uint16_t y, const char *s, uint32_t hexColor, uint8_t style, bool drawOnTop )
+void plDebugTextManager::AddString(uint16_t x, uint16_t y, ST::string s, uint32_t hexColor, uint8_t style, bool drawOnTop)
 {
     if( drawOnTop )
-        fDrawOnTopList.emplace_back(s, hexColor, x, y, style);
+        fDrawOnTopList.emplace_back(std::move(s), hexColor, x, y, style);
     else
-        fList.emplace_back(s, hexColor, x, y, style);
+        fList.emplace_back(std::move(s), hexColor, x, y, style);
 }
 
 //// DrawRect ////////////////////////////////////////////////////////////////
@@ -260,7 +259,7 @@ void    plDebugTextManager::DrawToDevice( plPipeline *pipe )
 
 //// CalcStringWidth /////////////////////////////////////////////////////////
 
-uint32_t  plDebugTextManager::CalcStringWidth( const char *string )
+uint32_t plDebugTextManager::CalcStringWidth(const ST::string& string)
 {
     if (!plDebugText::Instance().IsEnabled() || fFont == nullptr)
         return 0;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.h
@@ -100,17 +100,11 @@ class plDebugText
 
         static plDebugText  &Instance() { return fInstance; }
 
-        uint32_t CalcStringWidth(const char *string);
-        uint32_t CalcStringWidth_TEMP(const ST::string &string) { return CalcStringWidth(string.c_str()); }
+        uint32_t CalcStringWidth(const ST::string& string);
 
-        void DrawString(uint16_t x, uint16_t y, const char *string, uint32_t hexColor, uint8_t style = 0);
+        void DrawString(uint16_t x, uint16_t y, ST::string string, uint32_t hexColor, uint8_t style = 0);
 
-        void DrawString_TEMP(uint16_t x, uint16_t y, const ST::string &string, uint32_t hexColor, uint8_t style = 0)
-        {
-            DrawString(x, y, string.c_str(), hexColor, style);
-        }
-
-        void DrawString(uint16_t x, uint16_t y, const ST::string &string, hsColorRGBA &color, uint8_t style = 0)
+        void DrawString(uint16_t x, uint16_t y, ST::string string, hsColorRGBA& color, uint8_t style = 0)
         {
             uint32_t  hex;
             uint8_t   r, g, b, a;
@@ -122,17 +116,17 @@ class plDebugText
             a = (uint8_t)( color.a * 255.0 );
             hex = ( a << 24 ) | ( r << 16 ) | ( g << 8 ) | ( b );
 
-            DrawString_TEMP(x, y, string, hex, style);
+            DrawString(x, y, std::move(string), hex, style);
         }
 
-        void DrawString(uint16_t x, uint16_t y, const ST::string& string)
+        void DrawString(uint16_t x, uint16_t y, ST::string string)
         {
-            DrawString_TEMP(x, y, string, 0xffffffff, 0);
+            DrawString(x, y, std::move(string), 0xffffffff, 0);
         }
 
-        void DrawString(uint16_t x, uint16_t y, const ST::string &string, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255, uint8_t style = 0)
+        void DrawString(uint16_t x, uint16_t y, ST::string string, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255, uint8_t style = 0)
         {
-            DrawString_TEMP(x, y, string, (uint32_t)( ( a << 24 ) | ( r << 16 ) | ( g << 8 ) | ( b ) ), style);
+            DrawString(x, y, std::move(string), (uint32_t)((a << 24) | (r << 16) | (g << 8) | (b)), style);
         }
 
         void    SetDrawOnTopMode( bool enable ) { fDrawOnTopMode = enable; }
@@ -173,13 +167,13 @@ class   plDebugTextManager
 
         struct plDebugTextNode
         {
-            char    fText[ 256 ];
+            ST::string fText;
             uint32_t  fColor, fDarkColor;
             uint16_t  fX, fY, fRight, fBottom;    // Last 2 are for rects only
             uint8_t   fStyle;                     // 0xff means rectangle, 0xfe means 3d border
 
-            plDebugTextNode() { fText[ 0 ] = 0; fColor = 0; fX = fY = 0; fStyle = 0; }
-            plDebugTextNode( const char *s, uint32_t c, uint16_t x, uint16_t y, uint8_t style ); 
+            plDebugTextNode() { fColor = 0; fX = fY = 0; fStyle = 0; }
+            plDebugTextNode(ST::string s, uint32_t c, uint16_t x, uint16_t y, uint8_t style);
             plDebugTextNode( uint16_t left, uint16_t top, uint16_t right, uint16_t bottom, uint32_t c ); 
             plDebugTextNode( uint16_t left, uint16_t top, uint16_t right, uint16_t bottom, uint32_t c1, uint32_t c2 );
             ~plDebugTextNode() { }
@@ -196,8 +190,8 @@ class   plDebugTextManager
         plDebugTextManager() { plDebugText::Instance().SetManager(this); fFont = nullptr; }
         ~plDebugTextManager();
 
-        void    AddString( uint16_t x, uint16_t y, const char *s, uint32_t hexColor, uint8_t style, bool drawOnTop = false );
-        uint32_t  CalcStringWidth( const char *string );
+        void AddString(uint16_t x, uint16_t y, ST::string s, uint32_t hexColor, uint8_t style, bool drawOnTop = false);
+        uint32_t CalcStringWidth(const ST::string& string);
 
         /// TEMPORARY FUNCTION (until we can find a better way to do this, one way or the other)
         void    DrawRect( uint16_t left, uint16_t top, uint16_t right, uint16_t bottom, uint32_t hexColor, bool drawOnTop = false );

--- a/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plDebugText.h
@@ -48,6 +48,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef _plDebugText_h
 #define _plDebugText_h
 
+#include <string_theory/string>
+#include <utility>
 #include <vector>
 
 #include "HeadSpin.h"
@@ -69,9 +71,9 @@ class plDebugText
         { 
             fManager = nullptr;
 #ifdef PLASMA_EXTERNAL_RELEASE
-            SetFont( "Trebuchet MS Bold", 8 );
+            SetFont(ST_LITERAL("Trebuchet MS Bold"), 8);
 #else
-            SetFont( "Courier New", 8 );
+            SetFont(ST_LITERAL("Courier New"), 8);
 #endif
             SetEnable( true );
             fLockEnable = false;
@@ -82,7 +84,7 @@ class plDebugText
 
         plDebugTextManager  *fManager;
 
-        char            fFontFace[ 128 ];
+        ST::string fFontFace;
         uint16_t          fFontSize;
         bool            fEnabled, fLockEnable, fDrawOnTopMode;
 
@@ -149,8 +151,8 @@ class plDebugText
 
         void    SetManager( plDebugTextManager *m ) { fManager = m; }
 
-        void            SetFont(const char *face, uint16_t size ) { hsStrncpy( fFontFace, face, sizeof( fFontFace ) ); fFontSize = size; }
-        const char     *GetFontFace() { return fFontFace; }
+        void SetFont(ST::string face, uint16_t size) { fFontFace = std::move(face); fFontSize = size; }
+        ST::string GetFontFace() { return fFontFace; }
         uint16_t        GetFontSize() { return fFontSize; }
         uint16_t        GetFontHeight();
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plNullPipeline.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plNullPipeline.h
@@ -42,6 +42,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef _plNullPipeline_inc_
 #define _plNullPipeline_inc_
 
+#include <string_theory/string>
+
 #include "pl3DPipeline.h"
 
 class plNullPipelineDevice
@@ -71,7 +73,7 @@ public:
 
     bool PreRender(plDrawable* drawable, std::vector<int16_t>& visList, plVisMgr* visMgr=nullptr) override { return false; }
     bool PrepForRender(plDrawable* drawable, std::vector<int16_t>& visList, plVisMgr* visMgr=nullptr) override { return false; }
-    plTextFont* MakeTextFont(char* face, uint16_t size) override { return nullptr; }
+    plTextFont* MakeTextFont(ST::string face, uint16_t size) override { return nullptr; }
     void CheckVertexBufferRef(plGBufferGroup* owner, uint32_t idx) override { }
     void CheckIndexBufferRef(plGBufferGroup* owner, uint32_t idx) override { }
     bool OpenAccess(plAccessSpan& dst, plDrawableSpans* d, const plVertexSpan* span, bool readOnly) override { return false; }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plPlates.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plPlates.cpp
@@ -82,7 +82,6 @@ plPlate::plPlate( plPlate **owningHandle )
     fPrevPtr = nullptr;
     fOwningHandle = owningHandle;
     fMipmap = nullptr;
-    memset( fTitle, 0, sizeof( fTitle ) );
 }
 
 plPlate::~plPlate()
@@ -300,7 +299,6 @@ bool plPlate::IsVisible()
 plGraphPlate::plGraphPlate( plPlate **owningHandle ) : plPlate( owningHandle )
 {
     fFlags |= kFlagIsAGraph;
-    SetLabelText(nullptr);
 }
 
 plGraphPlate::~plGraphPlate()
@@ -531,33 +529,6 @@ void    plGraphPlate::SetDataColors( uint32_t hexColor1, uint32_t hexColor2, uin
 void    plGraphPlate::SetDataColors( const std::vector<uint32_t> & hexColors )
 {
     fDataHexColors = hexColors;
-}
-
-//// SetLabelText ////////////////////////////////////////////////////////////
-
-void    plGraphPlate::SetLabelText(const char *text1, const char *text2, const char *text3, const char *text4 )
-{
-    std::vector<std::string> strings;
-    if (text1 != nullptr)
-        strings.push_back(text1);
-    else
-        strings.push_back("");
-
-    if (text2 != nullptr)
-        strings.push_back(text2);
-    else
-        strings.push_back("");
-
-    if (text3 != nullptr)
-        strings.push_back(text3);
-    else
-        strings.push_back("");
-
-    if (text4 != nullptr)
-        strings.push_back(text4);
-    else
-        strings.push_back("");
-    SetLabelText(strings);
 }
 
 //// IDrawNumber /////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plPipeline/plPlates.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plPlates.h
@@ -50,7 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
-#include <string>
+#include <string_theory/string>
 #include <vector>
 
 #include "hsColorRGBA.h"
@@ -81,7 +81,7 @@ class plPlate
         plMipmap        *fMipmap;
         float        fDepth, fOpacity;
         uint32_t          fFlags;
-        char            fTitle[ 64 ];
+        ST::string fTitle;
 
         plPlate         *fNext;
         plPlate         **fPrevPtr;
@@ -122,11 +122,11 @@ class plPlate
         void    SetTransform( hsMatrix44 &matrix, bool reSort = true );
         void    SetMaterial( hsGMaterial *material );
         void    SetTexture(plBitmap *texture); // Creates a new single layer material to use the texture.
-        void    SetTitle(const char *title) { if (title != nullptr) strncpy(fTitle, title, sizeof(fTitle)); else fTitle[0] = 0; }
+        void SetTitle(ST::string title) { fTitle = std::move(title); }
 
         hsGMaterial     *GetMaterial() { return fMaterial; }
         hsMatrix44      &GetTransform() { return fXformMatrix; }
-        const char      *GetTitle() { return fTitle; }
+        ST::string GetTitle() { return fTitle; }
         uint32_t          GetFlags() { return fFlags; }
         const plMipmap  *GetMipmap() { return fMipmap; }
 
@@ -160,7 +160,7 @@ class plGraphPlate : public plPlate
         std::vector<uint32_t> fDataHexColors;
         uint32_t          fMin, fMax, fLabelMin, fLabelMax;
         std::vector<int32_t>  fLastValues;
-        std::vector<std::string>    fLabelText;
+        std::vector<ST::string> fLabelText;
 
         uint32_t      IMakePow2( uint32_t value );
         void        IDrawNumber( uint32_t number, uint32_t *dataPtr, uint32_t stride, uint32_t color );
@@ -172,8 +172,7 @@ class plGraphPlate : public plPlate
 
         void    SetDataRange( uint32_t min, uint32_t max, uint32_t width );
         void    SetDataLabels( uint32_t min, uint32_t max );
-        void    SetLabelText(const char *text1, const char *text2 = nullptr, const char *text3 = nullptr, const char *text4 = nullptr);
-        void    SetLabelText(std::vector<std::string> text) { fLabelText = std::move(text); }
+        void SetLabelText(std::vector<ST::string> text) { fLabelText = std::move(text); }
         void    ClearData();
 
         void    AddData( int32_t value, int32_t value2 = -1, int32_t value3 = -1, int32_t value4 = -1 );
@@ -183,7 +182,7 @@ class plGraphPlate : public plPlate
         void    SetDataColors( uint32_t hexColor1 = 0xff00ff00, uint32_t hexColor2 = 0xff0000ff, uint32_t hexColor3 = 0xffffff00, uint32_t hexColor4 = 0xffff00ff );
         void    SetDataColors( const std::vector<uint32_t> & hexColors );
 
-        const char      *GetLabelText( int i ) { return fLabelText[ i ].c_str(); }
+        ST::string GetLabelText(int i) { return fLabelText[i]; }
         uint32_t        GetDataColor( int i ) { return fDataHexColors[ i ]; }
         uint32_t        GetNumLabels() { return (uint32_t)fLabelText.size(); }
         uint32_t        GetNumColors() { return (uint32_t)fDataHexColors.size(); }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plStatusLogDrawer.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plStatusLogDrawer.cpp
@@ -65,7 +65,7 @@ void plStatusLogDrawer::IDrawLogNames(plStatusLog* curLog, plStatusLog* firstLog
     plStatusLog* iLog = firstLog;
     while (iLog)
     {
-        width = std::max(drawText.CalcStringWidth_TEMP(iLog->GetFileName().AsString()) + 4, width);
+        width = std::max(drawText.CalcStringWidth(iLog->GetFileName().AsString()) + 4, width);
         iLog = iLog->fNext;
         numLogs++;
     }
@@ -120,7 +120,7 @@ void    plStatusLogDrawer::Draw(plStatusLog* curLog, plStatusLog* firstLog)
     y += lineHt * 2;
     for( i = 0; i < IGetMaxNumLines( curLog ); i++ )
     {
-        drawText.DrawString_TEMP( x + 4, y, IGetLines( curLog )[ i ], IGetColors( curLog )[ i ] );
+        drawText.DrawString(x + 4, y, IGetLines(curLog)[i], IGetColors(curLog)[i]);
         y += lineHt;
     }
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.cpp
@@ -318,24 +318,22 @@ void    plTextFont::IInitObjects()
 
 //// DrawString ///////////////////////////////////////////////////////////////
 
-void    plTextFont::DrawString( const char *string, int sX, int sY, uint32_t hexColor, 
-                                uint8_t style, uint32_t rightEdge )
+void plTextFont::DrawString(const ST::string& string, int sX, int sY, uint32_t hexColor,
+                            uint8_t style, uint32_t rightEdge)
 {
     static std::vector<plFontVertex> verts;
     
     size_t     i, j, width, height, count, thisCount;
     uint32_t   italOffset;
     float   x = (float)sX;
-    char    c, *strPtr;
-
 
     if( !fInitialized )
         IInitObjects();
 
     /// Set up to draw
     italOffset = ( style & plDebugText::kStyleItalic ) ? fSize / 2: 0;
-    count = strlen( string );
-    strPtr = (char *)string;
+    count = string.size();
+    const char* strPtr = string.data();
     while( count > 0 )
     {
         thisCount = ( count > 64 ) ? 64 : count;
@@ -353,7 +351,7 @@ void    plTextFont::DrawString( const char *string, int sX, int sY, uint32_t hex
 
         for( i = 0, j = 0; i < thisCount; i++, j += 6 )
         {
-            c = strPtr[ i ];
+            char c = strPtr[i];
             if (!(c >= 32 && c < 127) && c != '\t') {
                 // Unsupported or non-printable character
                 c = '?';
@@ -452,17 +450,14 @@ void    plTextFont::DrawString( const char *string, int sX, int sY, uint32_t hex
 
 //// CalcStringWidth //////////////////////////////////////////////////////////
 
-uint32_t  plTextFont::CalcStringWidth( const char *string )
+uint32_t plTextFont::CalcStringWidth(const ST::string& string)
 {
-    int     i, width = 0;
-
+    int width = 0;
 
     if( !fInitialized )
         IInitObjects();
     
-    for( i = 0; i < strlen( string ); i++ )
-    {
-        char c = string[ i ];
+    for (char c : string) {
         if (!(c >= 32 && c < 127) && c != '\t') {
             // Unsupported or non-printable character
             c = '?';

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.cpp
@@ -211,10 +211,12 @@ uint16_t  *plTextFont::IInitFontTexture()
     } size;
 
     // Loop through characters, drawing them one at a time
+    hsAssert(face->charmap != nullptr, "Font has no Unicode-compatible character map!");
     int x = 1;
     int y = 0;
-    for (char32_t c = 32; c < 127; c++) {
+    for (char32_t c = 32; c < std::size(fCharInfo); c++) {
         ftError = FT_Load_Char( face, c, FT_LOAD_RENDER | FT_LOAD_TARGET_MONO | FT_LOAD_MONOCHROME | FT_LOAD_NO_AUTOHINT );
+        hsAssert(ftError == FT_Err_Ok, "Failed to load character");
 
         FT_GlyphSlot slot = face->glyph;
 
@@ -350,9 +352,9 @@ void plTextFont::DrawString(const ST::string& string, int sX, int sY, uint32_t h
         for( i = 0, j = 0; i < thisCount; i++, j += 6 )
         {
             char32_t c = codepointsPtr[i];
-            if (!(c >= 32 && c < 127) && c != U'\t') {
+            if (!(c >= 32 && c < std::size(fCharInfo)) && c != U'\t') {
                 // Unsupported or non-printable character
-                c = U'?';
+                c = U'\xbf';
             }
             plDXCharInfo const& info = fCharInfo[c];
             width = info.fW + 1;
@@ -457,9 +459,9 @@ uint32_t plTextFont::CalcStringWidth(const ST::string& string)
         IInitObjects();
     
     for (char32_t c : string.to_utf32()) {
-        if (!(c >= 32 && c < 127) && c != U'\t') {
+        if (!(c >= 32 && c < std::size(fCharInfo)) && c != U'\t') {
             // Unsupported or non-printable character
-            c = U'?';
+            c = U'\xbf';
         }
         width += fCharInfo[c].fW + 2;
     }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.cpp
@@ -351,6 +351,10 @@ void    plTextFont::DrawString( const char *string, int sX, int sY, uint32_t hex
         for( i = 0, j = 0; i < thisCount; i++, j += 6 )
         {
             c = strPtr[ i ];
+            if (!(c >= 32 && c < 127) && c != '\t') {
+                // Unsupported or non-printable character
+                c = '?';
+            }
             width = fCharInfo[uint8_t(c)].fW + 1;
             height = fCharInfo[uint8_t(c)].fH + 1;
 
@@ -455,7 +459,12 @@ uint32_t  plTextFont::CalcStringWidth( const char *string )
     
     for( i = 0; i < strlen( string ); i++ )
     {
-        width += fCharInfo[uint8_t(string[i])].fW + 2;
+        char c = string[ i ];
+        if (!(c >= 32 && c < 127) && c != '\t') {
+            // Unsupported or non-printable character
+            c = '?';
+        }
+        width += fCharInfo[uint8_t(c)].fW + 2;
     }
 
     return width;

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.cpp
@@ -122,6 +122,7 @@ uint16_t  *plTextFont::IInitFontTexture()
     void* fontData = std::malloc( fontDataSize );
     GetFontData(hDC, 0, 0, fontData, fontDataSize);
     ftError = FT_New_Memory_Face(library, (FT_Byte *) fontData, fontDataSize, 0, &face);
+    ASSERT(ftError == FT_Err_Ok);
     FT_UInt freeTypeResolution = plWinDpi::Instance().GetDpi();
 
     DeleteDC( hDC );
@@ -142,6 +143,7 @@ uint16_t  *plTextFont::IInitFontTexture()
     CFStringGetCString(fileSystemPath, cPath, PATH_MAX, kCFStringEncodingUTF8);
     
     ftError = FT_New_Face(library, cPath, 0, &face);
+    ASSERT(ftError == FT_Err_Ok);
     
     CFRelease(fulfilledFontDescriptor);
     CFRelease(fontURL);
@@ -162,7 +164,8 @@ uint16_t  *plTextFont::IInitFontTexture()
     FcPatternDestroy(pattern);
 
     if (result) {
-        FT_Done_FreeType(library);
+        ftError = FT_Done_FreeType(library);
+        ASSERT(ftError == FT_Err_Ok);
         return nullptr;
     }
 
@@ -172,7 +175,8 @@ uint16_t  *plTextFont::IInitFontTexture()
     if (result) {
         FcPatternDestroy(match);
 
-        FT_Done_FreeType(library);
+        ftError = FT_Done_FreeType(library);
+        ASSERT(ftError == FT_Err_Ok);
         return nullptr;
     }
 
@@ -182,11 +186,13 @@ uint16_t  *plTextFont::IInitFontTexture()
     FcPatternDestroy(match);
 
     ftError = FT_New_Face(library, filename, 0, &face);
+    ASSERT(ftError == FT_Err_Ok);
 
     FT_UInt freeTypeResolution = 96;
 #endif
 
     ftError = FT_Set_Char_Size(face, 0, fSize * 64, freeTypeResolution, freeTypeResolution);
+    ASSERT(ftError == FT_Err_Ok);
     FT_Size_Metrics fontMetrics = face->size->metrics;
 
     fFontHeight = int(fontMetrics.height / 64.f);
@@ -221,7 +227,8 @@ uint16_t  *plTextFont::IInitFontTexture()
         FT_GlyphSlot slot = face->glyph;
 
         FT_Glyph glyph;
-        FT_Get_Glyph(slot, &glyph);
+        ftError = FT_Get_Glyph(slot, &glyph);
+        ASSERT(ftError == FT_Err_Ok);
 
         FT_BBox cBox;
         FT_Glyph_Get_CBox( glyph, FT_GLYPH_BBOX_TRUNCATE, &cBox );
@@ -280,8 +287,10 @@ uint16_t  *plTextFont::IInitFontTexture()
     fCharInfo[U'\t'].fW = fCharInfo[32].fW * 4;
     fCharInfo[U'\t'].fH = fCharInfo[32].fH;
 
-    FT_Done_Face(face);
-    FT_Done_FreeType(library);
+    ftError = FT_Done_Face(face);
+    ASSERT(ftError == FT_Err_Ok);
+    ftError = FT_Done_FreeType(library);
+    ASSERT(ftError == FT_Err_Ok);
 
     return data;
 }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.h
@@ -129,10 +129,10 @@ class plTextFont
         virtual ~plTextFont();
 
         void Create(ST::string face, uint16_t size);
-        void    DrawString( const char *string, int x, int y, uint32_t hexColor, uint8_t style, uint32_t rightEdge = 0 );
+        void DrawString(const ST::string& string, int x, int y, uint32_t hexColor, uint8_t style, uint32_t rightEdge = 0);
         void    DrawRect( int left, int top, int right, int bottom, uint32_t hexColor );
         void    Draw3DBorder( int left, int top, int right, int bottom, uint32_t hexColor1, uint32_t hexColor2 );
-        uint32_t  CalcStringWidth( const char *string );
+        uint32_t CalcStringWidth(const ST::string& string);
         uint32_t  GetFontSize() { return fSize; }
 
         uint16_t  GetFontHeight() { return fFontHeight; }

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.h
@@ -101,7 +101,7 @@ class plTextFont
         plTextFont      *fNext;
         plTextFont      **fPrevPtr;
 
-        plDXCharInfo    fCharInfo[ 128 ];
+        plDXCharInfo fCharInfo[256];
 
 
         virtual void    IInitObjects();

--- a/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plTextFont.h
@@ -54,6 +54,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef _plTextFont_h
 #define _plTextFont_h
 
+#include <string_theory/string>
+
 #include "hsGeometry3.h"
 
 //// plTextFont Class Definition //////////////////////////////////////////////
@@ -89,7 +91,7 @@ class plTextFont
         uint32_t  fMaxNumIndices;
         uint32_t  fTextureWidth, fTextureHeight;
 
-        char    fFace[ 128 ];
+        ST::string fFace;
         uint16_t  fSize;
         bool    fInitialized;
         uint16_t  fFontHeight;
@@ -126,7 +128,7 @@ class plTextFont
         plTextFont( plPipeline *pipe );
         virtual ~plTextFont();
 
-        void    Create( char *face, uint16_t size );
+        void Create(ST::string face, uint16_t size);
         void    DrawString( const char *string, int x, int y, uint32_t hexColor, uint8_t style, uint32_t rightEdge = 0 );
         void    DrawRect( int left, int top, int right, int bottom, uint32_t hexColor );
         void    Draw3DBorder( int left, int top, int right, int bottom, uint32_t hexColor1, uint32_t hexColor2 );

--- a/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
@@ -327,7 +327,7 @@ bool plAutoProfileImp::MsgReceive(plMessage* msg)
     if (evalMsg)
     {
         if (fStatusMessage.size() > 0)
-            plDebugText::Instance().DrawString(10, 10, fStatusMessage.c_str());
+            plDebugText::Instance().DrawString(10, 10, fStatusMessage);
     }
 
     plAgeLoadedMsg* ageLoaded = plAgeLoadedMsg::ConvertNoRef(msg);

--- a/Sources/Plasma/PubUtilLib/plStatGather/plCalculatedProfiles.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plCalculatedProfiles.cpp
@@ -107,8 +107,8 @@ void CreateStandardGraphs(const char* groupName, bool create)
         {
             if (ICreateStdPlate(&fFPSPlate))
             {
-                fFPSPlate->SetTitle("mSecs");       
-                fFPSPlate->SetLabelText("Tot", "Draw", "Upd");
+                fFPSPlate->SetTitle(ST_LITERAL("mSecs"));
+                fFPSPlate->SetLabelText({ST_LITERAL("Tot"), ST_LITERAL("Draw"), ST_LITERAL("Upd")});
             }
         }
         else

--- a/Sources/Plasma/PubUtilLib/plStatGather/plProfileManagerFull.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plProfileManagerFull.cpp
@@ -143,12 +143,13 @@ void plProfileManagerFull::ShowNextGroup()
     }
 }
 
-plProfileVar* plProfileManagerFull::IFindTimer(const char *name)
+plProfileVar* plProfileManagerFull::IFindTimer(const ST::string& name)
 {
     for (int i = 0; i < fVars.size(); i++)
     {
-        if (stricmp(fVars[i]->GetName(), name) == 0)
+        if (name.compare_i(fVars[i]->GetName()) == 0) {
             return fVars[i];
+        }
     }
 
     return nullptr;
@@ -532,8 +533,7 @@ void plProfileManagerFull::CreateGraph(const char* varName, uint32_t min, uint32
     // If the graph is already created, destroy it
     for (int i = 0; i < fGraphs.size(); i++)
     {
-        if (strcmp(fGraphs[i]->GetTitle(), varName) == 0)
-        {
+        if (fGraphs[i]->GetTitle() == varName) {
             plPlateManager::Instance().DestroyPlate(fGraphs[i]);
             fGraphs.erase(fGraphs.begin()+i);
             return;
@@ -580,7 +580,7 @@ void plProfileManagerFull::ShowDetailGraph()
     fDetailGraph->SetSize(0.9f, 0.9f);
     fDetailGraph->SetDataRange(0,500,500);
     fDetailGraph->SetDataLabels(0,100); // should be relatively simple to cast everything to a 0-100 range
-    fDetailGraph->SetTitle("Detail");
+    fDetailGraph->SetTitle(ST_LITERAL("Detail"));
     UpdateDetailLabels();
 }
 
@@ -635,7 +635,7 @@ void plProfileManagerFull::UpdateDetailLabels()
     if (fDetailGraph)
     {
         int i;
-        std::vector<std::string> labels;
+        std::vector<ST::string> labels;
         for (i=0; i<fDetailVars.size(); i++)
             labels.push_back(fDetailVars[i].var->GetName());
 

--- a/Sources/Plasma/PubUtilLib/plStatGather/plProfileManagerFull.h
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plProfileManagerFull.h
@@ -86,7 +86,7 @@ protected:
     void IPrintGroup(hsStream* s, const char* groupName, bool printTitle=false);
     void ILogStats();
 
-    plProfileVar* IFindTimer(const char* name);
+    plProfileVar* IFindTimer(const ST::string& name);
 
     void ISetActive(const char* groupName, bool active);
 


### PR DESCRIPTION
Fixes the last remaining problems with rendering non-ASCII characters. The main effect is that avatar tooltips work for non-ASCII names now:

![Screenshot of avatar tooltip for "Æthelred the Unready" with working "Æ" character](https://github.com/H-uru/Plasma/assets/6641959/9714fc40-017e-4a64-b9c0-36cd8a346a6f)

Aside from that, it fixes non-ASCII text rendering in the console, log drawer, other debug views, and the loading screen. With this, I *think* Plasma now supports Unicode (or at least Latin-1) in all places where it matters.

Internally, this expands the supported character range of `plTextFont` from ASCII to Latin-1. Characters beyond the supported range don't cause rendering glitches anymore and instead show a fallback character (currently `¿`, because the real replacement character `�` is not in Latin-1).

Because `plTextFont` uses the OS native fonts instead of the game's .p2f files, it's easy to extend the character range further, theoretically up to all of Unicode. The practical limit is currently much lower than that though, because `plTextFont` pre-renders the entire character set into a texture with hardcoded sizes. I stuck with Latin-1 for now, because it fits into the current texture sizes, and anything else isn't usable by players yet anyway (though that would change with H-uru/moul-assets#237 adding Russian fonts).

If we want to support more than Latin-1, we need to adjust the hardcoded texture sizes accordingly, or calculate the required texture size dynamically as the font is loaded. Might also be good to support non-contiguous ranges of characters - that's an open issue for `plFont` as well I think.

The diff is quite big, but most of it are boring `ST::string`ification changes for all the debug views. The actually interesting changes are are in `plTextFont` and `pfConsole`.