### PR TITLE
Fix #1620

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
@@ -191,18 +191,19 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     CGPoint viewLocation = [self convertPoint:windowLocation fromView:nil];
 
     NSRect windowViewBounds = self.bounds;
-    CGFloat deltaX = (windowLocation.x) / windowViewBounds.size.width;
-    CGFloat deltaY =
+    CGFloat xNormal = (windowLocation.x) / windowViewBounds.size.width;
+    CGFloat yNormal =
         (windowViewBounds.size.height - windowLocation.y) / windowViewBounds.size.height;
 
     plIMouseXEventMsg* pXMsg = new plIMouseXEventMsg;
     plIMouseYEventMsg* pYMsg = new plIMouseYEventMsg;
 
-    pXMsg->fWx = viewLocation.x;
-    pXMsg->fX = deltaX;
+    pXMsg->fX = xNormal;
+    pYMsg->fY = yNormal;
 
-    pYMsg->fWy = (windowViewBounds.size.height - windowLocation.y);
-    pYMsg->fY = deltaY;
+    // Plasma internally uses input coords as display coords
+    pXMsg->fWx = viewLocation.x * self.window.screen.backingScaleFactor;
+    pYMsg->fWy = (windowViewBounds.size.height - windowLocation.y) * self.window.screen.backingScaleFactor;
 
     @synchronized(self.layer) {
         if (self.inputManager) {
@@ -219,7 +220,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
             newWindowLocation.x = CGRectGetMidX(self.window.contentView.bounds);
 
             // macOS won't generate a new message on warp, need to tell Plasma by hand
-            pXMsg->fWx = newWindowLocation.x;
+            pXMsg->fWx = newWindowLocation.x * self.window.screen.backingScaleFactor;;
             pXMsg->fX = 0.5f;
             self.inputManager->MsgReceive(pXMsg);
         }
@@ -228,7 +229,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
             newWindowLocation.y = CGRectGetMidY(self.window.contentView.bounds);
 
             // macOS won't generate a new message on warp, need to tell Plasma by hand
-            pYMsg->fWy = newWindowLocation.y;
+            pYMsg->fWy = newWindowLocation.y * self.window.screen.backingScaleFactor;;
             pYMsg->fY = 0.5f;
             self.inputManager->MsgReceive(pYMsg);
         }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputDevice.cpp
@@ -492,7 +492,7 @@ bool plMouseDevice::MsgReceive(plMessage* msg)
             fXPos = pXMsg->fX;
 
         SetCursorX(fXPos);
-        fWXPos = pXMsg->fWx * fScale;
+        fWXPos = pXMsg->fWx;
         return true;
     }
 
@@ -529,7 +529,7 @@ bool plMouseDevice::MsgReceive(plMessage* msg)
         else
             fYPos = pYMsg->fY;
 
-        fWYPos = pYMsg->fWy * fScale;
+        fWYPos = pYMsg->fWy;
         SetCursorY(fYPos);
         
         return true;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputManager.cpp
@@ -42,6 +42,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // plInputManager.cpp
 #include "HeadSpin.h"
 #include "hsWindows.h"
+#ifdef WIN32
+#   include <Windowsx.h>
+#endif
 
 #include "plInputManager.h"
 #include "plPipeline.h"
@@ -294,10 +297,10 @@ void plInputManager::HandleWin32ControlEvent(UINT message, WPARAM Wparam, LPARAM
             plIMouseYEventMsg* pYMsg = new plIMouseYEventMsg;
             plIMouseBEventMsg* pBMsg = new plIMouseBEventMsg;
 
-            pXMsg->fWx = LOWORD(Lparam);
-            pXMsg->fX = (float)LOWORD(Lparam) / (float)rect.right;
-            pYMsg->fWy = HIWORD(Lparam);
-            pYMsg->fY = (float)HIWORD(Lparam) / (float)rect.bottom;
+            pXMsg->fWx = GET_X_LPARAM(Lparam);
+            pXMsg->fX = (float)GET_X_LPARAM(Lparam) / (float)rect.right;
+            pYMsg->fWy = GET_Y_LPARAM(Lparam);
+            pYMsg->fY = (float)GET_Y_LPARAM(Lparam) / (float)rect.bottom;
 
             // Apply mouse scale
 //          pXMsg->fX *= fMouseScale;


### PR DESCRIPTION
Fixes #1620 by avoiding a double-scale of mouse coordinates. I also included a bonus multi-monitor fix.

I hardwired the cursor to always think it's hovering over a player with the name `It's a Spooky Ghost!`...

On master:
![image](https://github.com/user-attachments/assets/6add0913-6ac2-4a7a-9ab1-4dad78d825bd)


With this PR:
![image](https://github.com/user-attachments/assets/b9063ec3-5041-4cbc-8c84-ad88d8d32b8a)

For reference:
![image](https://github.com/user-attachments/assets/1be935a3-4aaf-4b7a-9044-66b0cbed146b)

