### PR TITLE
Sort Python stubs consistently

### DIFF
--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -492,12 +492,12 @@ def PtGetMouseTurnSensitivity():
     """Returns the sensitivity"""
     pass
 
-def PtGetNPCCount():
-    """This will return the number of NPCs in the current age"""
-    pass
-
 def PtGetNPCByID(npcID):
     """This will return the NPC with a specific ID"""
+    pass
+
+def PtGetNPCCount():
+    """This will return the number of NPCs in the current age"""
     pass
 
 def PtGetNumCameras():
@@ -2399,23 +2399,23 @@ class ptGameScore:
         pass
 
     @staticmethod
-    def findAgeScores(scoreName, key):
-        """Finds matching scores for this age"""
-        pass
-
-    @staticmethod
     def findAgeHighScores(name, maxScores, key):
         """Finds the highest matching scores for the current age's owners"""
         pass
 
     @staticmethod
-    def findGlobalScores(scoreName, key):
-        """Finds matching global scores"""
+    def findAgeScores(scoreName, key):
+        """Finds matching scores for this age"""
         pass
 
     @staticmethod
     def findGlobalHighScores(name, maxScores, key):
         """Finds the highest matching scores"""
+        pass
+
+    @staticmethod
+    def findGlobalScores(scoreName, key):
+        """Finds matching global scores"""
         pass
 
     @staticmethod
@@ -4237,12 +4237,12 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """Returns the size of the buffer"""
         pass
 
-    def getCursor(self) -> int:
-        """Get the current position of the cursor in the encoded buffer."""
-        ...
-
     def getCurrentLink(self) -> int:
         """Returns the link the mouse is currently over."""
+        ...
+
+    def getCursor(self) -> int:
+        """Get the current position of the cursor in the encoded buffer."""
         ...
 
     def getEncodedBuffer(self):
@@ -5024,13 +5024,13 @@ class ptGUIDialog:
         """Returns the ptKey of the control with the specified index (not tag ID!)"""
         pass
 
-    def getControlModFromIndex(self, index: int) -> ptGUIControl:
-        """Returns the ptGUIControl with the specified index (not tag ID!)"""
-        ...
-
     def getControlFromTag(self,tagID):
         """Returns the ptKey of the control with the specified tag ID"""
         pass
+
+    def getControlModFromIndex(self, index: int) -> ptGUIControl:
+        """Returns the ptGUIControl with the specified index (not tag ID!)"""
+        ...
 
     def getControlModFromTag(self, tagID: int) -> ptGUIControl:
         """Returns the GUI control with the specified tag ID"""
@@ -5712,29 +5712,29 @@ class ptNotify:
         """Add a responder state event record to the notify message"""
         pass
 
+    def addVarFloat(self,name,number):
+        """Add a float variable event record to the Notify message
+This event record is used to pass a number variable to another python program"""
+        pass
+
+    def addVarInt(self,name,number):
+        """Add a integer variable event record to the Notify message
+This event record is used to pass a number variable to another python program"""
+        pass
+
     def addVarKey(self,name,key):
         """Add a ptKey variable event record to the Notify message
 This event record is used to pass a ptKey variable to another python program"""
         pass
 
+    def addVarNull(self,name):
+        """Add a null (no data) variable event record to the Notify message
+This event record is used to pass a number variable to another python program"""
+        pass
+
     def addVarNumber(self,name,number):
         """Add a number variable event record to the Notify message
 Method will try to pick appropriate variable type
-This event record is used to pass a number variable to another python program"""
-        pass
-        
-    def addVarFloat(self,name,number):
-        """Add a float variable event record to the Notify message
-This event record is used to pass a number variable to another python program"""
-        pass
-        
-    def addVarInt(self,name,number):
-        """Add a integer variable event record to the Notify message
-This event record is used to pass a number variable to another python program"""
-        pass
-        
-    def addVarNull(self,name):
-        """Add a null (no data) variable event record to the Notify message
 This event record is used to pass a number variable to another python program"""
         pass
 
