### PR TITLE
Modernize NucleusLib async callbacks using lambdas

### DIFF
--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
@@ -165,7 +165,7 @@ void AsyncSocketEnableNagling (
 typedef std::function<void(const std::vector<plNetAddress>& /* addrs */)> FAsyncLookupProc;
 
 void AsyncAddressLookupName (
-    FAsyncLookupProc    lookupProc,
-    const ST::string &  name,
-    unsigned            port
+    const ST::string& name,
+    unsigned port,
+    FAsyncLookupProc lookupProc
 );

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
@@ -82,11 +82,7 @@ enum EAsyncNotifySocket {
     kNotifySocketWrite
 };
 
-struct AsyncNotifySocket {
-    void *          param;
-
-    AsyncNotifySocket() : param() { }
-};
+struct AsyncNotifySocket {};
 
 struct AsyncNotifySocketConnect : AsyncNotifySocket {
     plNetAddress    localAddr;
@@ -113,7 +109,7 @@ struct AsyncNotifySocketWrite : AsyncNotifySocketRead {
     \param code
     \param notify
 */
-using FAsyncNotifySocketProc = std::function<bool(AsyncSocket, EAsyncNotifySocket, AsyncNotifySocket*, void**)> ;
+using FAsyncNotifySocketProc = std::function<bool(AsyncSocket, EAsyncNotifySocket, AsyncNotifySocket*)>;
 
 
 /****************************************************************************
@@ -126,7 +122,6 @@ void AsyncSocketConnect (
     AsyncCancelId *         cancelId,
     const plNetAddress&     netAddr,
     FAsyncNotifySocketProc  notifyProc,
-    void *                  param = nullptr,
     const void *            sendData = nullptr,
     unsigned                sendBytes = 0
 );

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
@@ -68,35 +68,6 @@ typedef struct AsyncCancelIdStruct *   AsyncCancelId;
 
 constexpr unsigned kAsyncSocketBufferSize   = 1460;
 
-
-/****************************************************************************
-*
-*   Socket event notifications
-*
-***/
-
-struct AsyncNotifySocket {};
-
-struct AsyncNotifySocketConnect : AsyncNotifySocket {
-    plNetAddress    localAddr;
-    plNetAddress    remoteAddr;
-};
-
-struct AsyncNotifySocketRead : AsyncNotifySocket {
-    uint8_t *       buffer;
-    size_t          bytes;
-    size_t          bytesProcessed;
-
-    AsyncNotifySocketRead() : buffer(), bytes(), bytesProcessed() { }
-};
-
-
-struct AsyncNotifySocketWrite : AsyncNotifySocketRead {
-    size_t          bytesCommitted;
-    
-    AsyncNotifySocketWrite() : AsyncNotifySocketRead(), bytesCommitted() { }
-};
-
 class AsyncNotifySocketCallbacks
 {
 public:

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
@@ -162,12 +162,10 @@ void AsyncSocketEnableNagling (
 *
 ***/
 
-typedef std::function<void (void* /* param */, const ST::string& /* name */,
-                            const std::vector<plNetAddress>& /* addrs */)> FAsyncLookupProc;
+typedef std::function<void(const std::vector<plNetAddress>& /* addrs */)> FAsyncLookupProc;
 
 void AsyncAddressLookupName (
     FAsyncLookupProc    lookupProc,
     const ST::string &  name,
-    unsigned            port,
-    void *              param
+    unsigned            port
 );

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
@@ -72,7 +72,7 @@ class AsyncNotifySocketCallbacks
 {
 public:
     virtual void AsyncNotifySocketConnectFailed(plNetAddress remoteAddr) = 0;
-    virtual bool AsyncNotifySocketConnectSuccess(AsyncSocket sock, plNetAddress localAddr, plNetAddress remoteAddr) = 0;
+    virtual bool AsyncNotifySocketConnectSuccess(AsyncSocket sock, const plNetAddress& localAddr, const plNetAddress& remoteAddr) = 0;
     virtual void AsyncNotifySocketDisconnect(AsyncSocket sock) = 0;
     virtual std::optional<size_t> AsyncNotifySocketRead(AsyncSocket sock, uint8_t* buffer, size_t bytes) = 0;
 };

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcIo.h
@@ -79,7 +79,6 @@ enum EAsyncNotifySocket {
     kNotifySocketConnectSuccess,
     kNotifySocketDisconnect,
     kNotifySocketRead,
-    kNotifySocketWrite
 };
 
 struct AsyncNotifySocket {};

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcTimer.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcTimer.h
@@ -73,8 +73,8 @@ typedef std::function<unsigned()> FAsyncTimerProc;
 // 1) Timer procs do not get starved by I/O, they are called periodically.
 // 2) Timer procs will never be called by multiple threads simultaneously.
 AsyncTimer* AsyncTimerCreate (
-    FAsyncTimerProc timerProc,
-    unsigned        callbackMs
+    unsigned callbackMs,
+    FAsyncTimerProc timerProc
 );
 
 // Timer procs can be in the process of getting called in

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcTimer.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcTimer.h
@@ -68,14 +68,13 @@ struct AsyncTimer;
 
 // Return callbackMs to wait that long until next callback.
 // Return kAsyncTimeInfinite to stop callbacks (note: does not destroy Timer structure)
-typedef std::function<unsigned (void* /* param */)> FAsyncTimerProc;
+typedef std::function<unsigned()> FAsyncTimerProc;
 
 // 1) Timer procs do not get starved by I/O, they are called periodically.
 // 2) Timer procs will never be called by multiple threads simultaneously.
 AsyncTimer* AsyncTimerCreate (
     FAsyncTimerProc timerProc,
-    unsigned        callbackMs,
-    void *          param = nullptr
+    unsigned        callbackMs
 );
 
 // Timer procs can be in the process of getting called in

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcTimer.h
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/Private/pnAcTimer.h
@@ -77,6 +77,8 @@ AsyncTimer* AsyncTimerCreate (
     FAsyncTimerProc timerProc
 );
 
+typedef std::function<void()> FAsyncTimerDestroyProc;
+
 // Timer procs can be in the process of getting called in
 // another thread during the unregister function -- be careful!
 // This will wait until the timer has been unregistered and is
@@ -84,7 +86,7 @@ AsyncTimer* AsyncTimerCreate (
 void AsyncTimerDelete(AsyncTimer* timer);
 void AsyncTimerDeleteCallback (
     AsyncTimer *    timer,
-    FAsyncTimerProc destroyProc
+    FAsyncTimerDestroyProc destroyProc
 );
 
 // Set the time value for a timer

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceDns.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceDns.cpp
@@ -73,7 +73,6 @@ struct DnsResolveData
 {
     ST::string       fName;
     FAsyncLookupProc fLookupProc;
-    void*            fParam;
 };
 
 static std::recursive_mutex s_critsect;
@@ -95,7 +94,7 @@ static void AddressResolved(const asio::error_code&            err,
     if (err || results.empty()) {
         if (err)
             LogMsg(kLogFatal, "DNS: Failed to resolve {}: {}", data.fName, err.message());
-        data.fLookupProc(data.fParam, data.fName, {});
+        data.fLookupProc({});
         return;
     }
 
@@ -113,14 +112,12 @@ static void AddressResolved(const asio::error_code&            err,
         addrs.emplace_back(ipv4_addr.to_bytes(), endpoint.port());
     }
 
-    data.fLookupProc(data.fParam, data.fName, addrs);
+    data.fLookupProc(addrs);
 
     PerfSubCounter(kAsyncPerfNameLookupAttemptsCurr, 1);
 }
 
-void AsyncAddressLookupName(FAsyncLookupProc lookupProc,
-
-                            const ST::string& name, unsigned port, void* param)
+void AsyncAddressLookupName(FAsyncLookupProc lookupProc, const ST::string& name, unsigned port)
 {
     ASSERT(lookupProc);
 
@@ -142,7 +139,6 @@ void AsyncAddressLookupName(FAsyncLookupProc lookupProc,
     DnsResolveData data;
     data.fName = name;
     data.fLookupProc = std::move(lookupProc);
-    data.fParam = param;
 
     hsLockGuard(s_critsect);
 

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceDns.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceDns.cpp
@@ -117,7 +117,7 @@ static void AddressResolved(const asio::error_code&            err,
     PerfSubCounter(kAsyncPerfNameLookupAttemptsCurr, 1);
 }
 
-void AsyncAddressLookupName(FAsyncLookupProc lookupProc, const ST::string& name, unsigned port)
+void AsyncAddressLookupName(const ST::string& name, unsigned port, FAsyncLookupProc lookupProc)
 {
     ASSERT(lookupProc);
 

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceTimer.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceTimer.cpp
@@ -143,7 +143,7 @@ void TimerDestroy(unsigned exitThreadWaitMs)
     }
 }
 
-AsyncTimer* AsyncTimerCreate(FAsyncTimerProc timerProc, unsigned callbackMs)
+AsyncTimer* AsyncTimerCreate(unsigned callbackMs, FAsyncTimerProc timerProc)
 {
     ASSERT(timerProc);
 

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceTimer.cpp
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/pnAceTimer.cpp
@@ -46,7 +46,7 @@ struct AsyncTimer
 {
     asio::steady_timer fTimer;
     FAsyncTimerProc    fTimerProc;
-    FAsyncTimerProc    fDestroyProc;
+    FAsyncTimerDestroyProc fDestroyProc;
 
     AsyncTimer(asio::io_context& context, FAsyncTimerProc&& timerProc)
         : fTimer(context),
@@ -164,7 +164,7 @@ void AsyncTimerDelete(AsyncTimer* timer)
     AsyncTimerDeleteCallback(timer, nullptr);
 }
 
-void AsyncTimerDeleteCallback(AsyncTimer* timer, FAsyncTimerProc destroyProc)
+void AsyncTimerDeleteCallback(AsyncTimer* timer, FAsyncTimerDestroyProc destroyProc)
 {
     ASSERT(timer);
     ASSERT(s_timerMgr);

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
@@ -48,6 +48,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef PLASMA20_SOURCES_PLASMA_NUCLEUSLIB_PNNETCLI_PNNETCLI_H
 #define PLASMA20_SOURCES_PLASMA_NUCLEUSLIB_PNNETCLI_PNNETCLI_H
 
+#include <functional>
+
 #include "pnEncryption/plBigNum.h"
 
 /*****************************************************************************
@@ -345,10 +347,7 @@ void NetMsgProtocolDestroy (
 // Manual forward declaration to avoid publicly including all of pnAsyncCore :(
 typedef struct AsyncSocketStruct* AsyncSocket;
 
-typedef bool (* FNetCliEncrypt) (
-    ENetError       error,
-    void *          encryptParam
-);
+typedef std::function<bool(ENetError /* error */)> FNetCliEncrypt;
 
 NetCli * NetCliConnectAccept (
     AsyncSocket         sock,
@@ -356,8 +355,7 @@ NetCli * NetCliConnectAccept (
     bool                unbuffered,
     FNetCliEncrypt      encryptFcn,
     unsigned            seedBytes,      // optional
-    const uint8_t          seedData[],     // optional
-    void *              encryptParam    // optional
+    const uint8_t       seedData[]      // optional
 );
 
 void NetCliClearSocket (

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -4719,20 +4719,16 @@ void NetCliAuthStartConnect (
         const char* pos;
         for (pos = name.begin(); pos != name.end(); ++pos) {
             if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {
-                AsyncAddressLookupName(
-                    [name](auto addrs) {
-                        if (addrs.empty()) {
-                            ReportNetError(kNetProtocolCli2Auth, kNetErrNameLookupFailed);
-                            return;
-                        }
+                AsyncAddressLookupName(name, GetClientPort(), [name](auto addrs) {
+                    if (addrs.empty()) {
+                        ReportNetError(kNetProtocolCli2Auth, kNetErrNameLookupFailed);
+                        return;
+                    }
 
-                        for (const plNetAddress& addr : addrs) {
-                            Connect(name, addr);
-                        }
-                    },
-                    name,
-                    GetClientPort()
-                );
+                    for (const plNetAddress& addr : addrs) {
+                        Connect(name, addr);
+                    }
+                });
                 break;
             }
         }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -1644,7 +1644,6 @@ void CliAuConn::StopAutoReconnect () {
         reconnectTimer = nullptr;
         AsyncTimerDeleteCallback(timer, [this]() {
             UnRef("ReconnectTimer");
-            return kAsyncTimeInfinite;
         });
     }
 }
@@ -1672,7 +1671,6 @@ void CliAuConn::StopAutoPing () {
     if (pingTimer) {
         AsyncTimerDeleteCallback(pingTimer, [this]() {
             UnRef("PingTimer");
-            return kAsyncTimeInfinite;
         });
         pingTimer = nullptr;
     }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -1675,13 +1675,10 @@ void CliAuConn::AutoReconnect () {
     ASSERT(!reconnectTimer);
     Ref("ReconnectTimer");
     hsLockGuard(critsect);
-    reconnectTimer = AsyncTimerCreate(
-        [this]() {
-            TimerReconnect();
-            return kAsyncTimeInfinite;
-        },
-        0 // immediate callback
-    );
+    reconnectTimer = AsyncTimerCreate(0, [this]() { // immediate callback
+        TimerReconnect();
+        return kAsyncTimeInfinite;
+    });
 }
 
 //============================================================================
@@ -1707,13 +1704,10 @@ void CliAuConn::AutoPing () {
     ASSERT(!pingTimer);
     Ref("PingTimer");
     hsLockGuard(critsect);
-    pingTimer = AsyncTimerCreate(
-        [this]() {
-            TimerPing();
-            return kPingIntervalMs;
-        },
-        sock ? 0 : kAsyncTimeInfinite
-    );
+    pingTimer = AsyncTimerCreate(sock ? 0 : kAsyncTimeInfinite, [this]() {
+        TimerPing();
+        return kPingIntervalMs;
+    });
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -75,7 +75,7 @@ struct CliAuConn : hsRefCnt, AsyncNotifySocketCallbacks {
 
     // Callbacks
     void AsyncNotifySocketConnectFailed(plNetAddress remoteAddr) override;
-    bool AsyncNotifySocketConnectSuccess(AsyncSocket sock, plNetAddress localAddr, plNetAddress remoteAddr) override;
+    bool AsyncNotifySocketConnectSuccess(AsyncSocket sock, const plNetAddress& localAddr, const plNetAddress& remoteAddr) override;
     void AsyncNotifySocketDisconnect(AsyncSocket sock) override;
     std::optional<size_t> AsyncNotifySocketRead(AsyncSocket sock, uint8_t* buffer, size_t bytes) override;
 
@@ -1361,7 +1361,7 @@ static void SendClientRegisterRequest (CliAuConn * conn) {
 }
 
 //============================================================================
-bool CliAuConn::AsyncNotifySocketConnectSuccess(AsyncSocket sock, plNetAddress localAddr, plNetAddress remoteAddr)
+bool CliAuConn::AsyncNotifySocketConnectSuccess(AsyncSocket sock, const plNetAddress& localAddr, const plNetAddress& remoteAddr)
 {
     bool wasAbandoned;
     {
@@ -4676,7 +4676,7 @@ void NetCliAuthStartConnect (
 
     for (unsigned i = 0; i < authAddrCount; ++i) {
         // Do we need to lookup the address?
-        ST::string name = authAddrList[i];
+        const ST::string& name = authAddrList[i];
         const char* pos;
         for (pos = name.begin(); pos != name.end(); ++pos) {
             if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -1504,10 +1504,6 @@ static bool SocketNotifyCallback (
         case kNotifySocketRead:
             result = NotifyConnSocketRead(conn, (AsyncNotifySocketRead *) notify);
         break;
-
-        case kNotifySocketWrite:
-            // No action
-        break;
     }
     
     return result;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -4728,22 +4728,22 @@ void NetCliAuthStartConnect (
 
     for (unsigned i = 0; i < authAddrCount; ++i) {
         // Do we need to lookup the address?
-        const char* name = authAddrList[i].c_str();
-        while (unsigned ch = *name) {
-            ++name;
-            if (!(isdigit(ch) || ch == L'.' || ch == L':')) {
+        ST::string name = authAddrList[i];
+        const char* pos;
+        for (pos = name.begin(); pos != name.end(); ++pos) {
+            if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {
                 AsyncAddressLookupName(
                     AsyncLookupCallback,
-                    authAddrList[i],
+                    name,
                     GetClientPort(),
                     nullptr
                 );
                 break;
             }
         }
-        if (!name[0]) {
-            plNetAddress addr(authAddrList[i], GetClientPort());
-            Connect(authAddrList[i], addr);
+        if (pos == name.end()) {
+            plNetAddress addr(name, GetClientPort());
+            Connect(name, addr);
         }
     }
 }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -1337,20 +1337,16 @@ void NetCliFileStartConnect (
         const char* pos;
         for (pos = name.begin(); pos != name.end(); ++pos) {
             if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {
-                AsyncAddressLookupName(
-                    [name](auto addrs) {
-                        if (addrs.empty()) {
-                            ReportNetError(kNetProtocolCli2File, kNetErrNameLookupFailed);
-                            return;
-                        }
+                AsyncAddressLookupName(name, GetClientPort(), [name](auto addrs) {
+                    if (addrs.empty()) {
+                        ReportNetError(kNetProtocolCli2File, kNetErrNameLookupFailed);
+                        return;
+                    }
 
-                        for (const plNetAddress& addr : addrs) {
-                            Connect(name, addr);
-                        }
-                    },
-                    name,
-                    GetClientPort()
-                );
+                    for (const plNetAddress& addr : addrs) {
+                        Connect(name, addr);
+                    }
+                });
                 break;
             }
         }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -605,7 +605,6 @@ void CliFileConn::StopAutoReconnect () {
         reconnectTimer = nullptr;
         AsyncTimerDeleteCallback(timer, [this]() {
             UnRef("ReconnectTimer");
-            return kAsyncTimeInfinite;
         });
     }
 }
@@ -634,7 +633,6 @@ void CliFileConn::StopAutoPing () {
         pingTimer = nullptr;
         AsyncTimerDeleteCallback(timer, [this]() {
             UnRef("PingTimer");
-            return kAsyncTimeInfinite;
         });
     }
 }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -101,7 +101,7 @@ struct CliFileConn : hsRefCnt, AsyncNotifySocketCallbacks {
 
     // Callbacks
     void AsyncNotifySocketConnectFailed(plNetAddress remoteAddr) override;
-    bool AsyncNotifySocketConnectSuccess(AsyncSocket sock, plNetAddress localAddr, plNetAddress remoteAddr) override;
+    bool AsyncNotifySocketConnectSuccess(AsyncSocket sock, const plNetAddress& localAddr, const plNetAddress& remoteAddr) override;
     void AsyncNotifySocketDisconnect(AsyncSocket sock) override;
     std::optional<size_t> AsyncNotifySocketRead(AsyncSocket sock, uint8_t* buffer, size_t bytes) override;
 
@@ -308,7 +308,7 @@ static void AbandonConn(CliFileConn* conn) {
 }
 
 //============================================================================
-bool CliFileConn::AsyncNotifySocketConnectSuccess(AsyncSocket sock, plNetAddress localAddr, plNetAddress remoteAddr)
+bool CliFileConn::AsyncNotifySocketConnectSuccess(AsyncSocket sock, const plNetAddress& localAddr, const plNetAddress& remoteAddr)
 {
     {
         hsLockGuard(s_critsect);
@@ -1300,7 +1300,7 @@ void NetCliFileStartConnect (
 
     for (unsigned i = 0; i < fileAddrCount; ++i) {
         // Do we need to lookup the address?
-        ST::string name = fileAddrList[i];
+        const ST::string& name = fileAddrList[i];
         const char* pos;
         for (pos = name.begin(); pos != name.end(); ++pos) {
             if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -474,10 +474,6 @@ static bool SocketNotifyCallback (
         case kNotifySocketRead:
             result = NotifyConnSocketRead(conn, (AsyncNotifySocketRead *) notify);
         break;
-
-        case kNotifySocketWrite:
-            // No action
-        break;
     }
 
     return result;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -636,13 +636,10 @@ void CliFileConn::AutoReconnect () {
     hsLockGuard(timerCritsect);
     ASSERT(!reconnectTimer);
     Ref("ReconnectTimer");
-    reconnectTimer = AsyncTimerCreate(
-        [this]() {
-            TimerReconnect();
-            return kAsyncTimeInfinite;            
-        },
-        0 // immediate callback
-    );
+    reconnectTimer = AsyncTimerCreate(0, [this]() { // immediate callback
+        TimerReconnect();
+        return kAsyncTimeInfinite;
+    });
 }
 
 //============================================================================
@@ -668,13 +665,10 @@ void CliFileConn::AutoPing () {
         timerPeriod = sock ? 0 : kAsyncTimeInfinite;
     }
 
-    pingTimer = AsyncTimerCreate(
-        [this]() {
-            TimerPing();
-            return kPingIntervalMs;
-        },
-        timerPeriod
-    );
+    pingTimer = AsyncTimerCreate(timerPeriod, [this]() {
+        TimerPing();
+        return kPingIntervalMs;
+    });
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -1346,22 +1346,22 @@ void NetCliFileStartConnect (
 
     for (unsigned i = 0; i < fileAddrCount; ++i) {
         // Do we need to lookup the address?
-        const char* name = fileAddrList[i].c_str();
-        while (unsigned ch = *name) {
-            ++name;
-            if (!(isdigit(ch) || ch == L'.' || ch == L':')) {
+        ST::string name = fileAddrList[i];
+        const char* pos;
+        for (pos = name.begin(); pos != name.end(); ++pos) {
+            if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {
                 AsyncAddressLookupName(
                     AsyncLookupCallback,
-                    fileAddrList[i],
+                    name,
                     GetClientPort(),
                     nullptr
                 );
                 break;
             }
         }
-        if (!name[0]) {
-            plNetAddress addr(fileAddrList[i], GetClientPort());
-            Connect(fileAddrList[i], addr);
+        if (pos == name.end()) {
+            plNetAddress addr(name, GetClientPort());
+            Connect(name, addr);
         }
     }
 }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
@@ -73,7 +73,7 @@ struct CliGmConn : hsRefCnt, AsyncNotifySocketCallbacks {
 
     // Callbacks
     void AsyncNotifySocketConnectFailed(plNetAddress remoteAddr) override;
-    bool AsyncNotifySocketConnectSuccess(AsyncSocket sock, plNetAddress localAddr, plNetAddress remoteAddr) override;
+    bool AsyncNotifySocketConnectSuccess(AsyncSocket sock, const plNetAddress& localAddr, const plNetAddress& remoteAddr) override;
     void AsyncNotifySocketDisconnect(AsyncSocket sock) override;
     std::optional<size_t> AsyncNotifySocketRead(AsyncSocket sock, uint8_t* buffer, size_t bytes) override;
 
@@ -212,7 +212,7 @@ static void AbandonConn(CliGmConn* conn) {
 }
 
 //============================================================================
-bool CliGmConn::AsyncNotifySocketConnectSuccess(AsyncSocket sock, plNetAddress localAddr, plNetAddress remoteAddr)
+bool CliGmConn::AsyncNotifySocketConnectSuccess(AsyncSocket sock, const plNetAddress& localAddr, const plNetAddress& remoteAddr)
 {
     bool wasAbandoned;
     {

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
@@ -349,10 +349,6 @@ static bool SocketNotifyCallback (
         case kNotifySocketRead:
             result = NotifyConnSocketRead(conn, (AsyncNotifySocketRead *) notify);
         break;
-
-        case kNotifySocketWrite:
-            // No action
-        break;
     }
     
     return result;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
@@ -433,13 +433,10 @@ void CliGmConn::AutoPing () {
     ASSERT(!pingTimer);
     Ref("PingTimer");
     hsLockGuard(critsect);
-    pingTimer = AsyncTimerCreate(
-        [this]() {
-            TimerPing();
-            return kPingIntervalMs;
-        },
-        sock ? 0 : kAsyncTimeInfinite
-    );
+    pingTimer = AsyncTimerCreate(sock ? 0 : kAsyncTimeInfinite, [this]() {
+        TimerPing();
+        return kPingIntervalMs;
+    });
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
@@ -418,7 +418,6 @@ void CliGmConn::StopAutoPing () {
     if (pingTimer) {
         AsyncTimerDeleteCallback(pingTimer, [this]() {
             UnRef("PingTimer");
-            return kAsyncTimeInfinite;
         });
         pingTimer = nullptr;
     }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
@@ -228,7 +228,6 @@ static bool ConnEncrypt (ENetError error, void * param) {
 //============================================================================
 bool CliGmConn::AsyncNotifySocketConnectSuccess(AsyncSocket sock, plNetAddress localAddr, plNetAddress remoteAddr)
 {
-    TransferRef("Connecting", "Connected");
     bool wasAbandoned;
     {
         hsLockGuard(s_critsect);

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -70,7 +70,7 @@ struct CliGkConn : hsRefCnt, AsyncNotifySocketCallbacks {
 
     // Callbacks
     void AsyncNotifySocketConnectFailed(plNetAddress remoteAddr) override;
-    bool AsyncNotifySocketConnectSuccess(AsyncSocket sock, plNetAddress localAddr, plNetAddress remoteAddr) override;
+    bool AsyncNotifySocketConnectSuccess(AsyncSocket sock, const plNetAddress& localAddr, const plNetAddress& remoteAddr) override;
     void AsyncNotifySocketDisconnect(AsyncSocket sock) override;
     std::optional<size_t> AsyncNotifySocketRead(AsyncSocket sock, uint8_t* buffer, size_t bytes) override;
 
@@ -242,7 +242,7 @@ static void AbandonConn(CliGkConn* conn) {
 }
 
 //============================================================================
-bool CliGkConn::AsyncNotifySocketConnectSuccess(AsyncSocket sock, plNetAddress localAddr, plNetAddress remoteAddr)
+bool CliGkConn::AsyncNotifySocketConnectSuccess(AsyncSocket sock, const plNetAddress& localAddr, const plNetAddress& remoteAddr)
 {
     bool wasAbandoned;
     {
@@ -906,7 +906,7 @@ void NetCliGateKeeperStartConnect (
 
     for (unsigned i = 0; i < gateKeeperAddrCount; ++i) {
         // Do we need to lookup the address?
-        ST::string name = gateKeeperAddrList[i];
+        const ST::string& name = gateKeeperAddrList[i];
         const char* pos;
         for (pos = name.begin(); pos != name.end(); ++pos) {
             if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -964,22 +964,22 @@ void NetCliGateKeeperStartConnect (
 
     for (unsigned i = 0; i < gateKeeperAddrCount; ++i) {
         // Do we need to lookup the address?
-        const char* name = gateKeeperAddrList[i].c_str();
-        while (unsigned ch = *name) {
-            ++name;
-            if (!(isdigit(ch) || ch == L'.' || ch == L':')) {
+        ST::string name = gateKeeperAddrList[i];
+        const char* pos;
+        for (pos = name.begin(); pos != name.end(); ++pos) {
+            if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {
                 AsyncAddressLookupName(
                     AsyncLookupCallback,
-                    gateKeeperAddrList[i],
+                    name,
                     GetClientPort(),
                     nullptr
                 );
                 break;
             }
         }
-        if (!name[0]) {
-            plNetAddress addr(gateKeeperAddrList[i], GetClientPort());
-            Connect(gateKeeperAddrList[i], addr);
+        if (pos == name.end()) {
+            plNetAddress addr(name, GetClientPort());
+            Connect(name, addr);
         }
     }
 }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -553,13 +553,10 @@ void CliGkConn::AutoReconnect () {
     ASSERT(!reconnectTimer);
     Ref("ReconnectTimer");
     hsLockGuard(critsect);
-    reconnectTimer = AsyncTimerCreate(
-        [this]() {
-            TimerReconnect();
-            return kAsyncTimeInfinite;
-        },
-        0 // immediate callback
-    );
+    reconnectTimer = AsyncTimerCreate(0, [this]() { // immediate callback
+        TimerReconnect();
+        return kAsyncTimeInfinite;
+    });
 }
 
 //============================================================================
@@ -585,13 +582,10 @@ void CliGkConn::AutoPing () {
     ASSERT(!pingTimer);
     Ref("PingTimer");
     hsLockGuard(critsect);
-    pingTimer = AsyncTimerCreate(
-        [this]() {
-            TimerPing();
-            return kPingIntervalMs;
-        },
-        sock ? 0 : kAsyncTimeInfinite
-    );
+    pingTimer = AsyncTimerCreate(sock ? 0 : kAsyncTimeInfinite, [this]() {
+        TimerPing();
+        return kPingIntervalMs;
+    });
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -389,10 +389,6 @@ static bool SocketNotifyCallback (
         case kNotifySocketRead:
             result = NotifyConnSocketRead(conn, (AsyncNotifySocketRead *) notify);
         break;
-
-        case kNotifySocketWrite:
-            // No action
-        break;
     }
     
     return result;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -953,20 +953,16 @@ void NetCliGateKeeperStartConnect (
         const char* pos;
         for (pos = name.begin(); pos != name.end(); ++pos) {
             if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {
-                AsyncAddressLookupName(
-                    [name](auto addrs) {
-                        if (addrs.empty()) {
-                            ReportNetError(kNetProtocolCli2GateKeeper, kNetErrNameLookupFailed);
-                            return;
-                        }
+                AsyncAddressLookupName(name, GetClientPort(), [name](auto addrs) {
+                    if (addrs.empty()) {
+                        ReportNetError(kNetProtocolCli2GateKeeper, kNetErrNameLookupFailed);
+                        return;
+                    }
 
-                        for (const plNetAddress& addr : addrs) {
-                            Connect(name, addr);
-                        }
-                    },
-                    name,
-                    GetClientPort()
-                );
+                    for (const plNetAddress& addr : addrs) {
+                        Connect(name, addr);
+                    }
+                });
                 break;
             }
         }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -521,7 +521,6 @@ void CliGkConn::StopAutoReconnect () {
         reconnectTimer = nullptr;
         AsyncTimerDeleteCallback(timer, [this]() {
             UnRef("ReconnectTimer");
-            return kAsyncTimeInfinite;
         });
     }
 }
@@ -549,7 +548,6 @@ void CliGkConn::StopAutoPing () {
     if (pingTimer) {
         AsyncTimerDeleteCallback(pingTimer, [this]() {
             UnRef("PingTimer");
-            return kAsyncTimeInfinite;
         });
         pingTimer = nullptr;
     }


### PR DESCRIPTION
Trying to improve the "callback hell" in the low-/middle-level network code. The AsyncCore APIs relied heavily on C-style callback functions with untyped `void*` context parameters, which made it difficult to follow the execution and data flow in NetGameLib.

This PR migrates almost all of the async callbacks to use `std::function` (where they didn't already) and the callers to use lambdas for capturing context variables. This obsoletes the `void*` parameters and removes lots of manual casts.

AsyncSocket is a special case: its callback function was really multiple distinct callbacks wrapped in a generic signature, so I replaced it with a "callbacks object" with multiple virtual methods that the caller has to implement. This is a very "Java-ish" solution and is incompatible with lambdas, but works well with how the AsyncSocket API is used. It also clarifies the different callbacks' signatures and helps with seeing where each one is called.

The PR diff for the NetGameLib files is a bit noisy, because I changed some functions to instance methods and had to rename a couple of fields. The individual commit diffs are more readable there (e34454cfd626a1489310a43a9ab21348a022eac1 is the noisy refactor).