### PR TITLE
Adds returning to last read page for journals

### DIFF
--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -80,7 +80,11 @@ GUIType             = ptAttribString(14,"Book GUI Type",default="bkBook")
 # globals
 LocalAvatar = None
 JournalBook = None
-CurrentPage = 2
+CurrentPage = -1
+
+
+# Timer variable
+CoverOrPage0 = 1
 
 class xJournalBookGUIPopup(ptModifier):
     "The Journal Book GUI Popup python code"
@@ -133,30 +137,35 @@ class xJournalBookGUIPopup(ptModifier):
                         # disable the KI
                         PtSendKIMessage(kDisableKIandBB,0)
                         if CurrentPage > -1:
-                            JournalBook.open(CurrentPage)
-                            JournalBook.goToPage(CurrentPage)
+                            JournalBook.open(CurrentPage) #Opens to saved page
+                            JournalBook.goToPage(CurrentPage) #shows page tabs at bottom when used after open
+                        CurrentPage = JournalBook.getCurrentPage() #Save current page
                     if event[1] == PtBookEventTypes.kNotifyHide:
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyHide")
+                        PtClearTimerCallbacks(self.key)
                         # re-enable KI
                         PtSendKIMessage(kEnableKIandBB,0)
                         # re-enable our avatar
                         PtToggleAvatarClickability(True)
-                        if CurrentPage == 0:
-                            CurrentPage = -1
-                        elif CurrentPage > 0:
+                        if CurrentPage > -1:
                             CurrentPage = JournalBook.getCurrentPage()
-                            PtDebugPrint(JournalBook.getCurrentPage())
                     elif event[1] == PtBookEventTypes.kNotifyClose:
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyClose")
+                        PtAtTimeCallback(self.key, 1.01, CoverOrPage0)
                     elif event[1] == PtBookEventTypes.kNotifyNextPage:
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyNextPage")
-                        CurrentPage = JournalBook.getCurrentPage()
+                        #CurrentPage = JournalBook.getCurrentPage()
                     elif event[1] == PtBookEventTypes.kNotifyPreviousPage:
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyPreviousPage")
-                        CurrentPage = JournalBook.getCurrentPage()
+                        #CurrentPage = JournalBook.getCurrentPage()
                     elif event[1] == PtBookEventTypes.kNotifyCheckUnchecked:
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyCheckUncheck",level=kDebugDumpLevel)
                         pass
+
+    def OnTimer(self, id):
+        global CurrentPage
+        if id == CoverOrPage0:
+            CurrentPage = -1
 
     def IShowBook(self):
         global JournalBook

--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -64,6 +64,7 @@ from PlasmaKITypes import *
 
 import xJournalBookDefs
 import json
+import zlib
 
 
 # define the attributes that will be entered in max
@@ -251,19 +252,22 @@ class xJournalBookGUIPopup(ptModifier):
             BookJson = json.loads(BookJson.getValue())
         else:
             BookJson = {}
-        CurrentPage = BookJson.get(LocPath.value, -1)
-        
+        CurrentPage = BookJson.get(self.EncodeLocPath(), -1)
         
     def WriteCurrentPage(self):
         PtDebugPrint("xJournalBookGUIPopup WriteCurrentPage",level=kDebugDumpLevel)
         global BookJson
         if CurrentPage > -1:
-            BookJson[LocPath.value] = JournalBook.getCurrentPage()
+            BookJson[self.EncodeLocPath()] = JournalBook.getCurrentPage()
         else:
-            BookJson.pop(LocPath.value, None)
+            BookJson.pop(self.EncodeLocPath(), None)
         temp = json.dumps(BookJson)
         while len(temp) > 1024:
             BookJson.pop(next(iter(BookJson)))
             temp = json.dumps(BookJson)
         ptVault().addChronicleEntry(kBookChronicle, 0, temp)
+        
+    def EncodeLocPath(self):
+        temp = zlib.adler32(LocPath.value.encode('utf-8')) & 0xffffffff
+        return f'{temp:x}'
 


### PR DESCRIPTION
https://youtu.be/A0GeF4ayUkA
This saves the last 68 journals read pages to a player chronicle and will open to that page when you open the journal again.

68 journals is how many alder32 hashed strings you can fit in a 1024 character json string
1024 is character limit decided on due to this [issue](https://github.com/H-uru/dirtsand/issues/174)
2048 is probably the string limit for other vault implementations

https://youtu.be/A0GeF4ayUkA?t=27
The only issue I found during testing has to do with the cover and first page of the journal.
There is currently no notify message when you turn from the cover to the first page. 
Due to this I coded after the book kNotifyShow is received, it sets the page to current page (zero).
If you open the book but dont turn any pages and leave, the next time you open the book it will open the book to page 0 instead of the cover.

Operations tested with new code:
I tested these also closing client and entering age again as well
Also tested journals that don't have a cover (Serene Journal)

Cover -> First Page -> Close = First Page
Cover -> First Page -> Cover = Cover
Cover -> Close = First Page (Only issue found so far)
Any Page -> Close = Last used page
Any Page -> Cover -> Close = Cover

