### PR TITLE
Fix a couple of endianness issues with `plNetAddress`

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
@@ -88,7 +88,8 @@ ST::string plNetAddress::AsString() const
 
 void plNetAddress::Read(hsStream * s)
 {
-    fHost = s->ReadLE32();
+    // No endianness conversion here - fHost is always big-endian in memory and in the stream!
+    s->Read(sizeof(fHost), &fHost);
     fPort = s->ReadLE16();
 
     // Family is always kInet
@@ -97,7 +98,8 @@ void plNetAddress::Read(hsStream * s)
 
 void plNetAddress::Write(hsStream * s)
 {
-    s->WriteLE32(fHost);
+    // No endianness conversion here - fHost is always big-endian in memory and in the stream!
+    s->Write(sizeof(fHost), &fHost);
     s->WriteLE16(fPort);
 
     s->WriteLE16(static_cast<uint16_t>(Family::kInet));

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -1861,7 +1861,7 @@ bool RecvMsg<Auth2Cli_ServerAddr>(const uint8_t in[], unsigned, void*)
     hsLockGuard(s_critsect);
     if (s_active) {
         s_active->token = msg.token;
-        s_active->addr.SetHost(msg.srvAddr);
+        s_active->addr.SetHost(hsToBE32(msg.srvAddr));
 
         LogMsg(kLogPerf, "SrvAuth addr: {}", s_active->addr.GetHostString());
     }


### PR DESCRIPTION
This fixes auth server reconnects for servers that send `Auth2Cli_ServerAddr` messages (i. e. Cyan's server and MOSS). Previously, the received IPv4 address was byte-swapped, making the reconnect always fail.