### PR TITLE
Reconciling D3D Adapter Enumeration

### DIFF
--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXEnumerate.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXEnumerate.cpp
@@ -63,16 +63,16 @@ const D3DFORMAT hsGDirect3DTnLEnumerate::kDisplayFormats[] =
 
 bool hsGDirect3DTnLEnumerate::SelectFromDevMode(const hsG3DDeviceRecord* devRec, const hsG3DDeviceMode* devMode)
 {
-    for (size_t i = 0; i < GetNumDrivers(); i++)
+    for (size_t i = 0; i < GetNumDisplays(); i++)
     {
-        if (devRec->GetDriverDesc().compare_i(GetDriver(i)->fAdapterInfo.Description) == 0)
+        if (devRec->GetDriverDesc().compare_i(GetDisplay(i)->fAdapterInfo.Description) == 0)
         {
-            for (D3DEnum_DeviceInfo& device : GetDriver(i)->fDevices)
+            for (D3DEnum_RendererInfo& device : GetDisplay(i)->fRenderers)
             {
                 if (devRec->GetDeviceDesc().compare_i(device.fStrName) == 0)
                 {
-                    SetCurrentDriver(GetDriver(i));
-                    SetCurrentDevice(&device);
+                    SetCurrentDisplay(GetDisplay(i));
+                    SetCurrentRenderer(&device);
                     D3DEnum_SelectDefaultMode(
                         devMode->GetWidth(),
                         devMode->GetHeight(),
@@ -98,17 +98,17 @@ bool hsGDirect3DTnLEnumerate::SelectFromDevMode(const hsG3DDeviceRecord* devRec,
         enumFlags |= D3DENUM_CANWINDOW;
     enumFlags |= D3DENUM_TNLHAL;
 
-    D3DEnum_SelectDefaultDriver(enumFlags);
+    D3DEnum_SelectDefaultDisplay(enumFlags);
 
     // If we didn't get what we want, try for anything.
-    if( !GetCurrentDriver() || !GetCurrentDevice() )
+    if( !GetCurrentDisplay() || !GetCurrentRenderer() )
     {
         enumFlags = colorDepth ? 0 : D3DENUM_CANWINDOW;
-        D3DEnum_SelectDefaultDriver(enumFlags);
+        D3DEnum_SelectDefaultDisplay(enumFlags);
     }
-    if( !GetCurrentDriver() || !GetCurrentDevice() )
-        D3DEnum_SelectDefaultDriver(0);
-    if( !GetCurrentDriver() || !GetCurrentDevice() )
+    if( !GetCurrentDisplay() || !GetCurrentRenderer() )
+        D3DEnum_SelectDefaultDisplay(0);
+    if( !GetCurrentDisplay() || !GetCurrentRenderer() )
     {
         if( !*GetEnumeErrorStr() )
             SetEnumeErrorStr("Error finding device");
@@ -127,7 +127,7 @@ bool hsGDirect3DTnLEnumerate::SelectFromDevMode(const hsG3DDeviceRecord* devRec,
 
 HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultMode(int width, int height, int depth)
 {
-    hsAssert(GetCurrentDriver() && GetCurrentDevice(), "Must have selected device already");
+    hsAssert(GetCurrentDisplay() && GetCurrentRenderer(), "Must have selected device already");
 
     BOOL windowed = false;
     if (depth == 0)
@@ -137,7 +137,7 @@ HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultMode(int width, int height
         depth = 32;
     }
 
-    D3DEnum_DeviceInfo* device = GetCurrentDevice();
+    D3DEnum_RendererInfo* device = GetCurrentRenderer();
     for (D3DEnum_ModeInfo& mode : device->fModes)
     {
         if (mode.fWindowed != windowed)
@@ -155,7 +155,7 @@ HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultMode(int width, int height
 
         if( GetCurrentMode() )
         {
-            D3DEnum_ModeInfo* curMode = GetCurrentDriver()->fCurrentMode;
+            D3DEnum_ModeInfo* curMode = GetCurrentDisplay()->fCurrentMode;
             if( depth )
             {
                 if (curMode->fDDmode.Width > mode.fDDmode.Width)
@@ -177,14 +177,14 @@ HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultMode(int width, int height
 // Name: D3DEnum_SelectDefaultDriver()
 // Desc: Picks a default driver according to the passed in flags.
 //-----------------------------------------------------------------------------
-HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultDriver( DWORD dwFlags )
+HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultDisplay( DWORD dwFlags )
 {
     // If a specific driver was requested, perform that search here
     if( dwFlags & D3DENUM_MASK )
     {
-        for (D3DEnum_DriverInfo& driver : fDrivers)
+        for (D3DEnum_DisplayInfo& driver : fDisplays)
         {
-            for (D3DEnum_DeviceInfo& device : driver.fDevices)
+            for (D3DEnum_RendererInfo& device : driver.fRenderers)
             {
                 BOOL bFound = FALSE;
 
@@ -203,7 +203,7 @@ HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultDriver( DWORD dwFlags )
                 {
                     if( dwFlags & D3DENUM_CANWINDOW )
                     {
-                        if ((&driver == &fDrivers[0]))
+                        if ((&driver == &fDisplays[0]))
                         {
                             if ((device.fDDCaps.DevCaps & D3DDEVCAPS_HWTRANSFORMANDLIGHT)
                                 ^ !(dwFlags & D3DENUM_TNLHAL) )
@@ -213,21 +213,21 @@ HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultDriver( DWORD dwFlags )
                     else
                         if( dwFlags & D3DENUM_PRIMARYHAL )
                         {
-                            if (&driver == &fDrivers[0])
+                            if (&driver == &fDisplays[0])
                                 bFound = TRUE;
                         }
                         else
                             if( dwFlags & D3DENUM_SECONDARYHAL )
                             {
-                                if (&driver != &fDrivers[0])
+                                if (&driver != &fDisplays[0])
                                     bFound = TRUE;
                             }
                 }
 
                 if( bFound )
                 {
-                    SetCurrentDriver(&driver);
-                    SetCurrentDevice(&device);
+                    SetCurrentDisplay(&driver);
+                    SetCurrentRenderer(&device);
                     return S_OK;
                 }
             }
@@ -235,15 +235,15 @@ HRESULT hsGDirect3DTnLEnumerate::D3DEnum_SelectDefaultDriver( DWORD dwFlags )
         return D3DENUMERR_NOTFOUND;
     }
 
-    for (D3DEnum_DriverInfo& driver : fDrivers)
+    for (D3DEnum_DisplayInfo& driver : fDisplays)
     {
-        for (D3DEnum_DeviceInfo& device : driver.fDevices)
+        for (D3DEnum_RendererInfo& device : driver.fRenderers)
         {
             if (!device.fIsHardware)
                 continue;
 
-            SetCurrentDriver(&driver);
-            SetCurrentDevice(&device);
+            SetCurrentDisplay(&driver);
+            SetCurrentRenderer(&device);
 
             return S_OK;
         }
@@ -262,8 +262,8 @@ hsGDirect3DTnLEnumerate::hsGDirect3DTnLEnumerate()
 {
     memset( &fEnumeErrorStr[0], 0x00, sizeof(fEnumeErrorStr) );
 
-    fCurrentDriver = nullptr;   // The selected DD driver
-    fDrivers.clear();           // List of DD drivers
+    fCurrentDisplay = nullptr;   // The selected DD driver
+    fDisplays.clear();           // List of DD drivers
 
     // Create a D3D object to use
     IDirect3D9* pD3D = hsGDirect3D::GetDirect3D();
@@ -277,7 +277,7 @@ hsGDirect3DTnLEnumerate::hsGDirect3DTnLEnumerate()
     UINT    iAdapter;
     for( iAdapter = 0; iAdapter < pD3D->GetAdapterCount(); iAdapter++ )
     {
-        D3DEnum_DriverInfo& newDriver = fDrivers.emplace_back();
+        D3DEnum_DisplayInfo& newDriver = fDisplays.emplace_back();
 
         // Copy data to a device info structure
         D3DADAPTER_IDENTIFIER9      adapterInfo;
@@ -301,7 +301,7 @@ hsGDirect3DTnLEnumerate::hsGDirect3DTnLEnumerate()
 //  two faked modes for HAL and REF, attaches the modes to each "device" that
 //  can support them. 
 
-void    hsGDirect3DTnLEnumerate::IEnumAdapterDevices( IDirect3D9 *pD3D, UINT iAdapter, D3DEnum_DriverInfo *drivInfo )
+void    hsGDirect3DTnLEnumerate::IEnumAdapterDevices( IDirect3D9 *pD3D, UINT iAdapter, D3DEnum_DisplayInfo *drivInfo )
 {
     // A bit backwards from DX8... First we have to go through our list of formats and check for validity.
     // Then we can enum through the modes for each format.
@@ -315,7 +315,7 @@ void    hsGDirect3DTnLEnumerate::IEnumAdapterDevices( IDirect3D9 *pD3D, UINT iAd
     UINT iDevice;
     for (iDevice = 0; iDevice < numDeviceTypes; iDevice++)
     {
-        D3DEnum_DeviceInfo& deviceInfo = drivInfo->fDevices.emplace_back();
+        D3DEnum_RendererInfo& deviceInfo = drivInfo->fRenderers.emplace_back();
 
         pD3D->GetDeviceCaps(iAdapter, deviceTypes[iDevice], &deviceInfo.fDDCaps);
         strncpy(deviceInfo.fStrName, strDeviceDescs[iDevice], 39);
@@ -604,8 +604,8 @@ bool    hsG3DDeviceSelector::IGetD3DCardInfo( hsG3DDeviceRecord &record,        
                                               uint32_t *vendorID, uint32_t *deviceID, // Out
                                               char **driverString, char **descString  )
 {
-    D3DEnum_DriverInfo  *driverD3DInfo = (D3DEnum_DriverInfo *)driverInfo;
-    D3DEnum_DeviceInfo  *deviceD3DInfo = (D3DEnum_DeviceInfo *)deviceInfo;
+    D3DEnum_DisplayInfo  *driverD3DInfo = (D3DEnum_DisplayInfo *)driverInfo;
+    D3DEnum_RendererInfo  *deviceD3DInfo = (D3DEnum_RendererInfo *)deviceInfo;
 
     D3DADAPTER_IDENTIFIER9  *adapterInfo;
 
@@ -625,9 +625,9 @@ void hsG3DDeviceSelector::ITryDirect3DTnL(hsWinRef winRef)
 {
     hsGDirect3DTnLEnumerate& d3dEnum = hsGDirect3D::EnumerateTnL();
 
-    for (size_t i = 0; i < d3dEnum.GetNumDrivers(); i++)
+    for (size_t i = 0; i < d3dEnum.GetNumDisplays(); i++)
     {
-        ITryDirect3DTnLDriver(d3dEnum.GetDriver(i));
+        ITryDirect3DTnLDriver(d3dEnum.GetDisplay(i));
     }
 }
 
@@ -635,7 +635,7 @@ void hsG3DDeviceSelector::ITryDirect3DTnL(hsWinRef winRef)
 //
 //  New DirectX Way
 
-void hsG3DDeviceSelector::ITryDirect3DTnLDriver(D3DEnum_DriverInfo* drivInfo)
+void hsG3DDeviceSelector::ITryDirect3DTnLDriver(D3DEnum_DisplayInfo* drivInfo)
 {
     hsG3DDeviceRecord devRec;
     devRec.Clear();
@@ -656,7 +656,7 @@ void hsG3DDeviceSelector::ITryDirect3DTnLDriver(D3DEnum_DriverInfo* drivInfo)
 
     devRec.SetMemoryBytes(drivInfo->fMemory);
 
-    for (D3DEnum_DeviceInfo& device : drivInfo->fDevices)
+    for (D3DEnum_RendererInfo& device : drivInfo->fRenderers)
     {
         /// 9.6.2000 mcn - Changed here so we can do fudging here, rather
         /// than passing all the messy driver data to the function
@@ -675,7 +675,7 @@ void hsG3DDeviceSelector::ITryDirect3DTnLDriver(D3DEnum_DriverInfo* drivInfo)
 //
 //  New DirectX Way
 
-void hsG3DDeviceSelector::ITryDirect3DTnLDevice(D3DEnum_DeviceInfo* devInfo, hsG3DDeviceRecord& devRec)
+void hsG3DDeviceSelector::ITryDirect3DTnLDevice(D3DEnum_RendererInfo* devInfo, hsG3DDeviceRecord& devRec)
 {
     devRec.SetDeviceDesc(devInfo->fStrName);
 

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXEnumerate.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXEnumerate.h
@@ -79,7 +79,7 @@ struct D3DEnum_ModeInfo
 //       primary information recorded here is the D3DDEVICEDESC and a ptr to a
 //       list of valid display modes.
 //-----------------------------------------------------------------------------
-struct D3DEnum_DeviceInfo
+struct D3DEnum_RendererInfo
 {
     D3DDEVTYPE          fDDType;
     CHAR                fStrName[40];
@@ -90,7 +90,7 @@ struct D3DEnum_DeviceInfo
 
     std::vector<D3DEnum_ModeInfo> fModes;
 
-    D3DEnum_DeviceInfo()
+    D3DEnum_RendererInfo()
         : fDDType(), fStrName(), fDDCaps(), fCanWindow(),
           fCompatibleWithDesktop(), fIsHardware() { }
 };
@@ -99,14 +99,14 @@ struct D3DEnum_DeviceInfo
 
 
 //-----------------------------------------------------------------------------
-// Name: D3DEnum_DriverInfo
-// Desc: Linked-list structure to hold information about a DirectX driver. The
-//       info stored is the capability bits for the driver plus a list
-//       of valid Direct3D devices for the driver. Note: most systems will only
-//       have one driver. The exception are multi-monitor systems, and systems
+// Name: D3DEnum_DisplayInfo
+// Desc: Linked-list structure to hold information about a DirectX display. The
+//       info stored is the capability bits for the display plus a list
+//       of valid Direct3D renderers for the display. Note: most systems will only
+//       have one display. The exception are multi-monitor systems, and systems
 //       with non-GDI 3D video cards.
 //-----------------------------------------------------------------------------
-struct D3DEnum_DriverInfo
+struct D3DEnum_DisplayInfo
 {
     GUID                 fGuid;
 
@@ -121,12 +121,12 @@ struct D3DEnum_DriverInfo
     std::vector<D3DEnum_ModeInfo> fModes;
     D3DEnum_ModeInfo*       fCurrentMode;
 
-    std::vector<D3DEnum_DeviceInfo> fDevices;
-    D3DEnum_DeviceInfo*     fCurrentDevice;
+    std::vector<D3DEnum_RendererInfo> fRenderers;
+    D3DEnum_RendererInfo*     fCurrentRenderer;
 
-    D3DEnum_DriverInfo()
+    D3DEnum_DisplayInfo()
         : fGuid(), fStrDesc(), fStrName(), fMemory(), fAdapterInfo(),
-          fDesktopMode(), fCurrentMode(), fCurrentDevice() { }
+          fDesktopMode(), fCurrentMode(), fCurrentRenderer() { }
 };
 
 
@@ -138,14 +138,14 @@ class hsGDirect3DTnLEnumerate
 protected:
     char    fEnumeErrorStr[128];            // Driver & device enumeration error message buffer
 
-    std::vector<D3DEnum_DriverInfo> fDrivers;
+    std::vector<D3DEnum_DisplayInfo> fDisplays;
 
-    D3DEnum_DriverInfo*  fCurrentDriver;    // The selected DD driver
+    D3DEnum_DisplayInfo*  fCurrentDisplay;    // The selected DD driver
 
     static short    IGetDXBitDepth( D3DFORMAT format );
 
     /// DirectX Helper Functions
-    void    IEnumAdapterDevices( IDirect3D9 *pD3D, UINT iAdapter, D3DEnum_DriverInfo *drivInfo );
+    void    IEnumAdapterDevices( IDirect3D9 *pD3D, UINT iAdapter, D3DEnum_DisplayInfo *drivInfo );
     bool    IFindDepthFormats( IDirect3D9 *pD3D, UINT iAdapter, D3DDEVTYPE deviceType, D3DEnum_ModeInfo *modeInfo );
     bool    IFindFSAATypes( IDirect3D9 *pD3D, UINT iAdapter, D3DDEVTYPE deviceType, D3DEnum_ModeInfo *modeInfo );
     bool    ICheckCubicRenderTargets( IDirect3D9 *pD3D, UINT iAdapter, D3DDEVTYPE deviceType, D3DEnum_ModeInfo *modeInfo );
@@ -164,18 +164,18 @@ public:
 
     bool SelectFromDevMode(const hsG3DDeviceRecord* devRec, const hsG3DDeviceMode* devMode);
     HRESULT D3DEnum_SelectDefaultMode(int width, int height, int depth);
-    HRESULT D3DEnum_SelectDefaultDriver( DWORD dwFlags );
+    HRESULT D3DEnum_SelectDefaultDisplay( DWORD dwFlags );
 
-    size_t GetNumDrivers() { return fDrivers.size(); }
-    D3DEnum_DriverInfo* GetDriver(size_t i) { return &fDrivers[i]; }
+    size_t GetNumDisplays() { return fDisplays.size(); }
+    D3DEnum_DisplayInfo* GetDisplay(size_t i) { return &fDisplays[i]; }
 
-    D3DEnum_DriverInfo* GetCurrentDriver() { return fCurrentDriver; }
-    D3DEnum_DeviceInfo* GetCurrentDevice() { return GetCurrentDriver() ? GetCurrentDriver()->fCurrentDevice : nullptr; }
-    D3DEnum_ModeInfo* GetCurrentMode() { return GetCurrentDevice() ? GetCurrentDriver()->fCurrentMode : nullptr; }
+    D3DEnum_DisplayInfo* GetCurrentDisplay() { return fCurrentDisplay; }
+    D3DEnum_RendererInfo* GetCurrentRenderer() { return GetCurrentDisplay() ? GetCurrentDisplay()->fCurrentRenderer : nullptr; }
+    D3DEnum_ModeInfo* GetCurrentMode() { return GetCurrentRenderer() ? GetCurrentDisplay()->fCurrentMode : nullptr; }
 
-    void SetCurrentDriver(D3DEnum_DriverInfo* d) { fCurrentDriver = d; }
-    void SetCurrentDevice(D3DEnum_DeviceInfo* d) { hsAssert(GetCurrentDriver(), "Set Driver first"); GetCurrentDriver()->fCurrentDevice = d; } 
-    void SetCurrentMode(D3DEnum_ModeInfo* m) { hsAssert(GetCurrentDriver(), "Set Driver first"); GetCurrentDriver()->fCurrentMode = m; } 
+    void SetCurrentDisplay(D3DEnum_DisplayInfo* d) { fCurrentDisplay = d; }
+    void SetCurrentRenderer(D3DEnum_RendererInfo* d) { hsAssert(GetCurrentDisplay(), "Set Display first"); GetCurrentDisplay()->fCurrentRenderer = d; } 
+    void SetCurrentMode(D3DEnum_ModeInfo* m) { hsAssert(GetCurrentDisplay(), "Set Display first"); GetCurrentDisplay()->fCurrentMode = m; } 
 
     char* GetEnumeErrorStr() { return fEnumeErrorStr; }
     void SetEnumeErrorStr(const char* s);

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.h
@@ -161,8 +161,8 @@ class plDXPlateManager : public plPlateManager
 //// Class Definition /////////////////////////////////////////////////////////
 
 class plDebugTextManager;
-struct D3DEnum_DriverInfo;
-struct D3DEnum_DeviceInfo;
+struct D3DEnum_DisplayInfo;
+struct D3DEnum_RendererInfo;
 struct D3DEnum_ModeInfo;
 class plGeometrySpan;
 class plDrawableSpans;
@@ -236,8 +236,8 @@ protected:
     bool                        fCurrD3DLiteState;
 
     UINT                    fCurrentAdapter;
-    D3DEnum_DriverInfo*     fCurrentDriver;
-    D3DEnum_DeviceInfo*     fCurrentDevice;
+    D3DEnum_DisplayInfo*     fCurrentDisplay;
+    D3DEnum_RendererInfo*     fCurrentRenderer;
     D3DEnum_ModeInfo*       fCurrentMode;
 
     hsGMatState     fLayerState[ 8 ]; // base stage (0) state is held in base class
@@ -436,8 +436,8 @@ protected:
     bool    IFindLuminanceFormats();
     bool    ITextureFormatAllowed( D3DFORMAT format );
 
-    void    ISetCurrentDriver( D3DEnum_DriverInfo *driv );
-    void    ISetCurrentDevice( D3DEnum_DeviceInfo *dev );
+    void    ISetCurrentDisplay( D3DEnum_DisplayInfo *driv );
+    void    ISetCurrentRenderer( D3DEnum_RendererInfo *dev );
     void    ISetCurrentMode( D3DEnum_ModeInfo *mode );
 
     bool        ICreateDevice(bool windowed);

--- a/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.cpp
@@ -550,8 +550,8 @@ namespace
 
 #ifdef PLASMA_PIPELINE_DX
 void    hsG3DDeviceSelector::IFudgeDirectXDevice( hsG3DDeviceRecord &record,
-                                                    D3DEnum_DriverInfo *driverInfo,
-                                                    D3DEnum_DeviceInfo *deviceInfo )
+                                                    D3DEnum_DisplayInfo *driverInfo,
+                                                    D3DEnum_RendererInfo *deviceInfo )
 {
     uint32_t    vendorID, deviceID;
     char        *szDriver, *szDesc;

--- a/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.h
@@ -73,10 +73,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 
 class hsStream;
-struct D3DEnum_DeviceInfo;
-struct D3DEnum_DriverInfo;
-struct D3DEnum_DeviceInfo;
-struct D3DEnum_DriverInfo;
+struct D3DEnum_RendererInfo;
+struct D3DEnum_DisplayInfo;
+struct D3DEnum_RendererInfo;
+struct D3DEnum_DisplayInfo;
 
 class hsG3DDeviceMode
 {
@@ -330,12 +330,12 @@ protected:
     void IClear();
     void IRemoveDiscarded();
 
-    void ITryDirect3DTnLDevice(D3DEnum_DeviceInfo* devInfo, hsG3DDeviceRecord& srcDevRec);
-    void ITryDirect3DTnLDriver(D3DEnum_DriverInfo* drivInfo);
+    void ITryDirect3DTnLDevice(D3DEnum_RendererInfo* devInfo, hsG3DDeviceRecord& srcDevRec);
+    void ITryDirect3DTnLDriver(D3DEnum_DisplayInfo* drivInfo);
     void ITryDirect3DTnL(hsWinRef winRef);
 
     void IFudgeDirectXDevice( hsG3DDeviceRecord &record,
-                                D3DEnum_DriverInfo *driverInfo, D3DEnum_DeviceInfo *deviceInfo );
+                                D3DEnum_DisplayInfo *driverInfo, D3DEnum_RendererInfo *deviceInfo );
     uint32_t  IAdjustDirectXMemory( uint32_t cardMem );
 
     bool      IGetD3DCardInfo( hsG3DDeviceRecord &record, void *driverInfo, void *deviceInfo,


### PR DESCRIPTION
D3D enumerates adapters. In kernel driver parlance - an adapter is a device that represents a video output on a card. Typically an enumeration API (like the one in D3D) will only enumerate adapters on a video card that have a display connected.

Basically:
- An adapter has one display.
- A GPU may have more than one adapter.
- An adapter may have more than one compatible renderer. There might be a software renderer. Or the GPU that hosts the adapter may have one or more renderers.

I think the original source code has muddled things by assuming that an adapter is a driver or a video card. This has led to weird descriptions in the code like a video card having display modes instead of a monitor having display modes.

Comments like this one are suspicious:
```
//-----------------------------------------------------------------------------
// Name: D3DEnum_DriverInfo
// Desc: Linked-list structure to hold information about a DirectX driver. The
//       info stored is the capability bits for the driver plus a list
//       of valid Direct3D devices for the driver. Note: most systems will only
//       have one driver. The exception are multi-monitor systems, and systems
//       with non-GDI 3D video cards.
```

Here DriverInfo represents an adapter/display - not a GPU driver. That's why more than one "driver" appears on multi monitor systems.

My goal is to have a client be able to tell a pipeline which display is the target display. This should allow the user to move between displays and have the display modes update. To do that - I need to begin untangling the Direct3D pipeline and reviewing changes that could impact the other pipelines.

The changes I'm proposing here for clarity:
- `D3DEnum_DriverInfo` becomes `D3DEnum_DisplayInfo`. `D3DEnum_DriverInfo` is an abstraction for an adapter - which already represents a video output, not a driver.
- `D3DEnum_DeviceInfo` becomes `D3DEnum_RendererInfo`. The information `D3DEnum_DeviceInfo` is wrapping are the possible renderers available for a display, not the possible devices available for a display.

I'm going to admit - I don't know if this language is correct. `Adapter` is the most correct description of a port on a video card connected to a display. But `Adapter` is a DX-ism - and it has a 1:1 relationship with a display. `Renderer` I feel a little better about. Plasma refers to the software renderer and the hardware renderer as 'Devices' which doesn't seem like the right language.

Things I'm thinking about but not actively addressing yet (but am open to feedback):
- I'm only inside of the Direct3D bubble right now. It would be best if a display could vend the different renderers available across APIs. I.E. a display should vend both its Direct3D and OpenGL renderers as options. You can get an HMONITOR back from a D3D display record so you can cross reference different kinds of renderers to the same display.
- Sometimes the GPU you want to render on is not the one attached to the display - like an eGPU. Rendering on a different GPU than the one attached to the display causes performance issues. Usually you should always use the GPU paired to the display unless the user manually overrides. I'm not worrying about that scenario yet.

I'm not sure of the origins of what happened here. This goes back to the original source drop. I think this file was a port of a D3D8 iterator - and possibly D3D8 had different terminology that mapped over badly.

Hoping to have this PR dragged through the wringer before I look at any changes to higher layers of Plasma that could spill into OpenGL and Metal.