### PR TITLE
Use the Ubuntu 22.04 runner for Linux CI for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           path: build/install
 
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: ${{ matrix.platform.str }}-${{ matrix.cfg.str }}
     strategy:
       matrix:


### PR DESCRIPTION
The newer 24.04 runner has too many issues 😞 