### PR TITLE
Fix macOS x86_64 CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
       matrix:
         platform:
           - { str: macos-arm64, arch: arm64, runner: "macos-14" }
-          - { str: macos-x64, arch: x86_64, runner: "macos-latest" }
+          - { str: macos-x64, arch: x86_64, runner: "macos-13" }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }


### PR DESCRIPTION
`macos-latest` now points to macos-14 on arm64, and vcpkg doesn't want to build Python for x86_64 when the host is arm64 🙄