### PR TITLE
Use M1 macOS runners for arm64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,13 +245,13 @@ jobs:
 
 
   macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.platform.runner }}
     name: ${{ matrix.platform.str }}-${{ matrix.cfg.str }}
     strategy:
       matrix:
         platform:
-          - { str: macos-arm64, arch: arm64 }
-          - { str: macos-x64, arch: x86_64 }
+          - { str: macos-arm64, arch: arm64, runner: "macos-14" }
+          - { str: macos-x64, arch: x86_64, runner: "macos-latest" }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -264,7 +264,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew install \
-              ${{ (matrix.platform.arch == 'x86_64' && 'qt@5') || '' }} \
+              qt@5 \
               autoconf \
               automake \
               libtool \
@@ -272,7 +272,7 @@ jobs:
 
       # Workaround for missing distutils on macOS: https://github.com/actions/runner/issues/2958
       - name: Install setuptools
-        run: sudo -H pip install setuptools
+        run: sudo -H pip3 install setuptools
 
       - name: Setup NuGet
         run: |
@@ -298,7 +298,7 @@ jobs:
             -DPLASMA_BUILD_TESTS=ON \
             -DPLASMA_BUILD_TOOLS=ON \
             -DPLASMA_EXTERNAL_RELEASE=${{ matrix.cfg.external }} \
-            ${{ (matrix.platform.arch == 'x86_64' && '-DQt5_ROOT=$(brew --prefix qt@5)') || '' }} \
+            -DQt5_ROOT=$(brew --prefix qt@5) \
             -DVCPKG_INSTALL_OPTIONS=--clean-after-build \
             -S . -B build
         env:


### PR DESCRIPTION
Build times seem to be cut in half using the M1 runners, and this allows us to properly install and build with Qt on arm64 builds.

Worth noting, I also tried running the x86_64 builds on M1 and it failed to compile Python. That might be something we need to look at in the future. For now, I've kept x86_64 running on Intel macOS 12.