### PR TITLE
Allow DPI awareness in plCrashHandler.

### DIFF
--- a/Sources/Plasma/Apps/plCrashHandler/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plCrashHandler/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(
         CoreLib
         plClipboard
         plMessageBox
+        plStatusLog
+        plWinDpi
         pfCrashHandler
 
         $<$<PLATFORM_ID:Windows>:Comctl32>

--- a/Sources/Plasma/Apps/plCrashHandler/plCrashHandler.rc
+++ b/Sources/Plasma/Apps/plCrashHandler/plCrashHandler.rc
@@ -58,7 +58,7 @@ STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_FIXEDSYS | DS_CENTER | 
 EXSTYLE WS_EX_APPWINDOW
 FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    CONTROL         IDB_BITMAP,IDB_BITMAP,"Static",SS_BITMAP | SS_SUNKEN,7,7,286,36
+    CONTROL         IDB_BITMAP,IDB_BITMAP,"Static",SS_BITMAP | SS_REALSIZECONTROL,7,7,291,36
     LTEXT           "Unfortunately, URU has experienced a serious error and had to exit. Please report the following information to the developers.",IDC_STATUS_TEXT,19,57,266,17
     GROUPBOX        "",IDC_STATIC,7,46,291,49
     RTEXT           "Product String",IDC_PRODUCTSTRING,19,85,272,8

--- a/Sources/Plasma/Apps/plCrashHandler/winmain.cpp
+++ b/Sources/Plasma/Apps/plCrashHandler/winmain.cpp
@@ -60,6 +60,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plClipboard/plClipboard.h"
 #include "plMessageBox/hsMessageBox.h"
+#include "plStatusLog/plStatusLog.h"
+#include "plWinDpi/plWinDpi.h"
 
 #include "pfCrashHandler/plCrashSrv.h"
 
@@ -363,6 +365,9 @@ static void IShowCrashDialog(HINSTANCE hInstance)
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
 {
+    plStatusLog::fLoggingOff = true;
+    plWinDpi::Instance();
+
     enum { kArgCrashFile, kArgForceShow };
     const plCmdArgDef cmdLineArgs[] = {
         { kCmdArgRequired | kCmdTypeString, "file", kArgCrashFile },


### PR DESCRIPTION
No more fuzzy crash dialog! This also fixes a minor visual issue whereby the Uru Live banner was slightly smaller than the rest of the dialog, even on 100% scaling.