### PR TITLE
Set custom names for all of our threads

### DIFF
--- a/Sources/Plasma/Apps/plClient/plClientLoader.cpp
+++ b/Sources/Plasma/Apps/plClient/plClientLoader.cpp
@@ -53,6 +53,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 void plClientLoader::Run()
 {
+    SetThisThreadName(ST_LITERAL("plClientLoader"));
+
     plResManager *resMgr = new plResManager;
     resMgr->SetDataPath("dat");
     hsgResMgr::Init(resMgr);

--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -743,6 +743,7 @@ INT_PTR CALLBACK UruLoginDialogProc( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
         {
             s_loginDlgRunning = true;
             s_statusThread = std::thread([hwndDlg]() {
+                hsThread::SetThisThreadName(ST_LITERAL("LoginDialogShardStatus"));
 #ifdef USE_VLD
                 VLDEnable();
 #endif

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
@@ -105,6 +105,8 @@ static size_t ICurlCallback(void* buffer, size_t size, size_t nmemb, void* threa
 
 void plShardStatus::Run()
 {
+    SetThisThreadName(ST_LITERAL("plShardStatus"));
+
     ST::string url = GetServerStatusUrl();
 
     // initialize CURL
@@ -180,6 +182,8 @@ public:
 
     void Run() override
     {
+        SetThisThreadName(ST_LITERAL("plRedistUpdater"));
+
         while (!fRedistQueue.empty()) {
             if (fInstallProc(fRedistQueue.back()))
                 fRedistQueue.pop_back();

--- a/Sources/Plasma/CoreLib/hsThread.cpp
+++ b/Sources/Plasma/CoreLib/hsThread.cpp
@@ -52,6 +52,7 @@ void hsThread::Start()
 {
     if (!fThread.joinable()) {
         fThread = std::thread([this]() {
+            hsThread::SetThisThreadName(ST_LITERAL("hsNoNameThread"));
 #ifdef USE_VLD
             // Needs to be enabled for each thread except the WinMain
             VLDEnable();

--- a/Sources/Plasma/CoreLib/hsThread.h
+++ b/Sources/Plasma/CoreLib/hsThread.h
@@ -100,6 +100,11 @@ public:
     // WILL NOT stop a detached thread!
     void StartDetached();
 
+    // Set a name for the current thread, to be displayed in debuggers and such.
+    // If possible, don't use names longer than 15 characters,
+    // because Linux has a really low limit.
+    static void SetThisThreadName(const ST::string& name);
+
     static inline size_t ThisThreadHash()
     {
         return std::hash<std::thread::id>()(std::this_thread::get_id());

--- a/Sources/Plasma/CoreLib/hsThread_Unix.cpp
+++ b/Sources/Plasma/CoreLib/hsThread_Unix.cpp
@@ -83,10 +83,7 @@ void hsThread::SetThisThreadName(const ST::string& name)
     hsAssert(res == 0, "Failed to set thread name");
 #elif defined(HS_BUILD_FOR_LINUX)
     // On Linux, thread names must fit into 16 bytes, including the terminator.
-    char buf[16];
-    strncpy(buf, name.c_str(), sizeof(buf));
-    buf[sizeof(buf) - 1] = '\0';
-    int res = pthread_setname_np(pthread_self(), buf);
+    int res = pthread_setname_np(pthread_self(), name.left(15).c_str());
     hsAssert(res == 0, "Failed to set thread name");
 #endif
     // Because this is just a debugging help, do nothing by default (sorry, BSDs).

--- a/Sources/Plasma/CoreLib/hsThread_Unix.cpp
+++ b/Sources/Plasma/CoreLib/hsThread_Unix.cpp
@@ -75,6 +75,23 @@ int clock_gettime(int clocktype, struct timespec* ts)
 
 /////////////////////////////////////////////////////////////////////////////
 
+void hsThread::SetThisThreadName(const ST::string& name)
+{
+#if defined(HS_BUILD_FOR_APPLE)
+    // The Apple version doesn't take a thread argument and always operates on the current thread.
+    int res = pthread_setname_np(name.c_str());
+    hsAssert(res == 0, "Failed to set thread name");
+#elif defined(HS_BUILD_FOR_LINUX)
+    // On Linux, thread names must fit into 16 bytes, including the terminator.
+    char buf[16];
+    strncpy(buf, name.c_str(), sizeof(buf));
+    buf[sizeof(buf) - 1] = '\0';
+    int res = pthread_setname_np(pthread_self(), buf);
+    hsAssert(res == 0, "Failed to set thread name");
+#endif
+    // Because this is just a debugging help, do nothing by default (sorry, BSDs).
+}
+
 hsGlobalSemaphore::hsGlobalSemaphore(int initialValue, const ST::string& name)
 {
 #ifdef USE_SEMA

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -525,6 +525,7 @@ bool pfPatcherWorker::IssueRequest()
 
 void pfPatcherWorker::Run()
 {
+    SetThisThreadName(ST_LITERAL("pfPatcherWorker"));
     // So here's the rub:
     // We have one or many manifests in the fRequests deque. We begin issuing those requests one-by one, starting here.
     // As we receive the answer, the NetCli thread populates fQueuedFiles and pings the fFileSignal semaphore, then issues the next request...

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceDns.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceDns.cpp
@@ -56,6 +56,7 @@ struct DnsResolver
     {
         // Start the resolver thread
         fLookupThread = AsyncThreadCreate([this] {
+            hsThread::SetThisThreadName(ST_LITERAL("AceDnsResolver"));
             fContext.run();
         });
     }

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceSocket.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceSocket.cpp
@@ -71,11 +71,14 @@ struct AsyncIoPool
         }
 
         // create IO worker threads
+        size_t i = 0;
         for (auto& threadHandle : fThreadHandles) {
-            threadHandle = AsyncThreadCreate([this] {
+            threadHandle = AsyncThreadCreate([this, i] {
+                hsThread::SetThisThreadName(ST::format("AceSocketPool{02d}", i));
                 // This can be run concurrently from several threads
                 fContext.run();
             });
+            i++;
         }
     }
 

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceThread.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceThread.cpp
@@ -49,6 +49,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 static void CreateThreadProc(AsyncThreadRef thread)
 {
+    hsThread::SetThisThreadName(ST_LITERAL("NoNameAceThread"));
+
 #ifdef USE_VLD
     VLDEnable();
 #endif

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceTimer.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceTimer.cpp
@@ -71,6 +71,7 @@ struct AsyncTimerManager
     AsyncTimerManager() : fWorkGuard(fContext.get_executor())
     {
         fTimerThread = AsyncThreadCreate([this] {
+            hsThread::SetThisThreadName(ST_LITERAL("AceTimerMgr"));
             fContext.run();
         });
     }

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plSoundBuffer.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plSoundBuffer.cpp
@@ -83,6 +83,8 @@ static plAudioFileReader *CreateReader( bool fullpath, const plFileName &filenam
 
 void plSoundPreloader::Run()
 {
+    SetThisThreadName(ST_LITERAL("SoundPreloader"));
+
     std::vector<plSoundBuffer*> templist;
 
     while (fRunning)

--- a/Sources/Tools/MaxComponent/plPickMaterialMap.cpp
+++ b/Sources/Tools/MaxComponent/plPickMaterialMap.cpp
@@ -69,6 +69,7 @@ protected:
 public:
     void Run() override
     {
+        SetThisThreadName(ST_LITERAL("hsHackWinFindThread"));
         while (1)
         {
             HWND hMtlDlg = FindWindow(nullptr, _T("Material/Map Browser"));


### PR DESCRIPTION
This is helpful when debugging, especially with all of the IO worker threads created by the asio-based socket code.

The APIs for setting thread names are really platform-specific, so this adds a wrapper function that supports Windows, Linux, and Apple platforms. (Only the Windows version has been tested so far.)