### PR TITLE
Downgrade liblzma in vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,11 +268,8 @@ jobs:
               autoconf \
               automake \
               libtool \
-              nasm
-
-      # Workaround for missing distutils on macOS: https://github.com/actions/runner/issues/2958
-      - name: Install setuptools
-        run: sudo -H pip3 install setuptools
+              nasm \
+              python-setuptools
 
       - name: Setup NuGet
         run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -41,6 +41,11 @@
         "name": "physx",
         "version": "4.1.2#6",
         "$comment": "Upstream vcpkg updated to PhysX 5, which drops support for several target platforms. Stick with 4.1.2 for now."
+      },
+      {
+        "name": "liblzma",
+        "version": "5.4.4",
+        "$comment": "liblzma & xz were compromised upstream: CVE-2024-3094."
       }
     ],
     "features": {


### PR DESCRIPTION
This is effectively the same fix they're [making upstream](https://github.com/microsoft/vcpkg/pull/37841), but relying on vcpkg.json to pin the version instead of waiting for their baseline change to make it into a release.

You can confirm that it is using the older liblzma version by looking at the log output of the Configure step and checking for output similar to the following at the top of the log:
```
The following packages will be built and installed:
    [...]
  * liblzma:arm64-macos-plasma@5.4.4 -- /Users/runner/work/Plasma/Plasma/vcpkg/[...]
    [...]
```

Also had to change how python setuptools are installed on macOS because new GitHub Actions runner images weren't happy with using `sudo pip` 🙄 