### PR TITLE
Implementing light range support in Metal

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
@@ -212,6 +212,11 @@ vertex ColorInOut pipelineVertexShader(Vertex in [[stage_in]],
             // Omni Light in all directions
             const float3 v2l = lightSource->position.xyz - position.xyz;
             const float distance = length(v2l);
+            
+            if (distance > lightSource->range) {
+                continue;
+            }
+            
             direction.xyz = normalize(v2l);
 
             direction.w = 1.f / (lightSource->constAtten + lightSource->linAtten * distance + lightSource->quadAtten * pow(distance, 2.f));

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderTypes.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderTypes.h
@@ -150,6 +150,7 @@ struct plMetalShaderLightSource
     half4 specular;
     simd::float3 direction;
     simd::float4 spotProps; // (falloff, theta, phi)
+    __fp16 range;
     __fp16 constAtten;
     __fp16 linAtten;
     __fp16 quadAtten;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -2374,6 +2374,8 @@ void plMetalPipeline::IEnableLight(size_t i, plLightInfo* light)
     plDirectionalLightInfo* dirLight = nullptr;
     plOmniLightInfo*        omniLight = nullptr;
     plSpotLightInfo*        spotLight = nullptr;
+    
+    const float             maxRange = 32767.f;
 
     if ((dirLight = plDirectionalLightInfo::ConvertNoRef(light)) != nullptr) {
         hsVector3 lightDir = dirLight->GetWorldDirection();
@@ -2383,6 +2385,9 @@ void plMetalPipeline::IEnableLight(size_t i, plLightInfo* light)
         fLights.lampSources[i].constAtten = 1.0f;
         fLights.lampSources[i].linAtten = 0.0f;
         fLights.lampSources[i].quadAtten = 0.0f;
+        
+        fLights.lampSources[i].range = maxRange;
+        
     } else if ((omniLight = plOmniLightInfo::ConvertNoRef(light)) != nullptr) {
         hsPoint3 pos = omniLight->GetWorldPosition();
         fLights.lampSources[i].position = {pos.fX, pos.fY, pos.fZ, 1.0};
@@ -2392,6 +2397,8 @@ void plMetalPipeline::IEnableLight(size_t i, plLightInfo* light)
         fLights.lampSources[i].constAtten = omniLight->GetConstantAttenuation();
         fLights.lampSources[i].linAtten = omniLight->GetLinearAttenuation();
         fLights.lampSources[i].quadAtten = omniLight->GetQuadraticAttenuation();
+        
+        fLights.lampSources[i].range = omniLight->GetRadius();
 
         if (!omniLight->GetProjection() && (spotLight = plSpotLightInfo::ConvertNoRef(omniLight)) != nullptr) {
             hsVector3 lightDir = spotLight->GetWorldDirection();

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -2376,6 +2376,7 @@ void plMetalPipeline::IEnableLight(size_t i, plLightInfo* light)
     plSpotLightInfo*        spotLight = nullptr;
     
     const float             maxRange = 32767.f;
+    fLights.lampSources[i].range = maxRange;
 
     if ((dirLight = plDirectionalLightInfo::ConvertNoRef(light)) != nullptr) {
         hsVector3 lightDir = dirLight->GetWorldDirection();
@@ -2386,19 +2387,17 @@ void plMetalPipeline::IEnableLight(size_t i, plLightInfo* light)
         fLights.lampSources[i].linAtten = 0.0f;
         fLights.lampSources[i].quadAtten = 0.0f;
         
-        fLights.lampSources[i].range = maxRange;
-        
     } else if ((omniLight = plOmniLightInfo::ConvertNoRef(light)) != nullptr) {
         hsPoint3 pos = omniLight->GetWorldPosition();
         fLights.lampSources[i].position = {pos.fX, pos.fY, pos.fZ, 1.0};
-
-        // TODO: Maximum Range
 
         fLights.lampSources[i].constAtten = omniLight->GetConstantAttenuation();
         fLights.lampSources[i].linAtten = omniLight->GetLinearAttenuation();
         fLights.lampSources[i].quadAtten = omniLight->GetQuadraticAttenuation();
         
-        fLights.lampSources[i].range = omniLight->GetRadius();
+        if (omniLight->GetRadius() != 0.f) {
+            fLights.lampSources[i].range = omniLight->GetRadius();
+        }
 
         if (!omniLight->GetProjection() && (spotLight = plSpotLightInfo::ConvertNoRef(omniLight)) != nullptr) {
             hsVector3 lightDir = spotLight->GetWorldDirection();

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -2375,8 +2375,8 @@ void plMetalPipeline::IEnableLight(size_t i, plLightInfo* light)
     plOmniLightInfo*        omniLight = nullptr;
     plSpotLightInfo*        spotLight = nullptr;
     
-    const float             maxRange = 32767.f;
-    fLights.lampSources[i].range = maxRange;
+    constexpr float         kMaxRange = 32767.f;
+    fLights.lampSources[i].range = kMaxRange;
 
     if ((dirLight = plDirectionalLightInfo::ConvertNoRef(light)) != nullptr) {
         hsVector3 lightDir = dirLight->GetWorldDirection();
@@ -2386,7 +2386,7 @@ void plMetalPipeline::IEnableLight(size_t i, plLightInfo* light)
         fLights.lampSources[i].constAtten = 1.0f;
         fLights.lampSources[i].linAtten = 0.0f;
         fLights.lampSources[i].quadAtten = 0.0f;
-        
+
     } else if ((omniLight = plOmniLightInfo::ConvertNoRef(light)) != nullptr) {
         hsPoint3 pos = omniLight->GetWorldPosition();
         fLights.lampSources[i].position = {pos.fX, pos.fY, pos.fZ, 1.0};
@@ -2394,7 +2394,7 @@ void plMetalPipeline::IEnableLight(size_t i, plLightInfo* light)
         fLights.lampSources[i].constAtten = omniLight->GetConstantAttenuation();
         fLights.lampSources[i].linAtten = omniLight->GetLinearAttenuation();
         fLights.lampSources[i].quadAtten = omniLight->GetQuadraticAttenuation();
-        
+
         if (omniLight->GetRadius() != 0.f) {
             fLights.lampSources[i].range = omniLight->GetRadius();
         }


### PR DESCRIPTION
This fixes the popping issue discovered while investigating bump maps in BumpDemo.

Similar changes may need to be done to OpenGL. These changes will also need to be back ported into the per pixel lighting branch.