### PR TITLE
Migrate pipelines and profiling code to `ST::string`

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -1617,7 +1617,7 @@ bool plClient::IUpdate()
     plgDispatch::MsgSend(eval);
     plProfile_EndTiming(EvalMsg);
 
-    const char *xFormLap1 = "Main";
+    const ST::string xFormLap1 = ST_LITERAL("Main");
     plProfile_BeginLap(TransformMsg, xFormLap1);
     plTransformMsg* xform = new plTransformMsg(nullptr, nullptr, nullptr, nullptr);
     plgDispatch::MsgSend(xform);
@@ -1635,7 +1635,7 @@ bool plClient::IUpdate()
     // At this point, we just register for a plDelayedTransformMsg when dirtied.
     if (!plCoordinateInterface::GetDelayedTransformsEnabled())
     {
-        const char *xFormLap2 = "Simulation";
+        const ST::string xFormLap2 = ST_LITERAL("Simulation");
         plProfile_BeginLap(TransformMsg, xFormLap2);
         xform = new plTransformMsg(nullptr, nullptr, nullptr, nullptr);
         plgDispatch::MsgSend(xform);
@@ -1643,7 +1643,7 @@ bool plClient::IUpdate()
     }
     else
     {
-        const char *xFormLap3 = "Delayed";
+        const ST::string xFormLap3 = ST_LITERAL("Delayed");
         plProfile_BeginLap(TransformMsg, xFormLap3);
         xform = new plDelayedTransformMsg(nullptr, nullptr, nullptr, nullptr);
         plgDispatch::MsgSend(xform);

--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -495,19 +495,17 @@ bool plClient::InitPipeline(hsWindowHndl display, uint32_t devType)
     }
 
     plPipeline *pipe = ICreatePipeline(display, fWindowHndl, &dmr);
