### PR TITLE
Fix a bad assert in hsRAMStream

### DIFF
--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -629,13 +629,15 @@ uint32_t hsRAMStream::Read(uint32_t byteCount, void * buffer)
 
 uint32_t hsRAMStream::Write(uint32_t byteCount, const void* buffer)
 {
-    hsAssert(fVector.data(), "Trying to write to a null RAM buffer");
-
     size_t spaceUntilEof = fVector.size() - fPosition;
     if (byteCount <= spaceUntilEof) {
+        hsAssert(fVector.data(), "Trying to write to a null RAM buffer");
         memcpy(fVector.data() + fPosition, buffer, byteCount);
     } else {
-        memcpy(fVector.data() + fPosition, buffer, spaceUntilEof);
+        if (spaceUntilEof) {
+            hsAssert(fVector.data(), "Trying to write to a null RAM buffer");
+            memcpy(fVector.data() + fPosition, buffer, spaceUntilEof);
+        }
         auto buf = static_cast<const uint8_t*>(buffer);
         fVector.insert(fVector.end(), buf + spaceUntilEof, buf + byteCount);
     }

--- a/Sources/Tests/CoreTests/CMakeLists.txt
+++ b/Sources/Tests/CoreTests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(CoreLibTest_SOURCES
     test_endianSwap.cpp
     test_plCmdParser.cpp
+    test_RAMStream.cpp
     $<$<PLATFORM_ID:Darwin>:test_hsDarwin_CF.cpp>
     $<$<PLATFORM_ID:Darwin>:test_hsDarwin_NS.mm>
 )

--- a/Sources/Tests/CoreTests/test_RAMStream.cpp
+++ b/Sources/Tests/CoreTests/test_RAMStream.cpp
@@ -1,0 +1,61 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <gtest/gtest.h>
+
+#include "hsStream.h"
+
+TEST(hsRAMStream, initializeBufferOnFirstWrite)
+{
+    const char* str = "hsRAMStream initializeBufferOnFirstWrite";
+    hsRAMStream s;
+
+    s.WriteSafeString(str);
+    EXPECT_EQ(s.GetPosition(), strlen(str) + 2);
+
+    s.WriteLE32(1);
+    EXPECT_EQ(s.GetPosition(), strlen(str) + 2 + 4);
+
+    s.Skip(-4);
+    s.WriteLE32(5);
+    EXPECT_EQ(s.GetPosition(), strlen(str) + 2 + 4);
+}


### PR DESCRIPTION
This was added because UBSan was warning that we were calling memcpy with a null destination, and while that is technically true, it was also a no-op because it was copying 0 bytes. A null buffer gets properly resized with the data in the next step, so this is actually expected behaviour that is broken by asserting too early.

Instead, detect the cases where we're calling memcpy with actual data, and assert in those cases that the RAMStream buffer is non-null.