### PR TITLE
Dynamically checking display depth for Mac client

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -189,6 +189,7 @@ static void* const DeviceDidChangeContext = (void*)&DeviceDidChangeContext;
                                                    styleMask:windowStyle
                                                      backing:NSBackingStoreBuffered
                                                        defer:NO];
+    window.depthLimit = NSWindowDepthSixtyfourBitRGB;
     window.backgroundColor = NSColor.blackColor;
 
     PLSView* view = [[PLSView alloc] init];


### PR DESCRIPTION
@Hoikas - This is a possible optimization for older GPUs.

I'm not happy about the approach - the way this is implemented is promoting the color depth of the entire window instead of just the Metal output. I'd like to figure out if there is a better way to do this - so I'm leaving this as a draft until the implementation and the potential improvements are better understood.