### PR TITLE
Create folder hierarchy in IDE project views

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ set(PRODUCT_UUID        "ea489821-6c35-4bd0-9dae-bb17c585e680"
 option(PRODUCT_EMBED_BUILD_INFO "Embed build revision information into plProduct" ON)
 cmake_dependent_option(PRODUCT_EMBED_BUILD_TIME "Embed build time into plProduct" ON [[PRODUCT_EMBED_BUILD_INFO]] OFF)
 
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set(CMAKE_FOLDER "CMakePredefinedTargets")
+
 # HeadSpin Configuration
 
 # Define HS_DEBUGGING for debug builds
@@ -188,6 +191,7 @@ include_directories(${PROJECT_BINARY_DIR})
 if(PLASMA_BUILD_TOOLS)
     # Custom dummy target for compiling all tools
     add_custom_target(tools)
+    set_target_properties(tools PROPERTIES XCODE_GENERATE_SCHEME TRUE)
 endif()
 
 include(TestBigEndian)
@@ -205,12 +209,8 @@ set(PLASMA_SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/Sources/Plasma")
 set(PLASMA_TOOLS_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/Sources/Tools")
 set(PLASMA_MAX_PLUGIN_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/Sources/MaxPlugin")
 
-add_subdirectory(Scripts)
 add_subdirectory(Sources/Plasma)
-
-if(PLASMA_BUILD_TOOLS)
-    add_subdirectory(Sources/Tools)
-endif()
+add_subdirectory(Scripts)
 
 if(PLASMA_BUILD_MAX_PLUGIN)
     add_subdirectory(Sources/MaxPlugin)
@@ -221,6 +221,10 @@ if(PLASMA_BUILD_TESTS)
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION>)
     add_subdirectory(Sources/Tests EXCLUDE_FROM_ALL)
 endif(PLASMA_BUILD_TESTS)
+
+if(PLASMA_BUILD_TOOLS)
+    add_subdirectory(Sources/Tools)
+endif()
 
 # This must be called only after all Qt targets are declared
 plasma_deploy_qt()

--- a/Scripts/CMakeLists.txt
+++ b/Scripts/CMakeLists.txt
@@ -9,6 +9,7 @@ source_group("Ages" FILES ${GameData})
 add_custom_target(Scripts
                   SOURCES ${GameScripts} ${GameSDL} ${GameData}
 )
+set_target_properties(Scripts PROPERTIES FOLDER "")
 
 install(
     DIRECTORY "Python/"

--- a/Sources/MaxPlugin/MaxComponent/CMakeLists.txt
+++ b/Sources/MaxPlugin/MaxComponent/CMakeLists.txt
@@ -166,6 +166,7 @@ set(MaxComponent_SOURCES
 )
 
 plasma_library(MaxComponent
+    FOLDER MaxPlugin
     SOURCES ${MaxComponent_HEADERS} ${MaxComponent_RESOURCES} ${MaxComponent_SOURCES}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/MaxPlugin/MaxConvert/CMakeLists.txt
+++ b/Sources/MaxPlugin/MaxConvert/CMakeLists.txt
@@ -37,6 +37,7 @@ set(MaxConvert_SOURCES
 )
 
 plasma_library(MaxConvert
+    FOLDER MaxPlugin
     SOURCES ${MaxConvert_HEADERS} ${MaxConvert_SOURCES}
     PRECOMPILED_HEADERS Pch.h
     NO_SANITIZE # The 3ds Max headers are full of clang diagnostic errors.

--- a/Sources/MaxPlugin/MaxExport/CMakeLists.txt
+++ b/Sources/MaxPlugin/MaxExport/CMakeLists.txt
@@ -18,6 +18,7 @@ set(MaxExport_SOURCES
 )
 
 plasma_library(MaxExport
+    FOLDER MaxPlugin
     SOURCES ${MaxExport_HEADERS} ${MaxExport_SOURCES}
     PRECOMPILED_HEADERS Pch.h
     NO_SANITIZE # The 3ds Max headers are full of clang diagnostic errors.

--- a/Sources/MaxPlugin/MaxMain/CMakeLists.txt
+++ b/Sources/MaxPlugin/MaxMain/CMakeLists.txt
@@ -69,6 +69,7 @@ set(MaxMain_SOURCES
 )
 
 plasma_library(MaxMain SHARED
+    FOLDER MaxPlugin
     SOURCES ${MaxMain_HEADERS} ${MaxMain_RESOURCES} ${MaxMain_SOURCES}
     PRECOMPILED_HEADERS Pch.h
     NO_SANITIZE # The 3ds Max headers are full of clang diagnostic errors.

--- a/Sources/MaxPlugin/MaxPlasmaLights/CMakeLists.txt
+++ b/Sources/MaxPlugin/MaxPlasmaLights/CMakeLists.txt
@@ -23,6 +23,7 @@ set(MaxPlasmaLights_SOURCES
 )
 
 plasma_library(MaxPlasmaLights SHARED
+    FOLDER MaxPlugin
     SOURCES ${MaxPlasmaLights_HEADERS} ${MaxPlasmaLights_RESOURCES} ${MaxPlasmaLights_SOURCES}
     PRECOMPILED_HEADERS Pch.h
     NO_SANITIZE # The 3ds Max headers are full of clang diagnostic errors.

--- a/Sources/MaxPlugin/MaxPlasmaMtls/CMakeLists.txt
+++ b/Sources/MaxPlugin/MaxPlasmaMtls/CMakeLists.txt
@@ -105,6 +105,7 @@ set(MaxPlasmaMtls_SOURCES_Materials
 )
 
 plasma_library(MaxPlasmaMtls
+    FOLDER MaxPlugin
     SOURCES ${MaxPlasmaMtls_HEADERS}
             ${MaxPlasmaMtls_HEADERS_Layers}
             ${MaxPlasmaMtls_HEADERS_Materials}

--- a/Sources/Plasma/Apps/SoundDecompress/CMakeLists.txt
+++ b/Sources/Plasma/Apps/SoundDecompress/CMakeLists.txt
@@ -15,7 +15,10 @@ if(SoundDecompress_MOULa_Mode)
     list(APPEND SoundDecompress_HEADERS plOldAudioFileReader.h)
 endif()
 
-plasma_executable(SoundDecompress TOOL SOURCES ${SoundDecompress_SOURCES})
+plasma_executable(SoundDecompress TOOL
+    FOLDER Apps
+    SOURCES ${SoundDecompress_SOURCES}
+)
 target_link_libraries(
     SoundDecompress
     PRIVATE

--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -127,6 +127,7 @@ else()
 endif()
 
 plasma_executable(plClient CLIENT INSTALL_PDB
+    FOLDER Apps
     SOURCES
         ${plClient_SOURCES} ${plClient_HEADERS}
         ${plClient_TEXT} ${plClient_RESOURCES}

--- a/Sources/Plasma/Apps/plCrashHandler/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plCrashHandler/CMakeLists.txt
@@ -7,7 +7,10 @@ set(plCrashHandler_RESOURCES
     resource.h
 )
 
-plasma_executable(plCrashHandler WIN32 CLIENT SOURCES ${plCrashHandler_SOURCES} ${plCrashHandler_RESOURCES})
+plasma_executable(plCrashHandler CLIENT
+    FOLDER Apps
+    SOURCES ${plCrashHandler_SOURCES} ${plCrashHandler_RESOURCES}
+)
 target_link_libraries(
     plCrashHandler
     PRIVATE

--- a/Sources/Plasma/Apps/plUruLauncher/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plUruLauncher/CMakeLists.txt
@@ -16,7 +16,8 @@ set(plUruLauncher_RESOURCES
     Dirt.ICO
 )
 
-plasma_executable(plUruLauncher WIN32 CLIENT
+plasma_executable(plUruLauncher CLIENT
+    FOLDER Apps
     SOURCES
         ${plUruLauncher_SOURCES} ${plUruLauncher_HEADERS}
         ${plUruLauncher_RESOURCES}

--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -72,6 +72,7 @@ set(CoreLib_HEADERS
 )
 
 plasma_library(CoreLib
+    FOLDER CoreLib
     SOURCES ${CoreLib_SOURCES} ${CoreLib_HEADERS}
     PRECOMPILED_HEADERS _CoreLibPch.h
 )
@@ -113,4 +114,5 @@ add_custom_target(pcBuildInfo
     COMMAND ${BUILD_INFO_COMMAND}
     BYPRODUCTS "${BUILD_INFO_FILE}"
 )
+set_target_properties(pcBuildInfo PROPERTIES FOLDER CoreLib)
 add_dependencies(CoreLib pcBuildInfo)

--- a/Sources/Plasma/FeatureLib/inc/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/inc/CMakeLists.txt
@@ -1,7 +1,10 @@
 set(pfFeatureInc_HEADERS
     pfAllCreatables.h
 )
-plasma_library(pfFeatureInc OBJECT SOURCES ${pfFeatureInc_HEADERS})
+plasma_library(pfFeatureInc OBJECT
+    FOLDER FeatureLib
+    SOURCES ${pfFeatureInc_HEADERS}
+)
 target_link_libraries(pfFeatureInc
     PUBLIC
         pfAnimation

--- a/Sources/Plasma/FeatureLib/pfAnimation/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfAnimation/CMakeLists.txt
@@ -25,7 +25,10 @@ set(pfAnimation_HEADERS
     plViewFaceModifier.h
 )
 
-plasma_library(pfAnimation SOURCES ${pfAnimation_SOURCES} ${pfAnimation_HEADERS})
+plasma_library(pfAnimation
+    FOLDER FeatureLib
+    SOURCES ${pfAnimation_SOURCES} ${pfAnimation_HEADERS}
+)
 target_link_libraries(
     pfAnimation
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfAudio/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfAudio/CMakeLists.txt
@@ -9,7 +9,10 @@ set(pfAudio_HEADERS
     plRandomSoundMod.h
 )
 
-plasma_library(pfAudio SOURCES ${pfAudio_SOURCES} ${pfAudio_HEADERS})
+plasma_library(pfAudio
+    FOLDER FeatureLib
+    SOURCES ${pfAudio_SOURCES} ${pfAudio_HEADERS}
+)
 target_link_libraries(
     pfAudio
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfCamera/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfCamera/CMakeLists.txt
@@ -15,7 +15,10 @@ set(pfCamera_HEADERS
     plVirtualCamNeu.h
 )
 
-plasma_library(pfCamera SOURCES ${pfCamera_SOURCES} ${pfCamera_HEADERS})
+plasma_library(pfCamera
+    FOLDER FeatureLib
+    SOURCES ${pfCamera_SOURCES} ${pfCamera_HEADERS}
+)
 target_link_libraries(
     pfCamera
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfCharacter/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfCharacter/CMakeLists.txt
@@ -11,7 +11,10 @@ set(pfCharacter_HEADERS
     pfMarkerMgr.h
 )
 
-plasma_library(pfCharacter SOURCES ${pfCharacter_SOURCES} ${pfCharacter_HEADERS})
+plasma_library(pfCharacter
+    FOLDER FeatureLib
+    SOURCES ${pfCharacter_SOURCES} ${pfCharacter_HEADERS}
+)
 target_link_libraries(
     pfCharacter
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfConditional/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfConditional/CMakeLists.txt
@@ -30,6 +30,7 @@ set(pfConditional_HEADERS
 )
 
 plasma_library(pfConditional
+    FOLDER FeatureLib
     SOURCES ${pfConditional_SOURCES} ${pfConditional_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/FeatureLib/pfConsole/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfConsole/CMakeLists.txt
@@ -17,6 +17,7 @@ set(pfConsole_HEADERS
 )
 
 plasma_library(pfConsole
+    FOLDER FeatureLib
     SOURCES ${pfConsole_SOURCES} ${pfConsole_HEADERS}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/CMakeLists.txt
@@ -13,7 +13,10 @@ set(pfConsoleCore_HEADERS
     pfConsoleParser.h
 )
 
-plasma_library(pfConsoleCore SOURCES ${pfConsoleCore_SOURCES} ${pfConsoleCore_HEADERS})
+plasma_library(pfConsoleCore
+    FOLDER FeatureLib
+    SOURCES ${pfConsoleCore_SOURCES} ${pfConsoleCore_HEADERS}
+)
 target_link_libraries(
     pfConsoleCore
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfCrashHandler/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfCrashHandler/CMakeLists.txt
@@ -23,7 +23,10 @@ else()
     )
 endif()
 
-plasma_library(pfCrashHandler SOURCES ${pfCrashHandler_SOURCES} ${pfCrashHandler_HEADERS})
+plasma_library(pfCrashHandler
+    FOLDER FeatureLib
+    SOURCES ${pfCrashHandler_SOURCES} ${pfCrashHandler_HEADERS}
+)
 target_link_libraries(
     pfCrashHandler
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/CMakeLists.txt
@@ -28,6 +28,7 @@ set(pfDXPipeline_HEADERS
 )
 
 plasma_library(pfDXPipeline
+    FOLDER FeatureLib
     SOURCES ${pfDXPipeline_SOURCES} ${pfDXPipeline_HEADERS}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/FeatureLib/pfGLPipeline/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfGLPipeline/CMakeLists.txt
@@ -14,7 +14,10 @@ set(pfGLPipeline_HEADERS
     plGLPlateManager.h
 )
 
-plasma_library(pfGLPipeline SOURCES ${pfGLPipeline_SOURCES} ${pfGLPipeline_HEADERS})
+plasma_library(pfGLPipeline
+    FOLDER FeatureLib
+    SOURCES ${pfGLPipeline_SOURCES} ${pfGLPipeline_HEADERS}
+)
 target_link_libraries(pfGLPipeline
     PUBLIC
         CoreLib

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/CMakeLists.txt
@@ -57,6 +57,7 @@ set(pfGameGUIMgr_HEADERS
 )
 
 plasma_library(pfGameGUIMgr
+    FOLDER FeatureLib
     SOURCES ${pfGameGUIMgr_SOURCES} ${pfGameGUIMgr_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/FeatureLib/pfGameMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/CMakeLists.txt
@@ -15,7 +15,10 @@ set(pfGameMgr_SOURCES
     pfGmMarker.cpp
 )
 
-plasma_library(pfGameMgr SOURCES ${pfGameMgr_HEADERS} ${pfGameMgr_SOURCES})
+plasma_library(pfGameMgr
+    FOLDER FeatureLib
+    SOURCES ${pfGameMgr_HEADERS} ${pfGameMgr_SOURCES}
+)
 target_link_libraries(
     pfGameMgr
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfGameScoreMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfGameScoreMgr/CMakeLists.txt
@@ -6,7 +6,10 @@ set(pfGameScoreMgr_HEADERS
     pfGameScoreMgr.h
 )
 
-plasma_library(pfGameScoreMgr SOURCES ${pfGameScoreMgr_SOURCES} ${pfGameScoreMgr_HEADERS})
+plasma_library(pfGameScoreMgr
+    FOLDER FeatureLib
+    SOURCES ${pfGameScoreMgr_SOURCES} ${pfGameScoreMgr_HEADERS}
+)
 target_link_libraries(
     pfGameScoreMgr
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfJournalBook/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/CMakeLists.txt
@@ -7,7 +7,10 @@ set(pfJournalBook_HEADERS
     pfJournalBookCreatable.h
 )
 
-plasma_library(pfJournalBook SOURCES ${pfJournalBook_SOURCES} ${pfJournalBook_HEADERS})
+plasma_library(pfJournalBook
+    FOLDER FeatureLib
+    SOURCES ${pfJournalBook_SOURCES} ${pfJournalBook_HEADERS}
+)
 target_link_libraries(
     pfJournalBook
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/CMakeLists.txt
@@ -18,7 +18,10 @@ set(pfLocalizationMgr_HEADERS
     pfLocalizedString.h
 )
 
-plasma_library(pfLocalizationMgr SOURCES ${pfLocalizationMgr_SOURCES} ${pfLocalizationMgr_HEADERS})
+plasma_library(pfLocalizationMgr
+    FOLDER FeatureLib
+    SOURCES ${pfLocalizationMgr_SOURCES} ${pfLocalizationMgr_HEADERS}
+)
 
 target_link_libraries(
     pfLocalizationMgr

--- a/Sources/Plasma/FeatureLib/pfMessage/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfMessage/CMakeLists.txt
@@ -23,7 +23,10 @@ set(pfMessage_HEADERS
     plClothingMsg.h
 )
 
-plasma_library(pfMessage SOURCES ${pfMessage_SOURCES} ${pfMessage_HEADERS})
+plasma_library(pfMessage
+    FOLDER FeatureLib
+    SOURCES ${pfMessage_SOURCES} ${pfMessage_HEADERS}
+)
 target_link_libraries(
     pfMessage
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
@@ -44,7 +44,10 @@ set(pfMetalPipeline_HEADERS
     pfMetalPipelineCreatable.h
 )
 
-plasma_library(pfMetalPipeline SOURCES ${pfMetalPipeline_SOURCES} ${pfMetalPipeline_HEADERS})
+plasma_library(pfMetalPipeline
+    FOLDER FeatureLib
+    SOURCES ${pfMetalPipeline_SOURCES} ${pfMetalPipeline_HEADERS}
+)
 target_link_libraries(pfMetalPipeline
     PUBLIC
         CoreLib
@@ -98,6 +101,7 @@ set_target_properties(pfMetalPipelineShadersMSL21 PROPERTIES
     XCODE_ATTRIBUTE_MTL_FAST_MATH "YES"
     XCODE_ATTRIBUTE_MTL_ENABLE_DEBUG_INFO[variant=Debug] "INCLUDE_SOURCE"
     XCODE_ATTRIBUTE_MTL_ENABLE_DEBUG_INFO[variant=RelWithDebInfo] "INCLUDE_SOURCE"
+    FOLDER FeatureLib
 )
 set_target_properties(pfMetalPipelineShadersMSL23 PROPERTIES
     XCODE_PRODUCT_TYPE com.apple.product-type.metal-library
@@ -108,6 +112,7 @@ set_target_properties(pfMetalPipelineShadersMSL23 PROPERTIES
     XCODE_ATTRIBUTE_MTL_FAST_MATH "YES"
     XCODE_ATTRIBUTE_MTL_ENABLE_DEBUG_INFO[variant=Debug] "INCLUDE_SOURCE"
     XCODE_ATTRIBUTE_MTL_ENABLE_DEBUG_INFO[variant=RelWithDebInfo] "INCLUDE_SOURCE"
+    FOLDER FeatureLib
 )
 set_source_files_properties(${pfMetalPipeline_SHADERS} TARGET_DIRECTORY pfMetalPipelineShadersMSL21 PROPERTIES LANGUAGE METAL)
 set_source_files_properties(${pfMetalPipeline_SHADERS} TARGET_DIRECTORY pfMetalPipelineShadersMSL23 PROPERTIES LANGUAGE METAL)

--- a/Sources/Plasma/FeatureLib/pfMoviePlayer/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfMoviePlayer/CMakeLists.txt
@@ -8,7 +8,10 @@ set(pfMoviePlayer_HEADERS
     plPlanarImage.h
 )
 
-plasma_library(pfMoviePlayer SOURCES ${pfMoviePlayer_SOURCES} ${pfMoviePlayer_HEADERS})
+plasma_library(pfMoviePlayer
+    FOLDER FeatureLib
+    SOURCES ${pfMoviePlayer_SOURCES} ${pfMoviePlayer_HEADERS}
+)
 target_link_libraries(
     pfMoviePlayer
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/CMakeLists.txt
@@ -15,7 +15,10 @@ elseif(TARGET Security::Security)
     list(APPEND pfPasswordStore_SOURCES pfPasswordStore_Apple.cpp)
 endif()
 
-plasma_library(pfPasswordStore SOURCES ${pfPasswordStore_HEADERS} ${pfPasswordStore_SOURCES})
+plasma_library(pfPasswordStore
+    FOLDER FeatureLib
+    SOURCES ${pfPasswordStore_HEADERS} ${pfPasswordStore_SOURCES}
+)
 target_link_libraries(
     pfPasswordStore
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfPatcher/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfPatcher/CMakeLists.txt
@@ -8,7 +8,10 @@ set(pfPatcher_HEADERS
     pfPatcher.h
 )
 
-plasma_library(pfPatcher SOURCES ${pfPatcher_SOURCES} ${pfPatcher_HEADERS})
+plasma_library(pfPatcher
+    FOLDER FeatureLib
+    SOURCES ${pfPatcher_SOURCES} ${pfPatcher_HEADERS}
+)
 target_link_libraries(
     pfPatcher
     PUBLIC

--- a/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
@@ -264,6 +264,7 @@ set(pfPython_GLUE
 )
 
 plasma_library(pfPython
+    FOLDER FeatureLib
     SOURCES ${pfPython_SOURCES} ${pfPython_HEADERS} ${pfPython_GLUE}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/FeatureLib/pfSurface/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfSurface/CMakeLists.txt
@@ -18,6 +18,7 @@ set(pfSurface_HEADERS
 )
 
 plasma_library(pfSurface
+    FOLDER FeatureLib
     SOURCES ${pfSurface_SOURCES} ${pfSurface_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/NucleusLib/inc/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/inc/CMakeLists.txt
@@ -30,7 +30,10 @@ set(pnNucleusInc_SOURCES
     pnSingletons.cpp
 )
 
-plasma_library(pnNucleusInc SOURCES ${pnNucleusInc_HEADERS} ${pnNucleusInc_SOURCES})
+plasma_library(pnNucleusInc
+    FOLDER NucleusLib
+    SOURCES ${pnNucleusInc_HEADERS} ${pnNucleusInc_SOURCES}
+)
 target_link_libraries(
     pnNucleusInc
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnAsyncCore/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnAsyncCore/CMakeLists.txt
@@ -13,7 +13,10 @@ set(pnAsyncCore_PRIVATE
     Private/pnAcTimer.h
 )
 
-plasma_library(pnAsyncCore SOURCES ${pnAsyncCore_PRIVATE} ${pnAsyncCore_HEADERS})
+plasma_library(pnAsyncCore
+    FOLDER NucleusLib
+    SOURCES ${pnAsyncCore_PRIVATE} ${pnAsyncCore_HEADERS}
+)
 
 target_include_directories(pnAsyncCore PRIVATE "${PLASMA_SOURCE_ROOT}/PubUtilLib")
 target_link_libraries(

--- a/Sources/Plasma/NucleusLib/pnAsyncCoreExe/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnAsyncCoreExe/CMakeLists.txt
@@ -15,6 +15,7 @@ set(pnAysncCoreExe_PRIVATE
 )
 
 plasma_library(pnAsyncCoreExe
+    FOLDER NucleusLib
     SOURCES ${pnAsyncCoreExe_SOURCES} ${pnAsyncCoreExe_HEADERS} ${pnAsyncCoreExe_PRIVATE}
 )
 

--- a/Sources/Plasma/NucleusLib/pnDispatch/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnDispatch/CMakeLists.txt
@@ -9,7 +9,10 @@ set(pnDispatch_HEADERS
     pnDispatchCreatable.h
 )
 
-plasma_library(pnDispatch SOURCES ${pnDispatch_SOURCES} ${pnDispatch_HEADERS})
+plasma_library(pnDispatch
+    FOLDER NucleusLib
+    SOURCES ${pnDispatch_SOURCES} ${pnDispatch_HEADERS}
+)
 target_link_libraries(
     pnDispatch
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnEncryption/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnEncryption/CMakeLists.txt
@@ -15,7 +15,10 @@ set(pnEncryption_HEADERS
     plRandom.h
 )
 
-plasma_library(pnEncryption SOURCES ${pnEncryption_SOURCES} ${pnEncryption_HEADERS})
+plasma_library(pnEncryption
+    FOLDER NucleusLib
+    SOURCES ${pnEncryption_SOURCES} ${pnEncryption_HEADERS}
+)
 target_link_libraries(
     pnEncryption
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnFactory/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnFactory/CMakeLists.txt
@@ -8,7 +8,10 @@ set(pnFactory_HEADERS
     plFactory.h
 )
 
-plasma_library(pnFactory SOURCES ${pnFactory_SOURCES} ${pnFactory_HEADERS})
+plasma_library(pnFactory
+    FOLDER NucleusLib
+    SOURCES ${pnFactory_SOURCES} ${pnFactory_HEADERS}
+)
 target_link_libraries(
     pnFactory
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnGameMgr/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnGameMgr/CMakeLists.txt
@@ -9,7 +9,10 @@ set(pnGameMgr_HEADERS
     pnGmVarSync.h
 )
 
-plasma_library(pnGameMgr OBJECT SOURCES ${pnGameMgr_HEADERS})
+plasma_library(pnGameMgr OBJECT
+    FOLDER NucleusLib
+    SOURCES ${pnGameMgr_HEADERS}
+)
 target_link_libraries(
     pnGameMgr
     INTERFACE

--- a/Sources/Plasma/NucleusLib/pnInputCore/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnInputCore/CMakeLists.txt
@@ -10,7 +10,10 @@ set(pnInputCore_SOURCES
     plInputMap.cpp
 )
 
-plasma_library(pnInputCore SOURCES ${pnInputCore_HEADERS} ${pnInputCore_SOURCES})
+plasma_library(pnInputCore
+    FOLDER NucleusLib
+    SOURCES ${pnInputCore_HEADERS} ${pnInputCore_SOURCES}
+)
 target_link_libraries(
     pnInputCore
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/CMakeLists.txt
@@ -19,6 +19,7 @@ set(pnKeyedObject_SOURCES
 )
 
 plasma_library(pnKeyedObject
+    FOLDER NucleusLib
     SOURCES ${pnKeyedObject_HEADERS} ${pnKeyedObject_SOURCES}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/NucleusLib/pnMessage/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnMessage/CMakeLists.txt
@@ -64,6 +64,7 @@ set(pnMessage_SOURCES
 )
 
 plasma_library(pnMessage
+    FOLDER NucleusLib
     SOURCES ${pnMessage_HEADERS} ${pnMessage_SOURCES}
     PRECOMPILED_HEADERS Pch.h
     UNITY_BUILD

--- a/Sources/Plasma/NucleusLib/pnModifier/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnModifier/CMakeLists.txt
@@ -16,6 +16,7 @@ set(pnModifier_SOURCES
 )
 
 plasma_library(pnModifier
+    FOLDER NucleusLib
     SOURCES ${pnModifier_HEADERS} ${pnModifier_SOURCES}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/NucleusLib/pnNetBase/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnNetBase/CMakeLists.txt
@@ -14,7 +14,10 @@ set(pnNetBase_SOURCES
     pnNbSrvs.cpp
 )
 
-plasma_library(pnNetBase SOURCES ${pnNetBase_HEADERS} ${pnNetBase_SOURCES})
+plasma_library(pnNetBase
+    FOLDER NucleusLib
+    SOURCES ${pnNetBase_HEADERS} ${pnNetBase_SOURCES}
+)
 target_link_libraries(
     pnNetBase
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnNetCli/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnNetCli/CMakeLists.txt
@@ -11,7 +11,10 @@ set(pnNetCli_SOURCES
     pnNcUtils.cpp
 )
 
-plasma_library(pnNetCli SOURCES ${pnNetCli_HEADERS} ${pnNetCli_SOURCES})
+plasma_library(pnNetCli
+    FOLDER NucleusLib
+    SOURCES ${pnNetCli_HEADERS} ${pnNetCli_SOURCES}
+)
 target_link_libraries(
     pnNetCli
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnNetCommon/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/CMakeLists.txt
@@ -22,7 +22,10 @@ set(pnNetCommon_SOURCES
     pnNetCommon.cpp
 )
 
-plasma_library(pnNetCommon SOURCES ${pnNetCommon_HEADERS} ${pnNetCommon_SOURCES})
+plasma_library(pnNetCommon
+    FOLDER NucleusLib
+    SOURCES ${pnNetCommon_HEADERS} ${pnNetCommon_SOURCES}
+)
 target_link_libraries(
     pnNetCommon
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/CMakeLists.txt
@@ -29,6 +29,7 @@ set(pnNetProtocol_PROTO_CLI2GK
 )
 
 plasma_library(pnNetProtocol
+    FOLDER NucleusLib
     SOURCES
         ${pnNetProtocol_HEADERS} ${pnNetProtocol_PRIVATE}
         ${pnNetProtocol_PROTO_CLI2AUTH} ${pnNetProtocol_PROTO_CLI2FILE}

--- a/Sources/Plasma/NucleusLib/pnSceneObject/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnSceneObject/CMakeLists.txt
@@ -17,7 +17,10 @@ set(pnSceneObject_SOURCES
     plSimulationInterface.cpp
 )
 
-plasma_library(pnSceneObject SOURCES ${pnSceneObject_HEADERS} ${pnSceneObject_SOURCES})
+plasma_library(pnSceneObject
+    FOLDER NucleusLib
+    SOURCES ${pnSceneObject_HEADERS} ${pnSceneObject_SOURCES}
+)
 target_link_libraries(
     pnSceneObject
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnTimer/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnTimer/CMakeLists.txt
@@ -7,7 +7,10 @@ set(pnTimer_SOURCES
     plTimerCallbackManager.cpp
 )
 
-plasma_library(pnTimer SOURCES ${pnTimer_HEADERS} ${pnTimer_SOURCES})
+plasma_library(pnTimer
+    FOLDER NucleusLib
+    SOURCES ${pnTimer_HEADERS} ${pnTimer_SOURCES}
+)
 target_link_libraries(
     pnTimer
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnUUID/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnUUID/CMakeLists.txt
@@ -8,7 +8,10 @@ set(pnUUID_HEADERS
     pnUUID.h
 )
 
-plasma_library(pnUUID SOURCES ${pnUUID_SOURCES} ${pnUUID_HEADERS})
+plasma_library(pnUUID
+    FOLDER NucleusLib
+    SOURCES ${pnUUID_SOURCES} ${pnUUID_HEADERS}
+)
 target_link_libraries(
     pnUUID
     PUBLIC

--- a/Sources/Plasma/NucleusLib/pnUtils/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnUtils/CMakeLists.txt
@@ -6,7 +6,10 @@ set(pnUtils_SOURCES
     pnUtStr.cpp
 )
 
-plasma_library(pnUtils SOURCES ${pnUtils_HEADERS} ${pnUtils_SOURCES})
+plasma_library(pnUtils
+    FOLDER NucleusLib
+    SOURCES ${pnUtils_HEADERS} ${pnUtils_SOURCES}
+)
 target_link_libraries(
     pnUtils
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/inc/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/inc/CMakeLists.txt
@@ -2,7 +2,10 @@ set(plPubUtilInc_HEADERS
     plAllCreatables.h
 )
 
-plasma_library(plPubUtilInc OBJECT SOURCES ${plPubUtilInc_HEADERS})
+plasma_library(plPubUtilInc OBJECT
+    FOLDER PubUtilLib
+    SOURCES ${plPubUtilInc_HEADERS}
+)
 target_link_libraries(plPubUtilInc
     PUBLIC
         plAgeLoader

--- a/Sources/Plasma/PubUtilLib/plAgeDescription/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAgeDescription/CMakeLists.txt
@@ -7,7 +7,10 @@ set(plAgeDescription_HEADERS
     plAgeManifest.h
 )
 
-plasma_library(plAgeDescription SOURCES ${plAgeDescription_SOURCES} ${plAgeDescription_HEADERS})
+plasma_library(plAgeDescription
+    FOLDER PubUtilLib
+    SOURCES ${plAgeDescription_SOURCES} ${plAgeDescription_HEADERS}
+)
 target_link_libraries(
     plAgeDescription
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/CMakeLists.txt
@@ -10,7 +10,10 @@ set(plAgeLoader_HEADERS
     plResPatcher.h
 )
 
-plasma_library(plAgeLoader SOURCES ${plAgeLoader_SOURCES} ${plAgeLoader_HEADERS})
+plasma_library(plAgeLoader
+    FOLDER PubUtilLib
+    SOURCES ${plAgeLoader_SOURCES} ${plAgeLoader_HEADERS}
+)
 
 target_include_directories(plAgeLoader PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
 target_link_libraries(

--- a/Sources/Plasma/PubUtilLib/plAnimation/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAnimation/CMakeLists.txt
@@ -27,6 +27,7 @@ set(plAnimation_HEADERS
 )
 
 plasma_library(plAnimation
+    FOLDER PubUtilLib
     SOURCES ${plAnimation_SOURCES} ${plAnimation_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/PubUtilLib/plAudible/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAudible/CMakeLists.txt
@@ -11,7 +11,10 @@ set(plAudible_HEADERS
     plWinAudibleProxy.h
 )
 
-plasma_library(plAudible SOURCES ${plAudible_SOURCES} ${plAudible_HEADERS})
+plasma_library(plAudible
+    FOLDER PubUtilLib
+    SOURCES ${plAudible_SOURCES} ${plAudible_HEADERS}
+)
 target_link_libraries(
     plAudible
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plAudio/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAudio/CMakeLists.txt
@@ -36,6 +36,7 @@ set(plAudio_HEADERS
 )
 
 plasma_library(plAudio
+    FOLDER PubUtilLib
     SOURCES ${plAudio_SOURCES} ${plAudio_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/PubUtilLib/plAudioCore/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/CMakeLists.txt
@@ -24,7 +24,10 @@ set(plAudioCore_HEADERS
     plWavFile.h
 )
 
-plasma_library(plAudioCore SOURCES ${plAudioCore_SOURCES} ${plAudioCore_HEADERS})
+plasma_library(plAudioCore
+    FOLDER PubUtilLib
+    SOURCES ${plAudioCore_SOURCES} ${plAudioCore_HEADERS}
+)
 target_link_libraries(
     plAudioCore
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plAvatar/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAvatar/CMakeLists.txt
@@ -68,6 +68,7 @@ set(plAvatar_HEADERS
 )
 
 plasma_library(plAvatar
+    FOLDER PubUtilLib
     SOURCES ${plAvatar_SOURCES} ${plAvatar_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/PubUtilLib/plClientResMgr/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plClientResMgr/CMakeLists.txt
@@ -6,7 +6,10 @@ set(plClientResMgr_HEADERS
     plClientResMgr.h
 )
 
-plasma_library(plClientResMgr SOURCES ${plClientResMgr_SOURCES} ${plClientResMgr_HEADERS})
+plasma_library(plClientResMgr
+    FOLDER PubUtilLib
+    SOURCES ${plClientResMgr_SOURCES} ${plClientResMgr_HEADERS}
+)
 target_link_libraries(
     plClientResMgr
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plClipboard/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plClipboard/CMakeLists.txt
@@ -6,7 +6,10 @@ set(plClipboard_HEADERS
     plClipboard.h
 )
 
-plasma_library(plClipboard SOURCES ${plClipboard_SOURCES} ${plClipboard_HEADERS})
+plasma_library(plClipboard
+    FOLDER PubUtilLib
+    SOURCES ${plClipboard_SOURCES} ${plClipboard_HEADERS}
+)
 target_link_libraries(
     plClipboard
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plCompression/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plCompression/CMakeLists.txt
@@ -9,7 +9,10 @@ set(plCompression_HEADERS
     plZlibStream.h
 )
 
-plasma_library(plCompression SOURCES ${plCompression_SOURCES} ${plCompression_HEADERS})
+plasma_library(plCompression
+    FOLDER PubUtilLib
+    SOURCES ${plCompression_SOURCES} ${plCompression_HEADERS}
+)
 target_link_libraries(
     plCompression
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plContainer/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plContainer/CMakeLists.txt
@@ -12,7 +12,10 @@ set(plContainer_HEADERS
     plKeysAndValues.h
 )
 
-plasma_library(plContainer SOURCES ${plContainer_SOURCES} ${plContainer_HEADERS})
+plasma_library(plContainer
+    FOLDER PubUtilLib
+    SOURCES ${plContainer_SOURCES} ${plContainer_HEADERS}
+)
 target_link_libraries(
     plContainer
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plDrawable/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plDrawable/CMakeLists.txt
@@ -101,6 +101,7 @@ set(plDrawable_HEADERS
 )
 
 plasma_library(plDrawable
+    FOLDER PubUtilLib
     SOURCES ${plDrawable_SOURCES} ${plDrawable_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/PubUtilLib/plFile/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plFile/CMakeLists.txt
@@ -14,7 +14,10 @@ set(plFile_HEADERS
     plStreamSource.h
 )
 
-plasma_library(plFile SOURCES ${plFile_SOURCES} ${plFile_HEADERS})
+plasma_library(plFile
+    FOLDER PubUtilLib
+    SOURCES ${plFile_SOURCES} ${plFile_HEADERS}
+)
 target_link_libraries(
     plFile
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plGImage/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plGImage/CMakeLists.txt
@@ -35,6 +35,7 @@ set(plGImage_HEADERS
 )
 
 plasma_library(plGImage
+    FOLDER PubUtilLib
     SOURCES ${plGImage_SOURCES} ${plGImage_HEADERS}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/PubUtilLib/plGLight/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plGLight/CMakeLists.txt
@@ -24,8 +24,10 @@ set(plGLight_HEADERS
     plShadowSlave.h
 )
 
-plasma_library(plGLight SOURCES ${plGLight_SOURCES} ${plGLight_HEADERS})
-
+plasma_library(plGLight
+    FOLDER PubUtilLib
+    SOURCES ${plGLight_SOURCES} ${plGLight_HEADERS}
+)
 target_link_libraries(plGLight
     PUBLIC
         CoreLib

--- a/Sources/Plasma/PubUtilLib/plInputCore/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plInputCore/CMakeLists.txt
@@ -21,7 +21,10 @@ set(plInputCore_HEADERS
     plTelescopeInputInterface.h
 )
 
-plasma_library(plInputCore SOURCES ${plInputCore_SOURCES} ${plInputCore_HEADERS})
+plasma_library(plInputCore
+    FOLDER PubUtilLib
+    SOURCES ${plInputCore_SOURCES} ${plInputCore_HEADERS}
+)
 target_link_libraries(
     plInputCore
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plInterp/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plInterp/CMakeLists.txt
@@ -21,6 +21,7 @@ set(plInterp_HEADERS
 )
 
 plasma_library(plInterp
+    FOLDER PubUtilLib
     SOURCES ${plInterp_SOURCES} ${plInterp_HEADERS}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/PubUtilLib/plIntersect/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plIntersect/CMakeLists.txt
@@ -20,8 +20,10 @@ set(plIntersect_HEADERS
     plVolumeIsect.h
 )
 
-plasma_library(plIntersect SOURCES ${plIntersect_SOURCES} ${plIntersect_HEADERS})
-
+plasma_library(plIntersect
+    FOLDER PubUtilLib
+    SOURCES ${plIntersect_SOURCES} ${plIntersect_HEADERS}
+)
 target_link_libraries(plIntersect
     PUBLIC
         CoreLib

--- a/Sources/Plasma/PubUtilLib/plMath/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plMath/CMakeLists.txt
@@ -8,7 +8,10 @@ set(plMath_HEADERS
     plTriUtils.h
 )
 
-plasma_library(plMath SOURCES ${plMath_SOURCES} ${plMath_HEADERS})
+plasma_library(plMath
+    FOLDER PubUtilLib
+    SOURCES ${plMath_SOURCES} ${plMath_HEADERS}
+)
 target_link_libraries(
     plMath
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plMessage/CMakeLists.txt
@@ -133,6 +133,7 @@ set(plMessage_HEADERS
 )
 
 plasma_library(plMessage
+    FOLDER PubUtilLib
     SOURCES ${plMessage_SOURCES} ${plMessage_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/PubUtilLib/plMessageBox/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plMessageBox/CMakeLists.txt
@@ -9,6 +9,7 @@ set(plMessageBox_HEADERS
 )
 
 plasma_library(plMessageBox
+    FOLDER PubUtilLib
     SOURCES ${plMessageBox_SOURCES} ${plMessageBox_HEADERS}
 )
 target_link_libraries(

--- a/Sources/Plasma/PubUtilLib/plModifier/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plModifier/CMakeLists.txt
@@ -46,6 +46,7 @@ set(plModifier_HEADERS
 )
 
 plasma_library(plModifier
+    FOLDER PubUtilLib
     SOURCES ${plModifier_SOURCES} ${plModifier_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/PubUtilLib/plNetClient/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plNetClient/CMakeLists.txt
@@ -30,6 +30,7 @@ set(plNetClient_HEADERS
 )
 
 plasma_library(plNetClient
+    FOLDER PubUtilLib
     SOURCES ${plNetClient_SOURCES} ${plNetClient_HEADERS}
     PRECOMPILED_HEADERS Pch.h
     UNITY_BUILD

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/CMakeLists.txt
@@ -7,7 +7,10 @@ set(plNetClientComm_HEADERS
     plNetClientCommCreatable.h
 )
 
-plasma_library(plNetClientComm SOURCES ${plNetClientComm_SOURCES} ${plNetClientComm_HEADERS})
+plasma_library(plNetClientComm
+    FOLDER PubUtilLib
+    SOURCES ${plNetClientComm_SOURCES} ${plNetClientComm_HEADERS}
+)
 target_link_libraries(
     plNetClientComm
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plNetClientRecorder/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plNetClientRecorder/CMakeLists.txt
@@ -8,7 +8,10 @@ set(plNetClientRecorder_HEADERS
     plNetClientRecorder.h
 )
 
-plasma_library(plNetClientRecorder SOURCES ${plNetClientRecorder_SOURCES} ${plNetClientRecorder_HEADERS})
+plasma_library(plNetClientRecorder
+    FOLDER PubUtilLib
+    SOURCES ${plNetClientRecorder_SOURCES} ${plNetClientRecorder_HEADERS}
+)
 target_link_libraries(
     plNetClientRecorder
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plNetCommon/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/CMakeLists.txt
@@ -23,6 +23,7 @@ set(plNetCommon_HEADERS
 )
 
 plasma_library(plNetCommon
+    FOLDER PubUtilLib
     SOURCES ${plNetCommon_SOURCES} ${plNetCommon_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/CMakeLists.txt
@@ -22,6 +22,7 @@ set(plNetGameLib_HEADERS
 
 # NOTE: Too many ODR violations and ambiguous names for UNITY_BUILD on this one.
 plasma_library(plNetGameLib
+    FOLDER PubUtilLib
     SOURCES ${plNetGameLib_PRIVATE} ${plNetGameLib_HEADERS}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/PubUtilLib/plNetMessage/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/CMakeLists.txt
@@ -10,7 +10,10 @@ set(plNetMessage_HEADERS
     plNetMsgVersion.h
 )
 
-plasma_library(plNetMessage SOURCES ${plNetMessage_SOURCES} ${plNetMessage_HEADERS})
+plasma_library(plNetMessage
+    FOLDER PubUtilLib
+    SOURCES ${plNetMessage_SOURCES} ${plNetMessage_HEADERS}
+)
 target_link_libraries(
     plNetMessage
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plNetTransport/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plNetTransport/CMakeLists.txt
@@ -8,7 +8,10 @@ set(plNetTransport_HEADERS
     plNetTransportMember.h
 )
 
-plasma_library(plNetTransport SOURCES ${plNetTransport_SOURCES} ${plNetTransport_HEADERS})
+plasma_library(plNetTransport
+    FOLDER PubUtilLib
+    SOURCES ${plNetTransport_SOURCES} ${plNetTransport_HEADERS}
+)
 target_link_libraries(
     plNetTransport
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plParticleSystem/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plParticleSystem/CMakeLists.txt
@@ -24,6 +24,7 @@ set(plParticleSystem_HEADERS
 )
 
 plasma_library(plParticleSystem
+    FOLDER PubUtilLib
     SOURCES ${plParticleSystem_SOURCES} ${plParticleSystem_HEADERS}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/PubUtilLib/plPhysX/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plPhysX/CMakeLists.txt
@@ -28,6 +28,7 @@ set(plPhysX_HEADERS
 )
 
 plasma_library(plPhysX
+    FOLDER PubUtilLib
     SOURCES ${plPhysX_SOURCES} ${plPhysX_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/PubUtilLib/plPhysical/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plPhysical/CMakeLists.txt
@@ -20,7 +20,10 @@ set(plPhysical_HEADERS
     plSimDefs.h
 )
 
-plasma_library(plPhysical SOURCES ${plPhysical_SOURCES} ${plPhysical_HEADERS})
+plasma_library(plPhysical
+    FOLDER PubUtilLib
+    SOURCES ${plPhysical_SOURCES} ${plPhysical_HEADERS}
+)
 target_link_libraries(
     plPhysical
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plPipeline/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plPipeline/CMakeLists.txt
@@ -42,6 +42,7 @@ set(plPipeline_HEADERS
 )
 
 plasma_library(plPipeline
+    FOLDER PubUtilLib
     SOURCES ${plPipeline_SOURCES} ${plPipeline_HEADERS}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/PubUtilLib/plProgressMgr/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plProgressMgr/CMakeLists.txt
@@ -6,7 +6,10 @@ set(plProgressMgr_HEADERS
     plProgressMgr.h
 )
 
-plasma_library(plProgressMgr SOURCES ${plProgressMgr_SOURCES} ${plProgressMgr_HEADERS})
+plasma_library(plProgressMgr
+    FOLDER PubUtilLib
+    SOURCES ${plProgressMgr_SOURCES} ${plProgressMgr_HEADERS}
+)
 target_link_libraries(
     plProgressMgr
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plResMgr/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plResMgr/CMakeLists.txt
@@ -25,6 +25,7 @@ set(plResMgr_HEADERS
 )
 
 plasma_library(plResMgr
+    FOLDER PubUtilLib
     SOURCES ${plResMgr_SOURCES} ${plResMgr_HEADERS}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/PubUtilLib/plSDL/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plSDL/CMakeLists.txt
@@ -28,6 +28,7 @@ set(plSDL_SDLFILES
 )
 
 plasma_library(plSDL
+    FOLDER PubUtilLib
     SOURCES ${plSDL_SOURCES} ${plSDL_HEADERS} ${plSDL_SDLFILES}
     PRECOMPILED_HEADERS Pch.h
 )

--- a/Sources/Plasma/PubUtilLib/plScene/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plScene/CMakeLists.txt
@@ -28,6 +28,7 @@ set(plScene_HEADERS
 )
 
 plasma_library(plScene
+    FOLDER PubUtilLib
     SOURCES ${plScene_SOURCES} ${plScene_HEADERS}
     UNITY_BUILD
     PRECOMPILED_HEADER Pch.h

--- a/Sources/Plasma/PubUtilLib/plStatGather/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plStatGather/CMakeLists.txt
@@ -11,7 +11,10 @@ set(plStatGather_HEADERS
     plStatGatherCreatable.h
 )
 
-plasma_library(plStatGather SOURCES ${plStatGather_SOURCES} ${plStatGather_HEADERS})
+plasma_library(plStatGather
+    FOLDER PubUtilLib
+    SOURCES ${plStatGather_SOURCES} ${plStatGather_HEADERS}
+)
 target_link_libraries(
     plStatGather
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plStatusLog/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/CMakeLists.txt
@@ -8,7 +8,10 @@ set(plStatusLog_HEADERS
     plStatusLog.h
 )
 
-plasma_library(plStatusLog SOURCES ${plStatusLog_SOURCES} ${plStatusLog_HEADERS})
+plasma_library(plStatusLog
+    FOLDER PubUtilLib
+    SOURCES ${plStatusLog_SOURCES} ${plStatusLog_HEADERS}
+)
 target_link_libraries(
     plStatusLog
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plSurface/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plSurface/CMakeLists.txt
@@ -68,6 +68,7 @@ set(plSurface_SHADERS
 )
 
 plasma_library(plSurface
+    FOLDER PubUtilLib
     SOURCES ${plSurface_SOURCES} ${plSurface_HEADERS} ${plSurface_SHADERS}
     UNITY_BUILD
     PRECOMPILED_HEADERS Pch.h

--- a/Sources/Plasma/PubUtilLib/plTransform/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plTransform/CMakeLists.txt
@@ -10,7 +10,10 @@ set(plTransform_HEADERS
     mat_decomp.h
 )
 
-plasma_library(plTransform SOURCES ${plTransform_SOURCES} ${plTransform_HEADERS})
+plasma_library(plTransform
+    FOLDER PubUtilLib
+    SOURCES ${plTransform_SOURCES} ${plTransform_HEADERS}
+)
 target_link_libraries(
     plTransform
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/CMakeLists.txt
@@ -10,7 +10,10 @@ set(plUnifiedTime_HEADERS
     plUnifiedTime.h
 )
 
-plasma_library(plUnifiedTime SOURCES ${plUnifiedTime_SOURCES} ${plUnifiedTime_HEADERS})
+plasma_library(plUnifiedTime
+    FOLDER PubUtilLib
+    SOURCES ${plUnifiedTime_SOURCES} ${plUnifiedTime_HEADERS}
+)
 target_link_libraries(
     plUnifiedTime
     PUBLIC

--- a/Sources/Plasma/PubUtilLib/plVault/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plVault/CMakeLists.txt
@@ -17,6 +17,7 @@ set(plVault_HEADERS
 )
 
 plasma_library(plVault
+    FOLDER PubUtilLib
     SOURCES ${plVault_SOURCES} ${plVault_HEADERS}
     PRECOMPILED_HEADERS Pch.h
     UNITY_BUILD

--- a/Sources/Plasma/PubUtilLib/plWinDpi/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plWinDpi/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND plWinDpi_SOURCES
 )
 
 plasma_library(plWinDpi
+    FOLDER PubUtilLib
     SOURCES ${plWinDpi_SOURCES} ${plWinDpi_HEADERS}
 )
 

--- a/Sources/Tools/plFileEncrypt/CMakeLists.txt
+++ b/Sources/Tools/plFileEncrypt/CMakeLists.txt
@@ -2,7 +2,10 @@ set(plFileEncrypt_SOURCES
     main.cpp
 )
 
-plasma_executable(plFileEncrypt TOOL SOURCES ${plFileEncrypt_SOURCES})
+plasma_executable(plFileEncrypt TOOL
+    FOLDER Tools
+    SOURCES ${plFileEncrypt_SOURCES}
+)
 target_link_libraries(
     plFileEncrypt
     PRIVATE

--- a/Sources/Tools/plFilePatcher/CMakeLists.txt
+++ b/Sources/Tools/plFilePatcher/CMakeLists.txt
@@ -9,9 +9,9 @@ set(plFilePatcher_HEADERS
 )
 
 plasma_executable(plFilePatcher TOOL
+    FOLDER Tools
     SOURCES ${plFilePatcher_SOURCES} ${plFilePatcher_HEADERS}
 )
-
 target_link_libraries(
     plFilePatcher
     PRIVATE

--- a/Sources/Tools/plFileSecure/CMakeLists.txt
+++ b/Sources/Tools/plFileSecure/CMakeLists.txt
@@ -2,7 +2,10 @@ set(plFileSecure_SOURCES
     main.cpp
 )
 
-plasma_executable(plFileSecure TOOL SOURCES ${plFileSecure_SOURCES})
+plasma_executable(plFileSecure TOOL
+    FOLDER Tools
+    SOURCES ${plFileSecure_SOURCES}
+)
 target_link_libraries(
     plFileSecure
     PRIVATE

--- a/Sources/Tools/plFontConverter/CMakeLists.txt
+++ b/Sources/Tools/plFontConverter/CMakeLists.txt
@@ -28,6 +28,7 @@ set(plFontConverter_UIC
 )
 
 plasma_executable(plFontConverter TOOL QT_GUI
+    FOLDER Tools
     SOURCES
         ${plFontConverter_HEADERS} ${plFontConverter_SOURCES}
         ${plFontConverter_RCC} ${plFontConverter_UIC}

--- a/Sources/Tools/plLocalizationBenchmark/CMakeLists.txt
+++ b/Sources/Tools/plLocalizationBenchmark/CMakeLists.txt
@@ -1,4 +1,8 @@
-plasma_executable(plLocalizationBenchmark EXCLUDE_FROM_ALL SOURCES main.cpp)
+plasma_executable(plLocalizationBenchmark
+    FOLDER Tools
+    EXCLUDE_FROM_ALL
+    SOURCES main.cpp
+)
 target_link_libraries(
     plLocalizationBenchmark
     PRIVATE

--- a/Sources/Tools/plLocalizationEditor/CMakeLists.txt
+++ b/Sources/Tools/plLocalizationEditor/CMakeLists.txt
@@ -28,6 +28,7 @@ set(plLocalizationEditor_UIC
 )
 
 plasma_executable(plLocalizationEditor TOOL QT_GUI
+    FOLDER Tools
     SOURCES
         ${plLocalizationEditor_HEADERS} ${plLocalizationEditor_SOURCES}
         ${plLocalizationEditor_RCC} ${plLocalizationEditor_UIC}

--- a/Sources/Tools/plNetLog/CMakeLists.txt
+++ b/Sources/Tools/plNetLog/CMakeLists.txt
@@ -31,6 +31,7 @@ set(plNetLog_GameMsg_SOURCES
 )
 
 plasma_executable(plNetLog TOOL QT_GUI
+    FOLDER Tools
     SOURCES
         ${plNetLog_HEADERS}
         ${plNetLog_SOURCES}

--- a/Sources/Tools/plPageInfo/CMakeLists.txt
+++ b/Sources/Tools/plPageInfo/CMakeLists.txt
@@ -3,7 +3,10 @@ set(plPageInfo_SOURCES
     plPageInfo.cpp
 )
 
-plasma_executable(plPageInfo TOOL SOURCES ${plPageInfo_SOURCES})
+plasma_executable(plPageInfo TOOL
+    FOLDER Tools
+    SOURCES ${plPageInfo_SOURCES}
+)
 target_link_libraries(
     plPageInfo
     PRIVATE

--- a/Sources/Tools/plPageOptimizer/CMakeLists.txt
+++ b/Sources/Tools/plPageOptimizer/CMakeLists.txt
@@ -9,6 +9,7 @@ set(plPageOptimizer_HEADERS
 )
 
 plasma_executable(plPageOptimizer TOOL
+    FOLDER Tools
     SOURCES ${plPageOptimizer_SOURCES} ${plPageOptimizer_HEADERS}
 )
 target_link_libraries(

--- a/Sources/Tools/plPythonPack/CMakeLists.txt
+++ b/Sources/Tools/plPythonPack/CMakeLists.txt
@@ -8,6 +8,7 @@ set(plPythonPack_HEADERS
 )
 
 plasma_executable(plPythonPack TOOL
+    FOLDER Tools
     SOURCES ${plPythonPack_SOURCES} ${plPythonPack_HEADERS}
 )
 target_link_libraries(

--- a/Sources/Tools/plResBrowser/CMakeLists.txt
+++ b/Sources/Tools/plResBrowser/CMakeLists.txt
@@ -29,6 +29,7 @@ set(plResBrowser_UIC
 )
 
 plasma_executable(plResBrowser TOOL QT_GUI
+    FOLDER Tools
     SOURCES
         ${plResBrowser_SOURCES} ${plResBrowser_HEADERS}
         ${plResBrowser_RCC} ${plResBrowser_UIC}

--- a/Sources/Tools/plShaderAssembler/CMakeLists.txt
+++ b/Sources/Tools/plShaderAssembler/CMakeLists.txt
@@ -2,7 +2,10 @@ set(plShaderAssembler_SOURCES
     main.cpp
 )
 
-plasma_executable(plShaderAssembler TOOL SOURCES ${plShaderAssembler_SOURCES})
+plasma_executable(plShaderAssembler TOOL
+    FOLDER Tools
+    SOURCES ${plShaderAssembler_SOURCES}
+)
 target_link_libraries(
     plShaderAssembler
     PRIVATE

--- a/Sources/Tools/plSystemInfo/CMakeLists.txt
+++ b/Sources/Tools/plSystemInfo/CMakeLists.txt
@@ -1,4 +1,7 @@
-plasma_executable(plSystemInfo TOOL SOURCES main.cpp)
+plasma_executable(plSystemInfo TOOL
+    FOLDER Tools
+    SOURCES main.cpp
+)
 target_link_libraries(
     plSystemInfo
     PRIVATE

--- a/cmake/PlasmaTargets.cmake
+++ b/cmake/PlasmaTargets.cmake
@@ -43,7 +43,7 @@ endif()
 function(plasma_executable TARGET)
     cmake_parse_arguments(PARSE_ARGV 1 _pex
         "WIN32;CLIENT;TOOL;QT_GUI;EXCLUDE_FROM_ALL;NO_SANITIZE;INSTALL_PDB"
-        ""
+        "FOLDER"
         "SOURCES"
     )
 
@@ -58,6 +58,10 @@ function(plasma_executable TARGET)
     endif()
     add_executable(${TARGET} ${addexe_args} ${_pex_SOURCES})
     set_target_properties(${TARGET} PROPERTIES XCODE_GENERATE_SCHEME TRUE)
+
+    if(_pex_FOLDER)
+        set_target_properties(${TARGET} PROPERTIES FOLDER ${_pex_FOLDER})
+    endif()
 
     if(_pex_CLIENT)
         set(install_destination client)
@@ -147,7 +151,7 @@ endfunction()
 function(plasma_library TARGET)
     cmake_parse_arguments(PARSE_ARGV 1 _plib
         "UNITY_BUILD;OBJECT;SHARED;NO_SANITIZE"
-        ""
+        "FOLDER"
         "PRECOMPILED_HEADERS;SOURCES"
     )
 
@@ -164,6 +168,10 @@ function(plasma_library TARGET)
     endif()
     add_library(${TARGET} ${libtype} ${_plib_SOURCES})
 
+    if(_plib_FOLDER)
+        set_target_properties(${TARGET} PROPERTIES FOLDER ${_plib_FOLDER})
+    endif()
+
     if(PLASMA_USE_PCH AND _plib_PRECOMPILED_HEADERS)
         target_precompile_headers(${TARGET} PRIVATE ${_plib_PRECOMPILED_HEADERS})
     endif()
@@ -178,7 +186,7 @@ function(plasma_library TARGET)
 endfunction()
 
 function(plasma_test TARGET)
-    plasma_executable(${TARGET} NO_SANITIZE ${ARGN})
+    plasma_executable(${TARGET} NO_SANITIZE FOLDER Tests ${ARGN})
     add_test(NAME ${TARGET} COMMAND ${TARGET})
     add_dependencies(check ${TARGET})
 endfunction()


### PR DESCRIPTION
Makes a folder hierarchy in IDEs that roughly matches the folder layout of the Plasma projects.

VS 2022 project Solution Explorer:
<img width="395" alt="Visual Studio 2022 Project" src="https://github.com/user-attachments/assets/b1735c54-a429-429a-92db-e2d421edfa5a">

VS 2022 open folder CMake Targets:
<img width="394" alt="Visual Studio 2022 CMake Folder View" src="https://github.com/user-attachments/assets/665c8342-0015-41ed-be6d-19caab553ed2">

Xcode project file sidebar:
<img width="367" alt="Xcode Project" src="https://github.com/user-attachments/assets/03acb562-5fa7-45d3-8662-904b87898a63">
