### PR TITLE
Per pixel lighting support in Metal

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
@@ -100,7 +100,7 @@ constant const uint32_t miscFlags8 [[ function_constant(FunctionConstantLayerFla
 constant const uint8_t sourceTypes[MAX_BLEND_PASSES] = { sourceType1, sourceType2, sourceType3, sourceType4, sourceType5, sourceType6, sourceType7, sourceType8};
 constant const uint32_t blendModes[MAX_BLEND_PASSES] = { blendModes1, blendModes2, blendModes3, blendModes4, blendModes5, blendModes6, blendModes7, blendModes8};
 constant const uint32_t miscFlags[MAX_BLEND_PASSES] = { miscFlags1, miscFlags2, miscFlags3, miscFlags4, miscFlags5, miscFlags6, miscFlags7, miscFlags8};
-    constant const uint8_t passCount = (sourceType1 > 0) + (sourceType2 > 0) + (sourceType3 > 0) + (sourceType4 > 0) + (sourceType5 > 0) + (sourceType6 > 0) + (sourceType7 > 0) + (sourceType8 > 0);
+constant const uint8_t passCount = (sourceType1 > 0) + (sourceType2 > 0) + (sourceType3 > 0) + (sourceType4 > 0) + (sourceType5 > 0) + (sourceType6 > 0) + (sourceType7 > 0) + (sourceType8 > 0);
     
 constant const bool has2DTexture1 = (sourceType1 == PassTypeTexture && hasLayer1);
 constant const bool has2DTexture2 = (sourceType2 == PassTypeTexture && hasLayer2);
@@ -172,31 +172,20 @@ typedef struct
     float4 position [[position, invariant]];
     float3 texCoord1;
 } ShadowCasterInOut;
-
-vertex ColorInOut pipelineVertexShader(Vertex in [[stage_in]],
-                                       constant VertexUniforms & uniforms   [[ buffer(    VertexShaderArgumentFixedFunctionUniforms) ]],
-                                       constant plMetalLights & lights      [[ buffer(VertexShaderArgumentLights) ]],
-                                       constant float4x4 & blendMatrix1     [[ buffer(VertexShaderArgumentBlendMatrix1), function_constant(temp_hasOnlyWeight1) ]])
+    
+half4 calcLitMaterialColor(constant plMetalLights & lights,
+                          const half4 materialColor,
+                          constant plMaterialLightingDescriptor & materialLighting,
+                          const float4 position,
+                          const float3 normal)
 {
-    ColorInOut out;
-    // we should have been able to swizzle, but it didn't work in Xcode beta? Try again later.
-    const half4 inColor = half4(in.color.b, in.color.g, in.color.r, in.color.a) / half4(255.f);
-
-    const half3 MAmbient = mix(inColor.rgb, uniforms.ambientCol, uniforms.ambientSrc);
-    const half4 MDiffuse = mix(inColor, uniforms.diffuseCol, uniforms.diffuseSrc);
-    const half3 MEmissive = mix(inColor.rgb, uniforms.emissiveCol, uniforms.emissiveSrc);
-
     half3 LAmbient = half3(0.h, 0.h, 0.h);
     half3 LDiffuse = half3(0.h, 0.h, 0.h);
-
-    const float3 Ndirection = normalize(float4(in.normal, 0.f) * uniforms.localToWorldMatrix).xyz;
-
-    float4 position = float4(in.position, 1.f) * uniforms.localToWorldMatrix;
-    if (temp_hasOnlyWeight1) {
-        const float4 position2 = blendMatrix1 * float4(in.position, 1.f);
-        position = (in.weight1 * position) + ((1.f - in.weight1) * position2);
-    }
-
+    
+    const half3 MAmbient = mix(materialColor.rgb, materialLighting.ambientCol, materialLighting.ambientSrc);
+    const half4 MDiffuse = mix(materialColor, materialLighting.diffuseCol, materialLighting.diffuseSrc);
+    const half3 MEmissive = mix(materialColor.rgb, materialLighting.emissiveCol, materialLighting.emissiveSrc);
+    
     for (size_t i = 0; i < lights.count; i++) {
         constant const plMetalShaderLightSource *lightSource = &lights.lampSources[i];
         if (lightSource->scale == 0.0h)
@@ -231,16 +220,35 @@ vertex ColorInOut pipelineVertexShader(Vertex in [[stage_in]],
         }
 
         LAmbient.rgb = LAmbient.rgb + half3(direction.w * (lightSource->ambient.rgb * lightSource->scale));
-        const float3 dotResult = dot(Ndirection, direction.xyz);
+        const float3 dotResult = dot(normal, direction.xyz);
         LDiffuse.rgb = LDiffuse.rgb + MDiffuse.rgb * (lightSource->diffuse.rgb * lightSource->scale) * half3(max(0.f, dotResult) * direction.w);
     }
 
-    const half3 ambient = (MAmbient.rgb) * clamp(uniforms.globalAmb.rgb + LAmbient.rgb, 0.h, 1.h);
+    const half3 ambient = (MAmbient.rgb) * clamp(materialLighting.globalAmb.rgb + LAmbient.rgb, 0.h, 1.h);
     const half3 diffuse = clamp(LDiffuse.rgb, 0.h, 1.h);
-    const half4 material = half4(clamp(ambient + diffuse + MEmissive.rgb, 0.h, 1.h),
-                                 abs(uniforms.invVtxAlpha - MDiffuse.a));
+    return clamp(half4(ambient + diffuse + MEmissive.rgb, MDiffuse.a), 0.h, 1.h);
+}
 
-    out.vtxColor = half4(material.rgb, abs(uniforms.invVtxAlpha - MDiffuse.a));
+vertex ColorInOut pipelineVertexShader(Vertex in [[stage_in]],
+                                       constant VertexUniforms & uniforms   [[ buffer(    VertexShaderArgumentFixedFunctionUniforms) ]],
+                                       constant plMaterialLightingDescriptor & materialLighting   [[ buffer(    VertexShaderArgumentMaterialLighting) ]],
+                                       constant plMetalLights & lights      [[ buffer(VertexShaderArgumentLights) ]],
+                                       constant float4x4 & blendMatrix1     [[ buffer(VertexShaderArgumentBlendMatrix1), function_constant(temp_hasOnlyWeight1) ]])
+{
+    ColorInOut out;
+    const half4 inColor = half4(in.color.b, in.color.g, in.color.r, in.color.a) / half4(255.f);
+
+    const float3 Ndirection = normalize(float4(in.normal, 0.f) * uniforms.localToWorldMatrix).xyz;
+
+    float4 position = float4(in.position, 1.f) * uniforms.localToWorldMatrix;
+    if (temp_hasOnlyWeight1) {
+        const float4 position2 = blendMatrix1 * float4(in.position, 1.f);
+        position = (in.weight1 * position) + ((1.f - in.weight1) * position2);
+    }
+
+    out.vtxColor = calcLitMaterialColor(lights, inColor, materialLighting, position, Ndirection);
+    out.vtxColor.a = abs(uniforms.invVtxAlpha - out.vtxColor.a);
+    
     const float4 vCamPosition = position * uniforms.worldToCameraMatrix;
     
     // Fog
@@ -612,6 +620,7 @@ fragment half4 shadowFragmentShader(ShadowCasterInOut in [[stage_in]])
 
 vertex ColorInOut shadowCastVertexShader(Vertex in                              [[ stage_in ]],
                                          constant VertexUniforms & uniforms     [[ buffer(    VertexShaderArgumentFixedFunctionUniforms) ]],
+                                         constant plMaterialLightingDescriptor & materialLighting   [[ buffer(    VertexShaderArgumentMaterialLighting) ]],
                                          constant plShadowState & shadowState   [[ buffer(VertexShaderArgumentShadowState) ]])
 {
     ColorInOut out;
@@ -619,7 +628,8 @@ vertex ColorInOut shadowCastVertexShader(Vertex in                              
     float4 position = (float4(in.position, 1.f) * uniforms.localToWorldMatrix);
     const float3 Ndirection = normalize(float4(in.normal, 0.f) * uniforms.localToWorldMatrix).xyz;
     // Shadow casting uses the diffuse material color to control opacity
-    const half4 MDiffuse = uniforms.diffuseCol;
+    // FIXME: Should this be something more specific
+    const half4 MDiffuse = materialLighting.diffuseCol;
 
     //w is attenation
     float4 direction;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
@@ -69,6 +69,9 @@ enum plUVWSrcModifiers: uint32_t
 
 using namespace metal;
 
+constant const bool perPixelLighting [[ function_constant(FunctionConstantPerPixelLighting)    ]];
+constant const bool perVertexLighting = !perPixelLighting;
+
 constant const uint8_t sourceType1 [[ function_constant(FunctionConstantSources + 0)    ]];
 constant const uint8_t sourceType2 [[ function_constant(FunctionConstantSources + 1)    ]];
 constant const uint8_t sourceType3 [[ function_constant(FunctionConstantSources + 2)    ]];
@@ -153,16 +156,18 @@ struct FragmentShaderArguments
 
 typedef struct
 {
-    float4 position [[position]];
-    float3 texCoord1 [[function_constant(hasLayer1)]];
-    float3 texCoord2 [[function_constant(hasLayer2)]];
-    float3 texCoord3 [[function_constant(hasLayer3)]];
-    float3 texCoord4 [[function_constant(hasLayer4)]];
-    float3 texCoord5 [[function_constant(hasLayer5)]];
-    float3 texCoord6 [[function_constant(hasLayer6)]];
-    float3 texCoord7 [[function_constant(hasLayer7)]];
-    float3 texCoord8 [[function_constant(hasLayer8)]];
-    half4 vtxColor [[ centroid_perspective ]];
+    float4 position  [[ position ]];
+    float4 worldPos  [[ function_constant(perPixelLighting) ]];
+    float3 normal    [[ function_constant(perPixelLighting) ]];
+    float3 texCoord1 [[ function_constant(hasLayer1) ]];
+    float3 texCoord2 [[ function_constant(hasLayer2) ]];
+    float3 texCoord3 [[ function_constant(hasLayer3) ]];
+    float3 texCoord4 [[ function_constant(hasLayer4) ]];
+    float3 texCoord5 [[ function_constant(hasLayer5) ]];
+    float3 texCoord6 [[ function_constant(hasLayer6) ]];
+    float3 texCoord7 [[ function_constant(hasLayer7) ]];
+    float3 texCoord8 [[ function_constant(hasLayer8) ]];
+    half4 vtxColor   [[ centroid_perspective ]];
     half4 fogColor;
 } ColorInOut;
 
@@ -174,10 +179,10 @@ typedef struct
 } ShadowCasterInOut;
     
 half4 calcLitMaterialColor(constant plMetalLights & lights,
-                          const half4 materialColor,
-                          constant plMaterialLightingDescriptor & materialLighting,
-                          const float4 position,
-                          const float3 normal)
+                           const half4 materialColor,
+                           constant plMaterialLightingDescriptor & materialLighting,
+                           const float4 position,
+                           const float3 normal)
 {
     half3 LAmbient = half3(0.h, 0.h, 0.h);
     half3 LDiffuse = half3(0.h, 0.h, 0.h);
@@ -226,13 +231,13 @@ half4 calcLitMaterialColor(constant plMetalLights & lights,
 
     const half3 ambient = (MAmbient.rgb) * clamp(materialLighting.globalAmb.rgb + LAmbient.rgb, 0.h, 1.h);
     const half3 diffuse = clamp(LDiffuse.rgb, 0.h, 1.h);
-    return clamp(half4(ambient + diffuse + MEmissive.rgb, MDiffuse.a), 0.h, 1.h);
+    return clamp(half4(ambient + diffuse + MEmissive.rgb, abs(materialLighting.invertAlpha - MDiffuse.a)), 0.h, 1.h);
 }
 
 vertex ColorInOut pipelineVertexShader(Vertex in [[stage_in]],
-                                       constant VertexUniforms & uniforms   [[ buffer(    VertexShaderArgumentFixedFunctionUniforms) ]],
-                                       constant plMaterialLightingDescriptor & materialLighting   [[ buffer(    VertexShaderArgumentMaterialLighting) ]],
-                                       constant plMetalLights & lights      [[ buffer(VertexShaderArgumentLights) ]],
+                                       constant VertexUniforms & uniforms   [[ buffer(VertexShaderArgumentFixedFunctionUniforms) ]],
+                                       constant plMaterialLightingDescriptor & materialLighting   [[ buffer(VertexShaderArgumentMaterialLighting), function_constant(perVertexLighting) ]],
+                                       constant plMetalLights & lights      [[ buffer(VertexShaderArgumentLights), function_constant(perVertexLighting) ]],
                                        constant float4x4 & blendMatrix1     [[ buffer(VertexShaderArgumentBlendMatrix1), function_constant(temp_hasOnlyWeight1) ]])
 {
     ColorInOut out;
@@ -245,9 +250,20 @@ vertex ColorInOut pipelineVertexShader(Vertex in [[stage_in]],
         const float4 position2 = blendMatrix1 * float4(in.position, 1.f);
         position = (in.weight1 * position) + ((1.f - in.weight1) * position2);
     }
-
-    out.vtxColor = calcLitMaterialColor(lights, inColor, materialLighting, position, Ndirection);
-    out.vtxColor.a = abs(uniforms.invVtxAlpha - out.vtxColor.a);
+    
+    if (perPixelLighting)
+    {
+        // send the world pos on to the pixel shader for lighting
+        out.worldPos = position;
+        out.normal = Ndirection;
+    }
+    
+    if (perPixelLighting)
+    {
+        out.vtxColor = inColor;
+    } else {
+        out.vtxColor = calcLitMaterialColor(lights, inColor, materialLighting, position, Ndirection);
+    }
     
     const float4 vCamPosition = position * uniforms.worldToCameraMatrix;
     
@@ -423,9 +439,12 @@ half4 FragmentShaderArguments::sampleLayer(const size_t index, const half4 verte
 }
 
 fragment half4 pipelineFragmentShader(ColorInOut in [[stage_in]],
-                                      const FragmentShaderArguments fragmentShaderArgs)
+                                      const FragmentShaderArguments fragmentShaderArgs,
+                                      constant plMetalLights & lights      [[ buffer(FragmentShaderArgumentLights), function_constant(perPixelLighting) ]],
+                                      constant plMaterialLightingDescriptor & materialLighting   [[ buffer(FragmentShaderArgumentMaterialLighting), function_constant(perPixelLighting) ]])
 {
-    half4 currentColor = in.vtxColor;
+    const half4 lightingContributionColor = perPixelLighting ? calcLitMaterialColor(lights, in.vtxColor, materialLighting, in.worldPos, in.normal) : in.vtxColor;
+    half4 currentColor = lightingContributionColor;
 
     /*
      SPECIAL PLASMA RULE:
@@ -453,7 +472,7 @@ fragment half4 pipelineFragmentShader(ColorInOut in [[stage_in]],
             }
         }
         
-        currentColor = half4(in.vtxColor.rgb, 1.0h) * currentColor;
+        currentColor = lightingContributionColor * currentColor;
     }
     
     currentColor.rgb = mix(in.fogColor.rgb, currentColor.rgb, (float)clamp(in.fogColor.a, 0.0h, 1.0h));

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderTypes.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderTypes.h
@@ -62,6 +62,8 @@ enum plMetalVertexShaderArgument
     VertexShaderArgumentMaterialShaderUniforms          = 3,
     /// Light Table
     VertexShaderArgumentLights                          = 4,
+    /// Material properties for vertex lighting
+    VertexShaderArgumentMaterialLighting                = 5,
     /// Blend matrix for GPU side animation blending
     VertexShaderArgumentBlendMatrix1                    = 6,
     /// Describes the state of a shadow caster for shadow cast shader
@@ -168,15 +170,8 @@ struct UVOutDescriptor
 static_assert(std::is_trivial_v<UVOutDescriptor>, "UVOutDescriptor must be a trivial type!");
 #endif
 
-struct VertexUniforms
+struct plMaterialLightingDescriptor
 {
-    // transformation
-    matrix_float4x4 projectionMatrix;
-    matrix_float4x4 localToWorldMatrix;
-    matrix_float4x4 cameraToWorldMatrix;
-    matrix_float4x4 worldToCameraMatrix;
-
-    // lighting
     half4 globalAmb;
     half3 ambientCol;
     uint8_t ambientSrc;
@@ -186,6 +181,16 @@ struct VertexUniforms
     uint8_t emissiveSrc;
     half3 specularCol;
     uint8_t specularSrc;
+};
+
+struct VertexUniforms
+{
+    // transformation
+    matrix_float4x4 projectionMatrix;
+    matrix_float4x4 localToWorldMatrix;
+    matrix_float4x4 cameraToWorldMatrix;
+    matrix_float4x4 worldToCameraMatrix;
+
     bool invVtxAlpha;
 
     uint8_t fogExponential;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderTypes.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderTypes.h
@@ -54,7 +54,7 @@ typedef __attribute__((__ext_vector_type__(3))) half half3;
 typedef __attribute__((__ext_vector_type__(4))) half half4;
 #endif
 
-enum plMetalVertexShaderArgument
+enum plMetalShaderArgument
 {
     /// Material State
     VertexShaderArgumentFixedFunctionUniforms           = 2,
@@ -67,11 +67,8 @@ enum plMetalVertexShaderArgument
     /// Blend matrix for GPU side animation blending
     VertexShaderArgumentBlendMatrix1                    = 6,
     /// Describes the state of a shadow caster for shadow cast shader
-    VertexShaderArgumentShadowState                     = 9
-};
-
-enum plMetalFragmentShaderArgumentIndex
-{
+    VertexShaderArgumentShadowState                     = 9,
+    
     /// Texture is a legacy argument for the simpler plate shader
     FragmentShaderArgumentTexture                       = 1,
     /// Fragment uniforms
@@ -79,7 +76,11 @@ enum plMetalFragmentShaderArgumentIndex
     /// Legacy argument buffer
     FragmentShaderArgumentUniforms                      = 5,
     /// Layer index of alpha for shadow fragment shader
-    FragmentShaderArgumentShadowCastAlphaSrc            = 8
+    FragmentShaderArgumentShadowCastAlphaSrc            = 8,
+    /// Light Table
+    FragmentShaderArgumentLights                        = 10,
+    /// Material properties for vertex lighting
+    FragmentShaderArgumentMaterialLighting              = 11
 };
 
 enum plMetalVertexAttribute
@@ -112,6 +113,8 @@ enum plMetalFunctionConstant
     FunctionConstantLayerFlags                          = 18,
     /// Numbrer of weights in the FVF vertex layout.
     FunctionConstantNumWeights                          = 26,
+    /// Per pixel lighting enable flag
+    FunctionConstantPerPixelLighting                    = 27,
 };
 
 enum plMetalLayerPassType: uint8_t
@@ -181,6 +184,8 @@ struct plMaterialLightingDescriptor
     uint8_t emissiveSrc;
     half3 specularCol;
     uint8_t specularSrc;
+    
+    bool invertAlpha;
 };
 
 struct VertexUniforms
@@ -190,8 +195,6 @@ struct VertexUniforms
     matrix_float4x4 localToWorldMatrix;
     matrix_float4x4 cameraToWorldMatrix;
     matrix_float4x4 worldToCameraMatrix;
-
-    bool invVtxAlpha;
 
     uint8_t fogExponential;
     simd::float2 fogValues;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -151,12 +151,22 @@ bool plRenderTriListFunc::RenderPrims() const
 
     size_t uniformsSize = offsetof(VertexUniforms, uvTransforms) + sizeof(UVOutDescriptor) * fDevice->fPipeline->fCurrNumLayers;
     fDevice->CurrentRenderCommandEncoder()->setVertexBytes(fDevice->fPipeline->fCurrentRenderPassUniforms, sizeof(VertexUniforms), VertexShaderArgumentFixedFunctionUniforms);
+    
     fDevice->CurrentRenderCommandEncoder()->setVertexBytes(&fDevice->fPipeline->fCurrentRenderPassMaterialLighting, sizeof(plMaterialLightingDescriptor), VertexShaderArgumentMaterialLighting);
+    if (PLASMA_PER_PIXEL_LIGHTING)
+    {
+        fDevice->CurrentRenderCommandEncoder()->setFragmentBytes(&fDevice->fPipeline->fCurrentRenderPassMaterialLighting, sizeof(plMaterialLightingDescriptor), FragmentShaderArgumentMaterialLighting);
+    }
 
     plMetalLights* lights = &fDevice->fPipeline->fLights;
     size_t         lightSize = offsetof(plMetalLights, lampSources) + (sizeof(plMetalShaderLightSource) * lights->count);
 
-    fDevice->CurrentRenderCommandEncoder()->setVertexBytes(lights, sizeof(plMetalLights), VertexShaderArgumentLights);
+    if (PLASMA_PER_PIXEL_LIGHTING)
+    {
+        fDevice->CurrentRenderCommandEncoder()->setFragmentBytes(lights, sizeof(plMetalLights), FragmentShaderArgumentLights);
+    } else {
+        fDevice->CurrentRenderCommandEncoder()->setVertexBytes(lights, sizeof(plMetalLights), VertexShaderArgumentLights);
+    }
     fDevice->CurrentRenderCommandEncoder()->drawIndexedPrimitives(MTL::PrimitiveTypeTriangle, fNumTris * 3, MTL::IndexTypeUInt16, fDevice->fCurrentIndexBuffer, (sizeof(uint16_t) * fIStart));
 }
 
@@ -1618,9 +1628,9 @@ bool plMetalPipeline::IHandleMaterialPass(hsGMaterial* material, uint32_t pass, 
         }
 
         if (s.fBlendFlags & hsGMatState::kBlendInvertVtxAlpha)
-            fCurrentRenderPassUniforms->invVtxAlpha = true;
+            fCurrentRenderPassMaterialLighting.invertAlpha = true;
         else
-            fCurrentRenderPassUniforms->invVtxAlpha = false;
+            fCurrentRenderPassMaterialLighting.invertAlpha = false;
 
         std::vector<plLightInfo*>& spanLights = currSpan->GetLightList(false);
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -151,6 +151,7 @@ bool plRenderTriListFunc::RenderPrims() const
 
     size_t uniformsSize = offsetof(VertexUniforms, uvTransforms) + sizeof(UVOutDescriptor) * fDevice->fPipeline->fCurrNumLayers;
     fDevice->CurrentRenderCommandEncoder()->setVertexBytes(fDevice->fPipeline->fCurrentRenderPassUniforms, sizeof(VertexUniforms), VertexShaderArgumentFixedFunctionUniforms);
+    fDevice->CurrentRenderCommandEncoder()->setVertexBytes(&fDevice->fPipeline->fCurrentRenderPassMaterialLighting, sizeof(plMaterialLightingDescriptor), VertexShaderArgumentMaterialLighting);
 
     plMetalLights* lights = &fDevice->fPipeline->fLights;
     size_t         lightSize = offsetof(plMetalLights, lampSources) + (sizeof(plMetalShaderLightSource) * lights->count);
@@ -1304,16 +1305,18 @@ void plMetalPipeline::IRenderProjection(const plRenderPrimFunc& render, plLightI
 
     IScaleLight(0, true);
 
-    fCurrentRenderPassUniforms->ambientSrc = 1;
-    fCurrentRenderPassUniforms->diffuseSrc = 1;
-    fCurrentRenderPassUniforms->emissiveSrc = 1;
-    fCurrentRenderPassUniforms->specularSrc = 1;
-    fCurrentRenderPassUniforms->globalAmb = {1.f, 1.f, 1.f};
-    fCurrentRenderPassUniforms->ambientCol = {0.f, 0.f, 0.f};
-    fCurrentRenderPassUniforms->emissiveCol = {0.f, 0.f, 0.f};
-    fCurrentRenderPassUniforms->specularCol = {0.f, 0.f, 0.f};
+    fCurrentRenderPassMaterialLighting.ambientSrc = 1;
+    fCurrentRenderPassMaterialLighting.diffuseSrc = 1;
+    fCurrentRenderPassMaterialLighting.emissiveSrc = 1;
+    fCurrentRenderPassMaterialLighting.specularSrc = 1;
+    fCurrentRenderPassMaterialLighting.globalAmb = {1.f, 1.f, 1.f};
+    fCurrentRenderPassMaterialLighting.ambientCol = {0.f, 0.f, 0.f};
+    fCurrentRenderPassMaterialLighting.emissiveCol = {0.f, 0.f, 0.f};
+    fCurrentRenderPassMaterialLighting.specularCol = {0.f, 0.f, 0.f};
+    fCurrentRenderPassMaterialLighting.diffuseCol = {1.f, 1.f, 1.f, 1.f};
+    
+    // FIXME: NEEDED?
     fCurrentRenderPassUniforms->fogColor = {0.f, 0.f, 0.f};
-    fCurrentRenderPassUniforms->diffuseCol = {1.f, 1.f, 1.f, 1.f};
 
     matrix_float4x4 tXfm;
     hsMatrix2SIMD(proj->GetTransform(), &tXfm);
@@ -1483,12 +1486,12 @@ void plMetalPipeline::IRenderAuxSpan(const plSpan& span, const plAuxSpan* aux)
     for (int32_t pass = 0; pass < mRef->GetNumPasses(); pass++) {
         IHandleMaterialPass(material, pass, &span, vRef);
         if (aux->fFlags & plAuxSpan::kOverrideLiteModel) {
-            fCurrentRenderPassUniforms->ambientCol = {1.0f, 1.0f, 1.0f};
+            fCurrentRenderPassMaterialLighting.ambientCol = {1.0f, 1.0f, 1.0f};
 
-            fCurrentRenderPassUniforms->diffuseSrc = 1.0;
-            fCurrentRenderPassUniforms->ambientSrc = 1.0;
-            fCurrentRenderPassUniforms->emissiveSrc = 0.0;
-            fCurrentRenderPassUniforms->specularSrc = 1.0;
+            fCurrentRenderPassMaterialLighting.diffuseSrc = 1.0;
+            fCurrentRenderPassMaterialLighting.ambientSrc = 1.0;
+            fCurrentRenderPassMaterialLighting.emissiveSrc = 0.0;
+            fCurrentRenderPassMaterialLighting.specularSrc = 1.0;
         }
 
         render.RenderPrims();
@@ -2118,18 +2121,18 @@ void plMetalPipeline::ICalcLighting(plMetalMaterialShaderRef* mRef, const plLaye
     // plProfile_Inc(MatLightState);
 
     if (IsDebugFlagSet(plPipeDbg::kFlagAllBright)) {
-        fCurrentRenderPassUniforms->globalAmb = {1.f, 1.f, 1.f, 1.f};
+        fCurrentRenderPassMaterialLighting.globalAmb = {1.f, 1.f, 1.f, 1.f};
 
-        fCurrentRenderPassUniforms->ambientCol = {1.f, 1.f, 1.f};
-        fCurrentRenderPassUniforms->diffuseCol = {1.f, 1.f, 1.f, 1.f};
-        fCurrentRenderPassUniforms->emissiveCol = {1.f, 1.f, 1.f};
-        fCurrentRenderPassUniforms->emissiveCol = {1.f, 1.f, 1.f};
-        fCurrentRenderPassUniforms->specularCol = {1.f, 1.f, 1.f};
+        fCurrentRenderPassMaterialLighting.ambientCol = {1.f, 1.f, 1.f};
+        fCurrentRenderPassMaterialLighting.diffuseCol = {1.f, 1.f, 1.f};
+        fCurrentRenderPassMaterialLighting.emissiveCol = {1.f, 1.f, 1.f};
+        fCurrentRenderPassMaterialLighting.emissiveCol = {1.f, 1.f, 1.f};
+        fCurrentRenderPassMaterialLighting.specularCol = {1.f, 1.f, 1.f};
 
-        fCurrentRenderPassUniforms->ambientSrc = 1;
-        fCurrentRenderPassUniforms->diffuseSrc = 1;
-        fCurrentRenderPassUniforms->emissiveSrc = 1;
-        fCurrentRenderPassUniforms->specularSrc = 1;
+        fCurrentRenderPassMaterialLighting.ambientSrc = 1;
+        fCurrentRenderPassMaterialLighting.diffuseSrc = 1;
+        fCurrentRenderPassMaterialLighting.emissiveSrc = 1;
+        fCurrentRenderPassMaterialLighting.specularSrc = 1;
 
         return;
     }
@@ -2149,42 +2152,42 @@ void plMetalPipeline::ICalcLighting(plMetalMaterialShaderRef* mRef, const plLaye
         case plSpan::kLiteMaterial: // Material shading
         {
             if (state.fShadeFlags & hsGMatState::kShadeWhite) {
-                fCurrentRenderPassUniforms->globalAmb = {1.f, 1.f, 1.f, 1.f};
-                fCurrentRenderPassUniforms->ambientCol = {1.f, 1.f, 1.f};
+                fCurrentRenderPassMaterialLighting.globalAmb = {1.f, 1.f, 1.f, 1.f};
+                fCurrentRenderPassMaterialLighting.ambientCol = {1.f, 1.f, 1.f};
             } else if (IsDebugFlagSet(plPipeDbg::kFlagNoPreShade)) {
-                fCurrentRenderPassUniforms->globalAmb = {0.f, 0.f, 0.f, 1.f};
-                fCurrentRenderPassUniforms->ambientCol = {0.f, 0.f, 0.f};
+                fCurrentRenderPassMaterialLighting.globalAmb = {0.f, 0.f, 0.f, 1.f};
+                fCurrentRenderPassMaterialLighting.ambientCol = {0.f, 0.f, 0.f};
             } else {
                 hsColorRGBA amb = currLayer->GetPreshadeColor();
-                fCurrentRenderPassUniforms->globalAmb = {static_cast<half>(amb.r), static_cast<half>(amb.g), static_cast<half>(amb.b), 1.f};
-                fCurrentRenderPassUniforms->ambientCol = {static_cast<half>(amb.r), static_cast<half>(amb.g), static_cast<half>(amb.b)};
+                fCurrentRenderPassMaterialLighting.globalAmb = {static_cast<half>(amb.r), static_cast<half>(amb.g), static_cast<half>(amb.b), 1.f};
+                fCurrentRenderPassMaterialLighting.ambientCol = {static_cast<half>(amb.r), static_cast<half>(amb.g), static_cast<half>(amb.b)};
             }
 
             hsColorRGBA dif = currLayer->GetRuntimeColor();
-            fCurrentRenderPassUniforms->diffuseCol = {static_cast<half>(dif.r), static_cast<half>(dif.g), static_cast<half>(dif.b), static_cast<half>(currLayer->GetOpacity())};
+            fCurrentRenderPassMaterialLighting.diffuseCol = {static_cast<half>(dif.r), static_cast<half>(dif.g), static_cast<half>(dif.b), static_cast<half>(currLayer->GetOpacity())};
 
             hsColorRGBA em = currLayer->GetAmbientColor();
-            fCurrentRenderPassUniforms->emissiveCol = {static_cast<half>(em.r), static_cast<half>(em.g), static_cast<half>(em.b)};
+            fCurrentRenderPassMaterialLighting.emissiveCol = {static_cast<half>(em.r), static_cast<half>(em.g), static_cast<half>(em.b)};
 
             // Set specular properties
             if (state.fShadeFlags & hsGMatState::kShadeSpecular) {
                 hsColorRGBA spec = currLayer->GetSpecularColor();
-                fCurrentRenderPassUniforms->specularCol = {static_cast<half>(spec.r), static_cast<half>(spec.g), static_cast<half>(spec.b)};
+                fCurrentRenderPassMaterialLighting.specularCol = {static_cast<half>(spec.r), static_cast<half>(spec.g), static_cast<half>(spec.b)};
 #if 0
                 mat.Power = currLayer->GetSpecularPower();
 #endif
             } else {
-                fCurrentRenderPassUniforms->specularCol = {0.f, 0.f, 0.f};
+                fCurrentRenderPassMaterialLighting.specularCol = {0.f, 0.f, 0.f};
             }
 
-            fCurrentRenderPassUniforms->diffuseSrc = 1.f;
-            fCurrentRenderPassUniforms->emissiveSrc = 1.f;
-            fCurrentRenderPassUniforms->specularSrc = 1.f;
+            fCurrentRenderPassMaterialLighting.diffuseSrc = 1.f;
+            fCurrentRenderPassMaterialLighting.emissiveSrc = 1.f;
+            fCurrentRenderPassMaterialLighting.specularSrc = 1.f;
 
             if (state.fShadeFlags & hsGMatState::kShadeNoShade) {
-                fCurrentRenderPassUniforms->ambientSrc = 1.f;
+                fCurrentRenderPassMaterialLighting.ambientSrc = 1.f;
             } else {
-                fCurrentRenderPassUniforms->ambientSrc = 0.f;
+                fCurrentRenderPassMaterialLighting.ambientSrc = 0.f;
             }
             fCurrLightingMethod = plSpan::kLiteMaterial;
 
@@ -2193,20 +2196,20 @@ void plMetalPipeline::ICalcLighting(plMetalMaterialShaderRef* mRef, const plLaye
 
         case plSpan::kLiteVtxPreshaded: // Vtx preshaded
         {
-            fCurrentRenderPassUniforms->globalAmb = {0.f, 0.f, 0.f};
-            fCurrentRenderPassUniforms->ambientCol = {0.f, 0.f, 0.f};
-            fCurrentRenderPassUniforms->diffuseCol = {0.f, 0.f, 0.f, 0.f};
-            fCurrentRenderPassUniforms->emissiveCol = {0.f, 0.f, 0.f};
-            fCurrentRenderPassUniforms->specularCol = {0.f, 0.f, 0.f};
+            fCurrentRenderPassMaterialLighting.globalAmb = {0.f, 0.f, 0.f};
+            fCurrentRenderPassMaterialLighting.ambientCol = {0.f, 0.f, 0.f};
+            fCurrentRenderPassMaterialLighting.diffuseCol = {0.f, 0.f, 0.f, 0.f};
+            fCurrentRenderPassMaterialLighting.emissiveCol = {0.f, 0.f, 0.f};
+            fCurrentRenderPassMaterialLighting.specularCol = {0.f, 0.f, 0.f};
 
-            fCurrentRenderPassUniforms->diffuseSrc = 0.f;
-            fCurrentRenderPassUniforms->ambientSrc = 1.f;
-            fCurrentRenderPassUniforms->specularSrc = 1.f;
+            fCurrentRenderPassMaterialLighting.diffuseSrc = 0.f;
+            fCurrentRenderPassMaterialLighting.ambientSrc = 1.f;
+            fCurrentRenderPassMaterialLighting.specularSrc = 1.f;
 
             if (state.fShadeFlags & hsGMatState::kShadeEmissive) {
-                fCurrentRenderPassUniforms->emissiveSrc = 0.f;
+                fCurrentRenderPassMaterialLighting.emissiveSrc = 0.f;
             } else {
-                fCurrentRenderPassUniforms->emissiveSrc = 1.f;
+                fCurrentRenderPassMaterialLighting.emissiveSrc = 1.f;
             }
 
             fCurrLightingMethod = plSpan::kLiteVtxPreshaded;
@@ -2215,30 +2218,30 @@ void plMetalPipeline::ICalcLighting(plMetalMaterialShaderRef* mRef, const plLaye
 
         case plSpan::kLiteVtxNonPreshaded: // Vtx non-preshaded
         {
-            fCurrentRenderPassUniforms->ambientCol = {0.f, 0.f, 0.f};
-            fCurrentRenderPassUniforms->diffuseCol = {0.f, 0.f, 0.f, 0.f};
+            fCurrentRenderPassMaterialLighting.ambientCol = {0.f, 0.f, 0.f};
+            fCurrentRenderPassMaterialLighting.diffuseCol = {0.f, 0.f, 0.f, 0.f};
 
             hsColorRGBA em = currLayer->GetAmbientColor();
-            fCurrentRenderPassUniforms->emissiveCol = {static_cast<half>(em.r), static_cast<half>(em.g), static_cast<half>(em.b)};
+            fCurrentRenderPassMaterialLighting.emissiveCol = {static_cast<half>(em.r), static_cast<half>(em.g), static_cast<half>(em.b)};
 
             // Set specular properties
             if (state.fShadeFlags & hsGMatState::kShadeSpecular) {
                 hsColorRGBA spec = currLayer->GetSpecularColor();
-                fCurrentRenderPassUniforms->specularCol = {static_cast<half>(spec.r), static_cast<half>(spec.g), static_cast<half>(spec.b)};
+                fCurrentRenderPassMaterialLighting.specularCol = {static_cast<half>(spec.r), static_cast<half>(spec.g), static_cast<half>(spec.b)};
 #if 0
                 mat.Power = currLayer->GetSpecularPower();
 #endif
             } else {
-                fCurrentRenderPassUniforms->specularCol = {0.f, 0.f, 0.f};
+                fCurrentRenderPassMaterialLighting.specularCol = {0.f, 0.f, 0.f};
             }
 
             hsColorRGBA amb = currLayer->GetPreshadeColor();
-            fCurrentRenderPassUniforms->globalAmb = {static_cast<half>(amb.r), static_cast<half>(amb.g), static_cast<half>(amb.b), static_cast<half>(amb.a)};
+            fCurrentRenderPassMaterialLighting.globalAmb = {static_cast<half>(amb.r), static_cast<half>(amb.g), static_cast<half>(amb.b), static_cast<half>(amb.a)};
 
-            fCurrentRenderPassUniforms->ambientSrc = 0;
-            fCurrentRenderPassUniforms->diffuseSrc = 0;
-            fCurrentRenderPassUniforms->emissiveSrc = 1;
-            fCurrentRenderPassUniforms->specularSrc = 1;
+            fCurrentRenderPassMaterialLighting.ambientSrc = 0;
+            fCurrentRenderPassMaterialLighting.diffuseSrc = 0;
+            fCurrentRenderPassMaterialLighting.emissiveSrc = 1;
+            fCurrentRenderPassMaterialLighting.specularSrc = 1;
 
             fCurrLightingMethod = plSpan::kLiteVtxNonPreshaded;
             break;
@@ -3197,7 +3200,7 @@ bool plMetalPipeline::IPushShadowCastState(plShadowSlave* slave)
         return false;
 
     // Set texture to U_LUT
-    fCurrentRenderPassUniforms->specularSrc = 0.0;
+    fCurrentRenderPassMaterialLighting.specularSrc = 0.0;
 
     // if( !ref->fTexture )
     //{
@@ -3886,17 +3889,17 @@ void plMetalPipeline::ISetShadowLightState(hsGMaterial* mat)
     fCurrLightingMethod = plSpan::kLiteShadow;
 
     if (mat && mat->GetNumLayers() && mat->GetLayer(0))
-        fCurrentRenderPassUniforms->diffuseCol.r = fCurrentRenderPassUniforms->diffuseCol.g = fCurrentRenderPassUniforms->diffuseCol.b = mat->GetLayer(0)->GetOpacity();
+        fCurrentRenderPassMaterialLighting.diffuseCol.r = fCurrentRenderPassMaterialLighting.diffuseCol.g = fCurrentRenderPassMaterialLighting.diffuseCol.b = mat->GetLayer(0)->GetOpacity();
     else
-        fCurrentRenderPassUniforms->diffuseCol.r = fCurrentRenderPassUniforms->diffuseCol.g = fCurrentRenderPassUniforms->diffuseCol.b = 1.f;
-    fCurrentRenderPassUniforms->diffuseCol.a = 1.f;
+        fCurrentRenderPassMaterialLighting.diffuseCol.r = fCurrentRenderPassMaterialLighting.diffuseCol.g = fCurrentRenderPassMaterialLighting.diffuseCol.b = 1.f;
+    fCurrentRenderPassMaterialLighting.diffuseCol.a = 1.f;
 
-    fCurrentRenderPassUniforms->diffuseSrc = 1.0f;
-    fCurrentRenderPassUniforms->emissiveSrc = 1.0f;
-    fCurrentRenderPassUniforms->emissiveCol = 0.0f;
-    fCurrentRenderPassUniforms->specularSrc = 0.0f;
-    fCurrentRenderPassUniforms->ambientSrc = 0.0f;
-    fCurrentRenderPassUniforms->globalAmb = 0.0f;
+    fCurrentRenderPassMaterialLighting.diffuseSrc = 1.0f;
+    fCurrentRenderPassMaterialLighting.emissiveSrc = 1.0f;
+    fCurrentRenderPassMaterialLighting.emissiveCol = 0.0f;
+    fCurrentRenderPassMaterialLighting.specularSrc = 0.0f;
+    fCurrentRenderPassMaterialLighting.ambientSrc = 0.0f;
+    fCurrentRenderPassMaterialLighting.globalAmb = 0.0f;
 }
 
 // IDisableLightsForShadow ///////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
@@ -168,6 +168,7 @@ public:
 
 private:
     VertexUniforms* fCurrentRenderPassUniforms;
+    plMaterialLightingDescriptor fCurrentRenderPassMaterialLighting;
     
     bool fIsFullscreen;
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.cpp
@@ -110,6 +110,8 @@ void plMetalMaterialPassPipelineState::GetFunctionConstants(MTL::FunctionConstan
     constants->setConstantValues(&fFragmentShaderDescription.fPassTypes, MTL::DataTypeUChar, NS::Range(FunctionConstantSources, 8));
     constants->setConstantValues(&fFragmentShaderDescription.fBlendModes, MTL::DataTypeUInt, NS::Range(FunctionConstantBlendModes, 8));
     constants->setConstantValues(&fFragmentShaderDescription.fMiscFlags, MTL::DataTypeUInt, NS::Range(FunctionConstantLayerFlags, 8));
+    bool perPixelLighting = PLASMA_PER_PIXEL_LIGHTING;
+    constants->setConstantValue(&perPixelLighting, MTL::DataTypeBool, FunctionConstantPerPixelLighting);
 }
 
 size_t plMetalMaterialPassPipelineState::GetHash() const
@@ -267,23 +269,21 @@ void plMetalRenderSpanPipelineState::ConfigureBlendMode(const uint32_t blendMode
 MTL::Function* plMetalMaterialPassPipelineState::GetVertexFunction(MTL::Library* library)
 {
     NS::Error*                   error = nullptr;
-    MTL::FunctionConstantValues* constants = MTL::FunctionConstantValues::alloc()->init()->autorelease();
-    GetFunctionConstants(constants);
-    MTL::Function* function = library->newFunction(
-                                         NS::String::string("pipelineVertexShader", NS::ASCIIStringEncoding),
-                                         MakeFunctionConstants(),
-                                         &error)
-                                  ->autorelease();
-    return function;
+    MTL::Function* function = library->newFunction(NS::String::string("pipelineVertexShader", NS::ASCIIStringEncoding),
+                                                   MakeFunctionConstants(),
+                                                   &error);
+    assert(!error);
+    return function->autorelease();
 }
 
 MTL::Function* plMetalMaterialPassPipelineState::GetFragmentFunction(MTL::Library* library)
 {
-    return library->newFunction(
-                      NS::String::string("pipelineFragmentShader", NS::ASCIIStringEncoding),
-                      MakeFunctionConstants(),
-                      (NS::Error**)nullptr)
-        ->autorelease();
+    NS::Error* error = nullptr;
+    MTL::Function* function = library->newFunction(NS::String::string("pipelineFragmentShader", NS::ASCIIStringEncoding),
+                                                   MakeFunctionConstants(),
+                                                   &error);
+    assert(!error);
+    return function->autorelease();
 }
 
 plMetalMaterialPassPipelineState::~plMetalMaterialPassPipelineState()

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.h
@@ -50,6 +50,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plMetalDevice.h"
 #include "plSurface/plShaderTable.h"
 
+#ifndef PLASMA_PER_PIXEL_LIGHTING
+#define PLASMA_PER_PIXEL_LIGHTING 0
+#endif
+
 enum plMetalPipelineType
 {
     // Unknown is for abstract types, don't use it


### PR DESCRIPTION
This PR adds Metal per pixel lighting support to the shaders - controlled by a preprocessor flag. Per pixel lighting defaults to off in since it's an alternative rendering mode that does not match the original engine. While per pixel lighting seems correct - it should be regarded as experimental. Per pixel shading enables a shader variant for the "fixed" pipeline shader. This shader variant is controlled by a shader compile time flag. However - this flag is a constant function which means evaluation of it can be deferred to when the shader is compiled from Metal byte code into vender specific assembly. I.E. - Metal can wait to apply the flag until the final runtime shader compilation.

Metal was originally ported from the OpenGL fork which used per pixel lighting. Metal switched back to per vertex for several reasons:
- The fragment shader function was trying to emulate the Direct3D fixed function pipeline - and because of high register usage was running into a lot of register overflows. The additional registers required by per pixel rendering was causing extreme performance issues. The shader has moved most of this register usage into compile time constants - so there are enough registers free now to do per pixel lighting.
- Most of Uru uses lower complexity meshes or light maps. Bump mapping was never in Uru. So the benefits of per pixel lighting were less - and per pixel lighting was deprioritized.

Please look over this closely - I want to make sure the per vertex path has remained unchanged. Not in a rush to get this in.