### PR TITLE
Fix `ptAttribLayer` being exported incorrectly from Max.

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plAutoUIBase.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plAutoUIBase.cpp
@@ -382,7 +382,7 @@ void plAutoUIBase::AddPickLayerButton(int16_t id, const ST::string& scriptName, 
     fDesc->AddParam(id, ST2M(scriptNameNew), TYPE_REFTARG, 0, 0,
         p_end,
         p_end);
-    plAutoUIParam* param = new plPickMaterialButtonParam(id, name);
+    plAutoUIParam* param = new plPickLayerButtonParam(id, name);
     param->SetVisInfo(vid, std::move(vstates));
     fParams.push_back(param);
 }

--- a/Sources/MaxPlugin/MaxComponent/plAutoUIParams.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plAutoUIParams.cpp
@@ -1672,6 +1672,30 @@ bool plPickMaterialAnimationButtonParam::IsMyMessage(UINT msg, WPARAM wParam, LP
 ///////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////
 
+plKey plPickLayerButtonParam::GetKey(IParamBlock2 *pb, int idx)
+{
+    // get the plKeys based on the texture map that the Texture map is on
+    Texmap* texmap = (Texmap* )pb->GetReferenceTarget(fID);
+    // make sure that there was a texmap set
+    if (texmap) {
+        plPlasmaMAXLayer *maxLayer = plPlasmaMAXLayer::GetPlasmaMAXLayer(texmap);
+        if (maxLayer != nullptr) {
+            // make sure the index is valid
+            if (idx >= 0 && idx < maxLayer->GetNumConversionTargets()) {
+                plLayerInterface* convertedLayer = maxLayer->GetConversionTarget(idx);
+                if (convertedLayer)
+                    return convertedLayer->GetKey();
+            }
+        }
+    }
+
+    // otherwise we didn't find one, because of one of many reasons
+    return nullptr;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////
+
 plDropDownListParam::plDropDownListParam(ParamID id, ST::string name, std::vector<ST::string> options)
     : plAutoUIParam(id, std::move(name)), fhList(), fOptions(std::move(options))
 {

--- a/Sources/MaxPlugin/MaxComponent/plAutoUIParams.h
+++ b/Sources/MaxPlugin/MaxComponent/plAutoUIParams.h
@@ -394,6 +394,17 @@ public:
     void DestroyKeyArray();
 };
 
+class plPickLayerButtonParam : public plPickMaterialButtonParam
+{
+public:
+    plPickLayerButtonParam(ParamID id, ST::string name)
+        : plPickMaterialButtonParam(id, std::move(name))
+    { }
+
+    int GetParamType() override { return kTypeLayer; }
+    plKey GetKey(IParamBlock2 *pb, int idx = 0) override;
+};
+
 class plDropDownListParam : public plAutoUIParam
 {
 protected:


### PR DESCRIPTION
Using the pick material button class causes the underlying mipmap to be exposed to Python instead of the layer. Therefore we add a shim to only expose the layer.