### PR TITLE
Update vcpkg to 2025.02.14 tag

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -66,7 +66,7 @@
         ]
       }
     },
-    "builtin-baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625",
+    "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf",
     "vcpkg-configuration": {
       "overlay-ports": ["./Scripts/Ports"],
       "overlay-triplets": ["./Scripts/Triplets"]


### PR DESCRIPTION
Of particular note, this updates OpenAL-Soft to bring in the fixes for surround sound on macOS.

### Updated Packages
* **asio**
  `1.30.2` -> `1.32.0`
* **curl**
  `8.8.0` -> `8.12.1`
* **expat**
  `2.6.2` -> `2.6.4`
* **fontconfig**
  `2.14.2#1` -> `2.15.0#2`
* **freetype**
  `2.13.2#1` -> `2.13.3`
* **libarchive**
  `3.7.2` -> `3.7.7#2`
* **libjpeg-turbo**
  `3.0.2` -> `3.1.0#1`
* **libpng**
  `1.6.43#2` -> `1.6.46`
* **libvpx**
  `1.13.1#3` -> `1.13.1#4`
* **libwebm**
  `1.0.0.28#1` -> `1.0.0.31#1`
* **openal-soft**
  `1.23.1` -> `1.24.2`
* **openssl**
  `3.3.1` -> `3.4.1`
* **opus**
  `1.5.1` -> `1.5.2`