### PR TITLE
Display Helpers

### DIFF
--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -92,6 +92,7 @@ if(WIN32)
 elseif(APPLE)
     list(APPEND plClient_SOURCES
         Mac-Cocoa/main.mm
+        Mac-Cocoa/plMacDisplayHelper.mm
         Mac-Cocoa/NSString+StringTheory.mm
         Mac-Cocoa/PLSKeyboardEventMonitor.mm
         Mac-Cocoa/PLSView.mm
@@ -102,6 +103,7 @@ elseif(APPLE)
     )
     list(APPEND plClient_HEADERS
         Mac-Cocoa/NSString+StringTheory.h
+        Mac-Cocoa/plMacDisplayHelper.h
         Mac-Cocoa/PLSKeyboardEventMonitor.h
         Mac-Cocoa/PLSView.h
         Mac-Cocoa/PLSLoginWindowController.h

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -202,6 +202,7 @@ static void* const DeviceDidChangeContext = (void*)&DeviceDidChangeContext;
     
     _displayHelper = std::make_shared<plMacDisplayHelper>();
     _displayHelper->SetCurrentScreen([window screen]);
+    _displayHelper->MakeCurrentDisplayHelper();
     
     gClient.SetClientWindow((__bridge void *)view.layer);
     gClient.SetClientDisplay((hsWindowHndl)NULL);
@@ -404,7 +405,6 @@ dispatch_queue_t loadingQueue = dispatch_queue_create("", DISPATCH_QUEUE_SERIAL)
         [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
     }
     
-    gClient->GetPipeline()->SetDisplayHelper(_displayHelper);
 
     if (!gClient || gClient->GetDone()) {
         [NSApp terminate:self];

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/plMacDisplayHelper.h
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/plMacDisplayHelper.h
@@ -1,0 +1,77 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef plMacDisplayHelper_hpp
+#define plMacDisplayHelper_hpp
+
+#include <stdio.h>
+// Currently requires Metal to query attached GPU capabilities
+// Capability check will also work for GL - but will need something
+// different for older GPUs.
+#include <AppKit/AppKit.h>
+#include <Metal/Metal.hpp>
+#include <QuartzCore/QuartzCore.h>
+
+#include "plPipeline.h"
+
+class plMacDisplayHelper: public plDisplayHelper
+{
+public:
+    CGDirectDisplayID CurrentDisplay() { return fCurrentDisplay; }
+    // we need NSScreen to query for non rectangular screen geometry
+    void SetCurrentScreen(NSScreen* screen);
+
+    plDisplayMode DefaultDisplayMode() override { return fDefaultDisplayMode; };
+    void GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth = 32) override;
+
+    MTL::Device* RenderDevice() { return fRenderDevice; }
+    
+    plMacDisplayHelper();
+    ~plMacDisplayHelper();
+private:
+    CGDirectDisplayID fCurrentDisplay;
+    MTL::Device* fRenderDevice = nullptr;
+    plDisplayMode fDefaultDisplayMode;
+    std::vector<plDisplayMode> fDisplayModes;
+};
+
+#endif /* plMacDisplayHelper_hpp */

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/plMacDisplayHelper.h
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/plMacDisplayHelper.h
@@ -51,7 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <Metal/Metal.hpp>
 #include <QuartzCore/QuartzCore.h>
 
-#include "plPipeline.h"
+#include "plPipeline/hsG3DDeviceSelector.h"
 
 class plMacDisplayHelper: public plDisplayHelper
 {
@@ -61,11 +61,13 @@ public:
     void SetCurrentScreen(NSScreen* screen);
 
     plDisplayMode DefaultDisplayMode() override { return fDefaultDisplayMode; };
-    void GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth = 32) override;
+    void GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth = 32) const override;
+    std::vector<plDisplayMode> GetDisplayModes() const override { return fDisplayModes; }
 
     MTL::Device* RenderDevice() { return fRenderDevice; }
     
     plMacDisplayHelper();
