### PR TITLE
Attempt to fix crash after receiving a KickedOff message

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -1797,7 +1797,6 @@ bool RecvMsg<Auth2Cli_KickedOff>(const uint8_t buffer[], unsigned bytes, void* p
     const Auth2Cli_KickedOff & msg = *(const Auth2Cli_KickedOff *)buffer;
 
     ReportNetError(kNetProtocolCli2Auth, msg.reason);
-    NetCliAuthDisconnect();
 
     return true;
 }


### PR DESCRIPTION
The client reliably crashes after the server sends a `Auth2Cli_KickedOff` message. I assume this went unnoticed because DIRTSAND never sends that message and even on other servers it doesn't occur in normal gameplay.

I spent a while staring at this in the debugger. Apparently the underlying issue is that the auth server socket is closed by its own notify callback (by the `NetCliAuthDisconnect` call in `RecvMsg<Auth2Cli_KickedOff>`). The async socket code doesn't notice the disconnect in this case, so the disconnect notify callback is never called and the auth connection isn't shut down properly. This causes the client to hang on exit, until it tries to send something to the auth server (usually a ping), which then crashes from trying to write to a closed socket.

This PR works around the issue by closing the auth connection asynchronously outside the notify callback, and tightening the locking in the async socket code so nothing else can manipulate a socket while its callbacks are running. This *seems* to fix the hang/crash, but I'm not confident that this is a complete or good solution, so I've made this a draft for now.

I feel like the right solution would be to fire the close notify callback some other way, without relying on the read operation to detect that the socket was closed, but I have no idea how...