### PR TITLE
Missing header includes & MinGW fixes

### DIFF
--- a/Sources/Plasma/Apps/plCrashHandler/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plCrashHandler/CMakeLists.txt
@@ -18,14 +18,18 @@ target_link_libraries(
         plWinDpi
         pfCrashHandler
 
-        $<$<PLATFORM_ID:Windows>:Comctl32>
-        $<$<PLATFORM_ID:Windows>:UxTheme>
+        $<$<PLATFORM_ID:Windows>:comctl32>
+        $<$<PLATFORM_ID:Windows>:uxtheme>
 )
 target_compile_definitions(
     plCrashHandler
     PRIVATE
         $<$<PLATFORM_ID:Windows>:UNICODE>
 )
+
+if(MINGW)
+    target_link_options(plCrashHandler PRIVATE -municode)
+endif()
 
 source_group("Source Files" FILES ${plCrashHandler_SOURCES})
 source_group("Resource Files" FILES ${plCrashHandler_RESOURCES})

--- a/Sources/Plasma/Apps/plCrashHandler/winmain.cpp
+++ b/Sources/Plasma/Apps/plCrashHandler/winmain.cpp
@@ -50,11 +50,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <string_view>
 #include <type_traits>
 
-#include <CommCtrl.h>
+#include <commctrl.h>
 #include <shellapi.h>
-#include <Vsstyle.h>
+#include <vsstyle.h>
 #include <vssym32.h>
-#include <Uxtheme.h>
+#include <uxtheme.h>
 
 #include "resource.h"
 

--- a/Sources/Plasma/CoreLib/hsMatrix44.cpp
+++ b/Sources/Plasma/CoreLib/hsMatrix44.cpp
@@ -50,6 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsStream.h"
 
 #include <cmath>
+#include <string_theory/format>
 
 #ifdef HS_BUILD_FOR_APPLE
 #include <Accelerate/Accelerate.h>

--- a/Sources/Plasma/CoreLib/hsThread_Unix.cpp
+++ b/Sources/Plasma/CoreLib/hsThread_Unix.cpp
@@ -45,6 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <cstring>
+#include <string_theory/format>
 
 #define NO_POSIX_CLOCK 1
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -55,6 +55,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plgDispatch.h"
 #include "hsResMgr.h"
 
+#include <string_theory/string_stream>
+
 #include "pfGameGUIMgr.h"
 
 #include "pnInputCore/plKeyMap.h"

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatar.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatar.cpp
@@ -41,7 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <Python.h>
-#include <string_theory/string>
+#include <string_theory/format>
 
 #include "plFileSystem.h"
 #include "plgDispatch.h"

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -56,6 +56,7 @@ class pyAgeInfoStruct;
 class pyPoint3;
 
 #include "HeadSpin.h"
+#include <vector>
 
 class pyGUIDialog;
 class plPipeline;

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue3.cpp
@@ -48,6 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "cyMisc.h"
 #include "pyGlueHelpers.h"
 #include "pySceneObject.h"
+#include "plFileSystem.h"
 #include "pnUUID/pnUUID.h"
 
 PYTHON_GLOBAL_METHOD_DEFINITION(PtSendPetitionToCCR, args, "Params: message,reason=0,title=\"\"\nSends a petition with a message to the CCR group")

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue4.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue4.cpp
@@ -41,7 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <Python.h>
-#include <string_theory/string>
+#include <string_theory/string_stream>
 #include <vector>
 
 #include "pyGeometry3.h"

--- a/Sources/Plasma/FeatureLib/pfPython/cyPhysics.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPhysics.cpp
@@ -50,6 +50,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "cyPhysics.h"
 
+#include <string_theory/format>
+
 #include "plMessage/plAngularVelocityMsg.h"
 #include "plMessage/plDampMsg.h"
 #include "pnMessage/plEnableMsg.h"

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.cpp
@@ -41,7 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <Python.h>
-#include <string_theory/string>
+#include <string_theory/string_stream>
 
 #include "pyKey.h"
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.cpp
@@ -41,7 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <Python.h>
-#include <string_theory/string>
+#include <string_theory/format>
 
 #include "pyKey.h"
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameCliGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameCliGlue.cpp
@@ -40,11 +40,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+#include <Python.h>
 #include "pyGameCli.h"
 
 #include "plPythonConvert.h"
 
