### PR TITLE
Optimized gamma correction on Apple Silicon

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -279,10 +279,9 @@ private:
     MTL::RenderPipelineState* fGammaAdjustState;
 
     // MARK:  - Device capabilities
-public:
-    /// Returns true if the device supports title memory features such as directly writable render buffers.
-    BOOL SupportsTileMemory() { return fSupportsTileMemory; }
 private:
+    /// Returns true if the device supports tile memory features such as directly writable render buffers.
+    inline BOOL SupportsTileMemory() const { return fSupportsTileMemory; }
     BOOL fSupportsTileMemory;
 };
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -259,20 +259,31 @@ private:
     
     void LoadLibrary();
 
-    bool NeedsPostprocessing() const
-    {
-        return fGammaLUTTexture != nullptr;
-    }
-    void                      PostprocessIntoDrawable();
-    void                      CreateGammaAdjustState();
-    MTL::RenderPipelineState* fGammaAdjustState;
-
     void BeginNewRenderPass();
     void ReleaseSamplerStates();
     void ReleaseFramebufferObjects();
 
     // Blur states
     std::unordered_map<float, NS::Object*> fBlurShaders;
+    
+    // MARK: - Post processing
+private:
+    bool NeedsPostprocessing() const
+    {
+        return fGammaLUTTexture != nullptr;
+    }
+    void                      PreparePostProcessing();
+    void                      FinalizePostProcessing();
+    void                      PostprocessIntoDrawable();
+    void                      CreateGammaAdjustState();
+    MTL::RenderPipelineState* fGammaAdjustState;
+
+    // MARK:  - Device capabilities
+public:
+    /// Returns true if the device supports title memory features such as directly writable render buffers.
+    BOOL SupportsTileMemory() { return fSupportsTileMemory; }
+private:
+    BOOL fSupportsTileMemory;
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -281,8 +281,8 @@ private:
     // MARK:  - Device capabilities
 private:
     /// Returns true if the device supports tile memory features such as directly writable render buffers.
-    inline BOOL SupportsTileMemory() const { return fSupportsTileMemory; }
-    BOOL fSupportsTileMemory;
+    inline bool SupportsTileMemory() const { return fSupportsTileMemory; }
+    bool fSupportsTileMemory;
 };
 
 #endif


### PR DESCRIPTION
This is a follow up to #1581. Previous pull request added an optional path for Metal 2.3 - this PR uses it.

In Metal - we have to manually do gamma correction. Traditionally - this has meant:

- Rendering the main render pass into an intermediate buffer we create.
- Ending the main render pass.
- Creating a new render pass that binds the actual framebuffer as the render target, and the intermediate buffer as a source texture.
- Executing a shader that passes through pixels from the intermediate buffer to the final buffer - doing the gamma correction.

Apple Silicon can read and write safely from a framebuffer - because each portion of the framebuffer is directly owned by a GPU core in its tile memory. So we don't need two passes, and we don't need an intermediate buffer. We render straight to the main framebuffer, and then execute a shader that reads each pixel value from the main buffer, and writes the corrected value back directly to the framebuffer. This improves performance (render pass changes on Apple Silicon can be expensive) and reduces memory use.

On macOS - Apple Silicon functionality requires shaders compiled against Metal 2.3. Metal 2.3 shaders also only run on macOS 11 - so we need to maintain Metal 2.1 shaders for earlier macOS versions. (macOS 11 is the first version to support Apple Silicon Macs, so we don't need to worry about an Apple Silicon Mac running Metal 2.1.)

Additionally - we need to do a check to make sure the GPU is an Apple GPU before attempting to load the optimized shader. This check has been surfaced to the device class as a tile memory capability.