### PR TITLE
Remove last uses of `hsStrcpy` and `hsStrncpy`

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plAudioComponents.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plAudioComponents.cpp
@@ -705,7 +705,7 @@ bool    plBaseSoundEmitterComponent::LookupLatestAsset( const char *waveName, ch
         }
 
         // Copy the string over and go
-        hsStrcpy( retPath, assetPath );
+        strcpy(retPath, assetPath);
         return true;
     }
 

--- a/Sources/MaxPlugin/MaxMain/plPythonMgr.cpp
+++ b/Sources/MaxPlugin/MaxMain/plPythonMgr.cpp
@@ -117,32 +117,20 @@ bool ICallIntFunc(PyObject *dict, const char *funcName, int& val)
     return false;
 }
 
-bool ICallStrFunc(PyObject *dict, const char *funcName, char*& val)
+bool ICallStrFunc(PyObject *dict, const char *funcName, ST::string& val)
 {
     PyObject *obj;
     if (ICallVoidFunc(dict, funcName, obj))
     {
         if (PyUnicode_Check(obj))
         {
-            val = hsStrcpy(PyUnicode_AsUTF8(obj));
-            Py_DECREF(obj);
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool ICallStrFunc(PyObject* dict, const char* funcName, wchar_t*& val)
-{
-    PyObject* obj;
-    if (ICallVoidFunc(dict, funcName, obj)) {
-        if (PyUnicode_Check(obj)) {
             Py_ssize_t size;
-            wchar_t* pyUtf16Str = PyUnicode_AsWideCharString(obj, &size);
-            val = new wchar_t[size + 1];
-            wcsncpy(val, pyUtf16Str, size + 1);
-            PyMem_Free(pyUtf16Str);
+            const char* utf8 = PyUnicode_AsUTF8AndSize(obj, &size);
+            if (utf8 == nullptr) {
+                Py_DECREF(obj);
+                return false;
+            }
+            val = ST::string::from_utf8(utf8, size);
             Py_DECREF(obj);
             return true;
         }
@@ -290,7 +278,7 @@ bool plPythonMgr::IQueryPythonFile(const ST::string& fileName)
         }
 
         // Get the class name
-        MCHAR* className = nullptr;
+        ST::string className;
         if (!ICallStrFunc(dict, kGetClassName, className))
         {
             Py_DECREF(module);
@@ -326,7 +314,7 @@ bool plPythonMgr::IQueryPythonFile(const ST::string& fileName)
 
         if (PyCallable_Check(getParamFunc))
         {
-            plAutoUIBlock *autoUI = new plAutoUIBlock(PythonFile::GetClassDesc(), blockID, className, version);
+            plAutoUIBlock *autoUI = new plAutoUIBlock(PythonFile::GetClassDesc(), blockID, std::move(className), version);
             // test to see if it is a multi-modifier type class
             if (isMulti)
                 autoUI->SetMultiModifierFlag(true);
@@ -466,7 +454,6 @@ bool plPythonMgr::IQueryPythonFile(const ST::string& fileName)
             PythonFile::AddAutoUIBlock(autoUI);
         }
 
-        delete [] className;
         Py_DECREF(module);
     }
     else

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -274,26 +274,3 @@ void hsStatusMessageF(const char * fmt, ...)
 }
 
 #endif
-
-/**************************************/
-char* hsStrcpy(char* dst, const char* src)
-{
-    if (src)
-    {
-        if (dst == nullptr)
-        {
-            size_t count = strlen(src);
-            dst = new char[count + 1];
-            memcpy(dst, src, count);
-            dst[count] = 0;
-            return dst;
-        }
-
-        int32_t i;
-        for (i = 0; src[i] != 0; i++)
-            dst[i] = src[i];
-        dst[i] = 0;
-    }
-
-    return dst;
-}

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -258,20 +258,6 @@ template <> inline double hsToLE(double value) { return hsToLEDouble(value); }
     void    hsStatusMessageF(const char * fmt, ...);
 #endif // PLASMA_EXTERNAL_RELEASE
 
-char*   hsStrcpy(char* dstOrNil, const char* src);
-
-inline char* hsStrcpy(const char* src)
-{
-    return hsStrcpy(nullptr, src);
-}
-
-inline char *hsStrncpy(char *strDest, const char *strSource, size_t count)
-{
-    char *temp = strncpy(strDest, strSource, count-1);
-    strDest[count-1] = 0;
-    return temp;
-}
-
 // Use "correct" non-standard string functions based on the
 // selected compiler / library
 #if HS_BUILD_FOR_WIN32

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -46,6 +46,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #include <algorithm>
+#include <string_theory/format>
 
 // singular
 #include "plAGAnimInstance.h"
@@ -621,35 +622,20 @@ void plAGAnimInstance::ISetupFade(float goal, float rate, bool detach, uint8_t t
     }
 }
 
-class agAlloc
+struct agAlloc
 {
-public:
-    agAlloc(plAGChannel *object, const char *chanName, const char *animName, uint16_t classIndex)
-        : fObject(object),
-          fClassIndex(classIndex)
-    {
-        fChannelName = hsStrcpy(chanName);
-        fAnimName = hsStrcpy(animName);
-    }
-
-    ~agAlloc()
-    {
-        delete[] fChannelName;
-        delete[] fAnimName;
-    }
-
     plAGChannel *fObject;
-    char *fChannelName;
-    char *fAnimName;
+    ST::string fChannelName;
+    ST::string fAnimName;
     uint16_t fClassIndex;
 };
 
 typedef std::map<plAGChannel *, agAlloc *> agAllocMap;
 static agAllocMap gAGAllocs;
 
-void RegisterAGAlloc(plAGChannel *object, const char *chanName, const char *animName, uint16_t classIndex)
+void RegisterAGAlloc(plAGChannel *object, ST::string chanName, ST::string animName, uint16_t classIndex)
 {
-    gAGAllocs[object] = new agAlloc(object, chanName, animName, classIndex);
+    gAGAllocs[object] = new agAlloc {object, std::move(chanName), std::move(animName), classIndex};
 }
 
 void DumpAGAllocs()
@@ -665,7 +651,7 @@ void DumpAGAllocs()
 
         uint16_t realClassIndex = al->fObject->ClassIndex();
 
-        hsStatusMessageF("agAlloc: an: %s ch: %s, cl: %s", al->fAnimName, al->fChannelName, plFactory::GetNameOfClass(realClassIndex));
+        hsStatusMessage(ST::format("agAlloc: an: {} ch: {}, cl: {}", al->fAnimName, al->fChannelName, plFactory::GetNameOfClass(realClassIndex)).c_str());
 
     }
     // it's not fast but it's safe and simple..

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.h
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.h
@@ -261,7 +261,7 @@ protected:
 extern ST::string gGlobalAnimName;
 extern ST::string gGlobalChannelName;
 
-void RegisterAGAlloc(plAGChannel *object, const char *chanName, const char *animName, uint16_t classIndex);
+void RegisterAGAlloc(plAGChannel *object, ST::string chanName, ST::string animName, uint16_t classIndex);
 void UnRegisterAGAlloc(plAGChannel *object);
 void DumpAGAllocs();
 

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGChannel.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGChannel.cpp
@@ -61,14 +61,13 @@ plAGChannel::plAGChannel()
 {
 #ifdef TRACK_AG_ALLOCS
     fName = gGlobalAnimName;
-    RegisterAGAlloc(this, gGlobalChannelName.c_str(), gGlobalAnimName.c_str(), this->ClassIndex());
+    RegisterAGAlloc(this, gGlobalChannelName, gGlobalAnimName, this->ClassIndex());
 #endif // TRACK_AG_ALLOCS
 }
 
 // DTOR
 plAGChannel::~plAGChannel()
 {
-    // we do not own the "fName" string, so don't delete it!
 #ifdef TRACK_AG_ALLOCS
     UnRegisterAGAlloc(this);
 #endif // TRACK_AG_ALLOCS

--- a/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.h
+++ b/Sources/Plasma/PubUtilLib/plNetMessage/plNetMessage.h
@@ -758,7 +758,14 @@ public:
     CLASSNAME_REGISTER( plNetMsgGetSharedState );
     GETINTERFACE_ANY( plNetMsgGetSharedState, plNetMsgObject );
 
-    void SetSharedStateName(char* n) { if (n) hsStrncpy(fSharedStateName, n, kMaxNameLen); }
+    void SetSharedStateName(char* n)
+    {
+        if (n) {
+            strncpy(fSharedStateName, n, kMaxNameLen - 1);
+            fSharedStateName[kMaxNameLen - 1] = 0;
+        }
+    }
+
     char* GetSharedStateName() { return fSharedStateName; }
 };
 

--- a/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plStateVariable.cpp
@@ -379,7 +379,10 @@ bool plSimpleStateVariable::SetFromString(const ST::string& value, int idx, bool
             int i=idx*fVar.GetAtomicCount();
             for (std::vector<ST::string>::iterator ptr = bits.begin(); ptr != bits.end(); ++ptr)
             {
-                hsStrncpy(fS32[i++], ptr->c_str(), 32);
+                plVarDescriptor::String32& dest = fS32[i];
+                strncpy(dest, ptr->c_str(), std::size(dest) - 1);
+                dest[std::size(dest) - 1] = 0;
+                i++;
             }
         }
         break;
@@ -1730,7 +1733,7 @@ bool plSimpleStateVariable::Get(char value[], int idx) const
 
     if (fVar.GetType()==plVarDescriptor::kString32)
     {
-        hsStrcpy(value, fS32[idx]);
+        strcpy(value, fS32[idx]);
         return true;
     }
     hsAssert(false, "passing wrong value type to SDL variable"); 


### PR DESCRIPTION
Most calls to these functions have already been removed in previous `ST::string`/Unicode conversion work. This PR takes care of the last few remaining uses and finally drops these custom functions (in favor of `ST::string` and standard C APIs).

Important difference: `hsStrncpy` always ensured that the destination string is 0-terminated, whereas the standard C `strncpy` will *not* add a 0 terminator if the destination buffer is too small to hold the entire source string. So we do lose this convenience/safety feature by switching to standard functions. But considering that (after this PR) the codebase only contains 12 `strncpy` calls in total, I don't think `hsStrncpy` is worth keeping around (especially not in the HeadSpin.h header that's included almost everywhere).