### PR TITLE
Handle xcasset files when building outside of Xcode

### DIFF
--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -132,7 +132,7 @@ plasma_executable(plClient CLIENT INSTALL_PDB
 if(APPLE)
     # We need to filter out the XIB files so the source XML files don't get bundled
     set(plClient_XCODE_RESOURCES ${plClient_RESOURCES})
-    list(FILTER plClient_XCODE_RESOURCES EXCLUDE REGEX "\\.xib$")
+    list(FILTER plClient_XCODE_RESOURCES EXCLUDE REGEX "\\.x(ib|cassets)$")
 
     set_target_properties(plClient PROPERTIES
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Mac-Cocoa/Info.plist.in"


### PR DESCRIPTION
Yes, this somehow manages to be worse than the XIB files because actool generates a partial plist output file that needs to be merged with the application plist in order to provide the correct icon.