### PR TITLE
Optimize some poorly performing parts of ASYS.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem.h
@@ -124,7 +124,7 @@ public:
 
     static bool LogStreamingUpdates() { return fLogStreamingUpdates; }
     static void SetLogStreamingUpdates(bool logUpdates) { fLogStreamingUpdates = logUpdates; }
-    static void RegisterSoftSound(const plKey& soundKey);
+    static void RegisterSoftSound(plKey soundKey);
     static void UnregisterSoftSound(const plKey& soundKey);
 
     static void SetDistanceModel(int type);

--- a/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem_Private.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plAudioSystem_Private.h
@@ -54,6 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #endif
 #include <memory>
 #include <set>
+#include <vector>
 
 #include "hsGeometry3.h"
 #include "pnKeyedObject/hsKeyedObject.h"
@@ -62,6 +63,20 @@ class plAudioEndpointVolume;
 class plEAXListenerMod;
 class plSoftSoundNode;
 class plStatusLog;
+
+class plSoftSound
+{
+public:
+    plKey fSoundKey;
+    float fRank;
+
+    plSoftSound(plKey s)
+        : fSoundKey(std::move(s))
+    {
+    }
+
+    void BootSourceOff() const;
+};
 
 class plAudioSystem : public hsKeyedObject
 {
@@ -110,12 +125,12 @@ protected:
     ALCdevice* fCaptureDevice;
     std::unique_ptr<plAudioEndpointVolume> fCaptureLevel;
 
-    plSoftSoundNode* fSoftRegionSounds;
-    plSoftSoundNode* fActiveSofts;
+    std::vector<plSoftSound> fSoftRegionSounds;
+    std::vector<plSoftSound> fActiveSofts;
     plStatusLog* fDebugActiveSoundDisplay;
 
     static int32_t fMaxNumSounds, fNumSoundsSlop;
-    plSoftSoundNode* fCurrDebugSound;
+    plKey fCurrDebugSound;
 
     hsPoint3 fCurrListenerPos;
     bool fActive, fUsingEAX, fRestartOnDestruct, fWaitingForShutdown;
@@ -137,7 +152,7 @@ protected:
     bool OpenCaptureDevice();
     bool RestartCapture();
 
-    void RegisterSoftSound(const plKey& soundKey);
+    void RegisterSoftSound(plKey soundKey);
     void UnregisterSoftSound(const plKey& soundKey);
     void IUpdateSoftSounds(const hsPoint3& newPosition);
 };

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.h
@@ -210,7 +210,7 @@ public:
 
     virtual void        Update();
     
-    plSoundBuffer *     GetDataBuffer() const { return (plSoundBuffer *)fDataBufferKey->ObjectIsLoaded(); }
+    plSoundBuffer *     GetDataBuffer() const { return fDataBuffer; }
     float               QueryCurrVolume() const;  // Returns the current volume, attenuated
 
     plFileName          GetFileName() const;

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32StaticSound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32StaticSound.cpp
@@ -99,11 +99,8 @@ bool plWin32StaticSound::LoadSound( bool is3D )
 
         // We need it to be resident to read in
         plSoundBuffer::ELoadReturnVal retVal = IPreLoadBuffer(true);
-        plSoundBuffer *buffer = (plSoundBuffer *)fDataBufferKey->ObjectIsLoaded();  
-        if(!buffer)
-        {
+        if (!fDataBuffer)
             return plSoundBuffer::kError;
-        }
 
         if( retVal == plSoundBuffer::kPending)  // we are still reading data. 
         {
@@ -120,7 +117,7 @@ bool plWin32StaticSound::LoadSound( bool is3D )
         
         SetProperty( kPropIs3DSound, is3D );
 
-        plWAVHeader header = buffer->GetHeader();
+        plWAVHeader header = fDataBuffer->GetHeader();
 
         // Debug flag #2
         if( fChannelSelect == 0 && header.fNumChannels > 1 && plgAudioSys::IsDebugFlagSet( plgAudioSys::kDisableLeftSelect ) )
@@ -129,7 +126,7 @@ bool plWin32StaticSound::LoadSound( bool is3D )
             fFailed = true;
             return false;
         }
-        uint32_t bufferSize = buffer->GetDataLength();
+        uint32_t bufferSize = fDataBuffer->GetDataLength();
 
         if( header.fNumChannels > 1 && is3D )
         {
@@ -163,7 +160,7 @@ bool plWin32StaticSound::LoadSound( bool is3D )
     
         plProfile_BeginTiming( StaticSndShoveTime );
 
-        if(!fDSoundBuffer->FillBuffer(buffer->GetData(), buffer->GetDataLength(), &header))
+        if (!fDSoundBuffer->FillBuffer(fDataBuffer->GetData(), fDataBuffer->GetDataLength(), &header))
         {
             delete fDSoundBuffer;
             fDSoundBuffer = nullptr;


### PR DESCRIPTION
This optimizes the "Soft Update" portion of the audio system update. According to my profiling, with 101 male avatars in an Age (resulting in approximately 31,000 sounds loaded), this function would take 7ms on my Ryzen 9 7900X3D. I have something of an overkill CPU, so this kind of drag in the update loop is unacceptable. The problem is that the sounds are all being stored in an intrusive doubly linked list, which is being traversed and partially bubble sorted each update. This pull request changes the container from the intrusive doubly-linked list to an `std::vector` and uses `std::sort()` to sort the active sounds. This change results in the "Soft Update" portion of the update loop only taking about 3ms on my Ryzen 9 7900X3D.

As a bonus, I have improved the semantics around accessing the `plSoundBuffer*` from `plSound` objects. There was already a `plSoundBuffer*` member variable, but it was only ever set by the exporter. The client code was grabbing an active ref and continually grabbing the object pointer from the `plKey`. I have changed this to store the `plSoundBuffer*` in the field that already exists, removing the pointless indirection.