### PR TITLE
Shader sanitization

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
@@ -69,6 +69,7 @@ set(pfMetalPipeline_SHADERS
     ShaderSrc/Grass.metal
     ShaderSrc/WaveDecEnv.metal
     ShaderSrc/Avatar.metal
+    ShaderSrc/Water.metal
     ShaderSrc/WaveDec1Lay_7.metal
     ShaderSrc/WaveRip.metal
     ShaderSrc/Clear.metal

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/Water.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/Water.h
@@ -1,0 +1,14 @@
+//
+//  Water.h
+//  Plasma
+//
+//  Created by Colin Cornaby on 12/29/22.
+//
+
+#ifndef Water_h
+#define Water_h
+#include <metal_stdlib>
+
+float3 CalcDepthFilter(const float4 depthOffset, const float4 depthScale, const float4 wPos, const float4 minAtten);
+
+#endif /* Water_h */

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/Water.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/Water.metal
@@ -1,0 +1,24 @@
+//
+//  Water.metal
+//  plClient
+//
+//  Created by Colin Cornaby on 12/29/22.
+//
+
+#include <metal_stdlib>
+#include "Water.h"
+using namespace metal;
+
+// Depth filter channels control:
+// dFilter.x => overall opacity
+// dFilter.y => reflection strength
+// dFilter.z => wave height
+float3 CalcDepthFilter(const float4 depthOffset, const float4 depthScale, const float4 wPos, const float4 minAtten) {
+    float3 dFilter = float3(depthOffset.xyz) - wPos.zzz;
+
+    dFilter *= float3(depthScale.xyz);
+    dFilter += minAtten.xyz;
+    dFilter = clamp(dFilter, 0, 1);
+
+    return dFilter;
+}


### PR DESCRIPTION
Plasma's shaders were written in assembly - which also carried to the Metal implementation.

Goals in this branch:

- The shaders should be written in clear code with proper variable names and functions where applicable.
- Algorithms should be documented.
- Any fast math assembly should be replaced with modern fast math functions where available. It is ok to drift from the HLSL 1.1 fast math code where imperceptible.
- Shaders should be clearly reviewable and easy to port to other languages.

For water shaders in particular, Chapter 1 of GPU Gems is a good reference:
https://developer.nvidia.com/gpugems/gpugems/part-i-natural-effects/chapter-1-effective-water-simulation-physical-models

There is a C code version of a water shader available here:
https://http.download.nvidia.com/developer/GPU_Gems/CD_Image/Index.html

Please note the shader supplied in GPU Gems does not appear to be the exact same shader that shipped with Uru.