### PR TITLE
Make `Python.Cheat` command more usable by not parsing its argument

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -6124,16 +6124,8 @@ PF_CONSOLE_CMD( Python,
                 "Run a cheat command" )
 {
     const ST::string& function = params[0];
-    ST::string args;
-    if (numParams > 1) 
-    {
-        args = ST::format("({},)", static_cast<const ST::string&>(params[1]));
-    }
-    else
-        args = "()";
-
-    PythonInterface::RunFunctionSafe("xCheat", function.c_str(), args.c_str());
-
+    const ST::string& args = numParams > 1 ? params[1] : ST::string();
+    PythonInterface::RunFunctionStringArg("xCheat", function.c_str(), args);
     // get the messages
     PrintString(PythonInterface::getOutputAndReset());
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -1724,50 +1724,18 @@ bool PythonInterface::RunPYC(PyObject* code, PyObject* module)
     return true;
 }
 
-/////////////////////////////////////////////////////////////////////////////
-//
-//  Function   : RunFunction
-//  PARAMETERS : module - module name to run 'name' in
-//             : name - name of function
-//             : args - tuple with arguments
-//
-//
-PyObject* PythonInterface::RunFunction(PyObject* module, const char* name, PyObject* args)
-{
-    if (module == nullptr)
-        return nullptr;
-
-    PyObject* function = PyObject_GetAttrString(module, name);
-
-    PyObject* result = nullptr;
-    if (function != nullptr)
-    {
-        result = PyObject_Call(function, args, nullptr);
-        Py_DECREF(function);
-    }
-
-    return result;
-}
-
 bool PythonInterface::RunFunctionStringArg(const char* module, const char* name, const ST::string& arg)
 {
-    PyObject* moduleObj = ImportModule(module);
+    pyObjectRef moduleObj = ImportModule(module);
     bool result = false;
     if (moduleObj) {
-        PyObject* argObj = PyUnicode_FromSTString(arg);
-        if (argObj) {
-            PyObject* argsObj = PyTuple_Pack(1, argObj);
-            if (argsObj) {
-                PyObject* callResult = RunFunction(moduleObj, name, argsObj);
-                if (callResult) {
-                    result = true;
-                    Py_DECREF(callResult);
-                }
-                Py_DECREF(argsObj);
+        pyObjectRef functionObj = PyObject_GetAttrString(moduleObj.Get(), name);
+        if (functionObj) {
+            pyObjectRef callResult = plPython::CallObject(functionObj, arg);
+            if (callResult) {
+                result = true;
             }
-            Py_DECREF(argObj);
         }
-        Py_DECREF(moduleObj);
     }
 
     if (!result) {

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -1749,44 +1749,28 @@ PyObject* PythonInterface::RunFunction(PyObject* module, const char* name, PyObj
     return result;
 }
 
-PyObject* PythonInterface::ParseArgs(const char* args)
-{
-    PyObject* result = nullptr;
-    PyObject* scope = PyDict_New();
-    if (scope) 
-    {
-        //- Py_eval_input makes this function accept only single expresion (not statement)
-        //- When using empty scope, functions and classes like 'file' or '__import__' are not visible
-        result = PyRun_String(args, Py_eval_input, scope, nullptr);
-        Py_DECREF(scope);
-    }
-   
-    return result;
-}
-
-bool PythonInterface::RunFunctionSafe(const char* module, const char* function, const char* args) 
+bool PythonInterface::RunFunctionStringArg(const char* module, const char* name, const ST::string& arg)
 {
     PyObject* moduleObj = ImportModule(module);
     bool result = false;
-    if (moduleObj) 
-    {
-        PyObject* argsObj = ParseArgs(args);
-        if (argsObj) 
-        {
-            PyObject* callResult = RunFunction(moduleObj, function, argsObj);
-            if (callResult) 
-            {
-                result = true;
-                Py_DECREF(callResult);
+    if (moduleObj) {
+        PyObject* argObj = PyUnicode_FromSTString(arg);
+        if (argObj) {
+            PyObject* argsObj = PyTuple_Pack(1, argObj);
+            if (argsObj) {
+                PyObject* callResult = RunFunction(moduleObj, name, argsObj);
+                if (callResult) {
+                    result = true;
+                    Py_DECREF(callResult);
+                }
+                Py_DECREF(argsObj);
             }
-
-            Py_DECREF(argsObj);
+            Py_DECREF(argObj);
         }
         Py_DECREF(moduleObj);
     }
 
-    if (!result)
-    {
+    if (!result) {
         PyErr_Print();
     }
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
@@ -221,9 +221,8 @@ public:
 
     static PyObject* RunFunction(PyObject* module, const char* name, PyObject* args);
 
-    static PyObject* ParseArgs(const char* args);
+    static bool RunFunctionStringArg(const char* module, const char* name, const ST::string& arg);
 
-    static bool RunFunctionSafe(const char* module, const char* function, const char* args);
     /////////////////////////////////////////////////////////////////////////////
     //
     //  Function   : GetpyKeyFromPython

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
@@ -219,8 +219,6 @@ public:
     //
     static bool RunPYC(PyObject* code, PyObject* module);
 
-    static PyObject* RunFunction(PyObject* module, const char* name, PyObject* args);
-
     static bool RunFunctionStringArg(const char* module, const char* name, const ST::string& arg);
 
     /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The argument is now always treated as a plain string and passed directly to the cheat. This is the behavior expected by all the functions in xCheat.py, which parse the string argument manually where needed.

The previous implementation evaluated the argument value as a Python expression. This theoretically allowed passing non-string arguments, but none of the cheats use this (and it's also a potential code execution issue). If no argument was passed, the function was called with no arguments, which is also not supported by any of the cheats.

In practice, this required unintuitive syntax for calling the cheats correctly, for example:

```
Python.Cheat GetPlayerID None
Python.Cheat GetSDL "'FirstWeekClothing'"
```

With the new argument handling, these have been simplified to:

```
Python.Cheat GetPlayerID
Python.Cheat GetSDL FirstWeekClothing
```