### PR TITLE
Fix crash when running multiple clients on Windows.

### DIFF
--- a/Sources/Plasma/CoreLib/hsFILELock.cpp
+++ b/Sources/Plasma/CoreLib/hsFILELock.cpp
@@ -61,7 +61,7 @@ bool hsFILELock::ILock(bool block) const
 #ifdef HS_BUILD_FOR_WIN32
     OVERLAPPED o{};
     DWORD flags = LOCKFILE_EXCLUSIVE_LOCK;
-    if (block)
+    if (!block)
         flags |= LOCKFILE_FAIL_IMMEDIATELY;
 
     // Lock only the first byte of the file - we have


### PR DESCRIPTION
The logic in `hsFILELock::ILock()` is incorrect on Win32. We should only fail immediately if we are *not* blocking. As it stands, running multiple clients can cause the lock to fail, resulting in an uncaught exception being thrown.