### PR TITLE
Fixing banner pngs being included in root folder of Mac client

### DIFF
--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -165,10 +165,6 @@ if(APPLE)
     set_source_files_properties(Mac-Cocoa/Assets.xcassets ${RESOURCES} PROPERTIES
          MACOSX_PACKAGE_LOCATION Resources
     )
-    install(
-        TARGETS plClient
-        DESTINATION client
-    )
     
     if(${CMAKE_VERSION} VERSION_LESS 3.28)
         message(FATAL_ERROR "Cannot build Mac client without CMake 3.28")


### PR DESCRIPTION
There's an extra `install` function call that seems to be causing the pngs to be copied to the client directory. This history of this seems to go back to 6fa6565 which was a commit about fixing Metal shaders. Metal shaders do not seem to be affected by this change now. The other possibility is that the Mac build didn't use to call plasma_executable (which I believe is where install dirs are supposed to be set) so this might have been patching over that missing bit.