### PR TITLE
Resolve Max texture paths before exporting

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plGUIComponents.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plGUIComponents.cpp
@@ -4793,6 +4793,7 @@ bool plGUISkinComp::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         PBBitmap *texture = layer->GetPBBitmap();
         if (texture != nullptr)
         {
+            BMMGetFullFilename(&texture->bi);
             plBitmap *bMap = plLayerConverter::Instance().CreateSimpleTexture( M2ST(texture->bi.Name()), fConvertedSkin->GetKey()->GetUoid().GetLocation(), 0, plMipmap::kForceNonCompressed | plMipmap::kAlphaChannelFlag | plMipmap::kNoMaxSize );
             if (bMap != nullptr && plMipmap::ConvertNoRef(bMap) != nullptr)
             {

--- a/Sources/MaxPlugin/MaxComponent/plMiscComponents.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plMiscComponents.cpp
@@ -2538,6 +2538,7 @@ bool pfImageLibComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
             PBBitmap *texture = layer->GetPBBitmap();
             if (texture != nullptr)
             {
+                BMMGetFullFilename(&texture->bi);
                 uint32_t flags = plBitmap::kAlphaChannelFlag;
 
                 plBitmap *bMap;

--- a/Sources/MaxPlugin/MaxConvert/hsMaterialConverter.cpp
+++ b/Sources/MaxPlugin/MaxConvert/hsMaterialConverter.cpp
@@ -1957,6 +1957,7 @@ static plLayerInterface* IProcessLayerMovie(plPassMtlBase* mtl, plLayerTex* layT
     if( !bi || !bi->Name() || !*bi->Name() )
         return layerIFace;
 
+    BMMGetFullFilename(bi);
     plFileName fileName = bi->Name();
 
     plAnimStealthNode* stealth = IGetEntireAnimation(mtl);
@@ -4529,6 +4530,7 @@ plClothingItem *hsMaterialConverter::GenerateClothingItem(plClothingMtl *mtl, co
             if (layer == nullptr || layer->GetPBBitmap() == nullptr)
                 continue;
 
+            BMMGetFullFilename(&layer->GetPBBitmap()->bi);
             ST::string texName = M2ST(layer->GetPBBitmap()->bi.Name());
 
             for (clipLevels = 0, startWidth = layer->GetPBBitmap()->bi.Width(); 

--- a/Sources/MaxPlugin/MaxConvert/plLayerConverter.cpp
+++ b/Sources/MaxPlugin/MaxConvert/plLayerConverter.cpp
@@ -323,6 +323,7 @@ plLayerInterface    *plLayerConverter::IConvertLayerTex( plPlasmaMAXLayer *layer
 
     // Setup the texture creation parameters
     plBitmapData bd;
+    BMMGetFullFilename(bi);
     bd.fileName = bi->Name();
 
     // Create texture and add it to list if unique
@@ -442,6 +443,7 @@ plLayerInterface    *plLayerConverter::IConvertStaticEnvLayer( plPlasmaMAXLayer 
 
     // Setup the texture creation parameters
     plBitmapData bd;
+    BMMGetFullFilename(bi);
     bd.fileName = bi->Name();
 
     // Create texture and add it to list if unique
@@ -474,6 +476,7 @@ plLayerInterface    *plLayerConverter::IConvertStaticEnvLayer( plPlasmaMAXLayer 
         PBBitmap *face = bitmapPB->GetBitmap( plStaticEnvLayer::kBmpFrontBitmap + i );
         if( !face )
             return (plLayerInterface *)plasmaLayer;
+        BMMGetFullFilename(&face->bi);
         bd.faceNames[ i ] = face->bi.Name();
     }
 

--- a/Sources/MaxPlugin/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.cpp
+++ b/Sources/MaxPlugin/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.cpp
@@ -400,6 +400,7 @@ bool    plPlasmaMAXLayer::GetBitmapFileName( TCHAR* destFilename, int maxLength,
     if (GetPBBitmap(index) == nullptr)
         return false;
 
+    BMMGetFullFilename(&GetPBBitmap(index)->bi);
     _tcsncpy( destFilename, GetPBBitmap( index )->bi.Name(), maxLength );
     return true;
 }


### PR DESCRIPTION
Max seems to save the original full file path to the texture image in its data, but happily resolves it against the current working directory when a file is opened in the editor. Except that it doesn't ever update the stored full file path, so when the PlasmaMax plugin asks for files it can get paths that don't exist. This is a problem because it tries to detect changes to textures based on modified times, and nonexistent files have nonexistent modified times, which can lead to the same image getting exported multiple times because PlasmaMax tries to treat each instance of it as a new texture.

The Max SDK includes a function to resolve texture file paths, so we'll call that in a bunch of spots before we use the texture file path for anything.