+    plMacDisplayHelper(hsWindowHndl window);
     ~plMacDisplayHelper();
 private:
     CGDirectDisplayID fCurrentDisplay;

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/plMacDisplayHelper.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/plMacDisplayHelper.mm
@@ -40,6 +40,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+#include "plPipeline.h"
 #include "plMacDisplayHelper.h"
 
 // CGDirectDisplayCopyCurrentMetalDevice only declared in Metal.h?
@@ -133,7 +134,7 @@ void plMacDisplayHelper::SetCurrentScreen(NSScreen* screen)
     }
 }
 
-void plMacDisplayHelper::GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth)
+void plMacDisplayHelper::GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth) const
 {
     *res = fDisplayModes;
 }
@@ -142,6 +143,13 @@ plMacDisplayHelper::plMacDisplayHelper()
 {
 
 };
+
+plMacDisplayHelper::plMacDisplayHelper(hsWindowHndl window)
+: plMacDisplayHelper()
+{
+    NSWindow* nsWindow = (__bridge NSWindow*)(window);
+    SetCurrentScreen(nsWindow.screen);
+}
 
 plMacDisplayHelper::~plMacDisplayHelper()
 {

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/plMacDisplayHelper.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/plMacDisplayHelper.mm
@@ -1,0 +1,149 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "plMacDisplayHelper.h"
+
+// CGDirectDisplayCopyCurrentMetalDevice only declared in Metal.h?
+#include <Metal/Metal.h>
+
+void plMacDisplayHelper::SetCurrentScreen(NSScreen* screen)
+{
+    fCurrentDisplay = [screen.deviceDescription[@"NSScreenNumber"] intValue];
+
+    // Calculate the region actually available for full screen
+    NSRect currentResolution = [screen frame];
+    if (@available(macOS 12.0, *)) {
+        NSEdgeInsets currentSafeAreaInsets = [screen safeAreaInsets];
+        // Sigh... Origin doesn't matter but lets do it for inspectability
+        currentResolution.origin.x += currentSafeAreaInsets.left;
+        currentResolution.origin.y += currentSafeAreaInsets.top;
+        currentResolution.size.width -= currentSafeAreaInsets.left + currentSafeAreaInsets.right;
+        currentResolution.size.height -= currentSafeAreaInsets.top + currentSafeAreaInsets.bottom;
+    }
+
+    float safeAspectRatio = currentResolution.size.width / currentResolution.size.height;
+
+    fDisplayModes.clear();
+
+    CFArrayRef displayModes = CGDisplayCopyAllDisplayModes(fCurrentDisplay, nullptr);
+    for(int i=0; i< CFArrayGetCount(displayModes); i++)
+    {
+        // Now filter out the ones that are taller than the safe area aspect ratio
+        // This could break in interesting ways if Apple ships displays that have unsafe
+        // areas along the side - but will prevent us stripping any aspect ratios that don't
+        // match the display entirely.
+        // Asked for better guidance here from Apple - FB13375033
+        CGDisplayModeRef mode = (CGDisplayModeRef)CFArrayGetValueAtIndex(displayModes, i);
+
+        float modeAspectRatio = float(CGDisplayModeGetWidth(mode)) / float(CGDisplayModeGetHeight(mode));
+        if(modeAspectRatio < safeAspectRatio)
+        {
+            continue;
+        }
+
+        // aspect ratio is good - add the mode to the list
+        plDisplayMode plasmaMode;
+        plasmaMode.ColorDepth = 32;
+        plasmaMode.Width = int(CGDisplayModeGetWidth(mode));
+        plasmaMode.Height = int(CGDisplayModeGetHeight(mode));
+
+        fDisplayModes.push_back(plasmaMode);
+    }
+    CFRelease(displayModes);
+
+    // we're going to look for a good default mode, but
+    // in case we somehow don't match at least pick one.
+
+    fDefaultDisplayMode = fDisplayModes.front();
+
+    fRenderDevice->release();
+    fRenderDevice = (__bridge MTL::Device *)(CGDirectDisplayCopyCurrentMetalDevice(fCurrentDisplay));
+
+    // now inspect the GPU and figure out a good default resolution
+    // This code is in Metal (for now) - but it should also work
+    // under OpenGL/Mac as long as the GPU also supports Metal.
+    if(fRenderDevice->supportsFamily(MTL::GPUFamilyMetal3))
+    {
+        // if it's a Metal 3 GPU - it should be good
+        // Pick the native display resolution
+        // (Re-picking the first one here for clarity)
+        fDefaultDisplayMode = fDisplayModes.front();
+    }
+    else
+    {
+        // time to go down the rabit hole
+        int maxWidth = INT_MAX;
+        if(fRenderDevice->lowPower())
+        {
+            // integrated - not Apple Silicon, we know it's not very good
+            maxWidth = 1080;
+        }
+        else if(fRenderDevice->recommendedMaxWorkingSetSize() < 4000000000)
+        {
+            // if it has less than around 4 gigs of VRAM it might still be performance
+            // limited
+            maxWidth = 1400;
+        }
+        
+        for (auto & mode : fDisplayModes) {
+            if(mode.Width <= maxWidth) {
+                fDefaultDisplayMode = mode;
+                abort();
+            }
+        }
+    }
+}
+
+void plMacDisplayHelper::GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth)
+{
+    *res = fDisplayModes;
+}
+
+plMacDisplayHelper::plMacDisplayHelper()
+{
+
+};
+
+plMacDisplayHelper::~plMacDisplayHelper()
+{
+    fRenderDevice->release();
+}

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalEnumerate.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalEnumerate.cpp
@@ -76,12 +76,14 @@ void plMetalEnumerate::Enumerate(std::vector<hsG3DDeviceRecord>& records)
 
         devRec.SetLayersAtOnce(8);
 
