### PR TITLE
Fix warnings on newer CMake about FetchContent

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
@@ -1,5 +1,9 @@
 include(FetchContent)
 
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
 FetchContent_Declare(
     metalcpp
     URL_HASH_SHA256 0afd87ca851465191ae4e3980aa036c7e9e02fe32e7c760ac1a74244aae6023b


### PR DESCRIPTION
This causes it to use the timestamp of the downloaded zip file rather than the timestamps from within the zip file, to ensure that a newer download is always compiled regardless of whether existing extracted files have newer timestamps.