### PR TITLE
Enable pipewire backend for OpenAL on Linux

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -22,7 +22,15 @@
       "libvorbis",
       "libvpx",
       "libwebm",
-      "openal-soft",
+      {
+        "name": "openal-soft",
+        "features": [
+          {
+            "name": "pipewire",
+            "platform": "linux"
+          }
+        ]
+      },
       "openssl",
       "opus",
       "physx",


### PR DESCRIPTION
Pipewire is supposed to become the new standard audio system on desktop Linux, replacing PulseAudio (which itself replaced the cursèd mess of Also/OSS/Jack (except all of those somehow still exist... 😣 ))

It's not enabled by default in vcpkg's openal-soft package, but is available as a feature that we can opt into.