-    if (pipe->GetErrorString() != nullptr)
-    {
+    if (!pipe->GetErrorString().empty()) {
         ISetGraphicsDefaults();
 #ifdef PLASMA_EXTERNAL_RELEASE
         hsMessageBox(ST_LITERAL("There was an error initializing the video card.\nSetting defaults."), ST_LITERAL("Error"), hsMessageBoxNormal);
 #else
-        hsMessageBox(ST::string(pipe->GetErrorString()), ST_LITERAL("Error creating pipeline"), hsMessageBoxNormal);
+        hsMessageBox(pipe->GetErrorString(), ST_LITERAL("Error creating pipeline"), hsMessageBoxNormal);
 #endif
         delete pipe;
         devSel.GetDefault(&dmr);
         pipe = ICreatePipeline(display, fWindowHndl, &dmr);
-        if (pipe->GetErrorString() != nullptr)
-        {
+        if (!pipe->GetErrorString().empty()) {
             // not much else we can do
             return true;
         }

--- a/Sources/Plasma/FeatureLib/pfAnimation/plFollowMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plFollowMod.cpp
@@ -72,11 +72,11 @@ bool plFollowMod::MsgReceive(plMessage* msg)
     plRenderMsg* rend = plRenderMsg::ConvertNoRef(msg);
     if( rend )
     {
-        plProfile_BeginLap(FollowMod, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(FollowMod, this->GetKey()->GetUoid().GetObjectName());
         fLeaderL2W = rend->Pipeline()->GetCameraToWorld();
         fLeaderW2L = rend->Pipeline()->GetWorldToCamera();
         fLeaderSet = true;
-        plProfile_EndLap(FollowMod, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(FollowMod, this->GetKey()->GetUoid().GetObjectName());
         return true;
     }
     plListenerMsg* list = plListenerMsg::ConvertNoRef(msg);

--- a/Sources/Plasma/FeatureLib/pfAnimation/plLineFollowMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plLineFollowMod.cpp
@@ -243,11 +243,11 @@ bool plLineFollowMod::MsgReceive(plMessage* msg)
     plRenderMsg* rend = plRenderMsg::ConvertNoRef(msg);
     if( rend )
     {
-        plProfile_BeginLap(LineFollow, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(LineFollow, this->GetKey()->GetUoid().GetObjectName());
         hsPoint3 oldPos = fSearchPos;
         fSearchPos = rend->Pipeline()->GetViewPositionWorld();
         ICheckForPop(oldPos, fSearchPos);
-        plProfile_EndLap(LineFollow, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(LineFollow, this->GetKey()->GetUoid().GetObjectName());
         return true;
     }
     plListenerMsg* list = plListenerMsg::ConvertNoRef(msg);

--- a/Sources/Plasma/FeatureLib/pfAnimation/plViewFaceModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plViewFaceModifier.cpp
@@ -274,7 +274,7 @@ bool plViewFaceModifier::MsgReceive(plMessage* msg)
 
     if( rend )
     {
-        plProfile_BeginLap(ViewFace, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(ViewFace, this->GetKey()->GetUoid().GetObjectName());
 
         if( HasFlag(kFaceCam) )
         {
@@ -310,7 +310,7 @@ bool plViewFaceModifier::MsgReceive(plMessage* msg)
 
         IFacePoint(rend->Pipeline(), fFacePoint);
         
-        plProfile_EndLap(ViewFace, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(ViewFace, this->GetKey()->GetUoid().GetObjectName());
         return true;
     }
     plArmatureUpdateMsg* armMsg = plArmatureUpdateMsg::ConvertNoRef(msg);

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -480,13 +480,12 @@ PF_CONSOLE_CMD( Stats, Show,    // Group name, Function name
                 "Shows or hides a given category of statistics.\n"
                 "List the valid categories using Stats.ListGroups")
 {
-    const ST::string& group = numParams > 0 ? params[0] : ST::string();
-
     if (numParams > 1) {
-        const ST::string& stat = params[1];
-        plProfileManagerFull::Instance().ShowLaps(group.c_str(), stat.c_str());
+        plProfileManagerFull::Instance().ShowLaps(params[0], params[1]);
+    } else if (numParams > 0) {
+        plProfileManagerFull::Instance().ShowGroup(params[0]);
     } else {
-        plProfileManagerFull::Instance().ShowGroup(group.c_str());
+        plProfileManagerFull::Instance().ShowGroup(ST_LITERAL("General"));
     }
 }
 
@@ -506,9 +505,7 @@ PF_CONSOLE_CMD(Stats, ShowLaps,
                 "string group, string stat",
                 "")
 {
-    const ST::string& group = params[0];
-    const ST::string& stat = params[1];
-    plProfileManagerFull::Instance().ShowLaps(group.c_str(), stat.c_str());
+    plProfileManagerFull::Instance().ShowLaps(params[0], params[1]);
 }
 
 PF_CONSOLE_CMD(Stats, ListGroups, "", "Prints the names of all the stat groups to the console")
@@ -554,8 +551,7 @@ PF_CONSOLE_CMD(Stats, SetAvgTime, "int ms", "Sets the amount of time stats are a
 
 PF_CONSOLE_CMD(Stats, Graph, "string stat, int min, int max", "Graphs the specified stat")
 {
-    const ST::string& stat = params[0];
-    plProfileManagerFull::Instance().CreateGraph(stat.c_str(), (int)params[1], (int)params[2]);
+    plProfileManagerFull::Instance().CreateGraph(params[0], (int)params[1], (int)params[2]);
 }
 
 PF_CONSOLE_CMD(Stats, ShowDetail, "", "Shows the detail stat graph")
@@ -575,36 +571,31 @@ PF_CONSOLE_CMD(Stats, ResetDetailDefaults, "", "Resets the detail graph's defaul
 
 PF_CONSOLE_CMD(Stats, AddDetailVar, "string stat", "Adds the specified var to the detail graph with the default range of 0->100")
 {
-    const ST::string& stat = params[0];
-    plProfileManagerFull::Instance().AddDetailVar(stat.c_str(), 0, 100);
+    plProfileManagerFull::Instance().AddDetailVar(params[0], 0, 100);
 }
 
 PF_CONSOLE_CMD(Stats, AddDetailVarWithOffset, "string stat, int offset", "Adds the specified var to the detail graph with a offset and default range\n"
                                               "of 0->(100-offset)")
 {
-    const ST::string& stat = params[0];
     int offset = (int)params[1];
-    plProfileManagerFull::Instance().AddDetailVar(stat.c_str(), -offset, 100-offset);
+    plProfileManagerFull::Instance().AddDetailVar(params[0], -offset, 100-offset);
 }
 
 PF_CONSOLE_CMD(Stats, AddDetailVarWithRange, "string stat, int min, int max", "Adds the specified var to the detail graph")
 {
-    const ST::string& stat = params[0];
-    plProfileManagerFull::Instance().AddDetailVar(stat.c_str(), (int)params[1], (int)params[2]);
+    plProfileManagerFull::Instance().AddDetailVar(params[0], (int)params[1], (int)params[2]);
 }
 
 PF_CONSOLE_CMD(Stats, AddDetailVarWithOffsetAndRange, "string stat, int offset, int min, int max", "Adds the specified var to the detail graph with an\n"
                                                       "offset and a range of min->(max-offset)")
 {
-    const ST::string& stat = params[0];
     int offset = (int)params[1];
-    plProfileManagerFull::Instance().AddDetailVar(stat.c_str(), (int)params[2]-offset, (int)params[3]-offset);
+    plProfileManagerFull::Instance().AddDetailVar(params[0], (int)params[2]-offset, (int)params[3]-offset);
 }
 
 PF_CONSOLE_CMD(Stats, RemoveDetailVar, "string stat", "Removes the specified var from the detail graph")
 {
-    const ST::string& stat = params[0];
-    plProfileManagerFull::Instance().RemoveDetailVar(stat.c_str());
+    plProfileManagerFull::Instance().RemoveDetailVar(params[0]);
 }
 
 

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXDevice.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXDevice.cpp
@@ -52,8 +52,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plDXVertexShader.h"
 #include "plDXPixelShader.h"
 
+#include <string_theory/string>
+
 //// Macros for D3D error handling
-#define INIT_ERROR_CHECK( cond, errMsg ) if( FAILED( fPipeline->fSettings.fDXError = cond ) ) { return fPipeline->ICreateFail( errMsg ); }    
+#define INIT_ERROR_CHECK(cond, errMsg) if (FAILED(fSettings.fDXError = cond)) { return ICreateFail(ST_LITERAL(errMsg)); }
 
 #if 1       // DEBUG
 #define STRONG_ERROR_CHECK( cond ) if( FAILED( fPipeline->fSettings.fDXError = cond ) ) { fPipeline->IGetD3DError(); fPipeline->IShowErrorMessage(); }   
@@ -189,7 +191,7 @@ void plDXDevice::SetLocalToWorldMatrix(const hsMatrix44& src)
     fD3DDevice->SetTransform(D3DTS_WORLD, &mat);
 }
 
-const char* plDXDevice::GetErrorString() const
+ST::string plDXDevice::GetErrorString() const
 {
     return fPipeline->fSettings.fErrorStr;
 }

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXDevice.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXDevice.h
@@ -54,6 +54,7 @@ class plDXPipeline;
 class plRenderTarget;
 struct IDirect3DDevice9;
 struct IDirect3DSurface9;
+namespace ST { class string; }
 
 class plDXDevice
 {
@@ -98,7 +99,7 @@ public:
     void SetWorldToCameraMatrix(const hsMatrix44& src);
     void SetLocalToWorldMatrix(const hsMatrix44& src);
 
-    const char* GetErrorString() const;
+    ST::string GetErrorString() const;
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXDeviceRefs.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXDeviceRefs.cpp
@@ -144,7 +144,7 @@ void    plDXVertexBufferRef::Release()
         if (!Volatile())
         {
             plProfile_DelMem(MemVertex, fCount * fVertexSize);
-            PROFILE_POOL_MEM(D3DPOOL_MANAGED, fCount * fVertexSize, false, "VtxBuff");
+            PROFILE_POOL_MEM(D3DPOOL_MANAGED, fCount * fVertexSize, false, ST_LITERAL("VtxBuff"));
             plDXPipeline::FreeManagedVertex(fCount * fVertexSize);
         }
     }
@@ -159,7 +159,7 @@ void    plDXIndexBufferRef::Release()
     if (fD3DBuffer != nullptr)
     {
         plProfile_DelMem(MemIndex, fCount * sizeof(uint16_t));
-        PROFILE_POOL_MEM(fPoolType, fCount * sizeof(uint16_t), false, "IndexBuff");
+        PROFILE_POOL_MEM(fPoolType, fCount * sizeof(uint16_t), false, ST_LITERAL("IndexBuff"));
         ReleaseObject( fD3DBuffer );
     }
 
@@ -221,7 +221,7 @@ void    plDXTextureRef::Release()
 {
     plProfile_DelMem(MemTexture, fDataSize + sizeof(plDXTextureRef));
     plProfile_Extern(ManagedMem);
-    PROFILE_POOL_MEM(D3DPOOL_MANAGED, fDataSize, false, (fOwner ? fOwner->GetKey() ? fOwner->GetKey()->GetUoid().GetObjectName().c_str() : "(UnknownTexture)" : "(UnknownTexture)"));
+    PROFILE_POOL_MEM(D3DPOOL_MANAGED, fDataSize, false, fOwner && fOwner->GetKey() ? fOwner->GetKey()->GetUoid().GetObjectName() : ST_LITERAL("(UnknownTexture)"));
     plDXPipeline::FreeManagedTexture(fDataSize);
     fDataSize = 0;
 

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXEnumerate.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXEnumerate.h
@@ -176,7 +176,7 @@ public:
     void SetCurrentRenderer(D3DEnum_RendererInfo* d) { hsAssert(GetCurrentDisplay(), "Set Display first"); GetCurrentDisplay()->fCurrentRenderer = d; } 
     void SetCurrentMode(D3DEnum_ModeInfo* m) { hsAssert(GetCurrentDisplay(), "Set Display first"); GetCurrentDisplay()->fCurrentMode = m; } 
 
-    ST::string GetEnumeErrorStr() { return fEnumeErrorStr; }
+    ST::string GetEnumeErrorStr() const { return fEnumeErrorStr; }
 };
 
 

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXEnumerate.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXEnumerate.h
@@ -42,6 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef hsGDirect3DTnLEnumerate_h
 #define hsGDirect3DTnLEnumerate_h
 
+#include <string_theory/string>
 #include <vector>
 
 #include "HeadSpin.h"
@@ -60,9 +61,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 struct D3DEnum_ModeInfo
 {
     D3DDISPLAYMODE      fDDmode;
-    CHAR                fStrDesc[40];
+    ST::string fStrDesc;
     BOOL                fWindowed;
-    char                fBitDepth;
+    uint8_t fBitDepth;
     DWORD               fDDBehavior;
     std::vector<D3DFORMAT> fDepthFormats;
     std::vector<D3DMULTISAMPLE_TYPE> fFSAATypes;
@@ -82,7 +83,7 @@ struct D3DEnum_ModeInfo
 struct D3DEnum_RendererInfo
 {
     D3DDEVTYPE          fDDType;
-    CHAR                fStrName[40];
+    ST::string fStrName;
     D3DCAPS9            fDDCaps;
     BOOL                fCanWindow;
     BOOL                fCompatibleWithDesktop;
@@ -110,8 +111,8 @@ struct D3DEnum_DisplayInfo
 {
     GUID                 fGuid;
 
-    CHAR                 fStrDesc[40];
-    CHAR                 fStrName[40];
+    ST::string fStrDesc;
+    ST::string fStrName;
 
     unsigned int         fMemory;
 
@@ -136,7 +137,7 @@ class hsG3DDeviceMode;
 class hsGDirect3DTnLEnumerate
 {
 protected:
-    char    fEnumeErrorStr[128];            // Driver & device enumeration error message buffer
+    ST::string fEnumeErrorStr; // Driver & device enumeration error message buffer
 
     std::vector<D3DEnum_DisplayInfo> fDisplays;
 
@@ -160,8 +161,6 @@ public:
 
     VOID    D3DEnum_FreeResources();
 
-    char* GetErrorString() { return (fEnumeErrorStr[0] ? fEnumeErrorStr : nullptr); }
-
     bool SelectFromDevMode(const hsG3DDeviceRecord* devRec, const hsG3DDeviceMode* devMode);
     HRESULT D3DEnum_SelectDefaultMode(int width, int height, int depth);
     HRESULT D3DEnum_SelectDefaultDisplay( DWORD dwFlags );
@@ -177,8 +176,7 @@ public:
     void SetCurrentRenderer(D3DEnum_RendererInfo* d) { hsAssert(GetCurrentDisplay(), "Set Display first"); GetCurrentDisplay()->fCurrentRenderer = d; } 
     void SetCurrentMode(D3DEnum_ModeInfo* m) { hsAssert(GetCurrentDisplay(), "Set Display first"); GetCurrentDisplay()->fCurrentMode = m; } 
 
-    char* GetEnumeErrorStr() { return fEnumeErrorStr; }
-    void SetEnumeErrorStr(const char* s);
+    ST::string GetEnumeErrorStr() { return fEnumeErrorStr; }
 };
 
 

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.h
@@ -417,11 +417,11 @@ protected:
     inline D3DCOLORVALUE    inlPlToD3DColor(const hsColorRGBA& c, float a) const;
 
     // Error handling
-    void    IAddErrorMessage(const char* errStr);
-    void    ISetErrorMessage(const char* errStr = nullptr);
-    void    IGetD3DError();
-    void    IShowErrorMessage(const char* errStr = nullptr);
-    bool    ICreateFail(const char* errStr);
+    void IAddErrorMessage(const ST::string& errStr);
+    void ISetErrorMessage(ST::string errStr);
+    void IGetD3DError();
+    void IShowErrorMessage(const ST::string& errStr = {});
+    bool ICreateFail(const ST::string& errStr);
 
     // Device initialization
     void    IInvalidateState();
@@ -476,7 +476,7 @@ protected:
     bool    IFindRenderTargetInfo( plRenderTarget *owner, D3DFORMAT &surfFormat, D3DRESOURCETYPE &resType );
 
     // From a D3DFORMAT enumeration, return the string literal for it
-    static const char   *IGetDXFormatName( D3DFORMAT format );
+    static ST::string IGetDXFormatName(D3DFORMAT format);
 
     /////// Shadow internals
     // Generation
@@ -573,7 +573,7 @@ public:
     static void     AllocManagedVertex(uint32_t sz) { fVtxManaged += sz; }
 
 #ifndef PLASMA_EXTERNAL_RELEASE
-    static void ProfilePoolMem(D3DPOOL poolType, uint32_t size, bool add, const char *id);
+    static void ProfilePoolMem(D3DPOOL poolType, uint32_t size, bool add, const ST::string& id);
 #endif // PLASMA_EXTERNAL_RELEASE
 
     //  From a D3DFORMAT enumeration, return the bit depth associated with it.
@@ -595,7 +595,7 @@ public:
     plMipmap*       ExtractMipMap(plRenderTarget* targ) override;
 
     /// Error handling
-    const char      *GetErrorString() override;
+    ST::string GetErrorString() override;
 
     bool            ManagedAlloced() const { return fManagedAlloced; }
 

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPixelShader.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPixelShader.cpp
@@ -66,8 +66,7 @@ void plDXPixelShader::Release()
     ReleaseObject(fHandle);
     fHandle = nullptr;
     fPipe = nullptr;
-
-    ISetError(nullptr);
+    fErrorString.clear();
 }
 
 bool plDXPixelShader::VerifyFormat(uint8_t format) const
@@ -94,17 +93,17 @@ HRESULT plDXPixelShader::ICreate(plDXPipeline* pipe)
 {
     fHandle = nullptr; // in case something goes wrong.
     fPipe = nullptr;
-    ISetError(nullptr);
+    fErrorString.clear();
 
     DWORD* shaderCodes = (DWORD*)(fOwner->GetDecl()->GetCodes());
 
     if( !shaderCodes )
-        return IOnError(-1, "Shaders must be compiled into the engine.");
+        return IOnError(-1, ST_LITERAL("Shaders must be compiled into the engine."));
 
     HRESULT hr = pipe->GetD3DDevice()->CreatePixelShader(shaderCodes, &fHandle);
     if( FAILED(hr) )
     {
-        return IOnError(hr, "Error on CreatePixelShader");
+        return IOnError(hr, ST_LITERAL("Error on CreatePixelShader"));
     }
 
     hsAssert(fHandle, "No error, but no pixel shader handle. Grrrr.");
@@ -123,7 +122,7 @@ HRESULT plDXPixelShader::ISetConstants(plDXPipeline* pipe)
                         (const float*)fOwner->GetConstBasePtr(),
                         fOwner->GetNumConsts());
         if( FAILED(hr) )
-            return IOnError(hr, "Error setting constants");
+            return IOnError(hr, ST_LITERAL("Error setting constants"));
     }
 
     return S_OK;

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXSettings.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXSettings.h
@@ -73,6 +73,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 //// General Settings /////////////////////////////////////////////////////////
 
+class plLightInfo;
 class plRenderRequest;
 class plRenderTarget;
 struct IDirect3DSurface9;

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXSettings.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXSettings.h
@@ -56,6 +56,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsWindows.h"
 #include <d3d9.h>
 
+#include <string_theory/string>
 #include <vector>
 
 #include "hsBitVector.h"
@@ -110,7 +111,7 @@ class plDXGeneralSettings
         DWORD                           fCurrFVFFormat;
 
         hsCOMError              fDXError;
-        char                    fErrorStr[ 256 ];
+        ST::string fErrorStr;
 
         void    Reset();
 };

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXShader.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXShader.cpp
@@ -60,8 +60,7 @@ plDXShader::plDXShader(plShader* owner)
 plDXShader::~plDXShader()
 {
     fPipe = nullptr;
-
-    ISetError(nullptr);
+    fErrorString.clear();
 }
 
 void plDXShader::SetOwner(plShader* owner)
@@ -74,13 +73,13 @@ void plDXShader::SetOwner(plShader* owner)
     }
 }
 
-HRESULT plDXShader::IOnError(HRESULT hr, const char* errStr)
+HRESULT plDXShader::IOnError(HRESULT hr, ST::string errStr)
 {
-    ISetError(errStr);
+    fErrorString = std::move(errStr);
 
     fOwner->Invalidate();
 
-    hsStatusMessage(errStr);
+    hsStatusMessage(fErrorString.c_str());
 
     return hr;
 }

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXShader.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXShader.h
@@ -56,8 +56,7 @@ protected:
     ST::string          fErrorString;
     plDXPipeline*       fPipe;
 
-    HRESULT             IOnError(HRESULT hr, const char* errStr);
-    void                ISetError(const char* errStr) { fErrorString = errStr; }
+    HRESULT IOnError(HRESULT hr, ST::string errStr);
 
     virtual HRESULT     ICreate(plDXPipeline* pipe) = 0;
     virtual HRESULT     ISetConstants(plDXPipeline* pipe) = 0; // On error, sets error string.

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXVertexShader.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXVertexShader.cpp
@@ -66,8 +66,7 @@ void plDXVertexShader::Release()
     ReleaseObject(fHandle);
     fHandle = nullptr;
     fPipe = nullptr;
-
-    ISetError(nullptr);
+    fErrorString.clear();
 }
 
 bool plDXVertexShader::VerifyFormat(uint8_t format) const
@@ -94,7 +93,7 @@ HRESULT plDXVertexShader::ICreate(plDXPipeline* pipe)
 {
     fHandle = nullptr; // in case something goes wrong.
     fPipe = nullptr;
-    ISetError(nullptr);
+    fErrorString.clear();
 
     // We could store the compiled buffer and skip the assembly step
     // if we need to recreate the shader (e.g. on device lost).
@@ -102,12 +101,12 @@ HRESULT plDXVertexShader::ICreate(plDXPipeline* pipe)
     DWORD* shaderCodes = (DWORD*)(fOwner->GetDecl()->GetCodes());
 
     if( !shaderCodes )
-        return IOnError(-1, "Shaders must be compiled into the engine.");
+        return IOnError(-1, ST_LITERAL("Shaders must be compiled into the engine."));
 
     HRESULT hr = pipe->GetD3DDevice()->CreateVertexShader(shaderCodes, &fHandle);
 
     if( FAILED(hr) )
-        return IOnError(hr, "Error on CreateVertexShader");
+        return IOnError(hr, ST_LITERAL("Error on CreateVertexShader"));
 
     hsAssert(fHandle, "No error, but no vertex shader handle. Grrrr.");
 
@@ -125,7 +124,7 @@ HRESULT plDXVertexShader::ISetConstants(plDXPipeline* pipe)
                                         (const float*)fOwner->GetConstBasePtr(),
                                         fOwner->GetNumConsts());
         if( FAILED(hr) )
-            return IOnError(hr, "Failure setting vertex shader constants");
+            return IOnError(hr, ST_LITERAL("Failure setting vertex shader constants"));
     }
 
     return S_OK;

--- a/Sources/Plasma/FeatureLib/pfGLPipeline/plGLDevice.h
+++ b/Sources/Plasma/FeatureLib/pfGLPipeline/plGLDevice.h
@@ -44,13 +44,15 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsMatrix44.h"
 
+#include <string_theory/string>
+
 class plGLPipeline;
 class plRenderTarget;
 
 class plGLDevice
 {
 protected:
-    const char*         fErrorMsg;
+    ST::string fErrorMsg;
     plGLPipeline*       fPipeline;
 
 public:
@@ -76,7 +78,7 @@ public:
     struct IndexBufferRef;
     struct TextureRef;
 
-    const char* GetErrorString() const { return fErrorMsg; }
+    ST::string GetErrorString() const { return fErrorMsg; }
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
@@ -549,9 +549,9 @@ bool    pfGUIControlMod::MsgReceive( plMessage *msg )
     if (rend || device) {
         plPipeline* pipe = rend ? rend->Pipeline() : device->Pipeline();
 
-        plProfile_BeginLap(GUITime, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(GUITime, this->GetKey()->GetUoid().GetObjectName());
         ISetUpDynTextMap(pipe);
-        plProfile_EndLap(GUITime, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(GUITime, this->GetKey()->GetUoid().GetObjectName());
 
         if (rend)
             plgDispatch::Dispatch()->UnRegisterForExactType(plRenderMsg::Index(), GetKey());

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <Metal/Metal.hpp>
 #include <QuartzCore/QuartzCore.hpp>
 #include <condition_variable>
+#include <string_theory/string>
 #include <unordered_map>
 
 #include "HeadSpin.h"
@@ -85,7 +86,7 @@ public:
     hsWindowHndl fDevice;
     hsWindowHndl fWindow;
 
-    const char* fErrorMsg;
+    ST::string fErrorMsg;
 
     MTL::RenderCommandEncoder* CurrentRenderCommandEncoder();
     MTL::Device*               fMetalDevice;
@@ -140,7 +141,7 @@ public:
     void MakeTextureRef(TextureRef* tRef, plMipmap* img);
     void MakeCubicTextureRef(TextureRef* tRef, plCubicEnvironmap* img);
 
-    const char* GetErrorString() const { return fErrorMsg; }
+    ST::string GetErrorString() const { return fErrorMsg; }
 
     void SetProjectionMatrix(const hsMatrix44& src);
     void SetWorldToCameraMatrix(const hsMatrix44& src);

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -337,7 +337,7 @@ public:
     virtual plMipmap*                   ExtractMipMap(plRenderTarget* targ) = 0;
 
     /// Error handling
-    virtual const char                  *GetErrorString() = 0;
+    virtual ST::string GetErrorString() = 0;
 
     // info about current rendering device
     virtual void GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth = 32 ) = 0;

--- a/Sources/Plasma/NucleusLib/inc/plProfile.h
+++ b/Sources/Plasma/NucleusLib/inc/plProfile.h
@@ -189,7 +189,7 @@ public:
 
     uint32_t GetTimerSamples() const { return fTimerSamples; }
 
-    ST::string GetName() { return fName; }
+    ST::string GetName() const { return fName; }
 
     void SetActive(bool s) { fActive = s; }
 
@@ -243,7 +243,7 @@ public:
     void BeginLap(const ST::string& lapName) { if (fActive && fRunning) IBeginLap(lapName); }
     void EndLap(const ST::string& lapName) { if (fActive && fRunning) IEndLap(lapName); }
 
-    ST::string GetGroup() { return fGroup; }
+    ST::string GetGroup() const { return fGroup; }
 
     plProfileLaps* GetLaps() { return fLaps; }
 

--- a/Sources/Plasma/NucleusLib/inc/plProfile.h
+++ b/Sources/Plasma/NucleusLib/inc/plProfile.h
@@ -44,6 +44,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
+#include <string_theory/string>
+
 #ifndef PLASMA_EXTERNAL_RELEASE
 #define PL_PROFILE_ENABLED
 #endif
@@ -79,23 +81,23 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #ifdef PL_PROFILE_ENABLED
 
-#define plProfile_CreateTimerNoReset(name, group, varName)  plProfileVar gProfileVar##varName(name, group, plProfileVar::kDisplayTime | plProfileVar::kDisplayNoReset)
-#define plProfile_CreateTimer(name, group, varName) plProfileVar gProfileVar##varName(name, group, plProfileVar::kDisplayTime)
-#define plProfile_CreateAsynchTimer(name, group, varName)   plProfileVar gProfileVar##varName(name, group, plProfileVar::kDisplayTime | plProfileVar::kDisplayResetEveryBegin | plProfileVar::kDisplayNoReset)
+#define plProfile_CreateTimerNoReset(name, group, varName)  plProfileVar gProfileVar##varName(ST_LITERAL(name), ST_LITERAL(group), plProfileVar::kDisplayTime | plProfileVar::kDisplayNoReset)
+#define plProfile_CreateTimer(name, group, varName) plProfileVar gProfileVar##varName(ST_LITERAL(name), ST_LITERAL(group), plProfileVar::kDisplayTime)
+#define plProfile_CreateAsynchTimer(name, group, varName)   plProfileVar gProfileVar##varName(ST_LITERAL(name), ST_LITERAL(group), plProfileVar::kDisplayTime | plProfileVar::kDisplayResetEveryBegin | plProfileVar::kDisplayNoReset)
 #define plProfile_BeginTiming(varName)              gProfileVar##varName.BeginTiming()
 #define plProfile_EndTiming(varName)                gProfileVar##varName.EndTiming()
 #define plProfile_BeginLap(varName, lapName)        gProfileVar##varName.BeginLap(lapName)
 #define plProfile_EndLap(varName, lapName)          gProfileVar##varName.EndLap(lapName)
 
-#define plProfile_CreateCounter(name, group, varName)   plProfileVar gProfileVar##varName(name, group, plProfileVar::kDisplayCount)
-#define plProfile_CreateCounterNoReset(name, group, varName)    plProfileVar gProfileVar##varName(name, group, plProfileVar::kDisplayCount | plProfileVar::kDisplayNoReset)
+#define plProfile_CreateCounter(name, group, varName)   plProfileVar gProfileVar##varName(ST_LITERAL(name), ST_LITERAL(group), plProfileVar::kDisplayCount)
+#define plProfile_CreateCounterNoReset(name, group, varName)    plProfileVar gProfileVar##varName(ST_LITERAL(name), ST_LITERAL(group), plProfileVar::kDisplayCount | plProfileVar::kDisplayNoReset)
 #define plProfile_Inc(varName)                          gProfileVar##varName.Inc()
 #define plProfile_IncCount(varName, count)              gProfileVar##varName.Inc(count)
 #define plProfile_Dec(varName)                          gProfileVar##varName.Dec()
 #define plProfile_Set(varName, value)                   gProfileVar##varName.Set(value)
 
-#define plProfile_CreateMemCounter(name, group, varName)    plProfileVar gProfileVar##varName(name, group, plProfileVar::kDisplayMem | plProfileVar::kDisplayNoReset)
-#define plProfile_CreateMemCounterReset(name, group, varName)   plProfileVar gProfileVar##varName(name, group, plProfileVar::kDisplayMem)
+#define plProfile_CreateMemCounter(name, group, varName)    plProfileVar gProfileVar##varName(ST_LITERAL(name), ST_LITERAL(group), plProfileVar::kDisplayMem | plProfileVar::kDisplayNoReset)
+#define plProfile_CreateMemCounterReset(name, group, varName)   plProfileVar gProfileVar##varName(ST_LITERAL(name), ST_LITERAL(group), plProfileVar::kDisplayMem)
 #define plProfile_NewMem(varName, memAmount)                gProfileVar##varName.NewMem(memAmount)
 #define plProfile_DelMem(varName, memAmount)                gProfileVar##varName.DelMem(memAmount)
 
@@ -151,7 +153,7 @@ public:
     };
 
 protected:
-    const char* fName;      // Name of timer
+    ST::string fName; // Name of timer
 
     uint64_t fValue;
 
@@ -168,7 +170,7 @@ protected:
 
     void IAddAvg();
 
-    void IPrintValue(uint64_t value, char* buf, bool printType);
+    ST::string IPrintValue(uint64_t value, bool printType);
 
 public:
     plProfileBase();
@@ -181,13 +183,13 @@ public:
 
     uint64_t GetValue();
 
-    void PrintValue(char* buf, bool printType=true);
-    void PrintAvg(char* buf, bool printType=true);
-    void PrintMax(char* buf, bool printType=true);
+    ST::string PrintValue(bool printType = true);
+    ST::string PrintAvg(bool printType = true);
+    ST::string PrintMax(bool printType = true);
 
     uint32_t GetTimerSamples() const { return fTimerSamples; }
 
-    const char* GetName() { return fName; }
+    ST::string GetName() { return fName; }
 
     void SetActive(bool s) { fActive = s; }
 
@@ -202,7 +204,7 @@ public:
 class plProfileVar : public plProfileBase
 {
 protected:
-    const char* fGroup;
+    ST::string fGroup;
     plProfileLaps* fLaps;
     bool fLapsActive;
 
@@ -210,13 +212,13 @@ protected:
 
     void IBeginTiming();
     void IEndTiming();
-    
-    void IBeginLap(const char* lapName); 
-    void IEndLap(const char* lapName);
+
+    void IBeginLap(const ST::string& lapName);
+    void IEndLap(const ST::string& lapName);
 
 public:
     // Name is the timer name. Each timer group gets its own plStatusLog
-    plProfileVar(const char *name, const char* group, uint8_t flags);
+    plProfileVar(ST::string name, ST::string group, uint8_t flags);
     ~plProfileVar();
 
     // For timing
@@ -238,10 +240,10 @@ public:
     // Will output to log like
     // Timername : lapCnt: (lapName) : 3.22 msec
     //
-    void BeginLap(const char* lapName) { if(fActive && fRunning) IBeginLap(lapName); }
-    void EndLap(const char* lapName) { if(fActive && fRunning) IEndLap(lapName); }
-    
-    const char* GetGroup() { return fGroup; }
+    void BeginLap(const ST::string& lapName) { if (fActive && fRunning) IBeginLap(lapName); }
+    void EndLap(const ST::string& lapName) { if (fActive && fRunning) IEndLap(lapName); }
+
+    ST::string GetGroup() { return fGroup; }
 
     plProfileLaps* GetLaps() { return fLaps; }
 

--- a/Sources/Plasma/NucleusLib/inc/plProfileManager.h
+++ b/Sources/Plasma/NucleusLib/inc/plProfileManager.h
@@ -43,6 +43,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plProfileManager_h_inc
 
 #include "HeadSpin.h"
+
+#include <string_theory/string>
+#include <utility>
 #include <vector>
 
 #include "plProfile.h"
@@ -88,7 +91,7 @@ protected:
 
     public:
         bool fUsedThisFrame;
-        LapInfo(const char* name) : fUsedThisFrame() { fName = name; fDisplayFlags = kDisplayTime; }
+        LapInfo(ST::string name) : fUsedThisFrame() { fName = std::move(name); fDisplayFlags = kDisplayTime; }
         bool operator<(const LapInfo& rhs) const { return fLastAvg < rhs.fLastAvg; }
 
         void BeginTiming(uint64_t value) { fValue -= value; }
@@ -96,11 +99,11 @@ protected:
     };
     std::vector<LapInfo> fLapTimes;
 
-    LapInfo* IFindLap(const char* lapName);
+    LapInfo* IFindLap(const ST::string& lapName);
 
 public:
-    void BeginLap(uint64_t curValue, const char* name);
-    void EndLap(uint64_t curValue, const char* name);
+    void BeginLap(uint64_t curValue, const ST::string& name);
+    void EndLap(uint64_t curValue, const ST::string& name);
 
     void BeginFrame();
     void EndFrame();

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
@@ -242,7 +242,7 @@ bool plAGMasterMod::IEval(double secs, float del, uint32_t dirty)
 // APPLYANIMATIONS
 void plAGMasterMod::ApplyAnimations(double time, float elapsed)
 {
-    plProfile_BeginLap(ApplyAnimation, this->GetKey()->GetUoid().GetObjectName().c_str());
+    plProfile_BeginLap(ApplyAnimation, this->GetKey()->GetUoid().GetObjectName());
 
     // update any fades
     for (int i = 0; i < fAnimInstances.size(); i++)
@@ -252,7 +252,7 @@ void plAGMasterMod::ApplyAnimations(double time, float elapsed)
     
     AdvanceAnimsToTime(time);
 
-    plProfile_EndLap(ApplyAnimation,this->GetKey()->GetUoid().GetObjectName().c_str());
+    plProfile_EndLap(ApplyAnimation,this->GetKey()->GetUoid().GetObjectName());
 }
 
 void plAGMasterMod::AdvanceAnimsToTime(double time)

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
@@ -817,7 +817,7 @@ bool plAudioSystem::MsgReceive(plMessage* msg)
     if (plRenderMsg* pRMsg = plRenderMsg::ConvertNoRef( msg )) {
         //if (fListener)
         {
-            plProfile_BeginLap(AudioUpdate, this->GetKey()->GetUoid().GetObjectName().c_str());
+            plProfile_BeginLap(AudioUpdate, this->GetKey()->GetUoid().GetObjectName());
             if (hsTimer::GetMilliSeconds() - fLastUpdateTimeMs > UPDATE_TIME_MS) {
                 IUpdateSoftSounds(fCurrListenerPos);
 
@@ -827,7 +827,7 @@ bool plAudioSystem::MsgReceive(plMessage* msg)
                     plProfile_EndTiming(SoundEAXUpdate);
                 }
             }
-            plProfile_EndLap(AudioUpdate, this->GetKey()->GetUoid().GetObjectName().c_str());
+            plProfile_EndLap(AudioUpdate, this->GetKey()->GetUoid().GetObjectName());
         }
         return true;
     }

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
@@ -1222,7 +1222,7 @@ bool plDrawableSpans::MsgReceive( plMessage* msg )
     }
     else if( plRenderMsg::ConvertNoRef( msg ) )
     {
-        plProfile_BeginLap(PalletteHack, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(PalletteHack, this->GetKey()->GetUoid().GetObjectName());
     
         IUpdateMatrixPaletteBoundsHack();
 
@@ -1233,7 +1233,7 @@ bool plDrawableSpans::MsgReceive( plMessage* msg )
         // The pipeline will then clear out those bits as it blends them, and then we simply
         // re-set them here, since plRenderMsg is sent once before all the rendering is done :)
         fFakeBlendingSpanVector = fBlendingSpanVector;
-        plProfile_EndLap(PalletteHack, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(PalletteHack, this->GetKey()->GetUoid().GetObjectName());
     
         return true;
     }
@@ -1433,7 +1433,7 @@ void    plDrawableSpans::SortSpan( uint32_t index, plPipeline *pipe )
 {
     plProfile_Inc(FaceSortCalls);
 
-    plProfile_BeginLap(FaceSort, "0");
+    plProfile_BeginLap(FaceSort, ST_LITERAL("0"));
 
     plIcicle            *span = (plIcicle *)fSpans[ index ];
     plGBufferTriangle   *list, temp;
@@ -1462,8 +1462,8 @@ void    plDrawableSpans::SortSpan( uint32_t index, plPipeline *pipe )
     tempTriList.resize(numTris * 3);
     elem = sortList.data();
 
-    plProfile_EndLap(FaceSort, "0");
-    plProfile_BeginLap(FaceSort, "1");
+    plProfile_EndLap(FaceSort, ST_LITERAL("0"));
+    plProfile_BeginLap(FaceSort, ST_LITERAL("1"));
 
     hsVector3 vec(w2cMatrix.fMap[2][0], w2cMatrix.fMap[2][1], w2cMatrix.fMap[2][2]);
     float trans = w2cMatrix.fMap[2][3];
@@ -1478,15 +1478,15 @@ void    plDrawableSpans::SortSpan( uint32_t index, plPipeline *pipe )
     }
     elem[i - 1].fNext = nullptr;
 
-    plProfile_EndLap(FaceSort, "1");
-    plProfile_BeginLap(FaceSort, "2");
+    plProfile_EndLap(FaceSort, ST_LITERAL("1"));
+    plProfile_BeginLap(FaceSort, ST_LITERAL("2"));
 
     // Do da sort thingy
     hsRadixSort         rad;
     hsRadixSort::Elem   *sortedList = rad.Sort( elem, 0 );
 
-    plProfile_EndLap(FaceSort, "2");
-    plProfile_BeginLap(FaceSort, "3");
+    plProfile_EndLap(FaceSort, ST_LITERAL("2"));
+    plProfile_BeginLap(FaceSort, ST_LITERAL("3"));
 
     uint16_t* indices = tempTriList.data();
     // Stuff into the temp array
@@ -1498,8 +1498,8 @@ void    plDrawableSpans::SortSpan( uint32_t index, plPipeline *pipe )
         elem = elem->fNext;
     }
 
-    plProfile_EndLap(FaceSort, "3");
-    plProfile_BeginLap(FaceSort, "4");
+    plProfile_EndLap(FaceSort, ST_LITERAL("3"));
+    plProfile_BeginLap(FaceSort, ST_LITERAL("4"));
 
     /// Now send them on to the buffer group
     fGroups[ span->fGroupIdx ]->StuffFromTriList( span->fIBufferIdx, span->fIStartIdx, 
@@ -1515,7 +1515,7 @@ void    plDrawableSpans::SortSpan( uint32_t index, plPipeline *pipe )
     /// All done! (force buffer groups to refresh during next render call)
     fReadyToRender = false;
 
-    plProfile_EndLap(FaceSort, "4");
+    plProfile_EndLap(FaceSort, ST_LITERAL("4"));
 }
 
 //// SortVisibleSpans ////////////////////////////////////////////////////////
@@ -1757,7 +1757,7 @@ void plDrawableSpans::SortVisibleSpans(const std::vector<int16_t>& visList, plPi
 
     plProfile_EndTiming(FaceSort);
 
-    plProfile_BeginLap(FaceSort, "0");
+    plProfile_BeginLap(FaceSort, ST_LITERAL("0"));
 
     startIndex.resize(fSpans.size());
 
@@ -1777,7 +1777,7 @@ void plDrawableSpans::SortVisibleSpans(const std::vector<int16_t>& visList, plPi
     }
     if( totTris == 0 )
     {
-        plProfile_EndLap(FaceSort, "0");
+        plProfile_EndLap(FaceSort, ST_LITERAL("0"));
         return;
     }
 
@@ -1788,12 +1788,12 @@ void plDrawableSpans::SortVisibleSpans(const std::vector<int16_t>& visList, plPi
 
     hsRadixSort::Elem* elem = sortScratch.data();
 
-    plProfile_EndLap(FaceSort, "0");
+    plProfile_EndLap(FaceSort, ST_LITERAL("0"));
 
     size_t iVis = 0;
     while (iVis < visList.size())
     {
-        plProfile_BeginLap(FaceSort, "1");
+        plProfile_BeginLap(FaceSort, ST_LITERAL("1"));
 
         // Pack them into the sort structure. We probably want to make the 
         // plGBufferTriangle look like plTriSortData (just add span index) 
@@ -1824,15 +1824,15 @@ void plDrawableSpans::SortVisibleSpans(const std::vector<int16_t>& visList, plPi
         }
         elem[cnt-1].fNext = nullptr;
 
-        plProfile_EndLap(FaceSort, "1");
-        plProfile_BeginLap(FaceSort, "2");
+        plProfile_EndLap(FaceSort, ST_LITERAL("1"));
+        plProfile_BeginLap(FaceSort, ST_LITERAL("2"));
 
         // Actual sort
         hsRadixSort         rad;
         hsRadixSort::Elem* sortedList = rad.Sort( elem, 0 );
 
-        plProfile_EndLap(FaceSort, "2");
-        plProfile_BeginLap(FaceSort, "3");
+        plProfile_EndLap(FaceSort, ST_LITERAL("2"));
+        plProfile_BeginLap(FaceSort, ST_LITERAL("3"));
 
         counters.assign(fSpans.size(), 0);
 
@@ -1853,10 +1853,10 @@ void plDrawableSpans::SortVisibleSpans(const std::vector<int16_t>& visList, plPi
             sortedList = sortedList->fNext;
         }
 
-        plProfile_EndLap(FaceSort, "3");
+        plProfile_EndLap(FaceSort, ST_LITERAL("3"));
     }
 
-    plProfile_BeginLap(FaceSort, "4");
+    plProfile_BeginLap(FaceSort, ST_LITERAL("4"));
 
     constexpr size_t kMaxBufferGroups = 20;
     constexpr size_t kMaxIndexBuffers = 20;
@@ -1882,7 +1882,7 @@ void plDrawableSpans::SortVisibleSpans(const std::vector<int16_t>& visList, plPi
                                                       span->fILength / 3, triList.data() + startIndex[idx]);
     }
 
-    plProfile_EndLap(FaceSort, "4");
+    plProfile_EndLap(FaceSort, ST_LITERAL("4"));
 
     fReadyToRender = false;
 

--- a/Sources/Plasma/PubUtilLib/plGLight/plLightInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plLightInfo.cpp
@@ -370,7 +370,7 @@ bool plLightInfo::MsgReceive(plMessage* msg)
     plRenderMsg* rendMsg = plRenderMsg::ConvertNoRef(msg);
     if( rendMsg )
     {
-        plProfile_BeginLap(LightInfo, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(LightInfo, this->GetKey()->GetUoid().GetObjectName());
 
         if( !fDeviceRef && !GetProperty(kLPShadowOnly) )
         {
@@ -379,7 +379,7 @@ bool plLightInfo::MsgReceive(plMessage* msg)
 
         ICheckMaxStrength();
 
-        plProfile_EndLap(LightInfo, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(LightInfo, this->GetKey()->GetUoid().GetObjectName());
         return true;
     }
     plGenRefMsg* refMsg = plGenRefMsg::ConvertNoRef(msg);

--- a/Sources/Plasma/PubUtilLib/plGLight/plShadowCaster.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plShadowCaster.cpp
@@ -210,9 +210,9 @@ bool plShadowCaster::MsgReceive(plMessage* msg)
     plRenderMsg* rendMsg = plRenderMsg::ConvertNoRef(msg);
     if( rendMsg )
     {
-        plProfile_BeginLap(ShadowCaster, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(ShadowCaster, this->GetKey()->GetUoid().GetObjectName());
         IOnRenderMsg(rendMsg);
-        plProfile_EndLap(ShadowCaster, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(ShadowCaster, this->GetKey()->GetUoid().GetObjectName());
         return true;
     }
 

--- a/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.cpp
+++ b/Sources/Plasma/PubUtilLib/plGLight/plShadowMaster.cpp
@@ -177,9 +177,9 @@ bool plShadowMaster::MsgReceive(plMessage* msg)
     plRenderMsg* rendMsg = plRenderMsg::ConvertNoRef(msg);
     if( rendMsg )
     {
-        plProfile_BeginLap(ShadowMaster, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(ShadowMaster, this->GetKey()->GetUoid().GetObjectName());
         IBeginRender();
-        plProfile_EndLap(ShadowMaster, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(ShadowMaster, this->GetKey()->GetUoid().GetObjectName());
         return true;
     }
 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -290,7 +290,7 @@ void    plInputInterfaceMgr::IUpdateCursor( int32_t newCursor )
 
 bool plInputInterfaceMgr::IEval( double secs, float del, uint32_t dirty )
 {
-    const char *inputEval = "Eval";
+    const ST::string inputEval = ST_LITERAL("Eval");
     plProfile_BeginLap(Input, inputEval);
 
 
@@ -420,7 +420,7 @@ bool    plInputInterfaceMgr::MsgReceive( plMessage *msg )
     plInputEventMsg *ieMsg = plInputEventMsg::ConvertNoRef( msg );
     if (ieMsg != nullptr)
     {
-        const char *inputIEM = "InputEventMsg";
+        const ST::string inputIEM = ST_LITERAL("InputEventMsg");
         plProfile_BeginLap(Input, inputIEM);
         bool handled = false;
         size_t missedInputStartIdx = 0;

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleEmitter.cpp
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleEmitter.cpp
@@ -325,7 +325,7 @@ void plParticleEmitter::IUpdateParticles(float delta)
     
     if ((fGenerator != nullptr) && (fTimeToLive >= 0))
     {
-        plProfile_BeginLap(ParticleGenerate, fSystem->GetKeyName().c_str());
+        plProfile_BeginLap(ParticleGenerate, fSystem->GetKeyName());
         if (!fGenerator->AddAutoParticles(this, delta))
         {
             delete fGenerator;
@@ -333,7 +333,7 @@ void plParticleEmitter::IUpdateParticles(float delta)
         }
         if( (fTimeToLive > 0) && ((fTimeToLive -= delta) <= 0) )
             fTimeToLive = -1.f;
-        plProfile_EndLap(ParticleGenerate, fSystem->GetKeyName().c_str());
+        plProfile_EndLap(ParticleGenerate, fSystem->GetKeyName());
     }
 
     fTargetInfo.fContext = fSystem->fContext;

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleSystem.cpp
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/plParticleSystem.cpp
@@ -485,9 +485,9 @@ bool plParticleSystem::MsgReceive(plMessage* msg)
 
     if ((rend = plRenderMsg::ConvertNoRef(msg)))
     {
-        plProfile_BeginLap(ParticleSys, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(ParticleSys, this->GetKey()->GetUoid().GetObjectName());
         IHandleRenderMsg(rend->Pipeline());
-        plProfile_EndLap(ParticleSys, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(ParticleSys, this->GetKey()->GetUoid().GetObjectName());
         return true;
     }
     else if ((refMsg = plGenRefMsg::ConvertNoRef(msg)))

--- a/Sources/Plasma/PubUtilLib/plPhysX/plGenericPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plGenericPhysical.cpp
@@ -500,7 +500,7 @@ void plPXPhysical::SendNewLocation(bool synchTransform, bool isSynchUpdate)
 
             if (!curl2w.Compare(fCachedLocal2World, .0001f)) {
                 plProfile_Inc(LocationsSent);
-                plProfile_BeginLap(PhysicsUpdates, GetKeyName().c_str());
+                plProfile_BeginLap(PhysicsUpdates, GetKeyName());
 
                 if (fCachedLocal2World.GetTranslate().fZ < kMaxNegativeZPos)
                 {
@@ -517,7 +517,7 @@ void plPXPhysical::SendNewLocation(bool synchTransform, bool isSynchUpdate)
                 pCorrMsg->Send();
                 if (fProxyGen)
                     fProxyGen->SetTransform(fCachedLocal2World, w2l);
-                plProfile_EndLap(PhysicsUpdates, GetKeyName().c_str());
+                plProfile_EndLap(PhysicsUpdates, GetKeyName());
             }
         }
     }

--- a/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.h
@@ -185,7 +185,7 @@ public:
     hsG3DDeviceRecord& operator=(const hsG3DDeviceRecord& src);
 
     uint32_t  GetG3DDeviceType() const { return fG3DDeviceType; }
-    const char* GetG3DDeviceTypeName() const;
+    ST::string GetG3DDeviceTypeName() const;
     uint32_t  GetG3DHALorHEL() const { return fG3DHALorHEL; }
 
     uint32_t GetMemoryBytes() const { return fMemoryBytes; }
@@ -326,7 +326,6 @@ protected:
     static std::list<DeviceEnumerator> sEnumerators;
 
     std::vector<hsG3DDeviceRecord> fRecords;
-    char    fErrorString[ 128 ];
 
     void IClear();
     void IRemoveDiscarded();
@@ -340,7 +339,7 @@ protected:
     uint32_t  IAdjustDirectXMemory( uint32_t cardMem );
 
     bool      IGetD3DCardInfo( hsG3DDeviceRecord &record, void *driverInfo, void *deviceInfo,
-                               uint32_t *vendorID, uint32_t *deviceID, char **driverString, char **descString );
+                               uint32_t *vendorID, uint32_t *deviceID, ST::string& driverString, ST::string& descString);
 
     void    ISetFudgeFactors( uint8_t chipsetID, hsG3DDeviceRecord &record );
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/pl3DPipeline.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/pl3DPipeline.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define _pl3DPipeline_inc_
 
 #include <stack>
+#include <string_theory/string>
 #include <vector>
 
 #include "plPipeline.h"
@@ -683,7 +684,8 @@ public:
     //virtual plMipmap* ExtractMipMap(plRenderTarget* targ) = 0;
 
     /** Return the current error string. */
-    const char* GetErrorString() override {
+    ST::string GetErrorString() override
+    {
         return fDevice.GetErrorString();
     }
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plNullPipeline.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plNullPipeline.h
@@ -59,7 +59,7 @@ public:
     void SetProjectionMatrix(const hsMatrix44& src) { }
     void SetWorldToCameraMatrix(const hsMatrix44& src) { }
     void SetLocalToWorldMatrix(const hsMatrix44& src) { }
-    const char* GetErrorString() const { return nullptr; }
+    ST::string GetErrorString() const { return {}; }
 };
 
 class plNullPipeline : public pl3DPipeline<plNullPipelineDevice>

--- a/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plPageTreeMgr.cpp
@@ -212,7 +212,7 @@ size_t plPageTreeMgr::IRenderVisList(plPipeline* pipe, std::vector<plDrawVisList
         plDrawable* p = sortedDrawList[i].fDrawable;
 
 
-        plProfile_BeginLap(DrawableTime, p->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(DrawableTime, p->GetKey()->GetUoid().GetObjectName());
     
         if( sortedDrawList[i].fDrawable->GetNativeProperty(plDrawable::kPropSortSpans) )
         {
@@ -230,7 +230,7 @@ size_t plPageTreeMgr::IRenderVisList(plPipeline* pipe, std::vector<plDrawVisList
 
         }
 
-        plProfile_EndLap(DrawableTime, p->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(DrawableTime, p->GetKey()->GetUoid().GetObjectName());
     }
 
     return numDrawn;

--- a/Sources/Plasma/PubUtilLib/plScene/plPostEffectMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plScene/plPostEffectMod.cpp
@@ -232,9 +232,9 @@ bool plPostEffectMod::MsgReceive(plMessage* msg)
     plRenderMsg* rend = plRenderMsg::ConvertNoRef(msg);
     if( rend && IIsEnabled() )
     {
-        plProfile_BeginLap(PostEffect, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_BeginLap(PostEffect, this->GetKey()->GetUoid().GetObjectName());
         ISubmitRequest();
-        plProfile_EndLap(PostEffect, this->GetKey()->GetUoid().GetObjectName().c_str());
+        plProfile_EndLap(PostEffect, this->GetKey()->GetUoid().GetObjectName());
 
         return true;
     }

--- a/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
@@ -73,7 +73,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plGImage/plMipmap.h"
 
 #include <algorithm>
-#include <string>
+#include <string_theory/string>
+#include <utility>
 
 class plAutoProfileImp : public plAutoProfile
 {
@@ -83,7 +84,7 @@ protected:
     int fNextSpawnPoint;
     ST::string fLastSpawnPointName;
     // For profiling a single age
-    std::string fAgeName;
+    ST::string fAgeName;
     bool fLinkedToSingleAge;
     bool fJustLinkToAges;
 
@@ -103,7 +104,7 @@ public:
         : fNextAge(), fNextSpawnPoint(), fLinkedToSingleAge(), fJustLinkToAges(), fLinkTime()
     { }
 
-    void StartProfile(const char* ageName) override;
+    void StartProfile(ST::string ageName) override;
     void LinkToAllAges() override;
 
     bool MsgReceive(plMessage* msg) override;
@@ -117,12 +118,9 @@ plAutoProfile* plAutoProfile::Instance()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void plAutoProfileImp::StartProfile(const char* ageName)
+void plAutoProfileImp::StartProfile(ST::string ageName)
 {
-    if (ageName)
-        fAgeName = ageName;
-    else
-        fAgeName = "";
+    fAgeName = std::move(ageName);
 
     IInit();
 
@@ -241,22 +239,19 @@ void plAutoProfileImp::INextProfile()
 
 bool plAutoProfileImp::INextAge()
 {
-    const char* ageName = nullptr;
+    ST::string ageName;
 
-    if (fAgeName.length() > 0)
-    {
+    if (!fAgeName.empty()) {
         if (fLinkedToSingleAge)
             return false;
 
         fLinkedToSingleAge = true;
-        ageName = fAgeName.c_str();
-    }
-    else
-    {
+        ageName = fAgeName;
+    } else {
         if (fNextAge >= fAges.size())
             return false;
 
-        ageName = fAges[fNextAge].c_str();
+        ageName = fAges[fNextAge];
     }
 
     fNextAge++;

--- a/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.h
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.h
@@ -44,6 +44,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnKeyedObject/hsKeyedObject.h"
 
+namespace ST { class string; }
+
 class plAutoProfile : public hsKeyedObject
 {
 public:
@@ -52,8 +54,8 @@ public:
 
     static plAutoProfile* Instance();
 
-    // If ageName is nil, do all ages
-    virtual void StartProfile(const char* ageName = nullptr) = 0;
+    // If ageName is empty, do all ages
+    virtual void StartProfile(ST::string ageName) = 0;
 
     // For when we just want to link to each age, for other reasons (profiling load times)
     virtual void LinkToAllAges()=0;

--- a/Sources/Plasma/PubUtilLib/plStatGather/plCalculatedProfiles.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plCalculatedProfiles.cpp
@@ -53,7 +53,7 @@ plProfile_CreateMemCounter("Allocated", "Memory", MemAllocated);
 plProfile_CreateMemCounter("Peak Alloc", "Memory", MemPeakAlloc);
 #endif
 
-static plProfileVar gVarRFPS("RFPS", "General", plProfileVar::kDisplayTime | plProfileVar::kDisplayFPS);
+static plProfileVar gVarRFPS(ST_LITERAL("RFPS"), ST_LITERAL("General"), plProfileVar::kDisplayTime | plProfileVar::kDisplayFPS);
 
 plProfile_Extern(DrawTriangles);
 plProfile_Extern(MatChange);
@@ -99,10 +99,9 @@ static bool ICreateStdPlate(plGraphPlate** graph)
     return false;
 }
 
-void CreateStandardGraphs(const char* groupName, bool create)
+void CreateStandardGraphs(const ST::string& groupName, bool create)
 {
-    if (strcmp(groupName, "General") == 0)
-    {
+    if (groupName == "General") {
         if (create)
         {
             if (ICreateStdPlate(&fFPSPlate))

--- a/Sources/Plasma/PubUtilLib/plStatGather/plCalculatedProfiles.h
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plCalculatedProfiles.h
@@ -40,6 +40,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+namespace ST { class string; }
+
 void CalculateProfiles();
-void CreateStandardGraphs(const char* groupName, bool create);
+void CreateStandardGraphs(const ST::string& groupName, bool create);
 void UpdateStandardGraphs(float xPos, float yPos);

--- a/Sources/Plasma/PubUtilLib/plStatGather/plProfileManagerFull.h
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plProfileManagerFull.h
@@ -83,12 +83,12 @@ protected:
     plProfileVar* fShowLaps;
     uint32_t fMinLap; // For Display
 
-    void IPrintGroup(hsStream* s, const char* groupName, bool printTitle=false);
+    void IPrintGroup(hsStream* s, const ST::string& groupName, bool printTitle = false);
     void ILogStats();
 
     plProfileVar* IFindTimer(const ST::string& name);
 
-    void ISetActive(const char* groupName, bool active);
+    void ISetActive(const ST::string& groupName, bool active);
 
     plProfileManagerFull();
 
@@ -99,24 +99,24 @@ public:
     void Update();
 
     void GetGroups(GroupSet& groups);
-    void ShowGroup(const char* groupName);
+    void ShowGroup(const ST::string& groupName);
     void ShowNextGroup();
 
-    struct LapPair { const char* group; const char* varName; };
+    struct LapPair { ST::string group; ST::string varName; };
     typedef std::vector<LapPair> LapNames;
     void GetLaps(LapNames& lapNames);
-    void ShowLaps(const char* groupName, const char* varName);
+    void ShowLaps(const ST::string& groupName, const ST::string& varName);
     void SetMinLap(int m) { fMinLap = m; };
     void PageDownLaps() { fMinLap += 40; }
     void PageUpLaps() { fMinLap = (fMinLap < 40) ? 0 : fMinLap - 40;}
 
-    void CreateGraph(const char* varName, uint32_t min, uint32_t max);
+    void CreateGraph(const ST::string& varName, uint32_t min, uint32_t max);
 
     void ResetDefaultDetailVars();
     void ShowDetailGraph();
     void HideDetailGraph();
-    void AddDetailVar(const char* varName, uint32_t min, uint32_t max);
-    void RemoveDetailVar(const char* varName);
+    void AddDetailVar(const ST::string& varName, uint32_t min, uint32_t max);
+    void RemoveDetailVar(const ST::string& varName);
     void UpdateDetailLabels();
 
     void ResetMax();

--- a/Sources/Plasma/PubUtilLib/plSurface/hsGMaterial.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/hsGMaterial.cpp
@@ -263,7 +263,7 @@ void hsGMaterial::Read(hsStream *stream, hsResMgr *group)
 
 void hsGMaterial::Eval(double secs, uint32_t frame)
 {
-    plProfile_BeginLap(MaterialAnims, GetKeyName().c_str());
+    plProfile_BeginLap(MaterialAnims, GetKeyName());
 
     for (size_t i = 0; i < GetNumLayers(); i++)
     {
@@ -276,7 +276,7 @@ void hsGMaterial::Eval(double secs, uint32_t frame)
             fPiggyBacks[i]->Eval(secs, frame, 0);
     }
 
-    plProfile_EndLap(MaterialAnims, GetKeyName().c_str());
+    plProfile_EndLap(MaterialAnims, GetKeyName());
 }
 
 void hsGMaterial::Reset()


### PR DESCRIPTION
Just some cleanup to replace more C-style string manipulation and fixed-size buffers. This should have no visible effect.

Almost all of these are "boring" changes. The only somewhat complex parts are the number formatting in `plProfileBase` and the graphics adapter/driver name checks in `hsG3DDeviceSelector`.