@@ -6071,6 +6071,10 @@ Add another sceneobject ptKey"""
         """Find a particular object in just the sceneobjects that are attached"""
         pass
 
+    def getImageLibMods(self):
+        """Returns list of ptKeys of the image library modifiers attached to this sceneobject"""
+        pass
+
     def getKey(self):
         """Get the ptKey of this sceneobject
 If there are more then one attached, get the first one"""
@@ -6098,10 +6102,6 @@ If there are more then one attached, get the first one"""
 
     def getPythonMods(self):
         """Returns list of ptKeys of the python modifiers attached to this sceneobject"""
-        pass
-
-    def getImageLibMods(self):
-        """Returns list of ptKeys of the image library modifiers attached to this sceneobject"""
         pass
 
     def getResponderState(self):
@@ -9327,12 +9327,12 @@ class ptVaultTextNoteNode(ptVaultNode):
         """Sets ID of this ptVaultNode."""
         pass
 
-    def setNoteType(self,type):
-        """Sets the type of text note for this text note node."""
-        pass
-
     def setNoteSubType(self,subType):
         """Sets the subtype of the this text note node."""
+        pass
+
+    def setNoteType(self,type):
+        """Sets the type of text note for this text note node."""
         pass
 
     def setOwnerNodeID(self,id):

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -2368,143 +2368,6 @@ unsetWrapping() is called"""
         """Stop text wrapping"""
         pass
 
-class ptGameScore:
-    """Plasma Game Score"""
-    def __init__(self):
-        """None"""
-        pass
-
-    def addPoints(self, points, key=None):
-        """Adds points to the score"""
-        pass
-
-    @staticmethod
-    def createAgeScore(scoreName, type, points=0, key=None):
-        """Creates a new score associated with this age"""
-        pass
-
-    @staticmethod
-    def createGlobalScore(scoreName, type, points=0, key=None):
-        """Creates a new global score"""
-        pass
-
-    @staticmethod
-    def createPlayerScore(scoreName, type, points=0, key=None):
-        """Creates a new score associated with this player"""
-        pass
-
-    @staticmethod
-    def createScore(ownerID, scoreName, type, points=0, key=None):
-        """Creates a new score for an arbitrary owner"""
-        pass
-
-    @staticmethod
-    def findAgeHighScores(name, maxScores, key):
-        """Finds the highest matching scores for the current age's owners"""
-        pass
-
-    @staticmethod
-    def findAgeScores(scoreName, key):
-        """Finds matching scores for this age"""
-        pass
-
-    @staticmethod
-    def findGlobalHighScores(name, maxScores, key):
-        """Finds the highest matching scores"""
-        pass
-
-    @staticmethod
-    def findGlobalScores(scoreName, key):
-        """Finds matching global scores"""
-        pass
-
-    @staticmethod
-    def findPlayerScores(scoreName, key):
-        """Finds matching player scores"""
-        pass
-
-    @staticmethod
-    def findScores(ownerID, scoreName, key):
-        """Finds matching scores for an arbitrary owner"""
-        pass
-
-    def getGameType(self):
-        """Returns the score game type."""
-        pass
-
-    def getName(self):
-        """Returns the score game name."""
-        pass
-
-    def getOwnerID(self):
-        """Returns the score game owner."""
-        pass
-
-    def getPoints(self):
-        """Returns the number of points in this score"""
-        pass
-
-    def remove(self):
-        """Removes this score from the server"""
-        pass
-
-    def setPoints(self):
-        """Sets the number of points in the score
-        Don't use to add/remove points, use only to reset values!"""
-        pass
-
-    def transferPoints(self, dest, points=0, key=None):
-        """Transfers points from this score to another"""
-        pass
-
-class ptGameScoreMsg:
-    """Game Score operation callback message"""
-    def __init__(self):
-        """None"""
-        pass
-
-class ptGameScoreListMsg(ptGameScoreMsg):
-    """Game Score message for scores found on the server"""
-    def __init__(self):
-        """None"""
-        pass
-
-    def getName(self):
-        """Returns the template score name"""
-        pass
-
-    def getOwnerID(self):
-        """Returns the template score ownerID"""
-        pass
-
-    def getScores(self):
-        """Returns a list of scores found by the server"""
-        pass
-
-class ptGameScoreTransferMsg(ptGameScoreMsg):
-    """Game Score message indicating a score point transfer"""
-    def __init__(self):
-        """None"""
-        pass
-
-    def getDestination(self):
-        """Returns the score points were transferred to"""
-        pass
-
-    def getSource(self):
-        """Returns the score points were transferred from"""
-        pass
-
-class ptGameScoreUpdateMsg(ptGameScoreMsg):
-    """Game Score message for a score update operation"""
-    def __init__(self):
-        """None"""
-        pass
-
-    def getScore(self):
-        """Returns the updated game score"""
-        pass
-
 class ptGUIControl:
     """Base class for all GUI controls"""
     def __init__(self,controlKey):
