### PR TITLE
Fix missing Anim FFwd Responder Cmd.

### DIFF
--- a/Sources/Tools/MaxComponent/plResponderAnim.cpp
+++ b/Sources/Tools/MaxComponent/plResponderAnim.cpp
@@ -126,9 +126,9 @@ int plResponderCmdAnim::NumTypes()
     return kNumTypes;
 }
 
-static int IndexToOldType(int idx)
+static constexpr int IndexToOldType(int idx)
 {
-    static int oldTypes[] =
+    constexpr int oldTypes[] =
     {
         kRespondPlayAnim,
         kRespondStopAnim, 
@@ -152,6 +152,7 @@ static int IndexToOldType(int idx)
         kRespondFastForwardAnim,
     };
 
+    static_assert(std::size(oldTypes) == kNumTypes, "ResponderAnim enumerations have differing lengths!");
     hsAssert(idx < kNumTypes, "Bad index");
     return oldTypes[idx];
 }

--- a/Sources/Tools/MaxComponent/plResponderAnim.cpp
+++ b/Sources/Tools/MaxComponent/plResponderAnim.cpp
@@ -118,7 +118,7 @@ enum
     kRespondRewindSound,
     kRespondFastForwardAnim,
     
-    kNumTypes = 16
+    kNumTypes = 17
 };
 
 int plResponderCmdAnim::NumTypes()


### PR DESCRIPTION
Fixes the Animation FFwd command missing from the list of potetial responder commands in the Max plugin. How long has this been broken?????????