### PR TITLE
Fix #1622

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plPickMaterialMap.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plPickMaterialMap.cpp
@@ -70,7 +70,7 @@ public:
     void Run() override
     {
         SetThisThreadName(ST_LITERAL("hsHackWinFindThread"));
-        while (1)
+        while (!GetQuit())
         {
             HWND hMtlDlg = FindWindow(nullptr, _T("Material/Map Browser"));
             if (hMtlDlg && IsWindowVisible(GetDlgItem(hMtlDlg, kOK)))

--- a/Sources/MaxPlugin/MaxComponent/plPickMaterialMap.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plPickMaterialMap.cpp
@@ -82,6 +82,8 @@ public:
                 EnableWindow(GetDlgItem(hMtlDlg, kNew), FALSE);
                 return;
             }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
 };


### PR DESCRIPTION
Fixes #1622 by changing the infinite loop to an "until we quit" loop. This will prevent 3ds Max from hanging when requesting the hack thread to go away. As a bonus, don't burn up the CPU.

Closes #1670. That PR tries to fix the issue by allowing the German window name to be found. Unfortunately, its implementation is not correct for 32-bit max builds. Also, this weird manual dialog fiddling doesn't have any effect in modern maxes. The items that we are trying to hide seem to simply not exist any more due to the UI changing so much since Max 7. IMO, it's better to just fix the hang and leave the UI changes alone.