### PR TITLE
Use 4 concurrent jobs in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,11 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build build --config "${{ matrix.cfg.type }}" -j 2
+          cmake --build build --config "${{ matrix.cfg.type }}" -j 4
 
       - name: Install
         run: |
-          cmake --build build --target INSTALL --config "${{ matrix.cfg.type }}" -j 2
+          cmake --build build --target INSTALL --config "${{ matrix.cfg.type }}" -j 4
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
@@ -98,7 +98,7 @@ jobs:
 
       - name: Test
         run: |
-          cmake --build build --target check --config "${{ matrix.cfg.type }}" -j 2
+          cmake --build build --target check --config "${{ matrix.cfg.type }}" -j 4
 
   max:
     # Can only run if we have a token for our super seekrit Max SDK repo. Sad.
@@ -161,7 +161,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build build --target INSTALL --config Release -j 2
+          cmake --build build --target INSTALL --config Release -j 4
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
@@ -231,11 +231,11 @@ jobs:
 
       - name: Test
         run: |
-          cmake --build build --target check -j 2
+          cmake --build build --target check -j 4
 
       - name: Install
         run: |
-          cmake --build build --target install -j 2
+          cmake --build build --target install -j 4
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/