### PR TITLE
Allow `ptLayer.setTexture()` for unloaded images.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pyImage.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyImage.cpp
@@ -42,7 +42,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pyImage.h"
 
-#include <algorithm>
 #include <vector>
 
 #include <string_theory/format>
@@ -209,12 +208,6 @@ PyObject* pyImage::Find(const ST::string& name)
 {
     std::vector<plKey> foundKeys;
     plKeyFinder::Instance().ReallyStupidSubstringSearch(name, plMipmap::Index(), foundKeys);
-    // Remove anything that isn't loaded - they aren't useful in  Python code
-    std::remove_if(
-        foundKeys.begin(),
-        foundKeys.end(),
-        [](const plKey& key) { return key->ObjectIsLoaded() == nullptr; }
-    );
 
     PyObject* tup = PyTuple_New(foundKeys.size());
     for (size_t i = 0; i < foundKeys.size(); ++i)

--- a/Sources/Plasma/FeatureLib/pfPython/pyLayer.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyLayer.cpp
@@ -66,13 +66,13 @@ plLayer* pyLayer::GetLayer() const
     return plLayer::ConvertNoRef(fLayerKey->ObjectIsLoaded());
 }
 
-void pyLayer::SetTexture(plBitmap* image)
+void pyLayer::SetTexture(const plKey& image)
 {
     plLayer* layer = GetLayer();
 
     if (image) {
         plLayRefMsg* refMsg = new plLayRefMsg(fLayerKey, plRefMsg::kOnReplace, 0, plLayRefMsg::kTexture);
-        hsgResMgr::ResMgr()->AddViaNotify(image->GetKey(), refMsg, plRefFlags::kActiveRef);
+        hsgResMgr::ResMgr()->AddViaNotify(image, refMsg, plRefFlags::kActiveRef);
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyLayer.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyLayer.h
@@ -119,7 +119,7 @@ public:
     plLayer* GetLayer() const;
 
     // For Python access
-    void SetTexture(plBitmap* image);
+    void SetTexture(const plKey& image);
     PyObject* GetTexture() const;
 
     static PyObject* Find(const ST::string& name, const ST::string& age, const ST::string& page);

--- a/Sources/Plasma/FeatureLib/pfPython/pyLayerGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyLayerGlue.cpp
@@ -87,7 +87,7 @@ PYTHON_METHOD_DEFINITION(ptLayer, setTexture, args)
         PYTHON_RETURN_ERROR;
     }
 
-    self->fThis->SetTexture(pyImage::ConvertFrom(imageObj)->GetImage());
+    self->fThis->SetTexture(pyImage::ConvertFrom(imageObj)->GetKey());
     PYTHON_RETURN_NONE;
 }
 


### PR DESCRIPTION
This is useful for setting textures that are in global PRPs.