-        // Just make a fake mode so the device selector will let it through
-        hsG3DDeviceMode devMode;
-        devMode.SetWidth(hsG3DDeviceSelector::kDefaultWidth);
-        devMode.SetHeight(hsG3DDeviceSelector::kDefaultHeight);
-        devMode.SetColorDepth(hsG3DDeviceSelector::kDefaultDepth);
-        devRec.GetModes().emplace_back(devMode);
+        const plDisplayHelper* displayHelper = plDisplayHelper::CurrentDisplayHelper();
+        for (const auto& mode : displayHelper->GetDisplayModes()) {
+            hsG3DDeviceMode devMode;
+            devMode.SetWidth(mode.Width);
+            devMode.SetHeight(mode.Height);
+            devMode.SetColorDepth(mode.ColorDepth);
+            devRec.GetModes().emplace_back(devMode);
+        }
 
         records.emplace_back(devRec);
     }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -970,7 +970,7 @@ plMipmap* plMetalPipeline::ExtractMipMap(plRenderTarget* targ)
 
 void plMetalPipeline::GetSupportedDisplayModes(std::vector<plDisplayMode>* res, int ColorDepth)
 {
-    fDisplayHelper->GetSupportedDisplayModes(res);
+    plDisplayHelper::CurrentDisplayHelper()->GetSupportedDisplayModes(res);
 }
 
 int plMetalPipeline::GetMaxAnisotropicSamples()

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -970,35 +970,7 @@ plMipmap* plMetalPipeline::ExtractMipMap(plRenderTarget* targ)
 
 void plMetalPipeline::GetSupportedDisplayModes(std::vector<plDisplayMode>* res, int ColorDepth)
 {
-    /*
-     There are decisions to make here.
-
-     Modern macOS does not support "display modes." You panel runs at native resolution at all times, 
-     and you can over-render or under-render. But you never set the display mode of the panel, or get
-     the display mode of the panel. Most games have a "scale slider."
-
-     Note: There are legacy APIs for display modes for compatibility with older software. In since 
-     we're here writing a new renderer, lets do things the right way. The display mode APIs also have
-     trouble with density. I.E. a 4k display might be reported as a 2k display if the window manager is
-     running in a higher DPI mode.
-
-     The basic approach should be to render at whatever the resolution of our output surface is. We're 
-     mostly doing that now (aspect ratio doesn't adjust.)
-
-     Ideally we should support some sort of scaling/semi dynamic renderbuffer resolution thing. But don't 
-     mess with the window servers framebuffer size. macOS has accelerated resolution scaling like consoles
-     do. Use that.
-     */
-
-    std::vector<plDisplayMode> supported;
-    CA::MetalLayer* layer = fDevice.GetOutputLayer();
-    CGSize drawableSize = layer->drawableSize();
-    supported.emplace_back();
-    supported[0].Width = drawableSize.width;
-    supported[0].Height = drawableSize.height;
-    supported[0].ColorDepth = 32;
-
-    *res = supported;
+    fDisplayHelper->GetSupportedDisplayModes(res);
 }
 
 int plMetalPipeline::GetMaxAnisotropicSamples()

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -142,10 +142,17 @@ class plDisplayHelper
 {
 public:
     virtual plDisplayMode DefaultDisplayMode() = 0;
-    virtual void GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth = 32) = 0;
+    virtual void GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth = 32) const = 0;
+    virtual std::vector<plDisplayMode> GetDisplayModes() const = 0;
     
     plDisplayHelper() = default;
     virtual ~plDisplayHelper() = default;
