### PR TITLE
Fix mouse cursor unpredictably not fading out

### DIFF
--- a/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.cpp
@@ -321,7 +321,7 @@ void plIMouseBEventMsg::Write(hsStream* stream, hsResMgr* mgr)
     stream->WriteLE16(fButton);
 }
 
-plMouseEventMsg::plMouseEventMsg() : fXPos(0.0f), fYPos(0.0f), fDX(0.0f), fDY(0.0f), fWheelDelta(), fButton(0)
+plMouseEventMsg::plMouseEventMsg() : fXPos(), fYPos(), fDX(), fDY(), fWheelDelta(), fButton()
 {
 }
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.cpp
@@ -321,7 +321,7 @@ void plIMouseBEventMsg::Write(hsStream* stream, hsResMgr* mgr)
     stream->WriteLE16(fButton);
 }
 
-plMouseEventMsg::plMouseEventMsg() : fXPos(0.0f),fYPos(0.0f),fDX(0.0f),fDY(0.0f),fButton(0)
+plMouseEventMsg::plMouseEventMsg() : fXPos(0.0f), fYPos(0.0f), fDX(0.0f), fDY(0.0f), fWheelDelta(), fButton(0)
 {
 }
 


### PR DESCRIPTION
Fixes #1677.

The field `plMouseEventMsg::fWheelDelta` was uninitialized by default and thus had an unpredictable value (which may or may not be 0) for most mouse events. This made the code for fading out the cursor sometimes wrongly think that the player is constantly scrolling, which prevented the cursor from ever fading out.

The underlying bug (the uninitialized field) has always been there since the original open-source release, but went unnoticed, because apparently nothing used the field. It only became noticeable recently with #1653, which added code to reset the cursor fade out timer upon scrolling.