-#include <Python.h>
 
 // ===========================================================================
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGmBlueSpiralGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGmBlueSpiralGlue.cpp
@@ -40,12 +40,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+#include <Python.h>
+
 #include "pyGmBlueSpiral.h"
 
 #include "pyGameCli.h"
 #include "plPythonConvert.h"
-
-#include <Python.h>
 
 // ===========================================================================
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGmMarkerGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGmMarkerGlue.cpp
@@ -40,14 +40,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+#include <Python.h>
+#include <string_theory/string>
+
 #include "pyGmMarker.h"
 
 #include "pyEnum.h"
 #include "pyGameCli.h"
 #include "plPythonConvert.h"
-
-#include <Python.h>
-#include <string_theory/string>
 
 // ===========================================================================
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyKey.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyKey.h
@@ -49,8 +49,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //////////////////////////////////////////////////////////////////////
 
 #include "pnKeyedObject/plKey.h"
-
 #include "pyGlueHelpers.h"
+#include <utility>
 
 class plPythonFileMod;
 class plPipeline;

--- a/Sources/Plasma/FeatureLib/pfPython/pyMarkerMgr.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyMarkerMgr.h
@@ -49,6 +49,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //////////////////////////////////////////////////////////////////////
 
 #include "HeadSpin.h"
+#include "pyGlueHelpers.h"
 
 class pyPoint3;
 

--- a/Sources/Plasma/FeatureLib/pfPython/pySceneObject.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pySceneObject.cpp
@@ -41,7 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <Python.h>
-#include <string_theory/string>
+#include <string_theory/format>
 
 #include "plAudible.h"
 #include "plgDispatch.h"

--- a/Sources/Plasma/FeatureLib/pfPython/pyStream.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyStream.h
@@ -50,12 +50,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 
 #include "HeadSpin.h"
+#include "hsStream.h"
 #include "pyGlueHelpers.h"
 
 #include <memory>
 #include <vector>
 
-class hsStream;
 class plFileName;
 namespace ST { class string; }
 

--- a/Sources/Plasma/FeatureLib/pfSurface/plGrabCubeMap.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plGrabCubeMap.cpp
@@ -50,6 +50,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsMatrix44.h"
 #include "plPipeline.h"
 
+#include <string_theory/format>
+
 #include "pnSceneObject/plDrawInterface.h"
 #include "pnSceneObject/plSceneObject.h"
 

--- a/Sources/Plasma/FeatureLib/pfSurface/plLayerMovie.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plLayerMovie.cpp
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsResMgr.h"
 #include "hsStream.h"
 
+#include <string_theory/format>
 
 #include "plMessage/plAnimCmdMsg.h"
 #include "plGImage/plMipmap.h"

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plMsgForwarder_h_inc
 
 #include <map>
+#include <vector>
 #include "hsKeyedObject.h"
 
 

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plUoid.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plUoid.cpp
@@ -41,6 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 #include "plUoid.h"
 #include "hsStream.h"
+#include <string_theory/format>
 
 
 //// plLocation //////////////////////////////////////////////////////////////

--- a/Sources/Plasma/NucleusLib/pnMessage/plSDLModifierMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSDLModifierMsg.h
@@ -43,7 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plSDLModifierMsg_INC
 
 #include "plMessage.h"
-
+#include <string_theory/string>
 
 //
 // A msg sent to an SDL modifier to tell it send or recv state.

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAnimStage.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAnimStage.cpp
@@ -54,6 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsTimer.h"
 
 #include <cstdio>
+#include <string_theory/string_stream>
 
 // other
 #include "pnMessage/plNotifyMsg.h"

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBehaviors.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBehaviors.cpp
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plAvBehaviors.h"
 
 #include <algorithm>
+#include <string_theory/format>
 
 #include "plAvBrainHuman.h"
 #include "plArmatureMod.h"

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainSwim.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainSwim.cpp
@@ -65,6 +65,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsTimer.h"
 
 #include <cmath>
+#include <string_theory/format>
 
 // other
 #include "pnMessage/plCameraMsg.h"

--- a/Sources/Plasma/PubUtilLib/plAvatar/plCoopCoordinator.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plCoopCoordinator.h
@@ -48,6 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#include <string_theory/string>
 // global
 #include "pnKeyedObject/hsKeyedObject.h"
 

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableGenerator.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableGenerator.cpp
@@ -55,6 +55,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plGeoSpanDice.h"
 #include "plGeometrySpan.h"
 #include "plGBufferGroup.h"
