### PR TITLE
Add support for new DynamicCamMap checkbox.

### DIFF
--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -827,6 +827,10 @@ def PtStartScreenCapture(selfKey,width=800,height=600):
     """Starts a capture of the screen"""
     pass
 
+def PtSupportsPlanarReflections() -> bool:
+    """Returns if planar reflections are supported"""
+    ...
+
 def PtToggleAvatarClickability(on):
     """Turns on and off our avatar's clickability"""
     pass

--- a/Scripts/Python/xIniDisplay.py
+++ b/Scripts/Python/xIniDisplay.py
@@ -62,9 +62,10 @@ kGraphicsQualityLevel = "Quality.Level"
 kGraphicsShadows = "Graphics.Shadow.Enable"
 kGraphicsVerticalSync = "Graphics.EnableVSync"
 kGraphicsShadowQuality = "Graphics.Shadow.VisibleDistance"
+kGraphicsDynamicReflections = "Graphics.EnablePlanarReflections"
 
-CmdList = [kGraphicsWidth, kGraphicsHeight, kGraphicsColorDepth, kGraphicsWindowed, kGraphicsTextureQuality, kGraphicsAntiAliasLevel, kGraphicsAnisotropicLevel, kGraphicsQualityLevel, kGraphicsShadows, kGraphicsVerticalSync, kGraphicsShadowQuality]
-DefaultsList = ["800", "600", "32", "false", "2", "0", "0", "2", "true", "false", "0"]
+CmdList = [kGraphicsWidth, kGraphicsHeight, kGraphicsColorDepth, kGraphicsWindowed, kGraphicsTextureQuality, kGraphicsAntiAliasLevel, kGraphicsAnisotropicLevel, kGraphicsQualityLevel, kGraphicsShadows, kGraphicsVerticalSync, kGraphicsShadowQuality, kGraphicsDynamicReflections]
+DefaultsList = ["800", "600", "32", "false", "2", "0", "0", "2", "true", "false", "0", "1"]
 
 def ConstructFilenameAndPath():
     global gFilenameAndPath
@@ -105,6 +106,7 @@ def ReadIni():
         gIniFile.addEntry(kGraphicsShadows + " true")
         gIniFile.addEntry(kGraphicsVerticalSync + " false")
         gIniFile.addEntry(kGraphicsShadowQuality + " 0")
+        gIniFile.addEntry(kGraphicsDynamicReflections + " 1")
         gIniFile.writeFile(gFilenameAndPath)
 
     else:
@@ -120,9 +122,9 @@ def ReadIni():
             ConstructFilenameAndPath()
             gIniFile.writeFile(gFilenameAndPath)
 
-def SetGraphicsOptions(width, heigth, colordepth, windowed, texquality, aaLevel, anisoLevel, qualityLevel, useShadows, vsync, shadowqual):
+def SetGraphicsOptions(width, heigth, colordepth, windowed, texquality, aaLevel, anisoLevel, qualityLevel, useShadows, vsync, shadowqual, dynRefl):
     if gIniFile:
-        paramList = [width, heigth, colordepth, windowed, texquality, aaLevel, anisoLevel, qualityLevel, useShadows, vsync, shadowqual]
+        paramList = [width, heigth, colordepth, windowed, texquality, aaLevel, anisoLevel, qualityLevel, useShadows, vsync, shadowqual, dynRefl]
         for idx in range(len(CmdList)):
             entry,junk = gIniFile.findByCommand(CmdList[idx])
             val = str(paramList[idx])

--- a/Scripts/Python/xOptionsMenu.py
+++ b/Scripts/Python/xOptionsMenu.py
@@ -585,9 +585,7 @@ class xOptionsMenu(ptModifier):
 ###############################################
         if id == OptionsMenuDlg.id:
             if event == kShowHide:
