### PR TITLE
Preventing resize overuse in SortVisibleSpans

### DIFF
--- a/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plDrawableSpans.cpp
@@ -1783,8 +1783,11 @@ void plDrawableSpans::SortVisibleSpans(const std::vector<int16_t>& visList, plPi
 
     plProfile_IncCount(FacesSorted, totTris);
 
-    sortScratch.resize(totTris);
-    triList.resize(3 * totTris);
+    if( sortScratch.size() < totTris )
+    {
+        sortScratch.resize(totTris);
+        triList.resize(3 * totTris);
+    }
 
     hsRadixSort::Elem* elem = sortScratch.data();
 


### PR DESCRIPTION
Adding an if check to resize the buffers only when there is a risk of an overflow.

Every pass through is resizing the scratch buffers in SortVisibleSpans. Resize is completely deallocating and reallocating the buffers. This is resulting in a ~5% performance drag - so this change results in a ~5% performance improvement on the main loop.

It’s possible this is a result of 78c0b48 which moved this storage over to std. I don’t know if the Cyan array implementation would have handled this.

I don’t see any reason this would create issues - there doesn’t seem to be code that relies on the size of the vectors. The vectors only need to be correctly sized to fit all the data required.