+    
+    static const plDisplayHelper* CurrentDisplayHelper() { return _currentDisplayHelper; }
+    void MakeCurrentDisplayHelper() { _currentDisplayHelper = this; }
+    
+private:
+    static plDisplayHelper* _currentDisplayHelper;
 };
 
 class plPipeline : public plCreatable

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -138,6 +138,16 @@ public:
     int ColorDepth;
 };
 
+class plDisplayHelper
+{
+public:
+    virtual plDisplayMode DefaultDisplayMode() = 0;
+    virtual void GetSupportedDisplayModes(std::vector<plDisplayMode> *res, int ColorDepth = 32) = 0;
+    
+    plDisplayHelper() = default;
+    virtual ~plDisplayHelper() = default;
+};
+
 class plPipeline : public plCreatable
 {
 public:
@@ -357,6 +367,9 @@ public:
     
     float fBackingScale = 1.0f;
     void SetBackingScale(float scale) { fBackingScale = scale; };
+    
+    std::shared_ptr<plDisplayHelper> fDisplayHelper;
+    void SetDisplayHelper(std::shared_ptr<plDisplayHelper> helper) { fDisplayHelper = helper; };
 };
 
 #endif // plPipeline_inc

--- a/Sources/Plasma/NucleusLib/inc/pnSingletons.cpp
+++ b/Sources/Plasma/NucleusLib/inc/pnSingletons.cpp
@@ -43,7 +43,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plgDispatch.h"
 #include "hsResMgr.h"
 #include "plPipeResReq.h"
+#include "plPipeline.h"
 
+plDisplayHelper* plDisplayHelper::_currentDisplayHelper = nullptr;
 hsResMgr* hsgResMgr::fResMgr = nullptr;
 
 plDispatchBase* plgDispatch::Dispatch()


### PR DESCRIPTION
Looking for feedback on this concept. Direct3D is funny in that it directly includes display mode queries as part of its API. For Metal - and OpenGL particularly - things are a bit more interesting. The display mode API is separate from the graphics API.
- Platforms that support multiple renderers may need to share display mode code between the renderers. I.E. Metal and OpenGL on Mac should share the same display mode code for maintainability.
- Some renderers support multiple platforms - and need a maintainable way of abstracting the display mode selection by platform. I.E. OpenGL needs to select display modes on Mac, Windows, and Linux.
- Some platforms have oddities that require deeper interaction with platform native API. I.E. macOS has non rectangular displays, and we need to filter down the available display modes to only that ones that fit on the screen.
- The client itself needs some sort of interaction with this class. It manages the window - and thus knows what display the window is on and when the window changes displays.

This PR adds display helpers as a structure to try to bridge a specific renderer to a platform specific implementation.

I'm not sure how this fits with enumerations - it's possible that this integration needs to happen at a deeper level in the code.