+#include <string_theory/format>
 #include "hsFastMath.h"
 #include "plRenderLevel.h"
 #include "hsResMgr.h"

--- a/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDynaDecalMgr.cpp
@@ -56,6 +56,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plPrintShape.h"
 
+#include <string_theory/format>
+
 #include "plAvatar/plArmatureMod.h"
 
 #include "plParticleSystem/plParticleSystem.h"

--- a/Sources/Plasma/PubUtilLib/plDrawable/plProxyGen.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plProxyGen.cpp
@@ -41,6 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <vector>
+#include <string_theory/format>
 
 #include "HeadSpin.h"
 #include "plProxyGen.h"

--- a/Sources/Plasma/PubUtilLib/plMessage/plAvatarMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAvatarMsg.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plAvatarMsg_inc
 #define plAvatarMsg_inc
 
+#include <string_theory/string>
 #include "hsBitVector.h"
 #include "pnMessage/plEventCallbackMsg.h"
 #include "plAvatar/plAvDefs.h"

--- a/Sources/Plasma/PubUtilLib/plMessage/plConsoleMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plConsoleMsg.h
@@ -45,6 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plConsoleMsg_inc
 #define plConsoleMsg_inc
 
+#include <string_theory/string>
 #include "pnMessage/plMessage.h"
 
 class plEventCallbackMsg;

--- a/Sources/Plasma/PubUtilLib/plMessage/plLoadAvatarMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plLoadAvatarMsg.h
@@ -44,6 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plLoadAvatarMsg_INC
 
 #include "plLoadCloneMsg.h"
+#include <string_theory/string>
 
 class plAvTask;
 class plKey;

--- a/Sources/Plasma/PubUtilLib/plMessage/plOneShotCallbacks.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plOneShotCallbacks.h
@@ -49,6 +49,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnKeyedObject/plKey.h"
 
 #include <vector>
+#include <string_theory/string>
 
 class hsStream;
 class hsResMgr;

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plClientGuid.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plClientGuid.cpp
@@ -43,6 +43,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plClientGuid.h"
 #include "plNetCommon.h"
 
+#include <string_theory/string_stream>
+
 #include "hsStream.h"
 
 #include "pnMessage/plMessage.h"

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetServerSessionInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetServerSessionInfo.cpp
@@ -44,6 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plNetCommon.h"
 
 #include <utility>
+#include <string_theory/string_stream>
 
 #include "hsStream.h"
 

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plSpawnPointInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plSpawnPointInfo.cpp
@@ -45,6 +45,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsStream.h"
 #include "hsBitVector.h"
 
+#include <string_theory/format>
+
 #include "pnMessage/plMessage.h"
 
 const plSpawnPointInfo kDefaultSpawnPoint( kDefaultSpawnPtTitle, kDefaultSpawnPtName );

--- a/Sources/Plasma/PubUtilLib/plPhysX/plLOSDispatch.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plLOSDispatch.h
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plLOSDispatch_H
 
 #include <vector>
+#include <string_theory/string>
 
 #include "hsGeometry3.h"
 

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXCooking.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXCooking.cpp
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plPXCooking.h"
 #include "hsGeometry3.h"
 #include "hsStream.h"
+#include <string_theory/format>
 
 // ==========================================================================
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plCaptureRender.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plCaptureRender.cpp
@@ -41,6 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include "plCaptureRender.h"
+#include <string_theory/format>
 
 #include "plPipeline.h"
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/plPlates.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plPlates.cpp
@@ -47,6 +47,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plPlates.h"
 
+#include <string_theory/format>
+
 #include "plPipeline.h"
 #include "hsGDeviceRef.h"
 #include "plPipeDebugFlags.h"

--- a/Sources/Plasma/PubUtilLib/plPipeline/plRenderTarget.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plRenderTarget.h
@@ -53,6 +53,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef _plRenderTarget_h
 #define _plRenderTarget_h
 
+#include <string_theory/string>
+
 #include "plPipeResReq.h"
 
 #include "plGImage/plBitmap.h"

