### PR TITLE
Volatile dynamic buffers in Metal

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
@@ -1198,7 +1198,7 @@ bool plMetalDevice::plMetalPipelineRecord::operator==(const plMetalPipelineRecor
            state->operator==(*p.state);
 }
 
-MTL::CommandBuffer* plMetalDevice::GetCurrentCommandBuffer()
+MTL::CommandBuffer* plMetalDevice::GetCurrentCommandBuffer() const
 {
     if (fCurrentOffscreenCommandBuffer) {
         return fCurrentOffscreenCommandBuffer;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -162,6 +162,7 @@ public:
     // Currently requires a CA drawable and not a Metal drawable. In since CA drawable is only abstract implementation I know about, not sure where we would find others?
     void                CreateNewCommandBuffer(CA::MetalDrawable* drawable);
     MTL::CommandBuffer* GetCurrentCommandBuffer();
+    MTL::CommandBuffer* GetCurrentDrawableCommandBuffer() { return fCurrentCommandBuffer; }
     CA::MetalDrawable*  GetCurrentDrawable() const;
     /// Submit the command buffer to the GPU and draws all the render passes. Clears the current command buffer.
     void                SubmitCommandBuffer();

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -161,8 +161,8 @@ public:
     /// Create a new command buffer to encode all the operations needed to draw a frame
     // Currently requires a CA drawable and not a Metal drawable. In since CA drawable is only abstract implementation I know about, not sure where we would find others?
     void                CreateNewCommandBuffer(CA::MetalDrawable* drawable);
-    MTL::CommandBuffer* GetCurrentCommandBuffer();
-    MTL::CommandBuffer* GetCurrentDrawableCommandBuffer() { return fCurrentCommandBuffer; }
+    MTL::CommandBuffer* GetCurrentCommandBuffer() const;
+    MTL::CommandBuffer* GetCurrentDrawableCommandBuffer() const { return fCurrentCommandBuffer; }
     CA::MetalDrawable*  GetCurrentDrawable() const;
     /// Submit the command buffer to the GPU and draws all the render passes. Clears the current command buffer.
     void                SubmitCommandBuffer();


### PR DESCRIPTION
Metal wasn't honoring that dynamic buffers should be volatile like the DX pipeline was. On modern systems - this should be pretty low impact. But it's still nice to implement.

Plasma refreshes its buffers every frame which can make volatile buffers a little niche. However - Metal Plasma triple buffers which means this could allow a buffer not currently being presented to be freed.