### PR TITLE
Don't deploy Qt if no Qt tools are built.

### DIFF
--- a/cmake/QtDeployment.cmake
+++ b/cmake/QtDeployment.cmake
@@ -63,7 +63,7 @@ function(plasma_deploy_qt)
     endforeach()
 
     # Deploy only once on install
-    if(PLASMA_INSTALL_QT)
+    if(PLASMA_INSTALL_QT AND _INSTALL_DEPLOY)
         string(JOIN [[" "]] _DEPLOY_ARG ${_INSTALL_DEPLOY})
         install(
             CODE


### PR DESCRIPTION
Trying to deploy Qt when no Qt tools have been built causes the install process to fail with a cryptic error. This error has persisted for quite some time, likely due to being silently masked by older Qt tools being present in build directories.