### PR TITLE
Fixing global semaphore deadlock for *NIX platforms

### DIFF
--- a/Sources/Plasma/CoreLib/hsThread_Unix.cpp
+++ b/Sources/Plasma/CoreLib/hsThread_Unix.cpp
@@ -106,6 +106,8 @@ hsGlobalSemaphore::hsGlobalSemaphore(int initialValue, const ST::string& name)
 
         /* Named semaphore shared between processes */
         fPSema = sem_open(semName.c_str(), O_CREAT, 0666, initialValue);
+        // Unlink it immediately so it will be freed if we unexpectedly leave it locked
+        sem_unlink(semName.c_str());
         if (fPSema == SEM_FAILED)
         {
             hsAssert(0, "hsOSException");


### PR DESCRIPTION
If the program crashed or behaved unexpectedly while a global semaphore was locked, that semaphore would stay locked until the machine was restarted. Unlinking the semaphore upon creation will cause the semaphore to be disposed of once the last process using that semaphore is no longer running.