### PR TITLE
Improve formatting of the Python stubs

### DIFF
--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -969,8 +969,6 @@ def PtYesNoDialog(cb: Union[None, ptKey, Callable], message: str, /, dialogType:
 
 class ptAgeInfoStruct:
     """Class to hold AgeInfo struct data"""
-    def __init__(self):
-        pass
 
     def copyFrom(self,other):
         """Copies data from one ptAgeInfoStruct or ptAgeInfoStructRef to this one"""
@@ -1038,8 +1036,6 @@ class ptAgeInfoStruct:
 
 class ptAgeInfoStructRef:
     """Class to hold AgeInfo struct data"""
-    def __init__(self):
-        pass
 
     def copyFrom(self,other):
         """Copies data from one ptAgeInfoStruct or ptAgeInfoStructRef to this one"""
@@ -1091,8 +1087,6 @@ class ptAgeInfoStructRef:
 
 class ptAgeLinkStruct:
     """Class to hold the data of the AgeLink structure"""
-    def __init__(self):
-        pass
 
     def copyFrom(self,other):
         """Copies data from one ptAgeLinkStruct or ptAgeLinkStructRef to this one"""
@@ -1132,8 +1126,6 @@ class ptAgeLinkStruct:
 
 class ptAgeLinkStructRef:
     """Class to hold the data of the AgeLink structure"""
-    def __init__(self):
-        pass
 
     def copyFrom(self,other):
         """Copies data from one ptAgeLinkStruct or ptAgeLinkStructRef to this one"""
@@ -1165,8 +1157,6 @@ class ptAgeLinkStructRef:
 
 class ptAgeVault:
     """Accessor class to the Age's vault"""
-    def __init__(self):
-        pass
 
     def addChronicleEntry(self,name,type,value):
         """Adds a chronicle entry with the specified type and value"""
@@ -1356,8 +1346,6 @@ class ptAnimation:
 
 class ptAudioControl:
     """Accessor class to the Audio controls"""
-    def __init__(self):
-        pass
 
     def areSubtitlesEnabled(self):
         """Are subtitles for the audio enabled? Returns 1 if true otherwise returns 0."""
@@ -1555,8 +1543,6 @@ class ptAudioControl:
 
 class ptAvatar:
     """Plasma avatar class"""
-    def __init__(self):
-        pass
 
     def addWardrobeClothingItem(self,clothing_name,tint1,tint2):
         """To add a clothing item to the avatar's wardrobe (closet)"""
@@ -1806,8 +1792,6 @@ class ptBook:
 
 class ptCamera:
     """Plasma camera class"""
-    def __init__(self):
-        pass
 
     def controlKey(self,controlKey,activateFlag):
         """Send a control key to the camera as if it was hit by the user.
@@ -2053,8 +2037,6 @@ class ptColor:
 
 class ptCritterBrain:
     """Object to manipulate critter brains"""
-    def __init__(self):
-        pass
 
     def addBehavior(self,animName, behaviorName, loop = 1, randomStartPos = 1, fadeInLen = 2.0, fadeOutLen = 2.0):
         """Adds a new animation to the brain as a behavior with the specified name and parameters. If multiple animations are assigned to the same behavior, they will be randomly picked from when started."""
@@ -2174,8 +2156,6 @@ class ptCritterBrain:
 
 class ptDniCoordinates:
     """Constructor for a D'Ni coordinate"""
-    def __init__(self):
-        pass
 
     def fromPoint(self,pt):
         """Update these coordinates with the specified ptPoint3"""
@@ -2199,8 +2179,6 @@ class ptDniCoordinates:
 
 class ptDniInfoSource:
     """DO NOT USE"""
-    def __init__(self):
-        pass
 
     def getAgeCoords(self):
         """Current coords of the player in current age as a ptDniCoordinates"""
@@ -2220,8 +2198,6 @@ class ptDniInfoSource:
 
 class ptDraw:
     """Plasma Draw class"""
-    def __init__(self):
-        pass
 
     def disable(self):
         """Disables the draw on the sceneobject attached
@@ -3293,8 +3269,6 @@ class ptGUISkin:
 
 class ptGameScore:
     """Plasma Game Score"""
-    def __init__(self):
-        pass
 
     def addPoints(self,points, key=None):
         """Adds points to the score"""
@@ -3382,13 +3356,9 @@ class ptGameScore:
 
 class ptGameScoreMsg:
     """Game Score operation callback message"""
-    def __init__(self):
-        pass
 
 class ptGameScoreListMsg(ptGameScoreMsg):
     """Game Score message for scores found on the server"""
-    def __init__(self):
-        pass
 
     def getName(self):
         """Returns the template score name"""
@@ -3404,8 +3374,6 @@ class ptGameScoreListMsg(ptGameScoreMsg):
 
 class ptGameScoreTransferMsg(ptGameScoreMsg):
     """Game Score message indicating a score point transfer"""
-    def __init__(self):
-        pass
 
     def getDestination(self):
         """Returns the score points were transferred to"""
@@ -3417,8 +3385,6 @@ class ptGameScoreTransferMsg(ptGameScoreMsg):
 
 class ptGameScoreUpdateMsg(ptGameScoreMsg):
     """Game Score message for a score update operation"""
-    def __init__(self):
-        pass
 
     def getScore(self):
         """Returns the updated game score"""
@@ -3505,8 +3471,6 @@ class ptImageLibMod:
 
 class ptInputInterface:
     """Plasma input interface class"""
-    def __init__(self):
-        pass
 
     def popTelescope(self):
         """pops off the telescope interface and gos back to previous interface"""
@@ -3518,8 +3482,6 @@ class ptInputInterface:
 
 class ptKey:
     """Plasma Key class"""
-    def __init__(self):
-        pass
 
     def disable(self):
         """Sends a disable message to whatever this ptKey is pointing to"""
@@ -3558,8 +3520,6 @@ class ptKey:
 
 class ptKeyMap:
     """Accessor class to the Key Mapping functions"""
-    def __init__(self):
-        pass
 
     def bindKey(self,key1,key2,action):
         """Bind keys to an action"""
@@ -3632,8 +3592,6 @@ class ptLayer:
 
 class ptMarkerMgr:
     """Marker manager accessor class"""
-    def __init__(self):
-        pass
 
     def addMarker(self,x, y, z, id, justCreated):
         """Add a marker in the specified location with the specified id"""
@@ -3689,8 +3647,6 @@ class ptMarkerMgr:
 
 class ptMatrix44:
     """Plasma Matrix44 class"""
-    def __init__(self):
-        pass
 
     def copy(self):
         """Copies the matrix and returns the copy"""
@@ -3823,8 +3779,6 @@ class ptMoviePlayer:
 
 class ptNetLinkingMgr:
     """Constructor to get access to the net link manager"""
-    def __init__(self):
-        pass
 
     def getCurrAgeLink(self):
         """Get the ptAgeLinkStruct for the current age"""
@@ -3975,8 +3929,6 @@ class ptNotify:
 
 class ptParticle:
     """Plasma particle system class"""
-    def __init__(self):
-        pass
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
@@ -4035,8 +3987,6 @@ class ptParticle:
 
 class ptPhysics:
     """Plasma physics class"""
-    def __init__(self):
-        pass
 
     def angularImpulse(self,impulseVector):
         """Add the given vector (representing a rotation axis and magnitude) to
@@ -4203,8 +4153,6 @@ class ptPoint3:
 
 class ptSDL:
     """SDL accessor"""
-    def __init__(self):
-        pass
 
     def sendToClients(self,key):
         """Sets it so changes to this key are sent to the
@@ -4246,8 +4194,6 @@ class ptSDL:
 
 class ptSDLStateDataRecord:
     """Basic SDL state data record class"""
-    def __init__(self):
-        pass
 
     def findVar(self,name):
         """Finds and returns the specified ptSimpleStateVariable"""
@@ -4450,8 +4396,6 @@ class ptSceneobject:
 
 class ptSimpleStateVariable:
     """Basic SDL state data record class"""
-    def __init__(self):
-        pass
 
     def getBool(self,idx=0):
         """Returns a boolean variable's value"""
@@ -4568,8 +4512,6 @@ class ptSpawnPointInfo:
 
 class ptSpawnPointInfoRef:
     """Class to hold spawn point data"""
-    def __init__(self):
-        pass
 
     def getCameraStack(self):
         """Returns the camera stack for this spawnpoint as a string"""
@@ -4597,8 +4539,6 @@ class ptSpawnPointInfoRef:
 
 class ptStatusLog:
     """A status log class"""
-    def __init__(self):
-        pass
 
     def close(self):
         """Close the status log file"""
@@ -4624,8 +4564,6 @@ class ptStatusLog:
 
 class ptStream:
     """A basic stream class"""
-    def __init__(self):
-        pass
 
     def close(self):
         """Close the status log file"""
@@ -4678,8 +4616,6 @@ class ptSwimCurrentInterface:
 
 class ptVault:
     """Accessor class to the player's vault"""
-    def __init__(self):
-        pass
 
     def addChronicleEntry(self,entryName,type,string):
         """Adds an entry to the player's chronicle with a value of 'string'."""
@@ -4847,8 +4783,6 @@ class ptVault:
 
 class ptVaultNode:
     """Vault node class"""
-    def __init__(self):
-        pass
 
     def addNode(self,node,cb=None,cbContext=0):
         """Adds 'node'(ptVaultNode) as a child to this node."""
@@ -5321,8 +5255,6 @@ class ptVaultMarkerGameNode(ptVaultNode):
 
 class ptVaultNodeRef:
     """Vault node relationship pseudo class"""
-    def __init__(self):
-        pass
 
     def beenSeen(self):
         """Returns true until we reimplement this"""
@@ -5383,8 +5315,6 @@ class ptVaultPlayerInfoListNode(ptVaultFolderNode):
 
 class ptVaultPlayerInfoNode(ptVaultNode):
     """Plasma vault folder node"""
-    def __init__(self):
-        pass
 
     def playerGetAgeGuid(self):
         """Returns the guid as a string of where the player is for this player info node."""
@@ -5432,8 +5362,6 @@ class ptVaultPlayerInfoNode(ptVaultNode):
 
 class ptVaultSDLNode(ptVaultNode):
     """Plasma vault SDL node"""
-    def __init__(self):
-        pass
 
     def getIdent(self):
         """UNKNOWN"""
@@ -5457,13 +5385,9 @@ class ptVaultSDLNode(ptVaultNode):
 
 class ptVaultSystemNode(ptVaultNode):
     """Plasma vault system node"""
-    def __init__(self):
-        pass
 
 class ptVaultTextNoteNode(ptVaultNode):
     """Plasma vault text note node"""
-    def __init__(self):
-        pass
 
     def getDeviceInbox(self):
         """Returns a ptVaultFolderNode"""

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 from PlasmaConstants import *
 from typing import *
 
-def PtAcceptInviteInGame(friendName,inviteKey):
+def PtAcceptInviteInGame(friendName, inviteKey):
     """Sends a VaultTask to the server to perform the invite"""
     pass
 
@@ -61,7 +61,7 @@ def PtAmCCR():
     """Returns true if local player is a CCR"""
     pass
 
-def PtAtTimeCallback(selfkey,time,id):
+def PtAtTimeCallback(selfkey, time, id):
     """This will create a timer callback that will call OnTimer when complete
     - 'selfkey' is the ptKey of the PythonFile component
     - 'time' is how much time from now (in seconds) to call back
@@ -69,7 +69,7 @@ def PtAtTimeCallback(selfkey,time,id):
     """
     pass
 
-def PtAttachObject(child,parent,netForce=False):
+def PtAttachObject(child, parent, netForce=False):
     """Attach child to parent based on ptKey or ptSceneobject
     - childKey is the ptKey or ptSceneobject of the one being attached
     - parentKey is the ptKey or ptSceneobject of the one being attached to
@@ -129,7 +129,7 @@ def PtChangePlayerName(name):
     """Change the local avatar's name"""
     pass
 
-def PtCheckVisLOS(startPoint,endPoint):
+def PtCheckVisLOS(startPoint, endPoint):
     """Does LOS check from start to end"""
     pass
 
@@ -161,7 +161,7 @@ def PtConsole(command):
     """This will execute 'command' as if it were typed into the Plasma console."""
     pass
 
-def PtConsoleNet(command,netForce):
+def PtConsoleNet(command, netForce):
     """This will execute 'command' on the console, over the network, on all clients.
     If 'netForce' is true then force command to be sent over the network.
     """
@@ -191,7 +191,7 @@ def PtDeletePlayer(playerInt):
     """Deletes a player associated with the current account"""
     pass
 
-def PtDetachObject(child,parent,netForce=False):
+def PtDetachObject(child, parent, netForce=False):
     """Detach child from parent based on ptKey or ptSceneobject
     - child is the ptKey or ptSceneobject of the one being detached
     - parent is the ptKey or ptSceneobject of the one being detached from
@@ -199,11 +199,11 @@ def PtDetachObject(child,parent,netForce=False):
     """
     pass
 
-def PtDirtySynchClients(selfKey,SDLStateName,flags):
+def PtDirtySynchClients(selfKey, SDLStateName, flags):
     """DO NOT USE - handled by ptSDL"""
     pass
 
-def PtDirtySynchState(selfKey,SDLStateName,flags):
+def PtDirtySynchState(selfKey, SDLStateName, flags):
     """DO NOT USE - handled by ptSDL"""
     pass
 
@@ -283,7 +283,7 @@ def PtEnableShadows():
     """Turns shadows on"""
     pass
 
-def PtExcludeRegionSet(senderKey,regionKey,state):
+def PtExcludeRegionSet(senderKey, regionKey, state):
     """This will set the state of an exclude region
     - 'senderKey' is a ptKey of the PythonFile component
     - 'regionKey' is a ptKey of the exclude region
@@ -291,7 +291,7 @@ def PtExcludeRegionSet(senderKey,regionKey,state):
     """
     pass
 
-def PtExcludeRegionSetNow(senderKey,regionKey,state):
+def PtExcludeRegionSetNow(senderKey, regionKey, state):
     """This will set the state of an exclude region immediately on the server
     - 'senderKey' is a ptKey of the PythonFile component
     - 'regionKey' is a ptKey of the exclude region
@@ -311,7 +311,7 @@ def PtFadeOut(lenTime, holdFlag, noSound=0):
     """Fades screen out for lenTime seconds"""
     pass
 
-def PtFakeLinkAvatarToObject(avatar,object):
+def PtFakeLinkAvatarToObject(avatar, object):
     """Pseudo-links avatar to object within the same age
     """
     pass
@@ -338,7 +338,7 @@ def PtFindLayer(name: str, age: str = "", page: str = "") -> Optional[ptLayer]:
     """Find a layer by name."""
     pass
 
-def PtFindSceneobject(name,ageName):
+def PtFindSceneobject(name, ageName):
     """This will try to find a sceneobject based on its name and what age its in
     - it will return a ptSceneObject if found- if not found then a NameError exception will happen
     """
@@ -360,15 +360,15 @@ def PtFogSetDefColor(color):
     """Sets default fog color"""
     pass
 
-def PtFogSetDefExp(end,density):
+def PtFogSetDefExp(end, density):
     """Set exp fog values"""
     pass
 
-def PtFogSetDefExp2(end,density):
+def PtFogSetDefExp2(end, density):
     """Set exp2 fog values"""
     pass
 
-def PtFogSetDefLinear(start,end,density):
+def PtFogSetDefLinear(start, end, density):
     """Set linear fog values"""
     pass
 
@@ -659,7 +659,7 @@ def PtIsSolo() -> bool:
     """Returns whether we are the only player in the Age"""
     pass
 
-def PtKillParticles(timeRemaining,pctToKill,particleSystem):
+def PtKillParticles(timeRemaining, pctToKill, particleSystem):
     """Tells particleSystem to kill pctToKill percent of its particles"""
     pass
 
@@ -675,19 +675,19 @@ def PtLoadBookGUI(guiName):
     """Loads the gui specified, a gui must be loaded before it can be used. If the gui is already loaded, doesn't do anything"""
     pass
 
-def PtLoadDialog(dialogName,selfKey=None,ageName=""):
+def PtLoadDialog(dialogName, selfKey=None, ageName=""):
     """Loads a GUI dialog by name and optionally set the Notify proc key
     If the dialog is already loaded then it won't load it again
     """
     pass
 
-def PtLoadJPEGFromDisk(filename,width,height):
+def PtLoadJPEGFromDisk(filename, width, height):
     """The image will be resized to fit the width and height arguments. Set to 0 if resizing is not desired.
     Returns a pyImage of the specified file.
     """
     pass
 
-def PtLoadPNGFromDisk(filename,width,height):
+def PtLoadPNGFromDisk(filename, width, height):
     """The image will be resized to fit the width and height arguments. Set to 0 if resizing is not desired.
     Returns a pyImage of the specified file.
     """
@@ -733,11 +733,11 @@ def PtPageOutNode(nodeName, netForce=False):
     """Pages out a node"""
     pass
 
-def PtRateIt(chronicleName,dialogPrompt,onceFlag):
+def PtRateIt(chronicleName, dialogPrompt, onceFlag):
     """Shows a dialog with dialogPrompt and stores user input rating into chronicleName"""
     pass
 
-def PtRebuildCameraStack(name,ageName):
+def PtRebuildCameraStack(name, ageName):
     """Push camera with this name on the stack"""
     pass
 
@@ -749,15 +749,15 @@ def PtRemovePublicAge(ageInstanceGuid):
     """Remove a public instance of the given age."""
     pass
 
-def PtRequestLOSScreen(selfKey,ID,xPos,yPos,distance,what,reportType):
+def PtRequestLOSScreen(selfKey, ID, xPos, yPos, distance, what, reportType):
     """Request a LOS check from a point on the screen"""
     pass
 
-def PtSaveScreenShot(fileName,width=640,height=480,quality=75):
+def PtSaveScreenShot(fileName, width=640, height=480, quality=75):
     """Takes a screenshot with the specified filename, size, and quality"""
     pass
 
-def PtSendChatToCCR(message,CCRPlayerID):
+def PtSendChatToCCR(message, CCRPlayerID):
     """Sends a chat message to a CCR that has contacted this player"""
     pass
 
@@ -765,18 +765,18 @@ def PtSendFriendInvite(emailAddress, toName = "Friend"):
     """Sends an email with invite code"""
     pass
 
-def PtSendKIGZMarkerMsg(markerNumber,sender):
+def PtSendKIGZMarkerMsg(markerNumber, sender):
     """Same as PtSendKIMessageInt except 'sender' could get a notify message back
     """
     pass
 
-def PtSendKIMessage(command,value):
+def PtSendKIMessage(command, value):
     """Sends a command message to the KI frontend.
     See PlasmaKITypes.py for list of commands
     """
     pass
 
-def PtSendKIMessageInt(command,value):
+def PtSendKIMessageInt(command, value):
     """Same as PtSendKIMessage except the value is guaranteed to be a uint32_t
     (for things like player IDs)
     """
@@ -786,7 +786,7 @@ def PtSendKIRegisterImagerMsg(imagerName, sender):
     """Sends a message to the KI to register the specified imager"""
     pass
 
-def PtSendPetitionToCCR(message,reason=0,title=""):
+def PtSendPetitionToCCR(message, reason=0, title=""):
     """Sends a petition with a message to the CCR group"""
     pass
 
@@ -794,7 +794,7 @@ def PtSendPrivateChatList(chatList):
     """Lock the local avatar into private vox messaging, and / or add new members to his chat list"""
     pass
 
-def PtSendRTChat(fromPlayer,toPlayerList,message,flags):
+def PtSendRTChat(fromPlayer, toPlayerList, message, flags):
     """Sends a realtime chat message to the list of ptPlayers
     If toPlayerList is an empty list, it is a broadcast message
     """
@@ -811,7 +811,7 @@ def PtSetAlarm(secs, cbObject, cbContext):
     """
     pass
 
-def PtSetBehaviorLoopCount(behaviorKey,stage,loopCount,netForce):
+def PtSetBehaviorLoopCount(behaviorKey, stage, loopCount, netForce):
     """This will set the loop count for a particular stage in a multistage behavior"""
     pass
 
@@ -819,7 +819,7 @@ def PtSetBehaviorNetFlags(behKey, netForce, netProp):
     """Sets net flags on the associated behavior"""
     pass
 
-def PtSetClearColor(red,green,blue):
+def PtSetClearColor(red, green, blue):
     """Set the clear color"""
     pass
 
@@ -839,11 +839,11 @@ def PtSetGraphicsOptions(width, height, colordepth, windowed, numAAsamples, numA
     """Set the graphics options"""
     pass
 
-def PtSetLightAnimStart(key,name,start):
+def PtSetLightAnimStart(key, name, start):
     """ Key is the key of scene object host to light, start is a bool. Name is the name of the light to manipulate"""
     pass
 
-def PtSetLightValue(key,name,r,g,b,a):
+def PtSetLightValue(key, name, r, g, b, a):
     """ Key is the key of scene object host to light. Name is the name of the light to manipulate"""
     pass
 
@@ -859,7 +859,7 @@ def PtSetMouseUninverted():
     """Uninverts the mouse"""
     pass
 
-def PtSetOfferBookMode(selfkey,ageFilename,ageInstanceName):
+def PtSetOfferBookMode(selfkey, ageFilename, ageInstanceName):
     """Put us into the offer book interface"""
     pass
 
@@ -867,7 +867,7 @@ def PtSetParticleDissentPoint(x, y, z, particlesys):
     """Sets the dissent point of the particlesys to x,y,z"""
     pass
 
-def PtSetParticleOffset(x,y,z,particlesys):
+def PtSetParticleOffset(x, y, z, particlesys):
     """Sets the particlesys particle system's offset"""
     pass
 
@@ -899,7 +899,7 @@ def PtShowDialog(dialogName):
     """Show a GUI dialog by name (does not load dialog)"""
     pass
 
-def PtStartScreenCapture(selfKey,width=800,height=600):
+def PtStartScreenCapture(selfKey, width=800, height=600):
     """Starts a capture of the screen"""
     pass
 
@@ -955,7 +955,7 @@ def PtWearDefaultClothingType(key, type, broadcast=False):
     """Forces the avatar to wear the default clothing of the specified type"""
     pass
 
-def PtWearMaintainerSuit(key,wearOrNot):
+def PtWearMaintainerSuit(key, wearOrNot):
     """Wears or removes the maintainer suit of clothes"""
     pass
 
@@ -970,7 +970,7 @@ def PtYesNoDialog(cb: Union[None, ptKey, Callable], message: str, /, dialogType:
 class ptAgeInfoStruct:
     """Class to hold AgeInfo struct data"""
 
-    def copyFrom(self,other):
+    def copyFrom(self, other):
         """Copies data from one ptAgeInfoStruct or ptAgeInfoStructRef to this one"""
         pass
 
@@ -1006,38 +1006,38 @@ class ptAgeInfoStruct:
         """Returns a string that is the displayable name of the age instance"""
         pass
 
-    def setAgeDescription(self,udName):
+    def setAgeDescription(self, udName):
         """Sets the description part of the Age"""
         pass
 
-    def setAgeFilename(self,filename):
+    def setAgeFilename(self, filename):
         """Sets the filename of the Age"""
         pass
 
-    def setAgeInstanceGuid(self,guid):
+    def setAgeInstanceGuid(self, guid):
         """Sets the Age instance's GUID"""
         pass
 
-    def setAgeInstanceName(self,instanceName):
+    def setAgeInstanceName(self, instanceName):
         """Sets the instance name of the Age"""
         pass
 
-    def setAgeLanguage(self,lang):
+    def setAgeLanguage(self, lang):
         """Sets the age's language (integer)"""
         pass
 
-    def setAgeSequenceNumber(self,seqNumber):
+    def setAgeSequenceNumber(self, seqNumber):
         """Sets the unique sequence number"""
         pass
 
-    def setAgeUserDefinedName(self,udName):
+    def setAgeUserDefinedName(self, udName):
         """Sets the user defined part of the Age"""
         pass
 
 class ptAgeInfoStructRef:
     """Class to hold AgeInfo struct data"""
 
-    def copyFrom(self,other):
+    def copyFrom(self, other):
         """Copies data from one ptAgeInfoStruct or ptAgeInfoStructRef to this one"""
         pass
 
@@ -1065,30 +1065,30 @@ class ptAgeInfoStructRef:
         """Returns a string that is the displayable name of the age instance"""
         pass
 
-    def setAgeFilename(self,filename):
+    def setAgeFilename(self, filename):
         """Sets the filename of the Age"""
         pass
 
-    def setAgeInstanceGuid(self,guid):
+    def setAgeInstanceGuid(self, guid):
         """Sets the Age instance's GUID"""
         pass
 
-    def setAgeInstanceName(self,instanceName):
+    def setAgeInstanceName(self, instanceName):
         """Sets the instance name of the Age"""
         pass
 
-    def setAgeSequenceNumber(self,seqNumber):
+    def setAgeSequenceNumber(self, seqNumber):
         """Sets the unique sequence number"""
         pass
 
-    def setAgeUserDefinedName(self,udName):
+    def setAgeUserDefinedName(self, udName):
         """Sets the user defined part of the Age"""
         pass
 
 class ptAgeLinkStruct:
     """Class to hold the data of the AgeLink structure"""
 
-    def copyFrom(self,other):
+    def copyFrom(self, other):
         """Copies data from one ptAgeLinkStruct or ptAgeLinkStructRef to this one"""
         pass
 
@@ -1108,26 +1108,26 @@ class ptAgeLinkStruct:
         """Gets the spawn point ptSpawnPointInfoRef of this link"""
         pass
 
-    def setAgeInfo(self,ageInfo):
+    def setAgeInfo(self, ageInfo):
         """Sets the AgeInfoStruct from the data in ageInfo (a ptAgeInfoStruct)"""
         pass
 
-    def setLinkingRules(self,rule):
+    def setLinkingRules(self, rule):
         """Sets the linking rules for this link"""
         pass
 
-    def setParentAgeFilename(self,filename):
+    def setParentAgeFilename(self, filename):
         """Sets the parent age filename for child age links"""
         pass
 
-    def setSpawnPoint(self,spawnPtInfo):
+    def setSpawnPoint(self, spawnPtInfo):
         """Sets the spawn point of this link (a ptSpawnPointInfo or ptSpawnPointInfoRef)"""
         pass
 
 class ptAgeLinkStructRef:
     """Class to hold the data of the AgeLink structure"""
 
-    def copyFrom(self,other):
+    def copyFrom(self, other):
         """Copies data from one ptAgeLinkStruct or ptAgeLinkStructRef to this one"""
         pass
 
@@ -1143,30 +1143,30 @@ class ptAgeLinkStructRef:
         """Gets the spawn point ptSpawnPointInfoRef of this link"""
         pass
 
-    def setAgeInfo(self,ageInfo):
+    def setAgeInfo(self, ageInfo):
         """Sets the AgeInfoStruct from the data in ageInfo (a ptAgeInfoStruct)"""
         pass
 
-    def setLinkingRules(self,rule):
+    def setLinkingRules(self, rule):
         """Sets the linking rules for this link"""
         pass
 
-    def setSpawnPoint(self,spawnPtInfo):
+    def setSpawnPoint(self, spawnPtInfo):
         """Sets the spawn point of this link (a ptSpawnPointInfo or ptSpawnPointInfoRef)"""
         pass
 
 class ptAgeVault:
     """Accessor class to the Age's vault"""
 
-    def addChronicleEntry(self,name,type,value):
+    def addChronicleEntry(self, name, type, value):
         """Adds a chronicle entry with the specified type and value"""
         pass
 
-    def addDevice(self,deviceName,cb=None,cbContext=0):
+    def addDevice(self, deviceName, cb=None, cbContext=0):
         """Adds a device to the age"""
         pass
 
-    def findChronicleEntry(self,entryName):
+    def findChronicleEntry(self, entryName):
         """Returns the named ptVaultChronicleNode"""
         pass
 
@@ -1198,11 +1198,11 @@ class ptAgeVault:
         """Returns a ptVaultFolderNode"""
         pass
 
-    def getDevice(self,deviceName):
+    def getDevice(self, deviceName):
         """Returns the specified device (ptVaultTextNoteNode)"""
         pass
 
-    def getDeviceInbox(self,deviceName):
+    def getDeviceInbox(self, deviceName):
         """Returns a ptVaultFolderNode of the inbox for the named device in this age."""
         pass
 
@@ -1214,7 +1214,7 @@ class ptAgeVault:
         """Returns a ptVaultFolderNode that contains all the public Ages"""
         pass
 
-    def getSubAgeLink(self,ageInfo):
+    def getSubAgeLink(self, ageInfo):
         """Returns a ptVaultAgeLinkNode to 'ageInfo' (a ptAgeInfoStruct) for this Age."""
         pass
 
@@ -1222,33 +1222,33 @@ class ptAgeVault:
         """Returns a ptVaultFolderNode of sub Age's folder."""
         pass
 
-    def hasDevice(self,deviceName):
+    def hasDevice(self, deviceName):
         """Does a device with this name exist?"""
         pass
 
-    def removeDevice(self,deviceName):
+    def removeDevice(self, deviceName):
         """Removes a device from the age"""
         pass
 
-    def setDeviceInbox(self,deviceName,inboxName,cb=None,cbContext=0):
+    def setDeviceInbox(self, deviceName, inboxName, cb=None, cbContext=0):
         """Set's the device's inbox"""
         pass
 
-    def updateAgeSDL(self,pyrec):
+    def updateAgeSDL(self, pyrec):
         """Updates the age's SDL"""
         pass
 
 class ptAnimation:
     """Plasma animation class"""
 
-    def __init__(self,key=None):
+    def __init__(self, key=None):
         pass
 
-    def addKey(self,key):
+    def addKey(self, key):
         """Adds an animation modifier to the list of receiver keys"""
         pass
 
-    def backwards(self,backwardsFlag):
+    def backwards(self, backwardsFlag):
         """Turn on and off playing the animation backwards"""
         pass
 
@@ -1266,11 +1266,11 @@ class ptAnimation:
         """Step the animation forward a frame"""
         pass
 
-    def looped(self,loopedFlag):
+    def looped(self, loopedFlag):
         """Turn on and off looping of the animation"""
         pass
 
-    def netForce(self,forceFlag):
+    def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
@@ -1281,15 +1281,15 @@ class ptAnimation:
         """Plays the animation"""
         pass
 
-    def playRange(self,start,end):
+    def playRange(self, start, end):
         """Play the animation from start to end"""
         pass
 
-    def playToPercentage(self,zeroToOne):
+    def playToPercentage(self, zeroToOne):
         """Play the animation to the specified percentage (0 to 1)"""
         pass
 
-    def playToTime(self,time):
+    def playToTime(self, time):
         """Play the animation to the specified time"""
         pass
 
@@ -1297,21 +1297,21 @@ class ptAnimation:
         """Resumes the animation from where it was stopped last"""
         pass
 
-    def sender(self,selfKey):
+    def sender(self, selfKey):
         """Sets the sender of the messages being sent to the animation modifier"""
         pass
 
-    def setAnimName(self,name):
+    def setAnimName(self, name):
         """Sets the animation notetrack name (or (Entire Animation))"""
         pass
 
-    def setLoopEnd(self,loopEnd):
+    def setLoopEnd(self, loopEnd):
         """Sets the loop ending position
         - 'loopEnd' is the number of seconds from the absolute beginning of the animation
         """
         pass
 
-    def setLoopStart(self,loopStart):
+    def setLoopStart(self, loopStart):
         """Sets the loop starting position
         - 'loopStart' is the number of seconds from the absolute beginning of the animation
         """
@@ -1333,11 +1333,11 @@ class ptAnimation:
         """Skip to the end of the animation loop (don't play)"""
         pass
 
-    def skipToTime(self,time):
+    def skipToTime(self, time):
         """Skip the animation to time (don't play)"""
         pass
 
-    def speed(self,speed):
+    def speed(self, speed):
         """Sets the animation playback speed"""
         pass
 
@@ -1372,11 +1372,11 @@ class ptAudioControl:
         """Enables subtitles for audio."""
         pass
 
-    def enableVoiceChat(self,state):
+    def enableVoiceChat(self, state):
         """Enables or disables voice chat."""
         pass
 
-    def enableVoiceRecording(self,state):
+    def enableVoiceRecording(self, state):
         """Enables or disables voice recording."""
         pass
 
@@ -1392,7 +1392,7 @@ class ptAudioControl:
         """Gets the name of all available audio capture devices."""
         pass
 
-    def getFriendlyDeviceName(self,devicename):
+    def getFriendlyDeviceName(self, devicename):
         """Returns the provided device name without any OpenAL prefixes applied."""
         pass
 
@@ -1460,67 +1460,67 @@ class ptAudioControl:
         """Mutes all sounds."""
         pass
 
-    def pushToTalk(self,state):
+    def pushToTalk(self, state):
         """Enables or disables 'push-to-talk'."""
         pass
 
-    def setAmbienceVolume(self,volume):
+    def setAmbienceVolume(self, volume):
         """Sets the Ambience volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
         pass
 
-    def setCaptureDevice(self,devicename):
+    def setCaptureDevice(self, devicename):
         """Sets the audio capture device by name."""
         pass
 
-    def setGUIVolume(self,volume):
+    def setGUIVolume(self, volume):
         """Sets the GUI dialog volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
         pass
 
-    def setLoadOnDemand(self,state):
+    def setLoadOnDemand(self, state):
         """Enables or disables the load on demand for sounds."""
         pass
 
-    def setMicLevel(self,level):
+    def setMicLevel(self, level):
         """Sets the microphone recording level (0.0 to 1.0)."""
         pass
 
-    def setMusicVolume(self,volume):
+    def setMusicVolume(self, volume):
         """Sets the Music volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
         pass
 
-    def setNPCVoiceVolume(self,volume):
+    def setNPCVoiceVolume(self, volume):
         """Sets the NPC's voice volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
         pass
 
-    def setPlaybackDevice(self,devicename,restart):
+    def setPlaybackDevice(self, devicename, restart):
         """Sets audio system output device by name, and optionally restarts it"""
         pass
 
-    def setPriorityCutoff(self,priority):
+    def setPriorityCutoff(self, priority):
         """Sets the sound priority"""
         pass
 
-    def setSoundFXVolume(self,volume):
+    def setSoundFXVolume(self, volume):
         """Sets the SoundFX volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
         pass
 
-    def setTwoStageLOD(self,state):
+    def setTwoStageLOD(self, state):
         """Enables or disables two-stage LOD, where sounds can be loaded into RAM but not into sound buffers.
         ...Less of a performance hit, harder on memory.
         """
         pass
 
-    def setVoiceVolume(self,volume):
+    def setVoiceVolume(self, volume):
         """Sets the Voice volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
@@ -1530,7 +1530,7 @@ class ptAudioControl:
         """Shows (enables) the voice recording icons."""
         pass
 
-    def squelchLevel(self,level):
+    def squelchLevel(self, level):
         """Sets the squelch level."""
         pass
 
@@ -1538,18 +1538,18 @@ class ptAudioControl:
         """Unmutes all sounds."""
         pass
 
-    def useEAXAcceleration(self,state):
+    def useEAXAcceleration(self, state):
         """Enables or disables EAX sound acceleration (requires hardware acceleration)."""
         pass
 
 class ptAvatar:
     """Plasma avatar class"""
 
-    def addWardrobeClothingItem(self,clothing_name,tint1,tint2):
+    def addWardrobeClothingItem(self, clothing_name, tint1, tint2):
         """To add a clothing item to the avatar's wardrobe (closet)"""
         pass
 
-    def enterSubWorld(self,sceneobject):
+    def enterSubWorld(self, sceneobject):
         """Places the avatar into the subworld of the ptSceneObject specified"""
         pass
 
@@ -1557,7 +1557,7 @@ class ptAvatar:
         """Exits the avatar from the subWorld where it was"""
         pass
 
-    def getAllWithSameMesh(self,clothing_name):
+    def getAllWithSameMesh(self, clothing_name):
         """Returns a lilst of all clothing items that use the same mesh as the specified one"""
         pass
 
@@ -1571,7 +1571,7 @@ class ptAvatar:
         """Returns a list of clothes that the avatar is currently wearing."""
         pass
 
-    def getClosetClothingList(self,clothing_type):
+    def getClosetClothingList(self, clothing_type):
         """Returns a list of clothes for the avatar that are in specified clothing group."""
         pass
 
@@ -1579,27 +1579,27 @@ class ptAvatar:
         """Returns current brain mode for avatar"""
         pass
 
-    def getEntireClothingList(self,clothing_type):
+    def getEntireClothingList(self, clothing_type):
         """Gets the entire list of clothing available. 'clothing_type' not used
         NOTE: should use getClosetClothingList
         """
         pass
 
-    def getMatchingClothingItem(self,clothingName):
+    def getMatchingClothingItem(self, clothingName):
         """Finds the matching clothing item that goes with 'clothingName'
         Used to find matching left and right gloves and shoes.
         """
         pass
 
-    def getMorph(self,clothing_name,layer):
+    def getMorph(self, clothing_name, layer):
         """Get the current morph value"""
         pass
 
-    def getSkinBlend(self,layer):
+    def getSkinBlend(self, layer):
         """Get the current skin blend value"""
         pass
 
-    def getTintClothingItem(self,clothing_name,layer=1):
+    def getTintClothingItem(self, clothing_name, layer=1):
         """Returns a ptColor of a particular item of clothing that the avatar is wearing.
         The color will be a ptColor object.
         """
@@ -1609,7 +1609,7 @@ class ptAvatar:
         """Returns a ptColor of the current skin tint for the avatar"""
         pass
 
-    def getUniqueMeshList(self,clothing_type):
+    def getUniqueMeshList(self, clothing_type):
         """Returns a list of unique clothing items of the desired type (different meshes)"""
         pass
 
@@ -1617,54 +1617,54 @@ class ptAvatar:
         """Return a list of items that are in the avatars closet"""
         pass
 
-    def gotoStage(self,behaviorKey,stage,transitionTime,setTimeFlag,newTime,SetDirectionFlag,isForward,netForce):
+    def gotoStage(self, behaviorKey, stage, transitionTime, setTimeFlag, newTime, SetDirectionFlag, isForward, netForce):
         """Tells a multistage behavior to go to a particular stage"""
         pass
 
-    def loadClothingFromFile(self,filename):
+    def loadClothingFromFile(self, filename):
         """Load avatar clothing from a file"""
         pass
 
-    def netForce(self,forceFlag):
+    def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
         pass
 
-    def nextStage(self,behaviorKey,transitionTime,setTimeFlag,newTime,SetDirectionFlag,isForward,netForce):
+    def nextStage(self, behaviorKey, transitionTime, setTimeFlag, newTime, SetDirectionFlag, isForward, netForce):
         """Tells a multistage behavior to go to the next stage (Why does Matt like so many parameters?)"""
         pass
 
-    def oneShot(self,seekKey,duration,usePhysicsFlag,animationName,drivableFlag,reversibleFlag):
+    def oneShot(self, seekKey, duration, usePhysicsFlag, animationName, drivableFlag, reversibleFlag):
         """Plays a one-shot animation on the avatar"""
         pass
 
-    def playSimpleAnimation(self,animName):
+    def playSimpleAnimation(self, animName):
         """Play simple animation on avatar"""
         pass
 
-    def previousStage(self,behaviorKey,transitionTime,setTimeFlag,newTime,SetDirectionFlag,isForward,netForce):
+    def previousStage(self, behaviorKey, transitionTime, setTimeFlag, newTime, SetDirectionFlag, isForward, netForce):
         """Tells a multistage behavior to go to the previous stage"""
         pass
 
-    def registerForBehaviorNotify(self,selfKey):
+    def registerForBehaviorNotify(self, selfKey):
         """This will register for behavior notifies from the avatar"""
         pass
 
-    def removeClothingItem(self,clothing_name,update=1):
+    def removeClothingItem(self, clothing_name, update=1):
         """Tells the avatar to remove a particular item of clothing."""
         pass
 
-    def runBehavior(self,behaviorKey,netForceFlag):
+    def runBehavior(self, behaviorKey, netForceFlag):
         """Runs a behavior on the avatar. Can be a single or multi-stage behavior."""
         pass
 
-    def runBehaviorSetNotify(self,behaviorKey,replyKey,netForceFlag):
+    def runBehaviorSetNotify(self, behaviorKey, replyKey, netForceFlag):
         """Same as runBehavior, except send notifications to specified keyed object"""
         pass
 
-    def runCoopAnim(self,targetKey,activeAvatarAnim,targetAvatarAnim,range=6,dist=3,move=1):
+    def runCoopAnim(self, targetKey, activeAvatarAnim, targetAvatarAnim, range=6, dist=3, move=1):
         """Seek near another avatar and run animations on both."""
         pass
 
@@ -1672,45 +1672,45 @@ class ptAvatar:
         """Saves the current clothing options (including morphs) to the vault"""
         pass
 
-    def saveClothingToFile(self,filename):
+    def saveClothingToFile(self, filename):
         """Save avatar clothing to a file"""
         pass
 
-    def setDontPanicLink(self,value: bool) -> None:
+    def setDontPanicLink(self, value: bool) -> None:
         """Disables panic linking to Personal Age (warps the avatar back to the start instead)"""
         pass
 
-    def setMorph(self,clothing_name,layer,value):
+    def setMorph(self, clothing_name, layer, value):
         """Set the morph value (clipped between -1 and 1)"""
         pass
 
-    def setReplyKey(self,key):
+    def setReplyKey(self, key):
         """Sets the sender's key"""
         pass
 
-    def setSkinBlend(self,layer,value):
+    def setSkinBlend(self, layer, value):
         """Set the skin blend (value between 0 and 1)"""
         pass
 
-    def tintClothingItem(self,clothing_name,tint,update=1):
+    def tintClothingItem(self, clothing_name, tint, update=1):
         """Tells the avatar to tint(color) a particular item of clothing that they are already wearing.
         'tint' is a ptColor object
         """
         pass
 
-    def tintClothingItemLayer(self,clothing_name,tint,layer,update=1):
+    def tintClothingItemLayer(self, clothing_name, tint, layer, update=1):
         """Tells the avatar to tint(color) a particular layer of a particular item of clothing."""
         pass
 
-    def tintSkin(self,tint,update=1):
+    def tintSkin(self, tint, update=1):
         """Tints all of the skin on the avatar, with the ptColor tint"""
         pass
 
-    def unRegisterForBehaviorNotify(self,selfKey):
+    def unRegisterForBehaviorNotify(self, selfKey):
         """This will unregister behavior notifications"""
         pass
 
-    def wearClothingItem(self,clothing_name,update=1):
+    def wearClothingItem(self, clothing_name, update=1):
         """Tells the avatar to wear a particular item of clothing.
         And optionally hold update until later (for applying tinting before wearing).
         """
@@ -1719,10 +1719,10 @@ class ptAvatar:
 class ptBook:
     """Creates a new book"""
 
-    def __init__(self,esHTMLSource,coverImage=None,callbackKey=None,guiName=''):
+    def __init__(self, esHTMLSource, coverImage=None, callbackKey=None, guiName=''):
         pass
 
-    def allowPageTurning(self,allow):
+    def allowPageTurning(self, allow):
         """Turns on and off the ability to flip the pages in a book"""
         pass
 
@@ -1742,11 +1742,11 @@ class ptBook:
         """Returns the editable text currently contained in the book."""
         pass
 
-    def getMovie(self,index):
+    def getMovie(self, index):
         """Grabs a ptAnimation object representing the movie indexed by index. The index is the index of the movie in the source code"""
         pass
 
-    def goToPage(self,page):
+    def goToPage(self, page):
         """Flips the book to the specified page"""
         pass
 
@@ -1758,7 +1758,7 @@ class ptBook:
         """Flips the book to the next page"""
         pass
 
-    def open(self,startingPage):
+    def open(self, startingPage):
         """Opens the book to the specified page"""
         pass
 
@@ -1766,36 +1766,36 @@ class ptBook:
         """Flips the book to the previous page"""
         pass
 
-    def setEditable(self,editable):
+    def setEditable(self, editable):
         """Turn book editing on or off. If the book GUI does not support editing, nothing will happen"""
         pass
 
-    def setEditableText(self,text):
+    def setEditableText(self, text):
         """Sets the book's editable text."""
         pass
 
-    def setGUI(self,guiName):
+    def setGUI(self, guiName):
         """Sets the gui to be used by the book, if the requested gui is not loaded, it will use the default
         Do not call while the book is open!
         """
         pass
 
-    def setPageMargin(self,margin):
+    def setPageMargin(self, margin):
         """Sets the text margin for the book"""
         pass
 
-    def setSize(self,width,height):
+    def setSize(self, width, height):
         """Sets the size of the book (width and height are floats from 0 to 1)"""
         pass
 
-    def show(self,startOpened):
+    def show(self, startOpened):
         """Shows the book closed, or open if the the startOpened flag is true"""
         pass
 
 class ptCamera:
     """Plasma camera class"""
 
-    def controlKey(self,controlKey,activateFlag):
+    def controlKey(self, controlKey, activateFlag):
         """Send a control key to the camera as if it was hit by the user.
         This is for sending things like pan-up, pan-down, zoom-in, etc.
         """
@@ -1833,35 +1833,35 @@ class ptCamera:
         """Refreshes the FOV"""
         pass
 
-    def restore(self,cameraKey):
+    def restore(self, cameraKey):
         """Restores camera to saved one"""
         pass
 
-    def save(self,cameraKey):
+    def save(self, cameraKey):
         """Saves the current camera and sets the camera to cameraKey"""
         pass
 
-    def set(self,cameraKey,time,save):
+    def set(self, cameraKey, time, save):
         """DO NOT USE"""
         pass
 
-    def setAspectRatio(self,aspect):
+    def setAspectRatio(self, aspect):
         """Set the global aspect ratio"""
         pass
 
-    def setFOV(self,fov, time):
+    def setFOV(self, fov, time):
         """Sets the current cameras FOV (based on h)"""
         pass
 
-    def setSmootherCam(self,state):
+    def setSmootherCam(self, state):
         """Set the faster cams thing"""
         pass
 
-    def setStayInFirstPerson(self,state):
+    def setStayInFirstPerson(self, state):
         """Set Stay In First Person Always"""
         pass
 
-    def setWalkAndVerticalPan(self,state):
+    def setWalkAndVerticalPan(self, state):
         """Set Walk and chew gum"""
         pass
 
@@ -1874,17 +1874,17 @@ class ptCamera:
 class ptCluster:
     """Creates a new ptCluster"""
 
-    def __init__(self,key):
+    def __init__(self, key):
         pass
 
-    def setVisible(self,visible):
+    def setVisible(self, visible):
         """Shows or hides the cluster object"""
         pass
 
 class ptColor:
     """Plasma color class"""
 
-    def __init__(self,red=0, green=0, blue=0, alpha=0):
+    def __init__(self, red=0, green=0, blue=0, alpha=0):
         pass
 
     def black(self):
@@ -1993,19 +1993,19 @@ class ptColor:
         """
         pass
 
-    def setAlpha(self,alpha):
+    def setAlpha(self, alpha):
         """Set the alpha blend component of the color. 0.0 to 1.0"""
         pass
 
-    def setBlue(self,blue):
+    def setBlue(self, blue):
         """Set the blue component of the color. 0.0 to 1.0"""
         pass
 
-    def setGreen(self,green):
+    def setGreen(self, green):
         """Set the green component of the color. 0.0 to 1.0"""
         pass
 
-    def setRed(self,red):
+    def setRed(self, red):
         """Set the red component of the color. 0.0 to 1.0"""
         pass
 
@@ -2042,15 +2042,15 @@ class ptColor:
 class ptCritterBrain:
     """Object to manipulate critter brains"""
 
-    def addBehavior(self,animName, behaviorName, loop = 1, randomStartPos = 1, fadeInLen = 2.0, fadeOutLen = 2.0):
+    def addBehavior(self, animName, behaviorName, loop = 1, randomStartPos = 1, fadeInLen = 2.0, fadeOutLen = 2.0):
         """Adds a new animation to the brain as a behavior with the specified name and parameters. If multiple animations are assigned to the same behavior, they will be randomly picked from when started."""
         pass
 
-    def addReceiver(self,key):
+    def addReceiver(self, key):
         """Tells the brain that the specified key wants AI messages"""
         pass
 
-    def animationName(self,behavior):
+    def animationName(self, behavior):
         """Returns the animation name associated with the specified integral behavior."""
         pass
 
@@ -2062,15 +2062,15 @@ class ptCritterBrain:
         """Are we currently avoiding avatars while pathfinding?"""
         pass
 
-    def behaviorName(self,behavior):
+    def behaviorName(self, behavior):
         """Returns the behavior name associated with the specified integral behavior."""
         pass
 
-    def canHearAvatar(self,avatarID):
+    def canHearAvatar(self, avatarID):
         """Returns whether this brain can hear the avatar with the specified id."""
         pass
 
-    def canSeeAvatar(self,avatarID):
+    def canSeeAvatar(self, avatarID):
         """Returns whether this brain can see the avatar with the specified id."""
         pass
 
@@ -2102,7 +2102,7 @@ class ptCritterBrain:
         """Returns how far away from the goal we could be and still be considered there."""
         pass
 
-    def goToGoal(self,newGoal, avoidingAvatars = 0):
+    def goToGoal(self, newGoal, avoidingAvatars = 0):
         """Tells the brain to start running towards the specified location, avoiding avatars it can see or hear if told to."""
         pass
 
@@ -2122,7 +2122,7 @@ class ptCritterBrain:
         """Returns a list of player ids which this brain can see."""
         pass
 
-    def removeReceiver(self,key):
+    def removeReceiver(self, key):
         """Tells the brain that the specified key no longer wants AI messages"""
         pass
 
@@ -2130,38 +2130,38 @@ class ptCritterBrain:
         """Returns the name of the brain's run behavior."""
         pass
 
-    def runningBehavior(self,behaviorName):
+    def runningBehavior(self, behaviorName):
         """Returns true if the named behavior is running."""
         pass
 
-    def setHearingDistance(self,dist):
+    def setHearingDistance(self, dist):
         """Set how far away the brain can hear (360 degree field of hearing)."""
         pass
 
-    def setSightCone(self,radians):
+    def setSightCone(self, radians):
         """Set how wide the brain's field of view is in radians. Note that it is the total angle of the cone, half on one side of the brain's line of sight, half on the other."""
         pass
 
-    def setSightDistance(self,dist):
+    def setSightDistance(self, dist):
         """Set how far away the brain can see."""
         pass
 
-    def setStopDistance(self,dist):
+    def setStopDistance(self, dist):
         """Set how far away from the goal we should be when we are considered there and stop running."""
         pass
 
-    def startBehavior(self,behaviorName, fade = 1):
+    def startBehavior(self, behaviorName, fade = 1):
         """Starts playing the named behavior. If fade is true, it will fade out the previous behavior and fade in the new one. If false, they will immediately switch."""
         pass
 
-    def vectorToPlayer(self,avatarID):
+    def vectorToPlayer(self, avatarID):
         """Returns the vector between us and the specified player."""
         pass
 
 class ptDniCoordinates:
     """Constructor for a D'Ni coordinate"""
 
-    def fromPoint(self,pt):
+    def fromPoint(self, pt):
         """Update these coordinates with the specified ptPoint3"""
         pass
 
@@ -2209,11 +2209,11 @@ class ptDraw:
         """
         pass
 
-    def enable(self,state=1):
+    def enable(self, state=1):
         """Sets the draw enable for the sceneobject attached"""
         pass
 
-    def netForce(self,forceFlag):
+    def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
@@ -2223,14 +2223,14 @@ class ptDraw:
 class ptDynamicMap:
     """Creates a ptDynamicMap object"""
 
-    def __init__(self,key=None):
+    def __init__(self, key=None):
         pass
 
-    def addKey(self,key):
+    def addKey(self, key):
         """Add a receiver... in other words a DynamicMap"""
         pass
 
-    def calcTextExtents(self,text):
+    def calcTextExtents(self, text):
         """Calculates the extent of the specified text, returns it as a (width, height) tuple"""
         pass
 
@@ -2238,28 +2238,28 @@ class ptDynamicMap:
         """Clears the receiver list"""
         pass
 
-    def clearToColor(self,color):
+    def clearToColor(self, color):
         """Clear the DynamicMap to the specified color
         - 'color' is a ptColor object
         """
         pass
 
-    def drawImage(self,x,y,image,respectAlphaFlag):
+    def drawImage(self, x, y, image, respectAlphaFlag):
         """Draws a ptImage object on the dynamicTextmap starting at the location x,y"""
         pass
 
-    def drawImageClipped(self,x,y,image,cx,cy,cw,ch,respectAlphaFlag):
+    def drawImageClipped(self, x, y, image, cx, cy, cw, ch, respectAlphaFlag):
         """Draws a ptImage object clipped to cx,cy with cw(width),ch(height)"""
         pass
 
-    def drawText(self,x,y,text):
+    def drawText(self, x, y, text):
         """Draw text at a specified location
         - x,y is the point to start drawing the text
         - 'text' is a string of the text to be drawn
         """
         pass
 
-    def fillRect(self,left,top,right,bottom,color):
+    def fillRect(self, left, top, right, bottom, color):
         """Fill in the specified rectangle with a color
         - left,top,right,bottom define the rectangle
         - 'color' is a ptColor object
@@ -2270,7 +2270,7 @@ class ptDynamicMap:
         """Flush all the commands that were issued since the last flush()"""
         pass
 
-    def frameRect(self,left,top,right,bottom,color):
+    def frameRect(self, left, top, right, bottom, color):
         """Frame a rectangle with a specified color
         - left,top,right,bottom define the rectangle
         - 'color' is a ptColor object
@@ -2289,7 +2289,7 @@ class ptDynamicMap:
         """Returns the width of the dynamicTextmap"""
         pass
 
-    def netForce(self,forceFlag):
+    def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
@@ -2297,7 +2297,7 @@ class ptDynamicMap:
         """
         pass
 
-    def netPropagate(self,propagateFlag):
+    def netPropagate(self, propagateFlag):
         """Specify whether this object needs to use messages that are sent on the network
         - The default is for this to be false.
         """
@@ -2307,40 +2307,40 @@ class ptDynamicMap:
         """Purge the DynamicTextMap images"""
         pass
 
-    def sender(self,sender):
+    def sender(self, sender):
         """Set the sender of the message being sent to the DynamicMap"""
         pass
 
-    def setClipping(self,clipLeft,clipTop,clipRight,clipBottom):
+    def setClipping(self, clipLeft, clipTop, clipRight, clipBottom):
         """Sets the clipping rectangle
         - All drawtext will be clipped to this until the
         unsetClipping() is called
         """
         pass
 
-    def setFont(self,facename,size):
+    def setFont(self, facename, size):
         """Set the font of the text to be written
         - 'facename' is a string with the name of the font
         - 'size' is the point size of the font to use
         """
         pass
 
-    def setJustify(self,justify):
+    def setJustify(self, justify):
         """Sets the justification of the text. (justify is a PtJustify)"""
         pass
 
-    def setLineSpacing(self,spacing):
+    def setLineSpacing(self, spacing):
         """Sets the line spacing (in pixels)"""
         pass
 
-    def setTextColor(self,color, blockRGB=0):
+    def setTextColor(self, color, blockRGB=0):
         """Set the color of the text to be written
         - 'color' is a ptColor object
         - 'blockRGB' must be true if you're trying to render onto a transparent or semi-transparent color
         """
         pass
 
-    def setWrapping(self,wrapWidth,wrapHeight):
+    def setWrapping(self, wrapWidth, wrapHeight):
         """Set where text will be wrapped horizontally and vertically
         - All drawtext commands will be wrapped until the
         unsetWrapping() is called
@@ -2358,14 +2358,14 @@ class ptDynamicMap:
 class ptGUIControl:
     """Base class for all GUI controls"""
 
-    def __init__(self,controlKey):
+    def __init__(self, controlKey):
         pass
 
     def disable(self):
         """Disables this GUI control"""
         pass
 
-    def enable(self,flag=1):
+    def enable(self, flag=1):
         """Enables this GUI control"""
         pass
 
@@ -2437,43 +2437,43 @@ class ptGUIControl:
         """UNKNOWN"""
         pass
 
-    def setBackColor(self,r,g,b,a):
+    def setBackColor(self, r, g, b, a):
         """Sets the background color"""
         pass
 
-    def setBackSelectColor(self,r,g,b,a):
+    def setBackSelectColor(self, r, g, b, a):
         """Sets the selection background color"""
         pass
 
-    def setFocus(self,state):
+    def setFocus(self, state):
         """Sets the state of the focus of this GUI control"""
         pass
 
-    def setFontFlags(self,fontflags):
+    def setFontFlags(self, fontflags):
         """Sets current fontflags"""
         pass
 
-    def setFontSize(self,fontSize):
+    def setFontSize(self, fontSize):
         """Sets the font size"""
         pass
 
-    def setForeColor(self,r,g,b,a):
+    def setForeColor(self, r, g, b, a):
         """Sets the foreground color"""
         pass
 
-    def setNotifyOnInteresting(self,state):
+    def setNotifyOnInteresting(self, state):
         """Sets whether this control should send interesting events or not"""
         pass
 
-    def setObjectCenter(self,point):
+    def setObjectCenter(self, point):
         """Sets the GUI controls object center to 'point'"""
         pass
 
-    def setSelectColor(self,r,g,b,a):
+    def setSelectColor(self, r, g, b, a):
         """Sets the selection color"""
         pass
 
-    def setVisible(self,state):
+    def setVisible(self, state):
         """Sets the state of visibility of this GUI control"""
         pass
 
@@ -2488,7 +2488,7 @@ class ptGUIControl:
 class ptGUIControlButton(ptGUIControl):
     """Plasma GUI Control Button class"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
     def getNotifyType(self):
@@ -2499,28 +2499,28 @@ class ptGUIControlButton(ptGUIControl):
         """Is the button down? Returns 1 for true otherwise returns 0"""
         pass
 
-    def setNotifyType(self,kind):
+    def setNotifyType(self, kind):
         """Sets this button's notify type. See PtButtonNotifyTypes"""
         pass
 
 class ptGUIControlCheckBox(ptGUIControl):
     """Plasma GUI Control Checkbox class"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
     def isChecked(self):
         """Is this checkbox checked? Returns 1 for true otherwise returns 0"""
         pass
 
-    def setChecked(self,checkedState):
+    def setChecked(self, checkedState):
         """Sets this checkbox to the 'checkedState'"""
         pass
 
 class ptGUIControlClickMap(ptGUIControl):
     """Plasma GUI control Click Map"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
     def getLastMouseDragPoint(self):
@@ -2538,7 +2538,7 @@ class ptGUIControlClickMap(ptGUIControl):
 class ptGUIControlDragBar(ptGUIControl):
     """Plasma GUI Control DragBar class"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
     def anchor(self):
@@ -2560,24 +2560,24 @@ class ptGUIControlDragBar(ptGUIControl):
 class ptGUIControlDraggable(ptGUIControl):
     """Plasma GUI control for something draggable"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
     def getLastMousePoint(self):
         """Returns the last point we were dragged to"""
         pass
 
-    def stopDragging(self,cancelFlag):
+    def stopDragging(self, cancelFlag):
         """UNKNOWN"""
         pass
 
 class ptGUIControlDynamicText(ptGUIControl):
     """Plasma GUI Control DynamicText class"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
-    def getMap(self,index):
+    def getMap(self, index):
         """Returns a specific ptDynamicText attached to this contol
         If there is no map at 'index' then a KeyError exception will be raised
         """
@@ -2590,7 +2590,7 @@ class ptGUIControlDynamicText(ptGUIControl):
 class ptGUIControlEditBox(ptGUIControl):
     """Plasma GUI Control Editbox class"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
     def clearString(self):
@@ -2617,31 +2617,31 @@ class ptGUIControlEditBox(ptGUIControl):
         """Sets the cursor in the editbox to before the first character."""
         pass
 
-    def setChatMode(self,state):
+    def setChatMode(self, state):
         """Set the Chat mode on this control"""
         pass
 
-    def setColor(self,foreColor,backColor):
+    def setColor(self, foreColor, backColor):
         """Sets the fore and back color of the editbox."""
         pass
 
-    def setLastKeyCapture(self,key, modifiers):
+    def setLastKeyCapture(self, key, modifiers):
         """Set last key captured"""
         pass
 
-    def setSelectionColor(self,foreColor,backColor):
+    def setSelectionColor(self, foreColor, backColor):
         """Sets the selection color of the editbox."""
         pass
 
-    def setSpecialCaptureKeyMode(self,state):
+    def setSpecialCaptureKeyMode(self, state):
         """Set the Capture mode on this control"""
         pass
 
-    def setString(self,text):
+    def setString(self, text):
         """Pre-sets the editbox to a string."""
         pass
 
-    def setStringSize(self,size):
+    def setStringSize(self, size):
         """Sets the maximum size of the string that can be inputted by the user."""
         pass
 
@@ -2652,7 +2652,7 @@ class ptGUIControlEditBox(ptGUIControl):
 class ptGUIControlValue(ptGUIControl):
     """Plasma GUI Control Value class  - knobs, spinners"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
     def getMax(self):
@@ -2671,67 +2671,67 @@ class ptGUIControlValue(ptGUIControl):
         """Returns the current value of the control."""
         pass
 
-    def setRange(self,minimum,maximum):
+    def setRange(self, minimum, maximum):
         """Sets the minimum and maximum range of the control."""
         pass
 
-    def setStep(self,step):
+    def setStep(self, step):
         """Sets the step increment of the control."""
         pass
 
-    def setValue(self,value):
+    def setValue(self, value):
         """Sets the current value of the control."""
         pass
 
 class ptGUIControlKnob(ptGUIControlValue):
     """Plasma GUI control for knob"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
 class ptGUIControlListBox(ptGUIControl):
     """Plasma GUI Control List Box class"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
-    def add2StringsWithColors(self,text1,color1,text2,color2,respectAlpha):
+    def add2StringsWithColors(self, text1, color1, text2, color2, respectAlpha):
         """Doesn't work right - DONT USE"""
         pass
 
-    def addBranch(self,name,initiallyOpen):
+    def addBranch(self, name, initiallyOpen):
         """UNKNOWN"""
         pass
 
-    def addImage(self,image,respectAlphaFlag):
+    def addImage(self, image, respectAlphaFlag):
         """Appends an image item to the listbox"""
         pass
 
-    def addImageAndSwatchesInBox(self,image,x,y,width,height,respectAlpha,primary,secondary):
+    def addImageAndSwatchesInBox(self, image, x, y, width, height, respectAlpha, primary, secondary):
         """Add the image and color swatches to the list"""
         pass
 
-    def addImageInBox(self,image,x,y,width,height,respectAlpha):
+    def addImageInBox(self, image, x, y, width, height, respectAlpha):
         """Appends an image item to the listbox, centering within the box dimension."""
         pass
 
-    def addSelection(self,item):
+    def addSelection(self, item):
         """Adds item to selection list"""
         pass
 
-    def addString(self,text):
+    def addString(self, text):
         """Appends a list item 'text' to the listbox."""
         pass
 
-    def addStringInBox(self,text,min_width,min_height):
+    def addStringInBox(self, text, min_width, min_height):
         """Adds a text list item that has a minimum width and height"""
         pass
 
-    def addStringWithColor(self,text,color,inheritAlpha):
+    def addStringWithColor(self, text, color, inheritAlpha):
         """Adds a colored string to the list box"""
         pass
 
-    def addStringWithColorWithSize(self,text,color,inheritAlpha,fontsize):
+    def addStringWithColorWithSize(self, text, color, inheritAlpha, fontsize):
         """Adds a text list item with a color and different font size"""
         pass
 
@@ -2755,7 +2755,7 @@ class ptGUIControlListBox(ptGUIControl):
         """The listbox must always have a selection"""
         pass
 
-    def findString(self,text):
+    def findString(self, text):
         """Finds and returns the index of the item that matches 'text' in the listbox."""
         pass
 
@@ -2763,7 +2763,7 @@ class ptGUIControlListBox(ptGUIControl):
         """get a list of branches in this list (index,isShowingChildren)"""
         pass
 
-    def getElement(self,index):
+    def getElement(self, index):
         """Get the string of the item at 'index' in the listbox."""
         pass
 
@@ -2797,11 +2797,11 @@ class ptGUIControlListBox(ptGUIControl):
         """Refresh the display of the listbox (after updating contents)."""
         pass
 
-    def removeElement(self,index):
+    def removeElement(self, index):
         """Removes element at 'index' in the listbox."""
         pass
 
-    def removeSelection(self,item):
+    def removeSelection(self, item):
         """Removes item from selection list"""
         pass
 
@@ -2813,27 +2813,27 @@ class ptGUIControlListBox(ptGUIControl):
         """Scrolls the listbox to the end of the list"""
         pass
 
-    def setElement(self,index,text):
+    def setElement(self, index, text):
         """Set a particular item in the listbox to a string."""
         pass
 
-    def setGlobalSwatchEdgeOffset(self,offset):
+    def setGlobalSwatchEdgeOffset(self, offset):
         """Sets the edge offset of the color swatches"""
         pass
 
-    def setGlobalSwatchSize(self,size):
+    def setGlobalSwatchSize(self, size):
         """Sets the size of the color swatches"""
         pass
 
-    def setScrollPos(self,pos):
+    def setScrollPos(self, pos):
         """Sets the scroll position of the listbox to 'pos'"""
         pass
 
-    def setSelection(self,selectionIndex):
+    def setSelection(self, selectionIndex):
         """Sets the current selection in the listbox."""
         pass
 
-    def setStringJustify(self,index,justify):
+    def setStringJustify(self, index, justify):
         """Sets the text justification"""
         pass
 
@@ -2850,7 +2850,7 @@ class ptGUIControlListBox(ptGUIControl):
 class ptGUIControlMultiLineEdit(ptGUIControl):
     """Plasma GUI Control Multi-line edit class"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
     def beginUpdate(self):
@@ -2873,7 +2873,7 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """Deletes a character at the current cursor position."""
         pass
 
-    def deleteLinesFromTop(self,numLines):
+    def deleteLinesFromTop(self, numLines):
         """Deletes the specified number of lines from the top of the text buffer"""
         pass
 
@@ -2885,7 +2885,7 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """Enables the scroll control if there is one"""
         pass
 
-    def endUpdate(self,redraw=True):
+    def endUpdate(self, redraw=True):
         """Signifies that the massive updates are over. We can now redraw."""
         pass
 
@@ -2925,25 +2925,25 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """Gets the string of the edit control."""
         pass
 
-    def insertChar(self,c):
+    def insertChar(self, c):
         """Inserts a character at the current cursor position."""
         pass
 
-    def insertColor(self,color):
+    def insertColor(self, color):
         """Inserts an encoded color object at the current cursor position.
         'color' is a ptColor object.
         """
         pass
 
-    def insertLink(self,linkId: int) -> None:
+    def insertLink(self, linkId: int) -> None:
         """Inserts a link hotspot at the current cursor position."""
         pass
 
-    def insertString(self,string):
+    def insertString(self, string):
         """Inserts a string at the current cursor position."""
         pass
 
-    def insertStyle(self,style):
+    def insertStyle(self, style):
         """Inserts an encoded font style at the current cursor position."""
         pass
 
@@ -2963,31 +2963,31 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """Locks the multi-line edit control so the user cannot make changes."""
         pass
 
-    def moveCursor(self,direction):
+    def moveCursor(self, direction):
         """Move the cursor in the specified direction (see PtGUIMultiLineDirection)"""
         pass
 
-    def setBufferLimit(self,bufferLimit):
+    def setBufferLimit(self, bufferLimit):
         """Sets the buffer max for the editbox"""
         pass
 
-    def setEncodedBuffer(self,bufferObject):
+    def setEncodedBuffer(self, bufferObject):
         """Sets the edit control to the encoded buffer in the python buffer object."""
         pass
 
-    def setFontSize(self,fontSize):
+    def setFontSize(self, fontSize):
         """Sets the default font size for the edit control"""
         pass
 
-    def setMargins(self,top: Optional[int] = None, left: Optional[int] = None, bottom: Optional[int] = None, right: Optional[int] = None) -> None:
+    def setMargins(self, top: Optional[int] = None, left: Optional[int] = None, bottom: Optional[int] = None, right: Optional[int] = None) -> None:
         """Sets the control's margins"""
         pass
 
-    def setScrollPosition(self,topLine):
+    def setScrollPosition(self, topLine):
         """Sets the what line is the top line."""
         pass
 
-    def setString(self,text):
+    def setString(self, text):
         """Sets the multi-line edit control string."""
         pass
 
@@ -3004,31 +3004,31 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 class ptGUIControlProgress(ptGUIControlValue):
     """Plasma GUI control for progress bar"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
-    def animateToPercent(self,percent):
+    def animateToPercent(self, percent):
         """Sets the value of the control and animates to that point."""
         pass
 
 class ptGUIControlRadioGroup(ptGUIControl):
     """Plasma GUI Control Radio Group class"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
     def getValue(self):
         """Returns the current selection of the radio group."""
         pass
 
-    def setValue(self,value):
+    def setValue(self, value):
         """Sets the current selection to 'value'"""
         pass
 
 class ptGUIControlTextBox(ptGUIControl):
     """Plasma GUI Control Textbox class"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
     def getForeColor(self):
@@ -3043,43 +3043,43 @@ class ptGUIControlTextBox(ptGUIControl):
         """Returns current justify"""
         pass
 
-    def setBackColor(self,color):
+    def setBackColor(self, color):
         """Sets the text backcolor to 'color', which is a ptColor object."""
         pass
 
-    def setFontSize(self,size):
+    def setFontSize(self, size):
         """Don't use"""
         pass
 
-    def setForeColor(self,color):
+    def setForeColor(self, color):
         """Sets the text forecolor to 'color', which is a ptColor object."""
         pass
 
-    def setString(self,text):
+    def setString(self, text):
         """Sets the textbox string to 'text'"""
         pass
 
-    def setStringJustify(self,justify):
+    def setStringJustify(self, justify):
         """Sets current justify"""
         pass
 
 class ptGUIControlUpDownPair(ptGUIControlValue):
     """Plasma GUI control for up/down pair"""
 
-    def __init__(self,ctrlKey):
+    def __init__(self, ctrlKey):
         pass
 
 class ptGUIDialog:
     """Plasma GUI dialog class"""
 
-    def __init__(self,dialogKey):
+    def __init__(self, dialogKey):
         pass
 
     def disable(self):
         """Disables this dialog"""
         pass
 
-    def enable(self,enableFlag=1):
+    def enable(self, enableFlag=1):
         """Enable this dialog"""
         pass
 
@@ -3091,19 +3091,19 @@ class ptGUIDialog:
         """Returns the select back color as a ptColor object"""
         pass
 
-    def getControlFromIndex(self,index):
+    def getControlFromIndex(self, index):
         """Returns the ptKey of the control with the specified index (not tag ID!)"""
         pass
 
-    def getControlFromTag(self,tagID):
+    def getControlFromTag(self, tagID):
         """Returns the ptKey of the control with the specified tag ID"""
         pass
 
-    def getControlModFromIndex(self,index: int) -> ptGUIControl:
+    def getControlModFromIndex(self, index: int) -> ptGUIControl:
         """Returns the ptGUIControl with the specified index (not tag ID!)"""
         pass
 
-    def getControlModFromTag(self,tagID: int) -> ptGUIControl:
+    def getControlModFromTag(self, tagID: int) -> ptGUIControl:
         """Returns the ptGUIControl with the specified tag ID"""
         pass
 
@@ -3155,27 +3155,27 @@ class ptGUIDialog:
         """Tells the dialog to redraw all its controls"""
         pass
 
-    def setBackColor(self,red,green,blue,alpha):
+    def setBackColor(self, red, green, blue, alpha):
         """Sets the back color, -1 means don't change"""
         pass
 
-    def setBackSelectColor(self,red,green,blue,alpha):
+    def setBackSelectColor(self, red, green, blue, alpha):
         """Sets the select back color, -1 means don't change"""
         pass
 
-    def setFocus(self,ctrlKey):
+    def setFocus(self, ctrlKey):
         """Sets the control that has input focus"""
         pass
 
-    def setFontSize(self,fontSize):
+    def setFontSize(self, fontSize):
         """Sets the font size"""
         pass
 
-    def setForeColor(self,red,green,blue,alpha):
+    def setForeColor(self, red, green, blue, alpha):
         """Sets the fore color, -1 means don't change"""
         pass
 
-    def setSelectColor(self,red,green,blue,alpha):
+    def setSelectColor(self, red, green, blue, alpha):
         """Sets the select color, -1 means don't change"""
         pass
 
@@ -3198,18 +3198,18 @@ class ptGUIPopUpMenu:
     name,parent,screenOriginX,screenOriginY
     """
 
-    def __init__(self,arg1,arg2=None,arg3=None,arg4=None):
+    def __init__(self, arg1, arg2=None, arg3=None, arg4=None):
         pass
 
-    def addConsoleCmdItem(self,name,consoleCmd):
+    def addConsoleCmdItem(self, name, consoleCmd):
         """Adds a new item to the menu that fires a console command"""
         pass
 
-    def addNotifyItem(self,name):
+    def addNotifyItem(self, name):
         """Adds a new item ot the mneu"""
         pass
 
-    def addSubMenuItem(self,name,subMenu):
+    def addSubMenuItem(self, name, subMenu):
         """Adds a submenu to this menu"""
         pass
 
@@ -3217,7 +3217,7 @@ class ptGUIPopUpMenu:
         """Disables this menu"""
         pass
 
-    def enable(self,state=1):
+    def enable(self, state=1):
         """Enables/disables this menu"""
         pass
 
@@ -3261,19 +3261,19 @@ class ptGUIPopUpMenu:
         """Returns whether this menu is enabled or not"""
         pass
 
-    def setBackColor(self,r,g,b,a):
+    def setBackColor(self, r, g, b, a):
         """Sets the background color"""
         pass
 
-    def setBackSelectColor(self,r,g,b,a):
+    def setBackSelectColor(self, r, g, b, a):
         """Sets the selection background color"""
         pass
 
-    def setForeColor(self,r,g,b,a):
+    def setForeColor(self, r, g, b, a):
         """Sets the foreground color"""
         pass
 
-    def setSelectColor(self,r,g,b,a):
+    def setSelectColor(self, r, g, b, a):
         """Sets the selection color"""
         pass
 
@@ -3284,7 +3284,7 @@ class ptGUIPopUpMenu:
 class ptGUISkin:
     """Plasma GUI Skin object"""
 
-    def __init__(self,key):
+    def __init__(self, key):
         pass
 
     def getKey(self):
@@ -3294,7 +3294,7 @@ class ptGUISkin:
 class ptGameScore:
     """Plasma Game Score"""
 
-    def addPoints(self,points, key=None):
+    def addPoints(self, points, key=None):
         """Adds points to the score"""
         pass
 
@@ -3368,13 +3368,13 @@ class ptGameScore:
         """Removes this score from the server"""
         pass
 
-    def setPoints(self,numPoints, key):
+    def setPoints(self, numPoints, key):
         """Sets the number of points in the score
         Don't use to add/remove points, use only to reset values!
         """
         pass
 
-    def transferPoints(self,dest, points=0, key=None):
+    def transferPoints(self, dest, points=0, key=None):
         """Transfers points from this score to another"""
         pass
 
@@ -3417,18 +3417,18 @@ class ptGameScoreUpdateMsg(ptGameScoreMsg):
 class ptGrassShader:
     """Plasma Grass Shader class"""
 
-    def __init__(self,key):
+    def __init__(self, key):
         pass
 
-    def getWaveDirection(self,waveNum):
+    def getWaveDirection(self, waveNum):
         """Gets the wave waveNum's direction as a tuple of x,y. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
         pass
 
-    def getWaveDistortion(self,waveNum):
+    def getWaveDistortion(self, waveNum):
         """Gets the wave waveNum's distortion as a tuple of x,y,z. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
         pass
 
-    def getWaveSpeed(self,waveNum):
+    def getWaveSpeed(self, waveNum):
         """Gets the wave waveNum's speed as a float. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
         pass
 
@@ -3436,25 +3436,25 @@ class ptGrassShader:
         """Resets wave data to 0"""
         pass
 
-    def setWaveDirection(self,waveNum, direction):
+    def setWaveDirection(self, waveNum, direction):
         """Sets the wave waveNum's direction as a tuple of x,y. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
         pass
 
-    def setWaveDistortion(self,waveNum, distortion):
+    def setWaveDistortion(self, waveNum, distortion):
         """Sets the wave waveNum's distortion as a tuple of x,y,z. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
         pass
 
-    def setWaveSpeed(self,waveNum, speed):
+    def setWaveSpeed(self, waveNum, speed):
         """Sets the wave waveNum's speed as a float. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
         pass
 
 class ptImage:
     """Plasma image class"""
 
-    def __init__(self,imgKey):
+    def __init__(self, imgKey):
         pass
 
-    def getColorLoc(self,color):
+    def getColorLoc(self, color):
         """Returns the ptPoint3 where the specified color is located"""
         pass
 
@@ -3462,7 +3462,7 @@ class ptImage:
         """Returns the height of the image"""
         pass
 
-    def getPixelColor(self,x,y):
+    def getPixelColor(self, x, y):
         """Returns the ptColor at the specified location (float from 0 to 1)"""
         pass
 
@@ -3470,21 +3470,21 @@ class ptImage:
         """Returns the width of the image"""
         pass
 
-    def saveAsJPEG(self,filename,quality=75):
+    def saveAsJPEG(self, filename, quality=75):
         """Saves this image to disk as a JPEG file"""
         pass
 
-    def saveAsPNG(self,filename):
+    def saveAsPNG(self, filename):
         """Saves this image to disk as a PNG file"""
         pass
 
 class ptImageLibMod:
     """Plasma image library modifier class"""
 
-    def __init__(self,ilmKey):
+    def __init__(self, ilmKey):
         pass
 
-    def getImage(self,name):
+    def getImage(self, name):
         """Returns the ptImage with the specified name"""
         pass
 
@@ -3538,7 +3538,7 @@ class ptKey:
         """Returns whether the python file mod is attached to a clone"""
         pass
 
-    def netForce(self,forceFlag):
+    def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
@@ -3548,55 +3548,55 @@ class ptKey:
 class ptKeyMap:
     """Accessor class to the Key Mapping functions"""
 
-    def bindKey(self,key1,key2,action):
+    def bindKey(self, key1, key2, action):
         """Bind keys to an action"""
         pass
 
-    def bindKeyToConsoleCommand(self,keyStr1, command):
+    def bindKeyToConsoleCommand(self, keyStr1, command):
         """Binds key to console command"""
         pass
 
-    def convertCharToControlCode(self,controlCodeString):
+    def convertCharToControlCode(self, controlCodeString):
         """Convert string version of control code to number"""
         pass
 
-    def convertCharToFlags(self,charString):
+    def convertCharToFlags(self, charString):
         """Convert char string to flags"""
         pass
 
-    def convertCharToVKey(self,charString):
+    def convertCharToVKey(self, charString):
         """Convert char string to virtual key"""
         pass
 
-    def convertControlCodeToString(self,controlCode):
+    def convertControlCodeToString(self, controlCode):
         """Convert control code to character string"""
         pass
 
-    def convertVKeyToChar(self,virtualKey,flags):
+    def convertVKeyToChar(self, virtualKey, flags):
         """Convert virtual key and shift flags to string"""
         pass
 
-    def getBindingFlags1(self,controlCode):
+    def getBindingFlags1(self, controlCode):
         """Returns modifier flags for controlCode"""
         pass
 
-    def getBindingFlags2(self,controlCode):
+    def getBindingFlags2(self, controlCode):
         """Returns modifier flags for controlCode"""
         pass
 
-    def getBindingFlagsConsole(self,command):
+    def getBindingFlagsConsole(self, command):
         """Returns modifier flags for the console command mapping"""
         pass
 
-    def getBindingKey1(self,controlCode):
+    def getBindingKey1(self, controlCode):
         """Returns key code for controlCode"""
         pass
 
-    def getBindingKey2(self,controlCode):
+    def getBindingKey2(self, controlCode):
         """Returns key code for controlCode"""
         pass
 
-    def getBindingKeyConsole(self,command):
+    def getBindingKeyConsole(self, command):
         """Returns key for console command mapping"""
         pass
 
@@ -3607,21 +3607,21 @@ class ptKeyMap:
 class ptLayer:
     """Plasma layer class"""
 
-    def __init__(self,layerKey):
+    def __init__(self, layerKey):
         pass
 
     def getTexture(self) -> ptImage:
         """Returns the image texture of the layer"""
         pass
 
-    def setTexture(self,image: ptImage) -> None:
+    def setTexture(self, image: ptImage) -> None:
         """Sets the ptImage texture of the layer"""
         pass
 
 class ptMarkerMgr:
     """Marker manager accessor class"""
 
-    def addMarker(self,x, y, z, id, justCreated):
+    def addMarker(self, x, y, z, id, justCreated):
         """Add a marker in the specified location with the specified id"""
         pass
 
@@ -3629,11 +3629,11 @@ class ptMarkerMgr:
         """Returns true if we are showing the markers on this local machine"""
         pass
 
-    def captureQuestMarker(self,id, captured):
+    def captureQuestMarker(self, id, captured):
         """Sets a marker as captured or not"""
         pass
 
-    def captureTeamMarker(self,id, team):
+    def captureTeamMarker(self, id, team):
         """Sets a marker as captured by the specified team (0 = not captured)"""
         pass
 
@@ -3657,15 +3657,15 @@ class ptMarkerMgr:
         """Removes all markers"""
         pass
 
-    def removeMarker(self,id):
+    def removeMarker(self, id):
         """Removes the specified marker from the game"""
         pass
 
-    def setMarkersRespawn(self,respawn):
+    def setMarkersRespawn(self, respawn):
         """Sets whether markers respawn after being captured, or not"""
         pass
 
-    def setSelectedMarker(self,id):
+    def setSelectedMarker(self, id):
         """Sets the selected marker to the one with the specified id"""
         pass
 
@@ -3680,7 +3680,7 @@ class ptMatrix44:
         """Copies the matrix and returns the copy"""
         pass
 
-    def getAdjoint(self,adjointMat):
+    def getAdjoint(self, adjointMat):
         """Returns the adjoint of the matrix"""
         pass
 
@@ -3692,7 +3692,7 @@ class ptMatrix44:
         """Get the matrix's determinant"""
         pass
 
-    def getInverse(self,inverseMat):
+    def getInverse(self, inverseMat):
         """Returns the inverse of the matrix"""
         pass
 
@@ -3700,31 +3700,31 @@ class ptMatrix44:
         """Get the parity of the matrix"""
         pass
 
-    def getTranslate(self,vector):
+    def getTranslate(self, vector):
         """Returns the translate vector of the matrix (and sets vector to it as well)"""
         pass
 
-    def getTranspose(self,transposeMat):
+    def getTranspose(self, transposeMat):
         """Returns the transpose of the matrix"""
         pass
 
-    def make(self,fromPt, atPt, upVec):
+    def make(self, fromPt, atPt, upVec):
         """Creates the matrix from from and at points, and the up vector"""
         pass
 
-    def makeRotateMat(self,axis,radians):
+    def makeRotateMat(self, axis, radians):
         """Makes the matrix a rotation matrix"""
         pass
 
-    def makeScaleMat(self,scale):
+    def makeScaleMat(self, scale):
         """Makes the matrix a scaling matrix"""
         pass
 
-    def makeTranslateMat(self,trans):
+    def makeTranslateMat(self, trans):
         """Makes the matrix a translation matrix"""
         pass
 
-    def makeUpPreserving(self,fromPt, atPt, upVec):
+    def makeUpPreserving(self, fromPt, atPt, upVec):
         """Creates the matrix from from and at points, and the up vector (perserving the up vector)"""
         pass
 
@@ -3736,19 +3736,19 @@ class ptMatrix44:
         """Returns the right vector of the matrix"""
         pass
 
-    def rotate(self,axis,radians):
+    def rotate(self, axis, radians):
         """Rotates the matrix by radians around the axis"""
         pass
 
-    def scale(self,scale):
+    def scale(self, scale):
         """Scales the matrix by the vector"""
         pass
 
-    def setData(self,mat):
+    def setData(self, mat):
         """Sets the matrix using tuples"""
         pass
 
-    def translate(self,vector):
+    def translate(self, vector):
         """Translates the matrix by the vector"""
         pass
 
@@ -3763,7 +3763,7 @@ class ptMatrix44:
 class ptMoviePlayer:
     """Accessor class to play in the MoviePlayer"""
 
-    def __init__(self,movieName,selfKey):
+    def __init__(self, movieName, selfKey):
         pass
 
     def pause(self):
@@ -3782,23 +3782,23 @@ class ptMoviePlayer:
         """Resumes movie after pausing"""
         pass
 
-    def setCenter(self,x,y):
+    def setCenter(self, x, y):
         """Sets the center of the movie"""
         pass
 
-    def setColor(self,color):
+    def setColor(self, color):
         """Sets the color of the movie"""
         pass
 
-    def setOpacity(self,opacity):
+    def setOpacity(self, opacity):
         """Sets the opacity of the movie"""
         pass
 
-    def setScale(self,width,height):
+    def setScale(self, width, height):
         """Sets the width and height scale of the movie"""
         pass
 
-    def setVolume(self,volume):
+    def setVolume(self, volume):
         """Set the volume of the movie"""
         pass
 
@@ -3821,15 +3821,15 @@ class ptNetLinkingMgr:
         """True if linking is enabled."""
         pass
 
-    def linkPlayerHere(self,pid):
+    def linkPlayerHere(self, pid):
         """link player(pid) to where I am"""
         pass
 
-    def linkPlayerToAge(self,ageLink,pid):
+    def linkPlayerToAge(self, ageLink, pid):
         """Link player(pid) to ageLink"""
         pass
 
-    def linkToAge(self,ageLink, linkAnim):
+    def linkToAge(self, ageLink, linkAnim):
         """Links to ageLink (ptAgeLinkStruct, string)"""
         pass
 
@@ -3845,11 +3845,11 @@ class ptNetLinkingMgr:
         """Link to my Personal Age with the YeeshaBook"""
         pass
 
-    def linkToPlayersAge(self,pid):
+    def linkToPlayersAge(self, pid):
         """Link me to where player(pid) is"""
         pass
 
-    def setEnabled(self,enable):
+    def setEnabled(self, enable):
         """Enable/Disable linking."""
         pass
 
@@ -3858,70 +3858,70 @@ class ptNotify:
     - selfKey is ptKey of your PythonFile modifier
     """
 
-    def __init__(self,selfKey):
+    def __init__(self, selfKey):
         pass
 
-    def addActivateEvent(self,activeFlag,activateFlag):
+    def addActivateEvent(self, activeFlag, activateFlag):
         """Add an activate event record to the notify message"""
         pass
 
-    def addCallbackEvent(self,eventNumber):
+    def addCallbackEvent(self, eventNumber):
         """Add a callback event record to the notify message"""
         pass
 
-    def addCollisionEvent(self,enterFlag,hitterKey,hitteeKey):
+    def addCollisionEvent(self, enterFlag, hitterKey, hitteeKey):
         """Add a collision event record to the Notify message"""
         pass
 
-    def addContainerEvent(self,enteringFlag,containerKey,containedKey):
+    def addContainerEvent(self, enteringFlag, containerKey, containedKey):
         """Add a container event record to the notify message"""
         pass
 
-    def addControlKeyEvent(self,keynumber,downFlag):
+    def addControlKeyEvent(self, keynumber, downFlag):
         """Add a keyboard event record to the Notify message"""
         pass
 
-    def addFacingEvent(self,enabledFlag,facerKey, faceeKey, dotProduct):
+    def addFacingEvent(self, enabledFlag, facerKey, faceeKey, dotProduct):
         """Add a facing event record to the Notify message"""
         pass
 
-    def addPickEvent(self,enabledFlag,pickerKey,pickeeKey,hitPoint):
+    def addPickEvent(self, enabledFlag, pickerKey, pickeeKey, hitPoint):
         """Add a pick event record to the Notify message"""
         pass
 
-    def addReceiver(self,key):
+    def addReceiver(self, key):
         """Add a receivers key to receive this Notify message"""
         pass
 
-    def addResponderState(self,state):
+    def addResponderState(self, state):
         """Add a responder state event record to the notify message"""
         pass
 
-    def addVarFloat(self,name,number):
+    def addVarFloat(self, name, number):
         """Add a float variable event record to the Notify message
         This event record is used to pass a number variable to another python program
         """
         pass
 
-    def addVarInt(self,name,number):
+    def addVarInt(self, name, number):
         """Add a int variable event record to the Notify message
         This event record is used to pass a number variable to another python program
         """
         pass
 
-    def addVarKey(self,name,key):
+    def addVarKey(self, name, key):
         """Add a ptKey variable event record to the Notify message
         This event record is used to pass a ptKey variable to another python program
         """
         pass
 
-    def addVarNull(self,name,number):
+    def addVarNull(self, name, number):
         """Add a null (no data) variable event record to the Notify message
         This event record is used to pass a number variable to another python program
         """
         pass
 
-    def addVarNumber(self,name,number):
+    def addVarNumber(self, name, number):
         """Add a number variable event record to the Notify message
         Method will try to pick appropriate variable type
         This event record is used to pass a number variable to another python program
@@ -3934,14 +3934,14 @@ class ptNotify:
         """
         pass
 
-    def netForce(self,forceFlag):
+    def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
         pass
 
-    def netPropagate(self,netFlag):
+    def netPropagate(self, netFlag):
         """Sets the net propagate flag - default to set"""
         pass
 
@@ -3949,82 +3949,82 @@ class ptNotify:
         """Send the notify message"""
         pass
 
-    def setActivate(self,state):
+    def setActivate(self, state):
         """Set the activate state to true(1.0) or false(0.0)"""
         pass
 
-    def setType(self,type):
+    def setType(self, type):
         """Sets the message type"""
         pass
 
 class ptParticle:
     """Plasma particle system class"""
 
-    def netForce(self,forceFlag):
+    def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
         pass
 
-    def setGeneratorLife(self,value):
+    def setGeneratorLife(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setHeightSize(self,value):
+    def setHeightSize(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setInitPitchRange(self,value):
+    def setInitPitchRange(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setInitYawRange(self,value):
+    def setInitYawRange(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setParticleLifeMaximum(self,value):
+    def setParticleLifeMaximum(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setParticleLifeMinimum(self,value):
+    def setParticleLifeMinimum(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setParticlesPerSecond(self,value):
+    def setParticlesPerSecond(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setScaleMaximum(self,value):
+    def setScaleMaximum(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setScaleMinimum(self,value):
+    def setScaleMinimum(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setVelocityMaximum(self,value):
+    def setVelocityMaximum(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setVelocityMinimum(self,value):
+    def setVelocityMinimum(self, value):
         """NEEDS DOCSTRING"""
         pass
 
-    def setWidthSize(self,value):
+    def setWidthSize(self, value):
         """NEEDS DOCSTRING"""
         pass
 
 class ptPhysics:
     """Plasma physics class"""
 
-    def angularImpulse(self,impulseVector):
+    def angularImpulse(self, impulseVector):
         """Add the given vector (representing a rotation axis and magnitude) to
         the attached sceneobject's velocity
         """
         pass
 
-    def damp(self,damp):
+    def damp(self, damp):
         """Reduce all velocities on the object (0 = all stop, 1 = no effect)"""
         pass
 
@@ -4036,7 +4036,7 @@ class ptPhysics:
         """Disables collision detection on the attached sceneobject"""
         pass
 
-    def enable(self,state=1):
+    def enable(self, state=1):
         """Sets the physics enable state for the sceneobject attached"""
         pass
 
@@ -4044,75 +4044,75 @@ class ptPhysics:
         """Enables collision detection on the attached sceneobject"""
         pass
 
-    def force(self,forceVector):
+    def force(self, forceVector):
         """Applies the specified force to the attached sceneobject"""
         pass
 
-    def forceWithOffset(self,forceVector,offsetPt):
+    def forceWithOffset(self, forceVector, offsetPt):
         """Applies the specified offsetted force to the attached sceneobject"""
         pass
 
-    def impulse(self,impulseVector):
+    def impulse(self, impulseVector):
         """Adds the given vector to the attached sceneobject's velocity"""
         pass
 
-    def impulseWithOffset(self,impulseVector,offsetPt):
+    def impulseWithOffset(self, impulseVector, offsetPt):
         """Adds the given vector to the attached sceneobject's velocity
         with the specified offset
         """
         pass
 
-    def move(self,direction,distance):
+    def move(self, direction, distance):
         """Moves the attached sceneobject the specified distance in the specified direction"""
         pass
 
-    def netForce(self,forceFlag):
+    def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
         pass
 
-    def rotate(self,radians,axis):
+    def rotate(self, radians, axis):
         """Rotates the attached sceneobject the specified radians around the specified axis"""
         pass
 
-    def setAngularVelocity(self,velocityVector):
+    def setAngularVelocity(self, velocityVector):
         """Sets the objects AngularVelocity to the specified vector"""
         pass
 
-    def setLinearVelocity(self,velocityVector):
+    def setLinearVelocity(self, velocityVector):
         """Sets the objects LinearVelocity to the specified vector"""
         pass
 
-    def shiftMass(self,offsetVector):
+    def shiftMass(self, offsetVector):
         """Shifts the attached sceneobject's center to mass in the specified direction and distance"""
         pass
 
-    def suppress(self,doSuppress):
+    def suppress(self, doSuppress):
         """Completely remove the physical, but keep it around so it
         can be added back later.
         """
         pass
 
-    def torque(self,torqueVector):
+    def torque(self, torqueVector):
         """Applies the specified torque to the attached sceneobject"""
         pass
 
-    def warp(self,position):
+    def warp(self, position):
         """Warps the sceneobject to a specified location.
         'position' can be a ptPoint3 or a ptMatrix44
         """
         pass
 
-    def warpObj(self,objkey):
+    def warpObj(self, objkey):
         """Warps the sceneobject to match the location and orientation of the specified object"""
         pass
 
 class ptPlayer:
     """And optionally __init__(name,playerID)"""
 
-    def __init__(self,avkey,name,playerID,distanceSq):
+    def __init__(self, avkey, name, playerID, distanceSq):
         pass
 
     def getDistanceSq(self):
@@ -4138,18 +4138,18 @@ class ptPlayer:
 class ptPoint3:
     """Plasma Point class"""
 
-    def __init__(self,x=0, y=0, z=0):
+    def __init__(self, x=0, y=0, z=0):
         pass
 
     def copy(self):
         """Returns a copy of the point in another ptPoint3 object"""
         pass
 
-    def distance(self,other):
+    def distance(self, other):
         """Computes the distance from this point to 'other' point"""
         pass
 
-    def distanceSq(self,other):
+    def distanceSq(self, other):
         """Computes the distance squared from this point to 'other' point
         - this function is faster than distance(other)
         """
@@ -4167,15 +4167,15 @@ class ptPoint3:
         """Returns the 'z' component of the point"""
         pass
 
-    def setX(self,x):
+    def setX(self, x):
         """Sets the 'x' component of the point"""
         pass
 
-    def setY(self,y):
+    def setY(self, y):
         """Sets the 'y' component of the point"""
         pass
 
-    def setZ(self,z):
+    def setZ(self, z):
         """Sets the 'z' component of the point"""
         pass
 
@@ -4186,48 +4186,48 @@ class ptPoint3:
 class ptSDL:
     """SDL accessor"""
 
-    def sendToClients(self,key):
+    def sendToClients(self, key):
         """Sets it so changes to this key are sent to the
         server AND the clients. (Normally it just goes
         to the server.)
         """
         pass
 
-    def setDefault(self,key,value):
+    def setDefault(self, key, value):
         """Like setitem, but doesn't broadcast over the net.
         Only use for setting defaults that everyone will
         already know (from reading it off disk)
         """
         pass
 
-    def setFlags(self,name,sendImmediate,skipOwnershipCheck):
+    def setFlags(self, name, sendImmediate, skipOwnershipCheck):
         """Sets the flags for a variable in this SDL"""
         pass
 
-    def setIndex(self,key,idx,value):
+    def setIndex(self, key, idx, value):
         """Sets the value at a specific index in the tuple,
         so you don't have to pass the whole thing in
         """
         pass
 
-    def setIndexNow(self,key,idx,value):
+    def setIndexNow(self, key, idx, value):
         """Same as setIndex but sends immediately"""
         pass
 
-    def setNotify(self,selfkey,key,tolerance):
+    def setNotify(self, selfkey, key, tolerance):
         """Sets the OnSDLNotify to be called when 'key'
         SDL variable changes by 'tolerance' (if number)
         """
         pass
 
-    def setTagString(self,name,tag):
+    def setTagString(self, name, tag):
         """Sets the tag string for a variable"""
         pass
 
 class ptSDLStateDataRecord:
     """Basic SDL state data record class"""
 
-    def findVar(self,name):
+    def findVar(self, name):
         """Finds and returns the specified ptSimpleStateVariable"""
         pass
 
@@ -4239,7 +4239,7 @@ class ptSDLStateDataRecord:
         """Returns the names of the vars we hold as a list of strings"""
         pass
 
-    def setFromDefaults(self,timeStampNow):
+    def setFromDefaults(self, timeStampNow):
         """Sets all our vars to their defaults"""
         pass
 
@@ -4254,10 +4254,10 @@ class ptSceneobject:
 
     physics: Any
 
-    def __init__(self,objKey, selfKey):
+    def __init__(self, objKey, selfKey):
         pass
 
-    def addKey(self,key):
+    def addKey(self, key):
         """Mostly used internally.
         Add another sceneobject ptKey
         """
@@ -4271,11 +4271,11 @@ class ptSceneobject:
         """Returns the velocity of the first attached avatar scene object"""
         pass
 
-    def fastForwardAttachedResponder(self,state):
+    def fastForwardAttachedResponder(self, state):
         """Fast forward the attached responder to the specified state"""
         pass
 
-    def findObject(self,name):
+    def findObject(self, name):
         """Find a particular object in just the sceneobjects that are attached"""
         pass
 
@@ -4325,7 +4325,7 @@ class ptSceneobject:
         """Returns list of ptKeys of the responders attached to this sceneobject"""
         pass
 
-    def getSoundIndex(self,sndComponentName):
+    def getSoundIndex(self, sndComponentName):
         """Get the index of the requested sound component"""
         pass
 
@@ -4349,7 +4349,7 @@ class ptSceneobject:
         """
         pass
 
-    def netForce(self,forceFlag):
+    def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
@@ -4358,15 +4358,15 @@ class ptSceneobject:
         """
         pass
 
-    def playAnimNamed(self,animName):
+    def playAnimNamed(self, animName):
         """Play the attached named animation"""
         pass
 
-    def popCamera(self,avKey):
+    def popCamera(self, avKey):
         """Pop the camera stack and go back to the previous camera"""
         pass
 
-    def popCutsceneCamera(self,avKey):
+    def popCutsceneCamera(self, avKey):
         """Pop the camera stack and go back to previous camera."""
         pass
 
@@ -4374,19 +4374,19 @@ class ptSceneobject:
         """Returns the scene object's current position"""
         pass
 
-    def pushCamera(self,avKey):
+    def pushCamera(self, avKey):
         """Switch to this object (if it is a camera)"""
         pass
 
-    def pushCameraCut(self,avKey):
+    def pushCameraCut(self, avKey):
         """Switch to this object, cutting the view (if it is a camera)"""
         pass
 
-    def pushCutsceneCamera(self,cutFlag,avKey):
+    def pushCutsceneCamera(self, cutFlag, avKey):
         """Switch to this object (assuming that it is actually a camera)"""
         pass
 
-    def rewindAnimNamed(self,animName):
+    def rewindAnimNamed(self, animName):
         """Rewind the attached named animation"""
         pass
 
@@ -4394,19 +4394,19 @@ class ptSceneobject:
         """Returns the scene object's current right vector"""
         pass
 
-    def runAttachedResponder(self,state):
+    def runAttachedResponder(self, state):
         """Run the attached responder to the specified state"""
         pass
 
-    def setSoundFilename(self,index, filename, isCompressed):
+    def setSoundFilename(self, index, filename, isCompressed):
         """Sets the sound attached to this sceneobject to use the specified sound file."""
         pass
 
-    def setTransform(self,local2world,world2local):
+    def setTransform(self, local2world, world2local):
         """Set our current transforms"""
         pass
 
-    def stopAnimNamed(self,animName):
+    def stopAnimNamed(self, animName):
         """Stop the attached named animation"""
         pass
 
@@ -4418,22 +4418,22 @@ class ptSceneobject:
         """Returns the scene object's current view vector"""
         pass
 
-    def volumeSensorIgnoreExtraEnters(self,ignore):
+    def volumeSensorIgnoreExtraEnters(self, ignore):
         """Tells the volume sensor attached to this object to ignore extra enters (default), or not (hack for garrison)."""
         pass
 
-    def volumeSensorNoArbitration(self,noArbitration):
+    def volumeSensorNoArbitration(self, noArbitration):
         """Tells the volume sensor attached to this object whether or not to negotiate exclusive locks with the server."""
         pass
 
 class ptSimpleStateVariable:
     """Basic SDL state data record class"""
 
-    def getBool(self,idx=0):
+    def getBool(self, idx=0):
         """Returns a boolean variable's value"""
         pass
 
-    def getByte(self,idx=0):
+    def getByte(self, idx=0):
         """Returns a byte variable's value"""
         pass
 
@@ -4445,27 +4445,27 @@ class ptSimpleStateVariable:
         """Returns the variable's display options"""
         pass
 
-    def getDouble(self,idx=0):
+    def getDouble(self, idx=0):
         """Returns a double variable's value"""
         pass
 
-    def getFloat(self,idx=0):
+    def getFloat(self, idx=0):
         """Returns a float variable's value"""
         pass
 
-    def getInt(self,idx=0):
+    def getInt(self, idx=0):
         """Returns an int variable's value"""
         pass
 
-    def getKey(self,idx=0):
+    def getKey(self, idx=0):
         """Returns a plKey variable's value"""
         pass
 
-    def getShort(self,idx=0):
+    def getShort(self, idx=0):
         """Returns a short variable's value"""
         pass
 
-    def getString(self,idx=0):
+    def getString(self, idx=0):
         """Returns a string variable's value"""
         pass
 
@@ -4485,38 +4485,38 @@ class ptSimpleStateVariable:
         """Is this variable used?"""
         pass
 
-    def setBool(self,val,idx=0):
+    def setBool(self, val, idx=0):
         """Sets a boolean variable's value"""
         pass
 
-    def setByte(self,val,idx=0):
+    def setByte(self, val, idx=0):
         """Sets a byte variable's value"""
         pass
 
-    def setDouble(self,val,idx=0):
+    def setDouble(self, val, idx=0):
         """Sets a double variable's value"""
         pass
 
-    def setFloat(self,val,idx=0):
+    def setFloat(self, val, idx=0):
         """Sets a float variable's value"""
         pass
 
-    def setInt(self,val,idx=0):
+    def setInt(self, val, idx=0):
         """Sets an int variable's value"""
         pass
 
-    def setShort(self,val,idx=0):
+    def setShort(self, val, idx=0):
         """Sets a short variable's value"""
         pass
 
-    def setString(self,val,idx=0):
+    def setString(self, val, idx=0):
         """Sets a string variable's value"""
         pass
 
 class ptSpawnPointInfo:
     """Class to hold spawn point data"""
 
-    def __init__(self,title=None,spawnPt=None):
+    def __init__(self, title=None, spawnPt=None):
         pass
 
     def getCameraStack(self):
@@ -4531,15 +4531,15 @@ class ptSpawnPointInfo:
         """Returns the spawnpoint's title"""
         pass
 
-    def setCameraStack(self,stack):
+    def setCameraStack(self, stack):
         """Sets the spawnpoint's camera stack (as a string)"""
         pass
 
-    def setName(self,name):
+    def setName(self, name):
         """Sets the spawnpoint's name"""
         pass
 
-    def setTitle(self,title):
+    def setTitle(self, title):
         """Sets the spawnpoint's title"""
         pass
 
@@ -4558,15 +4558,15 @@ class ptSpawnPointInfoRef:
         """Returns the spawnpoint's title"""
         pass
 
-    def setCameraStack(self,stack):
+    def setCameraStack(self, stack):
         """Sets the spawnpoint's camera stack (as a string)"""
         pass
 
-    def setName(self,name):
+    def setName(self, name):
         """Sets the spawnpoint's name"""
         pass
 
-    def setTitle(self,title):
+    def setTitle(self, title):
         """Sets the spawnpoint's title"""
         pass
 
@@ -4581,7 +4581,7 @@ class ptStatusLog:
         """Returns whether the status log is currently opened"""
         pass
 
-    def open(self,logName,numLines,flags):
+    def open(self, logName, numLines, flags):
         """Open a status log for writing to
         'logname' is the name of the log file (example: special.log)
         'numLines' is the number of lines to display on debug screen
@@ -4589,7 +4589,7 @@ class ptStatusLog:
         """
         pass
 
-    def write(self,text,color=None):
+    def write(self, text, color=None):
         """If the status log is open, write 'text' to log
         'color' is the display color in debug screen
         """
@@ -4606,7 +4606,7 @@ class ptStream:
         """Returns whether the stream file is currently opened"""
         pass
 
-    def open(self,fileName,flags):
+    def open(self, fileName, flags):
         """Open a stream file for reading or writing"""
         pass
 
@@ -4614,7 +4614,7 @@ class ptStream:
         """Reads a list of strings from the file"""
         pass
 
-    def writelines(self,lines):
+    def writelines(self, lines):
         """Write a list of strings to the file"""
         pass
 
@@ -4636,7 +4636,7 @@ class ptSwimCurrentInterface:
     rotation: Any
     """UNKNOWN"""
 
-    def __init__(self,key):
+    def __init__(self, key):
         pass
 
     def disable(self):
@@ -4650,15 +4650,15 @@ class ptSwimCurrentInterface:
 class ptVault:
     """Accessor class to the player's vault"""
 
-    def addChronicleEntry(self,entryName,type,string):
+    def addChronicleEntry(self, entryName, type, string):
         """Adds an entry to the player's chronicle with a value of 'string'."""
         pass
 
-    def amAgeCzar(self,ageInfo):
+    def amAgeCzar(self, ageInfo):
         """Are we the czar (WTH is this?) of the specified age?"""
         pass
 
-    def amAgeOwner(self,ageInfo):
+    def amAgeOwner(self, ageInfo):
         """Are we the owner of the specified age?"""
         pass
 
@@ -4674,11 +4674,11 @@ class ptVault:
         """Creates a new neighborhood"""
         pass
 
-    def findChronicleEntry(self,entryName):
+    def findChronicleEntry(self, entryName):
         """Returns a ptVaultNode of type kNodeTypeChronicle of the current player's chronicle entry by entryName."""
         pass
 
-    def findNode(self,templateNode):
+    def findNode(self, templateNode):
         """Find the node matching the template"""
         pass
 
@@ -4746,7 +4746,7 @@ class ptVault:
         """Returns a ptVaultAgeLinkNode that will go to my neighborhood"""
         pass
 
-    def getOwnedAgeLink(self,ageInfo):
+    def getOwnedAgeLink(self, ageInfo):
         """Returns a ptVaultAgeLinkNode to my owned age(ageInfo)"""
         pass
 
@@ -4762,7 +4762,7 @@ class ptVault:
         """Returns the personal age SDL"""
         pass
 
-    def getVisitAgeLink(self,ageInfo):
+    def getVisitAgeLink(self, ageInfo):
         """Returns a ptVaultAgeLinkNode for a visitor to age(ageInfo)"""
         pass
 
@@ -4774,54 +4774,54 @@ class ptVault:
         """Are we in the player's personal age?"""
         pass
 
-    def invitePlayerToAge(self,link,playerID):
+    def invitePlayerToAge(self, link, playerID):
         """Sends an invitation to visit the age to the specified player"""
         pass
 
-    def offerLinkToPlayer(self,link,playerID):
+    def offerLinkToPlayer(self, link, playerID):
         """Offer a one-time link to the specified player"""
         pass
 
-    def registerMTStation(self,stationName,mtSpawnPoint):
+    def registerMTStation(self, stationName, mtSpawnPoint):
         """Registers this player at the specified mass-transit point"""
         pass
 
-    def registerOwnedAge(self,link):
+    def registerOwnedAge(self, link):
         """Registers the specified age as owned by the player"""
         pass
 
-    def registerVisitAge(self,link):
+    def registerVisitAge(self, link):
         """Register this age as visitable by this player"""
         pass
 
-    def setAgePublic(self,ageInfo,makePublic):
+    def setAgePublic(self, ageInfo, makePublic):
         """Makes the specified age public or private"""
         pass
 
-    def unInvitePlayerToAge(self,guid,playerID):
+    def unInvitePlayerToAge(self, guid, playerID):
         """Revokes the invitation to visit the age"""
         pass
 
-    def unRegisterOwnedAge(self,ageFilename):
+    def unRegisterOwnedAge(self, ageFilename):
         """Unregisters the specified age so it's no longer owned by this player"""
         pass
 
-    def unRegisterVisitAge(self,guid):
+    def unRegisterVisitAge(self, guid):
         """Unregisters the specified age so it can no longer be visited by this player"""
         pass
 
-    def updatePsnlAgeSDL(self,pyrec):
+    def updatePsnlAgeSDL(self, pyrec):
         """Updates the personal age SDL to the specified data"""
         pass
 
 class ptVaultNode:
     """Vault node class"""
 
-    def addNode(self,node,cb=None,cbContext=0):
+    def addNode(self, node, cb=None, cbContext=0):
         """Adds 'node'(ptVaultNode) as a child to this node."""
         pass
 
-    def findNode(self,templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
+    def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
         pass
 
@@ -4877,7 +4877,7 @@ class ptVaultNode:
         """Returns the modified time of this node, that is useable by python's time library."""
         pass
 
-    def getNode(self,id):
+    def getNode(self, id):
         """Returns ptVaultNodeRef if is a child node, or None"""
         pass
 
@@ -4895,11 +4895,11 @@ class ptVaultNode:
         """
         pass
 
-    def hasNode(self,id):
+    def hasNode(self, id):
         """Returns true if node if a child node"""
         pass
 
-    def linkToNode(self,nodeID,cb=None,cbContext=0):
+    def linkToNode(self, nodeID, cb=None, cbContext=0):
         """Adds a link to the node designated by nodeID"""
         pass
 
@@ -4907,43 +4907,43 @@ class ptVaultNode:
         """Removes all the child nodes on this node."""
         pass
 
-    def removeNode(self,node,cb=None,cbContext=0):
+    def removeNode(self, node, cb=None, cbContext=0):
         """Removes the child 'node'(ptVaultNode) from this node."""
         pass
 
-    def save(self,cb=None,cbContext=0):
+    def save(self, cb=None, cbContext=0):
         """Save the changes made to this node."""
         pass
 
-    def saveAll(self,cb=None,cbContext=0):
+    def saveAll(self, cb=None, cbContext=0):
         """Saves this node and all its children nodes."""
         pass
 
-    def sendTo(self,destID,cb=None,cbContext=0):
+    def sendTo(self, destID, cb=None, cbContext=0):
         """Send this node to inbox at 'destID'"""
         pass
 
-    def setCreateAgeGuid(self,guid):
+    def setCreateAgeGuid(self, guid):
         """Set guid as a string of the Age where this node was created."""
         pass
 
-    def setCreateAgeName(self,name):
+    def setCreateAgeName(self, name):
         """Set name of the Age where this node was created."""
         pass
 
-    def setCreatorNodeID(self,id):
+    def setCreatorNodeID(self, id):
         """Set creator's node ID"""
         pass
 
-    def setID(self,id):
+    def setID(self, id):
         """Sets ID of this ptVaultNode."""
         pass
 
-    def setOwnerNodeID(self,id):
+    def setOwnerNodeID(self, id):
         """Set node ID of the owner of this node"""
         pass
 
-    def setType(self,type):
+    def setType(self, type):
         """Set the type of ptVaultNode this is."""
         pass
 
@@ -5002,7 +5002,7 @@ class ptVaultNode:
 class ptVaultFolderNode(ptVaultNode):
     """Plasma vault folder node"""
 
-    def __init__(self,n=0):
+    def __init__(self, n=0):
         pass
 
     def getFolderName(self):
@@ -5013,36 +5013,36 @@ class ptVaultFolderNode(ptVaultNode):
         """Returns the folder type (of the standard folder types)"""
         pass
 
-    def setFolderName(self,name):
+    def setFolderName(self, name):
         """Set the folder name"""
         pass
 
-    def setFolderType(self,type):
+    def setFolderType(self, type):
         """Set the folder type"""
         pass
 
 class ptVaultAgeInfoListNode(ptVaultFolderNode):
     """Plasma vault age info list node"""
 
-    def __init__(self,n=0):
+    def __init__(self, n=0):
         pass
 
-    def addAge(self,ageID):
+    def addAge(self, ageID):
         """Adds ageID to list of ages"""
         pass
 
-    def hasAge(self,ageID):
+    def hasAge(self, ageID):
         """Returns whether ageID is in the list of ages"""
         pass
 
-    def removeAge(self,ageID):
+    def removeAge(self, ageID):
         """Removes ageID from list of ages"""
         pass
 
 class ptVaultAgeInfoNode(ptVaultNode):
     """Plasma vault age info node"""
 
-    def __init__(self,n=0):
+    def __init__(self, n=0):
         pass
 
     def asAgeInfoStruct(self):
@@ -5117,45 +5117,45 @@ class ptVaultAgeInfoNode(ptVaultNode):
         """Returns whether the age is Public or Not"""
         pass
 
-    def setAgeDescription(self,description):
+    def setAgeDescription(self, description):
         """Sets the description of the age"""
         pass
 
-    def setAgeFilename(self,fileName):
+    def setAgeFilename(self, fileName):
         """Sets the filename"""
         pass
 
-    def setAgeID(self,ageID):
+    def setAgeID(self, ageID):
         """Sets the age ID"""
         pass
 
-    def setAgeInstanceGuid(self,guid):
+    def setAgeInstanceGuid(self, guid):
         """Sets the age instance GUID"""
         pass
 
-    def setAgeInstanceName(self,instanceName):
+    def setAgeInstanceName(self, instanceName):
         """Sets the instance name"""
         pass
 
-    def setAgeLanguage(self,lang):
+    def setAgeLanguage(self, lang):
         """Sets the age's language (integer)"""
         pass
 
-    def setAgeSequenceNumber(self,seqNumber):
+    def setAgeSequenceNumber(self, seqNumber):
         """Sets the sequence number"""
         pass
 
-    def setAgeUserDefinedName(self,udname):
+    def setAgeUserDefinedName(self, udname):
         """Sets the user defined part of the name"""
         pass
 
 class ptVaultAgeLinkNode(ptVaultNode):
     """Plasma vault age link node"""
 
-    def __init__(self,n=0):
+    def __init__(self, n=0):
         pass
 
-    def addSpawnPoint(self,point):
+    def addSpawnPoint(self, point):
         """Adds the specified ptSpawnPointInfo or ptSpawnPointInfoRef"""
         pass
 
@@ -5179,26 +5179,26 @@ class ptVaultAgeLinkNode(ptVaultNode):
         """Returns whether the link is volatile or not"""
         pass
 
-    def hasSpawnPoint(self,spawnPtName):
+    def hasSpawnPoint(self, spawnPtName):
         """Returns true if this link has the specified spawn point"""
         pass
 
-    def removeSpawnPoint(self,point):
+    def removeSpawnPoint(self, point):
         """Removes the specified spawn point based on a ptSpawnPointInfo, ptSpawnPointInfoRef, or string"""
         pass
 
-    def setLocked(self,state):
+    def setLocked(self, state):
         """Sets whether the link is locked or not"""
         pass
 
-    def setVolatile(self,state):
+    def setVolatile(self, state):
         """Sets the state of the volitility of the link"""
         pass
 
 class ptVaultChronicleNode(ptVaultNode):
     """Plasma vault chronicle node"""
 
-    def __init__(self,n=0):
+    def __init__(self, n=0):
         pass
 
     def getEntryType(self):
@@ -5213,22 +5213,22 @@ class ptVaultChronicleNode(ptVaultNode):
         """Returns the value as a string of this chronicle node."""
         pass
 
-    def setEntryType(self,type):
+    def setEntryType(self, type):
         """Sets this chronicle node to a user defined type."""
         pass
 
-    def setName(self,name):
+    def setName(self, name):
         """Sets the name of the chronicle node."""
         pass
 
-    def setValue(self,value):
+    def setValue(self, value):
         """Sets the chronicle to a value that is a string"""
         pass
 
 class ptVaultImageNode(ptVaultNode):
     """Plasma vault image node"""
 
-    def __init__(self,n=0):
+    def __init__(self, n=0):
         pass
 
     def getImage(self):
@@ -5239,11 +5239,11 @@ class ptVaultImageNode(ptVaultNode):
         """Returns the title (caption) of this image node"""
         pass
 
-    def setImage(self,image):
+    def setImage(self, image):
         """Sets the image(ptImage) of this image node"""
         pass
 
-    def setImageFromBuf(self,buf):
+    def setImageFromBuf(self, buf):
         """Sets our image from a buffer"""
         pass
 
@@ -5251,14 +5251,14 @@ class ptVaultImageNode(ptVaultNode):
         """Grabs a screenshot and stuffs it into this node"""
         pass
 
-    def setTitle(self,title):
+    def setTitle(self, title):
         """Sets the title (caption) of this image node"""
         pass
 
 class ptVaultMarkerGameNode(ptVaultNode):
     """Plasma vault age info node"""
 
-    def __init__(self,n=0):
+    def __init__(self, n=0):
         pass
 
     def getGameGuid(self):
@@ -5277,19 +5277,19 @@ class ptVaultMarkerGameNode(ptVaultNode):
         """Returns a string representing the reward for completing this game"""
         pass
 
-    def setGameGuid(self,guid):
+    def setGameGuid(self, guid):
         """Sets the marker game's guid"""
         pass
 
-    def setGameName(self,name):
+    def setGameName(self, name):
         """Sets marker game's name"""
         pass
 
-    def setMarkers(self,markers):
+    def setMarkers(self, markers):
         """Sets markers associated with this game"""
         pass
 
-    def setReward(self,reward):
+    def setReward(self, reward):
         """Sets the reward for completing this marker game"""
         pass
 
@@ -5331,22 +5331,22 @@ class ptVaultNodeRef:
 class ptVaultPlayerInfoListNode(ptVaultFolderNode):
     """Plasma vault player info list node"""
 
-    def __init__(self,n=0):
+    def __init__(self, n=0):
         pass
 
-    def addPlayer(self,playerID):
+    def addPlayer(self, playerID):
         """Adds playerID player to this player info list node."""
         pass
 
-    def getPlayer(self,playerID):
+    def getPlayer(self, playerID):
         """Gets the player info node for the specified player."""
         pass
 
-    def hasPlayer(self,playerID):
+    def hasPlayer(self, playerID):
         """Returns whether the 'playerID' is a member of this player info list node."""
         pass
 
-    def removePlayer(self,playerID):
+    def removePlayer(self, playerID):
         """Removes playerID player from this player info list node."""
         pass
 
@@ -5381,23 +5381,23 @@ class ptVaultPlayerInfoNode(ptVaultNode):
         """Returns the online status of the player for this player info node."""
         pass
 
-    def playerSetAgeGuid(self,guidString):
+    def playerSetAgeGuid(self, guidString):
         """Not sure this should be used. Sets the guid for this player info node."""
         pass
 
-    def playerSetAgeInstanceName(self,name):
+    def playerSetAgeInstanceName(self, name):
         """Not sure this should be used. Sets the name of the age where the player is for this player info node."""
         pass
 
-    def playerSetID(self,playerID):
+    def playerSetID(self, playerID):
         """Not sure this should be used. Sets the playerID for this player info node."""
         pass
 
-    def playerSetName(self,name):
+    def playerSetName(self, name):
         """Not sure this should be used. Sets the player name of this player info node."""
         pass
 
-    def playerSetOnline(self,state):
+    def playerSetOnline(self, state):
         """Not sure this should be used. Sets the state of the player online status for this player info node."""
         pass
 
@@ -5412,15 +5412,15 @@ class ptVaultSDLNode(ptVaultNode):
         """Returns the ptSDLStateDataRecord associated with this node"""
         pass
 
-    def initStateDataRecord(self,filename,flags):
+    def initStateDataRecord(self, filename, flags):
         """Read the SDL Rec from File if needed"""
         pass
 
-    def setIdent(self,v):
+    def setIdent(self, v):
         """UNKNOWN"""
         pass
 
-    def setStateDataRecord(self,rec,writeOptions=0):
+    def setStateDataRecord(self, rec, writeOptions=0):
         """Sets the ptSDLStateDataRecord"""
         pass
 
@@ -5450,33 +5450,33 @@ class ptVaultTextNoteNode(ptVaultNode):
         """Returns the title of this text note node."""
         pass
 
-    def setDeviceInbox(self,inboxName,cb=None,cbContext=0):
+    def setDeviceInbox(self, inboxName, cb=None, cbContext=0):
         """Sets the device inbox"""
         pass
 
-    def setNoteSubType(self,subType):
+    def setNoteSubType(self, subType):
         """Sets the subtype of the this text note node."""
         pass
 
-    def setNoteType(self,type):
+    def setNoteType(self, type):
         """Sets the type of text note for this text note node."""
         pass
 
-    def setText(self,text):
+    def setText(self, text):
         """Sets text of the this text note node."""
         pass
 
-    def setTitle(self,title):
+    def setTitle(self, title):
         """Sets the title of this text note node."""
         pass
 
 class ptVector3:
     """Plasma 3D Vector class"""
 
-    def __init__(self,x=0, y=0, z=0):
+    def __init__(self, x=0, y=0, z=0):
         pass
 
-    def add(self,other):
+    def add(self, other):
         """Adds other to the current vector"""
         pass
 
@@ -5484,11 +5484,11 @@ class ptVector3:
         """Copies the vector into another one (which it returns)"""
         pass
 
-    def crossProduct(self,other):
+    def crossProduct(self, other):
         """Finds the cross product between other and this vector"""
         pass
 
-    def dotProduct(self,other):
+    def dotProduct(self, other):
         """Finds the dot product between other and this vector"""
         pass
 
@@ -5518,23 +5518,23 @@ class ptVector3:
         """Normalizes the vector to length 1"""
         pass
 
-    def scale(self,scale):
+    def scale(self, scale):
         """Scale the vector by scale"""
         pass
 
-    def setX(self,x):
+    def setX(self, x):
         """Sets the 'x' component of the vector"""
         pass
 
-    def setY(self,y):
+    def setY(self, y):
         """Sets the 'y' component of the vector"""
         pass
 
-    def setZ(self,z):
+    def setZ(self, z):
         """Sets the 'z' component of the vector"""
         pass
 
-    def subtract(self,other):
+    def subtract(self, other):
         """Subtracts other from the current vector"""
         pass
 
@@ -5545,10 +5545,10 @@ class ptVector3:
 class ptWaveSet:
     """Creates a new ptWaveSet"""
 
-    def __init__(self,key):
+    def __init__(self, key):
         pass
 
-    def addBuoy(self,soKey: ptKey) -> None:
+    def addBuoy(self, soKey: ptKey) -> None:
         """Adds the specified object as a buoy"""
         pass
 
@@ -5680,134 +5680,134 @@ class ptWaveSet:
         """Returns the attribute's value"""
         pass
 
-    def removeBuoy(self,soKey: ptKey) -> None:
+    def removeBuoy(self, soKey: ptKey) -> None:
         """Removes the specified object as a buoy"""
         pass
 
-    def setDepthFalloff(self,s, secs = 0):
+    def setDepthFalloff(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setEnvCenter(self,s, secs = 0):
+    def setEnvCenter(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setEnvRadius(self,s, secs = 0):
+    def setEnvRadius(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setGeoAmpOverLen(self,s, secs = 0):
+    def setGeoAmpOverLen(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setGeoAngleDev(self,s, secs = 0):
+    def setGeoAngleDev(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setGeoChop(self,s, secs = 0):
+    def setGeoChop(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setGeoMaxLength(self,s, secs = 0):
+    def setGeoMaxLength(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setGeoMinLength(self,s, secs = 0):
+    def setGeoMinLength(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setMaxAtten(self,s, secs = 0):
+    def setMaxAtten(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setMinAtten(self,s, secs = 0):
+    def setMinAtten(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setOpacFalloff(self,s, secs = 0):
+    def setOpacFalloff(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setOpacOffset(self,s, secs = 0):
+    def setOpacOffset(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setReflFalloff(self,s, secs = 0):
+    def setReflFalloff(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setReflOffset(self,s, secs = 0):
+    def setReflOffset(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setRippleScale(self,s, secs = 0):
+    def setRippleScale(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setSpecularEnd(self,s, secs = 0):
+    def setSpecularEnd(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setSpecularMute(self,s, secs = 0):
+    def setSpecularMute(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setSpecularNoise(self,s, secs = 0):
+    def setSpecularNoise(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setSpecularStart(self,s, secs = 0):
+    def setSpecularStart(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setSpecularTint(self,s, secs = 0):
+    def setSpecularTint(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setTexAmpOverLen(self,s, secs = 0):
+    def setTexAmpOverLen(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setTexAngleDev(self,s, secs = 0):
+    def setTexAngleDev(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setTexChop(self,s, secs = 0):
+    def setTexChop(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setTexMaxLength(self,s, secs = 0):
+    def setTexMaxLength(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setTexMinLength(self,s, secs = 0):
+    def setTexMinLength(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setWaterHeight(self,s, secs = 0):
+    def setWaterHeight(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setWaterOffset(self,s, secs = 0):
+    def setWaterOffset(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setWaterOpacity(self,s, secs = 0):
+    def setWaterOpacity(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setWaterTint(self,s, secs = 0):
+    def setWaterTint(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setWaveFalloff(self,s, secs = 0):
+    def setWaveFalloff(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setWaveOffset(self,s, secs = 0):
+    def setWaveOffset(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass
 
-    def setWindDir(self,s, secs = 0):
+    def setWindDir(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
         pass

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -55,11 +55,11 @@ from typing import *
 
 def PtAcceptInviteInGame(friendName, inviteKey):
     """Sends a VaultTask to the server to perform the invite"""
-    pass
+    ...
 
 def PtAmCCR():
     """Returns true if local player is a CCR"""
-    pass
+    ...
 
 def PtAtTimeCallback(selfkey, time, id):
     """This will create a timer callback that will call OnTimer when complete
@@ -67,7 +67,7 @@ def PtAtTimeCallback(selfkey, time, id):
     - 'time' is how much time from now (in seconds) to call back
     - 'id' is an integer id that will be returned in the OnTimer call
     """
-    pass
+    ...
 
 def PtAttachObject(child, parent, netForce=False):
     """Attach child to parent based on ptKey or ptSceneobject
@@ -75,121 +75,121 @@ def PtAttachObject(child, parent, netForce=False):
     - parentKey is the ptKey or ptSceneobject of the one being attached to
     (both arguments must be ptKeys or ptSceneobjects, you cannot mix types)
     """
-    pass
+    ...
 
 def PtAvatarEnterAFK():
     """Tells the local avatar to enter AwayFromKeyboard idle loop (netpropagated)"""
-    pass
+    ...
 
 def PtAvatarEnterAnimMode(animName):
     """Enter a custom anim loop (netpropagated)"""
-    pass
+    ...
 
 def PtAvatarEnterLookingAtKI():
     """Tells the local avatar to enter looking at KI idle loop (netpropagated)"""
-    pass
+    ...
 
 def PtAvatarEnterUsePersBook():
     """Tells the local avatar to enter using their personal book idle loop (netpropagated)"""
-    pass
+    ...
 
 def PtAvatarExitAFK():
     """Tells the local avatar to exit AwayFromKeyboard idle loop (netpropagated)"""
-    pass
+    ...
 
 def PtAvatarExitLookingAtKI():
     """Tells the local avatar to exit looking at KI idle loop (netpropagated)"""
-    pass
+    ...
 
 def PtAvatarExitUsePersBook():
     """Tells the local avatar to exit using their personal book idle loop (netpropagated)"""
-    pass
+    ...
 
 def PtAvatarSitOnGround():
     """Tells the local avatar to sit on ground and enter sit idle loop (netpropagated)"""
-    pass
+    ...
 
 def PtAvatarSpawnNext():
     """Send the avatar to the next spawn point"""
-    pass
+    ...
 
 def PtCanShadowCast():
     """Can we cast shadows?"""
-    pass
+    ...
 
 def PtChangeAvatar(gender):
     """Change the local avatar's gender (or clothing type)"""
-    pass
+    ...
 
 def PtChangePassword(password):
     """Changes the current account's password"""
-    pass
+    ...
 
 def PtChangePlayerName(name):
     """Change the local avatar's name"""
-    pass
+    ...
 
 def PtCheckVisLOS(startPoint, endPoint):
     """Does LOS check from start to end"""
-    pass
+    ...
 
 def PtCheckVisLOSFromCursor():
     """Does LOS check from where the mouse cursor is, into the screen"""
-    pass
+    ...
 
 def PtClearCameraStack():
     """clears all cameras"""
-    pass
+    ...
 
 def PtClearOfferBookMode():
     """Cancel the offer book interface"""
-    pass
+    ...
 
 def PtClearPrivateChatList(memberKey):
     """Remove the local avatar from private vox messaging, and / or clear members from his chat list"""
-    pass
+    ...
 
 def PtClearTimerCallbacks(key):
     """This will remove timer callbacks to the specified key"""
-    pass
+    ...
 
 def PtCloneKey(key, loading=False):
     """Creates clone of key"""
-    pass
+    ...
 
 def PtConsole(command):
     """This will execute 'command' as if it were typed into the Plasma console."""
-    pass
+    ...
 
 def PtConsoleNet(command, netForce):
     """This will execute 'command' on the console, over the network, on all clients.
     If 'netForce' is true then force command to be sent over the network.
     """
-    pass
+    ...
 
 def PtCreateDir(directory):
     """Creates the directory and all parent folders. Returns false on failure"""
-    pass
+    ...
 
 def PtCreatePlayer(playerName, avatarShape, invitation):
     """Creates a new player"""
-    pass
+    ...
 
 def PtCreatePublicAge(ageInfo):
     """Create a public instance of the given age."""
-    pass
+    ...
 
 def PtDebugAssert(cond, msg):
     """Debug only: Assert if condition is false."""
-    pass
+    ...
 
 def PtDebugPrint(*msgs, level=3, sep=" ", end="\n"):
     """Prints msgs to the Python log given the message's level, optionally separated and terminated by the given strings"""
-    pass
+    ...
 
 def PtDeletePlayer(playerInt):
     """Deletes a player associated with the current account"""
-    pass
+    ...
 
 def PtDetachObject(child, parent, netForce=False):
     """Detach child from parent based on ptKey or ptSceneobject
@@ -197,91 +197,91 @@ def PtDetachObject(child, parent, netForce=False):
     - parent is the ptKey or ptSceneobject of the one being detached from
     (both arguments must be ptKeys or ptSceneobjects, you cannot mix types)
     """
-    pass
+    ...
 
 def PtDirtySynchClients(selfKey, SDLStateName, flags):
     """DO NOT USE - handled by ptSDL"""
-    pass
+    ...
 
 def PtDirtySynchState(selfKey, SDLStateName, flags):
     """DO NOT USE - handled by ptSDL"""
-    pass
+    ...
 
 def PtDisableAvatarCursorFade():
     """Disable the avatar cursor fade"""
-    pass
+    ...
 
 def PtDisableAvatarJump():
     """Disable the ability of the avatar to jump"""
-    pass
+    ...
 
 def PtDisableControlKeyEvents(selfKey):
     """Disable the control key events from calling OnControlKeyEvent"""
-    pass
+    ...
 
 def PtDisableForwardMovement():
     """Disable the ability of the avatar to move forward"""
-    pass
+    ...
 
 def PtDisableMouseMovement():
     """Disable avatar mouse movement input"""
-    pass
+    ...
 
 def PtDisableMovementKeys():
     """Disable avatar movement input"""
-    pass
+    ...
 
 def PtDisableRenderScene():
     """UNKNOWN"""
-    pass
+    ...
 
 def PtDisableShadows():
     """Turns shadows off"""
-    pass
+    ...
 
 def PtDumpLogs(folder):
     """Dumps all current log files to the specified folder (a sub-folder to the log folder)"""
-    pass
+    ...
 
 def PtEmoteAvatar(emote):
     """Play an emote on the local avatar (netpropagated)"""
-    pass
+    ...
 
 def PtEnableAvatarCursorFade():
     """Enable the avatar cursor fade"""
-    pass
+    ...
 
 def PtEnableAvatarJump():
     """Enable the ability of the avatar to jump"""
-    pass
+    ...
 
 def PtEnableControlKeyEvents(selfKey):
     """Enable control key events to call OnControlKeyEvent(controlKey,activateFlag)"""
-    pass
+    ...
 
 def PtEnableForwardMovement():
     """Enable the ability of the avatar to move forward"""
-    pass
+    ...
 
 def PtEnableMouseMovement():
     """Enable avatar mouse movement input"""
-    pass
+    ...
 
 def PtEnableMovementKeys():
     """Enable avatar movement input"""
-    pass
+    ...
 
 def PtEnablePlanarReflections(on):
     """Enables/disables planar reflections"""
-    pass
+    ...
 
 def PtEnableRenderScene():
     """UNKNOWN"""
-    pass
+    ...
 
 def PtEnableShadows():
     """Turns shadows on"""
-    pass
+    ...
 
 def PtExcludeRegionSet(senderKey, regionKey, state):
     """This will set the state of an exclude region
@@ -289,7 +289,7 @@ def PtExcludeRegionSet(senderKey, regionKey, state):
     - 'regionKey' is a ptKey of the exclude region
     - 'state' is either kExRegRelease or kExRegClear
     """
-    pass
+    ...
 
 def PtExcludeRegionSetNow(senderKey, regionKey, state):
     """This will set the state of an exclude region immediately on the server
@@ -297,1500 +297,1500 @@ def PtExcludeRegionSetNow(senderKey, regionKey, state):
     - 'regionKey' is a ptKey of the exclude region
     - 'state' is either kExRegRelease or kExRegClear
     """
-    pass
+    ...
 
 def PtFadeIn(lenTime, holdFlag, noSound=0):
     """Fades screen in for lenTime seconds"""
-    pass
+    ...
 
 def PtFadeLocalAvatar(fade):
     """Fade (or unfade) the local avatar"""
-    pass
+    ...
 
 def PtFadeOut(lenTime, holdFlag, noSound=0):
     """Fades screen out for lenTime seconds"""
-    pass
+    ...
 
 def PtFakeLinkAvatarToObject(avatar, object):
     """Pseudo-links avatar to object within the same age
     """
-    pass
+    ...
 
 def PtFileExists(filename):
     """Returns true if the specified file exists"""
-    pass
+    ...
 
 def PtFindActivator(name):
     """This will try to find an activator based on its name
     - it will return a ptKey if found- it will return None if not found
     """
-    pass
+    ...
 
 def PtFindClones(key):
     """Finds all clones"""
-    pass
+    ...
 
 def PtFindImage(name: str) -> Iterable[ptImage]:
     """Find an already loaded image by name."""
-    pass
+    ...
 
 def PtFindLayer(name: str, age: str = "", page: str = "") -> Optional[ptLayer]:
     """Find a layer by name."""
-    pass
+    ...
 
 def PtFindSceneobject(name, ageName):
     """This will try to find a sceneobject based on its name and what age its in
     - it will return a ptSceneObject if found- if not found then a NameError exception will happen
     """
-    pass
+    ...
 
 def PtFindSceneobjects(name):
     """This will try to find a any sceneobject containing string in name"""
-    pass
+    ...
 
 def PtFirstPerson():
     """is the local avatar in first person mode"""
-    pass
+    ...
 
 def PtFlashWindow():
     """Flashes the client window if it is not focused"""
-    pass
+    ...
 
 def PtFogSetDefColor(color):
     """Sets default fog color"""
-    pass
+    ...
 
 def PtFogSetDefExp(end, density):
     """Set exp fog values"""
-    pass
+    ...
 
 def PtFogSetDefExp2(end, density):
     """Set exp2 fog values"""
-    pass
+    ...
 
 def PtFogSetDefLinear(start, end, density):
     """Set linear fog values"""
-    pass
+    ...
 
 def PtForceCursorHidden():
     """Forces the cursor to hide, overriding everything.
     Only call if other methods won't work. The only way to show the cursor after this call is PtForceMouseShown()
     """
-    pass
+    ...
 
 def PtForceCursorShown():
     """Forces the cursor to show, overriding everything.
     Only call if other methods won't work. This is the only way to show the cursor after a call to PtForceMouseHidden()
     """
-    pass
+    ...
 
 def PtForceVaultNodeUpdate(nodeId):
     """Forces a vault node to update"""
-    pass
+    ...
 
 def PtGMTtoDniTime(gtime):
     """Converts GMT time (passed in) to D'Ni time"""
-    pass
+    ...
 
 def PtGUICursorDimmed():
     """Dimms the GUI cursor"""
-    pass
+    ...
 
 def PtGUICursorOff():
     """Turns the GUI cursor off"""
-    pass
+    ...
 
 def PtGUICursorOn():
     """Turns the GUI cursor on"""
-    pass
+    ...
 
 def PtGetAIAvatarsByModelName(modelName):
     """Returns a list of tuples representing the matching ai avatars"""
-    pass
+    ...
 
 def PtGetAccountName():
     """Returns the account name for the current account"""
-    pass
+    ...
 
 def PtGetAccountPlayerList():
     """Returns list of players associated with the current account"""
-    pass
+    ...
 
 def PtGetAgeInfo():
     """Returns ptAgeInfoStruct of the current Age"""
-    pass
+    ...
 
 def PtGetAgeName():
     """DEPRECIATED - use ptDniInfoSource instead"""
-    pass
+    ...
 
 def PtGetAgeSDL():
     """Returns the global ptSDL for the current Age"""
-    pass
+    ...
 
 def PtGetAgeTime():
     """DEPRECIATED - use ptDniInfoSource instead"""
-    pass
+    ...
 
 def PtGetAgeTimeOfDayPercent():
     """Returns the current age time of day as a percent (0 to 1)"""
-    pass
+    ...
 
 def PtGetAvatarKeyFromClientID(clientID):
     """From an integer that is the clientID, find the avatar and return its ptKey"""
-    pass
+    ...
 
 def PtGetCameraNumber(x):
     """Returns camera x's name from stack"""
-    pass
+    ...
 
 def PtGetClientIDFromAvatarKey(avatarKey):
     """From a ptKey that points at an avatar, return the players clientID (integer)"""
-    pass
+    ...
 
 def PtGetClientName(avatarKey=None):
     """This will return the name of the client that is owned by the avatar
     - avatarKey is the ptKey of the avatar to get the client name of.
     If avatarKey is omitted then the local avatar is used
     """
-    pass
+    ...
 
 def PtGetControlEvents(on, key):
     """Registers or unregisters for control event messages"""
-    pass
+    ...
 
 def PtGetDefaultDisplayParams():
     """Returns the default resolution and display settings"""
-    pass
+    ...
 
 def PtGetDefaultSpawnPoint():
     """Returns the default spawnpoint definition (as a ptSpawnPointInfo)"""
-    pass
+    ...
 
 def PtGetDesktopColorDepth():
     """Returns desktop ColorDepth"""
-    pass
+    ...
 
 def PtGetDesktopHeight():
     """Returns desktop height"""
-    pass
+    ...
 
 def PtGetDesktopWidth():
     """Returns desktop width"""
-    pass
+    ...
 
 def PtGetDialogFromString(dialogName):
     """Get a ptGUIDialog from its name"""
-    pass
+    ...
 
 def PtGetDialogFromTagID(tagID):
     """Returns the dialog associated with the tagID"""
-    pass
+    ...
 
 def PtGetDniTime():
     """Returns current D'Ni time"""
-    pass
+    ...
 
 def PtGetFrameDeltaTime():
     """Returns the amount of time that has elapsed since last frame."""
-    pass
+    ...
 
 def PtGetGameTime():
     """Returns the system game time (frame based) in seconds."""
-    pass
+    ...
 
 def PtGetInitPath():
     """Returns the path to the client's init directory."""
-    pass
+    ...
 
 def PtGetLanguage():
     """Returns the current language as a PtLanguage enum"""
-    pass
+    ...
 
 def PtGetLocalAvatar():
     """This will return a ptSceneobject of the local avatar
     - if there is no local avatar a NameError exception will happen.
     """
-    pass
+    ...
 
 def PtGetLocalClientID():
     """Returns our local client ID number"""
-    pass
+    ...
 
 def PtGetLocalKILevel():
     """returns local player's ki level"""
-    pass
+    ...
 
 def PtGetLocalPlayer():
     """Returns a ptPlayer object of the local player"""
-    pass
+    ...
 
 def PtGetLocalizedString(name, arguments=None):
     """Returns the localized string specified by name (format is Age.Set.Name) and substitutes the arguments in the list of strings passed in as arguments."""
-    pass
+    ...
 
 def PtGetMouseTurnSensitivity():
     """Returns the sensitivity"""
-    pass
+    ...
 
 def PtGetNPCByID(npcID):
     """This will return the NPC with a specific ID"""
-    pass
+    ...
 
 def PtGetNPCCount():
     """Returns the number of NPCs in the current age"""
-    pass
+    ...
 
 def PtGetNumCameras():
     """returns camera stack size"""
-    pass
+    ...
 
 def PtGetNumParticles(key):
     """Key is the key of scene object host to particle system"""
-    pass
+    ...
 
 def PtGetNumRemotePlayers():
     """Returns the number of remote players in this Age with you."""
-    pass
+    ...
 
 def PtGetPlayerList():
     """Returns a list of ptPlayer objects of all the remote players"""
-    pass
+    ...
 
 def PtGetPlayerListDistanceSorted():
     """Returns a list of ptPlayers, sorted by distance"""
-    pass
+    ...
 
 def PtGetPrevAgeInfo():
     """Returns ptAgeInfoStruct of previous age visited"""
-    pass
+    ...
 
 def PtGetPrevAgeName():
     """Returns filename of previous age visited"""
-    pass
+    ...
 
 def PtGetPublicAgeList(ageName, cbObject=None):
     """Get list of public ages for the given age name.
     cbObject, if supplied should have a method called gotPublicAgeList(self,ageList). ageList is a list of tuple(ptAgeInfoStruct,nPlayersInAge)
     """
-    pass
+    ...
 
 def PtGetPythonLoggingLevel():
     """Returns the current level of python logging"""
-    pass
+    ...
 
 def PtGetServerTime():
     """Returns the current time on the server (which is GMT)"""
-    pass
+    ...
 
 def PtGetShadowVisDistance():
     """Returns the maximum shadow visibility distance"""
-    pass
+    ...
 
 def PtGetSupportedDisplayModes():
     """Returns a list of supported resolutions"""
-    pass
+    ...
 
 def PtGetTime():
     """Returns the number of seconds since the game was started."""
-    pass
+    ...
 
 def PtGetUserPath():
     """Returns the path to the client's root user directory."""
-    pass
+    ...
 
 def PtGuidGenerate():
     """Returns string representation for a new guid"""
-    pass
+    ...
 
 def PtHideDialog(dialogName):
     """Hide a GUI dialog by name (does not unload dialog)"""
-    pass
+    ...
 
 def PtIsActivePlayerSet():
     """Returns whether or not an active player is set"""
-    pass
+    ...
 
 def PtIsCCRAway():
     """Returns current status of CCR dept"""
-    pass
+    ...
 
 def PtIsClickToTurn():
     """Is click-to-turn on?"""
-    pass
+    ...
 
 def PtIsCurrentBrainHuman():
     """Returns whether the local avatar current brain is the human brain"""
-    pass
+    ...
 
 def PtIsDemoMode():
     """Returns whether the game is in Demo mode or not"""
-    pass
+    ...
 
 def PtIsDialogLoaded(dialogName):
     """Test to see if a GUI dialog is loaded, by name"""
-    pass
+    ...
 
 def PtIsEnterChatModeKeyBound():
     """Returns whether the EnterChatMode is bound to a key"""
-    pass
+    ...
 
 def PtIsGUIModal():
     """Returns true if the GUI is displaying a modal dialog and blocking input"""
-    pass
+    ...
 
 def PtIsInternalRelease():
     """Returns whether the client is an internal build or not"""
-    pass
+    ...
 
 def PtIsMouseInverted():
     """Is the mouse currently inverted?"""
-    pass
+    ...
 
 def PtIsShadowsEnabled():
     """Returns whether shadows are currently turned on"""
-    pass
+    ...
 
 def PtIsSinglePlayerMode():
     """Returns whether the game is in single player mode or not"""
-    pass
+    ...
 
 def PtIsSolo() -> bool:
     """Returns whether we are the only player in the Age"""
-    pass
+    ...
 
 def PtKillParticles(timeRemaining, pctToKill, particleSystem):
     """Tells particleSystem to kill pctToKill percent of its particles"""
-    pass
+    ...
 
 def PtLimitAvatarLOD(LODlimit):
     """Sets avatar's LOD limit"""
-    pass
+    ...
 
 def PtLoadAvatarModel(modelName, spawnPoint, userStr = ""):
     """Loads an avatar model at the given spawn point. Assigns the user specified string to it."""
-    pass
+    ...
 
 def PtLoadBookGUI(guiName):
     """Loads the gui specified, a gui must be loaded before it can be used. If the gui is already loaded, doesn't do anything"""
-    pass
+    ...
 
 def PtLoadDialog(dialogName, selfKey=None, ageName=""):
     """Loads a GUI dialog by name and optionally set the Notify proc key
     If the dialog is already loaded then it won't load it again
     """
-    pass
+    ...
 
 def PtLoadJPEGFromDisk(filename, width, height):
     """The image will be resized to fit the width and height arguments. Set to 0 if resizing is not desired.
     Returns a pyImage of the specified file.
     """
-    pass
+    ...
 
 def PtLoadPNGFromDisk(filename, width, height):
     """The image will be resized to fit the width and height arguments. Set to 0 if resizing is not desired.
     Returns a pyImage of the specified file.
     """
-    pass
+    ...
 
 def PtLocalAvatarIsMoving():
     """Returns true if the local avatar is moving (a movement key is held down)"""
-    pass
+    ...
 
 def PtLocalAvatarRunKeyDown():
     """Returns true if the run key is being held down for the local avatar"""
-    pass
+    ...
 
 def PtLocalizedYesNoDialog(cb: Union[None, Callable, ptKey], path: str, *args, dialogType: int = PtConfirmationType.YesNo) -> None:
     """This will display a confirmation dialog to the user with the localized text `path` with any optional localization `args` applied. This dialog _has_ to be answered by the user, and their answer will be returned in a Notify message or callback given by `cb`."""
-    pass
+    ...
 
 def PtMaxListenDistSq():
     """Returns the maximum distance (squared) of the listen range"""
-    pass
+    ...
 
 def PtMaxListenListSize():
     """Returns the maximum listen number of players"""
-    pass
+    ...
 
 def PtNotifyOffererLinkAccepted(offerer):
     """Tell the offerer that we accepted the link offer"""
-    pass
+    ...
 
 def PtNotifyOffererLinkCompleted(offerer):
     """Tell the offerer that we completed the link"""
-    pass
+    ...
 
 def PtNotifyOffererLinkRejected(offerer):
     """Tell the offerer that we rejected the link offer"""
-    pass
+    ...
 
 def PtPageInNode(nodeName, netForce=False, ageName=""):
     """Pages in node, or a list of nodes"""
-    pass
+    ...
 
 def PtPageOutNode(nodeName, netForce=False):
     """Pages out a node"""
-    pass
+    ...
 
 def PtRateIt(chronicleName, dialogPrompt, onceFlag):
     """Shows a dialog with dialogPrompt and stores user input rating into chronicleName"""
-    pass
+    ...
 
 def PtRebuildCameraStack(name, ageName):
     """Push camera with this name on the stack"""
-    pass
+    ...
 
 def PtRecenterCamera():
     """re-centers the camera"""
-    pass
+    ...
 
 def PtRemovePublicAge(ageInstanceGuid):
     """Remove a public instance of the given age."""
-    pass
+    ...
 
 def PtRequestLOSScreen(selfKey, ID, xPos, yPos, distance, what, reportType):
     """Request a LOS check from a point on the screen"""
-    pass
+    ...
 
 def PtSaveScreenShot(fileName, width=640, height=480, quality=75):
     """Takes a screenshot with the specified filename, size, and quality"""
-    pass
+    ...
 
 def PtSendChatToCCR(message, CCRPlayerID):
     """Sends a chat message to a CCR that has contacted this player"""
-    pass
+    ...
 
 def PtSendFriendInvite(emailAddress, toName = "Friend"):
     """Sends an email with invite code"""
-    pass
+    ...
 
 def PtSendKIGZMarkerMsg(markerNumber, sender):
     """Same as PtSendKIMessageInt except 'sender' could get a notify message back
     """
-    pass
+    ...
 
 def PtSendKIMessage(command, value):
     """Sends a command message to the KI frontend.
     See PlasmaKITypes.py for list of commands
     """
-    pass
+    ...
 
 def PtSendKIMessageInt(command, value):
     """Same as PtSendKIMessage except the value is guaranteed to be a uint32_t
     (for things like player IDs)
     """
-    pass
+    ...
 
 def PtSendKIRegisterImagerMsg(imagerName, sender):
     """Sends a message to the KI to register the specified imager"""
-    pass
+    ...
 
 def PtSendPetitionToCCR(message, reason=0, title=""):
     """Sends a petition with a message to the CCR group"""
-    pass
+    ...
 
 def PtSendPrivateChatList(chatList):
     """Lock the local avatar into private vox messaging, and / or add new members to his chat list"""
-    pass
+    ...
 
 def PtSendRTChat(fromPlayer, toPlayerList, message, flags):
     """Sends a realtime chat message to the list of ptPlayers
     If toPlayerList is an empty list, it is a broadcast message
     """
-    pass
+    ...
 
 def PtSetActivePlayer(playerInt):
     """Sets the active player associated with the current account"""
-    pass
+    ...
 
 def PtSetAlarm(secs, cbObject, cbContext):
     """secs is the amount of time before your alarm goes off.
     cbObject is a python object with the method onAlarm(int context)
     cbContext is an integer.
     """
-    pass
+    ...
 
 def PtSetBehaviorLoopCount(behaviorKey, stage, loopCount, netForce):
     """This will set the loop count for a particular stage in a multistage behavior"""
-    pass
+    ...
 
 def PtSetBehaviorNetFlags(behKey, netForce, netProp):
     """Sets net flags on the associated behavior"""
-    pass
+    ...
 
 def PtSetClearColor(red, green, blue):
     """Set the clear color"""
-    pass
+    ...
 
 def PtSetClickToTurn(state):
     """Turns on click-to-turn"""
-    pass
+    ...
 
 def PtSetGamma2(gamma):
     """Set the gamma with gamma2 rules"""
-    pass
+    ...
 
 def PtSetGlobalClickability(enable):
     """Enable or disable all clickables on the local client"""
-    pass
+    ...
 
 def PtSetGraphicsOptions(width, height, colordepth, windowed, numAAsamples, numAnisoSamples, VSync):
     """Set the graphics options"""
-    pass
+    ...
 
 def PtSetLightAnimStart(key, name, start):
     """ Key is the key of scene object host to light, start is a bool. Name is the name of the light to manipulate"""
-    pass
+    ...
 
 def PtSetLightValue(key, name, r, g, b, a):
     """ Key is the key of scene object host to light. Name is the name of the light to manipulate"""
-    pass
+    ...
 
 def PtSetMouseInverted():
     """Inverts the mouse"""
-    pass
+    ...
 
 def PtSetMouseTurnSensitivity(sensitivity):
     """Set the mouse sensitivity"""
-    pass
+    ...
 
 def PtSetMouseUninverted():
     """Uninverts the mouse"""
-    pass
+    ...
 
 def PtSetOfferBookMode(selfkey, ageFilename, ageInstanceName):
     """Put us into the offer book interface"""
-    pass
+    ...
 
 def PtSetParticleDissentPoint(x, y, z, particlesys):
     """Sets the dissent point of the particlesys to x,y,z"""
-    pass
+    ...
 
 def PtSetParticleOffset(x, y, z, particlesys):
     """Sets the particlesys particle system's offset"""
-    pass
+    ...
 
 def PtSetPythonLoggingLevel(level):
     """Sets the current level of python logging"""
-    pass
+    ...
 
 def PtSetShadowVisDistance(distance):
     """Set the maximum shadow visibility distance"""
-    pass
+    ...
 
 def PtSetShareAgeInstanceGuid(instanceGuid):
     """This sets the desired age instance guid for the receiver to link to"""
-    pass
+    ...
 
 def PtSetShareSpawnPoint(spawnPoint):
     """This sets the desired spawn point for the receiver to link to"""
-    pass
+    ...
 
 def PtShootBulletFromObject(selfkey, gunObj, radius, range):
     """Shoots a bullet from an object"""
-    pass
+    ...
 
 def PtShootBulletFromScreen(selfkey, xPos, yPos, radius, range):
     """Shoots a bullet from a position on the screen"""
-    pass
+    ...
 
 def PtShowDialog(dialogName):
     """Show a GUI dialog by name (does not load dialog)"""
-    pass
+    ...
 
 def PtStartScreenCapture(selfKey, width=800, height=600):
     """Starts a capture of the screen"""
-    pass
+    ...
 
 def PtSupportsPlanarReflections() -> bool:
     """Returns if planar reflections are supported"""
-    pass
+    ...
 
 def PtToggleAvatarClickability(on):
     """Turns on and off our avatar's clickability"""
-    pass
+    ...
 
 def PtTransferParticlesToObject(objFrom, objTo, num):
     """Transfers num particles from objFrom to objTo"""
-    pass
+    ...
 
 def PtUnLoadAvatarModel(avatarKey):
     """Forcibly unloads the specified avatar model.
     Do not use this method unless you require fine-grained control of avatar unloading.
     """
-    pass
+    ...
 
 def PtUnloadAllBookGUIs():
     """Unloads all loaded guis except for the default one"""
-    pass
+    ...
 
 def PtUnloadBookGUI(guiName):
     """Unloads the gui specified. If the gui isn't loaded, doesn't do anything"""
-    pass
+    ...
 
 def PtUnloadDialog(dialogName):
     """This will unload the GUI dialog by name. If not loaded then nothing will happen"""
-    pass
+    ...
 
 def PtValidateKey(key):
     """Returns true(1) if 'key' is valid and loaded,
     otherwise returns false(0)
     """
-    pass
+    ...
 
 def PtVaultDownload(nodeId):
     """Downloads the vault tree of the given nodeid"""
-    pass
+    ...
 
 def PtWasLocallyNotified(selfKey):
     """Returns 1 if the last notify was local or 0 if the notify originated on the network"""
-    pass
+    ...
 
 def PtWearDefaultClothing(key, broadcast=False):
     """Forces the avatar to wear the default clothing set"""
-    pass
+    ...
 
 def PtWearDefaultClothingType(key, type, broadcast=False):
     """Forces the avatar to wear the default clothing of the specified type"""
-    pass
+    ...
 
 def PtWearMaintainerSuit(key, wearOrNot):
     """Wears or removes the maintainer suit of clothes"""
-    pass
+    ...
 
 def PtWhatGUIControlType(guiKey):
     """Returns the control type of the key passed in"""
-    pass
+    ...
 
 def PtYesNoDialog(cb: Union[None, ptKey, Callable], message: str, /, dialogType: int = PtConfirmationType.YesNo) -> None:
     """This will display a confirmation dialog to the user with the text `message`. This dialog _has_ to be answered by the user, and their answer will be returned in a Notify message or callback given by `cb`."""
-    pass
+    ...
 
 class ptAgeInfoStruct:
     """Class to hold AgeInfo struct data"""
 
     def copyFrom(self, other):
         """Copies data from one ptAgeInfoStruct or ptAgeInfoStructRef to this one"""
-        pass
+        ...
 
     def getAgeDescription(self):
         """Gets the description part of the Age name"""
-        pass
+        ...
 
     def getAgeFilename(self):
         """Gets the Age's filename"""
-        pass
+        ...
 
     def getAgeInstanceGuid(self):
         """Get the Age's instance GUID"""
-        pass
+        ...
 
     def getAgeInstanceName(self):
         """Get the instance name of the Age"""
-        pass
+        ...
 
     def getAgeLanguage(self):
         """Gets the age's language (integer)"""
-        pass
+        ...
 
     def getAgeSequenceNumber(self):
         """Gets the unique sequence number"""
-        pass
+        ...
 
     def getAgeUserDefinedName(self):
         """Gets the user defined part of the Age name"""
-        pass
+        ...
 
     def getDisplayName(self):
         """Returns a string that is the displayable name of the age instance"""
-        pass
+        ...
 
     def setAgeDescription(self, udName):
         """Sets the description part of the Age"""
-        pass
+        ...
 
     def setAgeFilename(self, filename):
         """Sets the filename of the Age"""
-        pass
+        ...
 
     def setAgeInstanceGuid(self, guid):
         """Sets the Age instance's GUID"""
-        pass
+        ...
 
     def setAgeInstanceName(self, instanceName):
         """Sets the instance name of the Age"""
-        pass
+        ...
 
     def setAgeLanguage(self, lang):
         """Sets the age's language (integer)"""
-        pass
+        ...
 
     def setAgeSequenceNumber(self, seqNumber):
         """Sets the unique sequence number"""
-        pass
+        ...
 
     def setAgeUserDefinedName(self, udName):
         """Sets the user defined part of the Age"""
-        pass
+        ...
 
 class ptAgeInfoStructRef:
     """Class to hold AgeInfo struct data"""
 
     def copyFrom(self, other):
         """Copies data from one ptAgeInfoStruct or ptAgeInfoStructRef to this one"""
-        pass
+        ...
 
     def getAgeFilename(self):
         """Gets the Age's filename"""
-        pass
+        ...
 
     def getAgeInstanceGuid(self):
         """Get the Age's instance GUID"""
-        pass
+        ...
 
     def getAgeInstanceName(self):
         """Get the instance name of the Age"""
-        pass
+        ...
 
     def getAgeSequenceNumber(self):
         """Gets the unique sequence number"""
-        pass
+        ...
 
     def getAgeUserDefinedName(self):
         """Gets the user defined part of the Age name"""
-        pass
+        ...
 
     def getDisplayName(self):
         """Returns a string that is the displayable name of the age instance"""
-        pass
+        ...
 
     def setAgeFilename(self, filename):
         """Sets the filename of the Age"""
-        pass
+        ...
 
     def setAgeInstanceGuid(self, guid):
         """Sets the Age instance's GUID"""
-        pass
+        ...
 
     def setAgeInstanceName(self, instanceName):
         """Sets the instance name of the Age"""
-        pass
+        ...
 
     def setAgeSequenceNumber(self, seqNumber):
         """Sets the unique sequence number"""
-        pass
+        ...
 
     def setAgeUserDefinedName(self, udName):
         """Sets the user defined part of the Age"""
-        pass
+        ...
 
 class ptAgeLinkStruct:
     """Class to hold the data of the AgeLink structure"""
 
     def copyFrom(self, other):
         """Copies data from one ptAgeLinkStruct or ptAgeLinkStructRef to this one"""
-        pass
+        ...
 
     def getAgeInfo(self):
         """Returns a ptAgeInfoStructRef of the AgeInfo for this link"""
-        pass
+        ...
 
     def getLinkingRules(self):
         """Returns the linking rules of this link"""
-        pass
+        ...
 
     def getParentAgeFilename(self):
         """Returns a string of the parent age filename"""
-        pass
+        ...
 
     def getSpawnPoint(self):
         """Gets the spawn point ptSpawnPointInfoRef of this link"""
-        pass
+        ...
 
     def setAgeInfo(self, ageInfo):
         """Sets the AgeInfoStruct from the data in ageInfo (a ptAgeInfoStruct)"""
-        pass
+        ...
 
     def setLinkingRules(self, rule):
         """Sets the linking rules for this link"""
-        pass
+        ...
 
     def setParentAgeFilename(self, filename):
         """Sets the parent age filename for child age links"""
-        pass
+        ...
 
     def setSpawnPoint(self, spawnPtInfo):
         """Sets the spawn point of this link (a ptSpawnPointInfo or ptSpawnPointInfoRef)"""
-        pass
+        ...
 
 class ptAgeLinkStructRef:
     """Class to hold the data of the AgeLink structure"""
 
     def copyFrom(self, other):
         """Copies data from one ptAgeLinkStruct or ptAgeLinkStructRef to this one"""
-        pass
+        ...
 
     def getAgeInfo(self):
         """Returns a ptAgeInfoStructRef of the AgeInfo for this link"""
-        pass
+        ...
 
     def getLinkingRules(self):
         """Returns the linking rules of this link"""
-        pass
+        ...
 
     def getSpawnPoint(self):
         """Gets the spawn point ptSpawnPointInfoRef of this link"""
-        pass
+        ...
 
     def setAgeInfo(self, ageInfo):
         """Sets the AgeInfoStruct from the data in ageInfo (a ptAgeInfoStruct)"""
-        pass
+        ...
 
     def setLinkingRules(self, rule):
         """Sets the linking rules for this link"""
-        pass
+        ...
 
     def setSpawnPoint(self, spawnPtInfo):
         """Sets the spawn point of this link (a ptSpawnPointInfo or ptSpawnPointInfoRef)"""
-        pass
+        ...
 
 class ptAgeVault:
     """Accessor class to the Age's vault"""
 
     def addChronicleEntry(self, name, type, value):
         """Adds a chronicle entry with the specified type and value"""
-        pass
+        ...
 
     def addDevice(self, deviceName, cb=None, cbContext=0):
         """Adds a device to the age"""
-        pass
+        ...
 
     def findChronicleEntry(self, entryName):
         """Returns the named ptVaultChronicleNode"""
-        pass
+        ...
 
     def getAgeDevicesFolder(self):
         """Returns a ptVaultFolderNode of the inboxes for the devices in this Age."""
-        pass
+        ...
 
     def getAgeGuid(self):
         """Returns the current Age's guid as a string."""
-        pass
+        ...
 
     def getAgeInfo(self):
         """Returns a ptVaultAgeInfoNode of the this Age"""
-        pass
+        ...
 
     def getAgeSDL(self):
         """Returns the age's SDL (ptSDLStateDataRecord)"""
-        pass
+        ...
 
     def getAgesIOwnFolder(self):
         """(depreciated, use getBookshelfFolder) Returns a ptVaultFolderNode that contain the Ages I own"""
-        pass
+        ...
 
     def getBookshelfFolder(self):
         """Personal age only: Returns a ptVaultFolderNode that contains the owning player's AgesIOwn age list"""
-        pass
+        ...
 
     def getChronicleFolder(self):
         """Returns a ptVaultFolderNode"""
-        pass
+        ...
 
     def getDevice(self, deviceName):
         """Returns the specified device (ptVaultTextNoteNode)"""
-        pass
+        ...
 
     def getDeviceInbox(self, deviceName):
         """Returns a ptVaultFolderNode of the inbox for the named device in this age."""
-        pass
+        ...
 
     def getPeopleIKnowAboutFolder(self):
         """Returns a ptVaultPlayerInfoListNode of the players the Age knows about(?)."""
-        pass
+        ...
 
     def getPublicAgesFolder(self):
         """Returns a ptVaultFolderNode that contains all the public Ages"""
-        pass
+        ...
 
     def getSubAgeLink(self, ageInfo):
         """Returns a ptVaultAgeLinkNode to 'ageInfo' (a ptAgeInfoStruct) for this Age."""
-        pass
+        ...
 
     def getSubAgesFolder(self):
         """Returns a ptVaultFolderNode of sub Age's folder."""
-        pass
+        ...
 
     def hasDevice(self, deviceName):
         """Does a device with this name exist?"""
-        pass
+        ...
 
     def removeDevice(self, deviceName):
         """Removes a device from the age"""
-        pass
+        ...
 
     def setDeviceInbox(self, deviceName, inboxName, cb=None, cbContext=0):
         """Set's the device's inbox"""
-        pass
+        ...
 
     def updateAgeSDL(self, pyrec):
         """Updates the age's SDL"""
-        pass
+        ...
 
 class ptAnimation:
     """Plasma animation class"""
 
     def __init__(self, key=None):
-        pass
+        ...
 
     def addKey(self, key):
         """Adds an animation modifier to the list of receiver keys"""
-        pass
+        ...
 
     def backwards(self, backwardsFlag):
         """Turn on and off playing the animation backwards"""
-        pass
+        ...
 
     def getFirstKey(self):
         """This will return a ptKey object that is the first receiver (target)
         However, if the parent is not a modifier or not loaded, then None is returned.
         """
-        pass
+        ...
 
     def incrementBackward(self):
         """Step the animation backward a frame"""
-        pass
+        ...
 
     def incrementForward(self):
         """Step the animation forward a frame"""
-        pass
+        ...
 
     def looped(self, loopedFlag):
         """Turn on and off looping of the animation"""
-        pass
+        ...
 
     def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
-        pass
+        ...
 
     def play(self):
         """Plays the animation"""
-        pass
+        ...
 
     def playRange(self, start, end):
         """Play the animation from start to end"""
-        pass
+        ...
 
     def playToPercentage(self, zeroToOne):
         """Play the animation to the specified percentage (0 to 1)"""
-        pass
+        ...
 
     def playToTime(self, time):
         """Play the animation to the specified time"""
-        pass
+        ...
 
     def resume(self):
         """Resumes the animation from where it was stopped last"""
-        pass
+        ...
 
     def sender(self, selfKey):
         """Sets the sender of the messages being sent to the animation modifier"""
-        pass
+        ...
 
     def setAnimName(self, name):
         """Sets the animation notetrack name (or (Entire Animation))"""
-        pass
+        ...
 
     def setLoopEnd(self, loopEnd):
         """Sets the loop ending position
         - 'loopEnd' is the number of seconds from the absolute beginning of the animation
         """
-        pass
+        ...
 
     def setLoopStart(self, loopStart):
         """Sets the loop starting position
         - 'loopStart' is the number of seconds from the absolute beginning of the animation
         """
-        pass
+        ...
 
     def skipToBegin(self):
         """Skip to the beginning of the animation (don't play)"""
-        pass
+        ...
 
     def skipToEnd(self):
         """Skip to the end of the animation (don't play)"""
-        pass
+        ...
 
     def skipToLoopBegin(self):
         """Skip to the beginning of the animation loop (don't play)"""
-        pass
+        ...
 
     def skipToLoopEnd(self):
         """Skip to the end of the animation loop (don't play)"""
-        pass
+        ...
 
     def skipToTime(self, time):
         """Skip the animation to time (don't play)"""
-        pass
+        ...
 
     def speed(self, speed):
         """Sets the animation playback speed"""
-        pass
+        ...
 
     def stop(self):
         """Stops the animation"""
-        pass
+        ...
 
 class ptAudioControl:
     """Accessor class to the Audio controls"""
 
     def areSubtitlesEnabled(self):
         """Are subtitles for the audio enabled? Returns 1 if true otherwise returns 0."""
-        pass
+        ...
 
     def canSetMicLevel(self):
         """Can the microphone level be set? Returns 1 if true otherwise returns 0."""
-        pass
+        ...
 
     def disable(self):
         """Disabled audio"""
-        pass
+        ...
 
     def disableSubtitles(self):
         """Disables subtitles for audio."""
-        pass
+        ...
 
     def enable(self):
         """Enables audio"""
-        pass
+        ...
 
     def enableSubtitles(self):
         """Enables subtitles for audio."""
-        pass
+        ...
 
     def enableVoiceChat(self, state):
         """Enables or disables voice chat."""
-        pass
+        ...
 
     def enableVoiceRecording(self, state):
         """Enables or disables voice recording."""
-        pass
+        ...
 
     def getAmbienceVolume(self):
         """Returns the volume (0.0 to 1.0) for the Ambiance."""
-        pass
+        ...
 
     def getCaptureDevice(self):
         """Gets the name for the capture device being used by the audio system."""
-        pass
+        ...
 
     def getCaptureDevices(self):
         """Gets the name of all available audio capture devices."""
-        pass
+        ...
 
     def getFriendlyDeviceName(self, devicename):
         """Returns the provided device name without any OpenAL prefixes applied."""
-        pass
+        ...
 
     def getGUIVolume(self):
         """Returns the volume (0.0 to 1.0) for the GUI dialogs."""
-        pass
+        ...
 
     def getMicLevel(self):
         """Returns the microphone recording level (0.0 to 1.0)."""
-        pass
+        ...
 
     def getMusicVolume(self):
         """Returns the volume (0.0 to 1.0) for the Music."""
-        pass
+        ...
 
     def getNPCVoiceVolume(self):
         """Returns the volume (0.0 to 1.0) for the NPC's voice."""
-        pass
+        ...
 
     def getPlaybackDevice(self):
         """Gets the name for the device being used by the audio system."""
-        pass
+        ...
 
     def getPlaybackDevices(self):
         """Gets the names of all available audio playback devices."""
-        pass
+        ...
 
     def getPriorityCutoff(self):
         """Returns current sound priority"""
-        pass
+        ...
 
     def getSoundFXVolume(self):
         """Returns the volume (0.0 to 1.0) for the Sound FX."""
-        pass
+        ...
 
     def getVoiceVolume(self):
         """Returns the volume (0.0 to 1.0) for the Voices."""
-        pass
+        ...
 
     def hideIcons(self):
         """Hides (disables) the voice recording icons."""
-        pass
+        ...
 
     def isEAXSupported(self):
         """Returns true or false based on whether or not a the device specified supports EAX"""
-        pass
+        ...
 
     def isEnabled(self):
         """Is the audio enabled? Returns 1 if true otherwise returns 0."""
-        pass
+        ...
 
     def isMuted(self):
         """Are all sounds muted? Returns 1 if true otherwise returns 0."""
-        pass
+        ...
 
     def isUsingEAXAcceleration(self):
         """Is EAX sound acceleration enabled? Returns 1 if true otherwise returns 0."""
-        pass
+        ...
 
     def isVoiceRecordingEnabled(self):
         """Is voice recording enabled? Returns 1 if true otherwise returns 0."""
-        pass
+        ...
 
     def muteAll(self):
         """Mutes all sounds."""
-        pass
+        ...
 
     def pushToTalk(self, state):
         """Enables or disables 'push-to-talk'."""
-        pass
+        ...
 
     def setAmbienceVolume(self, volume):
         """Sets the Ambience volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
-        pass
+        ...
 
     def setCaptureDevice(self, devicename):
         """Sets the audio capture device by name."""
-        pass
+        ...
 
     def setGUIVolume(self, volume):
         """Sets the GUI dialog volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
-        pass
+        ...
 
     def setLoadOnDemand(self, state):
         """Enables or disables the load on demand for sounds."""
-        pass
+        ...
 
     def setMicLevel(self, level):
         """Sets the microphone recording level (0.0 to 1.0)."""
-        pass
+        ...
 
     def setMusicVolume(self, volume):
         """Sets the Music volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
-        pass
+        ...
 
     def setNPCVoiceVolume(self, volume):
         """Sets the NPC's voice volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
-        pass
+        ...
 
     def setPlaybackDevice(self, devicename, restart):
         """Sets audio system output device by name, and optionally restarts it"""
-        pass
+        ...
 
     def setPriorityCutoff(self, priority):
         """Sets the sound priority"""
-        pass
+        ...
 
     def setSoundFXVolume(self, volume):
         """Sets the SoundFX volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
-        pass
+        ...
 
     def setTwoStageLOD(self, state):
         """Enables or disables two-stage LOD, where sounds can be loaded into RAM but not into sound buffers.
         ...Less of a performance hit, harder on memory.
         """
-        pass
+        ...
 
     def setVoiceVolume(self, volume):
         """Sets the Voice volume (0.0 to 1.0) for the game.
         This only sets the volume for this game session.
         """
-        pass
+        ...
 
     def showIcons(self):
         """Shows (enables) the voice recording icons."""
-        pass
+        ...
 
     def squelchLevel(self, level):
         """Sets the squelch level."""
-        pass
+        ...
 
     def unmuteAll(self):
         """Unmutes all sounds."""
-        pass
+        ...
 
     def useEAXAcceleration(self, state):
         """Enables or disables EAX sound acceleration (requires hardware acceleration)."""
-        pass
+        ...
 
 class ptAvatar:
     """Plasma avatar class"""
 
     def addWardrobeClothingItem(self, clothing_name, tint1, tint2):
         """To add a clothing item to the avatar's wardrobe (closet)"""
-        pass
+        ...
 
     def enterSubWorld(self, sceneobject):
         """Places the avatar into the subworld of the ptSceneObject specified"""
-        pass
+        ...
 
     def exitSubWorld(self):
         """Exits the avatar from the subWorld where it was"""
-        pass
+        ...
 
     def getAllWithSameMesh(self, clothing_name):
         """Returns a lilst of all clothing items that use the same mesh as the specified one"""
-        pass
+        ...
 
     def getAvatarClothingGroup(self):
         """Returns what clothing group the avatar belongs to.
         It is also a means to determine if avatar is male or female
         """
-        pass
+        ...
 
     def getAvatarClothingList(self):
         """Returns a list of clothes that the avatar is currently wearing."""
-        pass
+        ...
 
     def getClosetClothingList(self, clothing_type):
         """Returns a list of clothes for the avatar that are in specified clothing group."""
-        pass
+        ...
 
     def getCurrentMode(self):
         """Returns current brain mode for avatar"""
-        pass
+        ...
 
     def getEntireClothingList(self, clothing_type):
         """Gets the entire list of clothing available. 'clothing_type' not used
         NOTE: should use getClosetClothingList
         """
-        pass
+        ...
 
     def getMatchingClothingItem(self, clothingName):
         """Finds the matching clothing item that goes with 'clothingName'
         Used to find matching left and right gloves and shoes.
         """
-        pass
+        ...
 
     def getMorph(self, clothing_name, layer):
         """Get the current morph value"""
-        pass
+        ...
 
     def getSkinBlend(self, layer):
         """Get the current skin blend value"""
-        pass
+        ...
 
     def getTintClothingItem(self, clothing_name, layer=1):
         """Returns a ptColor of a particular item of clothing that the avatar is wearing.
         The color will be a ptColor object.
         """
-        pass
+        ...
 
     def getTintSkin(self):
         """Returns a ptColor of the current skin tint for the avatar"""
-        pass
+        ...
 
     def getUniqueMeshList(self, clothing_type):
         """Returns a list of unique clothing items of the desired type (different meshes)"""
-        pass
+        ...
 
     def getWardrobeClothingList(self):
         """Return a list of items that are in the avatars closet"""
-        pass
+        ...
 
     def gotoStage(self, behaviorKey, stage, transitionTime, setTimeFlag, newTime, SetDirectionFlag, isForward, netForce):
         """Tells a multistage behavior to go to a particular stage"""
-        pass
+        ...
 
     def loadClothingFromFile(self, filename):
         """Load avatar clothing from a file"""
-        pass
+        ...
 
     def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
-        pass
+        ...
 
     def nextStage(self, behaviorKey, transitionTime, setTimeFlag, newTime, SetDirectionFlag, isForward, netForce):
         """Tells a multistage behavior to go to the next stage (Why does Matt like so many parameters?)"""
-        pass
+        ...
 
     def oneShot(self, seekKey, duration, usePhysicsFlag, animationName, drivableFlag, reversibleFlag):
         """Plays a one-shot animation on the avatar"""
-        pass
+        ...
 
     def playSimpleAnimation(self, animName):
         """Play simple animation on avatar"""
-        pass
+        ...
 
     def previousStage(self, behaviorKey, transitionTime, setTimeFlag, newTime, SetDirectionFlag, isForward, netForce):
         """Tells a multistage behavior to go to the previous stage"""
-        pass
+        ...
 
     def registerForBehaviorNotify(self, selfKey):
         """This will register for behavior notifies from the avatar"""
-        pass
+        ...
 
     def removeClothingItem(self, clothing_name, update=1):
         """Tells the avatar to remove a particular item of clothing."""
-        pass
+        ...
 
     def runBehavior(self, behaviorKey, netForceFlag):
         """Runs a behavior on the avatar. Can be a single or multi-stage behavior."""
-        pass
+        ...
 
     def runBehaviorSetNotify(self, behaviorKey, replyKey, netForceFlag):
         """Same as runBehavior, except send notifications to specified keyed object"""
-        pass
+        ...
 
     def runCoopAnim(self, targetKey, activeAvatarAnim, targetAvatarAnim, range=6, dist=3, move=1):
         """Seek near another avatar and run animations on both."""
-        pass
+        ...
 
     def saveClothing(self):
         """Saves the current clothing options (including morphs) to the vault"""
-        pass
+        ...
 
     def saveClothingToFile(self, filename):
         """Save avatar clothing to a file"""
-        pass
+        ...
 
     def setDontPanicLink(self, value: bool) -> None:
         """Disables panic linking to Personal Age (warps the avatar back to the start instead)"""
-        pass
+        ...
 
     def setMorph(self, clothing_name, layer, value):
         """Set the morph value (clipped between -1 and 1)"""
-        pass
+        ...
 
     def setReplyKey(self, key):
         """Sets the sender's key"""
-        pass
+        ...
 
     def setSkinBlend(self, layer, value):
         """Set the skin blend (value between 0 and 1)"""
-        pass
+        ...
 
     def tintClothingItem(self, clothing_name, tint, update=1):
         """Tells the avatar to tint(color) a particular item of clothing that they are already wearing.
         'tint' is a ptColor object
         """
-        pass
+        ...
 
     def tintClothingItemLayer(self, clothing_name, tint, layer, update=1):
         """Tells the avatar to tint(color) a particular layer of a particular item of clothing."""
-        pass
+        ...
 
     def tintSkin(self, tint, update=1):
         """Tints all of the skin on the avatar, with the ptColor tint"""
-        pass
+        ...
 
     def unRegisterForBehaviorNotify(self, selfKey):
         """This will unregister behavior notifications"""
-        pass
+        ...
 
     def wearClothingItem(self, clothing_name, update=1):
         """Tells the avatar to wear a particular item of clothing.
         And optionally hold update until later (for applying tinting before wearing).
         """
-        pass
+        ...
 
 class ptBook:
     """Creates a new book"""
 
     def __init__(self, esHTMLSource, coverImage=None, callbackKey=None, guiName=''):
-        pass
+        ...
 
     def allowPageTurning(self, allow):
         """Turns on and off the ability to flip the pages in a book"""
-        pass
+        ...
 
     def close(self):
         """Closes the book"""
-        pass
+        ...
 
     def closeAndHide(self):
         """Closes the book and hides it once it finishes animating"""
-        pass
+        ...
 
     def getCurrentPage(self):
         """Returns the currently shown page"""
-        pass
+        ...
 
     def getEditableText(self):
         """Returns the editable text currently contained in the book."""
-        pass
+        ...
 
     def getMovie(self, index):
         """Grabs a ptAnimation object representing the movie indexed by index. The index is the index of the movie in the source code"""
-        pass
+        ...
 
     def goToPage(self, page):
         """Flips the book to the specified page"""
-        pass
+        ...
 
     def hide(self):
         """Hides the book"""
-        pass
+        ...
 
     def nextPage(self):
         """Flips the book to the next page"""
-        pass
+        ...
 
     def open(self, startingPage):
         """Opens the book to the specified page"""
-        pass
+        ...
 
     def previousPage(self):
         """Flips the book to the previous page"""
-        pass
+        ...
 
     def setEditable(self, editable):
         """Turn book editing on or off. If the book GUI does not support editing, nothing will happen"""
-        pass
+        ...
 
     def setEditableText(self, text):
         """Sets the book's editable text."""
-        pass
+        ...
 
     def setGUI(self, guiName):
         """Sets the gui to be used by the book, if the requested gui is not loaded, it will use the default
         Do not call while the book is open!
         """
-        pass
+        ...
 
     def setPageMargin(self, margin):
         """Sets the text margin for the book"""
-        pass
+        ...
 
     def setSize(self, width, height):
         """Sets the size of the book (width and height are floats from 0 to 1)"""
-        pass
+        ...
 
     def show(self, startOpened):
         """Shows the book closed, or open if the the startOpened flag is true"""
-        pass
+        ...
 
 class ptCamera:
     """Plasma camera class"""
@@ -1799,406 +1799,406 @@ class ptCamera:
         """Send a control key to the camera as if it was hit by the user.
         This is for sending things like pan-up, pan-down, zoom-in, etc.
         """
-        pass
+        ...
 
     def disableFirstPersonOverride(self):
         """Does _not_ allow the user to override the camera to go to first person camera."""
-        pass
+        ...
 
     def enableFirstPersonOverride(self):
         """Allows the user to override the camera and go to a first person camera."""
-        pass
+        ...
 
     def getAspectRatio(self):
         """Get the global aspect ratio"""
-        pass
+        ...
 
     def getFOV(self):
         """Returns the current camera's FOV(h)"""
-        pass
+        ...
 
     def isSmootherCam(self):
         """Returns true if we are using the faster cams thing"""
-        pass
+        ...
 
     def isStayInFirstPerson(self):
         """Are we staying in first person?"""
-        pass
+        ...
 
     def isWalkAndVerticalPan(self):
         """Returns true if we are walking and chewing gum"""
-        pass
+        ...
 
     def refreshFOV(self):
         """Refreshes the FOV"""
-        pass
+        ...
 
     def restore(self, cameraKey):
         """Restores camera to saved one"""
-        pass
+        ...
 
     def save(self, cameraKey):
         """Saves the current camera and sets the camera to cameraKey"""
-        pass
+        ...
 
     def set(self, cameraKey, time, save):
         """DO NOT USE"""
-        pass
+        ...
 
     def setAspectRatio(self, aspect):
         """Set the global aspect ratio"""
-        pass
+        ...
 
     def setFOV(self, fov, time):
         """Sets the current cameras FOV (based on h)"""
-        pass
+        ...
 
     def setSmootherCam(self, state):
         """Set the faster cams thing"""
-        pass
+        ...
 
     def setStayInFirstPerson(self, state):
         """Set Stay In First Person Always"""
-        pass
+        ...
 
     def setWalkAndVerticalPan(self, state):
         """Set Walk and chew gum"""
-        pass
+        ...
 
     def undoFirstPerson(self):
         """If the user has overridden the camera to be in first person, this will take them out of first person.
         If the user didn't override the camera, then this will do nothing.
         """
-        pass
+        ...
 
 class ptCluster:
     """Creates a new ptCluster"""
 
     def __init__(self, key):
-        pass
+        ...
 
     def setVisible(self, visible):
         """Shows or hides the cluster object"""
-        pass
+        ...
 
 class ptColor:
     """Plasma color class"""
 
     def __init__(self, red=0, green=0, blue=0, alpha=0):
-        pass
+        ...
 
     def black(self):
         """Sets the color to be black
         Example: black = ptColor().black()
         """
-        pass
+        ...
 
     def blue(self):
         """Sets the color to be blue
         Example: blue = ptColor().blue()
         """
-        pass
+        ...
 
     def brown(self):
         """Sets the color to be brown
         Example: brown = ptColor().brown()
         """
-        pass
+        ...
 
     def cyan(self):
         """Sets the color to be cyan
         Example: cyan = ptColor.cyan()
         """
-        pass
+        ...
 
     def darkbrown(self):
         """Sets the color to be darkbrown
         Example: darkbrown = ptColor().darkbrown()
         """
-        pass
+        ...
 
     def darkgreen(self):
         """Sets the color to be darkgreen
         Example: darkgreen = ptColor().darkgreen()
         """
-        pass
+        ...
 
     def darkpurple(self):
         """Sets the color to be darkpurple
         Example: darkpurple = ptColor().darkpurple()
         """
-        pass
+        ...
 
     def getAlpha(self):
         """Get the alpha blend component of the color"""
-        pass
+        ...
 
     def getBlue(self):
         """Get the blue component of the color"""
-        pass
+        ...
 
     def getGreen(self):
         """Get the green component of the color"""
-        pass
+        ...
 
     def getRed(self):
         """Get the red component of the color"""
-        pass
+        ...
 
     def gray(self):
         """Sets the color to be gray
         Example: gray = ptColor().gray()
         """
-        pass
+        ...
 
     def green(self):
         """Sets the color to be green
         Example: green = ptColor().green()
         """
-        pass
+        ...
 
     def magenta(self):
         """Sets the color to be magenta
         Example: magenta = ptColor().magenta()
         """
-        pass
+        ...
 
     def maroon(self):
         """Sets the color to be maroon
         Example: maroon = ptColor().maroon()
         """
-        pass
+        ...
 
     def navyblue(self):
         """Sets the color to be navyblue
         Example: navyblue = ptColor().navyblue()
         """
-        pass
+        ...
 
     def orange(self):
         """Sets the color to be orange
         Example: orange = ptColor().orange()
         """
-        pass
+        ...
 
     def pink(self):
         """Sets the color to be pink
         Example: pink = ptColor().pink()
         """
-        pass
+        ...
 
     def red(self):
         """Sets the color to be red
         Example: red = ptColor().red()
         """
-        pass
+        ...
 
     def setAlpha(self, alpha):
         """Set the alpha blend component of the color. 0.0 to 1.0"""
-        pass
+        ...
 
     def setBlue(self, blue):
         """Set the blue component of the color. 0.0 to 1.0"""
-        pass
+        ...
 
     def setGreen(self, green):
         """Set the green component of the color. 0.0 to 1.0"""
-        pass
+        ...
 
     def setRed(self, red):
         """Set the red component of the color. 0.0 to 1.0"""
-        pass
+        ...
 
     def slateblue(self):
         """Sets the color to be slateblue
         Example: slateblue = ptColor().slateblue()
         """
-        pass
+        ...
 
     def steelblue(self):
         """Sets the color to be steelblue
         Example: steelblue = ptColor().steelblue()
         """
-        pass
+        ...
 
     def tan(self):
         """Sets the color to be tan
         Example: tan = ptColor().tan()
         """
-        pass
+        ...
 
     def white(self):
         """Sets the color to be white
         Example: white = ptColor().white()
         """
-        pass
+        ...
 
     def yellow(self):
         """Sets the color to be yellow
         Example: yellow = ptColor().yellow()
         """
-        pass
+        ...
 
 class ptCritterBrain:
     """Object to manipulate critter brains"""
 
     def addBehavior(self, animName, behaviorName, loop = 1, randomStartPos = 1, fadeInLen = 2.0, fadeOutLen = 2.0):
         """Adds a new animation to the brain as a behavior with the specified name and parameters. If multiple animations are assigned to the same behavior, they will be randomly picked from when started."""
-        pass
+        ...
 
     def addReceiver(self, key):
         """Tells the brain that the specified key wants AI messages"""
-        pass
+        ...
 
     def animationName(self, behavior):
         """Returns the animation name associated with the specified integral behavior."""
-        pass
+        ...
 
     def atGoal(self):
         """Are we currently are our final destination?"""
-        pass
+        ...
 
     def avoidingAvatars(self):
         """Are we currently avoiding avatars while pathfinding?"""
-        pass
+        ...
 
     def behaviorName(self, behavior):
         """Returns the behavior name associated with the specified integral behavior."""
-        pass
+        ...
 
     def canHearAvatar(self, avatarID):
         """Returns whether this brain can hear the avatar with the specified id."""
-        pass
+        ...
 
     def canSeeAvatar(self, avatarID):
         """Returns whether this brain can see the avatar with the specified id."""
-        pass
+        ...
 
     def curBehavior(self):
         """Returns the current integral behavior the brain is running."""
-        pass
+        ...
 
     def currentGoal(self):
         """Returns the current ptPoint that the brain is running towards."""
-        pass
+        ...
 
     def getHearingDistance(self):
         """Returns how far away the brain can hear."""
-        pass
+        ...
 
     def getSceneObject(self):
         """Returns the ptSceneObject this brain controls."""
-        pass
+        ...
 
     def getSightCone(self):
         """Returns the width of the brain's field of view in radians."""
-        pass
+        ...
 
     def getSightDistance(self):
         """Returns how far the brain can see."""
-        pass
+        ...
 
     def getStopDistance(self):
         """Returns how far away from the goal we could be and still be considered there."""
-        pass
+        ...
 
     def goToGoal(self, newGoal, avoidingAvatars = 0):
         """Tells the brain to start running towards the specified location, avoiding avatars it can see or hear if told to."""
-        pass
+        ...
 
     def idleBehaviorName(self):
         """Returns the name of the brain's idle behavior."""
-        pass
+        ...
 
     def nextBehavior(self):
         """Returns the behavior the brain will be switching to next frame. (-1 if no change)"""
-        pass
+        ...
 
     def playersICanHear(self):
         """Returns a list of player ids which this brain can hear."""
-        pass
+        ...
 
     def playersICanSee(self):
         """Returns a list of player ids which this brain can see."""
-        pass
+        ...
 
     def removeReceiver(self, key):
         """Tells the brain that the specified key no longer wants AI messages"""
-        pass
+        ...
 
     def runBehaviorName(self):
         """Returns the name of the brain's run behavior."""
-        pass
+        ...
 
     def runningBehavior(self, behaviorName):
         """Returns true if the named behavior is running."""
-        pass
+        ...
 
     def setHearingDistance(self, dist):
         """Set how far away the brain can hear (360 degree field of hearing)."""
-        pass
+        ...
 
     def setSightCone(self, radians):
         """Set how wide the brain's field of view is in radians. Note that it is the total angle of the cone, half on one side of the brain's line of sight, half on the other."""
-        pass
+        ...
 
     def setSightDistance(self, dist):
         """Set how far away the brain can see."""
-        pass
+        ...
 
     def setStopDistance(self, dist):
         """Set how far away from the goal we should be when we are considered there and stop running."""
-        pass
+        ...
 
     def startBehavior(self, behaviorName, fade = 1):
         """Starts playing the named behavior. If fade is true, it will fade out the previous behavior and fade in the new one. If false, they will immediately switch."""
-        pass
+        ...
 
     def vectorToPlayer(self, avatarID):
         """Returns the vector between us and the specified player."""
-        pass
+        ...
 
 class ptDniCoordinates:
     """Constructor for a D'Ni coordinate"""
 
     def fromPoint(self, pt):
         """Update these coordinates with the specified ptPoint3"""
-        pass
+        ...
 
     def getHSpans(self):
         """Returns the HSpans component of the coordinate"""
-        pass
+        ...
 
     def getTorans(self):
         """Returns the Torans component of the coordinate"""
-        pass
+        ...
 
     def getVSpans(self):
         """Returns the VSpans component of the coordinate"""
-        pass
+        ...
 
     def update(self):
         """Update these coordinates with the players current position"""
-        pass
+        ...
 
 class ptDniInfoSource:
     """DO NOT USE"""
 
     def getAgeCoords(self):
         """Current coords of the player in current age as a ptDniCoordinates"""
-        pass
+        ...
 
     def getAgeGuid(self):
         """Unique identifier for this age instance"""
-        pass
+        ...
 
     def getAgeName(self):
         """Name of current age"""
-        pass
+        ...
 
     def getAgeTime(self):
         """Current time in current age (tbd)"""
-        pass
+        ...
 
 class ptDraw:
     """Plasma Draw class"""
@@ -2207,87 +2207,87 @@ class ptDraw:
         """Disables the draw on the sceneobject attached
         In other words, makes it invisible
         """
-        pass
+        ...
 
     def enable(self, state=1):
         """Sets the draw enable for the sceneobject attached"""
-        pass
+        ...
 
     def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
-        pass
+        ...
 
 class ptDynamicMap:
     """Creates a ptDynamicMap object"""
 
     def __init__(self, key=None):
-        pass
+        ...
 
     def addKey(self, key):
         """Add a receiver... in other words a DynamicMap"""
-        pass
+        ...
 
     def calcTextExtents(self, text):
         """Calculates the extent of the specified text, returns it as a (width, height) tuple"""
-        pass
+        ...
 
     def clearKeys(self):
         """Clears the receiver list"""
-        pass
+        ...
 
     def clearToColor(self, color):
         """Clear the DynamicMap to the specified color
         - 'color' is a ptColor object
         """
-        pass
+        ...
 
     def drawImage(self, x, y, image, respectAlphaFlag):
         """Draws a ptImage object on the dynamicTextmap starting at the location x,y"""
-        pass
+        ...
 
     def drawImageClipped(self, x, y, image, cx, cy, cw, ch, respectAlphaFlag):
         """Draws a ptImage object clipped to cx,cy with cw(width),ch(height)"""
-        pass
+        ...
 
     def drawText(self, x, y, text):
         """Draw text at a specified location
         - x,y is the point to start drawing the text
         - 'text' is a string of the text to be drawn
         """
-        pass
+        ...
 
     def fillRect(self, left, top, right, bottom, color):
         """Fill in the specified rectangle with a color
         - left,top,right,bottom define the rectangle
         - 'color' is a ptColor object
         """
-        pass
+        ...
 
     def flush(self):
         """Flush all the commands that were issued since the last flush()"""
-        pass
+        ...
 
     def frameRect(self, left, top, right, bottom, color):
         """Frame a rectangle with a specified color
         - left,top,right,bottom define the rectangle
         - 'color' is a ptColor object
         """
-        pass
+        ...
 
     def getHeight(self):
         """Returns the height of the dynamicTextmap"""
-        pass
+        ...
 
     def getImage(self):
         """Returns a pyImage associated with the dynamicTextmap"""
-        pass
+        ...
 
     def getWidth(self):
         """Returns the width of the dynamicTextmap"""
-        pass
+        ...
 
     def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
@@ -2295,901 +2295,901 @@ class ptDynamicMap:
         Such as a game master, only running on the client that owns a particular object
         This only applies when NetPropagate is set to true
         """
-        pass
+        ...
 
     def netPropagate(self, propagateFlag):
         """Specify whether this object needs to use messages that are sent on the network
         - The default is for this to be false.
         """
-        pass
+        ...
 
     def purgeImage(self):
         """Purge the DynamicTextMap images"""
-        pass
+        ...
 
     def sender(self, sender):
         """Set the sender of the message being sent to the DynamicMap"""
-        pass
+        ...
 
     def setClipping(self, clipLeft, clipTop, clipRight, clipBottom):
         """Sets the clipping rectangle
         - All drawtext will be clipped to this until the
         unsetClipping() is called
         """
-        pass
+        ...
 
     def setFont(self, facename, size):
         """Set the font of the text to be written
         - 'facename' is a string with the name of the font
         - 'size' is the point size of the font to use
         """
-        pass
+        ...
 
     def setJustify(self, justify):
         """Sets the justification of the text. (justify is a PtJustify)"""
-        pass
+        ...
 
     def setLineSpacing(self, spacing):
         """Sets the line spacing (in pixels)"""
-        pass
+        ...
 
     def setTextColor(self, color, blockRGB=0):
         """Set the color of the text to be written
         - 'color' is a ptColor object
         - 'blockRGB' must be true if you're trying to render onto a transparent or semi-transparent color
         """
-        pass
+        ...
 
     def setWrapping(self, wrapWidth, wrapHeight):
         """Set where text will be wrapped horizontally and vertically
         - All drawtext commands will be wrapped until the
         unsetWrapping() is called
         """
-        pass
+        ...
 
     def unsetClipping(self):
         """Stop the clipping of text"""
-        pass
+        ...
 
     def unsetWrapping(self):
         """Stop text wrapping"""
-        pass
+        ...
 
 class ptGUIControl:
     """Base class for all GUI controls"""
 
     def __init__(self, controlKey):
-        pass
+        ...
 
     def disable(self):
         """Disables this GUI control"""
-        pass
+        ...
 
     def enable(self, flag=1):
         """Enables this GUI control"""
-        pass
+        ...
 
     def focus(self):
         """Gets focus for this GUI control"""
-        pass
+        ...
 
     def getBackColor(self):
         """Returns the background color"""
-        pass
+        ...
 
     def getBackSelectColor(self):
         """Returns the background selection color"""
-        pass
+        ...
 
     def getFontFlags(self):
         """Returns the current fontflags"""
-        pass
+        ...
 
     def getFontSize(self):
         """Returns the font size"""
-        pass
+        ...
 
     def getForeColor(self):
         """Returns the foreground color"""
-        pass
+        ...
 
     def getKey(self):
         """Returns the ptKey for this GUI control"""
-        pass
+        ...
 
     def getObjectCenter(self):
         """Returns ptPoint3 of the center of the GUI control object"""
-        pass
+        ...
 
     def getOwnerDialog(self):
         """Returns a ptGUIDialog of the dialog that owns this GUI control"""
-        pass
+        ...
 
     def getSelectColor(self):
         """Returns the selection color"""
-        pass
+        ...
 
     def getTagID(self):
         """Returns the Tag ID for this GUI control"""
-        pass
+        ...
 
     def hide(self):
         """Hides this GUI control"""
-        pass
+        ...
 
     def isEnabled(self):
         """Returns whether this GUI control is enabled"""
-        pass
+        ...
 
     def isFocused(self):
         """Returns whether this GUI control has focus"""
-        pass
+        ...
 
     def isInteresting(self):
         """Returns whether this GUI control is interesting at the moment"""
-        pass
+        ...
 
     def isVisible(self):
         """Returns whether this GUI control is visible"""
-        pass
+        ...
 
     def refresh(self):
         """UNKNOWN"""
-        pass
+        ...
 
     def setBackColor(self, r, g, b, a):
         """Sets the background color"""
-        pass
+        ...
 
     def setBackSelectColor(self, r, g, b, a):
         """Sets the selection background color"""
-        pass
+        ...
 
     def setFocus(self, state):
         """Sets the state of the focus of this GUI control"""
-        pass
+        ...
 
     def setFontFlags(self, fontflags):
         """Sets current fontflags"""
-        pass
+        ...
 
     def setFontSize(self, fontSize):
         """Sets the font size"""
-        pass
+        ...
 
     def setForeColor(self, r, g, b, a):
         """Sets the foreground color"""
-        pass
+        ...
 
     def setNotifyOnInteresting(self, state):
         """Sets whether this control should send interesting events or not"""
-        pass
+        ...
 
     def setObjectCenter(self, point):
         """Sets the GUI controls object center to 'point'"""
-        pass
+        ...
 
     def setSelectColor(self, r, g, b, a):
         """Sets the selection color"""
-        pass
+        ...
 
     def setVisible(self, state):
         """Sets the state of visibility of this GUI control"""
-        pass
+        ...
 
     def show(self):
         """Shows this GUI control"""
-        pass
+        ...
 
     def unFocus(self):
         """Releases focus for this GUI control"""
-        pass
+        ...
 
 class ptGUIControlButton(ptGUIControl):
     """Plasma GUI Control Button class"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def getNotifyType(self):
         """Returns this button's notify type. See PtButtonNotifyTypes"""
-        pass
+        ...
 
     def isButtonDown(self):
         """Is the button down? Returns 1 for true otherwise returns 0"""
-        pass
+        ...
 
     def setNotifyType(self, kind):
         """Sets this button's notify type. See PtButtonNotifyTypes"""
-        pass
+        ...
 
 class ptGUIControlCheckBox(ptGUIControl):
     """Plasma GUI Control Checkbox class"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def isChecked(self):
         """Is this checkbox checked? Returns 1 for true otherwise returns 0"""
-        pass
+        ...
 
     def setChecked(self, checkedState):
         """Sets this checkbox to the 'checkedState'"""
-        pass
+        ...
 
 class ptGUIControlClickMap(ptGUIControl):
     """Plasma GUI control Click Map"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def getLastMouseDragPoint(self):
         """Returns the last point the mouse was dragged to"""
-        pass
+        ...
 
     def getLastMousePoint(self):
         """Returns the last point the mouse was at"""
-        pass
+        ...
 
     def getLastMouseUpPoint(self):
         """Returns the last point the mouse was released at"""
-        pass
+        ...
 
 class ptGUIControlDragBar(ptGUIControl):
     """Plasma GUI Control DragBar class"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def anchor(self):
         """Don't allow this dragbar object to be moved by the user.
         Drop anchor!
         """
-        pass
+        ...
 
     def isAnchored(self):
         """Is this dragbar control anchored? Returns 1 if true otherwise returns 0"""
-        pass
+        ...
 
     def unanchor(self):
         """Allow the user to drag this control around the screen.
         Raise anchor.
         """
-        pass
+        ...
 
 class ptGUIControlDraggable(ptGUIControl):
     """Plasma GUI control for something draggable"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def getLastMousePoint(self):
         """Returns the last point we were dragged to"""
-        pass
+        ...
 
     def stopDragging(self, cancelFlag):
         """UNKNOWN"""
-        pass
+        ...
 
 class ptGUIControlDynamicText(ptGUIControl):
     """Plasma GUI Control DynamicText class"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def getMap(self, index):
         """Returns a specific ptDynamicText attached to this contol
         If there is no map at 'index' then a KeyError exception will be raised
         """
-        pass
+        ...
 
     def getNumMaps(self):
         """Returns the number of ptDynamicText maps attached"""
-        pass
+        ...
 
 class ptGUIControlEditBox(ptGUIControl):
     """Plasma GUI Control Editbox class"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def clearString(self):
         """Clears the editbox."""
-        pass
+        ...
 
     def end(self):
         """Sets the cursor in the editbox to the after the last character."""
-        pass
+        ...
 
     def getLastKeyCaptured(self):
         """Gets the last capture key"""
-        pass
+        ...
 
     def getLastModifiersCaptured(self):
         """Gets the last modifiers flags captured"""
-        pass
+        ...
 
     def getString(self):
         """Returns the sting that the user typed in."""
-        pass
+        ...
 
     def home(self):
         """Sets the cursor in the editbox to before the first character."""
-        pass
+        ...
 
     def setChatMode(self, state):
         """Set the Chat mode on this control"""
-        pass
+        ...
 
     def setColor(self, foreColor, backColor):
         """Sets the fore and back color of the editbox."""
-        pass
+        ...
 
     def setLastKeyCapture(self, key, modifiers):
         """Set last key captured"""
-        pass
+        ...
 
     def setSelectionColor(self, foreColor, backColor):
         """Sets the selection color of the editbox."""
-        pass
+        ...
 
     def setSpecialCaptureKeyMode(self, state):
         """Set the Capture mode on this control"""
-        pass
+        ...
 
     def setString(self, text):
         """Pre-sets the editbox to a string."""
-        pass
+        ...
 
     def setStringSize(self, size):
         """Sets the maximum size of the string that can be inputted by the user."""
-        pass
+        ...
 
     def wasEscaped(self):
         """If the editbox was escaped then return 1 else return 0"""
-        pass
+        ...
 
 class ptGUIControlValue(ptGUIControl):
     """Plasma GUI Control Value class  - knobs, spinners"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def getMax(self):
         """Returns the maximum of the control."""
-        pass
+        ...
 
     def getMin(self):
         """Returns the minimum of the control."""
-        pass
+        ...
 
     def getStep(self):
         """Returns the step increment of the control."""
-        pass
+        ...
 
     def getValue(self):
         """Returns the current value of the control."""
-        pass
+        ...
 
     def setRange(self, minimum, maximum):
         """Sets the minimum and maximum range of the control."""
-        pass
+        ...
 
     def setStep(self, step):
         """Sets the step increment of the control."""
-        pass
+        ...
 
     def setValue(self, value):
         """Sets the current value of the control."""
-        pass
+        ...
 
 class ptGUIControlKnob(ptGUIControlValue):
     """Plasma GUI control for knob"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
 class ptGUIControlListBox(ptGUIControl):
     """Plasma GUI Control List Box class"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def add2StringsWithColors(self, text1, color1, text2, color2, respectAlpha):
         """Doesn't work right - DONT USE"""
-        pass
+        ...
 
     def addBranch(self, name, initiallyOpen):
         """UNKNOWN"""
-        pass
+        ...
 
     def addImage(self, image, respectAlphaFlag):
         """Appends an image item to the listbox"""
-        pass
+        ...
 
     def addImageAndSwatchesInBox(self, image, x, y, width, height, respectAlpha, primary, secondary):
         """Add the image and color swatches to the list"""
-        pass
+        ...
 
     def addImageInBox(self, image, x, y, width, height, respectAlpha):
         """Appends an image item to the listbox, centering within the box dimension."""
-        pass
+        ...
 
     def addSelection(self, item):
         """Adds item to selection list"""
-        pass
+        ...
 
     def addString(self, text):
         """Appends a list item 'text' to the listbox."""
-        pass
+        ...
 
     def addStringInBox(self, text, min_width, min_height):
         """Adds a text list item that has a minimum width and height"""
-        pass
+        ...
 
     def addStringWithColor(self, text, color, inheritAlpha):
         """Adds a colored string to the list box"""
-        pass
+        ...
 
     def addStringWithColorWithSize(self, text, color, inheritAlpha, fontsize):
         """Adds a text list item with a color and different font size"""
-        pass
+        ...
 
     def allowNoSelect(self):
         """Allows the listbox to have no selection"""
-        pass
+        ...
 
     def clearAllElements(self):
         """Removes all the items from the listbox, making it empty."""
-        pass
+        ...
 
     def clickable(self):
         """Sets this listbox to be clickable by the user."""
-        pass
+        ...
 
     def closeBranch(self):
         """UNKNOWN"""
-        pass
+        ...
 
     def disallowNoSelect(self):
         """The listbox must always have a selection"""
-        pass
+        ...
 
     def findString(self, text):
         """Finds and returns the index of the item that matches 'text' in the listbox."""
-        pass
+        ...
 
     def getBranchList(self):
         """get a list of branches in this list (index,isShowingChildren)"""
-        pass
+        ...
 
     def getElement(self, index):
         """Get the string of the item at 'index' in the listbox."""
-        pass
+        ...
 
     def getNumElements(self):
         """Return the number of items in the listbox."""
-        pass
+        ...
 
     def getScrollPos(self):
         """Returns the current scroll position in the listbox."""
-        pass
+        ...
 
     def getScrollRange(self):
         """Returns the max scroll position"""
-        pass
+        ...
 
     def getSelection(self):
         """Returns the currently selected list item in the listbox."""
-        pass
+        ...
 
     def getSelectionList(self):
         """Returns the current selection list"""
-        pass
+        ...
 
     def lock(self):
         """Locks the updates to a listbox, so a number of operations can be performed
         NOTE: an unlock() call must be made before the next lock() can be.
         """
-        pass
+        ...
 
     def refresh(self):
         """Refresh the display of the listbox (after updating contents)."""
-        pass
+        ...
 
     def removeElement(self, index):
         """Removes element at 'index' in the listbox."""
-        pass
+        ...
 
     def removeSelection(self, item):
         """Removes item from selection list"""
-        pass
+        ...
 
     def scrollToBegin(self):
         """Scrolls the listbox to the beginning of the list"""
-        pass
+        ...
 
     def scrollToEnd(self):
         """Scrolls the listbox to the end of the list"""
-        pass
+        ...
 
     def setElement(self, index, text):
         """Set a particular item in the listbox to a string."""
-        pass
+        ...
 
     def setGlobalSwatchEdgeOffset(self, offset):
         """Sets the edge offset of the color swatches"""
-        pass
+        ...
 
     def setGlobalSwatchSize(self, size):
         """Sets the size of the color swatches"""
-        pass
+        ...
 
     def setScrollPos(self, pos):
         """Sets the scroll position of the listbox to 'pos'"""
-        pass
+        ...
 
     def setSelection(self, selectionIndex):
         """Sets the current selection in the listbox."""
-        pass
+        ...
 
     def setStringJustify(self, index, justify):
         """Sets the text justification"""
-        pass
+        ...
 
     def unclickable(self):
         """Makes this listbox not clickable by the user.
         Useful when just displaying a list that is not really selectable.
         """
-        pass
+        ...
 
     def unlock(self):
         """Unlocks updates to a listbox and does any saved up changes"""
-        pass
+        ...
 
 class ptGUIControlMultiLineEdit(ptGUIControl):
     """Plasma GUI Control Multi-line edit class"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def beginUpdate(self):
         """Signifies that the control will be updated heavily starting now, so suppress all redraws"""
-        pass
+        ...
 
     def clearBuffer(self):
         """Clears all text from the multi-line edit control."""
-        pass
+        ...
 
     def clearLink(self) -> None:
         """Ends the hyperlink hotspot, if any, at the current cursor position."""
-        pass
+        ...
 
     def clickable(self):
         """Sets this listbox to be clickable by the user."""
-        pass
+        ...
 
     def deleteChar(self):
         """Deletes a character at the current cursor position."""
-        pass
+        ...
 
     def deleteLinesFromTop(self, numLines):
         """Deletes the specified number of lines from the top of the text buffer"""
-        pass
+        ...
 
     def disableScrollControl(self):
         """Disables the scroll control if there is one"""
-        pass
+        ...
 
     def enableScrollControl(self):
         """Enables the scroll control if there is one"""
-        pass
+        ...
 
     def endUpdate(self, redraw=True):
         """Signifies that the massive updates are over. We can now redraw."""
-        pass
+        ...
 
     def getBufferLimit(self):
         """Returns the current buffer limit"""
-        pass
+        ...
 
     def getBufferSize(self):
         """Returns the size of the buffer"""
-        pass
+        ...
 
     def getCurrentLink(self) -> int:
         """Returns the link the mouse is currently over."""
-        pass
+        ...
 
     def getCursor(self) -> int:
         """Get the current position of the cursor in the encoded buffer."""
-        pass
+        ...
 
     def getEncodedBuffer(self):
         """Returns the encoded buffer in a python buffer object."""
-        pass
+        ...
 
     def getFontSize(self):
         """Returns the current default font size"""
-        pass
+        ...
 
     def getMargins(self) -> Tuple[int, int, int, int]:
         """Returns a tuple of (top, left, bottom, right) margins"""
-        pass
+        ...
 
     def getScrollPosition(self):
         """Returns what line is the top line."""
-        pass
+        ...
 
     def getString(self):
         """Gets the string of the edit control."""
-        pass
+        ...
 
     def insertChar(self, c):
         """Inserts a character at the current cursor position."""
-        pass
+        ...
 
     def insertColor(self, color):
         """Inserts an encoded color object at the current cursor position.
         'color' is a ptColor object.
         """
-        pass
+        ...
 
     def insertLink(self, linkId: int) -> None:
         """Inserts a link hotspot at the current cursor position."""
-        pass
+        ...
 
     def insertString(self, string):
         """Inserts a string at the current cursor position."""
-        pass
+        ...
 
     def insertStyle(self, style):
         """Inserts an encoded font style at the current cursor position."""
-        pass
+        ...
 
     def isAtEnd(self):
         """Returns true if the end of the buffer has been reached."""
-        pass
+        ...
 
     def isLocked(self):
         """Is the multi-line edit control locked? Returns 1 if true otherwise returns 0"""
-        pass
+        ...
 
     def isUpdating(self) -> bool:
         """Is someone else already suppressing redraws of the control?"""
-        pass
+        ...
 
     def lock(self):
         """Locks the multi-line edit control so the user cannot make changes."""
-        pass
+        ...
 
     def moveCursor(self, direction):
         """Move the cursor in the specified direction (see PtGUIMultiLineDirection)"""
-        pass
+        ...
 
     def setBufferLimit(self, bufferLimit):
         """Sets the buffer max for the editbox"""
-        pass
+        ...
 
     def setEncodedBuffer(self, bufferObject):
         """Sets the edit control to the encoded buffer in the python buffer object."""
-        pass
+        ...
 
     def setFontSize(self, fontSize):
         """Sets the default font size for the edit control"""
-        pass
+        ...
 
     def setMargins(self, top: Optional[int] = None, left: Optional[int] = None, bottom: Optional[int] = None, right: Optional[int] = None) -> None:
         """Sets the control's margins"""
-        pass
+        ...
 
     def setScrollPosition(self, topLine):
         """Sets the what line is the top line."""
-        pass
+        ...
 
     def setString(self, text):
         """Sets the multi-line edit control string."""
-        pass
+        ...
 
     def unclickable(self):
         """Makes this listbox not clickable by the user.
         Useful when just displaying a list that is not really selectable.
         """
-        pass
+        ...
 
     def unlock(self):
         """Unlocks the multi-line edit control so that the user can make changes."""
-        pass
+        ...
 
 class ptGUIControlProgress(ptGUIControlValue):
     """Plasma GUI control for progress bar"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def animateToPercent(self, percent):
         """Sets the value of the control and animates to that point."""
-        pass
+        ...
 
 class ptGUIControlRadioGroup(ptGUIControl):
     """Plasma GUI Control Radio Group class"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def getValue(self):
         """Returns the current selection of the radio group."""
-        pass
+        ...
 
     def setValue(self, value):
         """Sets the current selection to 'value'"""
-        pass
+        ...
 
 class ptGUIControlTextBox(ptGUIControl):
     """Plasma GUI Control Textbox class"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
     def getForeColor(self):
         """Returns the current forecolor"""
-        pass
+        ...
 
     def getString(self):
         """Returns the string that the TextBox is set to (in case you forgot)"""
-        pass
+        ...
 
     def getStringJustify(self):
         """Returns current justify"""
-        pass
+        ...
 
     def setBackColor(self, color):
         """Sets the text backcolor to 'color', which is a ptColor object."""
-        pass
+        ...
 
     def setFontSize(self, size):
         """Don't use"""
-        pass
+        ...
 
     def setForeColor(self, color):
         """Sets the text forecolor to 'color', which is a ptColor object."""
-        pass
+        ...
 
     def setString(self, text):
         """Sets the textbox string to 'text'"""
-        pass
+        ...
 
     def setStringJustify(self, justify):
         """Sets current justify"""
-        pass
+        ...
 
 class ptGUIControlUpDownPair(ptGUIControlValue):
     """Plasma GUI control for up/down pair"""
 
     def __init__(self, ctrlKey):
-        pass
+        ...
 
 class ptGUIDialog:
     """Plasma GUI dialog class"""
 
     def __init__(self, dialogKey):
-        pass
+        ...
 
     def disable(self):
         """Disables this dialog"""
-        pass
+        ...
 
     def enable(self, enableFlag=1):
         """Enable this dialog"""
-        pass
+        ...
 
     def getBackColor(self):
         """Returns the back color as a ptColor object"""
-        pass
+        ...
 
     def getBackSelectColor(self):
         """Returns the select back color as a ptColor object"""
-        pass
+        ...
 
     def getControlFromIndex(self, index):
         """Returns the ptKey of the control with the specified index (not tag ID!)"""
-        pass
+        ...
 
     def getControlFromTag(self, tagID):
         """Returns the ptKey of the control with the specified tag ID"""
-        pass
+        ...
 
     def getControlModFromIndex(self, index: int) -> ptGUIControl:
         """Returns the ptGUIControl with the specified index (not tag ID!)"""
-        pass
+        ...
 
     def getControlModFromTag(self, tagID: int) -> ptGUIControl:
         """Returns the ptGUIControl with the specified tag ID"""
-        pass
+        ...
 
     def getFontSize(self):
         """Returns the font size"""
-        pass
+        ...
 
     def getForeColor(self):
         """Returns the fore color as a ptColor object"""
-        pass
+        ...
 
     def getKey(self):
         """Returns this dialog's ptKey"""
-        pass
+        ...
 
     def getName(self):
         """Returns the dialog's name"""
-        pass
+        ...
 
     def getNumControls(self):
         """Returns the number of controls in this dialog"""
-        pass
+        ...
 
     def getSelectColor(self):
         """Returns the select color as a ptColor object"""
-        pass
+        ...
 
     def getTagID(self):
         """Returns this dialog's tag ID"""
-        pass
+        ...
 
     def getVersion(self):
         """UNKNOWN"""
-        pass
+        ...
 
     def hide(self):
         """Hides the dialog"""
-        pass
+        ...
 
     def isEnabled(self):
         """Is this dialog currently enabled?"""
-        pass
+        ...
 
     def noFocus(self):
         """Makes sure no control has input focus"""
-        pass
+        ...
 
     def refreshAllControls(self):
         """Tells the dialog to redraw all its controls"""
-        pass
+        ...
 
     def setBackColor(self, red, green, blue, alpha):
         """Sets the back color, -1 means don't change"""
-        pass
+        ...
 
     def setBackSelectColor(self, red, green, blue, alpha):
         """Sets the select back color, -1 means don't change"""
-        pass
+        ...
 
     def setFocus(self, ctrlKey):
         """Sets the control that has input focus"""
-        pass
+        ...
 
     def setFontSize(self, fontSize):
         """Sets the font size"""
-        pass
+        ...
 
     def setForeColor(self, red, green, blue, alpha):
         """Sets the fore color, -1 means don't change"""
-        pass
+        ...
 
     def setSelectColor(self, red, green, blue, alpha):
         """Sets the select color, -1 means don't change"""
-        pass
+        ...
 
     def show(self):
         """Shows the dialog"""
-        pass
+        ...
 
     def showNoReset(self):
         """Show dialog without resetting clickables"""
-        pass
+        ...
 
     def updateAllBounds(self):
         """Tells the dialog to recompute all the bounds for its controls"""
-        pass
+        ...
 
 class ptGUIPopUpMenu:
     """Takes three diferent argument lists:
@@ -3199,184 +3199,184 @@ class ptGUIPopUpMenu:
     """
 
     def __init__(self, arg1, arg2=None, arg3=None, arg4=None):
-        pass
+        ...
 
     def addConsoleCmdItem(self, name, consoleCmd):
         """Adds a new item to the menu that fires a console command"""
-        pass
+        ...
 
     def addNotifyItem(self, name):
         """Adds a new item ot the mneu"""
-        pass
+        ...
 
     def addSubMenuItem(self, name, subMenu):
         """Adds a submenu to this menu"""
-        pass
+        ...
 
     def disable(self):
         """Disables this menu"""
-        pass
+        ...
 
     def enable(self, state=1):
         """Enables/disables this menu"""
-        pass
+        ...
 
     def getBackColor(self):
         """Returns the background color"""
-        pass
+        ...
 
     def getBackSelectColor(self):
         """Returns the background selection color"""
-        pass
+        ...
 
     def getForeColor(self):
         """Returns the foreground color"""
-        pass
+        ...
 
     def getKey(self):
         """Returns this menu's key"""
-        pass
+        ...
 
     def getName(self):
         """Returns this menu's name"""
-        pass
+        ...
 
     def getSelectColor(self):
         """Returns the selection color"""
-        pass
+        ...
 
     def getTagID(self):
         """Returns this menu's tag id"""
-        pass
+        ...
 
     def getVersion(self):
         """UNKNOWN"""
-        pass
+        ...
 
     def hide(self):
         """Hides this menu"""
-        pass
+        ...
 
     def isEnabled(self):
         """Returns whether this menu is enabled or not"""
-        pass
+        ...
 
     def setBackColor(self, r, g, b, a):
         """Sets the background color"""
-        pass
+        ...
 
     def setBackSelectColor(self, r, g, b, a):
         """Sets the selection background color"""
-        pass
+        ...
 
     def setForeColor(self, r, g, b, a):
         """Sets the foreground color"""
-        pass
+        ...
 
     def setSelectColor(self, r, g, b, a):
         """Sets the selection color"""
-        pass
+        ...
 
     def show(self):
         """Shows this menu"""
-        pass
+        ...
 
 class ptGUISkin:
     """Plasma GUI Skin object"""
 
     def __init__(self, key):
-        pass
+        ...
 
     def getKey(self):
         """Returns this object's ptKey"""
-        pass
+        ...
 
 class ptGameScore:
     """Plasma Game Score"""
 
     def addPoints(self, points, key=None):
         """Adds points to the score"""
-        pass
+        ...
 
     @staticmethod
     def createAgeScore(scoreName, type, points=0, key=None):
         """Creates a new score associated with this age"""
-        pass
+        ...
 
     @staticmethod
     def createGlobalScore(scoreName, type, points=0, key=None):
         """Creates a new global score"""
-        pass
+        ...
 
     @staticmethod
     def createPlayerScore(scoreName, type, points=0, key=None):
         """Creates a new score associated with this player"""
-        pass
+        ...
 
     @staticmethod
     def createScore(ownerID, scoreName, type, points=0, key=None):
         """Creates a new score for an arbitrary owner"""
-        pass
+        ...
 
     @staticmethod
     def findAgeHighScores(name, maxScores, key):
         """Finds the highest matching scores for the current age's owners"""
-        pass
+        ...
 
     @staticmethod
     def findAgeScores(scoreName, key):
         """Finds matching scores for this age"""
-        pass
+        ...
 
     @staticmethod
     def findGlobalHighScores(name, maxScores, key):
         """Finds the highest matching scores"""
-        pass
+        ...
 
     @staticmethod
     def findGlobalScores(scoreName, key):
         """Finds matching global scores"""
-        pass
+        ...
 
     @staticmethod
     def findPlayerScores(scoreName, key):
         """Finds matching player scores"""
-        pass
+        ...
 
     @staticmethod
     def findScores(ownerID, scoreName, key):
         """Finds matching scores for an arbitrary owner"""
-        pass
+        ...
 
     def getGameType(self):
         """Returns the score game type."""
-        pass
+        ...
 
     def getName(self):
         """Returns the score game name."""
-        pass
+        ...
 
     def getOwnerID(self):
         """Returns the score owner."""
-        pass
+        ...
 
     def getPoints(self):
         """Returns the number of points in this score"""
-        pass
+        ...
 
     def remove(self):
         """Removes this score from the server"""
-        pass
+        ...
 
     def setPoints(self, numPoints, key):
         """Sets the number of points in the score
         Don't use to add/remove points, use only to reset values!
         """
-        pass
+        ...
 
     def transferPoints(self, dest, points=0, key=None):
         """Transfers points from this score to another"""
-        pass
+        ...
 
 class ptGameScoreMsg:
     """Game Score operation callback message"""
@@ -3386,472 +3386,472 @@ class ptGameScoreListMsg(ptGameScoreMsg):
 
     def getName(self):
         """Returns the template score name"""
-        pass
+        ...
 
     def getOwnerID(self):
         """Returns the template score ownerID"""
-        pass
+        ...
 
     def getScores(self):
         """Returns a list of scores found by the server"""
-        pass
+        ...
 
 class ptGameScoreTransferMsg(ptGameScoreMsg):
     """Game Score message indicating a score point transfer"""
 
     def getDestination(self):
         """Returns the score points were transferred to"""
-        pass
+        ...
 
     def getSource(self):
         """Returns the score points were transferred from"""
-        pass
+        ...
 
 class ptGameScoreUpdateMsg(ptGameScoreMsg):
     """Game Score message for a score update operation"""
 
     def getScore(self):
         """Returns the updated game score"""
-        pass
+        ...
 
 class ptGrassShader:
     """Plasma Grass Shader class"""
 
     def __init__(self, key):
-        pass
+        ...
 
     def getWaveDirection(self, waveNum):
         """Gets the wave waveNum's direction as a tuple of x,y. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
-        pass
+        ...
 
     def getWaveDistortion(self, waveNum):
         """Gets the wave waveNum's distortion as a tuple of x,y,z. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
-        pass
+        ...
 
     def getWaveSpeed(self, waveNum):
         """Gets the wave waveNum's speed as a float. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
-        pass
+        ...
 
     def resetWaves(self):
         """Resets wave data to 0"""
-        pass
+        ...
 
     def setWaveDirection(self, waveNum, direction):
         """Sets the wave waveNum's direction as a tuple of x,y. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
-        pass
+        ...
 
     def setWaveDistortion(self, waveNum, distortion):
         """Sets the wave waveNum's distortion as a tuple of x,y,z. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
-        pass
+        ...
 
     def setWaveSpeed(self, waveNum, speed):
         """Sets the wave waveNum's speed as a float. waveNum must be between 0 and plGrassShaderMod::kNumWaves-1 (currently 3) inclusive"""
-        pass
+        ...
 
 class ptImage:
     """Plasma image class"""
 
     def __init__(self, imgKey):
-        pass
+        ...
 
     def getColorLoc(self, color):
         """Returns the ptPoint3 where the specified color is located"""
-        pass
+        ...
 
     def getHeight(self):
         """Returns the height of the image"""
-        pass
+        ...
 
     def getPixelColor(self, x, y):
         """Returns the ptColor at the specified location (float from 0 to 1)"""
-        pass
+        ...
 
     def getWidth(self):
         """Returns the width of the image"""
-        pass
+        ...
 
     def saveAsJPEG(self, filename, quality=75):
         """Saves this image to disk as a JPEG file"""
-        pass
+        ...
 
     def saveAsPNG(self, filename):
         """Saves this image to disk as a PNG file"""
-        pass
+        ...
 
 class ptImageLibMod:
     """Plasma image library modifier class"""
 
     def __init__(self, ilmKey):
-        pass
+        ...
 
     def getImage(self, name):
         """Returns the ptImage with the specified name"""
-        pass
+        ...
 
     def getImages(self):
         """Returns a tuple of the library's ptImages"""
-        pass
+        ...
 
     def getNames(self):
         """Returns a tuple of the image names"""
-        pass
+        ...
 
 class ptInputInterface:
     """Plasma input interface class"""
 
     def popTelescope(self):
         """pops off the telescope interface and gos back to previous interface"""
-        pass
+        ...
 
     def pushTelescope(self):
         """pushes on the telescope interface"""
-        pass
+        ...
 
 class ptKey:
     """Plasma Key class"""
 
     def disable(self):
         """Sends a disable message to whatever this ptKey is pointing to"""
-        pass
+        ...
 
     def enable(self):
         """Sends an enable message to whatever this ptKey is pointing to"""
-        pass
+        ...
 
     def getName(self):
         """Get the name of the object that this ptKey is pointing to"""
-        pass
+        ...
 
     def getParentKey(self):
         """This will return a ptKey object that is the parent of this modifer
         However, if the parent is not a modifier or not loaded, then None is returned.
         """
-        pass
+        ...
 
     def getSceneObject(self):
         """This will return a ptSceneobject object that is associated with this ptKey
         However, if this ptKey is _not_ a sceneobject, then unpredicatable results will ensue
         """
-        pass
+        ...
 
     def isAttachedToClone(self):
         """Returns whether the python file mod is attached to a clone"""
-        pass
+        ...
 
     def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
-        pass
+        ...
 
 class ptKeyMap:
     """Accessor class to the Key Mapping functions"""
 
     def bindKey(self, key1, key2, action):
         """Bind keys to an action"""
-        pass
+        ...
 
     def bindKeyToConsoleCommand(self, keyStr1, command):
         """Binds key to console command"""
-        pass
+        ...
 
     def convertCharToControlCode(self, controlCodeString):
         """Convert string version of control code to number"""
-        pass
+        ...
 
     def convertCharToFlags(self, charString):
         """Convert char string to flags"""
-        pass
+        ...
 
     def convertCharToVKey(self, charString):
         """Convert char string to virtual key"""
-        pass
+        ...
 
     def convertControlCodeToString(self, controlCode):
         """Convert control code to character string"""
-        pass
+        ...
 
     def convertVKeyToChar(self, virtualKey, flags):
         """Convert virtual key and shift flags to string"""
-        pass
+        ...
 
     def getBindingFlags1(self, controlCode):
         """Returns modifier flags for controlCode"""
-        pass
+        ...
 
     def getBindingFlags2(self, controlCode):
         """Returns modifier flags for controlCode"""
-        pass
+        ...
 
     def getBindingFlagsConsole(self, command):
         """Returns modifier flags for the console command mapping"""
-        pass
+        ...
 
     def getBindingKey1(self, controlCode):
         """Returns key code for controlCode"""
-        pass
+        ...
 
     def getBindingKey2(self, controlCode):
         """Returns key code for controlCode"""
-        pass
+        ...
 
     def getBindingKeyConsole(self, command):
         """Returns key for console command mapping"""
-        pass
+        ...
 
     def writeKeyMap(self):
         """Forces write of the keymap file"""
-        pass
+        ...
 
 class ptLayer:
     """Plasma layer class"""
 
     def __init__(self, layerKey):
-        pass
+        ...
 
     def getTexture(self) -> ptImage:
         """Returns the image texture of the layer"""
-        pass
+        ...
 
     def setTexture(self, image: ptImage) -> None:
         """Sets the ptImage texture of the layer"""
-        pass
+        ...
 
 class ptMarkerMgr:
     """Marker manager accessor class"""
 
     def addMarker(self, x, y, z, id, justCreated):
         """Add a marker in the specified location with the specified id"""
-        pass
+        ...
 
     def areLocalMarkersShowing(self):
         """Returns true if we are showing the markers on this local machine"""
-        pass
+        ...
 
     def captureQuestMarker(self, id, captured):
         """Sets a marker as captured or not"""
-        pass
+        ...
 
     def captureTeamMarker(self, id, team):
         """Sets a marker as captured by the specified team (0 = not captured)"""
-        pass
+        ...
 
     def clearSelectedMarker(self):
         """Unselects the selected marker"""
-        pass
+        ...
 
     def getMarkersRespawn(self):
         """Returns whether markers respawn after being captured, or not"""
-        pass
+        ...
 
     def getSelectedMarker(self):
         """Returns the id of the selected marker"""
-        pass
+        ...
 
     def hideMarkersLocal(self):
         """Hides the markers on your machine, so you can no longer see where they are"""
-        pass
+        ...
 
     def removeAllMarkers(self):
         """Removes all markers"""
-        pass
+        ...
 
     def removeMarker(self, id):
         """Removes the specified marker from the game"""
-        pass
+        ...
 
     def setMarkersRespawn(self, respawn):
         """Sets whether markers respawn after being captured, or not"""
-        pass
+        ...
 
     def setSelectedMarker(self, id):
         """Sets the selected marker to the one with the specified id"""
-        pass
+        ...
 
     def showMarkersLocal(self):
         """Shows the markers on your machine, so you can see where they are"""
-        pass
+        ...
 
 class ptMatrix44:
     """Plasma Matrix44 class"""
 
     def copy(self):
         """Copies the matrix and returns the copy"""
-        pass
+        ...
 
     def getAdjoint(self, adjointMat):
         """Returns the adjoint of the matrix"""
-        pass
+        ...
 
     def getData(self):
         """Returns the matrix in tuple form"""
-        pass
+        ...
 
     def getDeterminant(self):
         """Get the matrix's determinant"""
-        pass
+        ...
 
     def getInverse(self, inverseMat):
         """Returns the inverse of the matrix"""
-        pass
+        ...
 
     def getParity(self):
         """Get the parity of the matrix"""
-        pass
+        ...
 
     def getTranslate(self, vector):
         """Returns the translate vector of the matrix (and sets vector to it as well)"""
-        pass
+        ...
 
     def getTranspose(self, transposeMat):
         """Returns the transpose of the matrix"""
-        pass
+        ...
 
     def make(self, fromPt, atPt, upVec):
         """Creates the matrix from from and at points, and the up vector"""
-        pass
+        ...
 
     def makeRotateMat(self, axis, radians):
         """Makes the matrix a rotation matrix"""
-        pass
+        ...
 
     def makeScaleMat(self, scale):
         """Makes the matrix a scaling matrix"""
-        pass
+        ...
 
     def makeTranslateMat(self, trans):
         """Makes the matrix a translation matrix"""
-        pass
+        ...
 
     def makeUpPreserving(self, fromPt, atPt, upVec):
         """Creates the matrix from from and at points, and the up vector (perserving the up vector)"""
-        pass
+        ...
 
     def reset(self):
         """Reset the matrix to identity"""
-        pass
+        ...
 
     def right(self):
         """Returns the right vector of the matrix"""
-        pass
+        ...
 
     def rotate(self, axis, radians):
         """Rotates the matrix by radians around the axis"""
-        pass
+        ...
 
     def scale(self, scale):
         """Scales the matrix by the vector"""
-        pass
+        ...
 
     def setData(self, mat):
         """Sets the matrix using tuples"""
-        pass
+        ...
 
     def translate(self, vector):
         """Translates the matrix by the vector"""
-        pass
+        ...
 
     def up(self):
         """Returns the up vector of the matrix"""
-        pass
+        ...
 
     def view(self):
         """Returns the view vector of the matrix"""
-        pass
+        ...
 
 class ptMoviePlayer:
     """Accessor class to play in the MoviePlayer"""
 
     def __init__(self, movieName, selfKey):
-        pass
+        ...
 
     def pause(self):
         """Pauses the movie"""
-        pass
+        ...
 
     def play(self):
         """Plays the movie"""
-        pass
+        ...
 
     def playPaused(self):
         """Plays movie, but pauses at first frame"""
-        pass
+        ...
 
     def resume(self):
         """Resumes movie after pausing"""
-        pass
+        ...
 
     def setCenter(self, x, y):
         """Sets the center of the movie"""
-        pass
+        ...
 
     def setColor(self, color):
         """Sets the color of the movie"""
-        pass
+        ...
 
     def setOpacity(self, opacity):
         """Sets the opacity of the movie"""
-        pass
+        ...
 
     def setScale(self, width, height):
         """Sets the width and height scale of the movie"""
-        pass
+        ...
 
     def setVolume(self, volume):
         """Set the volume of the movie"""
-        pass
+        ...
 
     def stop(self):
         """Stops the movie"""
-        pass
+        ...
 
 class ptNetLinkingMgr:
     """Constructor to get access to the net link manager"""
 
     def getCurrAgeLink(self):
         """Get the ptAgeLinkStruct for the current age"""
-        pass
+        ...
 
     def getPrevAgeLink(self):
         """Get the ptAgeLinkStruct for the previous age"""
-        pass
+        ...
 
     def isEnabled(self):
         """True if linking is enabled."""
-        pass
+        ...
 
     def linkPlayerHere(self, pid):
         """link player(pid) to where I am"""
-        pass
+        ...
 
     def linkPlayerToAge(self, ageLink, pid):
         """Link player(pid) to ageLink"""
-        pass
+        ...
 
     def linkToAge(self, ageLink, linkAnim):
         """Links to ageLink (ptAgeLinkStruct, string)"""
-        pass
+        ...
 
     def linkToMyNeighborhoodAge(self):
         """Link to my Neighborhood Age"""
-        pass
+        ...
 
     def linkToMyPersonalAge(self):
         """Link to my Personal Age"""
-        pass
+        ...
 
     def linkToMyPersonalAgeWithYeeshaBook(self):
         """Link to my Personal Age with the YeeshaBook"""
-        pass
+        ...
 
     def linkToPlayersAge(self, pid):
         """Link me to where player(pid) is"""
-        pass
+        ...
 
     def setEnabled(self, enable):
         """Enable/Disable linking."""
-        pass
+        ...
 
 class ptNotify:
     """Creates a Notify message
@@ -3859,103 +3859,103 @@ class ptNotify:
     """
 
     def __init__(self, selfKey):
-        pass
+        ...
 
     def addActivateEvent(self, activeFlag, activateFlag):
         """Add an activate event record to the notify message"""
-        pass
+        ...
 
     def addCallbackEvent(self, eventNumber):
         """Add a callback event record to the notify message"""
-        pass
+        ...
 
     def addCollisionEvent(self, enterFlag, hitterKey, hitteeKey):
         """Add a collision event record to the Notify message"""
-        pass
+        ...
 
     def addContainerEvent(self, enteringFlag, containerKey, containedKey):
         """Add a container event record to the notify message"""
-        pass
+        ...
 
     def addControlKeyEvent(self, keynumber, downFlag):
         """Add a keyboard event record to the Notify message"""
-        pass
+        ...
 
     def addFacingEvent(self, enabledFlag, facerKey, faceeKey, dotProduct):
         """Add a facing event record to the Notify message"""
-        pass
+        ...
 
     def addPickEvent(self, enabledFlag, pickerKey, pickeeKey, hitPoint):
         """Add a pick event record to the Notify message"""
-        pass
+        ...
 
     def addReceiver(self, key):
         """Add a receivers key to receive this Notify message"""
-        pass
+        ...
 
     def addResponderState(self, state):
         """Add a responder state event record to the notify message"""
-        pass
+        ...
 
     def addVarFloat(self, name, number):
         """Add a float variable event record to the Notify message
         This event record is used to pass a number variable to another python program
         """
-        pass
+        ...
 
     def addVarInt(self, name, number):
         """Add a int variable event record to the Notify message
         This event record is used to pass a number variable to another python program
         """
-        pass
+        ...
 
     def addVarKey(self, name, key):
         """Add a ptKey variable event record to the Notify message
         This event record is used to pass a ptKey variable to another python program
         """
-        pass
+        ...
 
     def addVarNull(self, name, number):
         """Add a null (no data) variable event record to the Notify message
         This event record is used to pass a number variable to another python program
         """
-        pass
+        ...
 
     def addVarNumber(self, name, number):
         """Add a number variable event record to the Notify message
         Method will try to pick appropriate variable type
         This event record is used to pass a number variable to another python program
         """
-        pass
+        ...
 
     def clearReceivers(self):
         """Remove all the receivers that this Notify message has
         - receivers are automatically added if from a ptAttribActivator
         """
-        pass
+        ...
 
     def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
-        pass
+        ...
 
     def netPropagate(self, netFlag):
         """Sets the net propagate flag - default to set"""
-        pass
+        ...
 
     def send(self):
         """Send the notify message"""
-        pass
+        ...
 
     def setActivate(self, state):
         """Set the activate state to true(1.0) or false(0.0)"""
-        pass
+        ...
 
     def setType(self, type):
         """Sets the message type"""
-        pass
+        ...
 
 class ptParticle:
     """Plasma particle system class"""
@@ -3965,55 +3965,55 @@ class ptParticle:
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
-        pass
+        ...
 
     def setGeneratorLife(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setHeightSize(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setInitPitchRange(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setInitYawRange(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setParticleLifeMaximum(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setParticleLifeMinimum(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setParticlesPerSecond(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setScaleMaximum(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setScaleMinimum(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setVelocityMaximum(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setVelocityMinimum(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
     def setWidthSize(self, value):
         """NEEDS DOCSTRING"""
-        pass
+        ...
 
 class ptPhysics:
     """Plasma physics class"""
@@ -4022,166 +4022,166 @@ class ptPhysics:
         """Add the given vector (representing a rotation axis and magnitude) to
         the attached sceneobject's velocity
         """
-        pass
+        ...
 
     def damp(self, damp):
         """Reduce all velocities on the object (0 = all stop, 1 = no effect)"""
-        pass
+        ...
 
     def disable(self):
         """Disables physics on the sceneobject attached"""
-        pass
+        ...
 
     def disableCollision(self):
         """Disables collision detection on the attached sceneobject"""
-        pass
+        ...
 
     def enable(self, state=1):
         """Sets the physics enable state for the sceneobject attached"""
-        pass
+        ...
 
     def enableCollision(self):
         """Enables collision detection on the attached sceneobject"""
-        pass
+        ...
 
     def force(self, forceVector):
         """Applies the specified force to the attached sceneobject"""
-        pass
+        ...
 
     def forceWithOffset(self, forceVector, offsetPt):
         """Applies the specified offsetted force to the attached sceneobject"""
-        pass
+        ...
 
     def impulse(self, impulseVector):
         """Adds the given vector to the attached sceneobject's velocity"""
-        pass
+        ...
 
     def impulseWithOffset(self, impulseVector, offsetPt):
         """Adds the given vector to the attached sceneobject's velocity
         with the specified offset
         """
-        pass
+        ...
 
     def move(self, direction, distance):
         """Moves the attached sceneobject the specified distance in the specified direction"""
-        pass
+        ...
 
     def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         """
-        pass
+        ...
 
     def rotate(self, radians, axis):
         """Rotates the attached sceneobject the specified radians around the specified axis"""
-        pass
+        ...
 
     def setAngularVelocity(self, velocityVector):
         """Sets the objects AngularVelocity to the specified vector"""
-        pass
+        ...
 
     def setLinearVelocity(self, velocityVector):
         """Sets the objects LinearVelocity to the specified vector"""
-        pass
+        ...
 
     def shiftMass(self, offsetVector):
         """Shifts the attached sceneobject's center to mass in the specified direction and distance"""
-        pass
+        ...
 
     def suppress(self, doSuppress):
         """Completely remove the physical, but keep it around so it
         can be added back later.
         """
-        pass
+        ...
 
     def torque(self, torqueVector):
         """Applies the specified torque to the attached sceneobject"""
-        pass
+        ...
 
     def warp(self, position):
         """Warps the sceneobject to a specified location.
         'position' can be a ptPoint3 or a ptMatrix44
         """
-        pass
+        ...
 
     def warpObj(self, objkey):
         """Warps the sceneobject to match the location and orientation of the specified object"""
-        pass
+        ...
 
 class ptPlayer:
     """And optionally __init__(name,playerID)"""
 
     def __init__(self, avkey, name, playerID, distanceSq):
-        pass
+        ...
 
     def getDistanceSq(self):
         """Returns the distance to remote player from local player"""
-        pass
+        ...
 
     def getPlayerID(self):
         """Returns the unique player ID"""
-        pass
+        ...
 
     def getPlayerName(self):
         """Returns the name of the player"""
-        pass
+        ...
 
     def isCCR(self):
         """Is this player a CCR?"""
-        pass
+        ...
 
     def isServer(self):
         """Is this player a server?"""
-        pass
+        ...
 
 class ptPoint3:
     """Plasma Point class"""
 
     def __init__(self, x=0, y=0, z=0):
-        pass
+        ...
 
     def copy(self):
         """Returns a copy of the point in another ptPoint3 object"""
-        pass
+        ...
 
     def distance(self, other):
         """Computes the distance from this point to 'other' point"""
-        pass
+        ...
 
     def distanceSq(self, other):
         """Computes the distance squared from this point to 'other' point
         - this function is faster than distance(other)
         """
-        pass
+        ...
 
     def getX(self):
         """Returns the 'x' component of the point"""
-        pass
+        ...
 
     def getY(self):
         """Returns the 'y' component of the point"""
-        pass
+        ...
 
     def getZ(self):
         """Returns the 'z' component of the point"""
-        pass
+        ...
 
     def setX(self, x):
         """Sets the 'x' component of the point"""
-        pass
+        ...
 
     def setY(self, y):
         """Sets the 'y' component of the point"""
-        pass
+        ...
 
     def setZ(self, z):
         """Sets the 'z' component of the point"""
-        pass
+        ...
 
     def zero(self):
         """Sets the 'x','y' and the 'z' component to zero"""
-        pass
+        ...
 
 class ptSDL:
     """SDL accessor"""
@@ -4191,57 +4191,57 @@ class ptSDL:
         server AND the clients. (Normally it just goes
         to the server.)
         """
-        pass
+        ...
 
     def setDefault(self, key, value):
         """Like setitem, but doesn't broadcast over the net.
         Only use for setting defaults that everyone will
         already know (from reading it off disk)
         """
-        pass
+        ...
 
     def setFlags(self, name, sendImmediate, skipOwnershipCheck):
         """Sets the flags for a variable in this SDL"""
-        pass
+        ...
 
     def setIndex(self, key, idx, value):
         """Sets the value at a specific index in the tuple,
         so you don't have to pass the whole thing in
         """
-        pass
+        ...
 
     def setIndexNow(self, key, idx, value):
         """Same as setIndex but sends immediately"""
-        pass
+        ...
 
     def setNotify(self, selfkey, key, tolerance):
         """Sets the OnSDLNotify to be called when 'key'
         SDL variable changes by 'tolerance' (if number)
         """
-        pass
+        ...
 
     def setTagString(self, name, tag):
         """Sets the tag string for a variable"""
-        pass
+        ...
 
 class ptSDLStateDataRecord:
     """Basic SDL state data record class"""
 
     def findVar(self, name):
         """Finds and returns the specified ptSimpleStateVariable"""
-        pass
+        ...
 
     def getName(self):
         """Returns our record's name"""
-        pass
+        ...
 
     def getVarList(self):
         """Returns the names of the vars we hold as a list of strings"""
-        pass
+        ...
 
     def setFromDefaults(self, timeStampNow):
         """Sets all our vars to their defaults"""
-        pass
+        ...
 
 class ptSceneobject:
     """Plasma Sceneobject class"""
@@ -4255,99 +4255,99 @@ class ptSceneobject:
     physics: Any
 
     def __init__(self, objKey, selfKey):
-        pass
+        ...
 
     def addKey(self, key):
         """Mostly used internally.
         Add another sceneobject ptKey
         """
-        pass
+        ...
 
     def animate(self):
         """If we can animate, start animating"""
-        pass
+        ...
 
     def avatarVelocity(self):
         """Returns the velocity of the first attached avatar scene object"""
-        pass
+        ...
 
     def fastForwardAttachedResponder(self, state):
         """Fast forward the attached responder to the specified state"""
-        pass
+        ...
 
     def findObject(self, name):
         """Find a particular object in just the sceneobjects that are attached"""
-        pass
+        ...
 
     def getImageLibMods(self):
         """Returns list of ptKeys of the image library modifiers attached to this sceneobject"""
-        pass
+        ...
 
     def getKey(self):
         """Get the ptKey of this sceneobject
         If there are more then one attached, get the first one
         """
-        pass
+        ...
 
     def getLocalToParent(self):
         """Returns ptMatrix44 of the local to parent transform for this sceneobject
         - If there is more than one sceneobject attached, returns just the first one
         """
-        pass
+        ...
 
     def getLocalToWorld(self):
         """Returns ptMatrix44 of the local to world transform for this sceneobject
         - If there is more than one sceneobject attached, returns just the first one
         """
-        pass
+        ...
 
     def getName(self):
         """Returns the name of the sceneobject (Max name)
         - If there are more than one sceneobject attached, return just the first one
         """
-        pass
+        ...
 
     def getParentToLocal(self):
         """Returns ptMatrix44 of the parent to local transform for this sceneobject
         - If there is more than one sceneobject attached, returns just the first one
         """
-        pass
+        ...
 
     def getPythonMods(self):
         """Returns list of ptKeys of the python modifiers attached to this sceneobject"""
-        pass
+        ...
 
     def getResponderState(self):
         """Return the responder state (if we are a responder)"""
-        pass
+        ...
 
     def getResponders(self):
         """Returns list of ptKeys of the responders attached to this sceneobject"""
-        pass
+        ...
 
     def getSoundIndex(self, sndComponentName):
         """Get the index of the requested sound component"""
-        pass
+        ...
 
     def getWorldToLocal(self):
         """Returns ptMatrix44 of the world to local transform for this sceneobject
         - If there is more than one sceneobject attached, returns just the first one
         """
-        pass
+        ...
 
     def isAvatar(self):
         """Returns true if the scene object is an avatar"""
-        pass
+        ...
 
     def isHuman(self):
         """Returns true if the scene object is a human avatar"""
-        pass
+        ...
 
     def isLocallyOwned(self):
         """Returns true(1) if this object is locally owned by this client
         or returns false(0) if it is not or don't know
         """
-        pass
+        ...
 
     def netForce(self, forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
@@ -4356,230 +4356,230 @@ class ptSceneobject:
         - Setting the netForce flag on a sceneobject will also set the netForce flag on
         its draw, physics, avatar, particle objects
         """
-        pass
+        ...
 
     def playAnimNamed(self, animName):
         """Play the attached named animation"""
-        pass
+        ...
 
     def popCamera(self, avKey):
         """Pop the camera stack and go back to the previous camera"""
-        pass
+        ...
 
     def popCutsceneCamera(self, avKey):
         """Pop the camera stack and go back to previous camera."""
-        pass
+        ...
 
     def position(self):
         """Returns the scene object's current position"""
-        pass
+        ...
 
     def pushCamera(self, avKey):
         """Switch to this object (if it is a camera)"""
-        pass
+        ...
 
     def pushCameraCut(self, avKey):
         """Switch to this object, cutting the view (if it is a camera)"""
-        pass
+        ...
 
     def pushCutsceneCamera(self, cutFlag, avKey):
         """Switch to this object (assuming that it is actually a camera)"""
-        pass
+        ...
 
     def rewindAnimNamed(self, animName):
         """Rewind the attached named animation"""
-        pass
+        ...
 
     def right(self):
         """Returns the scene object's current right vector"""
-        pass
+        ...
 
     def runAttachedResponder(self, state):
         """Run the attached responder to the specified state"""
-        pass
+        ...
 
     def setSoundFilename(self, index, filename, isCompressed):
         """Sets the sound attached to this sceneobject to use the specified sound file."""
-        pass
+        ...
 
     def setTransform(self, local2world, world2local):
         """Set our current transforms"""
-        pass
+        ...
 
     def stopAnimNamed(self, animName):
         """Stop the attached named animation"""
-        pass
+        ...
 
     def up(self):
         """Returns the scene object's current up vector"""
-        pass
+        ...
 
     def view(self):
         """Returns the scene object's current view vector"""
-        pass
+        ...
 
     def volumeSensorIgnoreExtraEnters(self, ignore):
         """Tells the volume sensor attached to this object to ignore extra enters (default), or not (hack for garrison)."""
-        pass
+        ...
 
     def volumeSensorNoArbitration(self, noArbitration):
         """Tells the volume sensor attached to this object whether or not to negotiate exclusive locks with the server."""
-        pass
+        ...
 
 class ptSimpleStateVariable:
     """Basic SDL state data record class"""
 
     def getBool(self, idx=0):
         """Returns a boolean variable's value"""
-        pass
+        ...
 
     def getByte(self, idx=0):
         """Returns a byte variable's value"""
-        pass
+        ...
 
     def getDefault(self):
         """Returns the variable's default"""
-        pass
+        ...
 
     def getDisplayOptions(self):
         """Returns the variable's display options"""
-        pass
+        ...
 
     def getDouble(self, idx=0):
         """Returns a double variable's value"""
-        pass
+        ...
 
     def getFloat(self, idx=0):
         """Returns a float variable's value"""
-        pass
+        ...
 
     def getInt(self, idx=0):
         """Returns an int variable's value"""
-        pass
+        ...
 
     def getKey(self, idx=0):
         """Returns a plKey variable's value"""
-        pass
+        ...
 
     def getShort(self, idx=0):
         """Returns a short variable's value"""
-        pass
+        ...
 
     def getString(self, idx=0):
         """Returns a string variable's value"""
-        pass
+        ...
 
     def getType(self):
         """Returns the variable's type"""
-        pass
+        ...
 
     def isAlwaysNew(self):
         """Is this variable always new?"""
-        pass
+        ...
 
     def isInternal(self):
         """Is this an internal variable?"""
-        pass
+        ...
 
     def isUsed(self):
         """Is this variable used?"""
-        pass
+        ...
 
     def setBool(self, val, idx=0):
         """Sets a boolean variable's value"""
-        pass
+        ...
 
     def setByte(self, val, idx=0):
         """Sets a byte variable's value"""
-        pass
+        ...
 
     def setDouble(self, val, idx=0):
         """Sets a double variable's value"""
-        pass
+        ...
 
     def setFloat(self, val, idx=0):
         """Sets a float variable's value"""
-        pass
+        ...
 
     def setInt(self, val, idx=0):
         """Sets an int variable's value"""
-        pass
+        ...
 
     def setShort(self, val, idx=0):
         """Sets a short variable's value"""
-        pass
+        ...
 
     def setString(self, val, idx=0):
         """Sets a string variable's value"""
-        pass
+        ...
 
 class ptSpawnPointInfo:
     """Class to hold spawn point data"""
 
     def __init__(self, title=None, spawnPt=None):
-        pass
+        ...
 
     def getCameraStack(self):
         """Returns the camera stack for this spawnpoint as a string"""
-        pass
+        ...
 
     def getName(self):
         """Returns the spawnpoint's name"""
-        pass
+        ...
 
     def getTitle(self):
         """Returns the spawnpoint's title"""
-        pass
+        ...
 
     def setCameraStack(self, stack):
         """Sets the spawnpoint's camera stack (as a string)"""
-        pass
+        ...
 
     def setName(self, name):
         """Sets the spawnpoint's name"""
-        pass
+        ...
 
     def setTitle(self, title):
         """Sets the spawnpoint's title"""
-        pass
+        ...
 
 class ptSpawnPointInfoRef:
     """Class to hold spawn point data"""
 
     def getCameraStack(self):
         """Returns the camera stack for this spawnpoint as a string"""
-        pass
+        ...
 
     def getName(self):
         """Returns the spawnpoint's name"""
-        pass
+        ...
 
     def getTitle(self):
         """Returns the spawnpoint's title"""
-        pass
+        ...
 
     def setCameraStack(self, stack):
         """Sets the spawnpoint's camera stack (as a string)"""
-        pass
+        ...
 
     def setName(self, name):
         """Sets the spawnpoint's name"""
-        pass
+        ...
 
     def setTitle(self, title):
         """Sets the spawnpoint's title"""
-        pass
+        ...
 
 class ptStatusLog:
     """A status log class"""
 
     def close(self):
         """Close the status log file"""
-        pass
+        ...
 
     def isOpen(self):
         """Returns whether the status log is currently opened"""
-        pass
+        ...
 
     def open(self, logName, numLines, flags):
         """Open a status log for writing to
@@ -4587,36 +4587,36 @@ class ptStatusLog:
         'numLines' is the number of lines to display on debug screen
         'flags' is a PlasmaConstants.PtStatusLogFlags
         """
-        pass
+        ...
 
     def write(self, text, color=None):
         """If the status log is open, write 'text' to log
         'color' is the display color in debug screen
         """
-        pass
+        ...
 
 class ptStream:
     """A basic stream class"""
 
     def close(self):
         """Close the status log file"""
-        pass
+        ...
 
     def isOpen(self):
         """Returns whether the stream file is currently opened"""
-        pass
+        ...
 
     def open(self, fileName, flags):
         """Open a stream file for reading or writing"""
-        pass
+        ...
 
     def readlines(self):
         """Reads a list of strings from the file"""
-        pass
+        ...
 
     def writelines(self, lines):
         """Write a list of strings to the file"""
-        pass
+        ...
 
 class ptSwimCurrentInterface:
     """Creates a new ptSwimCurrentInterface"""
@@ -4637,792 +4637,792 @@ class ptSwimCurrentInterface:
     """UNKNOWN"""
 
     def __init__(self, key):
-        pass
+        ...
 
     def disable(self):
         """UNKNOWN"""
-        pass
+        ...
 
     def enable(self):
         """UNKNOWN"""
-        pass
+        ...
 
 class ptVault:
     """Accessor class to the player's vault"""
 
     def addChronicleEntry(self, entryName, type, string):
         """Adds an entry to the player's chronicle with a value of 'string'."""
-        pass
+        ...
 
     def amAgeCzar(self, ageInfo):
         """Are we the czar (WTH is this?) of the specified age?"""
-        pass
+        ...
 
     def amAgeOwner(self, ageInfo):
         """Are we the owner of the specified age?"""
-        pass
+        ...
 
     def amCzarOfCurrentAge(self):
         """Are we the czar (WTH is this?) of the current age?"""
-        pass
+        ...
 
     def amOwnerOfCurrentAge(self):
         """Are we the owner of the current age?"""
-        pass
+        ...
 
     def createNeighborhood(self):
         """Creates a new neighborhood"""
-        pass
+        ...
 
     def findChronicleEntry(self, entryName):
         """Returns a ptVaultNode of type kNodeTypeChronicle of the current player's chronicle entry by entryName."""
-        pass
+        ...
 
     def findNode(self, templateNode):
         """Find the node matching the template"""
-        pass
+        ...
 
     def getAgeJournalsFolder(self):
         """Returns a ptVaultFolderNode of the current player's age journals folder."""
-        pass
+        ...
 
     def getAgesICanVisitFolder(self):
         """Returns a ptVaultFolderNode of ages I can visit"""
-        pass
+        ...
 
     def getAgesIOwnFolder(self):
         """Returns a ptVaultFolderNode of ages that I own"""
-        pass
+        ...
 
     def getAllPlayersFolder(self):
         """Returns a ptVaultPlayerInfoListNode of the all players folder."""
-        pass
+        ...
 
     def getAvatarClosetFolder(self):
         """Do not use.
         Returns a ptVaultFolderNode of the avatars outfit in their closet.
         """
-        pass
+        ...
 
     def getAvatarOutfitFolder(self):
         """Do not use.
         Returns a ptVaultFolderNode of the avatars outfit.
         """
-        pass
+        ...
 
     def getBuddyListFolder(self):
         """Returns a ptVaultPlayerInfoListNode of the current player's buddy list folder."""
-        pass
+        ...
 
     def getChronicleFolder(self):
         """Returns a ptVaultFolderNode of the current player's chronicle folder."""
-        pass
+        ...
 
     def getGlobalInbox(self):
         """Returns a ptVaultFolderNode of the global inbox folder."""
-        pass
+        ...
 
     def getIgnoreListFolder(self):
         """Returns a ptVaultPlayerInfoListNode of the current player's ignore list folder."""
-        pass
+        ...
 
     def getInbox(self):
         """Returns a ptVaultFolderNode of the current player's inbox folder."""
-        pass
+        ...
 
     def getInviteFolder(self):
         """Returns a ptVaultFolderNode of invites"""
-        pass
+        ...
 
     def getKIUsage(self):
         """Returns a tuple with usage statistics of the KI (# of pics, # of text notes, # of marker games)"""
-        pass
+        ...
 
     def getLinkToCity(self):
         """Returns a ptVaultAgeLinkNode that will go to the city"""
-        pass
+        ...
 
     def getLinkToMyNeighborhood(self):
         """Returns a ptVaultAgeLinkNode that will go to my neighborhood"""
-        pass
+        ...
 
     def getOwnedAgeLink(self, ageInfo):
         """Returns a ptVaultAgeLinkNode to my owned age(ageInfo)"""
-        pass
+        ...
 
     def getPeopleIKnowAboutFolder(self):
         """Returns a ptVaultPlayerInfoListNode of the current player's people I know about (Recent) list folder."""
-        pass
+        ...
 
     def getPlayerInfo(self):
         """Returns a ptVaultNode of type kNodeTypePlayerInfo of the current player"""
-        pass
+        ...
 
     def getPsnlAgeSDL(self):
         """Returns the personal age SDL"""
-        pass
+        ...
 
     def getVisitAgeLink(self, ageInfo):
         """Returns a ptVaultAgeLinkNode for a visitor to age(ageInfo)"""
-        pass
+        ...
 
     def inMyNeighborhoodAge(self):
         """Are we in the player's neighborhood age?"""
-        pass
+        ...
 
     def inMyPersonalAge(self):
         """Are we in the player's personal age?"""
-        pass
+        ...
 
     def invitePlayerToAge(self, link, playerID):
         """Sends an invitation to visit the age to the specified player"""
-        pass
+        ...
 
     def offerLinkToPlayer(self, link, playerID):
         """Offer a one-time link to the specified player"""
-        pass
+        ...
 
     def registerMTStation(self, stationName, mtSpawnPoint):
         """Registers this player at the specified mass-transit point"""
-        pass
+        ...
 
     def registerOwnedAge(self, link):
         """Registers the specified age as owned by the player"""
-        pass
+        ...
 
     def registerVisitAge(self, link):
         """Register this age as visitable by this player"""
-        pass
+        ...
 
     def setAgePublic(self, ageInfo, makePublic):
         """Makes the specified age public or private"""
-        pass
+        ...
 
     def unInvitePlayerToAge(self, guid, playerID):
         """Revokes the invitation to visit the age"""
-        pass
+        ...
 
     def unRegisterOwnedAge(self, ageFilename):
         """Unregisters the specified age so it's no longer owned by this player"""
-        pass
+        ...
 
     def unRegisterVisitAge(self, guid):
         """Unregisters the specified age so it can no longer be visited by this player"""
-        pass
+        ...
 
     def updatePsnlAgeSDL(self, pyrec):
         """Updates the personal age SDL to the specified data"""
-        pass
+        ...
 
 class ptVaultNode:
     """Vault node class"""
 
     def addNode(self, node, cb=None, cbContext=0):
         """Adds 'node'(ptVaultNode) as a child to this node."""
-        pass
+        ...
 
     def findNode(self, templateNode: ptVaultNode, /, maxDepth: int = 1) -> Optional[ptVaultNode]:
         """Returns ptVaultNode if child node found matching template, or None"""
-        pass
+        ...
 
     def forceSave(self):
         """Force the current node to save immediately"""
-        pass
+        ...
 
     def getChildNodeCount(self):
         """Returns how many children this node has."""
-        pass
+        ...
 
     def getChildNodeRefList(self):
         """Returns a list of ptVaultNodeRef that are the children of this node."""
-        pass
+        ...
 
     def getClientID(self):
         """Returns the client's ID."""
-        pass
+        ...
 
     def getCreateAgeCoords(self):
         """Returns the location in the Age where this node was created."""
-        pass
+        ...
 
     def getCreateAgeGuid(self):
         """Returns the guid as a string of the Age where this node was created."""
-        pass
+        ...
 
     def getCreateAgeName(self):
         """Returns the name of the Age where this node was created."""
-        pass
+        ...
 
     def getCreateAgeTime(self):
         """Returns the time in the Age that the node was created...(?)"""
-        pass
+        ...
 
     def getCreateTime(self):
         """Returns the when this node was created, that is useable by python's time library."""
-        pass
+        ...
 
     def getCreatorNode(self):
         """Returns the creator's node"""
-        pass
+        ...
 
     def getCreatorNodeID(self):
         """Returns the creator's node ID"""
-        pass
+        ...
 
     def getID(self):
         """Returns the unique ID of this ptVaultNode."""
-        pass
+        ...
 
     def getModifyTime(self):
         """Returns the modified time of this node, that is useable by python's time library."""
-        pass
+        ...
 
     def getNode(self, id):
         """Returns ptVaultNodeRef if is a child node, or None"""
-        pass
+        ...
 
     def getOwnerNode(self):
         """Returns a ptVaultNode of the owner of this node"""
-        pass
+        ...
 
     def getOwnerNodeID(self):
         """Returns the node ID of the owner of this node"""
-        pass
+        ...
 
     def getType(self):
         """Returns the type of ptVaultNode this is.
         See PlasmaVaultTypes.py
         """
-        pass
+        ...
 
     def hasNode(self, id):
         """Returns true if node if a child node"""
-        pass
+        ...
 
     def linkToNode(self, nodeID, cb=None, cbContext=0):
         """Adds a link to the node designated by nodeID"""
-        pass
+        ...
 
     def removeAllNodes(self):
         """Removes all the child nodes on this node."""
-        pass
+        ...
 
     def removeNode(self, node, cb=None, cbContext=0):
         """Removes the child 'node'(ptVaultNode) from this node."""
-        pass
+        ...
 
     def save(self, cb=None, cbContext=0):
         """Save the changes made to this node."""
-        pass
+        ...
 
     def saveAll(self, cb=None, cbContext=0):
         """Saves this node and all its children nodes."""
-        pass
+        ...
 
     def sendTo(self, destID, cb=None, cbContext=0):
         """Send this node to inbox at 'destID'"""
-        pass
+        ...
 
     def setCreateAgeGuid(self, guid):
         """Set guid as a string of the Age where this node was created."""
-        pass
+        ...
 
     def setCreateAgeName(self, name):
         """Set name of the Age where this node was created."""
-        pass
+        ...
 
     def setCreatorNodeID(self, id):
         """Set creator's node ID"""
-        pass
+        ...
 
     def setID(self, id):
         """Sets ID of this ptVaultNode."""
-        pass
+        ...
 
     def setOwnerNodeID(self, id):
         """Set node ID of the owner of this node"""
-        pass
+        ...
 
     def setType(self, type):
         """Set the type of ptVaultNode this is."""
-        pass
+        ...
 
     def upcastToAgeInfoListNode(self):
         """Returns this ptVaultNode as ptVaultAgeInfoListNode"""
-        pass
+        ...
 
     def upcastToAgeInfoNode(self):
         """Returns this ptVaultNode as ptVaultAgeInfoNode"""
-        pass
+        ...
 
     def upcastToAgeLinkNode(self):
         """Returns this ptVaultNode as ptVaultAgeLinkNode"""
-        pass
+        ...
 
     def upcastToChronicleNode(self):
         """Returns this ptVaultNode as ptVaultChronicleNode"""
-        pass
+        ...
 
     def upcastToFolderNode(self):
         """Returns this ptVaultNode as ptVaultFolderNode"""
-        pass
+        ...
 
     def upcastToImageNode(self):
         """Returns this ptVaultNode as ptVaultImageNode"""
-        pass
+        ...
 
     def upcastToMarkerGameNode(self):
         """Returns this ptVaultNode as ptVaultMarkerNode"""
-        pass
+        ...
 
     def upcastToPlayerInfoListNode(self):
         """Returns this ptVaultNode as ptVaultPlayerInfoListNode"""
-        pass
+        ...
 
     def upcastToPlayerInfoNode(self):
         """Returns this ptVaultNode as ptVaultPlayerInfoNode"""
-        pass
+        ...
 
     def upcastToPlayerNode(self):
         """Returns this ptVaultNode as a ptVaultPlayerNode"""
-        pass
+        ...
 
     def upcastToSDLNode(self):
         """Returns this ptVaultNode as a ptVaultSDLNode"""
-        pass
+        ...
 
     def upcastToSystemNode(self):
         """Returns this ptVaultNode as a ptVaultSystemNode"""
-        pass
+        ...
 
     def upcastToTextNoteNode(self):
         """Returns this ptVaultNode as ptVaultTextNoteNode"""
-        pass
+        ...
 
 class ptVaultFolderNode(ptVaultNode):
     """Plasma vault folder node"""
 
     def __init__(self, n=0):
-        pass
+        ...
 
     def getFolderName(self):
         """Returns the folder's name"""
-        pass
+        ...
 
     def getFolderType(self):
         """Returns the folder type (of the standard folder types)"""
-        pass
+        ...
 
     def setFolderName(self, name):
         """Set the folder name"""
-        pass
+        ...
 
     def setFolderType(self, type):
         """Set the folder type"""
-        pass
+        ...
 
 class ptVaultAgeInfoListNode(ptVaultFolderNode):
     """Plasma vault age info list node"""
 
     def __init__(self, n=0):
-        pass
+        ...
 
     def addAge(self, ageID):
         """Adds ageID to list of ages"""
-        pass
+        ...
 
     def hasAge(self, ageID):
         """Returns whether ageID is in the list of ages"""
-        pass
+        ...
 
     def removeAge(self, ageID):
         """Removes ageID from list of ages"""
-        pass
+        ...
 
 class ptVaultAgeInfoNode(ptVaultNode):
     """Plasma vault age info node"""
 
     def __init__(self, n=0):
-        pass
+        ...
 
     def asAgeInfoStruct(self):
         """Returns this ptVaultAgeInfoNode as a ptAgeInfoStruct"""
-        pass
+        ...
 
     def getAgeDescription(self):
         """Returns the description of the age"""
-        pass
+        ...
 
     def getAgeFilename(self):
         """Returns the age filename"""
-        pass
+        ...
 
     def getAgeID(self):
         """Returns the age ID"""
-        pass
+        ...
 
     def getAgeInstanceGuid(self):
         """Returns the age instance guid"""
-        pass
+        ...
 
     def getAgeInstanceName(self):
         """Returns the instance name of the age"""
-        pass
+        ...
 
     def getAgeLanguage(self):
         """Returns the age's language (integer)"""
-        pass
+        ...
 
     def getAgeOwnersFolder(self):
         """Returns a ptVaultPlayerInfoList of the players that own this age"""
-        pass
+        ...
 
     def getAgeSDL(self):
         """Returns a ptVaultSDLNode of the age's SDL"""
-        pass
+        ...
 
     def getAgeSequenceNumber(self):
         """Returns the sequence number of this instance of the age"""
-        pass
+        ...
 
     def getAgeUserDefinedName(self):
         """Returns the user define part of the age name"""
-        pass
+        ...
 
     def getCanVisitFolder(self):
         """Returns a ptVaultPlayerInfoList of the players that can visit this age"""
-        pass
+        ...
 
     def getChildAgesFolder(self):
         """Returns a ptVaultFolderNode of the child ages of this age"""
-        pass
+        ...
 
     def getCzar(self):
         """Returns ptVaultPlayerInfoNode of the player that is the Czar"""
-        pass
+        ...
 
     def getCzarID(self):
         """Returns the ID of the age's czar"""
-        pass
+        ...
 
     def getDisplayName(self):
         """Returns the displayable version of the age name"""
-        pass
+        ...
 
     def getParentAgeLink(self):
         """Returns ptVaultAgeLinkNode of the age's parent age, or None if not a child age"""
-        pass
+        ...
 
     def isPublic(self):
         """Returns whether the age is Public or Not"""
-        pass
+        ...
 
     def setAgeDescription(self, description):
         """Sets the description of the age"""
-        pass
+        ...
 
     def setAgeFilename(self, fileName):
         """Sets the filename"""
-        pass
+        ...
 
     def setAgeID(self, ageID):
         """Sets the age ID"""
-        pass
+        ...
 
     def setAgeInstanceGuid(self, guid):
         """Sets the age instance GUID"""
-        pass
+        ...
 
     def setAgeInstanceName(self, instanceName):
         """Sets the instance name"""
-        pass
+        ...
 
     def setAgeLanguage(self, lang):
         """Sets the age's language (integer)"""
-        pass
+        ...
 
     def setAgeSequenceNumber(self, seqNumber):
         """Sets the sequence number"""
-        pass
+        ...
 
     def setAgeUserDefinedName(self, udname):
         """Sets the user defined part of the name"""
-        pass
+        ...
 
 class ptVaultAgeLinkNode(ptVaultNode):
     """Plasma vault age link node"""
 
     def __init__(self, n=0):
-        pass
+        ...
 
     def addSpawnPoint(self, point):
         """Adds the specified ptSpawnPointInfo or ptSpawnPointInfoRef"""
-        pass
+        ...
 
     def asAgeLinkStruct(self):
         """Returns this ptVaultAgeLinkNode as a ptAgeLinkStruct"""
-        pass
+        ...
 
     def getAgeInfo(self):
         """Returns the ageInfo as a ptAgeInfoStruct"""
-        pass
+        ...
 
     def getLocked(self):
         """Returns whether the link is locked or not"""
-        pass
+        ...
 
     def getSpawnPoints(self):
         """Returns a list of ptSpawnPointInfo objects"""
-        pass
+        ...
 
     def getVolatile(self):
         """Returns whether the link is volatile or not"""
-        pass
+        ...
 
     def hasSpawnPoint(self, spawnPtName):
         """Returns true if this link has the specified spawn point"""
-        pass
+        ...
 
     def removeSpawnPoint(self, point):
         """Removes the specified spawn point based on a ptSpawnPointInfo, ptSpawnPointInfoRef, or string"""
-        pass
+        ...
 
     def setLocked(self, state):
         """Sets whether the link is locked or not"""
-        pass
+        ...
 
     def setVolatile(self, state):
         """Sets the state of the volitility of the link"""
-        pass
+        ...
 
 class ptVaultChronicleNode(ptVaultNode):
     """Plasma vault chronicle node"""
 
     def __init__(self, n=0):
-        pass
+        ...
 
     def getEntryType(self):
         """Returns the user defined type of the chronicle node."""
-        pass
+        ...
 
     def getName(self):
         """Returns the name of the chronicle node."""
-        pass
+        ...
 
     def getValue(self):
         """Returns the value as a string of this chronicle node."""
-        pass
+        ...
 
     def setEntryType(self, type):
         """Sets this chronicle node to a user defined type."""
-        pass
+        ...
 
     def setName(self, name):
         """Sets the name of the chronicle node."""
-        pass
+        ...
 
     def setValue(self, value):
         """Sets the chronicle to a value that is a string"""
-        pass
+        ...
 
 class ptVaultImageNode(ptVaultNode):
     """Plasma vault image node"""
 
     def __init__(self, n=0):
-        pass
+        ...
 
     def getImage(self):
         """Returns the image(ptImage) of this image node"""
-        pass
+        ...
 
     def getTitle(self):
         """Returns the title (caption) of this image node"""
-        pass
+        ...
 
     def setImage(self, image):
         """Sets the image(ptImage) of this image node"""
-        pass
+        ...
 
     def setImageFromBuf(self, buf):
         """Sets our image from a buffer"""
-        pass
+        ...
 
     def setImageFromScrShot(self):
         """Grabs a screenshot and stuffs it into this node"""
-        pass
+        ...
 
     def setTitle(self, title):
         """Sets the title (caption) of this image node"""
-        pass
+        ...
 
 class ptVaultMarkerGameNode(ptVaultNode):
     """Plasma vault age info node"""
 
     def __init__(self, n=0):
-        pass
+        ...
 
     def getGameGuid(self):
         """Returns the marker game's guid"""
-        pass
+        ...
 
     def getGameName(self):
         """Returns the marker game's name"""
-        pass
+        ...
 
     def getMarkers(self):
         """Returns a tuple of markers associated with this game"""
-        pass
+        ...
 
     def getReward(self):
         """Returns a string representing the reward for completing this game"""
-        pass
+        ...
 
     def setGameGuid(self, guid):
         """Sets the marker game's guid"""
-        pass
+        ...
 
     def setGameName(self, name):
         """Sets marker game's name"""
-        pass
+        ...
 
     def setMarkers(self, markers):
         """Sets markers associated with this game"""
-        pass
+        ...
 
     def setReward(self, reward):
         """Sets the reward for completing this marker game"""
-        pass
+        ...
 
 class ptVaultNodeRef:
     """Vault node relationship pseudo class"""
 
     def beenSeen(self):
         """Returns true until we reimplement this"""
-        pass
+        ...
 
     def getChild(self):
         """Returns a ptVaultNode that is the child of this reference"""
-        pass
+        ...
 
     def getChildID(self):
         """Returns id of the child node"""
-        pass
+        ...
 
     def getParent(self):
         """Returns a ptVaultNode that is the parent of the reference"""
-        pass
+        ...
 
     def getParentID(self):
         """Returns id of the parent node"""
-        pass
+        ...
 
     def getSaver(self):
         """Returns a ptVaultPlayerInfoNode of player that created this relationship"""
-        pass
+        ...
 
     def getSaverID(self):
         """Returns id of player that created this relationship"""
-        pass
+        ...
 
     def setSeen(self):
         """Does nothing until we reimplement this"""
-        pass
+        ...
 
 class ptVaultPlayerInfoListNode(ptVaultFolderNode):
     """Plasma vault player info list node"""
 
     def __init__(self, n=0):
-        pass
+        ...
 
     def addPlayer(self, playerID):
         """Adds playerID player to this player info list node."""
-        pass
+        ...
 
     def getPlayer(self, playerID):
         """Gets the player info node for the specified player."""
-        pass
+        ...
 
     def hasPlayer(self, playerID):
         """Returns whether the 'playerID' is a member of this player info list node."""
-        pass
+        ...
 
     def removePlayer(self, playerID):
         """Removes playerID player from this player info list node."""
-        pass
+        ...
 
     def sort(self):
         """Sorts the player list by some means...?"""
-        pass
+        ...
 
 class ptVaultPlayerInfoNode(ptVaultNode):
     """Plasma vault folder node"""
 
     def playerGetAgeGuid(self):
         """Returns the guid as a string of where the player is for this player info node."""
-        pass
+        ...
 
     def playerGetAgeInstanceName(self):
         """Returns the name of the Age where the player is for this player info node."""
-        pass
+        ...
 
     def playerGetCCRLevel(self):
         """Returns the ccr level of the player for this player info node."""
-        pass
+        ...
 
     def playerGetID(self):
         """Returns the player ID for this player info node."""
-        pass
+        ...
 
     def playerGetName(self):
         """Returns the player name of this player info node."""
-        pass
+        ...
 
     def playerIsOnline(self):
         """Returns the online status of the player for this player info node."""
-        pass
+        ...
 
     def playerSetAgeGuid(self, guidString):
         """Not sure this should be used. Sets the guid for this player info node."""
-        pass
+        ...
 
     def playerSetAgeInstanceName(self, name):
         """Not sure this should be used. Sets the name of the age where the player is for this player info node."""
-        pass
+        ...
 
     def playerSetID(self, playerID):
         """Not sure this should be used. Sets the playerID for this player info node."""
-        pass
+        ...
 
     def playerSetName(self, name):
         """Not sure this should be used. Sets the player name of this player info node."""
-        pass
+        ...
 
     def playerSetOnline(self, state):
         """Not sure this should be used. Sets the state of the player online status for this player info node."""
-        pass
+        ...
 
 class ptVaultSDLNode(ptVaultNode):
     """Plasma vault SDL node"""
 
     def getIdent(self):
         """UNKNOWN"""
-        pass
+        ...
 
     def getStateDataRecord(self):
         """Returns the ptSDLStateDataRecord associated with this node"""
-        pass
+        ...
 
     def initStateDataRecord(self, filename, flags):
         """Read the SDL Rec from File if needed"""
-        pass
+        ...
 
     def setIdent(self, v):
         """UNKNOWN"""
-        pass
+        ...
 
     def setStateDataRecord(self, rec, writeOptions=0):
         """Sets the ptSDLStateDataRecord"""
-        pass
+        ...
 
 class ptVaultSystemNode(ptVaultNode):
     """Plasma vault system node"""
@@ -5432,382 +5432,382 @@ class ptVaultTextNoteNode(ptVaultNode):
 
     def getDeviceInbox(self):
         """Returns a ptVaultFolderNode"""
-        pass
+        ...
 
     def getNoteSubType(self):
         """Returns the subtype of this text note node."""
-        pass
+        ...
 
     def getNoteType(self):
         """Returns the type of text note for this text note node."""
-        pass
+        ...
 
     def getText(self):
         """Returns the text of this text note node."""
-        pass
+        ...
 
     def getTitle(self):
         """Returns the title of this text note node."""
-        pass
+        ...
 
     def setDeviceInbox(self, inboxName, cb=None, cbContext=0):
         """Sets the device inbox"""
-        pass
+        ...
 
     def setNoteSubType(self, subType):
         """Sets the subtype of the this text note node."""
-        pass
+        ...
 
     def setNoteType(self, type):
         """Sets the type of text note for this text note node."""
-        pass
+        ...
 
     def setText(self, text):
         """Sets text of the this text note node."""
-        pass
+        ...
 
     def setTitle(self, title):
         """Sets the title of this text note node."""
-        pass
+        ...
 
 class ptVector3:
     """Plasma 3D Vector class"""
 
     def __init__(self, x=0, y=0, z=0):
-        pass
+        ...
 
     def add(self, other):
         """Adds other to the current vector"""
-        pass
+        ...
 
     def copy(self):
         """Copies the vector into another one (which it returns)"""
-        pass
+        ...
 
     def crossProduct(self, other):
         """Finds the cross product between other and this vector"""
-        pass
+        ...
 
     def dotProduct(self, other):
         """Finds the dot product between other and this vector"""
-        pass
+        ...
 
     def getX(self):
         """Returns the 'x' component of the vector"""
-        pass
+        ...
 
     def getY(self):
         """Returns the 'y' component of the vector"""
-        pass
+        ...
 
     def getZ(self):
         """Returns the 'z' component of the vector"""
-        pass
+        ...
 
     def length(self):
         """Returns the length of the vector"""
-        pass
+        ...
 
     def lengthSq(self):
         """Returns the length of the vector, squared
         - this function is faster then length(other)
         """
-        pass
+        ...
 
     def normalize(self):
         """Normalizes the vector to length 1"""
-        pass
+        ...
 
     def scale(self, scale):
         """Scale the vector by scale"""
-        pass
+        ...
 
     def setX(self, x):
         """Sets the 'x' component of the vector"""
-        pass
+        ...
 
     def setY(self, y):
         """Sets the 'y' component of the vector"""
-        pass
+        ...
 
     def setZ(self, z):
         """Sets the 'z' component of the vector"""
-        pass
+        ...
 
     def subtract(self, other):
         """Subtracts other from the current vector"""
-        pass
+        ...
 
     def zero(self):
         """Zeros the vector's components"""
-        pass
+        ...
 
 class ptWaveSet:
     """Creates a new ptWaveSet"""
 
     def __init__(self, key):
-        pass
+        ...
 
     def addBuoy(self, soKey: ptKey) -> None:
         """Adds the specified object as a buoy"""
-        pass
+        ...
 
     def getDepthFalloff(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getEnvCenter(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getEnvRadius(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getGeoAmpOverLen(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getGeoAngleDev(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getGeoChop(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getGeoMaxLength(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getGeoMinLength(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getMaxAtten(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getMinAtten(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getOpacFalloff(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getOpacOffset(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getReflFalloff(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getReflOffset(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getRippleScale(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getSpecularEnd(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getSpecularMute(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getSpecularNoise(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getSpecularStart(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getSpecularTint(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getTexAmpOverLen(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getTexAngleDev(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getTexChop(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getTexMaxLength(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getTexMinLength(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getWaterHeight(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getWaterOffset(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getWaterOpacity(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getWaterTint(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getWaveFalloff(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getWaveOffset(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def getWindDir(self):
         """Returns the attribute's value"""
-        pass
+        ...
 
     def removeBuoy(self, soKey: ptKey) -> None:
         """Removes the specified object as a buoy"""
-        pass
+        ...
 
     def setDepthFalloff(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setEnvCenter(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setEnvRadius(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setGeoAmpOverLen(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setGeoAngleDev(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setGeoChop(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setGeoMaxLength(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setGeoMinLength(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setMaxAtten(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setMinAtten(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setOpacFalloff(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setOpacOffset(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setReflFalloff(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setReflOffset(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setRippleScale(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setSpecularEnd(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setSpecularMute(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setSpecularNoise(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setSpecularStart(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setSpecularTint(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setTexAmpOverLen(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setTexAngleDev(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setTexChop(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setTexMaxLength(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setTexMinLength(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setWaterHeight(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setWaterOffset(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setWaterOpacity(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setWaterTint(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setWaveFalloff(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setWaveOffset(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...
 
     def setWindDir(self, s, secs = 0):
         """Sets the attribute to s over secs time"""
-        pass
+        ...

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -65,14 +65,16 @@ def PtAtTimeCallback(selfkey,time,id):
     """This will create a timer callback that will call OnTimer when complete
     - 'selfkey' is the ptKey of the PythonFile component
     - 'time' is how much time from now (in seconds) to call back
-    - 'id' is an integer id that will be returned in the OnTimer call"""
+    - 'id' is an integer id that will be returned in the OnTimer call
+    """
     pass
 
 def PtAttachObject(child,parent,netForce=False):
     """Attach child to parent based on ptKey or ptSceneobject
     - childKey is the ptKey or ptSceneobject of the one being attached
     - parentKey is the ptKey or ptSceneobject of the one being attached to
-    (both arguments must be ptKeys or ptSceneobjects, you cannot mix types)"""
+    (both arguments must be ptKeys or ptSceneobjects, you cannot mix types)
+    """
     pass
 
 def PtAvatarEnterAFK():
@@ -161,7 +163,8 @@ def PtConsole(command):
 
 def PtConsoleNet(command,netForce):
     """This will execute 'command' on the console, over the network, on all clients.
-    If 'netForce' is true then force command to be sent over the network."""
+    If 'netForce' is true then force command to be sent over the network.
+    """
     pass
 
 def PtCreateDir(directory):
@@ -192,7 +195,8 @@ def PtDetachObject(child,parent,netForce=False):
     """Detach child from parent based on ptKey or ptSceneobject
     - child is the ptKey or ptSceneobject of the one being detached
     - parent is the ptKey or ptSceneobject of the one being detached from
-    (both arguments must be ptKeys or ptSceneobjects, you cannot mix types)"""
+    (both arguments must be ptKeys or ptSceneobjects, you cannot mix types)
+    """
     pass
 
 def PtDirtySynchClients(selfKey,SDLStateName,flags):
@@ -283,14 +287,16 @@ def PtExcludeRegionSet(senderKey,regionKey,state):
     """This will set the state of an exclude region
     - 'senderKey' is a ptKey of the PythonFile component
     - 'regionKey' is a ptKey of the exclude region
-    - 'state' is either kExRegRelease or kExRegClear"""
+    - 'state' is either kExRegRelease or kExRegClear
+    """
     pass
 
 def PtExcludeRegionSetNow(senderKey,regionKey,state):
     """This will set the state of an exclude region immediately on the server
     - 'senderKey' is a ptKey of the PythonFile component
     - 'regionKey' is a ptKey of the exclude region
-    - 'state' is either kExRegRelease or kExRegClear"""
+    - 'state' is either kExRegRelease or kExRegClear
+    """
     pass
 
 def PtFadeIn(lenTime, holdFlag, noSound=0):
@@ -316,7 +322,8 @@ def PtFileExists(filename):
 
 def PtFindActivator(name):
     """This will try to find an activator based on its name
-    - it will return a ptKey if found- it will return None if not found"""
+    - it will return a ptKey if found- it will return None if not found
+    """
     pass
 
 def PtFindClones(key):
@@ -333,7 +340,8 @@ def PtFindLayer(name: str, age: str = "", page: str = "") -> Optional[ptLayer]:
 
 def PtFindSceneobject(name,ageName):
     """This will try to find a sceneobject based on its name and what age its in
-    - it will return a ptSceneObject if found- if not found then a NameError exception will happen"""
+    - it will return a ptSceneObject if found- if not found then a NameError exception will happen
+    """
     pass
 
 def PtFindSceneobjects(name):
@@ -366,12 +374,14 @@ def PtFogSetDefLinear(start,end,density):
 
 def PtForceCursorHidden():
     """Forces the cursor to hide, overriding everything.
-    Only call if other methods won't work. The only way to show the cursor after this call is PtForceMouseShown()"""
+    Only call if other methods won't work. The only way to show the cursor after this call is PtForceMouseShown()
+    """
     pass
 
 def PtForceCursorShown():
     """Forces the cursor to show, overriding everything.
-    Only call if other methods won't work. This is the only way to show the cursor after a call to PtForceMouseHidden()"""
+    Only call if other methods won't work. This is the only way to show the cursor after a call to PtForceMouseHidden()
+    """
     pass
 
 def PtForceVaultNodeUpdate(nodeId):
@@ -441,7 +451,8 @@ def PtGetClientIDFromAvatarKey(avatarKey):
 def PtGetClientName(avatarKey=None):
     """This will return the name of the client that is owned by the avatar
     - avatarKey is the ptKey of the avatar to get the client name of.
-    If avatarKey is omitted then the local avatar is used"""
+    If avatarKey is omitted then the local avatar is used
+    """
     pass
 
 def PtGetControlEvents(on, key):
@@ -498,7 +509,8 @@ def PtGetLanguage():
 
 def PtGetLocalAvatar():
     """This will return a ptSceneobject of the local avatar
-    - if there is no local avatar a NameError exception will happen."""
+    - if there is no local avatar a NameError exception will happen.
+    """
     pass
 
 def PtGetLocalClientID():
@@ -559,7 +571,8 @@ def PtGetPrevAgeName():
 
 def PtGetPublicAgeList(ageName, cbObject=None):
     """Get list of public ages for the given age name.
-    cbObject, if supplied should have a method called gotPublicAgeList(self,ageList). ageList is a list of tuple(ptAgeInfoStruct,nPlayersInAge)"""
+    cbObject, if supplied should have a method called gotPublicAgeList(self,ageList). ageList is a list of tuple(ptAgeInfoStruct,nPlayersInAge)
+    """
     pass
 
 def PtGetPythonLoggingLevel():
@@ -664,17 +677,20 @@ def PtLoadBookGUI(guiName):
 
 def PtLoadDialog(dialogName,selfKey=None,ageName=""):
     """Loads a GUI dialog by name and optionally set the Notify proc key
-    If the dialog is already loaded then it won't load it again"""
+    If the dialog is already loaded then it won't load it again
+    """
     pass
 
 def PtLoadJPEGFromDisk(filename,width,height):
     """The image will be resized to fit the width and height arguments. Set to 0 if resizing is not desired.
-    Returns a pyImage of the specified file."""
+    Returns a pyImage of the specified file.
+    """
     pass
 
 def PtLoadPNGFromDisk(filename,width,height):
     """The image will be resized to fit the width and height arguments. Set to 0 if resizing is not desired.
-    Returns a pyImage of the specified file."""
+    Returns a pyImage of the specified file.
+    """
     pass
 
 def PtLocalAvatarIsMoving():
@@ -756,12 +772,14 @@ def PtSendKIGZMarkerMsg(markerNumber,sender):
 
 def PtSendKIMessage(command,value):
     """Sends a command message to the KI frontend.
-    See PlasmaKITypes.py for list of commands"""
+    See PlasmaKITypes.py for list of commands
+    """
     pass
 
 def PtSendKIMessageInt(command,value):
     """Same as PtSendKIMessage except the value is guaranteed to be a uint32_t
-    (for things like player IDs)"""
+    (for things like player IDs)
+    """
     pass
 
 def PtSendKIRegisterImagerMsg(imagerName, sender):
@@ -778,7 +796,8 @@ def PtSendPrivateChatList(chatList):
 
 def PtSendRTChat(fromPlayer,toPlayerList,message,flags):
     """Sends a realtime chat message to the list of ptPlayers
-    If toPlayerList is an empty list, it is a broadcast message"""
+    If toPlayerList is an empty list, it is a broadcast message
+    """
     pass
 
 def PtSetActivePlayer(playerInt):
@@ -788,7 +807,8 @@ def PtSetActivePlayer(playerInt):
 def PtSetAlarm(secs, cbObject, cbContext):
     """secs is the amount of time before your alarm goes off.
     cbObject is a python object with the method onAlarm(int context)
-    cbContext is an integer."""
+    cbContext is an integer.
+    """
     pass
 
 def PtSetBehaviorLoopCount(behaviorKey,stage,loopCount,netForce):
@@ -897,7 +917,8 @@ def PtTransferParticlesToObject(objFrom, objTo, num):
 
 def PtUnLoadAvatarModel(avatarKey):
     """Forcibly unloads the specified avatar model.
-    Do not use this method unless you require fine-grained control of avatar unloading."""
+    Do not use this method unless you require fine-grained control of avatar unloading.
+    """
     pass
 
 def PtUnloadAllBookGUIs():
@@ -914,7 +935,8 @@ def PtUnloadDialog(dialogName):
 
 def PtValidateKey(key):
     """Returns true(1) if 'key' is valid and loaded,
-    otherwise returns false(0)"""
+    otherwise returns false(0)
+    """
     pass
 
 def PtVaultDownload(nodeId):
@@ -1247,7 +1269,8 @@ class ptAnimation:
 
     def getFirstKey(self):
         """This will return a ptKey object that is the first receiver (target)
-        However, if the parent is not a modifier or not loaded, then None is returned."""
+        However, if the parent is not a modifier or not loaded, then None is returned.
+        """
         pass
 
     def incrementBackward(self):
@@ -1265,7 +1288,8 @@ class ptAnimation:
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
-        Such as a game master, only running on the client that owns a particular object"""
+        Such as a game master, only running on the client that owns a particular object
+        """
         pass
 
     def play(self):
@@ -1298,12 +1322,14 @@ class ptAnimation:
 
     def setLoopEnd(self,loopEnd):
         """Sets the loop ending position
-        - 'loopEnd' is the number of seconds from the absolute beginning of the animation"""
+        - 'loopEnd' is the number of seconds from the absolute beginning of the animation
+        """
         pass
 
     def setLoopStart(self,loopStart):
         """Sets the loop starting position
-        - 'loopStart' is the number of seconds from the absolute beginning of the animation"""
+        - 'loopStart' is the number of seconds from the absolute beginning of the animation
+        """
         pass
 
     def skipToBegin(self):
@@ -1458,7 +1484,8 @@ class ptAudioControl:
 
     def setAmbienceVolume(self,volume):
         """Sets the Ambience volume (0.0 to 1.0) for the game.
-        This only sets the volume for this game session."""
+        This only sets the volume for this game session.
+        """
         pass
 
     def setCaptureDevice(self,devicename):
@@ -1467,7 +1494,8 @@ class ptAudioControl:
 
     def setGUIVolume(self,volume):
         """Sets the GUI dialog volume (0.0 to 1.0) for the game.
-        This only sets the volume for this game session."""
+        This only sets the volume for this game session.
+        """
         pass
 
     def setLoadOnDemand(self,state):
@@ -1480,12 +1508,14 @@ class ptAudioControl:
 
     def setMusicVolume(self,volume):
         """Sets the Music volume (0.0 to 1.0) for the game.
-        This only sets the volume for this game session."""
+        This only sets the volume for this game session.
+        """
         pass
 
     def setNPCVoiceVolume(self,volume):
         """Sets the NPC's voice volume (0.0 to 1.0) for the game.
-        This only sets the volume for this game session."""
+        This only sets the volume for this game session.
+        """
         pass
 
     def setPlaybackDevice(self,devicename,restart):
@@ -1498,17 +1528,20 @@ class ptAudioControl:
 
     def setSoundFXVolume(self,volume):
         """Sets the SoundFX volume (0.0 to 1.0) for the game.
-        This only sets the volume for this game session."""
+        This only sets the volume for this game session.
+        """
         pass
 
     def setTwoStageLOD(self,state):
         """Enables or disables two-stage LOD, where sounds can be loaded into RAM but not into sound buffers.
-        ...Less of a performance hit, harder on memory."""
+        ...Less of a performance hit, harder on memory.
+        """
         pass
 
     def setVoiceVolume(self,volume):
         """Sets the Voice volume (0.0 to 1.0) for the game.
-        This only sets the volume for this game session."""
+        This only sets the volume for this game session.
+        """
         pass
 
     def showIcons(self):
@@ -1551,7 +1584,8 @@ class ptAvatar:
 
     def getAvatarClothingGroup(self):
         """Returns what clothing group the avatar belongs to.
-        It is also a means to determine if avatar is male or female"""
+        It is also a means to determine if avatar is male or female
+        """
         pass
 
     def getAvatarClothingList(self):
@@ -1568,12 +1602,14 @@ class ptAvatar:
 
     def getEntireClothingList(self,clothing_type):
         """Gets the entire list of clothing available. 'clothing_type' not used
-        NOTE: should use getClosetClothingList"""
+        NOTE: should use getClosetClothingList
+        """
         pass
 
     def getMatchingClothingItem(self,clothingName):
         """Finds the matching clothing item that goes with 'clothingName'
-        Used to find matching left and right gloves and shoes."""
+        Used to find matching left and right gloves and shoes.
+        """
         pass
 
     def getMorph(self,clothing_name,layer):
@@ -1586,7 +1622,8 @@ class ptAvatar:
 
     def getTintClothingItem(self,clothing_name,layer=1):
         """Returns a ptColor of a particular item of clothing that the avatar is wearing.
-        The color will be a ptColor object."""
+        The color will be a ptColor object.
+        """
         pass
 
     def getTintSkin(self):
@@ -1612,7 +1649,8 @@ class ptAvatar:
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
-        Such as a game master, only running on the client that owns a particular object"""
+        Such as a game master, only running on the client that owns a particular object
+        """
         pass
 
     def nextStage(self,behaviorKey,transitionTime,setTimeFlag,newTime,SetDirectionFlag,isForward,netForce):
@@ -1677,7 +1715,8 @@ class ptAvatar:
 
     def tintClothingItem(self,clothing_name,tint,update=1):
         """Tells the avatar to tint(color) a particular item of clothing that they are already wearing.
-        'tint' is a ptColor object"""
+        'tint' is a ptColor object
+        """
         pass
 
     def tintClothingItemLayer(self,clothing_name,tint,layer,update=1):
@@ -1694,7 +1733,8 @@ class ptAvatar:
 
     def wearClothingItem(self,clothing_name,update=1):
         """Tells the avatar to wear a particular item of clothing.
-        And optionally hold update until later (for applying tinting before wearing)."""
+        And optionally hold update until later (for applying tinting before wearing).
+        """
         pass
 
 class ptBook:
@@ -1757,7 +1797,8 @@ class ptBook:
 
     def setGUI(self,guiName):
         """Sets the gui to be used by the book, if the requested gui is not loaded, it will use the default
-        Do not call while the book is open!"""
+        Do not call while the book is open!
+        """
         pass
 
     def setPageMargin(self,margin):
@@ -1780,7 +1821,8 @@ class ptCamera:
 
     def controlKey(self,controlKey,activateFlag):
         """Send a control key to the camera as if it was hit by the user.
-        This is for sending things like pan-up, pan-down, zoom-in, etc."""
+        This is for sending things like pan-up, pan-down, zoom-in, etc.
+        """
         pass
 
     def disableFirstPersonOverride(self):
@@ -1849,7 +1891,8 @@ class ptCamera:
 
     def undoFirstPerson(self):
         """If the user has overridden the camera to be in first person, this will take them out of first person.
-        If the user didn't override the camera, then this will do nothing."""
+        If the user didn't override the camera, then this will do nothing.
+        """
         pass
 
 class ptCluster:
@@ -1870,37 +1913,44 @@ class ptColor:
 
     def black(self):
         """Sets the color to be black
-        Example: black = ptColor().black()"""
+        Example: black = ptColor().black()
+        """
         pass
 
     def blue(self):
         """Sets the color to be blue
-        Example: blue = ptColor().blue()"""
+        Example: blue = ptColor().blue()
+        """
         pass
 
     def brown(self):
         """Sets the color to be brown
-        Example: brown = ptColor().brown()"""
+        Example: brown = ptColor().brown()
+        """
         pass
 
     def cyan(self):
         """Sets the color to be cyan
-        Example: cyan = ptColor.cyan()"""
+        Example: cyan = ptColor.cyan()
+        """
         pass
 
     def darkbrown(self):
         """Sets the color to be darkbrown
-        Example: darkbrown = ptColor().darkbrown()"""
+        Example: darkbrown = ptColor().darkbrown()
+        """
         pass
 
     def darkgreen(self):
         """Sets the color to be darkgreen
-        Example: darkgreen = ptColor().darkgreen()"""
+        Example: darkgreen = ptColor().darkgreen()
+        """
         pass
 
     def darkpurple(self):
         """Sets the color to be darkpurple
-        Example: darkpurple = ptColor().darkpurple()"""
+        Example: darkpurple = ptColor().darkpurple()
+        """
         pass
 
     def getAlpha(self):
@@ -1921,42 +1971,50 @@ class ptColor:
 
     def gray(self):
         """Sets the color to be gray
-        Example: gray = ptColor().gray()"""
+        Example: gray = ptColor().gray()
+        """
         pass
 
     def green(self):
         """Sets the color to be green
-        Example: green = ptColor().green()"""
+        Example: green = ptColor().green()
+        """
         pass
 
     def magenta(self):
         """Sets the color to be magenta
-        Example: magenta = ptColor().magenta()"""
+        Example: magenta = ptColor().magenta()
+        """
         pass
 
     def maroon(self):
         """Sets the color to be maroon
-        Example: maroon = ptColor().maroon()"""
+        Example: maroon = ptColor().maroon()
+        """
         pass
 
     def navyblue(self):
         """Sets the color to be navyblue
-        Example: navyblue = ptColor().navyblue()"""
+        Example: navyblue = ptColor().navyblue()
+        """
         pass
 
     def orange(self):
         """Sets the color to be orange
-        Example: orange = ptColor().orange()"""
+        Example: orange = ptColor().orange()
+        """
         pass
 
     def pink(self):
         """Sets the color to be pink
-        Example: pink = ptColor().pink()"""
+        Example: pink = ptColor().pink()
+        """
         pass
 
     def red(self):
         """Sets the color to be red
-        Example: red = ptColor().red()"""
+        Example: red = ptColor().red()
+        """
         pass
 
     def setAlpha(self,alpha):
@@ -1977,27 +2035,32 @@ class ptColor:
 
     def slateblue(self):
         """Sets the color to be slateblue
-        Example: slateblue = ptColor().slateblue()"""
+        Example: slateblue = ptColor().slateblue()
+        """
         pass
 
     def steelblue(self):
         """Sets the color to be steelblue
-        Example: steelblue = ptColor().steelblue()"""
+        Example: steelblue = ptColor().steelblue()
+        """
         pass
 
     def tan(self):
         """Sets the color to be tan
-        Example: tan = ptColor().tan()"""
+        Example: tan = ptColor().tan()
+        """
         pass
 
     def white(self):
         """Sets the color to be white
-        Example: white = ptColor().white()"""
+        Example: white = ptColor().white()
+        """
         pass
 
     def yellow(self):
         """Sets the color to be yellow
-        Example: yellow = ptColor().yellow()"""
+        Example: yellow = ptColor().yellow()
+        """
         pass
 
 class ptCritterBrain:
@@ -2178,7 +2241,8 @@ class ptDraw:
 
     def disable(self):
         """Disables the draw on the sceneobject attached
-        In other words, makes it invisible"""
+        In other words, makes it invisible
+        """
         pass
 
     def enable(self,state=1):
@@ -2188,7 +2252,8 @@ class ptDraw:
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
-        Such as a game master, only running on the client that owns a particular object"""
+        Such as a game master, only running on the client that owns a particular object
+        """
         pass
 
 class ptDynamicMap:
@@ -2211,7 +2276,8 @@ class ptDynamicMap:
 
     def clearToColor(self,color):
         """Clear the DynamicMap to the specified color
-        - 'color' is a ptColor object"""
+        - 'color' is a ptColor object
+        """
         pass
 
     def drawImage(self,x,y,image,respectAlphaFlag):
@@ -2225,13 +2291,15 @@ class ptDynamicMap:
     def drawText(self,x,y,text):
         """Draw text at a specified location
         - x,y is the point to start drawing the text
-        - 'text' is a string of the text to be drawn"""
+        - 'text' is a string of the text to be drawn
+        """
         pass
 
     def fillRect(self,left,top,right,bottom,color):
         """Fill in the specified rectangle with a color
         - left,top,right,bottom define the rectangle
-        - 'color' is a ptColor object"""
+        - 'color' is a ptColor object
+        """
         pass
 
     def flush(self):
@@ -2241,7 +2309,8 @@ class ptDynamicMap:
     def frameRect(self,left,top,right,bottom,color):
         """Frame a rectangle with a specified color
         - left,top,right,bottom define the rectangle
-        - 'color' is a ptColor object"""
+        - 'color' is a ptColor object
+        """
         pass
 
     def getHeight(self):
@@ -2260,12 +2329,14 @@ class ptDynamicMap:
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
-        This only applies when NetPropagate is set to true"""
+        This only applies when NetPropagate is set to true
+        """
         pass
 
     def netPropagate(self,propagateFlag):
         """Specify whether this object needs to use messages that are sent on the network
-        - The default is for this to be false."""
+        - The default is for this to be false.
+        """
         pass
 
     def purgeImage(self):
@@ -2279,13 +2350,15 @@ class ptDynamicMap:
     def setClipping(self,clipLeft,clipTop,clipRight,clipBottom):
         """Sets the clipping rectangle
         - All drawtext will be clipped to this until the
-        unsetClipping() is called"""
+        unsetClipping() is called
+        """
         pass
 
     def setFont(self,facename,size):
         """Set the font of the text to be written
         - 'facename' is a string with the name of the font
-        - 'size' is the point size of the font to use"""
+        - 'size' is the point size of the font to use
+        """
         pass
 
     def setJustify(self,justify):
@@ -2299,13 +2372,15 @@ class ptDynamicMap:
     def setTextColor(self,color, blockRGB=0):
         """Set the color of the text to be written
         - 'color' is a ptColor object
-        - 'blockRGB' must be true if you're trying to render onto a transparent or semi-transparent color"""
+        - 'blockRGB' must be true if you're trying to render onto a transparent or semi-transparent color
+        """
         pass
 
     def setWrapping(self,wrapWidth,wrapHeight):
         """Set where text will be wrapped horizontally and vertically
         - All drawtext commands will be wrapped until the
-        unsetWrapping() is called"""
+        unsetWrapping() is called
+        """
         pass
 
     def unsetClipping(self):
@@ -2504,7 +2579,8 @@ class ptGUIControlDragBar(ptGUIControl):
 
     def anchor(self):
         """Don't allow this dragbar object to be moved by the user.
-        Drop anchor!"""
+        Drop anchor!
+        """
         pass
 
     def isAnchored(self):
@@ -2513,7 +2589,8 @@ class ptGUIControlDragBar(ptGUIControl):
 
     def unanchor(self):
         """Allow the user to drag this control around the screen.
-        Raise anchor."""
+        Raise anchor.
+        """
         pass
 
 class ptGUIControlDraggable(ptGUIControl):
@@ -2538,7 +2615,8 @@ class ptGUIControlDynamicText(ptGUIControl):
 
     def getMap(self,index):
         """Returns a specific ptDynamicText attached to this contol
-        If there is no map at 'index' then a KeyError exception will be raised"""
+        If there is no map at 'index' then a KeyError exception will be raised
+        """
         pass
 
     def getNumMaps(self):
@@ -2747,7 +2825,8 @@ class ptGUIControlListBox(ptGUIControl):
 
     def lock(self):
         """Locks the updates to a listbox, so a number of operations can be performed
-        NOTE: an unlock() call must be made before the next lock() can be."""
+        NOTE: an unlock() call must be made before the next lock() can be.
+        """
         pass
 
     def refresh(self):
@@ -2796,7 +2875,8 @@ class ptGUIControlListBox(ptGUIControl):
 
     def unclickable(self):
         """Makes this listbox not clickable by the user.
-        Useful when just displaying a list that is not really selectable."""
+        Useful when just displaying a list that is not really selectable.
+        """
         pass
 
     def unlock(self):
@@ -2887,7 +2967,8 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 
     def insertColor(self,color):
         """Inserts an encoded color object at the current cursor position.
-        'color' is a ptColor object."""
+        'color' is a ptColor object.
+        """
         pass
 
     def insertLink(self,linkId: int) -> None:
@@ -2948,7 +3029,8 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 
     def unclickable(self):
         """Makes this listbox not clickable by the user.
-        Useful when just displaying a list that is not really selectable."""
+        Useful when just displaying a list that is not really selectable.
+        """
         pass
 
     def unlock(self):
@@ -3149,7 +3231,8 @@ class ptGUIPopUpMenu:
     """Takes three diferent argument lists:
     gckey
     name,screenOriginX,screenOriginY
-    name,parent,screenOriginX,screenOriginY"""
+    name,parent,screenOriginX,screenOriginY
+    """
     def __init__(self,arg1,arg2=None,arg3=None,arg4=None):
         """None"""
         pass
@@ -3326,7 +3409,8 @@ class ptGameScore:
 
     def setPoints(self,numPoints, key):
         """Sets the number of points in the score
-        Don't use to add/remove points, use only to reset values!"""
+        Don't use to add/remove points, use only to reset values!
+        """
         pass
 
     def transferPoints(self,dest, points=0, key=None):
@@ -3497,12 +3581,14 @@ class ptKey:
 
     def getParentKey(self):
         """This will return a ptKey object that is the parent of this modifer
-        However, if the parent is not a modifier or not loaded, then None is returned."""
+        However, if the parent is not a modifier or not loaded, then None is returned.
+        """
         pass
 
     def getSceneObject(self):
         """This will return a ptSceneobject object that is associated with this ptKey
-        However, if this ptKey is _not_ a sceneobject, then unpredicatable results will ensue"""
+        However, if this ptKey is _not_ a sceneobject, then unpredicatable results will ensue
+        """
         pass
 
     def isAttachedToClone(self):
@@ -3512,7 +3598,8 @@ class ptKey:
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
-        Such as a game master, only running on the client that owns a particular object"""
+        Such as a game master, only running on the client that owns a particular object
+        """
         pass
 
 class ptKeyMap:
@@ -3837,7 +3924,8 @@ class ptNetLinkingMgr:
 
 class ptNotify:
     """Creates a Notify message
-    - selfKey is ptKey of your PythonFile modifier"""
+    - selfKey is ptKey of your PythonFile modifier
+    """
     def __init__(self,selfKey):
         """None"""
         pass
@@ -3880,39 +3968,46 @@ class ptNotify:
 
     def addVarFloat(self,name,number):
         """Add a float variable event record to the Notify message
-        This event record is used to pass a number variable to another python program"""
+        This event record is used to pass a number variable to another python program
+        """
         pass
 
     def addVarInt(self,name,number):
         """Add a int variable event record to the Notify message
-        This event record is used to pass a number variable to another python program"""
+        This event record is used to pass a number variable to another python program
+        """
         pass
 
     def addVarKey(self,name,key):
         """Add a ptKey variable event record to the Notify message
-        This event record is used to pass a ptKey variable to another python program"""
+        This event record is used to pass a ptKey variable to another python program
+        """
         pass
 
     def addVarNull(self,name,number):
         """Add a null (no data) variable event record to the Notify message
-        This event record is used to pass a number variable to another python program"""
+        This event record is used to pass a number variable to another python program
+        """
         pass
 
     def addVarNumber(self,name,number):
         """Add a number variable event record to the Notify message
         Method will try to pick appropriate variable type
-        This event record is used to pass a number variable to another python program"""
+        This event record is used to pass a number variable to another python program
+        """
         pass
 
     def clearReceivers(self):
         """Remove all the receivers that this Notify message has
-        - receivers are automatically added if from a ptAttribActivator"""
+        - receivers are automatically added if from a ptAttribActivator
+        """
         pass
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
-        Such as a game master, only running on the client that owns a particular object"""
+        Such as a game master, only running on the client that owns a particular object
+        """
         pass
 
     def netPropagate(self,netFlag):
@@ -3940,7 +4035,8 @@ class ptParticle:
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
-        Such as a game master, only running on the client that owns a particular object"""
+        Such as a game master, only running on the client that owns a particular object
+        """
         pass
 
     def setGeneratorLife(self,value):
@@ -3999,7 +4095,8 @@ class ptPhysics:
 
     def angularImpulse(self,impulseVector):
         """Add the given vector (representing a rotation axis and magnitude) to
-        the attached sceneobject's velocity"""
+        the attached sceneobject's velocity
+        """
         pass
 
     def damp(self,damp):
@@ -4036,7 +4133,8 @@ class ptPhysics:
 
     def impulseWithOffset(self,impulseVector,offsetPt):
         """Adds the given vector to the attached sceneobject's velocity
-        with the specified offset"""
+        with the specified offset
+        """
         pass
 
     def move(self,direction,distance):
@@ -4046,7 +4144,8 @@ class ptPhysics:
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
         - This is to be used if your Python program is running on only one client
-        Such as a game master, only running on the client that owns a particular object"""
+        Such as a game master, only running on the client that owns a particular object
+        """
         pass
 
     def rotate(self,radians,axis):
@@ -4067,7 +4166,8 @@ class ptPhysics:
 
     def suppress(self,doSuppress):
         """Completely remove the physical, but keep it around so it
-        can be added back later."""
+        can be added back later.
+        """
         pass
 
     def torque(self,torqueVector):
@@ -4076,7 +4176,8 @@ class ptPhysics:
 
     def warp(self,position):
         """Warps the sceneobject to a specified location.
-        'position' can be a ptPoint3 or a ptMatrix44"""
+        'position' can be a ptPoint3 or a ptMatrix44
+        """
         pass
 
     def warpObj(self,objkey):
@@ -4125,7 +4226,8 @@ class ptPoint3:
 
     def distanceSq(self,other):
         """Computes the distance squared from this point to 'other' point
-        - this function is faster than distance(other)"""
+        - this function is faster than distance(other)
+        """
         pass
 
     def getX(self):
@@ -4165,13 +4267,15 @@ class ptSDL:
     def sendToClients(self,key):
         """Sets it so changes to this key are sent to the
         server AND the clients. (Normally it just goes
-        to the server.)"""
+        to the server.)
+        """
         pass
 
     def setDefault(self,key,value):
         """Like setitem, but doesn't broadcast over the net.
         Only use for setting defaults that everyone will
-        already know (from reading it off disk)"""
+        already know (from reading it off disk)
+        """
         pass
 
     def setFlags(self,name,sendImmediate,skipOwnershipCheck):
@@ -4180,7 +4284,8 @@ class ptSDL:
 
     def setIndex(self,key,idx,value):
         """Sets the value at a specific index in the tuple,
-        so you don't have to pass the whole thing in"""
+        so you don't have to pass the whole thing in
+        """
         pass
 
     def setIndexNow(self,key,idx,value):
@@ -4189,7 +4294,8 @@ class ptSDL:
 
     def setNotify(self,selfkey,key,tolerance):
         """Sets the OnSDLNotify to be called when 'key'
-        SDL variable changes by 'tolerance' (if number)"""
+        SDL variable changes by 'tolerance' (if number)
+        """
         pass
 
     def setTagString(self,name,tag):
@@ -4235,7 +4341,8 @@ class ptSceneobject:
 
     def addKey(self,key):
         """Mostly used internally.
-        Add another sceneobject ptKey"""
+        Add another sceneobject ptKey
+        """
         pass
 
     def animate(self):
@@ -4260,27 +4367,32 @@ class ptSceneobject:
 
     def getKey(self):
         """Get the ptKey of this sceneobject
-        If there are more then one attached, get the first one"""
+        If there are more then one attached, get the first one
+        """
         pass
 
     def getLocalToParent(self):
         """Returns ptMatrix44 of the local to parent transform for this sceneobject
-        - If there is more than one sceneobject attached, returns just the first one"""
+        - If there is more than one sceneobject attached, returns just the first one
+        """
         pass
 
     def getLocalToWorld(self):
         """Returns ptMatrix44 of the local to world transform for this sceneobject
-        - If there is more than one sceneobject attached, returns just the first one"""
+        - If there is more than one sceneobject attached, returns just the first one
+        """
         pass
 
     def getName(self):
         """Returns the name of the sceneobject (Max name)
-        - If there are more than one sceneobject attached, return just the first one"""
+        - If there are more than one sceneobject attached, return just the first one
+        """
         pass
 
     def getParentToLocal(self):
         """Returns ptMatrix44 of the parent to local transform for this sceneobject
-        - If there is more than one sceneobject attached, returns just the first one"""
+        - If there is more than one sceneobject attached, returns just the first one
+        """
         pass
 
     def getPythonMods(self):
@@ -4301,7 +4413,8 @@ class ptSceneobject:
 
     def getWorldToLocal(self):
         """Returns ptMatrix44 of the world to local transform for this sceneobject
-        - If there is more than one sceneobject attached, returns just the first one"""
+        - If there is more than one sceneobject attached, returns just the first one
+        """
         pass
 
     def isAvatar(self):
@@ -4314,7 +4427,8 @@ class ptSceneobject:
 
     def isLocallyOwned(self):
         """Returns true(1) if this object is locally owned by this client
-        or returns false(0) if it is not or don't know"""
+        or returns false(0) if it is not or don't know
+        """
         pass
 
     def netForce(self,forceFlag):
@@ -4322,7 +4436,8 @@ class ptSceneobject:
         - This is to be used if your Python program is running on only one client
         Such as a game master, only running on the client that owns a particular object
         - Setting the netForce flag on a sceneobject will also set the netForce flag on
-        its draw, physics, avatar, particle objects"""
+        its draw, physics, avatar, particle objects
+        """
         pass
 
     def playAnimNamed(self,animName):
@@ -4561,12 +4676,14 @@ class ptStatusLog:
         """Open a status log for writing to
         'logname' is the name of the log file (example: special.log)
         'numLines' is the number of lines to display on debug screen
-        'flags' is a PlasmaConstants.PtStatusLogFlags"""
+        'flags' is a PlasmaConstants.PtStatusLogFlags
+        """
         pass
 
     def write(self,text,color=None):
         """If the status log is open, write 'text' to log
-        'color' is the display color in debug screen"""
+        'color' is the display color in debug screen
+        """
         pass
 
 class ptStream:
@@ -4681,12 +4798,14 @@ class ptVault:
 
     def getAvatarClosetFolder(self):
         """Do not use.
-        Returns a ptVaultFolderNode of the avatars outfit in their closet."""
+        Returns a ptVaultFolderNode of the avatars outfit in their closet.
+        """
         pass
 
     def getAvatarOutfitFolder(self):
         """Do not use.
-        Returns a ptVaultFolderNode of the avatars outfit."""
+        Returns a ptVaultFolderNode of the avatars outfit.
+        """
         pass
 
     def getBuddyListFolder(self):
@@ -4873,7 +4992,8 @@ class ptVaultNode:
 
     def getType(self):
         """Returns the type of ptVaultNode this is.
-        See PlasmaVaultTypes.py"""
+        See PlasmaVaultTypes.py
+        """
         pass
 
     def hasNode(self,id):
@@ -5506,7 +5626,8 @@ class ptVector3:
 
     def lengthSq(self):
         """Returns the length of the vector, squared
-        - this function is faster then length(other)"""
+        - this function is faster then length(other)
+        """
         pass
 
     def normalize(self):

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -970,7 +970,6 @@ def PtYesNoDialog(cb: Union[None, ptKey, Callable], message: str, /, dialogType:
 class ptAgeInfoStruct:
     """Class to hold AgeInfo struct data"""
     def __init__(self):
-        """None"""
         pass
 
     def copyFrom(self,other):
@@ -1040,7 +1039,6 @@ class ptAgeInfoStruct:
 class ptAgeInfoStructRef:
     """Class to hold AgeInfo struct data"""
     def __init__(self):
-        """None"""
         pass
 
     def copyFrom(self,other):
@@ -1094,7 +1092,6 @@ class ptAgeInfoStructRef:
 class ptAgeLinkStruct:
     """Class to hold the data of the AgeLink structure"""
     def __init__(self):
-        """None"""
         pass
 
     def copyFrom(self,other):
@@ -1136,7 +1133,6 @@ class ptAgeLinkStruct:
 class ptAgeLinkStructRef:
     """Class to hold the data of the AgeLink structure"""
     def __init__(self):
-        """None"""
         pass
 
     def copyFrom(self,other):
@@ -1170,7 +1166,6 @@ class ptAgeLinkStructRef:
 class ptAgeVault:
     """Accessor class to the Age's vault"""
     def __init__(self):
-        """None"""
         pass
 
     def addChronicleEntry(self,name,type,value):
@@ -1256,7 +1251,6 @@ class ptAgeVault:
 class ptAnimation:
     """Plasma animation class"""
     def __init__(self,key=None):
-        """None"""
         pass
 
     def addKey(self,key):
@@ -1363,7 +1357,6 @@ class ptAnimation:
 class ptAudioControl:
     """Accessor class to the Audio controls"""
     def __init__(self):
-        """None"""
         pass
 
     def areSubtitlesEnabled(self):
@@ -1563,7 +1556,6 @@ class ptAudioControl:
 class ptAvatar:
     """Plasma avatar class"""
     def __init__(self):
-        """None"""
         pass
 
     def addWardrobeClothingItem(self,clothing_name,tint1,tint2):
@@ -1740,7 +1732,6 @@ class ptAvatar:
 class ptBook:
     """Creates a new book"""
     def __init__(self,esHTMLSource,coverImage=None,callbackKey=None,guiName=''):
-        """None"""
         pass
 
     def allowPageTurning(self,allow):
@@ -1816,7 +1807,6 @@ class ptBook:
 class ptCamera:
     """Plasma camera class"""
     def __init__(self):
-        """None"""
         pass
 
     def controlKey(self,controlKey,activateFlag):
@@ -1898,7 +1888,6 @@ class ptCamera:
 class ptCluster:
     """Creates a new ptCluster"""
     def __init__(self,key):
-        """None"""
         pass
 
     def setVisible(self,visible):
@@ -1908,7 +1897,6 @@ class ptCluster:
 class ptColor:
     """Plasma color class"""
     def __init__(self,red=0, green=0, blue=0, alpha=0):
-        """None"""
         pass
 
     def black(self):
@@ -2066,7 +2054,6 @@ class ptColor:
 class ptCritterBrain:
     """Object to manipulate critter brains"""
     def __init__(self):
-        """None"""
         pass
 
     def addBehavior(self,animName, behaviorName, loop = 1, randomStartPos = 1, fadeInLen = 2.0, fadeOutLen = 2.0):
@@ -2188,7 +2175,6 @@ class ptCritterBrain:
 class ptDniCoordinates:
     """Constructor for a D'Ni coordinate"""
     def __init__(self):
-        """None"""
         pass
 
     def fromPoint(self,pt):
@@ -2214,7 +2200,6 @@ class ptDniCoordinates:
 class ptDniInfoSource:
     """DO NOT USE"""
     def __init__(self):
-        """None"""
         pass
 
     def getAgeCoords(self):
@@ -2236,7 +2221,6 @@ class ptDniInfoSource:
 class ptDraw:
     """Plasma Draw class"""
     def __init__(self):
-        """None"""
         pass
 
     def disable(self):
@@ -2259,7 +2243,6 @@ class ptDraw:
 class ptDynamicMap:
     """Creates a ptDynamicMap object"""
     def __init__(self,key=None):
-        """None"""
         pass
 
     def addKey(self,key):
@@ -2394,7 +2377,6 @@ class ptDynamicMap:
 class ptGUIControl:
     """Base class for all GUI controls"""
     def __init__(self,controlKey):
-        """None"""
         pass
 
     def disable(self):
@@ -2524,7 +2506,6 @@ class ptGUIControl:
 class ptGUIControlButton(ptGUIControl):
     """Plasma GUI Control Button class"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def getNotifyType(self):
@@ -2542,7 +2523,6 @@ class ptGUIControlButton(ptGUIControl):
 class ptGUIControlCheckBox(ptGUIControl):
     """Plasma GUI Control Checkbox class"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def isChecked(self):
@@ -2556,7 +2536,6 @@ class ptGUIControlCheckBox(ptGUIControl):
 class ptGUIControlClickMap(ptGUIControl):
     """Plasma GUI control Click Map"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def getLastMouseDragPoint(self):
@@ -2574,7 +2553,6 @@ class ptGUIControlClickMap(ptGUIControl):
 class ptGUIControlDragBar(ptGUIControl):
     """Plasma GUI Control DragBar class"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def anchor(self):
@@ -2596,7 +2574,6 @@ class ptGUIControlDragBar(ptGUIControl):
 class ptGUIControlDraggable(ptGUIControl):
     """Plasma GUI control for something draggable"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def getLastMousePoint(self):
@@ -2610,7 +2587,6 @@ class ptGUIControlDraggable(ptGUIControl):
 class ptGUIControlDynamicText(ptGUIControl):
     """Plasma GUI Control DynamicText class"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def getMap(self,index):
@@ -2626,7 +2602,6 @@ class ptGUIControlDynamicText(ptGUIControl):
 class ptGUIControlEditBox(ptGUIControl):
     """Plasma GUI Control Editbox class"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def clearString(self):
@@ -2688,7 +2663,6 @@ class ptGUIControlEditBox(ptGUIControl):
 class ptGUIControlValue(ptGUIControl):
     """Plasma GUI Control Value class  - knobs, spinners"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def getMax(self):
@@ -2722,13 +2696,11 @@ class ptGUIControlValue(ptGUIControl):
 class ptGUIControlKnob(ptGUIControlValue):
     """Plasma GUI control for knob"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
 class ptGUIControlListBox(ptGUIControl):
     """Plasma GUI Control List Box class"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def add2StringsWithColors(self,text1,color1,text2,color2,respectAlpha):
@@ -2886,7 +2858,6 @@ class ptGUIControlListBox(ptGUIControl):
 class ptGUIControlMultiLineEdit(ptGUIControl):
     """Plasma GUI Control Multi-line edit class"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def beginUpdate(self):
@@ -3040,7 +3011,6 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 class ptGUIControlProgress(ptGUIControlValue):
     """Plasma GUI control for progress bar"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def animateToPercent(self,percent):
@@ -3050,7 +3020,6 @@ class ptGUIControlProgress(ptGUIControlValue):
 class ptGUIControlRadioGroup(ptGUIControl):
     """Plasma GUI Control Radio Group class"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def getValue(self):
@@ -3064,7 +3033,6 @@ class ptGUIControlRadioGroup(ptGUIControl):
 class ptGUIControlTextBox(ptGUIControl):
     """Plasma GUI Control Textbox class"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
     def getForeColor(self):
@@ -3102,13 +3070,11 @@ class ptGUIControlTextBox(ptGUIControl):
 class ptGUIControlUpDownPair(ptGUIControlValue):
     """Plasma GUI control for up/down pair"""
     def __init__(self,ctrlKey):
-        """None"""
         pass
 
 class ptGUIDialog:
     """Plasma GUI dialog class"""
     def __init__(self,dialogKey):
-        """None"""
         pass
 
     def disable(self):
@@ -3234,7 +3200,6 @@ class ptGUIPopUpMenu:
     name,parent,screenOriginX,screenOriginY
     """
     def __init__(self,arg1,arg2=None,arg3=None,arg4=None):
-        """None"""
         pass
 
     def addConsoleCmdItem(self,name,consoleCmd):
@@ -3320,7 +3285,6 @@ class ptGUIPopUpMenu:
 class ptGUISkin:
     """Plasma GUI Skin object"""
     def __init__(self,key):
-        """None"""
         pass
 
     def getKey(self):
@@ -3330,7 +3294,6 @@ class ptGUISkin:
 class ptGameScore:
     """Plasma Game Score"""
     def __init__(self):
-        """None"""
         pass
 
     def addPoints(self,points, key=None):
@@ -3420,13 +3383,11 @@ class ptGameScore:
 class ptGameScoreMsg:
     """Game Score operation callback message"""
     def __init__(self):
-        """None"""
         pass
 
 class ptGameScoreListMsg(ptGameScoreMsg):
     """Game Score message for scores found on the server"""
     def __init__(self):
-        """None"""
         pass
 
     def getName(self):
@@ -3444,7 +3405,6 @@ class ptGameScoreListMsg(ptGameScoreMsg):
 class ptGameScoreTransferMsg(ptGameScoreMsg):
     """Game Score message indicating a score point transfer"""
     def __init__(self):
-        """None"""
         pass
 
     def getDestination(self):
@@ -3458,7 +3418,6 @@ class ptGameScoreTransferMsg(ptGameScoreMsg):
 class ptGameScoreUpdateMsg(ptGameScoreMsg):
     """Game Score message for a score update operation"""
     def __init__(self):
-        """None"""
         pass
 
     def getScore(self):
@@ -3468,7 +3427,6 @@ class ptGameScoreUpdateMsg(ptGameScoreMsg):
 class ptGrassShader:
     """Plasma Grass Shader class"""
     def __init__(self,key):
-        """None"""
         pass
 
     def getWaveDirection(self,waveNum):
@@ -3502,7 +3460,6 @@ class ptGrassShader:
 class ptImage:
     """Plasma image class"""
     def __init__(self,imgKey):
-        """None"""
         pass
 
     def getColorLoc(self,color):
@@ -3532,7 +3489,6 @@ class ptImage:
 class ptImageLibMod:
     """Plasma image library modifier class"""
     def __init__(self,ilmKey):
-        """None"""
         pass
 
     def getImage(self,name):
@@ -3550,7 +3506,6 @@ class ptImageLibMod:
 class ptInputInterface:
     """Plasma input interface class"""
     def __init__(self):
-        """None"""
         pass
 
     def popTelescope(self):
@@ -3564,7 +3519,6 @@ class ptInputInterface:
 class ptKey:
     """Plasma Key class"""
     def __init__(self):
-        """None"""
         pass
 
     def disable(self):
@@ -3605,7 +3559,6 @@ class ptKey:
 class ptKeyMap:
     """Accessor class to the Key Mapping functions"""
     def __init__(self):
-        """None"""
         pass
 
     def bindKey(self,key1,key2,action):
@@ -3667,7 +3620,6 @@ class ptKeyMap:
 class ptLayer:
     """Plasma layer class"""
     def __init__(self,layerKey):
-        """None"""
         pass
 
     def getTexture(self) -> ptImage:
@@ -3681,7 +3633,6 @@ class ptLayer:
 class ptMarkerMgr:
     """Marker manager accessor class"""
     def __init__(self):
-        """None"""
         pass
 
     def addMarker(self,x, y, z, id, justCreated):
@@ -3739,7 +3690,6 @@ class ptMarkerMgr:
 class ptMatrix44:
     """Plasma Matrix44 class"""
     def __init__(self):
-        """None"""
         pass
 
     def copy(self):
@@ -3829,7 +3779,6 @@ class ptMatrix44:
 class ptMoviePlayer:
     """Accessor class to play in the MoviePlayer"""
     def __init__(self,movieName,selfKey):
-        """None"""
         pass
 
     def pause(self):
@@ -3875,7 +3824,6 @@ class ptMoviePlayer:
 class ptNetLinkingMgr:
     """Constructor to get access to the net link manager"""
     def __init__(self):
-        """None"""
         pass
 
     def getCurrAgeLink(self):
@@ -3927,7 +3875,6 @@ class ptNotify:
     - selfKey is ptKey of your PythonFile modifier
     """
     def __init__(self,selfKey):
-        """None"""
         pass
 
     def addActivateEvent(self,activeFlag,activateFlag):
@@ -4029,7 +3976,6 @@ class ptNotify:
 class ptParticle:
     """Plasma particle system class"""
     def __init__(self):
-        """None"""
         pass
 
     def netForce(self,forceFlag):
@@ -4090,7 +4036,6 @@ class ptParticle:
 class ptPhysics:
     """Plasma physics class"""
     def __init__(self):
-        """None"""
         pass
 
     def angularImpulse(self,impulseVector):
@@ -4187,7 +4132,6 @@ class ptPhysics:
 class ptPlayer:
     """And optionally __init__(name,playerID)"""
     def __init__(self,avkey,name,playerID,distanceSq):
-        """None"""
         pass
 
     def getDistanceSq(self):
@@ -4213,7 +4157,6 @@ class ptPlayer:
 class ptPoint3:
     """Plasma Point class"""
     def __init__(self,x=0, y=0, z=0):
-        """None"""
         pass
 
     def copy(self):
@@ -4261,7 +4204,6 @@ class ptPoint3:
 class ptSDL:
     """SDL accessor"""
     def __init__(self):
-        """None"""
         pass
 
     def sendToClients(self,key):
@@ -4305,7 +4247,6 @@ class ptSDL:
 class ptSDLStateDataRecord:
     """Basic SDL state data record class"""
     def __init__(self):
-        """None"""
         pass
 
     def findVar(self,name):
@@ -4336,7 +4277,6 @@ class ptSceneobject:
     physics: Any
 
     def __init__(self,objKey, selfKey):
-        """None"""
         pass
 
     def addKey(self,key):
@@ -4511,7 +4451,6 @@ class ptSceneobject:
 class ptSimpleStateVariable:
     """Basic SDL state data record class"""
     def __init__(self):
-        """None"""
         pass
 
     def getBool(self,idx=0):
@@ -4601,7 +4540,6 @@ class ptSimpleStateVariable:
 class ptSpawnPointInfo:
     """Class to hold spawn point data"""
     def __init__(self,title=None,spawnPt=None):
-        """None"""
         pass
 
     def getCameraStack(self):
@@ -4631,7 +4569,6 @@ class ptSpawnPointInfo:
 class ptSpawnPointInfoRef:
     """Class to hold spawn point data"""
     def __init__(self):
-        """None"""
         pass
 
     def getCameraStack(self):
@@ -4661,7 +4598,6 @@ class ptSpawnPointInfoRef:
 class ptStatusLog:
     """A status log class"""
     def __init__(self):
-        """None"""
         pass
 
     def close(self):
@@ -4689,7 +4625,6 @@ class ptStatusLog:
 class ptStream:
     """A basic stream class"""
     def __init__(self):
-        """None"""
         pass
 
     def close(self):
@@ -4731,7 +4666,6 @@ class ptSwimCurrentInterface:
     """UNKNOWN"""
 
     def __init__(self,key):
-        """None"""
         pass
 
     def disable(self):
@@ -4745,7 +4679,6 @@ class ptSwimCurrentInterface:
 class ptVault:
     """Accessor class to the player's vault"""
     def __init__(self):
-        """None"""
         pass
 
     def addChronicleEntry(self,entryName,type,string):
@@ -4915,7 +4848,6 @@ class ptVault:
 class ptVaultNode:
     """Vault node class"""
     def __init__(self):
-        """None"""
         pass
 
     def addNode(self,node,cb=None,cbContext=0):
@@ -5103,7 +5035,6 @@ class ptVaultNode:
 class ptVaultFolderNode(ptVaultNode):
     """Plasma vault folder node"""
     def __init__(self,n=0):
-        """None"""
         pass
 
     def getFolderName(self):
@@ -5125,7 +5056,6 @@ class ptVaultFolderNode(ptVaultNode):
 class ptVaultAgeInfoListNode(ptVaultFolderNode):
     """Plasma vault age info list node"""
     def __init__(self,n=0):
-        """None"""
         pass
 
     def addAge(self,ageID):
@@ -5143,7 +5073,6 @@ class ptVaultAgeInfoListNode(ptVaultFolderNode):
 class ptVaultAgeInfoNode(ptVaultNode):
     """Plasma vault age info node"""
     def __init__(self,n=0):
-        """None"""
         pass
 
     def asAgeInfoStruct(self):
@@ -5253,7 +5182,6 @@ class ptVaultAgeInfoNode(ptVaultNode):
 class ptVaultAgeLinkNode(ptVaultNode):
     """Plasma vault age link node"""
     def __init__(self,n=0):
-        """None"""
         pass
 
     def addSpawnPoint(self,point):
@@ -5299,7 +5227,6 @@ class ptVaultAgeLinkNode(ptVaultNode):
 class ptVaultChronicleNode(ptVaultNode):
     """Plasma vault chronicle node"""
     def __init__(self,n=0):
-        """None"""
         pass
 
     def getEntryType(self):
@@ -5329,7 +5256,6 @@ class ptVaultChronicleNode(ptVaultNode):
 class ptVaultImageNode(ptVaultNode):
     """Plasma vault image node"""
     def __init__(self,n=0):
-        """None"""
         pass
 
     def getImage(self):
@@ -5359,7 +5285,6 @@ class ptVaultImageNode(ptVaultNode):
 class ptVaultMarkerGameNode(ptVaultNode):
     """Plasma vault age info node"""
     def __init__(self,n=0):
-        """None"""
         pass
 
     def getGameGuid(self):
@@ -5397,7 +5322,6 @@ class ptVaultMarkerGameNode(ptVaultNode):
 class ptVaultNodeRef:
     """Vault node relationship pseudo class"""
     def __init__(self):
-        """None"""
         pass
 
     def beenSeen(self):
@@ -5435,7 +5359,6 @@ class ptVaultNodeRef:
 class ptVaultPlayerInfoListNode(ptVaultFolderNode):
     """Plasma vault player info list node"""
     def __init__(self,n=0):
-        """None"""
         pass
 
     def addPlayer(self,playerID):
@@ -5461,7 +5384,6 @@ class ptVaultPlayerInfoListNode(ptVaultFolderNode):
 class ptVaultPlayerInfoNode(ptVaultNode):
     """Plasma vault folder node"""
     def __init__(self):
-        """None"""
         pass
 
     def playerGetAgeGuid(self):
@@ -5511,7 +5433,6 @@ class ptVaultPlayerInfoNode(ptVaultNode):
 class ptVaultSDLNode(ptVaultNode):
     """Plasma vault SDL node"""
     def __init__(self):
-        """None"""
         pass
 
     def getIdent(self):
@@ -5537,13 +5458,11 @@ class ptVaultSDLNode(ptVaultNode):
 class ptVaultSystemNode(ptVaultNode):
     """Plasma vault system node"""
     def __init__(self):
-        """None"""
         pass
 
 class ptVaultTextNoteNode(ptVaultNode):
     """Plasma vault text note node"""
     def __init__(self):
-        """None"""
         pass
 
     def getDeviceInbox(self):
@@ -5589,7 +5508,6 @@ class ptVaultTextNoteNode(ptVaultNode):
 class ptVector3:
     """Plasma 3D Vector class"""
     def __init__(self,x=0, y=0, z=0):
-        """None"""
         pass
 
     def add(self,other):
@@ -5661,7 +5579,6 @@ class ptVector3:
 class ptWaveSet:
     """Creates a new ptWaveSet"""
     def __init__(self,key):
-        """None"""
         pass
 
     def addBuoy(self,soKey: ptKey) -> None:

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -63,16 +63,16 @@ def PtAmCCR():
 
 def PtAtTimeCallback(selfkey,time,id):
     """This will create a timer callback that will call OnTimer when complete
-- 'selfkey' is the ptKey of the PythonFile component
-- 'time' is how much time from now (in seconds) to call back
-- 'id' is an integer id that will be returned in the OnTimer call"""
+    - 'selfkey' is the ptKey of the PythonFile component
+    - 'time' is how much time from now (in seconds) to call back
+    - 'id' is an integer id that will be returned in the OnTimer call"""
     pass
 
 def PtAttachObject(child,parent,netForce=False):
     """Attach child to parent based on ptKey or ptSceneobject
-- childKey is the ptKey or ptSceneobject of the one being attached
-- parentKey is the ptKey or ptSceneobject of the one being attached to
-(both arguments must be ptKeys or ptSceneobjects, you cannot mix types)"""
+    - childKey is the ptKey or ptSceneobject of the one being attached
+    - parentKey is the ptKey or ptSceneobject of the one being attached to
+    (both arguments must be ptKeys or ptSceneobjects, you cannot mix types)"""
     pass
 
 def PtAvatarEnterAFK():
@@ -161,7 +161,7 @@ def PtConsole(command):
 
 def PtConsoleNet(command,netForce):
     """This will execute 'command' on the console, over the network, on all clients.
-If 'netForce' is true then force command to be sent over the network."""
+    If 'netForce' is true then force command to be sent over the network."""
     pass
 
 def PtCreateDir(directory):
@@ -190,9 +190,9 @@ def PtDeletePlayer(playerInt):
 
 def PtDetachObject(child,parent,netForce=False):
     """Detach child from parent based on ptKey or ptSceneobject
-- child is the ptKey or ptSceneobject of the one being detached
-- parent is the ptKey or ptSceneobject of the one being detached from
-(both arguments must be ptKeys or ptSceneobjects, you cannot mix types)"""
+    - child is the ptKey or ptSceneobject of the one being detached
+    - parent is the ptKey or ptSceneobject of the one being detached from
+    (both arguments must be ptKeys or ptSceneobjects, you cannot mix types)"""
     pass
 
 def PtDirtySynchClients(selfKey,SDLStateName,flags):
@@ -281,16 +281,16 @@ def PtEnableShadows():
 
 def PtExcludeRegionSet(senderKey,regionKey,state):
     """This will set the state of an exclude region
-- 'senderKey' is a ptKey of the PythonFile component
-- 'regionKey' is a ptKey of the exclude region
-- 'state' is either kExRegRelease or kExRegClear"""
+    - 'senderKey' is a ptKey of the PythonFile component
+    - 'regionKey' is a ptKey of the exclude region
+    - 'state' is either kExRegRelease or kExRegClear"""
     pass
 
 def PtExcludeRegionSetNow(senderKey,regionKey,state):
     """This will set the state of an exclude region immediately on the server
-- 'senderKey' is a ptKey of the PythonFile component
-- 'regionKey' is a ptKey of the exclude region
-- 'state' is either kExRegRelease or kExRegClear"""
+    - 'senderKey' is a ptKey of the PythonFile component
+    - 'regionKey' is a ptKey of the exclude region
+    - 'state' is either kExRegRelease or kExRegClear"""
     pass
 
 def PtFadeIn(lenTime, holdFlag, noSound=0):
@@ -307,7 +307,7 @@ def PtFadeOut(lenTime, holdFlag, noSound=0):
 
 def PtFakeLinkAvatarToObject(avatar,object):
     """Pseudo-links avatar to object within the same age
-"""
+    """
     pass
 
 def PtFileExists(filename):
@@ -316,7 +316,7 @@ def PtFileExists(filename):
 
 def PtFindActivator(name):
     """This will try to find an activator based on its name
-- it will return a ptKey if found- it will return None if not found"""
+    - it will return a ptKey if found- it will return None if not found"""
     pass
 
 def PtFindClones(key):
@@ -333,7 +333,7 @@ def PtFindLayer(name: str, age: str = "", page: str = "") -> Optional[ptLayer]:
 
 def PtFindSceneobject(name,ageName):
     """This will try to find a sceneobject based on its name and what age its in
-- it will return a ptSceneObject if found- if not found then a NameError exception will happen"""
+    - it will return a ptSceneObject if found- if not found then a NameError exception will happen"""
     pass
 
 def PtFindSceneobjects(name):
@@ -366,12 +366,12 @@ def PtFogSetDefLinear(start,end,density):
 
 def PtForceCursorHidden():
     """Forces the cursor to hide, overriding everything.
-Only call if other methods won't work. The only way to show the cursor after this call is PtForceMouseShown()"""
+    Only call if other methods won't work. The only way to show the cursor after this call is PtForceMouseShown()"""
     pass
 
 def PtForceCursorShown():
     """Forces the cursor to show, overriding everything.
-Only call if other methods won't work. This is the only way to show the cursor after a call to PtForceMouseHidden()"""
+    Only call if other methods won't work. This is the only way to show the cursor after a call to PtForceMouseHidden()"""
     pass
 
 def PtForceVaultNodeUpdate(nodeId):
@@ -440,8 +440,8 @@ def PtGetClientIDFromAvatarKey(avatarKey):
 
 def PtGetClientName(avatarKey=None):
     """This will return the name of the client that is owned by the avatar
-- avatarKey is the ptKey of the avatar to get the client name of.
-If avatarKey is omitted then the local avatar is used"""
+    - avatarKey is the ptKey of the avatar to get the client name of.
+    If avatarKey is omitted then the local avatar is used"""
     pass
 
 def PtGetControlEvents(on, key):
@@ -498,7 +498,7 @@ def PtGetLanguage():
 
 def PtGetLocalAvatar():
     """This will return a ptSceneobject of the local avatar
-- if there is no local avatar a NameError exception will happen."""
+    - if there is no local avatar a NameError exception will happen."""
     pass
 
 def PtGetLocalClientID():
@@ -559,7 +559,7 @@ def PtGetPrevAgeName():
 
 def PtGetPublicAgeList(ageName, cbObject=None):
     """Get list of public ages for the given age name.
-cbObject, if supplied should have a method called gotPublicAgeList(self,ageList). ageList is a list of tuple(ptAgeInfoStruct,nPlayersInAge)"""
+    cbObject, if supplied should have a method called gotPublicAgeList(self,ageList). ageList is a list of tuple(ptAgeInfoStruct,nPlayersInAge)"""
     pass
 
 def PtGetPythonLoggingLevel():
@@ -664,17 +664,17 @@ def PtLoadBookGUI(guiName):
 
 def PtLoadDialog(dialogName,selfKey=None,ageName=""):
     """Loads a GUI dialog by name and optionally set the Notify proc key
-If the dialog is already loaded then it won't load it again"""
+    If the dialog is already loaded then it won't load it again"""
     pass
 
 def PtLoadJPEGFromDisk(filename,width,height):
     """The image will be resized to fit the width and height arguments. Set to 0 if resizing is not desired.
-Returns a pyImage of the specified file."""
+    Returns a pyImage of the specified file."""
     pass
 
 def PtLoadPNGFromDisk(filename,width,height):
     """The image will be resized to fit the width and height arguments. Set to 0 if resizing is not desired.
-Returns a pyImage of the specified file."""
+    Returns a pyImage of the specified file."""
     pass
 
 def PtLocalAvatarIsMoving():
@@ -751,17 +751,17 @@ def PtSendFriendInvite(emailAddress, toName = "Friend"):
 
 def PtSendKIGZMarkerMsg(markerNumber,sender):
     """Same as PtSendKIMessageInt except 'sender' could get a notify message back
-"""
+    """
     pass
 
 def PtSendKIMessage(command,value):
     """Sends a command message to the KI frontend.
-See PlasmaKITypes.py for list of commands"""
+    See PlasmaKITypes.py for list of commands"""
     pass
 
 def PtSendKIMessageInt(command,value):
     """Same as PtSendKIMessage except the value is guaranteed to be a uint32_t
-(for things like player IDs)"""
+    (for things like player IDs)"""
     pass
 
 def PtSendKIRegisterImagerMsg(imagerName, sender):
@@ -778,7 +778,7 @@ def PtSendPrivateChatList(chatList):
 
 def PtSendRTChat(fromPlayer,toPlayerList,message,flags):
     """Sends a realtime chat message to the list of ptPlayers
-If toPlayerList is an empty list, it is a broadcast message"""
+    If toPlayerList is an empty list, it is a broadcast message"""
     pass
 
 def PtSetActivePlayer(playerInt):
@@ -787,8 +787,8 @@ def PtSetActivePlayer(playerInt):
 
 def PtSetAlarm(secs, cbObject, cbContext):
     """secs is the amount of time before your alarm goes off.
-cbObject is a python object with the method onAlarm(int context)
-cbContext is an integer."""
+    cbObject is a python object with the method onAlarm(int context)
+    cbContext is an integer."""
     pass
 
 def PtSetBehaviorLoopCount(behaviorKey,stage,loopCount,netForce):
@@ -897,7 +897,7 @@ def PtTransferParticlesToObject(objFrom, objTo, num):
 
 def PtUnLoadAvatarModel(avatarKey):
     """Forcibly unloads the specified avatar model.
-Do not use this method unless you require fine-grained control of avatar unloading."""
+    Do not use this method unless you require fine-grained control of avatar unloading."""
     pass
 
 def PtUnloadAllBookGUIs():
@@ -914,7 +914,7 @@ def PtUnloadDialog(dialogName):
 
 def PtValidateKey(key):
     """Returns true(1) if 'key' is valid and loaded,
-otherwise returns false(0)"""
+    otherwise returns false(0)"""
     pass
 
 def PtVaultDownload(nodeId):
@@ -1247,7 +1247,7 @@ class ptAnimation:
 
     def getFirstKey(self):
         """This will return a ptKey object that is the first receiver (target)
-However, if the parent is not a modifier or not loaded, then None is returned."""
+        However, if the parent is not a modifier or not loaded, then None is returned."""
         pass
 
     def incrementBackward(self):
@@ -1264,8 +1264,8 @@ However, if the parent is not a modifier or not loaded, then None is returned.""
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
-- This is to be used if your Python program is running on only one client
-Such as a game master, only running on the client that owns a particular object"""
+        - This is to be used if your Python program is running on only one client
+        Such as a game master, only running on the client that owns a particular object"""
         pass
 
     def play(self):
@@ -1298,12 +1298,12 @@ Such as a game master, only running on the client that owns a particular object"
 
     def setLoopEnd(self,loopEnd):
         """Sets the loop ending position
-- 'loopEnd' is the number of seconds from the absolute beginning of the animation"""
+        - 'loopEnd' is the number of seconds from the absolute beginning of the animation"""
         pass
 
     def setLoopStart(self,loopStart):
         """Sets the loop starting position
-- 'loopStart' is the number of seconds from the absolute beginning of the animation"""
+        - 'loopStart' is the number of seconds from the absolute beginning of the animation"""
         pass
 
     def skipToBegin(self):
@@ -1458,7 +1458,7 @@ class ptAudioControl:
 
     def setAmbienceVolume(self,volume):
         """Sets the Ambience volume (0.0 to 1.0) for the game.
-This only sets the volume for this game session."""
+        This only sets the volume for this game session."""
         pass
 
     def setCaptureDevice(self,devicename):
@@ -1467,7 +1467,7 @@ This only sets the volume for this game session."""
 
     def setGUIVolume(self,volume):
         """Sets the GUI dialog volume (0.0 to 1.0) for the game.
-This only sets the volume for this game session."""
+        This only sets the volume for this game session."""
         pass
 
     def setLoadOnDemand(self,state):
@@ -1480,12 +1480,12 @@ This only sets the volume for this game session."""
 
     def setMusicVolume(self,volume):
         """Sets the Music volume (0.0 to 1.0) for the game.
-This only sets the volume for this game session."""
+        This only sets the volume for this game session."""
         pass
 
     def setNPCVoiceVolume(self,volume):
         """Sets the NPC's voice volume (0.0 to 1.0) for the game.
-This only sets the volume for this game session."""
+        This only sets the volume for this game session."""
         pass
 
     def setPlaybackDevice(self,devicename,restart):
@@ -1498,17 +1498,17 @@ This only sets the volume for this game session."""
 
     def setSoundFXVolume(self,volume):
         """Sets the SoundFX volume (0.0 to 1.0) for the game.
-This only sets the volume for this game session."""
+        This only sets the volume for this game session."""
         pass
 
     def setTwoStageLOD(self,state):
         """Enables or disables two-stage LOD, where sounds can be loaded into RAM but not into sound buffers.
-...Less of a performance hit, harder on memory."""
+        ...Less of a performance hit, harder on memory."""
         pass
 
     def setVoiceVolume(self,volume):
         """Sets the Voice volume (0.0 to 1.0) for the game.
-This only sets the volume for this game session."""
+        This only sets the volume for this game session."""
         pass
 
     def showIcons(self):
@@ -1551,7 +1551,7 @@ class ptAvatar:
 
     def getAvatarClothingGroup(self):
         """Returns what clothing group the avatar belongs to.
-It is also a means to determine if avatar is male or female"""
+        It is also a means to determine if avatar is male or female"""
         pass
 
     def getAvatarClothingList(self):
@@ -1568,12 +1568,12 @@ It is also a means to determine if avatar is male or female"""
 
     def getEntireClothingList(self,clothing_type):
         """Gets the entire list of clothing available. 'clothing_type' not used
-NOTE: should use getClosetClothingList"""
+        NOTE: should use getClosetClothingList"""
         pass
 
     def getMatchingClothingItem(self,clothingName):
         """Finds the matching clothing item that goes with 'clothingName'
-Used to find matching left and right gloves and shoes."""
+        Used to find matching left and right gloves and shoes."""
         pass
 
     def getMorph(self,clothing_name,layer):
@@ -1586,7 +1586,7 @@ Used to find matching left and right gloves and shoes."""
 
     def getTintClothingItem(self,clothing_name,layer=1):
         """Returns a ptColor of a particular item of clothing that the avatar is wearing.
-The color will be a ptColor object."""
+        The color will be a ptColor object."""
         pass
 
     def getTintSkin(self):
@@ -1611,8 +1611,8 @@ The color will be a ptColor object."""
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
-- This is to be used if your Python program is running on only one client
-Such as a game master, only running on the client that owns a particular object"""
+        - This is to be used if your Python program is running on only one client
+        Such as a game master, only running on the client that owns a particular object"""
         pass
 
     def nextStage(self,behaviorKey,transitionTime,setTimeFlag,newTime,SetDirectionFlag,isForward,netForce):
@@ -1677,7 +1677,7 @@ Such as a game master, only running on the client that owns a particular object"
 
     def tintClothingItem(self,clothing_name,tint,update=1):
         """Tells the avatar to tint(color) a particular item of clothing that they are already wearing.
-'tint' is a ptColor object"""
+        'tint' is a ptColor object"""
         pass
 
     def tintClothingItemLayer(self,clothing_name,tint,layer,update=1):
@@ -1694,7 +1694,7 @@ Such as a game master, only running on the client that owns a particular object"
 
     def wearClothingItem(self,clothing_name,update=1):
         """Tells the avatar to wear a particular item of clothing.
-And optionally hold update until later (for applying tinting before wearing)."""
+        And optionally hold update until later (for applying tinting before wearing)."""
         pass
 
 class ptBook:
@@ -1757,7 +1757,7 @@ class ptBook:
 
     def setGUI(self,guiName):
         """Sets the gui to be used by the book, if the requested gui is not loaded, it will use the default
-Do not call while the book is open!"""
+        Do not call while the book is open!"""
         pass
 
     def setPageMargin(self,margin):
@@ -1780,7 +1780,7 @@ class ptCamera:
 
     def controlKey(self,controlKey,activateFlag):
         """Send a control key to the camera as if it was hit by the user.
-This is for sending things like pan-up, pan-down, zoom-in, etc."""
+        This is for sending things like pan-up, pan-down, zoom-in, etc."""
         pass
 
     def disableFirstPersonOverride(self):
@@ -1849,7 +1849,7 @@ This is for sending things like pan-up, pan-down, zoom-in, etc."""
 
     def undoFirstPerson(self):
         """If the user has overridden the camera to be in first person, this will take them out of first person.
-If the user didn't override the camera, then this will do nothing."""
+        If the user didn't override the camera, then this will do nothing."""
         pass
 
 class ptCluster:
@@ -1870,37 +1870,37 @@ class ptColor:
 
     def black(self):
         """Sets the color to be black
-Example: black = ptColor().black()"""
+        Example: black = ptColor().black()"""
         pass
 
     def blue(self):
         """Sets the color to be blue
-Example: blue = ptColor().blue()"""
+        Example: blue = ptColor().blue()"""
         pass
 
     def brown(self):
         """Sets the color to be brown
-Example: brown = ptColor().brown()"""
+        Example: brown = ptColor().brown()"""
         pass
 
     def cyan(self):
         """Sets the color to be cyan
-Example: cyan = ptColor.cyan()"""
+        Example: cyan = ptColor.cyan()"""
         pass
 
     def darkbrown(self):
         """Sets the color to be darkbrown
-Example: darkbrown = ptColor().darkbrown()"""
+        Example: darkbrown = ptColor().darkbrown()"""
         pass
 
     def darkgreen(self):
         """Sets the color to be darkgreen
-Example: darkgreen = ptColor().darkgreen()"""
+        Example: darkgreen = ptColor().darkgreen()"""
         pass
 
     def darkpurple(self):
         """Sets the color to be darkpurple
-Example: darkpurple = ptColor().darkpurple()"""
+        Example: darkpurple = ptColor().darkpurple()"""
         pass
 
     def getAlpha(self):
@@ -1921,42 +1921,42 @@ Example: darkpurple = ptColor().darkpurple()"""
 
     def gray(self):
         """Sets the color to be gray
-Example: gray = ptColor().gray()"""
+        Example: gray = ptColor().gray()"""
         pass
 
     def green(self):
         """Sets the color to be green
-Example: green = ptColor().green()"""
+        Example: green = ptColor().green()"""
         pass
 
     def magenta(self):
         """Sets the color to be magenta
-Example: magenta = ptColor().magenta()"""
+        Example: magenta = ptColor().magenta()"""
         pass
 
     def maroon(self):
         """Sets the color to be maroon
-Example: maroon = ptColor().maroon()"""
+        Example: maroon = ptColor().maroon()"""
         pass
 
     def navyblue(self):
         """Sets the color to be navyblue
-Example: navyblue = ptColor().navyblue()"""
+        Example: navyblue = ptColor().navyblue()"""
         pass
 
     def orange(self):
         """Sets the color to be orange
-Example: orange = ptColor().orange()"""
+        Example: orange = ptColor().orange()"""
         pass
 
     def pink(self):
         """Sets the color to be pink
-Example: pink = ptColor().pink()"""
+        Example: pink = ptColor().pink()"""
         pass
 
     def red(self):
         """Sets the color to be red
-Example: red = ptColor().red()"""
+        Example: red = ptColor().red()"""
         pass
 
     def setAlpha(self,alpha):
@@ -1977,27 +1977,27 @@ Example: red = ptColor().red()"""
 
     def slateblue(self):
         """Sets the color to be slateblue
-Example: slateblue = ptColor().slateblue()"""
+        Example: slateblue = ptColor().slateblue()"""
         pass
 
     def steelblue(self):
         """Sets the color to be steelblue
-Example: steelblue = ptColor().steelblue()"""
+        Example: steelblue = ptColor().steelblue()"""
         pass
 
     def tan(self):
         """Sets the color to be tan
-Example: tan = ptColor().tan()"""
+        Example: tan = ptColor().tan()"""
         pass
 
     def white(self):
         """Sets the color to be white
-Example: white = ptColor().white()"""
+        Example: white = ptColor().white()"""
         pass
 
     def yellow(self):
         """Sets the color to be yellow
-Example: yellow = ptColor().yellow()"""
+        Example: yellow = ptColor().yellow()"""
         pass
 
 class ptCritterBrain:
@@ -2178,7 +2178,7 @@ class ptDraw:
 
     def disable(self):
         """Disables the draw on the sceneobject attached
-In other words, makes it invisible"""
+        In other words, makes it invisible"""
         pass
 
     def enable(self,state=1):
@@ -2187,8 +2187,8 @@ In other words, makes it invisible"""
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
-- This is to be used if your Python program is running on only one client
-Such as a game master, only running on the client that owns a particular object"""
+        - This is to be used if your Python program is running on only one client
+        Such as a game master, only running on the client that owns a particular object"""
         pass
 
 class ptDynamicMap:
@@ -2211,7 +2211,7 @@ class ptDynamicMap:
 
     def clearToColor(self,color):
         """Clear the DynamicMap to the specified color
-- 'color' is a ptColor object"""
+        - 'color' is a ptColor object"""
         pass
 
     def drawImage(self,x,y,image,respectAlphaFlag):
@@ -2224,14 +2224,14 @@ class ptDynamicMap:
 
     def drawText(self,x,y,text):
         """Draw text at a specified location
-- x,y is the point to start drawing the text
-- 'text' is a string of the text to be drawn"""
+        - x,y is the point to start drawing the text
+        - 'text' is a string of the text to be drawn"""
         pass
 
     def fillRect(self,left,top,right,bottom,color):
         """Fill in the specified rectangle with a color
-- left,top,right,bottom define the rectangle
-- 'color' is a ptColor object"""
+        - left,top,right,bottom define the rectangle
+        - 'color' is a ptColor object"""
         pass
 
     def flush(self):
@@ -2240,8 +2240,8 @@ class ptDynamicMap:
 
     def frameRect(self,left,top,right,bottom,color):
         """Frame a rectangle with a specified color
-- left,top,right,bottom define the rectangle
-- 'color' is a ptColor object"""
+        - left,top,right,bottom define the rectangle
+        - 'color' is a ptColor object"""
         pass
 
     def getHeight(self):
@@ -2258,14 +2258,14 @@ class ptDynamicMap:
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
-- This is to be used if your Python program is running on only one client
-Such as a game master, only running on the client that owns a particular object
-This only applies when NetPropagate is set to true"""
+        - This is to be used if your Python program is running on only one client
+        Such as a game master, only running on the client that owns a particular object
+        This only applies when NetPropagate is set to true"""
         pass
 
     def netPropagate(self,propagateFlag):
         """Specify whether this object needs to use messages that are sent on the network
-- The default is for this to be false."""
+        - The default is for this to be false."""
         pass
 
     def purgeImage(self):
@@ -2278,14 +2278,14 @@ This only applies when NetPropagate is set to true"""
 
     def setClipping(self,clipLeft,clipTop,clipRight,clipBottom):
         """Sets the clipping rectangle
-- All drawtext will be clipped to this until the
-unsetClipping() is called"""
+        - All drawtext will be clipped to this until the
+        unsetClipping() is called"""
         pass
 
     def setFont(self,facename,size):
         """Set the font of the text to be written
-- 'facename' is a string with the name of the font
-- 'size' is the point size of the font to use"""
+        - 'facename' is a string with the name of the font
+        - 'size' is the point size of the font to use"""
         pass
 
     def setJustify(self,justify):
@@ -2298,14 +2298,14 @@ unsetClipping() is called"""
 
     def setTextColor(self,color, blockRGB=0):
         """Set the color of the text to be written
-- 'color' is a ptColor object
-- 'blockRGB' must be true if you're trying to render onto a transparent or semi-transparent color"""
+        - 'color' is a ptColor object
+        - 'blockRGB' must be true if you're trying to render onto a transparent or semi-transparent color"""
         pass
 
     def setWrapping(self,wrapWidth,wrapHeight):
         """Set where text will be wrapped horizontally and vertically
-- All drawtext commands will be wrapped until the
-unsetWrapping() is called"""
+        - All drawtext commands will be wrapped until the
+        unsetWrapping() is called"""
         pass
 
     def unsetClipping(self):
@@ -2504,7 +2504,7 @@ class ptGUIControlDragBar(ptGUIControl):
 
     def anchor(self):
         """Don't allow this dragbar object to be moved by the user.
-Drop anchor!"""
+        Drop anchor!"""
         pass
 
     def isAnchored(self):
@@ -2513,7 +2513,7 @@ Drop anchor!"""
 
     def unanchor(self):
         """Allow the user to drag this control around the screen.
-Raise anchor."""
+        Raise anchor."""
         pass
 
 class ptGUIControlDraggable(ptGUIControl):
@@ -2538,7 +2538,7 @@ class ptGUIControlDynamicText(ptGUIControl):
 
     def getMap(self,index):
         """Returns a specific ptDynamicText attached to this contol
-If there is no map at 'index' then a KeyError exception will be raised"""
+        If there is no map at 'index' then a KeyError exception will be raised"""
         pass
 
     def getNumMaps(self):
@@ -2747,7 +2747,7 @@ class ptGUIControlListBox(ptGUIControl):
 
     def lock(self):
         """Locks the updates to a listbox, so a number of operations can be performed
-NOTE: an unlock() call must be made before the next lock() can be."""
+        NOTE: an unlock() call must be made before the next lock() can be."""
         pass
 
     def refresh(self):
@@ -2796,7 +2796,7 @@ NOTE: an unlock() call must be made before the next lock() can be."""
 
     def unclickable(self):
         """Makes this listbox not clickable by the user.
-Useful when just displaying a list that is not really selectable."""
+        Useful when just displaying a list that is not really selectable."""
         pass
 
     def unlock(self):
@@ -2887,7 +2887,7 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 
     def insertColor(self,color):
         """Inserts an encoded color object at the current cursor position.
-'color' is a ptColor object."""
+        'color' is a ptColor object."""
         pass
 
     def insertLink(self,linkId: int) -> None:
@@ -2948,7 +2948,7 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 
     def unclickable(self):
         """Makes this listbox not clickable by the user.
-Useful when just displaying a list that is not really selectable."""
+        Useful when just displaying a list that is not really selectable."""
         pass
 
     def unlock(self):
@@ -3147,9 +3147,9 @@ class ptGUIDialog:
 
 class ptGUIPopUpMenu:
     """Takes three diferent argument lists:
-gckey
-name,screenOriginX,screenOriginY
-name,parent,screenOriginX,screenOriginY"""
+    gckey
+    name,screenOriginX,screenOriginY
+    name,parent,screenOriginX,screenOriginY"""
     def __init__(self,arg1,arg2=None,arg3=None,arg4=None):
         """None"""
         pass
@@ -3326,7 +3326,7 @@ class ptGameScore:
 
     def setPoints(self,numPoints, key):
         """Sets the number of points in the score
-Don't use to add/remove points, use only to reset values!"""
+        Don't use to add/remove points, use only to reset values!"""
         pass
 
     def transferPoints(self,dest, points=0, key=None):
@@ -3497,12 +3497,12 @@ class ptKey:
 
     def getParentKey(self):
         """This will return a ptKey object that is the parent of this modifer
-However, if the parent is not a modifier or not loaded, then None is returned."""
+        However, if the parent is not a modifier or not loaded, then None is returned."""
         pass
 
     def getSceneObject(self):
         """This will return a ptSceneobject object that is associated with this ptKey
-However, if this ptKey is _not_ a sceneobject, then unpredicatable results will ensue"""
+        However, if this ptKey is _not_ a sceneobject, then unpredicatable results will ensue"""
         pass
 
     def isAttachedToClone(self):
@@ -3511,8 +3511,8 @@ However, if this ptKey is _not_ a sceneobject, then unpredicatable results will 
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
-- This is to be used if your Python program is running on only one client
-Such as a game master, only running on the client that owns a particular object"""
+        - This is to be used if your Python program is running on only one client
+        Such as a game master, only running on the client that owns a particular object"""
         pass
 
 class ptKeyMap:
@@ -3837,7 +3837,7 @@ class ptNetLinkingMgr:
 
 class ptNotify:
     """Creates a Notify message
-- selfKey is ptKey of your PythonFile modifier"""
+    - selfKey is ptKey of your PythonFile modifier"""
     def __init__(self,selfKey):
         """None"""
         pass
@@ -3880,39 +3880,39 @@ class ptNotify:
 
     def addVarFloat(self,name,number):
         """Add a float variable event record to the Notify message
-This event record is used to pass a number variable to another python program"""
+        This event record is used to pass a number variable to another python program"""
         pass
 
     def addVarInt(self,name,number):
         """Add a int variable event record to the Notify message
-This event record is used to pass a number variable to another python program"""
+        This event record is used to pass a number variable to another python program"""
         pass
 
     def addVarKey(self,name,key):
         """Add a ptKey variable event record to the Notify message
-This event record is used to pass a ptKey variable to another python program"""
+        This event record is used to pass a ptKey variable to another python program"""
         pass
 
     def addVarNull(self,name,number):
         """Add a null (no data) variable event record to the Notify message
-This event record is used to pass a number variable to another python program"""
+        This event record is used to pass a number variable to another python program"""
         pass
 
     def addVarNumber(self,name,number):
         """Add a number variable event record to the Notify message
-Method will try to pick appropriate variable type
-This event record is used to pass a number variable to another python program"""
+        Method will try to pick appropriate variable type
+        This event record is used to pass a number variable to another python program"""
         pass
 
     def clearReceivers(self):
         """Remove all the receivers that this Notify message has
-- receivers are automatically added if from a ptAttribActivator"""
+        - receivers are automatically added if from a ptAttribActivator"""
         pass
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
-- This is to be used if your Python program is running on only one client
-Such as a game master, only running on the client that owns a particular object"""
+        - This is to be used if your Python program is running on only one client
+        Such as a game master, only running on the client that owns a particular object"""
         pass
 
     def netPropagate(self,netFlag):
@@ -3939,8 +3939,8 @@ class ptParticle:
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
-- This is to be used if your Python program is running on only one client
-Such as a game master, only running on the client that owns a particular object"""
+        - This is to be used if your Python program is running on only one client
+        Such as a game master, only running on the client that owns a particular object"""
         pass
 
     def setGeneratorLife(self,value):
@@ -3999,7 +3999,7 @@ class ptPhysics:
 
     def angularImpulse(self,impulseVector):
         """Add the given vector (representing a rotation axis and magnitude) to
-the attached sceneobject's velocity"""
+        the attached sceneobject's velocity"""
         pass
 
     def damp(self,damp):
@@ -4036,7 +4036,7 @@ the attached sceneobject's velocity"""
 
     def impulseWithOffset(self,impulseVector,offsetPt):
         """Adds the given vector to the attached sceneobject's velocity
-with the specified offset"""
+        with the specified offset"""
         pass
 
     def move(self,direction,distance):
@@ -4045,8 +4045,8 @@ with the specified offset"""
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
-- This is to be used if your Python program is running on only one client
-Such as a game master, only running on the client that owns a particular object"""
+        - This is to be used if your Python program is running on only one client
+        Such as a game master, only running on the client that owns a particular object"""
         pass
 
     def rotate(self,radians,axis):
@@ -4067,7 +4067,7 @@ Such as a game master, only running on the client that owns a particular object"
 
     def suppress(self,doSuppress):
         """Completely remove the physical, but keep it around so it
-can be added back later."""
+        can be added back later."""
         pass
 
     def torque(self,torqueVector):
@@ -4076,7 +4076,7 @@ can be added back later."""
 
     def warp(self,position):
         """Warps the sceneobject to a specified location.
-'position' can be a ptPoint3 or a ptMatrix44"""
+        'position' can be a ptPoint3 or a ptMatrix44"""
         pass
 
     def warpObj(self,objkey):
@@ -4125,7 +4125,7 @@ class ptPoint3:
 
     def distanceSq(self,other):
         """Computes the distance squared from this point to 'other' point
-- this function is faster than distance(other)"""
+        - this function is faster than distance(other)"""
         pass
 
     def getX(self):
@@ -4164,14 +4164,14 @@ class ptSDL:
 
     def sendToClients(self,key):
         """Sets it so changes to this key are sent to the
-server AND the clients. (Normally it just goes
-to the server.)"""
+        server AND the clients. (Normally it just goes
+        to the server.)"""
         pass
 
     def setDefault(self,key,value):
         """Like setitem, but doesn't broadcast over the net.
-Only use for setting defaults that everyone will
-already know (from reading it off disk)"""
+        Only use for setting defaults that everyone will
+        already know (from reading it off disk)"""
         pass
 
     def setFlags(self,name,sendImmediate,skipOwnershipCheck):
@@ -4180,7 +4180,7 @@ already know (from reading it off disk)"""
 
     def setIndex(self,key,idx,value):
         """Sets the value at a specific index in the tuple,
-so you don't have to pass the whole thing in"""
+        so you don't have to pass the whole thing in"""
         pass
 
     def setIndexNow(self,key,idx,value):
@@ -4189,7 +4189,7 @@ so you don't have to pass the whole thing in"""
 
     def setNotify(self,selfkey,key,tolerance):
         """Sets the OnSDLNotify to be called when 'key'
-SDL variable changes by 'tolerance' (if number)"""
+        SDL variable changes by 'tolerance' (if number)"""
         pass
 
     def setTagString(self,name,tag):
@@ -4235,7 +4235,7 @@ class ptSceneobject:
 
     def addKey(self,key):
         """Mostly used internally.
-Add another sceneobject ptKey"""
+        Add another sceneobject ptKey"""
         pass
 
     def animate(self):
@@ -4260,27 +4260,27 @@ Add another sceneobject ptKey"""
 
     def getKey(self):
         """Get the ptKey of this sceneobject
-If there are more then one attached, get the first one"""
+        If there are more then one attached, get the first one"""
         pass
 
     def getLocalToParent(self):
         """Returns ptMatrix44 of the local to parent transform for this sceneobject
-- If there is more than one sceneobject attached, returns just the first one"""
+        - If there is more than one sceneobject attached, returns just the first one"""
         pass
 
     def getLocalToWorld(self):
         """Returns ptMatrix44 of the local to world transform for this sceneobject
-- If there is more than one sceneobject attached, returns just the first one"""
+        - If there is more than one sceneobject attached, returns just the first one"""
         pass
 
     def getName(self):
         """Returns the name of the sceneobject (Max name)
-- If there are more than one sceneobject attached, return just the first one"""
+        - If there are more than one sceneobject attached, return just the first one"""
         pass
 
     def getParentToLocal(self):
         """Returns ptMatrix44 of the parent to local transform for this sceneobject
-- If there is more than one sceneobject attached, returns just the first one"""
+        - If there is more than one sceneobject attached, returns just the first one"""
         pass
 
     def getPythonMods(self):
@@ -4301,7 +4301,7 @@ If there are more then one attached, get the first one"""
 
     def getWorldToLocal(self):
         """Returns ptMatrix44 of the world to local transform for this sceneobject
-- If there is more than one sceneobject attached, returns just the first one"""
+        - If there is more than one sceneobject attached, returns just the first one"""
         pass
 
     def isAvatar(self):
@@ -4314,15 +4314,15 @@ If there are more then one attached, get the first one"""
 
     def isLocallyOwned(self):
         """Returns true(1) if this object is locally owned by this client
-or returns false(0) if it is not or don't know"""
+        or returns false(0) if it is not or don't know"""
         pass
 
     def netForce(self,forceFlag):
         """Specify whether this object needs to use messages that are forced to the network
-- This is to be used if your Python program is running on only one client
-Such as a game master, only running on the client that owns a particular object
-- Setting the netForce flag on a sceneobject will also set the netForce flag on
-its draw, physics, avatar, particle objects"""
+        - This is to be used if your Python program is running on only one client
+        Such as a game master, only running on the client that owns a particular object
+        - Setting the netForce flag on a sceneobject will also set the netForce flag on
+        its draw, physics, avatar, particle objects"""
         pass
 
     def playAnimNamed(self,animName):
@@ -4559,14 +4559,14 @@ class ptStatusLog:
 
     def open(self,logName,numLines,flags):
         """Open a status log for writing to
-'logname' is the name of the log file (example: special.log)
-'numLines' is the number of lines to display on debug screen
-'flags' is a PlasmaConstants.PtStatusLogFlags"""
+        'logname' is the name of the log file (example: special.log)
+        'numLines' is the number of lines to display on debug screen
+        'flags' is a PlasmaConstants.PtStatusLogFlags"""
         pass
 
     def write(self,text,color=None):
         """If the status log is open, write 'text' to log
-'color' is the display color in debug screen"""
+        'color' is the display color in debug screen"""
         pass
 
 class ptStream:
@@ -4681,12 +4681,12 @@ class ptVault:
 
     def getAvatarClosetFolder(self):
         """Do not use.
-Returns a ptVaultFolderNode of the avatars outfit in their closet."""
+        Returns a ptVaultFolderNode of the avatars outfit in their closet."""
         pass
 
     def getAvatarOutfitFolder(self):
         """Do not use.
-Returns a ptVaultFolderNode of the avatars outfit."""
+        Returns a ptVaultFolderNode of the avatars outfit."""
         pass
 
     def getBuddyListFolder(self):
@@ -4873,7 +4873,7 @@ class ptVaultNode:
 
     def getType(self):
         """Returns the type of ptVaultNode this is.
-See PlasmaVaultTypes.py"""
+        See PlasmaVaultTypes.py"""
         pass
 
     def hasNode(self,id):
@@ -5506,7 +5506,7 @@ class ptVector3:
 
     def lengthSq(self):
         """Returns the length of the vector, squared
-- this function is faster then length(other)"""
+        - this function is faster then length(other)"""
         pass
 
     def normalize(self):

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -1240,6 +1240,7 @@ class ptAgeVault:
 
 class ptAnimation:
     """Plasma animation class"""
+
     def __init__(self,key=None):
         pass
 
@@ -1717,6 +1718,7 @@ class ptAvatar:
 
 class ptBook:
     """Creates a new book"""
+
     def __init__(self,esHTMLSource,coverImage=None,callbackKey=None,guiName=''):
         pass
 
@@ -1871,6 +1873,7 @@ class ptCamera:
 
 class ptCluster:
     """Creates a new ptCluster"""
+
     def __init__(self,key):
         pass
 
@@ -1880,6 +1883,7 @@ class ptCluster:
 
 class ptColor:
     """Plasma color class"""
+
     def __init__(self,red=0, green=0, blue=0, alpha=0):
         pass
 
@@ -2218,6 +2222,7 @@ class ptDraw:
 
 class ptDynamicMap:
     """Creates a ptDynamicMap object"""
+
     def __init__(self,key=None):
         pass
 
@@ -2352,6 +2357,7 @@ class ptDynamicMap:
 
 class ptGUIControl:
     """Base class for all GUI controls"""
+
     def __init__(self,controlKey):
         pass
 
@@ -2481,6 +2487,7 @@ class ptGUIControl:
 
 class ptGUIControlButton(ptGUIControl):
     """Plasma GUI Control Button class"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2498,6 +2505,7 @@ class ptGUIControlButton(ptGUIControl):
 
 class ptGUIControlCheckBox(ptGUIControl):
     """Plasma GUI Control Checkbox class"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2511,6 +2519,7 @@ class ptGUIControlCheckBox(ptGUIControl):
 
 class ptGUIControlClickMap(ptGUIControl):
     """Plasma GUI control Click Map"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2528,6 +2537,7 @@ class ptGUIControlClickMap(ptGUIControl):
 
 class ptGUIControlDragBar(ptGUIControl):
     """Plasma GUI Control DragBar class"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2549,6 +2559,7 @@ class ptGUIControlDragBar(ptGUIControl):
 
 class ptGUIControlDraggable(ptGUIControl):
     """Plasma GUI control for something draggable"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2562,6 +2573,7 @@ class ptGUIControlDraggable(ptGUIControl):
 
 class ptGUIControlDynamicText(ptGUIControl):
     """Plasma GUI Control DynamicText class"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2577,6 +2589,7 @@ class ptGUIControlDynamicText(ptGUIControl):
 
 class ptGUIControlEditBox(ptGUIControl):
     """Plasma GUI Control Editbox class"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2638,6 +2651,7 @@ class ptGUIControlEditBox(ptGUIControl):
 
 class ptGUIControlValue(ptGUIControl):
     """Plasma GUI Control Value class  - knobs, spinners"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2671,11 +2685,13 @@ class ptGUIControlValue(ptGUIControl):
 
 class ptGUIControlKnob(ptGUIControlValue):
     """Plasma GUI control for knob"""
+
     def __init__(self,ctrlKey):
         pass
 
 class ptGUIControlListBox(ptGUIControl):
     """Plasma GUI Control List Box class"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2833,6 +2849,7 @@ class ptGUIControlListBox(ptGUIControl):
 
 class ptGUIControlMultiLineEdit(ptGUIControl):
     """Plasma GUI Control Multi-line edit class"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2986,6 +3003,7 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 
 class ptGUIControlProgress(ptGUIControlValue):
     """Plasma GUI control for progress bar"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -2995,6 +3013,7 @@ class ptGUIControlProgress(ptGUIControlValue):
 
 class ptGUIControlRadioGroup(ptGUIControl):
     """Plasma GUI Control Radio Group class"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -3008,6 +3027,7 @@ class ptGUIControlRadioGroup(ptGUIControl):
 
 class ptGUIControlTextBox(ptGUIControl):
     """Plasma GUI Control Textbox class"""
+
     def __init__(self,ctrlKey):
         pass
 
@@ -3045,11 +3065,13 @@ class ptGUIControlTextBox(ptGUIControl):
 
 class ptGUIControlUpDownPair(ptGUIControlValue):
     """Plasma GUI control for up/down pair"""
+
     def __init__(self,ctrlKey):
         pass
 
 class ptGUIDialog:
     """Plasma GUI dialog class"""
+
     def __init__(self,dialogKey):
         pass
 
@@ -3175,6 +3197,7 @@ class ptGUIPopUpMenu:
     name,screenOriginX,screenOriginY
     name,parent,screenOriginX,screenOriginY
     """
+
     def __init__(self,arg1,arg2=None,arg3=None,arg4=None):
         pass
 
@@ -3260,6 +3283,7 @@ class ptGUIPopUpMenu:
 
 class ptGUISkin:
     """Plasma GUI Skin object"""
+
     def __init__(self,key):
         pass
 
@@ -3392,6 +3416,7 @@ class ptGameScoreUpdateMsg(ptGameScoreMsg):
 
 class ptGrassShader:
     """Plasma Grass Shader class"""
+
     def __init__(self,key):
         pass
 
@@ -3425,6 +3450,7 @@ class ptGrassShader:
 
 class ptImage:
     """Plasma image class"""
+
     def __init__(self,imgKey):
         pass
 
@@ -3454,6 +3480,7 @@ class ptImage:
 
 class ptImageLibMod:
     """Plasma image library modifier class"""
+
     def __init__(self,ilmKey):
         pass
 
@@ -3579,6 +3606,7 @@ class ptKeyMap:
 
 class ptLayer:
     """Plasma layer class"""
+
     def __init__(self,layerKey):
         pass
 
@@ -3734,6 +3762,7 @@ class ptMatrix44:
 
 class ptMoviePlayer:
     """Accessor class to play in the MoviePlayer"""
+
     def __init__(self,movieName,selfKey):
         pass
 
@@ -3828,6 +3857,7 @@ class ptNotify:
     """Creates a Notify message
     - selfKey is ptKey of your PythonFile modifier
     """
+
     def __init__(self,selfKey):
         pass
 
@@ -4081,6 +4111,7 @@ class ptPhysics:
 
 class ptPlayer:
     """And optionally __init__(name,playerID)"""
+
     def __init__(self,avkey,name,playerID,distanceSq):
         pass
 
@@ -4106,6 +4137,7 @@ class ptPlayer:
 
 class ptPoint3:
     """Plasma Point class"""
+
     def __init__(self,x=0, y=0, z=0):
         pass
 
@@ -4483,6 +4515,7 @@ class ptSimpleStateVariable:
 
 class ptSpawnPointInfo:
     """Class to hold spawn point data"""
+
     def __init__(self,title=None,spawnPt=None):
         pass
 
@@ -4968,6 +5001,7 @@ class ptVaultNode:
 
 class ptVaultFolderNode(ptVaultNode):
     """Plasma vault folder node"""
+
     def __init__(self,n=0):
         pass
 
@@ -4989,6 +5023,7 @@ class ptVaultFolderNode(ptVaultNode):
 
 class ptVaultAgeInfoListNode(ptVaultFolderNode):
     """Plasma vault age info list node"""
+
     def __init__(self,n=0):
         pass
 
@@ -5006,6 +5041,7 @@ class ptVaultAgeInfoListNode(ptVaultFolderNode):
 
 class ptVaultAgeInfoNode(ptVaultNode):
     """Plasma vault age info node"""
+
     def __init__(self,n=0):
         pass
 
@@ -5115,6 +5151,7 @@ class ptVaultAgeInfoNode(ptVaultNode):
 
 class ptVaultAgeLinkNode(ptVaultNode):
     """Plasma vault age link node"""
+
     def __init__(self,n=0):
         pass
 
@@ -5160,6 +5197,7 @@ class ptVaultAgeLinkNode(ptVaultNode):
 
 class ptVaultChronicleNode(ptVaultNode):
     """Plasma vault chronicle node"""
+
     def __init__(self,n=0):
         pass
 
@@ -5189,6 +5227,7 @@ class ptVaultChronicleNode(ptVaultNode):
 
 class ptVaultImageNode(ptVaultNode):
     """Plasma vault image node"""
+
     def __init__(self,n=0):
         pass
 
@@ -5218,6 +5257,7 @@ class ptVaultImageNode(ptVaultNode):
 
 class ptVaultMarkerGameNode(ptVaultNode):
     """Plasma vault age info node"""
+
     def __init__(self,n=0):
         pass
 
@@ -5290,6 +5330,7 @@ class ptVaultNodeRef:
 
 class ptVaultPlayerInfoListNode(ptVaultFolderNode):
     """Plasma vault player info list node"""
+
     def __init__(self,n=0):
         pass
 
@@ -5431,6 +5472,7 @@ class ptVaultTextNoteNode(ptVaultNode):
 
 class ptVector3:
     """Plasma 3D Vector class"""
+
     def __init__(self,x=0, y=0, z=0):
         pass
 
@@ -5502,6 +5544,7 @@ class ptVector3:
 
 class ptWaveSet:
     """Creates a new ptWaveSet"""
+
     def __init__(self,key):
         pass
 

--- a/Scripts/Python/plasma/PlasmaConstants.py
+++ b/Scripts/Python/plasma/PlasmaConstants.py
@@ -55,23 +55,19 @@ from typing import *
 class Enum:
     """Enum base class"""
     def __init__(self):
-        """None"""
         pass
 
 class EnumValue:
     """A basic enumeration value"""
     def __init__(self):
-        """None"""
         pass
 
 class PtAIMsgType:
-    """(none)"""
     kUnknown = 0
     kBrainCreated = 1
     kArrivedAtGoal = 2
 
 class PtAccountUpdateType:
-    """(none)"""
     kCreatePlayer = 1
     kDeletePlayer = 2
     kUpgradePlayer = 3
@@ -79,7 +75,6 @@ class PtAccountUpdateType:
     kChangePassword = 5
 
 class PtBehaviorTypes:
-    """(none)"""
     kBehaviorTypeStandingJump = 1
     kBehaviorTypeWalkingJump = 2
     kBehaviorTypeRunningJump = 4
@@ -102,7 +97,6 @@ class PtBehaviorTypes:
     kBehaviorTypeLinkOut = 131072
 
 class PtBookEventTypes:
-    """(none)"""
     kNotifyImageLink = 0
     kNotifyShow = 1
     kNotifyHide = 2
@@ -112,7 +106,6 @@ class PtBookEventTypes:
     kNotifyClose = 6
 
 class PtBrainModes:
-    """(none)"""
     kGeneric = 0
     kLadder = 1
     kSit = 2
@@ -122,13 +115,11 @@ class PtBrainModes:
     kNonGeneric = 6
 
 class PtButtonNotifyTypes:
-    """(none)"""
     kNotifyOnUp = 0
     kNotifyOnDown = 1
     kNotifyOnUpAndDown = 2
 
 class PtCCRPetitionType:
-    """(none)"""
     kGeneralHelp = 0
     kBug = 1
     kFeedback = 2
@@ -138,7 +129,6 @@ class PtCCRPetitionType:
     kTechnical = 6
 
 class PtConfirmationResult:
-    """(none)"""
     Cancel = 0
     No = 0
     OK = 1
@@ -147,14 +137,12 @@ class PtConfirmationResult:
     Logout = 62
 
 class PtConfirmationType:
-    """(none)"""
     OK = 0
     ConfirmQuit = 1
     ForceQuit = 2
     YesNo = 3
 
 class PtEventType:
-    """(none)"""
     kCollision = 1
     kPicked = 2
     kControlKey = 3
@@ -171,13 +159,11 @@ class PtEventType:
     kBook = 15
 
 class PtFontFlags:
-    """(none)"""
     kFontBold = 1
     kFontItalic = 2
     kFontShadowed = 4
 
 class PtGUIMultiLineDirection:
-    """(none)"""
     kLineStart = 1
     kLineEnd = 2
     kBufferStart = 3
@@ -192,32 +178,27 @@ class PtGUIMultiLineDirection:
     kPageDown = 12
 
 class PtGameScoreTypes:
-    """(none)"""
     kFixed = 0
     kAccumulative = 1
     kAccumAllowNegative = 2
 
 class PtJustify:
-    """(none)"""
     kLeftJustify = 0
     kCenter = 1
     kRightJustify = 2
 
 class PtLOSObjectType:
-    """(none)"""
     kClickables = 0
     kCameraBlockers = 1
     kCustom = 2
     kShootable = 3
 
 class PtLOSReportType:
-    """(none)"""
     kReportHit = 0
     kReportMiss = 1
     kReportHitOrMiss = 2
 
 class PtLanguage:
-    """(none)"""
     kEnglish = 0
     kFrench = 1
     kGerman = 2
@@ -231,22 +212,18 @@ class PtLanguage:
     kNumLanguages = 10
 
 class PtMarkerMsgType:
-    """(none)"""
     kMarkerCaptured = 0
 
 class PtMovieEventReason:
-    """(none)"""
     kMovieDone = 0
 
 class PtMultiStageEventType:
-    """(none)"""
     kEnterStage = 1
     kBeginingOfLoop = 2
     kAdvanceNextStage = 3
     kRegressPrevStage = 4
 
 class PtNotificationType:
-    """(none)"""
     kActivator = 0
     kVarNotification = 1
     kNotifySelf = 2
@@ -254,21 +231,18 @@ class PtNotificationType:
     kResponderChangeState = 4
 
 class PtNotifyDataType:
-    """(none)"""
     kFloat = 1
     kKey = 2
     kInt = 3
     kNull = 4
 
 class PtSDLReadWriteOptions:
-    """(none)"""
     kDirtyOnly = 1
     kSkipNotificationInfo = 2
     kBroadcast = 4
     kTimeStampOnRead = 16
 
 class PtSDLVarType:
-    """(none)"""
     kNone = -1
     kInt = 0
     kFloat = 1
@@ -288,19 +262,16 @@ class PtSDLVarType:
     kQuaternion = 54
 
 class PtScoreRankGroups:
-    """(none)"""
     kIndividual = 0
     kNeighborhood = 1
 
 class PtScoreTimePeriods:
-    """(none)"""
     kOverall = 0
     kYear = 1
     kMonth = 2
     kDay = 3
 
 class PtStatusLogFlags:
-    """(none)"""
     kFilledBackground = 1
     kAppendToLast = 2
     kDontWriteFile = 4

--- a/Scripts/Python/plasma/PlasmaConstants.py
+++ b/Scripts/Python/plasma/PlasmaConstants.py
@@ -54,13 +54,9 @@ from typing import *
 
 class Enum:
     """Enum base class"""
-    def __init__(self):
-        pass
 
 class EnumValue:
     """A basic enumeration value"""
-    def __init__(self):
-        pass
 
 class PtAIMsgType:
     kUnknown = 0

--- a/Scripts/Python/plasma/PlasmaGame.py
+++ b/Scripts/Python/plasma/PlasmaGame.py
@@ -69,78 +69,78 @@ class ptGameCli:
 
     def leaveGame(self) -> None:
         """Explicitly ask the server to allow us to leave the game."""
-        pass
+        ...
 
 class ptGmBlueSpiral(ptGameCli):
     """Legacy blue spiral game client."""
 
     def hitCloth(self, cloth: int) -> None:
         """Request for the server to hit a specific cloth index and validate the correct sequence of cloth inputs."""
-        pass
+        ...
 
     @staticmethod
     def isSupported() -> bool:
         """Checks for the presence of a server-side blue spiral game manager."""
-        pass
+        ...
 
     @staticmethod
     def join(handler: Any, tableID: int) -> None:
         """Join a common blue spiral game in the current Age."""
-        pass
+        ...
 
     def startGame(self) -> None:
         """Request for the server to start the game timer."""
-        pass
+        ...
 
 class ptGmMarker(ptGameCli):
     """Legacy marker game client."""
 
     def addMarker(self, x: float, y: float, z: float, name: str, age: str) -> None:
         """Request for the server to add a new marker to the game."""
-        pass
+        ...
 
     def captureMarker(self, markerId: int) -> None:
         """Request for the server to register a capture of the specified marker for our team."""
-        pass
+        ...
 
     def changeGameName(self, name: str) -> None:
         """Request for the server to change the internal marker game name."""
-        pass
+        ...
 
     def changeMarkerName(self, markerID: int) -> None:
         """Request for the server to change the name of a specific marker from the game."""
-        pass
+        ...
 
     def changeTimeLimit(self, timeLimit: int) -> None:
         """Request for the server to change the marker game's time limit."""
-        pass
+        ...
 
     @staticmethod
     def create(handler: Any, gameType: int, templateId: Optional[str]) -> None:
         """Initialize a new marker game client with the server."""
-        pass
+        ...
 
     def deleteGame(self) -> None:
         """Request for the server to delete all data associated with this game, including the marker definitions and game name."""
-        pass
+        ...
 
     def deleteMarker(self, markerID: int) -> None:
         """Request for the server to delete a specific marker from the game."""
-        pass
+        ...
 
     @staticmethod
     def isSupported() -> bool:
         """Checks for the presence of a server-side marker game manager."""
-        pass
+        ...
 
     def pauseGame(self) -> None:
         """Request for the server to pause the marker game."""
-        pass
+        ...
 
     def resetGame(self) -> None:
         """Request for the server to clear all markers to the uncaptured state."""
-        pass
+        ...
 
     def startGame(self) -> None:
         """Request for the server to start the marker game."""
-        pass
+        ...

--- a/Scripts/Python/plasma/PlasmaGame.py
+++ b/Scripts/Python/plasma/PlasmaGame.py
@@ -67,17 +67,12 @@ class ptGameCli:
     ownerID: int
     """The ID of the player who owns this game instance."""
 
-    def __init__(self):
-        pass
-
     def leaveGame(self) -> None:
         """Explicitly ask the server to allow us to leave the game."""
         pass
 
 class ptGmBlueSpiral(ptGameCli):
     """Legacy blue spiral game client."""
-    def __init__(self):
-        pass
 
     def hitCloth(self,cloth: int) -> None:
         """Request for the server to hit a specific cloth index and validate the correct sequence of cloth inputs."""
@@ -99,8 +94,6 @@ class ptGmBlueSpiral(ptGameCli):
 
 class ptGmMarker(ptGameCli):
     """Legacy marker game client."""
-    def __init__(self):
-        pass
 
     def addMarker(self,x: float, y: float, z: float, name: str, age: str) -> None:
         """Request for the server to add a new marker to the game."""

--- a/Scripts/Python/plasma/PlasmaGame.py
+++ b/Scripts/Python/plasma/PlasmaGame.py
@@ -74,7 +74,7 @@ class ptGameCli:
 class ptGmBlueSpiral(ptGameCli):
     """Legacy blue spiral game client."""
 
-    def hitCloth(self,cloth: int) -> None:
+    def hitCloth(self, cloth: int) -> None:
         """Request for the server to hit a specific cloth index and validate the correct sequence of cloth inputs."""
         pass
 
@@ -95,23 +95,23 @@ class ptGmBlueSpiral(ptGameCli):
 class ptGmMarker(ptGameCli):
     """Legacy marker game client."""
 
-    def addMarker(self,x: float, y: float, z: float, name: str, age: str) -> None:
+    def addMarker(self, x: float, y: float, z: float, name: str, age: str) -> None:
         """Request for the server to add a new marker to the game."""
         pass
 
-    def captureMarker(self,markerId: int) -> None:
+    def captureMarker(self, markerId: int) -> None:
         """Request for the server to register a capture of the specified marker for our team."""
         pass
 
-    def changeGameName(self,name: str) -> None:
+    def changeGameName(self, name: str) -> None:
         """Request for the server to change the internal marker game name."""
         pass
 
-    def changeMarkerName(self,markerID: int) -> None:
+    def changeMarkerName(self, markerID: int) -> None:
         """Request for the server to change the name of a specific marker from the game."""
         pass
 
-    def changeTimeLimit(self,timeLimit: int) -> None:
+    def changeTimeLimit(self, timeLimit: int) -> None:
         """Request for the server to change the marker game's time limit."""
         pass
 
@@ -124,7 +124,7 @@ class ptGmMarker(ptGameCli):
         """Request for the server to delete all data associated with this game, including the marker definitions and game name."""
         pass
 
-    def deleteMarker(self,markerID: int) -> None:
+    def deleteMarker(self, markerID: int) -> None:
         """Request for the server to delete a specific marker from the game."""
         pass
 

--- a/Scripts/Python/plasma/PlasmaGame.py
+++ b/Scripts/Python/plasma/PlasmaGame.py
@@ -68,7 +68,6 @@ class ptGameCli:
     """The ID of the player who owns this game instance."""
 
     def __init__(self):
-        """None"""
         pass
 
     def leaveGame(self) -> None:
@@ -78,7 +77,6 @@ class ptGameCli:
 class ptGmBlueSpiral(ptGameCli):
     """Legacy blue spiral game client."""
     def __init__(self):
-        """None"""
         pass
 
     def hitCloth(self,cloth: int) -> None:
@@ -102,7 +100,6 @@ class ptGmBlueSpiral(ptGameCli):
 class ptGmMarker(ptGameCli):
     """Legacy marker game client."""
     def __init__(self):
-        """None"""
         pass
 
     def addMarker(self,x: float, y: float, z: float, name: str, age: str) -> None:

--- a/Scripts/Python/plasma/PlasmaGameConstants.py
+++ b/Scripts/Python/plasma/PlasmaGameConstants.py
@@ -53,7 +53,6 @@ from __future__ import annotations
 from typing import *
 
 class PtGameJoinError:
-    """(none)"""
     kGameJoinPending = -1
     kGameJoinSuccess = 0
     kGameJoinErrNotExist = 1
@@ -66,7 +65,6 @@ class PtGameJoinError:
     kNumGameJoinErrors = 8
 
 class PtMarkerGameType:
-    """(none)"""
     kMarkerGameQuest = 0
     kMarkerGameCGZ = 1
     kMarkerGameCapture = 2

--- a/Scripts/Python/plasma/PlasmaNetConstants.py
+++ b/Scripts/Python/plasma/PlasmaNetConstants.py
@@ -53,7 +53,6 @@ from __future__ import annotations
 from typing import *
 
 class PtLinkingRules:
-    """(none)"""
     kBasicLink = 0
     kOriginalBook = 1
     kSubAgeBook = 2

--- a/Scripts/Python/plasma/PlasmaVaultConstants.py
+++ b/Scripts/Python/plasma/PlasmaVaultConstants.py
@@ -53,7 +53,6 @@ from __future__ import annotations
 from typing import *
 
 class PtVaultCallbackTypes:
-    """(none)"""
     kVaultConnected = 1
     kVaultNodeSaved = 2
     kVaultNodeRefAdded = 3
@@ -65,7 +64,6 @@ class PtVaultCallbackTypes:
     kVaultDisconnected = 9
 
 class PtVaultNodeTypes:
-    """(none)"""
     kInvalidNode = 0
     kVNodeMgrPlayerNode = 2
     kVNodeMgrAgeNode = 3
@@ -82,7 +80,6 @@ class PtVaultNodeTypes:
     kMarkerGameNode = 35
 
 class PtVaultNotifyTypes:
-    """(none)"""
     kRegisteredOwnedAge = 9
     kUnRegisteredOwnedAge = 10
     kRegisteredVisitAge = 11
@@ -91,7 +88,6 @@ class PtVaultNotifyTypes:
     kPublicAgeRemoved = 14
 
 class PtVaultStandardNodes:
-    """(none)"""
     kUserDefinedNode = 0
     kInboxFolder = 1
     kBuddyListFolder = 2
@@ -117,10 +113,8 @@ class PtVaultStandardNodes:
     kGlobalInboxFolder = 30
 
 class PtVaultTextNoteSubTypes:
-    """(none)"""
     kGeneric = 0
 
 class PtVaultTextNoteTypes:
-    """(none)"""
     kGeneric = 0
     kCCRPetition = 1

--- a/Scripts/Python/plasma/generate_stubs.py
+++ b/Scripts/Python/plasma/generate_stubs.py
@@ -42,6 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
  *==LICENSE==* """
 
 import os.path
+import re
 import textwrap
 import types
 
@@ -148,6 +149,10 @@ def parse_type_from_doc(doc: str) -> tuple[str, str]:
         # Example: "Params: x,y"
         params_line, _, doc_body = doc.partition("\n")
         params = params_line.removeprefix(docstring_params_prefix)
+        # Put a space after each comma if there isn't one already.
+        # Semi-temporarily doing this using a regex replacement here
+        # so that we don't have to immediately adjust all the old C++-defined docstrings.
+        params = re.sub(r",([^ ])", r", \1", params)
         return f"({params})", doc_body
     else:
         return "", doc
@@ -208,9 +213,8 @@ def generate_function_stub(kind: FunctionKind, name: str, signature: str, doc: s
             signature_tail = signature.removeprefix("()")
             signature = f"({self_param}){signature_tail}"
         elif signature.startswith("("):
-            # No space after the comma for now, to match the existing stubs.
             signature_tail = signature.removeprefix("(")
-            signature = f"({self_param},{signature_tail}"
+            signature = f"({self_param}, {signature_tail}"
         else:
             raise ValueError(f"{docstring_type_prefix!r} declaration in method docstring doesn't look like a function signature: {signature!r}")
 

--- a/Scripts/Python/plasma/generate_stubs.py
+++ b/Scripts/Python/plasma/generate_stubs.py
@@ -248,17 +248,12 @@ def generate_class_stub(name: str, cls: type) -> Iterable[str]:
     yield f"class {name}{class_parens}:"
     yield from add_indents("    ", format_docstring(doc))
 
-    first = True
     for name, value in iter_attributes(cls):
         if name == "__init__":
             # Special case for __init__: use the signature from the class docstring.
             # Don't output a stub for __init__ if it has no arguments (the default).
             if init_signature and init_signature != "()":
-                # Don't put a blank line between the class docstring and __init__, to match the existing stubs.
-                if not first:
-                    yield ""
-                first = False
-
+                yield ""
                 # C-defined __init__ methods have a dummy docstring - don't output that.
                 yield from add_indents("    ", generate_function_stub("method", name, init_signature, ""))
             continue
@@ -266,7 +261,6 @@ def generate_class_stub(name: str, cls: type) -> Iterable[str]:
             # Ignore all other special attributes.
             continue
 
-        first = False
         yield ""
 
         if isinstance(value, type):

--- a/Scripts/Python/plasma/generate_stubs.py
+++ b/Scripts/Python/plasma/generate_stubs.py
@@ -222,7 +222,7 @@ def generate_function_stub(kind: FunctionKind, name: str, signature: str, doc: s
         yield decorator
     yield f"def {name}{signature}:"
     yield from add_indents("    ", format_docstring(doc))
-    yield "    pass"
+    yield "    ..."
 
 def generate_enum_stub(name: str, enum_obj: PlasmaConstants.Enum) -> Iterable[str]:
     yield f"class {name}:"

--- a/Scripts/Python/plasma/generate_stubs.py
+++ b/Scripts/Python/plasma/generate_stubs.py
@@ -42,6 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
  *==LICENSE==* """
 
 import os.path
+import textwrap
 import types
 
 from typing import Iterable, Literal
@@ -159,11 +160,7 @@ def format_qualified_name(cls: type, context_module_name: str) -> str:
 
 def add_indents(indent: str, lines: Iterable[str]) -> Iterable[str]:
     for line in lines:
-        if line:
-            yield f"{indent}{line}"
-        else:
-            # Don't add extra whitespace on blank lines.
-            yield ""
+        yield textwrap.indent(line, indent)
 
 FunctionKind = Literal["function", "method", "classmethod", "staticmethod", "property"]
 
@@ -209,7 +206,7 @@ def generate_function_stub(kind: FunctionKind, name: str, signature: str, doc: s
         yield decorator
     yield f"def {name}{signature}:"
     if doc:
-        yield f'    """{doc}"""'
+        yield textwrap.indent(f'"""{doc}"""', "    ")
     yield "    pass"
 
 def generate_enum_stub(name: str, enum_obj: PlasmaConstants.Enum) -> Iterable[str]:
@@ -238,7 +235,7 @@ def generate_class_stub(name: str, cls: type) -> Iterable[str]:
 
     yield f"class {name}{class_parens}:"
     if doc:
-        yield f'    """{doc}"""'
+        yield textwrap.indent(f'"""{doc}"""', "    ")
 
     first = True
     for name, value in iter_attributes(cls):
@@ -300,7 +297,7 @@ def generate_class_stub(name: str, cls: type) -> Iterable[str]:
             property_type = property_type or "Any"
             yield f"    {name}: {property_type}"
             if doc:
-                yield f'    """{doc}"""'
+                yield textwrap.indent(f'"""{doc}"""', "    ")
         else:
             yield f"    {name}: {format_qualified_name(type(value), cls.__module__)} = ... # = {value!r}"
 

--- a/Scripts/Python/plasma/generate_stubs.py
+++ b/Scripts/Python/plasma/generate_stubs.py
@@ -156,6 +156,12 @@ def format_docstring(doc: str) -> Iterable[str]:
     if not doc:
         return
 
+    # If the docstring has more than one line,
+    # then ensure that the closing triple quotes are on their own line,
+    # even if the real docstring doesn't contain a trailing newline.
+    if "\n" in doc and not doc.rstrip(" ").endswith("\n"):
+        doc += "\n"
+
     yield f'"""{doc}"""'
 
 def format_qualified_name(cls: type, context_module_name: str) -> str:

--- a/Scripts/Python/plasma/generate_stubs.py
+++ b/Scripts/Python/plasma/generate_stubs.py
@@ -251,14 +251,16 @@ def generate_class_stub(name: str, cls: type) -> Iterable[str]:
     first = True
     for name, value in iter_attributes(cls):
         if name == "__init__":
-            # Don't put a blank line between the class docstring and __init__, to match the existing stubs.
-            if not first:
-                yield ""
-            first = False
-
             # Special case for __init__: use the signature from the class docstring.
-            # C-defined __init__ methods have a dummy docstring - don't output that.
-            yield from add_indents("    ", generate_function_stub("method", name, init_signature, ""))
+            # Don't output a stub for __init__ if it has no arguments (the default).
+            if init_signature and init_signature != "()":
+                # Don't put a blank line between the class docstring and __init__, to match the existing stubs.
+                if not first:
+                    yield ""
+                first = False
+
+                # C-defined __init__ methods have a dummy docstring - don't output that.
+                yield from add_indents("    ", generate_function_stub("method", name, init_signature, ""))
             continue
         elif name.startswith("__"):
             # Ignore all other special attributes.


### PR DESCRIPTION
Big automated reformatting of the stubs to get rid of some weirdness from Cyan's original formatting style. See commit messages for details.

I think all of these formatting choices are uncontroversial, but let me know if anything doesn't seem right. Thankfully, it's now very easy to re-adjust the formatting 🙂