### PR TITLE
Fix incorrect parsing of some KeyMap chronicles written by old code

### DIFF
--- a/Scripts/Python/xOptionsMenu.py
+++ b/Scripts/Python/xOptionsMenu.py
@@ -1778,7 +1778,7 @@ class xOptionsMenu(ptModifier):
             return
 
         # set the key binds back to the saved
-        for controlCode, mappedKey in zip(kDefaultControlCodeBinds, KeyMapString.split(" ")):
+        for controlCode, mappedKey in zip(kDefaultControlCodeBinds, KeyMapString.split()):
             if isinstance(controlCode, str):
                 PtDebugPrint(f"xOptionsMenu.LoadKeyMap(): Binding {mappedKey=} to {controlCode=}", level=kWarningLevel)
                 km.bindKeyToConsoleCommand(mappedKey, controlCode)


### PR DESCRIPTION
The old code sometimes wrote KeyMap chronicles containing *two* spaces between key bindings. The new code incorrectly assumed that there is always exactly *one* space between key bindings, causing all of the key bindings to be shifted around if the KeyMap chronicle contained an extra space.

Detailed repro steps:

1. Log in using a client that has the "old" key map code (before #1573).
2. Change a key binding for an action that can have two keys (e. g. add "J" as the secondary key for "Jump").
3. Close the game.
4. Log in with the same avatar using a client that has the "new" key map code (after #1573).
5. Open the Key Map options and observe that most key bindings are mixed up.

If you repeat steps 4 and 5 with a client that has this PR applied, the key bindings should show up correctly again.

(If you played with a client that has #1573, but not this PR, and you changed any key bindings after encountering this bug, your key map is now persistently mixed up in the chronicle - you need to remap/reset them all manually.)