-                if control.isEnabled():
-                    textField = ptGUIControlTextBox(OptionsMenuDlg.dialog.getControlFromTag(kOptionsOkText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Resume"))
+                pass
 
             elif event == kAction or event == kValueChanged:
                 # test to see which control had the event
@@ -667,12 +665,6 @@ class xOptionsMenu(ptModifier):
                 self._releaseNotesCtrl.lock()
             elif event == kShowHide:
                 if control.isEnabled():
-                    # buttons localized
-                    textField = ptGUIControlTextBox(ReleaseNotesDlg.dialog.getControlFromTag(kRNOkText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Resume"))
-                    textField = ptGUIControlTextBox(ReleaseNotesDlg.dialog.getControlFromTag(kRNGoBackText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.GoBack"))
-
                     # BOOM if you do this on dialog load. Probably due to how early it happens
                     # in the init process. Do it now.
                     if not self._releaseNotesCtrl.getBufferSize():
@@ -701,42 +693,6 @@ class xOptionsMenu(ptModifier):
         elif id == KeyMapDlg.id:
             if event == kDialogLoaded:
                 pass
-            elif event == kShowHide:
-                # reset the edit text lines
-                if control.isEnabled():
-                    # localize the strings
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kKMTextLine1))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.KeyCommands.MoveForward"))
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kKMTextLine2))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.KeyCommands.MoveBackward"))
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kKMTextLine3))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.KeyCommands.RotateLeft"))
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kKMTextLine4))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.KeyCommands.RotateRight"))
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kKMTextLine5))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.KeyCommands.Jump"))
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kKMTextLine6))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.KeyCommands.StrafeLeft"))
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kKMTextLine7))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.KeyCommands.StrafeRight"))
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kKMTextLine8))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.KeyCommands.ExitMode"))
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kKMTextLine9))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.KeyCommands.FirstPerson"))
-
-                    # buttons localized
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kOptionsOkText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Resume"))
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kOptionsDefaultsText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Defaults"))
-                    textField = ptGUIControlTextBox(KeyMapDlg.dialog.getControlFromTag(kOptionsGoBackText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.GoBack"))
-                    self.IShowMappedKeys(control,gKM1ControlCodesRow1,gKM1ControlCodesRow2)
-                    # read the ini file in
-                    # xIniInput.ReadIni()
-                else:
-                    # xIniInput.WriteIni()
-                    pass
             elif event == kAction or event == kValueChanged:
                 kmID = control.getTagID()
                 if kmID == kKMOkBtn:
@@ -843,31 +799,6 @@ class xOptionsMenu(ptModifier):
             elif event == kShowHide:
                 if control.isEnabled():
                     self.IRefreshAdvSettings()
-
-                    # localize the strings
-                    textField = ptGUIControlTextBox(AdvGameSettingDlg.dialog.getControlFromTag(kAGSAdvanceHeader))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.Advanced"))
-                    textField = ptGUIControlTextBox(AdvGameSettingDlg.dialog.getControlFromTag(kAGSQuickerCameraText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.SmootherCamera"))
-                    textField = ptGUIControlTextBox(AdvGameSettingDlg.dialog.getControlFromTag(kAGSMouseInvert))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.InvertMouse"))
-                    textField = ptGUIControlTextBox(AdvGameSettingDlg.dialog.getControlFromTag(kAGSWalkAndPan))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.WalkAndPan"))
-                    textField = ptGUIControlTextBox(AdvGameSettingDlg.dialog.getControlFromTag(kAGSStayInFirstPerson))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.StayInFP"))
-                    textField = ptGUIControlTextBox(AdvGameSettingDlg.dialog.getControlFromTag(kAGSClickToTurn))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.ClickToTurn"))
-                    textField = ptGUIControlTextBox(AdvGameSettingDlg.dialog.getControlFromTag(kAGSMouseTurn))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.MouseTurn"))
-
-                    # buttons localized
-                    textField = ptGUIControlTextBox(AdvGameSettingDlg.dialog.getControlFromTag(kOptionsGoBackText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.GoBack"))
-                    textField = ptGUIControlTextBox(AdvGameSettingDlg.dialog.getControlFromTag(kOptionsOkText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Resume"))
-                    textField = ptGUIControlTextBox(AdvGameSettingDlg.dialog.getControlFromTag(kOptionsDefaultsText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Defaults"))
-
             elif event == kAction or event == kValueChanged:
                 gsID = control.getTagID()
                 PtDebugPrint("gsID = " + str(gsID))
@@ -964,14 +895,7 @@ class xOptionsMenu(ptModifier):
 ##
 ###############################################
         elif id == CalibrateDlg.id:
-            if event == kDialogLoaded:
-                textField = ptGUIControlTextBox(CalibrateDlg.dialog.getControlFromTag(kCalMessageText))
-                textField.setString(PtGetLocalizedString("OptionsMenu.Messages.Calibration"))
-            elif event == kShowHide:
-                if control.isEnabled():
-                    textField = ptGUIControlTextBox(CalibrateDlg.dialog.getControlFromTag(kCalMessageText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Messages.Calibration"))
-            elif event == kAction or event == kValueChanged:
+            if event == kAction or event == kValueChanged:
                 cbID = control.getTagID()
                 if cbID == kClickOnMeBtn:
                     CalibrateDlg.dialog.hide()
@@ -1072,14 +996,6 @@ class xOptionsMenu(ptModifier):
                 if control.isEnabled():
                     self.IRefreshHelpSettings()
 
-                    # buttons localized
-                    textField = ptGUIControlTextBox(NavigationDlg.dialog.getControlFromTag(kOptionsGoBackText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.GoBack"))
-                    textField = ptGUIControlTextBox(NavigationDlg.dialog.getControlFromTag(kOptionsOkText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Resume"))
-                    textField = ptGUIControlTextBox(NavigationDlg.dialog.getControlFromTag(kGSAdvancedBtnText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Advanced"))
-
             elif event == kAction or event == kValueChanged:
                 NavigationID = control.getTagID()
                 PtDebugPrint("NavigationID = ", NavigationID)                
@@ -1124,16 +1040,6 @@ class xOptionsMenu(ptModifier):
             if event == kShowHide:
                 if control.isEnabled():
                     self.InitVideoControlsGUI()
-
-                    # buttons localized
-                    # Temporary HACK - These controls lack TagIDs in the 902 PRPs, so we're going to call them up by index instead.
-                    textField = ptGUIControlTextBox(GraphicsSettingsDlg.dialog.getControlFromIndex(3)) # (kOptionsGoBackText) GSGoBackBtnText_5
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.GoBack"))
-                    textField = ptGUIControlTextBox(GraphicsSettingsDlg.dialog.getControlFromIndex(4)) # (kOptionsOkText) GSOkBtnText_6
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Resume"))
-                    textField = ptGUIControlTextBox(GraphicsSettingsDlg.dialog.getControlFromIndex(6)) # (kOptionsDefaultsText) GSDefaultsBtnText_2
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Defaults"))
-
                     self.restartWarn = 0
                     
             elif (event == kAction or event == kValueChanged):
@@ -1253,30 +1159,6 @@ class xOptionsMenu(ptModifier):
             elif event == kShowHide:
                 # reset the edit text lines
                 if control.isEnabled():
-                    # localize the strings
-                    textField = ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kGSVolumeHeader))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.AudioSettings"))
-                    textField = ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kGSVolSoundFXText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.SoundFX"))
-                    textField = ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kGSVolMusicText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.Music"))
-                    textField = ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kGSMyVoiceHeader))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.MyVoice"))
-                    textField = ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kGSVolAmbientText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.Ambient"))
-                    textField = ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kGSVoiceHeader))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.OtherVoice"))
-                    textField = ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kGSVolMuteText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.GameSettings.Mute"))
-
-                    # buttons localized
-                    textField = ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kOptionsGoBackText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.GoBack"))
-                    textField = ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kOptionsOkText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Resume"))
-                    textField = ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kOptionsDefaultsText))
-                    textField.setString(PtGetLocalizedString("OptionsMenu.Main.Defaults"))
-
                     self.restartAudio = 0
 
                 else:

--- a/Scripts/Python/xOptionsMenu.py
+++ b/Scripts/Python/xOptionsMenu.py
@@ -695,6 +695,9 @@ class xOptionsMenu(ptModifier):
         elif id == KeyMapDlg.id:
             if event == kDialogLoaded:
                 pass
+            elif event == kShowHide:
+                if control.isEnabled():
+                    self.IShowMappedKeys(control, gKM1ControlCodesRow1, gKM1ControlCodesRow2)
             elif event == kAction or event == kValueChanged:
                 kmID = control.getTagID()
                 if kmID == kKMOkBtn:

--- a/Scripts/Python/xOptionsMenu.py
+++ b/Scripts/Python/xOptionsMenu.py
@@ -82,7 +82,7 @@ TrailerDlg              = ptAttribGUIDialog(9, "The Trailer dialog")
 AdvGameSettingDlg       = ptAttribGUIDialog(10, "The Adv Game Settings dialog")
 ResetWarnDlg            = ptAttribGUIDialog(11, "The Reset Warning dialog")
 ReleaseNotesDlg         = ptAttribGUIDialog(12, "Release Notes dialog")
-respDisableItems        = ptAttribResponder(13, "resp: Disable Items", ["enableRes", "disableRes", "enableWindow", "disableWindow", "enableEAX", "disableEAX", "enableGamma", "disableGamma"])
+respDisableItems        = ptAttribResponder(13, "resp: Disable Items", ["enableRes", "disableRes", "enableWindow", "disableWindow", "enableEAX", "disableEAX", "enableGamma", "disableGamma", "enableDynRefl", "disableDynRefl"])
 SupportDlg              = ptAttribGUIDialog(14, "Support dialog")
 
 
@@ -372,6 +372,8 @@ kVideoShadowQualitySliderTag = 459
 kVideoResSliderTag = 461
 kVideoResTextTag = 473
 kVideoVerticalSyncCheckTag = 453
+kVideoDynamicReflectionsCheckTag = 900
+kVideoDynamicReflectionsTextTag = 901
 
 kGSAudioMuteCheckbox = 456
 kGSMouseTurnSensSlider = 460
@@ -1450,6 +1452,19 @@ class xOptionsMenu(ptModifier):
         else:
             videoField.setChecked(0)
 
+        dynReflCB = GraphicsSettingsDlg.dialog.getControlModFromTag(kVideoDynamicReflectionsCheckTag)
+        dynReflTB = GraphicsSettingsDlg.dialog.getControlModFromTag(kVideoDynamicReflectionsTextTag)
+        if PtSupportsPlanarReflections():
+            respDisableItems.run(self.key, state="enableDynRefl")
+            dynReflCB.setChecked(bool(opts[xIniDisplay.kGraphicsDynamicReflections]))
+            dynReflCB.enable()
+            dynReflTB.setForeColor(ptColor().white())
+        else:
+            respDisableItems.run(self.key, state="disableDynRefl")
+            dynReflCB.setChecked(False)
+            dynReflCB.disable()
+            dynReflTB.setForeColor(ptColor(0.839, 0.785, 0.695, 1))
+
         # video res stuff
         vidRes = str(opts[xIniDisplay.kGraphicsWidth]) + "x" + str(opts[xIniDisplay.kGraphicsHeight])
         videoResField = ptGUIControlTextBox(GraphicsSettingsDlg.dialog.getControlFromTag(kVideoResTextTag))
@@ -1567,7 +1582,9 @@ class xOptionsMenu(ptModifier):
         gammaField = ptGUIControlKnob(GraphicsSettingsDlg.dialog.getControlFromTag(kGSDisplayGammaSlider))
         gamma = gammaField.getValue()
 
-        xIniDisplay.SetGraphicsOptions(width, height, colordepth, windowed, tex_quality, antialias, aniso, quality, shadowsstr, vsyncstr, shadow_quality)
+        dynRefl = int(GraphicsSettingsDlg.dialog.getControlModFromTag(kVideoDynamicReflectionsCheckTag).isChecked())
+
+        xIniDisplay.SetGraphicsOptions(width, height, colordepth, windowed, tex_quality, antialias, aniso, quality, shadowsstr, vsyncstr, shadow_quality, dynRefl)
         xIniDisplay.WriteIni()
         self.setNewChronicleVar("gamma", gamma)
 
@@ -1576,6 +1593,7 @@ class xOptionsMenu(ptModifier):
             PtDebugPrint("SETTING GAMMA")
             PtSetGamma2(gamma)
             PtSetShadowVisDistance(shadow_quality)
+            PtEnablePlanarReflections(dynRefl)
 
             if shadows:
                 PtEnableShadows()

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -2541,6 +2541,11 @@ void cyMisc::EnablePlanarReflections(bool enable)
     plDynamicCamMap::SetEnabled(enable);
 }
 
+bool cyMisc::ArePlanarReflectionsSupported()
+{
+    return plDynamicCamMap::GetCapable();
+}
+
 void cyMisc::GetSupportedDisplayModes(std::vector<plDisplayMode> *res)
 {
     fPipeline->GetSupportedDisplayModes(res);

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -898,6 +898,7 @@ public:
     static ST::string GetLocalizedString(const ST::string& name, const std::vector<ST::string> & arguments);
 
     static void EnablePlanarReflections(bool enable = true);
+    static bool ArePlanarReflectionsSupported();
     static void SetGraphicsOptions(int Width, int Height, int ColorDepth, bool Windowed, int NumAASamples, int MaxAnisotropicSamples, bool VSync);
     static void GetSupportedDisplayModes(std::vector<plDisplayMode> *res);
     static int GetDesktopWidth();

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue4.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue4.cpp
@@ -610,6 +610,11 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtEnablePlanarReflections, args, "Params: on\nEn
     PYTHON_RETURN_NONE;
 }
 
+PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtSupportsPlanarReflections, "Returns if planar reflections are supported")
+{
+    return PyBool_FromLong(cyMisc::ArePlanarReflectionsSupported() ? 1 : 0);
+}
+
 PYTHON_GLOBAL_METHOD_DEFINITION_NOARGS(PtGetSupportedDisplayModes, "Returns a list of supported resolutions")
 {
     std::vector<plDisplayMode> res;
@@ -818,6 +823,7 @@ void cyMisc::AddPlasmaMethods4(PyObject* m)
         PYTHON_GLOBAL_METHOD_NOARGS(PtCheckVisLOSFromCursor)
 
         PYTHON_GLOBAL_METHOD(PtEnablePlanarReflections)
+        PYTHON_GLOBAL_METHOD_NOARGS(PtSupportsPlanarReflections)
         PYTHON_GLOBAL_METHOD_NOARGS(PtGetSupportedDisplayModes)
         PYTHON_GLOBAL_METHOD_NOARGS(PtGetDesktopWidth)
         PYTHON_GLOBAL_METHOD_NOARGS(PtGetDesktopHeight)


### PR DESCRIPTION
This is the companion piece to H-uru/moul-assets#251. There is no longer any need to manually localize the options menu :tada:. I didn't bother with improving the quality of tangential Python code. All of the options menu Python is terrible, and I didn't want to get bogged down with that.