### PR TITLE
SetActivePlayer when double clicking on the player name.

### DIFF
--- a/Scripts/Python/xDialogStartUp.py
+++ b/Scripts/Python/xDialogStartUp.py
@@ -301,6 +301,17 @@ class xDialogStartUp(ptResponder):
             elif event == kInterestingEvent: ## RollOver Event ##
                 self.ToggleColor(GUIDiag4b, tagID)
 
+            elif event == kSpecialAction:
+                if tagID in gExp_HotSpot or tagID in gVis_HotSpot:
+                    if gSelectedSlot and gPlayerList[gSelectedSlot-gMinusExplorer]:
+                        PtShowDialog("GUIDialog06a")
+                        PtDebugPrint("Player selected.")
+
+                        # start setting active player (we'll link out when this operation completes)
+                        playerID = gPlayerList[gSelectedSlot-gMinusExplorer][1]
+                        PtDebugPrint("Setting active player.")
+                        PtSetActivePlayer(playerID)
+
         #################################
         ##        Delete Player        ##
         #################################

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIButtonMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIButtonMod.cpp
@@ -315,6 +315,11 @@ void    pfGUIButtonMod::HandleMouseDrag( hsPoint3 &mousePt, uint8_t modifiers )
     }
 }
 
+void    pfGUIButtonMod::HandleMouseDblClick(hsPoint3& mousePt, uint8_t modifiers)
+{
+    HandleExtendedEvent(kDoubleClick);
+}
+
 void    pfGUIButtonMod::SetNotifyType(int32_t kind)
 {
     fNotifyType = kind;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIButtonMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIButtonMod.h
@@ -105,6 +105,7 @@ class pfGUIButtonMod : public pfGUIControlMod
         void    HandleMouseDown(hsPoint3 &mousePt, uint8_t modifiers) override;
         void    HandleMouseUp(hsPoint3 &mousePt, uint8_t modifiers) override;
         void    HandleMouseDrag(hsPoint3 &mousePt, uint8_t modifiers) override;
+        void    HandleMouseDblClick(hsPoint3 &mousePt, uint8_t modifiers) override;
 
         void    UpdateBounds(hsMatrix44 *invXformMatrix = nullptr, bool force = false) override;
 
@@ -130,6 +131,11 @@ class pfGUIButtonMod : public pfGUIControlMod
             kNotifyOnUp = 0,
             kNotifyOnDown,
             kNotifyOnUpAndDown
+        };
+
+        enum ExtendedEvents
+        {
+            kDoubleClick,
         };
 
         void    StartDragging();

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogNotifyProc.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogNotifyProc.cpp
@@ -105,6 +105,12 @@ void pfGUIDialogNotifyProc::HandleExtendedEvent( pfGUIControlMod *ctrl, uint32_t
         if (event == pfGUIMultiLineEditCtrl::kLinkClicked)
             ISendNotify(ctrl->GetKey(), pfGUINotifyMsg::kAction);
     }
+
+    pfGUIButtonMod* button = pfGUIButtonMod::ConvertNoRef(ctrl);
+    if (button) {
+        if (event == pfGUIButtonMod::kDoubleClick)
+            ISendNotify(ctrl->GetKey(), pfGUINotifyMsg::kSpecialAction);
+    }
 }
 
 void pfGUIDialogNotifyProc::OnInit()

--- a/Sources/Plasma/FeatureLib/pfMessage/pfGUINotifyMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfGUINotifyMsg.h
@@ -91,7 +91,8 @@ public:
 // kDialog
 //    kShowHide         - when the dialog is shown or hidden
 // kButton
-//    kAction           - when the button clicked (should be on mouse button up)
+//    kAction           - when the button is clicked (should be on mouse button up)
+//    kSpecialAction    - when the button is double clicked
 // kListBox
 //    kAction           - single click on item(s)
 // kEditBox


### PR DESCRIPTION
This allows setting the active player from the StartUp Age by simply double clicking on the button corresponding to the player you want to activate.