### PR TITLE
Detect pthread_setname_np with CMake

### DIFF
--- a/Sources/Plasma/CoreLib/hsThread_Unix.cpp
+++ b/Sources/Plasma/CoreLib/hsThread_Unix.cpp
@@ -78,6 +78,7 @@ int clock_gettime(int clocktype, struct timespec* ts)
 
 void hsThread::SetThisThreadName(const ST::string& name)
 {
+#ifdef HAVE_PTHREAD_SETNAME_NP
 #if defined(HS_BUILD_FOR_APPLE)
     // The Apple version doesn't take a thread argument and always operates on the current thread.
     int res = pthread_setname_np(name.c_str());
@@ -86,7 +87,8 @@ void hsThread::SetThisThreadName(const ST::string& name)
     // On Linux, thread names must fit into 16 bytes, including the terminator.
     int res = pthread_setname_np(pthread_self(), name.left(15).c_str());
     hsAssert(res == 0, "Failed to set thread name");
-#endif
+#endif // HS_BUILD_FOR_LINUX
+#endif // HAVE_PTHREAD_SETNAME_NP
     // Because this is just a debugging help, do nothing by default (sorry, BSDs).
 }
 

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -10,9 +10,11 @@ if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
     endif()
 endif()
 
-# Check for Linux sysinfo.
 include(CheckCXXSymbolExists)
+# Check for Linux sysinfo.
 check_cxx_symbol_exists("sysinfo" "sys/sysinfo.h" HAVE_SYSINFO)
+# Check for pthread setname_np API
+check_cxx_symbol_exists(pthread_setname_np pthread.h HAVE_PTHREAD_SETNAME_NP)
 
 # Check for BSD style sysctl.
 try_compile(HAVE_SYSCTL ${PROJECT_BINARY_DIR}

--- a/cmake/hsConfig.h.cmake
+++ b/cmake/hsConfig.h.cmake
@@ -67,5 +67,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #cmakedefine HAVE_SYSDIR
 #cmakedefine HAVE_SYSINFO
 #cmakedefine HAVE_SHELLSCALINGAPI
+#cmakedefine HAVE_PTHREAD_SETNAME_NP
 
 #endif


### PR DESCRIPTION
In some non-standard setups that slip through our checks, this function doesn't exist and we should guard against calling it. Since it's only used for debugging, let's just use CMake to check if it's defined in the header rather than complicated conditionals in the code for all the different possible versions of this that might exist (or not exist).