### PR TITLE
Don't try to enable Metal on older Macs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ find_package(ZLIB REQUIRED)
 
 if(APPLE)
     find_package(Security)
+    find_package(Metal)
 elseif(UNIX)
     find_package(LIBSECRET)
     find_package(Uuid REQUIRED)
@@ -147,7 +148,7 @@ endif(PLASMA_EXTERNAL_RELEASE)
 # Pipeline Renderers
 cmake_dependent_option(PLASMA_PIPELINE_DX "Enable DirectX rendering pipeline?" ON "DirectX_FOUND" OFF)
 cmake_dependent_option(PLASMA_PIPELINE_GL "Enable OpenGL rendering pipeline?" ON "TARGET epoxy::epoxy" OFF)
-cmake_dependent_option(PLASMA_PIPELINE_METAL "Enable Metal rendering pipeline?" ON "APPLE" OFF)
+cmake_dependent_option(PLASMA_PIPELINE_METAL "Enable Metal rendering pipeline?" ON "TARGET Metal::Metal" OFF)
 
 if(PLASMA_PIPELINE_DX)
     add_definitions(-DPLASMA_PIPELINE_DX)

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
@@ -49,7 +49,7 @@ target_link_libraries(pfMetalPipeline
         CoreLib
         pnNucleusInc
         plPipeline
-        "-framework Metal"
+        Metal::Metal
         "-framework MetalPerformanceShaders"
     PRIVATE
         plStatusLog

--- a/cmake/FindMetal.cmake
+++ b/cmake/FindMetal.cmake
@@ -1,0 +1,17 @@
+include(FindPackageHandleStandardArgs)
+
+find_library(
+    Metal_LIBRARY
+    NAMES Metal
+)
+
+find_package_handle_standard_args(Metal REQUIRED_VARS Metal_LIBRARY)
+
+if(Metal_FOUND AND NOT TARGET Metal::Metal)
+    add_library(Metal::Metal INTERFACE IMPORTED)
+    set_target_properties(
+        Metal::Metal PROPERTIES
+        INTERFACE_LINK_LIBRARIES ${Metal_LIBRARY}
+    )
+endif()
+


### PR DESCRIPTION
Metal was introduced in OS X 10.11 El Capitan, so the framework doesn't exist on older Apple systems. Instead of trying to unconditionally use it on Apple devices, check for the framework first.

Note: Metal still only works with the Xcode project generator, and not with Makefiles/Ninja because CMake doesn't yet know how to handle the metal shaders.