### PR TITLE
Improve the prerelease workflow a bit

### DIFF
--- a/.github/PRERELEASE_NOTES.md
+++ b/.github/PRERELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Here you will find the build artifacts for the last successful build of the master branch of the Plasma repository. These builds are automatically generated and are not tested. They may include bugs, errors, and partially-completed work.  
 **These are made available for you to use at your own risk.**
 
+> [!IMPORTANT]
+> This build corresponds to commit @@COMMIT_SHA@@
+
 For Age building and development activities, use an **Internal** client.  
 
 The client for Linux is not functional at this time, but other tools should run as expected.
@@ -38,3 +41,5 @@ Linux Clients & Tools
 * Max 2019: `plasma-windows-x64-max-2019.zip`
 * Max 2020: `plasma-windows-x64-max-2020.zip`
 * Max 2022: `plasma-windows-x64-internal-release.zip`
+* Max 2023: `plasma-windows-x64-max-2023.zip`
+* Max 2024: `plasma-windows-x64-max-2024.zip`

--- a/.github/PRERELEASE_NOTES.md
+++ b/.github/PRERELEASE_NOTES.md
@@ -3,7 +3,7 @@ Here you will find the build artifacts for the last successful build of the mast
 
 For Age building and development activities, use an **Internal** client.  
 
-The clients for macOS and Linux are not functional at this time, but other tools should run as expected.
+The client for Linux is not functional at this time, but other tools should run as expected.
 
 Windows Clients & Tools
 -----------------------
@@ -14,10 +14,14 @@ Windows Clients & Tools
 
 macOS Clients & Tools
 ---------------------
-Currently the automated build system does not produce Apple Silicon (M1) builds.
 
-* 64-bit Intel Internal Client: `plasma-macos-x64-internal-release.zip`
-* 64-bit Intel External Client: `plasma-macos-x64-external-release.zip`
+### Intel
+* 64-bit Internal Client: `plasma-macos-x64-internal-release.zip`
+* 64-bit External Client: `plasma-macos-x64-external-release.zip`
+
+### Apple Silicon
+* 64-bit Internal Client: `plasma-macos-arm64-internal-release.zip`
+* 64-bit External Client: `plasma-macos-arm64-external-release.zip`
 
 Linux Clients & Tools
 ---------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: Checkout Plasma
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout MaxSDK
         continue-on-error: true
         if: needs.max-secrets.outputs.HAS_MACHINE_USER_TOKEN == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: H-uruMachineUser/3dsMaxSDK
           token: ${{ secrets.MACHINE_USER_REPO_READ }}
@@ -122,10 +122,10 @@ jobs:
 
     steps:
       - name: Checkout Plasma
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout MaxSDK
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: H-uruMachineUser/3dsMaxSDK
           token: ${{ secrets.MACHINE_USER_REPO_READ }}
@@ -183,7 +183,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
@@ -259,7 +259,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -24,18 +24,21 @@ jobs:
     needs: [check-publishing-enabled]
     if: needs.check-publishing-enabled.outputs.SHOULD_PUBLISH == 'true'
 
+    permissions:
+      contents: write
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: |
           mkdir artifacts
           echo "updated_on=$(/bin/date -u '+%Y-%m-%d %H:%M')" >> $GITHUB_ENV
 
       - name: Download Build Artifacts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
+            const fs = require('node:fs');
             const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -52,18 +55,25 @@ jobs:
               fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/artifacts/${art.name}.zip`, Buffer.from(download.data));
             }));
 
-      - name: Delete Previous Release
-        uses: dev-drprasad/delete-tag-and-release@v1.0.1
-        with:
-          tag_name: last-successful
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get release body text
+        id: read_release
+        shell: bash
+        run: |
+          r=$(cat .github/PRERELEASE_NOTES.md)
+          r="${r//'%'/'%25'}"   # Multiline escape sequences for %
+          r="${r//$'\n'/'%0A'}" # Multiline escape sequences for '\n'
+          r="${r//$'\r'/'%0D'}" # Multiline escape sequences for '\r'
+          echo "RELEASE_BODY=$r" >> $GITHUB_OUTPUT
 
       - name: Update Release
         id: release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: svenstaro/upload-release-action@v2
         with:
           prerelease: true
-          tag_name: last-successful
-          name: "Last successful build (unstable)"
-          files: 'artifacts/*.zip'
-          body_path: '.github/PRERELEASE_NOTES.md'
+          overwrite: true
+          tag: last-successful
+          release_name: "Last successful build (unstable)"
+          file_glob: true
+          file: artifacts/*.zip
+          body: |
+            ${{ steps.read_release.outputs.RELEASE_BODY }}

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -63,7 +63,10 @@ jobs:
           r="${r//'%'/'%25'}"   # Multiline escape sequences for %
           r="${r//$'\n'/'%0A'}" # Multiline escape sequences for '\n'
           r="${r//$'\r'/'%0D'}" # Multiline escape sequences for '\r'
+          r="${r//@@COMMIT_SHA@@/$GITHUB_SHA}"
           echo "RELEASE_BODY=$r" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_SHA: ${{ github.sha }}
 
       - name: Update Release
         id: release

--- a/.github/workflows/scripts_review.yml
+++ b/.github/workflows/scripts_review.yml
@@ -14,7 +14,7 @@ jobs:
       PLASMA_PATH: ${{ github.workspace }}
     steps:
       - name: Checkout Plasma
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Unfortunately this still does not handle deleting and re-creating releases properly, so we're likely to move to a system with a static tag on a placeholder commit, and just update the release description and attachments every time.

As part of that, this will now embed the commit SHA in the release notes for easier tracking.
Also adds mention of the macOS arm64 clients and the 3DS Max 2023 & 2024 builds.