### PR TITLE
Remove dead/server-only network protocol code

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetCli/Intern.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/Intern.h
@@ -59,10 +59,8 @@ namespace pnNetCli {
 *
 ***/
 
-struct NetMsgChannel;
-
-NetMsgChannel * NetMsgChannelLock (
-    unsigned protocol
+void NetMsgChannelLock(
+    NetMsgChannel* channel
 );
 void NetMsgChannelUnlock (
     NetMsgChannel * channel
@@ -74,6 +72,9 @@ const NetMsgInitRecv * NetMsgChannelFindRecvMessage (
 const NetMsgInitSend * NetMsgChannelFindSendMessage (
     NetMsgChannel * channel,
     uintptr_t       messageId
+);
+uint32_t NetMsgChannelGetProtocol(
+    NetMsgChannel* channel
 );
 void NetMsgChannelGetDhConstants (
     const NetMsgChannel *   channel,

--- a/Sources/Plasma/NucleusLib/pnNetCli/Intern.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/Intern.h
@@ -63,8 +63,7 @@ struct NetMsgChannel;
 
 NetMsgChannel * NetMsgChannelLock (
     unsigned        protocol,
-    bool            server,
-    unsigned *      largestRecv
+    bool            server
 );
 void NetMsgChannelUnlock (
     NetMsgChannel * channel

--- a/Sources/Plasma/NucleusLib/pnNetCli/Intern.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/Intern.h
@@ -62,8 +62,7 @@ namespace pnNetCli {
 struct NetMsgChannel;
 
 NetMsgChannel * NetMsgChannelLock (
-    unsigned        protocol,
-    bool            server
+    unsigned protocol
 );
 void NetMsgChannelUnlock (
     NetMsgChannel * channel
@@ -79,7 +78,7 @@ const NetMsgInitSend * NetMsgChannelFindSendMessage (
 void NetMsgChannelGetDhConstants (
     const NetMsgChannel *   channel,
     unsigned *              dh_g,
-    const plBigNum**        dh_xa,  // client: dh_x     server: dh_a
+    const plBigNum**        dh_x,
     const plBigNum**        dh_n
 );
 
@@ -96,13 +95,6 @@ void NetMsgCryptClientStart (
     const uint8_t   seedData[],
     plBigNum*       clientSeed,
     plBigNum*       serverSeed
-);
-
-void NetMsgCryptServerConnect (
-    NetMsgChannel*  channel,
-    unsigned        seedBytes,
-    const uint8_t   seedData[],
-    plBigNum*       clientSeed
 );
 
 

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcChannel.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcChannel.cpp
@@ -106,7 +106,7 @@ static unsigned ValidateMsg (const NetMsg & msg) {
                 gotVarCount = true;
                 break;
             }
-            if (field.type == kNetMsgFieldVarPtr || field.type == kNetMsgFieldRawVarPtr) {
+            if (field.type == kNetMsgFieldVarPtr) {
                 if (gotVarField || gotVarCount)
                     FATAL("Msg definition may only include one variable length field");
                 if (!prevFieldWasVarCount)
@@ -130,17 +130,13 @@ static unsigned ValidateMsg (const NetMsg & msg) {
             break;
 
             case kNetMsgFieldVarPtr:
-            case kNetMsgFieldRawVarPtr:
             break;
 
             case kNetMsgFieldVarCount:
                 prevFieldWasVarCount = true;
                 // fall-thru...
             case kNetMsgFieldString:
-            case kNetMsgFieldPtr:
-            case kNetMsgFieldRawPtr:
             case kNetMsgFieldData:
-            case kNetMsgFieldRawData:
                 maxBytes += msg.fields[i].count * msg.fields[i].size;
             break;
 

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcChannel.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcChannel.cpp
@@ -125,10 +125,6 @@ static unsigned ValidateMsg (const NetMsg & msg) {
                 maxBytes += sizeof(uint64_t);
             break;
 
-            case kNetMsgFieldReal:
-                maxBytes += sizeof(double);
-            break;
-
             case kNetMsgFieldVarPtr:
             break;
 

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -923,12 +923,7 @@ static NetCli * ConnCreate (
     ENetCliMode     mode
 ) {
     // find channel
-    unsigned largestRecv;
-    NetMsgChannel * channel = NetMsgChannelLock(
-        protocol,
-        mode == kNetCliModeServerStart,
-        &largestRecv
-    );
+    NetMsgChannel * channel = NetMsgChannelLock(protocol, mode == kNetCliModeServerStart);
     if (!channel)
         return nullptr;
 

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -368,8 +368,7 @@ static void BufferedSendData (
             }
             break;
 
-            case kNetMsgFieldData:
-            case kNetMsgFieldRawData: {
+            case kNetMsgFieldData: {
                 // write values to send buffer
                 AddToSendBuffer(cli, cmd->count * cmd->size, (const void *) *msg);
             }
@@ -386,20 +385,12 @@ static void BufferedSendData (
             }
             break;
 
-            case kNetMsgFieldVarPtr:
-            case kNetMsgFieldRawVarPtr: {
+            case kNetMsgFieldVarPtr: {
                 ASSERT(varSize);
                 // write var sized array
                 AddToSendBuffer(cli, varCount * varSize, (const void *) *msg);
                 varCount    = 0;
                 varSize     = 0;
-            }
-            break;
-
-            case kNetMsgFieldPtr:
-            case kNetMsgFieldRawPtr: {
-                // write values
-                AddToSendBuffer(cli, cmd->count * cmd->size, (const void *) *msg);
             }
             break;
 
@@ -505,8 +496,7 @@ static bool DispatchData (NetCli * cli, void * param) {
                 }
                 break;
 
-                case kNetMsgFieldData:
-                case kNetMsgFieldRawData: {
+                case kNetMsgFieldData: {
                     // Read fixed-length data into destination buffer
                     const unsigned bytes = cli->recvField->count * cli->recvField->size;
                     const size_t oldSize = cli->recvBuffer.size();
@@ -542,8 +532,7 @@ static bool DispatchData (NetCli * cli, void * param) {
                 }
                 break;
 
-                case kNetMsgFieldVarPtr:
-                case kNetMsgFieldRawVarPtr: {
+                case kNetMsgFieldVarPtr: {
                     // Read var-length data into destination buffer
                     const unsigned bytes = cli->recvFieldBytes;
                     const size_t oldSize = cli->recvBuffer.size();

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcEncrypt.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcEncrypt.cpp
@@ -82,31 +82,6 @@ static_assert(IS_POW2(kNetDiffieHellmanKeyBits), "DH Key bit count is not a powe
 
 /*****************************************************************************
 *
-*   Private
-*
-***/
-
-//============================================================================
-// TODO: Cache computed keys
-static void GetCachedServerKey (
-    NetMsgChannel*   channel,
-    plBigNum*        ka,
-    const plBigNum&  dh_y
-) {
-    // Get diffie-hellman constants
-    unsigned         DH_G;
-    const plBigNum*  DH_A;
-    const plBigNum*  DH_N;
-    NetMsgChannelGetDhConstants(channel, &DH_G, &DH_A, &DH_N);
-    hsAssert(!DH_N->isZero(), "DH_N must not be zero in encrypted mode");
-
-    // Compute the result
-    ka->PowMod(dh_y, *DH_A, *DH_N);
-}
-
-
-/*****************************************************************************
-*
 *   Module functions
 *
 ***/
@@ -139,18 +114,6 @@ void NetMsgCryptClientStart (
         // Client sends y to server
         serverSeed->PowMod(g, b, *DH_N);
     }
-}
-
-//============================================================================
-void NetMsgCryptServerConnect (
-    NetMsgChannel*  channel,
-    unsigned        seedBytes,
-    const uint8_t   seedData[],
-    plBigNum*       clientSeed
-) {
-    // Server computes client key: ka = y^a mod n
-    const plBigNum dh_y(seedBytes, seedData);
-    GetCachedServerKey(channel, clientSeed, dh_y);
 }
 
 }   // namespace pnNetCli

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
@@ -247,26 +247,24 @@ struct NetCli;
 
 #define NET_MSG(msgId, msgFields)               { #msgId, msgId, msgFields, (unsigned)std::size(msgFields) }
 
-#define NET_MSG_FIELD(type, count, size)        { type, count, size }
+#define NET_MSG_FIELD_BYTE()                    { kNetMsgFieldInteger, 0, sizeof(uint8_t) }
+#define NET_MSG_FIELD_WORD()                    { kNetMsgFieldInteger, 0, sizeof(uint16_t) }
+#define NET_MSG_FIELD_DWORD()                   { kNetMsgFieldInteger, 0, sizeof(uint32_t) }
+#define NET_MSG_FIELD_QWORD()                   { kNetMsgFieldInteger, 0, sizeof(uint64_t) }
+#define NET_MSG_FIELD_FLOAT()                   { kNetMsgFieldReal, 0, sizeof(float) }
+#define NET_MSG_FIELD_DOUBLE()                  { kNetMsgFieldReal, 0, sizeof(double) }
 
-#define NET_MSG_FIELD_BYTE()                    NET_MSG_FIELD(kNetMsgFieldInteger, 0, sizeof(uint8_t))
-#define NET_MSG_FIELD_WORD()                    NET_MSG_FIELD(kNetMsgFieldInteger, 0, sizeof(uint16_t))
-#define NET_MSG_FIELD_DWORD()                   NET_MSG_FIELD(kNetMsgFieldInteger, 0, sizeof(uint32_t))
-#define NET_MSG_FIELD_QWORD()                   NET_MSG_FIELD(kNetMsgFieldInteger, 0, sizeof(uint64_t))
-#define NET_MSG_FIELD_FLOAT()                   NET_MSG_FIELD(kNetMsgFieldReal, 0, sizeof(float))
-#define NET_MSG_FIELD_DOUBLE()                  NET_MSG_FIELD(kNetMsgFieldReal, 0, sizeof(double))
+#define NET_MSG_FIELD_BYTE_ARRAY(maxCount)      { kNetMsgFieldInteger, maxCount, sizeof(uint8_t) }
+#define NET_MSG_FIELD_WORD_ARRAY(maxCount)      { kNetMsgFieldInteger, maxCount, sizeof(uint16_t) }
+#define NET_MSG_FIELD_DWORD_ARRAY(maxCount)     { kNetMsgFieldInteger, maxCount, sizeof(uint32_t) }
+#define NET_MSG_FIELD_QWORD_ARRAY(maxCount)     { kNetMsgFieldInteger, maxCount, sizeof(uint64_t) }
+#define NET_MSG_FIELD_FLOAT_ARRAY(maxCount)     { kNetMsgFieldReal, maxCount, sizeof(float) }
+#define NET_MSG_FIELD_DOUBLE_ARRAY(maxCount)    { kNetMsgFieldReal, maxCount, sizeof(double) }
 
-#define NET_MSG_FIELD_BYTE_ARRAY(maxCount)      NET_MSG_FIELD(kNetMsgFieldInteger, maxCount, sizeof(uint8_t))
-#define NET_MSG_FIELD_WORD_ARRAY(maxCount)      NET_MSG_FIELD(kNetMsgFieldInteger, maxCount, sizeof(uint16_t))
-#define NET_MSG_FIELD_DWORD_ARRAY(maxCount)     NET_MSG_FIELD(kNetMsgFieldInteger, maxCount, sizeof(uint32_t))
-#define NET_MSG_FIELD_QWORD_ARRAY(maxCount)     NET_MSG_FIELD(kNetMsgFieldInteger, maxCount, sizeof(uint64_t))
-#define NET_MSG_FIELD_FLOAT_ARRAY(maxCount)     NET_MSG_FIELD(kNetMsgFieldReal, maxCount, sizeof(float))
-#define NET_MSG_FIELD_DOUBLE_ARRAY(maxCount)    NET_MSG_FIELD(kNetMsgFieldReal, maxCount, sizeof(double))
-
-#define NET_MSG_FIELD_STRING(maxLength)         NET_MSG_FIELD(kNetMsgFieldString, maxLength, sizeof(char16_t))
-#define NET_MSG_FIELD_DATA(maxBytes)            NET_MSG_FIELD(kNetMsgFieldData, maxBytes, 1)
-#define NET_MSG_FIELD_VAR_PTR()                 NET_MSG_FIELD(kNetMsgFieldVarPtr, 0, 0)
-#define NET_MSG_FIELD_VAR_COUNT(elemSize, maxCount) NET_MSG_FIELD(kNetMsgFieldVarCount, maxCount, elemSize)
+#define NET_MSG_FIELD_STRING(maxLength)         { kNetMsgFieldString, maxLength, sizeof(char16_t) }
+#define NET_MSG_FIELD_DATA(maxBytes)            { kNetMsgFieldData, maxBytes, 1 }
+#define NET_MSG_FIELD_VAR_PTR()                 { kNetMsgFieldVarPtr, 0, 0 }
+#define NET_MSG_FIELD_VAR_COUNT(elemSize, maxCount) { kNetMsgFieldVarCount, maxCount, elemSize }
 
 
 /*****************************************************************************

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
@@ -132,41 +132,20 @@ How to create a message sender/receiver:
 
 5. Register message description blocks
 
-// for server:
-    static const NetMsgInitSend s_srvSend[] = {
-        { s_moveObject  },
-        { s_playerJoin  },
-        { s_ping        },
-    };
-
-    static const NetMsgInitRecv s_srvRecv[] = {
-        { s_pingReply,  RecvMsgPingReply    },
-    };
-
-    s_srvConn = NetMsgProtocolRegister(
-        kNetProtocolCliToGame,
-        true,
-        s_srvSend, std::size(s_srvSend),
-        s_srvRecv, std::size(s_srvRecv)
-    );
-
-
-// for client:
-    static const NetMsgInitSend s_cliSend[] = {
+    static const NetMsgInitSend s_send[] = {
         { s_pingReply },
     };
 
-    static const NetMsgInitRecv s_cliRecv[] = {
+    static const NetMsgInitRecv s_recv[] = {
         { s_moveObject, RecvMsgMoveObject   },
         { s_playerJoin, RecvMsgPlayerJoin   },
         { s_ping,       RecvMsgPing         },
     };
 
-    s_cliConn = NetMsgProtocolRegister(
+    NetMsgProtocolRegister(
         kNetProtocolCliToGame,
-        false,
-        s_cliSend, std::size(s_cliSend),
-        s_cliRecv, std::size(s_cliRecv)
+        s_send, std::size(s_send),
+        s_recv, std::size(s_recv)
     );
 
 
@@ -321,20 +300,18 @@ struct NetMsgInitRecv {
 
 void NetMsgProtocolRegister (
     uint32_t                protocol,       // from pnNetBase/pnNbProtocol.h
-    bool                    server,
     const NetMsgInitSend    sendMsgs[],     // messages this program can send
     uint32_t                sendMsgCount,
     const NetMsgInitRecv    recvMsgs[],     // messages this program can receive
     uint32_t                recvMsgCount,
     // Diffie-Hellman keys
     uint32_t                dh_g,
-    const plBigNum&         dh_xa,          // client: dh_x     server: dh_a
+    const plBigNum&         dh_x,
     const plBigNum&         dh_n
 );
 
 void NetMsgProtocolDestroy (
-    uint32_t                protocol,
-    bool                    server
+    uint32_t protocol
 );
 
 

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
@@ -142,7 +142,7 @@ How to create a message sender/receiver:
         { s_ping,       RecvMsgPing         },
     };
 
-    NetMsgProtocolRegister(
+    s_channel = NetMsgChannelCreate(
         kNetProtocolCliToGame,
         s_send, std::size(s_send),
         s_recv, std::size(s_recv)
@@ -290,6 +290,10 @@ struct NetCli;
 *
 ***/
 
+// Opaque type
+namespace pnNetCli { struct NetMsgChannel; }
+using pnNetCli::NetMsgChannel;
+
 struct NetMsgInitSend {
     const NetMsg  *msg;
 };
@@ -298,7 +302,7 @@ struct NetMsgInitRecv {
     bool (* recv)(const uint8_t msg[], unsigned bytes, void * param);
 };
 
-void NetMsgProtocolRegister (
+NetMsgChannel* NetMsgChannelCreate(
     uint32_t                protocol,       // from pnNetBase/pnNbProtocol.h
     const NetMsgInitSend    sendMsgs[],     // messages this program can send
     uint32_t                sendMsgCount,
@@ -310,8 +314,8 @@ void NetMsgProtocolRegister (
     const plBigNum&         dh_n
 );
 
-void NetMsgProtocolDestroy (
-    uint32_t protocol
+void NetMsgChannelDelete(
+    NetMsgChannel* channel
 );
 
 
@@ -328,7 +332,7 @@ typedef std::function<bool(ENetError /* error */)> FNetCliEncrypt;
 
 NetCli * NetCliConnectAccept (
     AsyncSocket         sock,
-    unsigned            protocol,
+    NetMsgChannel*      channel,
     bool                unbuffered,
     FNetCliEncrypt      encryptFcn,
     unsigned            seedBytes,      // optional

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
@@ -212,7 +212,6 @@ How to create a message sender/receiver:
 
 enum ENetMsgFieldType {
     kNetMsgFieldInteger,
-    kNetMsgFieldReal,
     kNetMsgFieldString,             // variable length unicode string
     kNetMsgFieldData,               // data with length <= sizeof(uint32_t)
     kNetMsgFieldVarPtr,             // pointer to variable length data
@@ -250,16 +249,10 @@ struct NetCli;
 #define NET_MSG_FIELD_BYTE()                    { kNetMsgFieldInteger, 0, sizeof(uint8_t) }
 #define NET_MSG_FIELD_WORD()                    { kNetMsgFieldInteger, 0, sizeof(uint16_t) }
 #define NET_MSG_FIELD_DWORD()                   { kNetMsgFieldInteger, 0, sizeof(uint32_t) }
-#define NET_MSG_FIELD_QWORD()                   { kNetMsgFieldInteger, 0, sizeof(uint64_t) }
-#define NET_MSG_FIELD_FLOAT()                   { kNetMsgFieldReal, 0, sizeof(float) }
-#define NET_MSG_FIELD_DOUBLE()                  { kNetMsgFieldReal, 0, sizeof(double) }
 
 #define NET_MSG_FIELD_BYTE_ARRAY(maxCount)      { kNetMsgFieldInteger, maxCount, sizeof(uint8_t) }
 #define NET_MSG_FIELD_WORD_ARRAY(maxCount)      { kNetMsgFieldInteger, maxCount, sizeof(uint16_t) }
 #define NET_MSG_FIELD_DWORD_ARRAY(maxCount)     { kNetMsgFieldInteger, maxCount, sizeof(uint32_t) }
-#define NET_MSG_FIELD_QWORD_ARRAY(maxCount)     { kNetMsgFieldInteger, maxCount, sizeof(uint64_t) }
-#define NET_MSG_FIELD_FLOAT_ARRAY(maxCount)     { kNetMsgFieldReal, maxCount, sizeof(float) }
-#define NET_MSG_FIELD_DOUBLE_ARRAY(maxCount)    { kNetMsgFieldReal, maxCount, sizeof(double) }
 
 #define NET_MSG_FIELD_STRING(maxLength)         { kNetMsgFieldString, maxLength, sizeof(char16_t) }
 #define NET_MSG_FIELD_DATA(maxBytes)            { kNetMsgFieldData, maxBytes, 1 }

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNetCli.h
@@ -103,7 +103,7 @@ How to create a message sender/receiver:
     static const NetMsgField kFieldPlayerId     = NET_MSG_FIELD_DWORD();
     static const NetMsgField kFieldObjectPos    = NET_MSG_FIELD_FLOAT_ARRAY(3);
     static const NetMsgField kFieldPlayerName   = NET_MSG_FIELD_STRING(kPlayerNameMaxLength);
-    static const NetMsgField kFieldPlayerData   = NET_MSG_FIELD_PTR(kPlayerDataMaxLength);
+    static const NetMsgField kFieldPlayerData   = NET_MSG_FIELD_DATA(kPlayerDataMaxLength);
     static const NetMsgField kFieldVaultDataLen = NET_MSG_FIELD_VAR_COUNT(kVaultDataMaxLength);
     static const NetMsgField kFieldVaultData    = NET_MSG_FIELD_VAR_PTR();
     static const NetMsgField kFieldPingTimeMs   = NET_MSG_FIELD_DWORD();
@@ -211,20 +211,12 @@ How to create a message sender/receiver:
 ***/
 
 enum ENetMsgFieldType {
-    // Compressable fields
     kNetMsgFieldInteger,
     kNetMsgFieldReal,
     kNetMsgFieldString,             // variable length unicode string
     kNetMsgFieldData,               // data with length <= sizeof(uint32_t)
-    kNetMsgFieldPtr,                // pointer to fixed length data
     kNetMsgFieldVarPtr,             // pointer to variable length data
-
-    // Non-compressible fields (images, sounds, encrypted data, etc)
-    kNetMsgFieldRawData,            // data with length <= sizeof(uint32_t)
-    kNetMsgFieldRawPtr,             // pointer to fixed length data
-    kNetMsgFieldRawVarPtr,          // pointer to variable length data
-
-    kNetMsgFieldVarCount,           // count for kNetMsgFieldVarPtr and kNetMsgFieldRawVarPtr
+    kNetMsgFieldVarCount,           // count for kNetMsgFieldVarPtr
 
     kNumNetMsgFieldTypes
 };
@@ -272,15 +264,8 @@ struct NetCli;
 #define NET_MSG_FIELD_DOUBLE_ARRAY(maxCount)    NET_MSG_FIELD(kNetMsgFieldReal, maxCount, sizeof(double))
 
 #define NET_MSG_FIELD_STRING(maxLength)         NET_MSG_FIELD(kNetMsgFieldString, maxLength, sizeof(char16_t))
-
-#define NET_MSG_FIELD_DATA(maxBytes)            NET_MSG_FIELD(kNetMsgFieldData,     maxBytes, 1)
-#define NET_MSG_FIELD_PTR(maxBytes)             NET_MSG_FIELD(kNetMsgFieldPtr,      maxBytes, 1)
-#define NET_MSG_FIELD_RAW_DATA(maxBytes)        NET_MSG_FIELD(kNetMsgFieldRawData,  maxBytes, 1)
-#define NET_MSG_FIELD_RAW_PTR(maxBytes)         NET_MSG_FIELD(kNetMsgFieldRawPtr,   maxBytes, 1)
-
-#define NET_MSG_FIELD_VAR_PTR()                 NET_MSG_FIELD(kNetMsgFieldVarPtr,    0, 0)
-#define NET_MSG_FIELD_RAW_VAR_PTR()             NET_MSG_FIELD(kNetMsgFieldRawVarPtr, 0, 0)
-
+#define NET_MSG_FIELD_DATA(maxBytes)            NET_MSG_FIELD(kNetMsgFieldData, maxBytes, 1)
+#define NET_MSG_FIELD_VAR_PTR()                 NET_MSG_FIELD(kNetMsgFieldVarPtr, 0, 0)
 #define NET_MSG_FIELD_VAR_COUNT(elemSize, maxCount) NET_MSG_FIELD(kNetMsgFieldVarCount, maxCount, elemSize)
 
 

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/pnNpCommon.h
@@ -126,7 +126,7 @@ struct AsyncSocketConnectPacket {
 
 const NetMsgField kNetMsgFieldAccountName   = NET_MSG_FIELD_STRING(kMaxAccountNameLength);
 const NetMsgField kNetMsgFieldPlayerName    = NET_MSG_FIELD_STRING(kMaxPlayerNameLength);
-const NetMsgField kNetMsgFieldShaDigest     = NET_MSG_FIELD_RAW_DATA(sizeof(ShaDigest));
+const NetMsgField kNetMsgFieldShaDigest     = NET_MSG_FIELD_DATA(sizeof(ShaDigest));
 const NetMsgField kNetMsgFieldUuid          = NET_MSG_FIELD_DATA(sizeof(plUUID));
 const NetMsgField kNetMsgFieldTransId       = NET_MSG_FIELD_DWORD();
 const NetMsgField kNetMsgFieldTimeMs        = NET_MSG_FIELD_DWORD();

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -4579,7 +4579,6 @@ void AuthInitialize () {
     s_running = true;
     NetMsgProtocolRegister(
         kNetProtocolCli2Auth,
-        false,
         s_send, std::size(s_send),
         s_recv, std::size(s_recv),
         kAuthDhGValue,
@@ -4604,11 +4603,8 @@ void AuthDestroy (bool wait) {
     NetTransCancelByProtocol(
         kNetProtocolCli2Auth,
         kNetErrRemoteShutdown
-    );    
-    NetMsgProtocolDestroy(
-        kNetProtocolCli2Auth,
-        false
     );
+    NetMsgProtocolDestroy(kNetProtocolCli2Auth);
 
     {
         hsLockGuard(s_critsect);

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -1242,11 +1242,8 @@ void FileDestroy (bool wait) {
     NetTransCancelByProtocol(
         kNetProtocolCli2File,
         kNetErrRemoteShutdown
-    );    
-    NetMsgProtocolDestroy(
-        kNetProtocolCli2File,
-        false
     );
+    NetMsgProtocolDestroy(kNetProtocolCli2File);
 
     {
         hsLockGuard(s_critsect);

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -1243,7 +1243,6 @@ void FileDestroy (bool wait) {
         kNetProtocolCli2File,
         kNetErrRemoteShutdown
     );
-    NetMsgProtocolDestroy(kNetProtocolCli2File);
 
     {
         hsLockGuard(s_critsect);

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
@@ -657,7 +657,6 @@ void GameInitialize () {
     s_running = true;
     NetMsgProtocolRegister(
         kNetProtocolCli2Game,
-        false,
         s_send, std::size(s_send),
         s_recv, std::size(s_recv),
         kGameDhGValue,
@@ -675,11 +674,8 @@ void GameDestroy (bool wait) {
     NetTransCancelByProtocol(
         kNetProtocolCli2Game,
         kNetErrRemoteShutdown
-    );    
-    NetMsgProtocolDestroy(
-        kNetProtocolCli2Game,
-        false
     );
+    NetMsgProtocolDestroy(kNetProtocolCli2Game);
     
     {
         hsLockGuard(s_critsect);

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -835,7 +835,6 @@ void GateKeeperInitialize () {
     s_running = true;
     NetMsgProtocolRegister(
         kNetProtocolCli2GateKeeper,
-        false,
         s_send, std::size(s_send),
         s_recv, std::size(s_recv),
         kGateKeeperDhGValue,
@@ -851,11 +850,8 @@ void GateKeeperDestroy (bool wait) {
     NetTransCancelByProtocol(
         kNetProtocolCli2GateKeeper,
         kNetErrRemoteShutdown
-    );    
-    NetMsgProtocolDestroy(
-        kNetProtocolCli2GateKeeper,
-        false
     );
+    NetMsgProtocolDestroy(kNetProtocolCli2GateKeeper);
 
     {
         hsLockGuard(s_critsect);


### PR DESCRIPTION
This drops various bits of code under pnNetCli that are unused and very unlikely to ever be useful, namely:

* The last remaining server-side network code. I assume that we'll never see the plServer sources that would need this code.
* Unused network message field types that are difficult/impossible to use correctly. With the base network protocols being almost frozen, I assume there will never be any use for these extra types.

As usual, the commit messages for the non-obvious changes have more detailed reasoning.