@@ -5217,6 +5080,143 @@ class ptGUISkin:
 
     def getKey(self):
         """Returns this object's ptKey"""
+        pass
+
+class ptGameScore:
+    """Plasma Game Score"""
+    def __init__(self):
+        """None"""
+        pass
+
+    def addPoints(self, points, key=None):
+        """Adds points to the score"""
+        pass
+
+    @staticmethod
+    def createAgeScore(scoreName, type, points=0, key=None):
+        """Creates a new score associated with this age"""
+        pass
+
+    @staticmethod
+    def createGlobalScore(scoreName, type, points=0, key=None):
+        """Creates a new global score"""
+        pass
+
+    @staticmethod
+    def createPlayerScore(scoreName, type, points=0, key=None):
+        """Creates a new score associated with this player"""
+        pass
+
+    @staticmethod
+    def createScore(ownerID, scoreName, type, points=0, key=None):
+        """Creates a new score for an arbitrary owner"""
+        pass
+
+    @staticmethod
+    def findAgeHighScores(name, maxScores, key):
+        """Finds the highest matching scores for the current age's owners"""
+        pass
+
+    @staticmethod
+    def findAgeScores(scoreName, key):
+        """Finds matching scores for this age"""
+        pass
+
+    @staticmethod
+    def findGlobalHighScores(name, maxScores, key):
+        """Finds the highest matching scores"""
+        pass
+
+    @staticmethod
+    def findGlobalScores(scoreName, key):
+        """Finds matching global scores"""
+        pass
+
+    @staticmethod
+    def findPlayerScores(scoreName, key):
+        """Finds matching player scores"""
+        pass
+
+    @staticmethod
+    def findScores(ownerID, scoreName, key):
+        """Finds matching scores for an arbitrary owner"""
+        pass
+
+    def getGameType(self):
+        """Returns the score game type."""
+        pass
+
+    def getName(self):
+        """Returns the score game name."""
+        pass
+
+    def getOwnerID(self):
+        """Returns the score game owner."""
+        pass
+
+    def getPoints(self):
+        """Returns the number of points in this score"""
+        pass
+
+    def remove(self):
+        """Removes this score from the server"""
+        pass
+
+    def setPoints(self):
+        """Sets the number of points in the score
+        Don't use to add/remove points, use only to reset values!"""
+        pass
+
+    def transferPoints(self, dest, points=0, key=None):
+        """Transfers points from this score to another"""
+        pass
+
+class ptGameScoreMsg:
+    """Game Score operation callback message"""
+    def __init__(self):
+        """None"""
+        pass
+
+class ptGameScoreListMsg(ptGameScoreMsg):
+    """Game Score message for scores found on the server"""
+    def __init__(self):
+        """None"""
+        pass
+
+    def getName(self):
+        """Returns the template score name"""
+        pass
+
+    def getOwnerID(self):
+        """Returns the template score ownerID"""
+        pass
+
+    def getScores(self):
+        """Returns a list of scores found by the server"""
+        pass
+
+class ptGameScoreTransferMsg(ptGameScoreMsg):
+    """Game Score message indicating a score point transfer"""
+    def __init__(self):
+        """None"""
+        pass
+
+    def getDestination(self):
+        """Returns the score points were transferred to"""
+        pass
+
+    def getSource(self):
+        """Returns the score points were transferred from"""
+        pass
+
+class ptGameScoreUpdateMsg(ptGameScoreMsg):
+    """Game Score message for a score update operation"""
+    def __init__(self):
+        """None"""
+        pass
+
+    def getScore(self):
+        """Returns the updated game score"""
         pass
 
 class ptGrassShader:

