### PR TITLE
Negilahn and Payiferen creature spawn time edge case

### DIFF
--- a/Scripts/Python/nglnTreeMonkey.py
+++ b/Scripts/Python/nglnTreeMonkey.py
@@ -235,6 +235,8 @@ class nglnTreeMonkey(ptResponder):
         spawnTimes = [firstTime]
 
         while isinstance(spawnTimes[-1], int):
+            if len(spawnTimes) >= 20:
+                break
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:

--- a/Scripts/Python/nglnUrwinBrain.py
+++ b/Scripts/Python/nglnUrwinBrain.py
@@ -326,6 +326,8 @@ class nglnUrwinBrain(ptResponder):
         spawnTimes = [firstTime]
 
         while isinstance(spawnTimes[-1], int):
+            if len(spawnTimes) >= 20:
+                break
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:

--- a/Scripts/Python/payiUrwinBrain.py
+++ b/Scripts/Python/payiUrwinBrain.py
@@ -431,6 +431,8 @@ class payiUrwinBrain(ptResponder):
         spawnTimes = [firstTime]
 
         while isinstance(spawnTimes[-1], int):
+            if len(spawnTimes) >= 20:
+                break
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:


### PR DESCRIPTION
If the spawn times array size exceeded 20 it would fail to write to the age SDL preventing that entire days creature appearances

This is pretty unlikely to happen due to the randomness and large timeframe the creatures can spawn
I only encountered it because I shortened the spawn windows to a few minutes.