### PR TITLE
[plLocalizationEditor] Remember the data dir across sessions.

### DIFF
--- a/Sources/Tools/plLocalizationEditor/plEditDlg.cpp
+++ b/Sources/Tools/plLocalizationEditor/plEditDlg.cpp
@@ -52,6 +52,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <QDialog>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QSettings>
 
 static void IAboutDialog(QWidget *parent)
 {
@@ -204,9 +205,12 @@ void EditDialog::closeEvent(QCloseEvent *event)
 
 void EditDialog::OpenDataDirectory()
 {
-    QString path = QFileDialog::getExistingDirectory(this,
+    QSettings settings;
+    QString path = settings.value("dataDir", QDir::current().absolutePath()).toString();
+
+    path = QFileDialog::getExistingDirectory(this,
                 tr("Select a localization data directory:"),
-                QDir::current().absolutePath(),
+                path,
                 QFileDialog::ShowDirsOnly | QFileDialog::ReadOnly);
 
     if (!path.isEmpty())
@@ -217,6 +221,7 @@ void EditDialog::OpenDataDirectory()
 
         fCurrentSavePath = path;
         pfLocalizationMgr::Initialize(fCurrentSavePath.toUtf8().constData());
+        settings.setValue("dataDir", path);
 
         fUI->fLocalizationTree->clear();
         fUI->fLocalizationTree->LoadData("");
@@ -261,6 +266,9 @@ void EditDialog::SaveToDirectory()
         plWaitCursor waitCursor(this);
 
         fCurrentSavePath = path;
+
+        QSettings settings;
+        settings.setValue("dataDir", path);
 
         SetTitle(path);
         pfLocalizationDataMgr::Instance().WriteDatabaseToDisk(fCurrentSavePath.toUtf8().constData());

--- a/Sources/Tools/plLocalizationEditor/plLocalizationEditor.cpp
+++ b/Sources/Tools/plLocalizationEditor/plLocalizationEditor.cpp
@@ -56,6 +56,7 @@ REGISTER_CREATABLE(plResMgrHelperMsg);
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+    app.setOrganizationName("Cyan Worlds");
     app.setApplicationName("plLocalizationEditor");
     app.setWindowIcon(QIcon(":/icon1.ico"));
 


### PR DESCRIPTION
QoL improvement for plLocalizationEditor. It now remembers your last selection for the data directory and puts that path into the open file dialog by default.