### PR TITLE
Fix ordering operators for `plKey`

### DIFF
--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
@@ -78,6 +78,11 @@ public:
     bool operator==(const plKeyData* rhs) const { return fKeyData == rhs; }
     bool operator!=(const plKey& rhs) const { return !(*this == rhs); }
     bool operator!=(const plKeyData* rhs) const { return !(*this == rhs); }
+    // Ordering operators for stdlib containers, etc. that rely on < (std::less) by default
+    bool operator<(const plKey& rhs) const { return fKeyData < rhs.fKeyData; }
+    bool operator>(const plKey& rhs) const { return fKeyData > rhs.fKeyData; }
+    bool operator<=(const plKey& rhs) const { return fKeyData <= rhs.fKeyData; }
+    bool operator>=(const plKey& rhs) const { return fKeyData >= rhs.fKeyData; }
 
     plKeyData* operator->() const;
     plKeyData& operator*() const;

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
@@ -518,7 +518,7 @@ void plKeyImp::INotifySelf(hsKeyedObject* ko)
                     // GetNumReceivers() should always be 1 for a refMsg.
                     for (int k = 0; k < refMsg->GetNumReceivers(); k++)
                     {
-                        if (&(*refMsg->GetReceiver(k)) == (plKeyData*)this)
+                        if (refMsg->GetReceiver(k) == this)
                         {
                             ref->SetNotified(j);
                             ref->SatisfyPending(refMsg);
@@ -612,7 +612,7 @@ void plKeyImp::IRelease(plKeyImp* iTargetKey)
         plMessage* rcvMsg = iTargetKey->GetNotifyCreated(i);
         for (int j = 0; j < rcvMsg->GetNumReceivers(); j++)
         {
-            if (&(*rcvMsg->GetReceiver(j)) == (plKeyData*)this)
+            if (rcvMsg->GetReceiver(j) == this)
             {
                 isActive = iTargetKey->IsActiveRef(iTarg = (hsSsize_t)i);
                 break;

--- a/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
@@ -51,7 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plResManager.h"
 
 #include "pnFactory/plFactory.h"
-#include "pnKeyedObject/plKey.h"
+#include "pnKeyedObject/plKeyImp.h"
 
 plResManager* IGetResMgr() { return (plResManager*)hsgResMgr::ResMgr(); }
 
@@ -438,7 +438,7 @@ plKey plKeyFinder::IFindSceneNodeKey(plRegistryPageNode* page) const
     {
         if (keyList->fKeys.size() == 1)
         {
-            return plKey::Make((plKeyData*)keyList->fKeys[0]);
+            return plKey::Make(keyList->fKeys[0]);
         }
     }
 
@@ -453,7 +453,7 @@ plKey plKeyFinder::IFindSceneNodeKey(plRegistryPageNode* page) const
     keyList = page->IGetKeyList(CLASS_INDEX_SCOPED(plSceneNode));
     if (keyList && keyList->fKeys.size() == 1)
     {
-        retVal = plKey::Make((plKeyData*)keyList->fKeys[0]);
+        retVal = plKey::Make(keyList->fKeys[0]);
     }
     // If we just loaded up all the keys for this page, then we
     // may have a bunch of keys with a refcount of 0. For any of 


### PR DESCRIPTION
Fixes #1479.

This was broken by #1429 (4ef380f10fef7523761c73bc4cb2aeec68fac6fd). Previously, `plKey`'s ordering operators were provided by the implicit conversion to `plKeyImp*`, meaning that `plKey`s were ordered by their `fKeyData` pointers. When this was replaced by the conversion to `bool`, the ordering operators unintentionally also changed - `plKey`s were now ordered only by their `bool` value, so all non-null `plKey`s were converted to the same value (`true`) and had no ordering relative to each other! This made anything that uses the ordering operators misbehave, such as stdlib containers like `std::set`.

This change adds explicit `plKey` ordering operators that match the previous behavior.

Also includes another change I made during debugging, which makes a few `plKey`/`plKeyData*`/`plKeyImp*` conversions more straightforward. That turned out to be irrelevant for the fix, but it makes the code cleaner, so I left it in.