--- a/Scripts/Python/plasma/PlasmaConstants.py
+++ b/Scripts/Python/plasma/PlasmaConstants.py
@@ -114,6 +114,16 @@ class PtButtonNotifyTypes:
     kNotifyOnDown = 1
     kNotifyOnUpAndDown = 2
 
+class PtCCRPetitionType:
+    """(none)"""
+    kGeneralHelp = 0
+    kBug = 1
+    kFeedback = 2
+    kExploit = 3
+    kHarass = 4
+    kStuck = 5
+    kTechnical = 6
+
 class PtConfirmationResult:
     OK = 1
     Cancel = 0
@@ -127,16 +137,6 @@ class PtConfirmationType:
     ConfirmQuit = 1
     ForceQuit = 2
     YesNo = 3
-
-class PtCCRPetitionType:
-    """(none)"""
-    kGeneralHelp = 0
-    kBug = 1
-    kFeedback = 2
-    kExploit = 3
-    kHarass = 4
-    kStuck = 5
-    kTechnical = 6
 
 class PtEventType:
     """(none)"""
@@ -154,6 +154,12 @@ class PtEventType:
     kClickDrag = 12
     kOfferLinkingBook = 14
     kBook = 15
+
+class PtFontFlags:
+    """(none)"""
+    kFontBold = 1
+    kFontItalic = 2
+    kFontShadowed = 4
 
 class PtGUIMultiLineDirection:
     """(none)"""
@@ -181,12 +187,6 @@ class PtJustify:
     kLeftJustify = 0
     kCenter = 1
     kRightJustify = 2
-
-class PtFontFlags:
-    """(none)"""
-    kFontBold = 1
-    kFontItalic = 2
-    kFontShadowed = 4
 
 class PtLOSObjectType:
     """(none)"""

--- a/Scripts/Python/plasma/PlasmaConstants.py
+++ b/Scripts/Python/plasma/PlasmaConstants.py
@@ -68,25 +68,25 @@ class PtAccountUpdateType:
 
 class PtBehaviorTypes:
     """(none)"""
-    kBehaviorTypeFall = 8192
-    kBehaviorTypeIdle = 32
+    kBehaviorTypeStandingJump = 1
     kBehaviorTypeWalkingJump = 2
-    kBehaviorTypeSidestepRight = 4096
     kBehaviorTypeRunningJump = 4
-    kBehaviorTypeLinkIn = 65536
     kBehaviorTypeAnyJump = 7
     kBehaviorTypeRunningImpact = 8
+    kBehaviorTypeGroundImpact = 16
+    kBehaviorTypeAnyImpact = 24
+    kBehaviorTypeIdle = 32
     kBehaviorTypeWalk = 64
     kBehaviorTypeRun = 128
-    kBehaviorTypeTurnRight = 1024
     kBehaviorTypeWalkBack = 256
-    kBehaviorTypeMovingTurnLeft = 16384
-    kBehaviorTypeGroundImpact = 16
-    kBehaviorTypeStandingJump = 1
     kBehaviorTypeTurnLeft = 512
-    kBehaviorTypeAnyImpact = 24
+    kBehaviorTypeTurnRight = 1024
     kBehaviorTypeSidestepLeft = 2048
