### PR TITLE
ModDLL & Linux hsGD3DeviceSelector fixes

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -132,8 +132,6 @@ void plClient::IResizeNativeDisplayDevice(int width, int height, bool windowed)
 }
 void plClient::IChangeResolution(int width, int height) {}
 void plClient::IUpdateProgressIndicator(plOperationProgress* progress) {}
-void plClient::InitDLLs() {}
-void plClient::ShutdownDLLs() {}
 void plClient::ShowClientWindow() {}
 void plClient::FlashWindow()
 {

--- a/Sources/Plasma/Apps/plClient/main.cpp
+++ b/Sources/Plasma/Apps/plClient/main.cpp
@@ -50,8 +50,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 void plClient::IResizeNativeDisplayDevice(int width, int height, bool windowed) {}
 void plClient::IChangeResolution(int width, int height) {}
 void plClient::IUpdateProgressIndicator(plOperationProgress* progress) {}
-void plClient::InitDLLs() {}
-void plClient::ShutdownDLLs() {}
 void plClient::ShowClientWindow() {}
 void plClient::FlashWindow() {}
 

--- a/Sources/Plasma/Apps/plClient/plClient.h
+++ b/Sources/Plasma/Apps/plClient/plClient.h
@@ -178,7 +178,9 @@ protected:
 
     int fNumPostLoadMsgs;
     float fPostLoadMsgInc;
-    
+
+    std::vector<hsLibraryHndl> fLoadedDLLs;
+
     void                    ICompleteInit ();
     void                    IOnAsyncInitComplete ();
     void                    IHandlePatcherMsg (plResPatcherMsg * msg);

--- a/Sources/Plasma/Apps/plClient/win32/plClient_Win.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/plClient_Win.cpp
@@ -51,12 +51,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plClient.h"
 #include "plWinDpi/plWinDpi.h"
 
-#include "pnFactory/plFactory.h"
 #include "pnNetCommon/plNetApp.h"
 #include "plProgressMgr/plProgressMgr.h"
 
 extern ITaskbarList3* gTaskbarList;
-static std::vector<HMODULE> fLoadedDLLs;
 
 void plClient::IResizeNativeDisplayDevice(int width, int height, bool windowed)
 {
@@ -144,34 +142,6 @@ void plClient::IUpdateProgressIndicator(plOperationProgress* progress)
             gTaskbarList->SetProgressState(fInstance->GetWindowHandle(), myState);
         lastState = myState;
     }
-}
-
-void plClient::InitDLLs()
-{
-    hsStatusMessage("Init dlls client\n");
-    std::vector<plFileName> dlls = plFileSystem::ListDir("ModDLL", "*.dll");
-    for (auto iter = dlls.begin(); iter != dlls.end(); ++iter)
-    {
-        HMODULE hMod = LoadLibraryW(iter->WideString().data());
-        if (hMod)
-        {
-            pInitGlobalsFunc initGlobals = (pInitGlobalsFunc)GetProcAddress(hMod, "InitGlobals");
-            (*initGlobals)(hsgResMgr::ResMgr(), plFactory::GetTheFactory(), plgTimerCallbackMgr::Mgr(),
-                hsTimer::GetTheTimer(), plNetClientApp::GetInstance());
-            fLoadedDLLs.emplace_back(hMod);
-        }
-    }
-}
-
-void plClient::ShutdownDLLs()
-{
-    for (HMODULE dll : fLoadedDLLs)
-    {
-        BOOL ret = FreeLibrary(dll);
-        if (!ret)
-            hsStatusMessage("Failed to free lib\n");
-    }
-    fLoadedDLLs.clear();
 }
 
 // Show the client window

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -71,14 +71,17 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     typedef HWND hsWindowHndl;
     typedef HINSTANCE hsWindowInst;
     typedef HINSTANCE HMODULE;
+    typedef HMODULE hsLibraryHndl;
     typedef long HRESULT;
     typedef void* HANDLE;
 #elif HS_BUILD_FOR_MACOS
     typedef void* hsWindowHndl;
     typedef void* hsWindowInst;
+    typedef void* hsLibraryHndl;
 #else
     typedef int32_t* hsWindowHndl;
     typedef int32_t* hsWindowInst;
+    typedef void* hsLibraryHndl;
 #endif // HS_BUILD_FOR_WIN32
 
 //======================================

--- a/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.cpp
@@ -243,7 +243,10 @@ hsG3DDeviceModeRecord& hsG3DDeviceModeRecord::operator=(const hsG3DDeviceModeRec
 ///////////////////////////////////////////////////
 ///////////////////////////////////////////////////
 
-std::list<hsG3DDeviceSelector::DeviceEnumerator> hsG3DDeviceSelector::sEnumerators;
+std::list<hsG3DDeviceSelector::DeviceEnumerator>& hsG3DDeviceSelector::Enumerators() {
+    static std::list<hsG3DDeviceSelector::DeviceEnumerator> sEnumerators;
+    return sEnumerators;
+}
 
 hsG3DDeviceSelector::~hsG3DDeviceSelector()
 {
@@ -354,7 +357,7 @@ void hsG3DDeviceSelector::Enumerate(hsWindowHndl winRef)
     ITryDirect3DTnL(winRef);
 #endif
 
-    for (const auto& enumerator : sEnumerators) {
+    for (const auto& enumerator : Enumerators()) {
         enumerator(fRecords);
     }
 }

--- a/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.h
@@ -323,7 +323,7 @@ public:
     typedef std::function<void(std::vector<hsG3DDeviceRecord>&)> DeviceEnumerator;
 
 protected:
-    static std::list<DeviceEnumerator> sEnumerators;
+    static std::list<DeviceEnumerator>& Enumerators();
 
     std::vector<hsG3DDeviceRecord> fRecords;
 
@@ -344,7 +344,7 @@ protected:
     void    ISetFudgeFactors( uint8_t chipsetID, hsG3DDeviceRecord &record );
 
 public:
-    static void AddDeviceEnumerator(const DeviceEnumerator& de) { sEnumerators.emplace_back(de); }
+    static void AddDeviceEnumerator(const DeviceEnumerator& de) { Enumerators().emplace_back(de); }
 
     hsG3DDeviceSelector() { }
     virtual ~hsG3DDeviceSelector();


### PR DESCRIPTION
* There's a static initializer ordering issue that sometimes crops up with the `hsG3DDeviceSelector` Device Enumerator vector on Linux which causes crashes (not that there's much of a client to crash at the moment). Easy enough to change the vector to a function static rather than a global static to work around the problem.

* Support loading ModDLLs on Linux and macOS using `dlopen` and `dlsym`.