### PR TITLE
Mac OS X 10.5 compiler fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,10 @@ if(APPLE)
         if (PLASMA_MAC_UNIVERSAL)
             set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
         endif()
+
+        if(CMAKE_SYSTEM_VERSION VERSION_LESS 10) # Darwin 10 == Mac OS X 10.6
+            set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+        endif()
     endif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 endif(APPLE)
 

--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CoreLib_SOURCES
     plLoadMask.cpp
     plProduct.cpp
     plViewTransform.cpp
-    hsWindows.cpp
+    $<$<PLATFORM_ID:Windows>:hsWindows.cpp>
 )
 
 if(CMAKE_USE_WIN32_THREADS_INIT)

--- a/Sources/Plasma/CoreLib/hsWindows.cpp
+++ b/Sources/Plasma/CoreLib/hsWindows.cpp
@@ -40,8 +40,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#ifdef HS_BUILD_FOR_WIN32
-
 #include "HeadSpin.h"
 #include "hsWindows.h"
 #include <combaseapi.h>
@@ -93,5 +91,3 @@ const RTL_OSVERSIONINFOEXW& hsGetWindowsVersion()
     }
     return s_WinVer;
 }
-
-#endif

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.cpp
@@ -79,6 +79,10 @@ ST::string kDefaultDeviceMagic = ST_LITERAL("(Default Device)");
 #define MAX_NUM_SOURCES 128
 #define UPDATE_TIME_MS 100
 
+#ifndef ALC_ALL_DEVICES_SPECIFIER
+#   define ALC_ALL_DEVICES_SPECIFIER 0x1013
+#endif
+
 plProfile_CreateTimer("EAX Update", "Sound", SoundEAXUpdate);
 plProfile_CreateTimer("Soft Update", "Sound", SoundSoftUpdate);
 plProfile_CreateCounter("Max Sounds", "Sound", SoundMaxNum);


### PR DESCRIPTION
This is not a full set of changes to make everything build on 10.5 PowerPC (because everything does not build on 10.5 PowerPC) but this is a hopefully uncontroversial set of small fixes.