### PR TITLE
Update to vcpkg tag 2024.01.12

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -38,11 +38,6 @@
     ],
     "overrides": [
       {
-        "name": "openssl",
-        "version": "3.0.8#2",
-        "$comment": "OpenSSL 3.1.x has a bug on arm64 macOS that causes crashes in debug builds. Use 3.0.x for now."
-      },
-      {
         "name": "physx",
         "version": "4.1.2#6",
         "$comment": "Upstream vcpkg updated to PhysX 5, which drops support for several target platforms. Stick with 4.1.2 for now."
@@ -59,7 +54,7 @@
         ]
       }
     },
-    "builtin-baseline": "a42af01b72c28a8e1d7b48107b33e4f286a55ef6",
+    "builtin-baseline": "53bef8994c541b6561884a8395ea35715ece75db",
     "vcpkg-configuration": {
       "overlay-ports": ["./Scripts/Ports"],
       "overlay-triplets": ["./Scripts/Triplets"]


### PR DESCRIPTION
This includes OpenSSL 3.2.0, so we can stop pinning an old 3.0.x version (because 3.1.x had bugs on macOS AArch64 that are solved in 3.2.0).

## Version Changes

* **curl**
  `8.4.0` -> `8.5.0`
* **freetype**
  `2.12.1#4` -> `2.12.1#5`
* **libpng**
  `1.6.39#1` -> `1.6.40#1`
* **libvpx**
  `1.13.1` -> `1.13.1#2`
* **openssl**
  `3.0.8#2` -> `3.2.0#2`
* **string-theory**
  `3.6` -> `3.8`