### PR TITLE
Remove old debug-only fields from `plKeyData`

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameScoreMgr/pfGameScoreMgr.h
+++ b/Sources/Plasma/FeatureLib/pfGameScoreMgr/pfGameScoreMgr.h
@@ -46,10 +46,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "hsRefCnt.h"
 
+#include <string_theory/string>
+
 #include "pnKeyedObject/plKey.h"
 #include "pnNetBase/pnNetBase.h"
-
-namespace ST { class string; }
 
 // TODO: Rank List (seems to be unused in regular gameplay though...)
 //       That's some strange stuff...

--- a/Sources/Plasma/NucleusLib/inc/plTimerCallbackManager.h
+++ b/Sources/Plasma/NucleusLib/inc/plTimerCallbackManager.h
@@ -42,6 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plTimerCallbackManager_Defined
 #define plTimerCallbackManager_Defined
 
+#include <vector>
 
 #include "pnKeyedObject/hsKeyedObject.h"
 

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
@@ -44,12 +44,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include "plRefFlags.h"
-#include <string_theory/string>
 
 class hsKeyedObject;
 class plRefMsg;
 class plUoid;
 class hsBitVector;
+namespace ST { class string; }
 
 //// plKey ///////////////////////////////////////////////////////////////////
 //  Pointer to a plKeyData struct, which is a handle to a keyedObject
@@ -140,12 +140,6 @@ protected:
     // Protected so only the registry can create it
     plKeyData();
     virtual ~plKeyData();
-
-#ifdef HS_DEBUGGING
-    // Debugging info fields
-    ST::string  fIDName;
-    const char* fClassType;
-#endif
 
     //// RefCount Stuff //////////////////////////////////////////////////////////
     //  The refcounts on plKeyData/plKeyImps are zero-based. When you first create

--- a/Sources/Plasma/NucleusLib/pnMessage/plMessage.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plMessage.h
@@ -43,6 +43,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plMessage_inc
 #define plMessage_inc
 
+#include <string>
+#include <vector>
+
 #include "pnFactory/plCreatable.h"
 #include "pnKeyedObject/plKey.h"
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plNotifyMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plNotifyMsg.h
@@ -44,6 +44,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plMessage.h"
 
+#include <string_theory/string>
+
 #include "hsGeometry3.h"
 
 

--- a/Sources/Plasma/NucleusLib/pnTimer/plTimerCallbackManager.cpp
+++ b/Sources/Plasma/NucleusLib/pnTimer/plTimerCallbackManager.cpp
@@ -42,6 +42,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include "plTimerCallbackManager.h"
+
+#include <algorithm>
+
 #include "pnMessage/plTimeMsg.h"
 #include "plgDispatch.h"
 #include "pnKeyedObject/plFixedKey.h"

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.h
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnInputCore/plControlDefinition.h"
 #include "hsGeometry3.h"
 
+#include <string_theory/string>
 #include <utility>
 
 class plKeyEventMsg;


### PR DESCRIPTION
The debugging message in the destructor was unconditionally disabled and no longer compiles if manually enabled. The debugging check in `plKeyImp::SetObjectPtr` can be rewritten to not require any extra fields (also making it a bit faster by removing the string comparison).

This uncovered missing includes in multiple places due to plKey.h not including `<string_theory/string>` anymore.