### PR TITLE
Try moving Metal Layer handling to the pipeline

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
@@ -41,7 +41,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #import "PLSView.h"
-#include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h>
 #include "plMessage/plInputEventMsg.h"
 
@@ -63,35 +62,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 @interface PLSView ()
 
 @property NSTrackingArea* mouseTrackingArea;
-#if PLASMA_PIPELINE_METAL
-@property(weak) CAMetalLayer* metalLayer;
-#endif
 
 @end
 
 @implementation PLSView
 
-// MARK: View setup
-- (id)initWithFrame:(NSRect)frameRect
-{
-    self = [super initWithFrame:frameRect];
-#if PLASMA_PIPELINE_METAL
-    CAMetalLayer* layer = [CAMetalLayer layer];
-    layer.contentsScale = [[NSScreen mainScreen] backingScaleFactor];
-    layer.maximumDrawableCount = 3;
-    layer.pixelFormat = MTLPixelFormatBGR10A2Unorm;
-    self.layer = self.metalLayer = layer;
-#endif
-    self.layer.backgroundColor = NSColor.blackColor.CGColor;
-    return self;
-}
-
 - (BOOL)acceptsFirstResponder
-{
-    return YES;
-}
-
-- (BOOL)wantsLayer
 {
     return YES;
 }
@@ -275,9 +251,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
         return;
     }
 
-#if PLASMA_PIPELINE_METAL
-    _metalLayer.drawableSize = newSize;
-#endif
+    self.layer.contentsScale = scaleFactor;
+
+    if ([self.layer isKindOfClass:[CAMetalLayer class]]) {
+        ((CAMetalLayer*)self.layer).drawableSize = newSize;
+    }
+
     [self.delegate renderView:self
           didChangeOutputSize:newSize
                         scale:scaleFactor];

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -4372,6 +4372,14 @@ uint32_t plMetalPipeline::IGetBufferFormatSize(uint8_t format) const
     return size;
 }
 
+CALayer* plMetalPipeline::GetRenderLayer()
+{
+    CA::MetalLayer* layer = CA::MetalLayer::layer();
+    layer->setPixelFormat(MTL::PixelFormatBGR10A2Unorm);
+
+    return reinterpret_cast<CALayer*>(layer);
+}
+
 void plMetalPipeline::plMetalPipelineCurrentState::Reset()
 {
     fCurrentPipelineState = nullptr;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -4372,7 +4372,7 @@ uint32_t plMetalPipeline::IGetBufferFormatSize(uint8_t format) const
     return size;
 }
 
-CALayer* plMetalPipeline::GetRenderLayer()
+CALayer* plMetalPipeline::GetRenderLayer() const
 {
     CA::MetalLayer* layer = CA::MetalLayer::layer();
     layer->setPixelFormat(MTL::PixelFormatBGR10A2Unorm);

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
@@ -138,6 +138,7 @@ public:
     int            GetMaxAnisotropicSamples() override;
     int            GetMaxAntiAlias(int Width, int Height, int ColorDepth) override;
     void           ResetDisplayDevice(int Width, int Height, int ColorDepth, bool Windowed, int NumAASamples, int MaxAnisotropicSamples, bool vSync = false) override;
+    CALayer*       GetRenderLayer() override;
     void           RenderSpans(plDrawableSpans* ice, const std::vector<int16_t>& visList) override;
     void           ISetupTransforms(plDrawableSpans* drawable, const plSpan& span, hsMatrix44& lastL2W);
     bool           ICheckDynBuffers(plDrawableSpans* drawable, plGBufferGroup* group, const plSpan* spanBase);

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
@@ -138,7 +138,7 @@ public:
     int            GetMaxAnisotropicSamples() override;
     int            GetMaxAntiAlias(int Width, int Height, int ColorDepth) override;
     void           ResetDisplayDevice(int Width, int Height, int ColorDepth, bool Windowed, int NumAASamples, int MaxAnisotropicSamples, bool vSync = false) override;
-    CALayer*       GetRenderLayer() override;
+    CALayer*       GetRenderLayer() const override;
     void           RenderSpans(plDrawableSpans* ice, const std::vector<int16_t>& visList) override;
     void           ISetupTransforms(plDrawableSpans* drawable, const plSpan& span, hsMatrix44& lastL2W);
     bool           ICheckDynBuffers(plDrawableSpans* drawable, plGBufferGroup* group, const plSpan* spanBase);

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -60,6 +60,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define DEFAULT_SHADOWS 0
 #define DEFAULT_PLANARREFLECTIONS 0
 
+#if __OBJC__
+    @class CALayer;
+#else
+    class CALayer;
+#endif
 
 struct hsPoint3;
 struct hsVector3;
@@ -354,7 +359,11 @@ public:
     plDisplayMode fDesktopParams;
 
     virtual size_t GetViewStackSize() const = 0;
-    
+
+#ifdef HS_BUILD_FOR_MACOS
+    virtual CALayer* GetRenderLayer() { return nullptr; }
+#endif
+
     float fBackingScale = 1.0f;
     void SetBackingScale(float scale) { fBackingScale = scale; };
 };

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -361,7 +361,7 @@ public:
     virtual size_t GetViewStackSize() const = 0;
 
 #ifdef HS_BUILD_FOR_MACOS
-    virtual CALayer* GetRenderLayer() { return nullptr; }
+    virtual CALayer* GetRenderLayer() const { return nullptr; }
 #endif
 
     float fBackingScale = 1.0f;


### PR DESCRIPTION
The goal here is to make the pipeline implementation responsible for constructing the renderer layer, so that everything related to Metal can be handled by the Metal pipeline and (eventually) everything related to GL can be handled by the GL pipeline. The client just has a layer as part of its view and doesn't need to care what renderer is being used.