### PR TITLE
Fix #1617.

### DIFF
--- a/Sources/MaxPlugin/MaxPlasmaMtls/Materials/plClothingMtlPBDec.h
+++ b/Sources/MaxPlugin/MaxPlasmaMtls/Materials/plClothingMtlPBDec.h
@@ -255,15 +255,27 @@ public:
         case WM_COMMAND:
             if (id == IDC_CLOTHING_TILESET)
             {
+                if (HIWORD(wParam) != CBN_SELCHANGE)
+                    return FALSE;
+
                 int setIdx = (int)SendMessage(GetDlgItem(hWnd, id), CB_GETCURSEL, 0, 0);
-                pb->SetValue(plClothingMtl::kTileset, t, setIdx);
+                if (setIdx != CB_ERR) {
+                    pb->SetValue(plClothingMtl::kTileset, t, setIdx);
+                    pb->GetDesc()->InvalidateUI();
+                }
                 return TRUE;
             }
 
             if (id == IDC_CLOTHING_LAYER)
             {
-                
-                pb->SetValue(plClothingMtl::kLayer, t, ComboBox_GetCurSel(GetDlgItem(hWnd, id)));
+                if (HIWORD(wParam) != CBN_SELCHANGE)
+                    return FALSE;
+
+                int setIdx = (int)ComboBox_GetCurSel(GetDlgItem(hWnd, id));
+                if (setIdx != CB_ERR) {
+                    pb->SetValue(plClothingMtl::kLayer, t, setIdx);
+                    pb->GetDesc()->InvalidateUI();
+                }
                 return TRUE;
             }
 


### PR DESCRIPTION
Fixes #1617.

This invalidates the UI when the clothing material combo box selections are changed. By invalidating the UI, the texture pickers update appropriately. I also added some extra safety valves to reduce spurious updates that the debugger showed coming through.