### PR TITLE
Fixing caps lock input on macOS

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSKeyboardEventMonitor.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSKeyboardEventMonitor.mm
@@ -152,6 +152,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     if (keycode == kVK_Control) {
         down = (event.modifierFlags & NSEventModifierFlagControl) != 0;
     }
+    if (keycode == kVK_CapsLock) {
+        down = (event.modifierFlags & NSEventModifierFlagCapsLock) != 0;
+    }
 
     /*
      This gets weird.

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSKeyboardEventMonitor.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSKeyboardEventMonitor.mm
@@ -66,6 +66,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 @property(weak) NSView* view;
 @property plInputManager* inputManager;
 @property(retain) id localMonitor;
+@property BOOL capsLockKeyDown;
 
 @end
 
@@ -152,10 +153,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     if (keycode == kVK_Control) {
         down = (event.modifierFlags & NSEventModifierFlagControl) != 0;
     }
-    if (keycode == kVK_CapsLock) {
-        down = (event.modifierFlags & NSEventModifierFlagCapsLock) != 0;
+    BOOL capsLockMaskPresent = (event.modifierFlags & NSEventModifierFlagCapsLock) != 0;
+    if (capsLockMaskPresent != self.capsLockKeyDown) {
+        self.capsLockKeyDown = capsLockMaskPresent;
+        self.inputManager->HandleKeyEvent((plKeyDef)kVK_CapsLock, self.capsLockKeyDown, false);
     }
-
+    
     /*
      This gets weird.
      Recent Apple hardware is starting to have its system key shortcuts assigned to the fn key
@@ -174,8 +177,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     }
 
     @synchronized(self.view.layer) {
-        self.inputManager->HandleKeyEvent(
-            (plKeyDef)keycode, down, event.type == NSEventTypeFlagsChanged ? false : event.ARepeat);
+        // Caps lock modifer has special handling that was earlier
+        if (keycode != kVK_CapsLock) {
+            self.inputManager->HandleKeyEvent(
+                                              (plKeyDef)keycode, down, event.type == NSEventTypeFlagsChanged ? false : event.ARepeat);
+        }
         if (!(modifierFlags & NSEventModifierFlagFunction) && down) {
             if (event.type != NSEventTypeFlagsChanged && event.characters.length > 0) {
                 // Only works for BMP code points (up to U+FFFF), but that's unlikely to matter at

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
@@ -186,6 +186,8 @@ void plKeyboardDevice::HandleKeyEvent(plKeyDef key, bool bKeyDown, bool bKeyRepe
         {
 #ifdef HS_BUILD_FOR_WIN32
             fCapsLockLock = (GetKeyState(KEY_CAPSLOCK) & 1) == 1;
+#else
+            fCapsLockLock = bKeyDown;
 #endif
             plAvatarInputInterface::GetInstance()->ForceAlwaysRun(fCapsLockLock);
         }


### PR DESCRIPTION
This is for fixing #1599.

I don't see any facilities in Cocoa to query the current state of caps lock, only updates. It seems like that might be present in HID - but HID is gated by security permissions in recent macOS releases. So far I've considered HID out of bounds for macOS.

@dpogue - If you have any Cocoa APIs I don't know about I'd be happy to implement. Would also be happy to forward on to Apple for guidance. I didn't see anything during my research online - and it does not even seem like the Game Controller framework supports querying Caps Lock. But my investigation was pretty shallow.