### PR TITLE
Drop the liblzma dependency entirely

### DIFF
--- a/Scripts/Ports/python3/0001-only-build-required-projects.patch
+++ b/Scripts/Ports/python3/0001-only-build-required-projects.patch
@@ -39,7 +39,8 @@ index 4d416c589e..ede9868a8f 100644
      <ExtensionModules Include="_asyncio;_zoneinfo;_decimal;_elementtree;_msi;_multiprocessing;_overlapped;pyexpat;_queue;select;unicodedata;winsound;_uuid" />
      <ExtensionModules Include="_ctypes" Condition="$(IncludeCTypes)" />
      <!-- Extension modules that require external sources -->
-     <ExternalModules Include="_bz2;_lzma;_sqlite3" />
+-    <ExternalModules Include="_bz2;_lzma;_sqlite3" />
++    <ExternalModules Include="_bz2;_sqlite3" />
      <!-- venv launchers -->
 -    <Projects Include="venvlauncher.vcxproj;venvwlauncher.vcxproj" />
 -    <!-- _ssl will build _socket as well, which may cause conflicts in parallel builds -->

--- a/Scripts/Ports/python3/portfile.cmake
+++ b/Scripts/Ports/python3/portfile.cmake
@@ -99,8 +99,6 @@ if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
         find_library(EXPAT_DEBUG NAMES libexpatd libexpatdMD libexpatdMT PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
         find_library(FFI_RELEASE NAMES ffi PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
         find_library(FFI_DEBUG NAMES ffi PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
-        find_library(LZMA_RELEASE NAMES lzma PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
-        find_library(LZMA_DEBUG NAMES lzma PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
         find_library(SQLITE_RELEASE NAMES sqlite3 PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
         find_library(SQLITE_DEBUG NAMES sqlite3 PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
         find_library(SSL_RELEASE NAMES libssl PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
@@ -238,6 +236,7 @@ else()
         "--with-suffix="
         "--with-system-expat"
         "--without-readline"
+        "--without-lzma"
         "--disable-test-modules"
     )
     set(libs "")

--- a/Scripts/Ports/python3/python_vcpkg.props.in
+++ b/Scripts/Ports/python3/python_vcpkg.props.in
@@ -20,10 +20,10 @@
 
       <!-- Extension modules -->
       <AdditionalDependencies Condition="'$(Configuration)|$(IncludeExtensions)' == 'Release|true'">
-        ${BZ2_RELEASE};${EXPAT_RELEASE};${FFI_RELEASE};${LZMA_RELEASE};${SQLITE_RELEASE};%(AdditionalDependencies)
+        ${BZ2_RELEASE};${EXPAT_RELEASE};${FFI_RELEASE};${SQLITE_RELEASE};%(AdditionalDependencies)
       </AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)|$(IncludeExtensions)' == 'Debug|true'">
-        ${BZ2_DEBUG};${EXPAT_DEBUG};${FFI_DEBUG};${LZMA_DEBUG};${SQLITE_DEBUG};%(AdditionalDependencies)
+        ${BZ2_DEBUG};${EXPAT_DEBUG};${FFI_DEBUG};${SQLITE_DEBUG};%(AdditionalDependencies)
       </AdditionalDependencies>
     </Link>
 
@@ -43,10 +43,10 @@
 
       <!-- Extension modules -->
       <AdditionalDependencies Condition="'$(Configuration)|$(IncludeExtensions)' == 'Release|true'">
-        ${BZ2_RELEASE};${EXPAT_RELEASE};${FFI_RELEASE};${LZMA_RELEASE};${SQLITE_RELEASE};%(AdditionalDependencies)
+        ${BZ2_RELEASE};${EXPAT_RELEASE};${FFI_RELEASE};${SQLITE_RELEASE};%(AdditionalDependencies)
       </AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)|$(IncludeExtensions)' == 'Debug|true'">
-        ${BZ2_DEBUG};${EXPAT_DEBUG};${FFI_DEBUG};${LZMA_DEBUG};${SQLITE_DEBUG};%(AdditionalDependencies)
+        ${BZ2_DEBUG};${EXPAT_DEBUG};${FFI_DEBUG};${SQLITE_DEBUG};%(AdditionalDependencies)
       </AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>

--- a/Scripts/Ports/python3/vcpkg.json
+++ b/Scripts/Ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.10.7",
-  "port-version": 9,
+  "port-version": 10,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",
@@ -23,10 +23,6 @@
     {
       "name": "libiconv",
       "platform": "!windows"
-    },
-    {
-      "name": "liblzma",
-      "platform": "!(windows & static)"
     },
     {
       "name": "libuuid",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -41,11 +41,6 @@
         "name": "physx",
         "version": "4.1.2#6",
         "$comment": "Upstream vcpkg updated to PhysX 5, which drops support for several target platforms. Stick with 4.1.2 for now."
-      },
-      {
-        "name": "liblzma",
-        "version": "5.4.4",
-        "$comment": "liblzma & xz were compromised upstream: CVE-2024-3094."
       }
     ],
     "features": {


### PR DESCRIPTION
It was only used for an optional Python module, which is not needed for Plasma. Since we already manage our own modified Python vcpkg port, we can just disable that optional module.