+    kBehaviorTypeSidestepRight = 4096
+    kBehaviorTypeFall = 8192
+    kBehaviorTypeMovingTurnLeft = 16384
     kBehaviorTypeMovingTurnRight = 32768
+    kBehaviorTypeLinkIn = 65536
     kBehaviorTypeLinkOut = 131072
 
 class PtBookEventTypes:
@@ -125,11 +125,11 @@ class PtCCRPetitionType:
     kTechnical = 6
 
 class PtConfirmationResult:
-    OK = 1
     Cancel = 0
-    Yes = 1
     No = 0
+    OK = 1
     Quit = 1
+    Yes = 1
     Logout = 62
 
 class PtConfirmationType:
@@ -247,13 +247,14 @@ class PtNotifyDataType:
 
 class PtSDLReadWriteOptions:
     """(none)"""
-    kTimeStampOnRead = 16
     kDirtyOnly = 1
     kSkipNotificationInfo = 2
     kBroadcast = 4
+    kTimeStampOnRead = 16
 
 class PtSDLVarType:
     """(none)"""
+    kNone = -1
     kInt = 0
     kFloat = 1
     kBool = 2
@@ -270,7 +271,6 @@ class PtSDLVarType:
     kRGB = 52
     kRGBA = 53
     kQuaternion = 54
-    kNone = -1
 
 class PtScoreRankGroups:
     """(none)"""
@@ -286,14 +286,14 @@ class PtScoreTimePeriods:
 
 class PtStatusLogFlags:
     """(none)"""
-    kDebugOutput = 32
     kFilledBackground = 1
     kAppendToLast = 2
     kDontWriteFile = 4
     kDeleteForMe = 8
+    kAlignToTop = 16
+    kDebugOutput = 32
     kTimestamp = 64
     kStdout = 128
     kTimeInSeconds = 256
-    kAlignToTop = 16
     kTimeAsDouble = 512
 

--- a/Scripts/Python/plasma/PlasmaGameConstants.py
+++ b/Scripts/Python/plasma/PlasmaGameConstants.py
@@ -44,6 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 from __future__ import annotations
 
 class PtGameJoinError:
+    kGameJoinPending = -1
     kGameJoinSuccess = 0
     kGameJoinErrNotExist = 1
     kGameJoinErrInitFailed = 2
@@ -53,7 +54,6 @@ class PtGameJoinError:
     kGameJoinErrAlreadyJoined = 6
     kGameJoinErrNoInvite = 7
     kNumGameJoinErrors = 8
-    kGameJoinPending = -1
 
 
 class PtMarkerGameType:

--- a/Scripts/Python/plasma/PlasmaVaultConstants.py
+++ b/Scripts/Python/plasma/PlasmaVaultConstants.py
@@ -55,9 +55,6 @@ class PtVaultCallbackTypes:
 class PtVaultNodeTypes:
     """(none)"""
     kInvalidNode = 0
-    kAgeInfoNode = 33
-    kAgeInfoListNode = 34
-    kMarkerGameNode = 35
     kVNodeMgrPlayerNode = 2
     kVNodeMgrAgeNode = 3
     kFolderNode = 22
@@ -68,6 +65,9 @@ class PtVaultNodeTypes:
     kAgeLinkNode = 28
     kChronicleNode = 29
     kPlayerInfoListNode = 30
+    kAgeInfoNode = 33
+    kAgeInfoListNode = 34
+    kMarkerGameNode = 35
 
 class PtVaultNotifyTypes:
     """(none)"""


### PR DESCRIPTION
Preparation for #1661 to make the diff more readable. This sorts all definitions in the Python stubs consistently, according to the established sorting style in the stubs:

* By default, all definitions are sorted in case-sensitive alphabetical order.
* Enum constants are sorted by their numeric value.
* In classes, all attributes/properties are placed before all methods.

This PR *only* fixes the sorting and contains no other fixes or style changes.