--- a/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.cpp
@@ -40,6 +40,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 #include "plKeyFinder.h"
+#include <string_theory/format>
 
 #include "plCreatableIndex.h"
 #include "hsResMgr.h"

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
@@ -41,6 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include "plRegistryNode.h"
+#include <string_theory/format>
 
 #include "hsStream.h"
 #include "plRegistryHelpers.h"

--- a/Sources/Plasma/PubUtilLib/plSurface/hsGMaterial.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/hsGMaterial.cpp
@@ -41,6 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <cmath>
+#include <string_theory/format>
 #include "hsGMaterial.h"
 
 #include "HeadSpin.h"

--- a/Sources/Plasma/PubUtilLib/plSurface/plGrassShaderMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plGrassShaderMod.cpp
@@ -40,6 +40,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 #include "plGrassShaderMod.h"
+#include <string_theory/format>
 
 #include "plgDispatch.h"
 #include "hsResMgr.h"

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.cpp
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.cpp
@@ -111,7 +111,10 @@ void plUnifiedTime::ToCurrentTime()
 {
     struct timespec ts;
 
-#if defined(HS_BUILD_FOR_APPLE)
+#if defined(__MINGW32__)
+    int res = clock_gettime(CLOCK_REALTIME, &ts);
+    hsAssert(res == 0, "clock_gettime failed");
+#elif defined(HS_BUILD_FOR_APPLE)
 #if defined(HAVE_BUILTIN_AVAILABLE) && MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
     if (__builtin_available(macOS 10.15, *)) {
         // timespec_get is only supported since macOS 10.15

--- a/Sources/Plasma/PubUtilLib/plWinDpi/plWinDpi.h
+++ b/Sources/Plasma/PubUtilLib/plWinDpi/plWinDpi.h
@@ -47,7 +47,25 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <variant>
 
 #include "hsWindows.h"
-#include <ShellScalingApi.h>
+
+#ifdef HAVE_SHELLSCALINGAPI
+#   include <ShellScalingApi.h>
+#else
+    typedef enum
+    {
+        PROCESS_DPI_UNAWARE = 0,
+        PROCESS_SYSTEM_DPI_AWARE = 1,
+        PROCESS_PER_MONITOR_DPI_AWARE = 2
+    } PROCESS_DPI_AWARENESS;
+
+    typedef enum
+    {
+        MDT_EFFECTIVE_DPI = 0,
+        MDT_ANGULAR_DPI = 1,
+        MDT_RAW_DPI = 2,
+        MDT_DEFAULT = MDT_EFFECTIVE_DPI
+    } MONITOR_DPI_TYPE;
+#endif
 
 #include "plStatusLog/plStatusLog.h"
 

--- a/Sources/Tools/plNetLog/ChunkBuffer.cpp
+++ b/Sources/Tools/plNetLog/ChunkBuffer.cpp
@@ -184,7 +184,7 @@ QString ChunkBuffer::readSafeWString()
     return QString::fromUtf16(buffer.get(), length);
 }
 
-void ChunkBuffer::waitOnData(QMutexLocker& lock)
+void ChunkBuffer::waitOnData(QMutexLocker<QMutex>& lock)
 {
     while (m_chunks.size() == 0) {
         // Give the buffer some time to fill

--- a/Sources/Tools/plNetLog/ChunkBuffer.cpp
+++ b/Sources/Tools/plNetLog/ChunkBuffer.cpp
@@ -184,7 +184,7 @@ QString ChunkBuffer::readSafeWString()
     return QString::fromUtf16(buffer.get(), length);
 }
 
-void ChunkBuffer::waitOnData(QMutexLocker<QMutex>& lock)
+void ChunkBuffer::waitOnData(qtMutexLocker& lock)
 {
     while (m_chunks.size() == 0) {
         // Give the buffer some time to fill

--- a/Sources/Tools/plNetLog/ChunkBuffer.h
+++ b/Sources/Tools/plNetLog/ChunkBuffer.h
@@ -50,6 +50,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <QString>
 #include <QMutex>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+using qtMutexLocker = QMutexLocker<QMutex>;
+#else
+using qtMutexLocker = QMutexLocker;
+#endif
+
 class ChunkBuffer
 {
     ChunkBuffer(const ChunkBuffer&) = delete;
@@ -149,7 +155,7 @@ private:
     QMutex              m_mutex;
     std::list<Buffer>   m_chunks;
 
-    void waitOnData(QMutexLocker<QMutex>& lock);
+    void waitOnData(qtMutexLocker& lock);
 };
 
 #endif

--- a/Sources/Tools/plNetLog/ChunkBuffer.h
+++ b/Sources/Tools/plNetLog/ChunkBuffer.h
@@ -149,7 +149,7 @@ private:
     QMutex              m_mutex;
     std::list<Buffer>   m_chunks;
 
-    void waitOnData(QMutexLocker& lock);
+    void waitOnData(QMutexLocker<QMutex>& lock);
 };
 
 #endif

--- a/Sources/Tools/plNetLog/plNetLog.cpp
+++ b/Sources/Tools/plNetLog/plNetLog.cpp
@@ -176,7 +176,7 @@ plNetLogGUI::plNetLogGUI(QWidget* parent)
     m_autoscroll = new QCheckBox(tr("&Autoscroll"), searchBar);
     m_autoscroll->setChecked(true);
     QGridLayout* searchLayout = new QGridLayout(searchBar);
-    searchLayout->setMargin(0);
+    searchLayout->setContentsMargins(0, 0, 0, 0);
     searchLayout->setHorizontalSpacing(4);
     searchLayout->addWidget(m_searchText, 0, 0);
     searchLayout->addWidget(btnSearch, 0, 1);
@@ -200,7 +200,7 @@ plNetLogGUI::plNetLogGUI(QWidget* parent)
     QLabel* lblPath = new QLabel(tr("MOULa &Client:"), pathSpec);
     lblPath->setBuddy(m_exePath);
     QGridLayout* pathLayout = new QGridLayout(pathSpec);
-    pathLayout->setMargin(0);
+    pathLayout->setContentsMargins(0, 0, 0, 0);
     pathLayout->setHorizontalSpacing(4);
     pathLayout->addWidget(lblPath, 0, 0);
     pathLayout->addWidget(m_exePath, 0, 1);
@@ -211,14 +211,14 @@ plNetLogGUI::plNetLogGUI(QWidget* parent)
     QPushButton* loadAuth = new QPushButton(tr("Load Auth Log"), loadBar);
     QPushButton* loadGame = new QPushButton(tr("Load Game Log"), loadBar);
     QGridLayout* loadLayout = new QGridLayout(loadBar);
-    loadLayout->setMargin(0);
+    loadLayout->setContentsMargins(0, 0, 0, 0);
     loadLayout->setHorizontalSpacing(4);
     loadLayout->addWidget(loadGate, 0, 0);
     loadLayout->addWidget(loadAuth, 0, 1);
     loadLayout->addWidget(loadGame, 0, 2);
 
     QGridLayout* layout = new QGridLayout(window);
-    layout->setMargin(4);
+    layout->setContentsMargins(4, 4, 4, 4);
     layout->addWidget(btnClear, 0, 0);
     layout->addWidget(searchBar, 1, 0);
     layout->addWidget(m_logView, 2, 0);

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -40,6 +40,9 @@ CHECK_INCLUDE_FILE("pmmintrin.h" HAVE_SSE3)
 CHECK_INCLUDE_FILE("emmintrin.h" HAVE_SSE2)
 CHECK_INCLUDE_FILE("xmmintrin.h" HAVE_SSE1)
 
+# Check for Windows Shell Scaling DPI support
+CHECK_INCLUDE_FILE("ShellScalingApi.h" HAVE_SHELLSCALINGAPI)
+
 # GCC requires us to set the -m<instructionset> flag for the source file using the intrinsics.
 # We can't do that project-wide or we'll just crash on launch with an illegal instruction on some
 # systems. So, we have another helper method...

--- a/cmake/hsConfig.h.cmake
+++ b/cmake/hsConfig.h.cmake
@@ -66,5 +66,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #cmakedefine HAVE_SYSCTL
 #cmakedefine HAVE_SYSDIR
 #cmakedefine HAVE_SYSINFO
+#cmakedefine HAVE_SHELLSCALINGAPI
 
 #endif


### PR DESCRIPTION
The first commit is a bunch of missing includes that are masked by PCH and Unity builds. Without those enabled, the project will fail to compile without these fixes.

The second commit is a few fixes to get some things building with MinGW again (I haven't been able to get MinGW Python working locally, so I can't promise that it will fix the whole engine build)