### PR TITLE
Enable macOS arm64 builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          #- { str: macos-arm64, arch: arm64 }
+          - { str: macos-arm64, arch: arm64 }
           - { str: macos-x64, arch: x86_64 }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
@@ -262,11 +262,11 @@ jobs:
       - name: Install dependencies
         run: |
           brew install \
+              ${{ (matrix.platform.arch == 'x86_64' && 'qt@5') || '' }} \
               autoconf \
               automake \
               libtool \
-              nasm \
-              qt@5
+              nasm
 
       - name: Setup NuGet
         run: |
@@ -303,6 +303,7 @@ jobs:
           cmake --build build --config "${{ matrix.cfg.type }}" -j 2
 
       - name: Test
+        if: matrix.platform.arch == 'x86_64'
         run: |
           cmake --build build --target check --config "${{ matrix.cfg.type }}" -j 2
 

--- a/Scripts/Ports/python3/vcpkg-cmake-wrapper.cmake
+++ b/Scripts/Ports/python3/vcpkg-cmake-wrapper.cmake
@@ -59,7 +59,7 @@ if(_PythonFinder_WantLibs)
         find_program(
             @PythonFinder_PREFIX@_EXECUTABLE
             NAMES "python" "python@PYTHON_VERSION_MAJOR@.@PYTHON_VERSION_MINOR@"
-            PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/tools/python3"
+            PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_HOST_TRIPLET}/tools/python3"
             NO_DEFAULT_PATH
         )
     endif()

--- a/Scripts/Ports/python3/vcpkg.json
+++ b/Scripts/Ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.10.7",
-  "port-version": 7,
+  "port-version": 8,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",


### PR DESCRIPTION
This requires using the host platform's Python interpreter rather than the target platform's interpreter, which runs as part of the build process for resource.dat generation.

Also have to disable running tests when cross-compiling because the host system can't run the test executables compiled for the target system.