### PR TITLE
Fix #1524

### DIFF
--- a/cmake/FindPhysX.cmake
+++ b/cmake/FindPhysX.cmake
@@ -229,8 +229,7 @@ macro(_find_physx_library SUFFIX)
         # The PhysX headers require that either _DEBUG or NDEBUG is always
         # defined (but not both at once), otherwise they produce an error.
         target_compile_definitions(${TARGET} INTERFACE
-            $<$<CONFIG:Debug>:_DEBUG>
-            $<$<NOT:$<CONFIG:Debug>>:NDEBUG>
+            $<IF:$<CONFIG:Debug>,_DEBUG,NDEBUG>
         )
     endif()
 

--- a/cmake/FindPhysX.cmake
+++ b/cmake/FindPhysX.cmake
@@ -228,12 +228,9 @@ macro(_find_physx_library SUFFIX)
 
         # The PhysX headers require that either _DEBUG or NDEBUG is always
         # defined (but not both at once), otherwise they produce an error.
-        # For release builds, NDEBUG is always automatically defined
-        # (either by CMake and/or the compilers).
-        # For debug builds, _DEBUG is automatically defined by MSVC,
-        # but for other compilers we need to define it ourselves.
         target_compile_definitions(${TARGET} INTERFACE
-            $<$<AND:$<CONFIG:Debug>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:_DEBUG>
+            $<$<CONFIG:Debug>:_DEBUG>
+            $<$<NOT:$<CONFIG:Debug>>:NDEBUG>
         )
     endif()
 


### PR DESCRIPTION
Fixes #1524.

Xcode is a multi-config generator that may not define `NDEBUG` if `CMAKE_BUILD_TYPE` is unset and the project is built in Release or RelWithDebInfo via `cmake --build`. Therefore, be sure to define `NDEBUG` if it's a non-debug config. Also, simplify the define for `_DEBUG`. It's OK to double-define something.