### PR TITLE
Restore vftable of `hsRefCount`.

### DIFF
--- a/Sources/Plasma/CoreLib/hsRefCnt.h
+++ b/Sources/Plasma/CoreLib/hsRefCnt.h
@@ -53,9 +53,9 @@ public:
                 hsRefCnt(int initRefs = 1);
     virtual     ~hsRefCnt();
 
-    inline int  RefCnt() const { return fRefCnt; }
-    void        UnRef(const char* tag = nullptr);
-    void        Ref(const char* tag = nullptr);
+    virtual int  RefCnt() const { return fRefCnt; }
+    virtual void UnRef(const char* tag = nullptr);
+    virtual void Ref(const char* tag = nullptr);
 
     // Useless, but left here for debugging compatibility with AtomicRef
     void        TransferRef(const char* oldTag, const char* newTag);


### PR DESCRIPTION
This restores the vftable of `hsRefCount` to match its layout in TPotS and the original MOUL. Having these methods be virtual is extremely helpful in the case of ModDLLs that define external creatables. If you're making an external creatable, it's important that those creatables are allocated and deallocated by the ModDLL itself. If `UnRef()` is not virtual, then your external creatable may be deleted by the engine, which may not be built against the same C++ runtime library as the engine. If the two C++ runtime libraries are not ABI compatible, this can result in sinister crashes. This is most relevant for very, very old builds of the engine, such as TPotS (Visual C++ 6) where it would be nice to build a ModDLL with a newer compiler.

(Yes, this does mean that I have made a ModDLL with an external creatable. The pure virtual function call was *very* surprising.)