### PR TITLE
Remove `plMessage` subclass constructors that ignore their arguments

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plIgnoreComponent.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plIgnoreComponent.cpp
@@ -405,7 +405,7 @@ bool plNoShowComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     {
         if( fCompPB->GetInt(kAffectDraw) )
         {
-            plEnableMsg* eMsg = new plEnableMsg(nullptr, plEnableMsg::kDisable, plEnableMsg::kDrawable);
+            plEnableMsg* eMsg = new plEnableMsg(plEnableMsg::kDisable, plEnableMsg::kDrawable);
             eMsg->AddReceiver(obj->GetKey());
             eMsg->Send();
         }

--- a/Sources/Plasma/FeatureLib/pfMessage/pfGameGUIMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfGameGUIMsg.h
@@ -71,7 +71,7 @@ class pfGameGUIMsg : public plMessage
         };
 
         pfGameGUIMsg() : plMessage(nullptr, nullptr, nullptr), fCommand() { SetBCastFlag(kBCastByExactType); }
-        pfGameGUIMsg(plKey &receiver, uint8_t command)
+        pfGameGUIMsg(const plKey& receiver, uint8_t command)
             : plMessage(nullptr, nullptr, nullptr), fCommand(command) { AddReceiver(receiver); }
 
         CLASSNAME_REGISTER( pfGameGUIMsg );

--- a/Sources/Plasma/FeatureLib/pfMessage/pfGameGUIMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfGameGUIMsg.h
@@ -72,7 +72,7 @@ class pfGameGUIMsg : public plMessage
 
         pfGameGUIMsg() : plMessage(nullptr, nullptr, nullptr), fCommand() { SetBCastFlag(kBCastByExactType); }
         pfGameGUIMsg(const plKey& receiver, uint8_t command)
-            : plMessage(nullptr, nullptr, nullptr), fCommand(command) { AddReceiver(receiver); }
+            : plMessage(nullptr, receiver, nullptr), fCommand(command) {}
 
         CLASSNAME_REGISTER( pfGameGUIMsg );
         GETINTERFACE_ANY( pfGameGUIMsg, plMessage );

--- a/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
@@ -181,7 +181,7 @@ class pfKIMsg : public plMessage
 
         pfKIMsg() : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); IInit(); }
         pfKIMsg(uint8_t command) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); IInit(); fCommand = command; }
-        pfKIMsg(plKey &receiver, uint8_t command) : plMessage(nullptr, nullptr, nullptr) { AddReceiver(receiver); IInit(); fCommand = command; }
+        pfKIMsg(const plKey& receiver, uint8_t command) : plMessage(nullptr, nullptr, nullptr) { AddReceiver(receiver); IInit(); fCommand = command; }
 
         CLASSNAME_REGISTER( pfKIMsg );
         GETINTERFACE_ANY( pfKIMsg, plMessage );

--- a/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
@@ -181,7 +181,7 @@ class pfKIMsg : public plMessage
 
         pfKIMsg() : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); IInit(); }
         pfKIMsg(uint8_t command) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); IInit(); fCommand = command; }
-        pfKIMsg(const plKey& receiver, uint8_t command) : plMessage(nullptr, nullptr, nullptr) { AddReceiver(receiver); IInit(); fCommand = command; }
+        pfKIMsg(const plKey& receiver, uint8_t command) : plMessage(nullptr, receiver, nullptr) { IInit(); fCommand = command; }
 
         CLASSNAME_REGISTER( pfKIMsg );
         GETINTERFACE_ANY( pfKIMsg, plMessage );

--- a/Sources/Plasma/NucleusLib/pnMessage/plAudioSysMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plAudioSysMsg.h
@@ -73,9 +73,6 @@ public:
     plAudioSysMsg() { SetBCastFlag(plMessage::kBCastByExactType); }
     plAudioSysMsg(const plKey &s) { SetBCastFlag(plMessage::kBCastByExactType);SetSender(s); }
     plAudioSysMsg(int i) { fAudFlag = i; SetBCastFlag(plMessage::kBCastByExactType); }
-    plAudioSysMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t) { SetBCastFlag(plMessage::kBCastByExactType); }
     ~plAudioSysMsg() { }
 
     CLASSNAME_REGISTER(plAudioSysMsg);

--- a/Sources/Plasma/NucleusLib/pnMessage/plCameraMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCameraMsg.h
@@ -116,10 +116,7 @@ public:
 
     
     plCameraTargetFadeMsg() { }
-    plCameraTargetFadeMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t) { }
-    
+
     CLASSNAME_REGISTER(plCameraTargetFadeMsg);
     GETINTERFACE_ANY(plCameraTargetFadeMsg, plMessage);
 
@@ -249,10 +246,7 @@ public:
     bool GetDisable() const { return fDisable; }
 
     plIfaceFadeAvatarMsg() : fEnable(false),fDisable(false) { }
-    plIfaceFadeAvatarMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t): fEnable(false),fDisable(false) { }
-    
+
     CLASSNAME_REGISTER(plIfaceFadeAvatarMsg);
     GETINTERFACE_ANY(plIfaceFadeAvatarMsg, plMessage);
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plClientMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plClientMsg.h
@@ -99,9 +99,7 @@ public:
 
 
     plClientMsg() { IReset();}
-    plClientMsg(const plKey &s) { IReset();}  
     plClientMsg(int i) { IReset(); fMsgFlag = i; }  
-    plClientMsg(const plKey &s, const plKey &r, const double* t) { IReset(); }
 
     CLASSNAME_REGISTER(plClientMsg);
     GETINTERFACE_ANY(plClientMsg, plMessage);

--- a/Sources/Plasma/NucleusLib/pnMessage/plCmdIfaceModMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCmdIfaceModMsg.h
@@ -54,10 +54,7 @@ protected:
 
 public:
     plCmdIfaceModMsg() : fInterface(), fIndex(), fControlCode() { SetBCastFlag(plMessage::kBCastByExactType); }
-    plCmdIfaceModMsg(const plKey* s, 
-                    const plKey* r, 
-                    const double* t) : fInterface() { }
-    
+
     CLASSNAME_REGISTER(plCmdIfaceModMsg);
     GETINTERFACE_ANY(plCmdIfaceModMsg, plMessage);
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plCursorChangeMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plCursorChangeMsg.h
@@ -53,9 +53,6 @@ protected:
 public:
     plCursorChangeMsg() : fType(0),fPriority(0) { }
     plCursorChangeMsg(int i, int p) { fType = i;fPriority =p; }
-    plCursorChangeMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t) : fType(0),fPriority(0) { }
 
     CLASSNAME_REGISTER(plCursorChangeMsg);
     GETINTERFACE_ANY(plCursorChangeMsg, plMessage);

--- a/Sources/Plasma/NucleusLib/pnMessage/plEnableMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plEnableMsg.h
@@ -76,8 +76,7 @@ public:
 
     plEnableMsg() { }
 
-    plEnableMsg(const plKey& s, int which, int type)
-        : plMessage()
+    plEnableMsg(int which, int type)
     {
         SetCmd(which);
         SetCmd(type);

--- a/Sources/Plasma/NucleusLib/pnMessage/plFakeOutMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plFakeOutMsg.h
@@ -61,10 +61,6 @@ public:
         SetBCastFlag(plMessage::kPropagateToModifiers);
     }
 
-    plFakeOutMsg(const plKey& s, const plKey& r, const double* t) {
-        SetBCastFlag(plMessage::kPropagateToModifiers);
-    }
-
     CLASSNAME_REGISTER(plFakeOutMsg);
     GETINTERFACE_ANY(plFakeOutMsg, plMessage);
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plPlayerPageMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plPlayerPageMsg.h
@@ -55,10 +55,7 @@ protected:
 
 public:
     plPlayerPageMsg() : fLocallyOriginated(), fUnload(), fLastOut(), fClientID(-1) { }
-    plPlayerPageMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t) : fLocallyOriginated(), fUnload(), fLastOut(), fClientID(-1) { }
-    
+
     CLASSNAME_REGISTER(plPlayerPageMsg);
     GETINTERFACE_ANY(plPlayerPageMsg, plMessage);
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plRemoteAvatarInfoMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plRemoteAvatarInfoMsg.h
@@ -55,9 +55,6 @@ protected:
     plKey fAvatar;
 public:
     plRemoteAvatarInfoMsg() { SetBCastFlag(plMessage::kBCastByExactType); }
-    plRemoteAvatarInfoMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t) { SetBCastFlag(plMessage::kBCastByExactType); }
 
     CLASSNAME_REGISTER(plRemoteAvatarInfoMsg);
     GETINTERFACE_ANY(plRemoteAvatarInfoMsg, plMessage);

--- a/Sources/Plasma/NucleusLib/pnMessage/plSelfDestructMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plSelfDestructMsg.h
@@ -48,7 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plSelfDestructMsg : public plMessage
 {
 protected:
-    plSelfDestructMsg(plKey& victim) : plMessage(victim, victim, nullptr) {}
+    plSelfDestructMsg(const plKey& victim) : plMessage(victim, victim, nullptr) {}
 
     friend class plKeyImp;
 

--- a/Sources/Plasma/NucleusLib/pnMessage/plWarpMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plWarpMsg.h
@@ -68,10 +68,6 @@ public:
         fTransform = mat;
     }
 
-    plWarpMsg(const plKey& s, const plKey& r, const double* t) {
-        Clear();
-    }
-
     plWarpMsg(const plKey& s, const plKey& r, uint32_t flags, const hsMatrix44& mat)
         : fWarpFlags(flags), fTransform(mat), plMessage(s, r, nullptr) { }
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plActivatorMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plActivatorMsg.h
@@ -52,9 +52,6 @@ public:
     plActivatorMsg()
         : fTriggerType()
     { }
-    plActivatorMsg(const plKey& s, const plKey& r, const double* t)
-        : fTriggerType()
-    { }
 
     CLASSNAME_REGISTER( plActivatorMsg );
     GETINTERFACE_ANY( plActivatorMsg, plMessage );

--- a/Sources/Plasma/PubUtilLib/plMessage/plCondRefMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plCondRefMsg.h
@@ -51,8 +51,8 @@ class plCondRefMsg : public plRefMsg
 public:
 
     plCondRefMsg() { fWhich = -1; }
-    plCondRefMsg(const plKey &s, int which)
-        : plRefMsg(s, plRefMsg::kOnCreate), fWhich(which) {}
+    plCondRefMsg(const plKey& r, int which)
+        : plRefMsg(r, plRefMsg::kOnCreate), fWhich(which) {}
 
     CLASSNAME_REGISTER( plCondRefMsg );
     GETINTERFACE_ANY( plCondRefMsg, plRefMsg );

--- a/Sources/Plasma/PubUtilLib/plMessage/plExcludeRegionMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plExcludeRegionMsg.h
@@ -60,7 +60,6 @@ protected:
 
 public:
     plExcludeRegionMsg() : fCmd(kClear), fSynchFlags(0) {}
-    plExcludeRegionMsg(const plKey &s, const plKey &r, const double* t) : fCmd(kClear), fSynchFlags(0) {}
     ~plExcludeRegionMsg() {}
 
     CLASSNAME_REGISTER(plExcludeRegionMsg);

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.cpp
@@ -42,21 +42,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include "hsBitVector.h"
-#include "pnKeyedObject/plKey.h"
 #include "hsResMgr.h"
 #include "hsStream.h"
 
 #include "plInputEventMsg.h"
 
 plInputEventMsg::plInputEventMsg() :
-fEvent(-1)
-{
-    SetBCastFlag(plMessage::kBCastByType);
-}
-
-plInputEventMsg::plInputEventMsg(const plKey &s, 
-            const plKey &r, 
-            const double* t) :
 fEvent(-1)
 {
     SetBCastFlag(plMessage::kBCastByType);
@@ -114,16 +105,6 @@ plControlEventMsg::plControlEventMsg() :
     fControlPct = 1.0f;
     SetBCastFlag(plMessage::kPropagateToModifiers);
     SetBCastFlag(plMessage::kBCastByType, false);
-}
-
-plControlEventMsg::plControlEventMsg(const plKey &s, 
-            const plKey &r, 
-            const double* t) :
-    fCmd()
-{
-    fControlPct = 1.0f;
-    SetBCastFlag(plMessage::kBCastByType, false);
-    SetBCastFlag(plMessage::kPropagateToModifiers);
 }
 
 void plControlEventMsg::Read(hsStream* stream, hsResMgr* mgr)
@@ -215,12 +196,6 @@ plKeyEventMsg::plKeyEventMsg()
 {
 }
 
-plKeyEventMsg::plKeyEventMsg(const plKey &s, 
-                             const plKey &r, 
-                             const double* t)
-{
-}
-
 plKeyEventMsg::~plKeyEventMsg()
 {
 }
@@ -248,12 +223,6 @@ void plKeyEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 }
 
 plDebugKeyEventMsg::plDebugKeyEventMsg()
-{
-}
-
-plDebugKeyEventMsg::plDebugKeyEventMsg(const plKey &s, 
-                                       const plKey &r, 
-                                       const double* t)
 {
 }
 
@@ -322,12 +291,6 @@ void plIMouseBEventMsg::Write(hsStream* stream, hsResMgr* mgr)
 }
 
 plMouseEventMsg::plMouseEventMsg() : fXPos(), fYPos(), fDX(), fDY(), fWheelDelta(), fButton()
-{
-}
-
-plMouseEventMsg::plMouseEventMsg(const plKey &s, 
-                                 const plKey &r, 
-                                 const double* t)
 {
 }
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputEventMsg.h
@@ -61,10 +61,6 @@ public:
         kConfigure = 0,
     };
     plInputEventMsg();
-    plInputEventMsg(const plKey &s,
-                      const plKey &r,
-                      const double* t);
-
     ~plInputEventMsg();
 
     CLASSNAME_REGISTER( plInputEventMsg );
@@ -94,9 +90,6 @@ protected:
 public:
 
     plControlEventMsg();
-    plControlEventMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t);
 
     CLASSNAME_REGISTER( plControlEventMsg );
     GETINTERFACE_ANY( plControlEventMsg, plInputEventMsg );
@@ -137,9 +130,6 @@ public:
 
     
     plKeyEventMsg();
-    plKeyEventMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t);
     ~plKeyEventMsg();
 
     CLASSNAME_REGISTER( plKeyEventMsg );
@@ -180,9 +170,6 @@ public:
 
     
     plDebugKeyEventMsg();
-    plDebugKeyEventMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t);
     ~plDebugKeyEventMsg();
 
     CLASSNAME_REGISTER( plDebugKeyEventMsg );
@@ -214,10 +201,6 @@ public:
     
     plIMouseXEventMsg() : 
     fX(0),fWx(0) {}
-    plIMouseXEventMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t) : 
-    fX(0),fWx(0) {}
     ~plIMouseXEventMsg(){}
 
     CLASSNAME_REGISTER( plIMouseXEventMsg );
@@ -235,10 +218,6 @@ public:
 
     plIMouseYEventMsg() : 
     fY(0),fWy(0) {}
-    plIMouseYEventMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t) : 
-    fY(0),fWy(0) {}
     ~plIMouseYEventMsg(){}
 
     CLASSNAME_REGISTER( plIMouseYEventMsg );
@@ -253,10 +232,6 @@ public:
     short   fButton;
 
     plIMouseBEventMsg() : 
-    fButton(0) {}
-    plIMouseBEventMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t) : 
     fButton(0) {}
     ~plIMouseBEventMsg(){}
 
@@ -283,9 +258,6 @@ protected:
 
 public:
     plMouseEventMsg();
-    plMouseEventMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t);
     ~plMouseEventMsg();
 
     CLASSNAME_REGISTER( plMouseEventMsg );

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.h
@@ -87,7 +87,7 @@ class plInputIfaceMgrMsg : public plMessage
         };
 
         plInputIfaceMgrMsg() : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fInterface = nullptr; fAvKey = nullptr; }
-        plInputIfaceMgrMsg(plKey &receiver, uint8_t command) : plMessage(nullptr, nullptr, nullptr) { AddReceiver(receiver); fCommand = command; fInterface = nullptr; fAvKey = nullptr; }
+        plInputIfaceMgrMsg(const plKey& receiver, uint8_t command) : plMessage(nullptr, nullptr, nullptr) { AddReceiver(receiver); fCommand = command; fInterface = nullptr; fAvKey = nullptr; }
         plInputIfaceMgrMsg(uint8_t command) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fCommand = command; fInterface = nullptr; fAvKey = nullptr; }
         plInputIfaceMgrMsg(uint8_t command, uint32_t pageID) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fCommand = command; fPageID = pageID; fInterface = nullptr; fAvKey = nullptr; }
         ~plInputIfaceMgrMsg();

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.h
@@ -87,7 +87,7 @@ class plInputIfaceMgrMsg : public plMessage
         };
 
         plInputIfaceMgrMsg() : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fInterface = nullptr; fAvKey = nullptr; }
-        plInputIfaceMgrMsg(const plKey& receiver, uint8_t command) : plMessage(nullptr, nullptr, nullptr) { AddReceiver(receiver); fCommand = command; fInterface = nullptr; fAvKey = nullptr; }
+        plInputIfaceMgrMsg(const plKey& receiver, uint8_t command) : plMessage(nullptr, receiver, nullptr) { fCommand = command; fInterface = nullptr; fAvKey = nullptr; }
         plInputIfaceMgrMsg(uint8_t command) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fCommand = command; fInterface = nullptr; fAvKey = nullptr; }
         plInputIfaceMgrMsg(uint8_t command, uint32_t pageID) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fCommand = command; fPageID = pageID; fInterface = nullptr; fAvKey = nullptr; }
         ~plInputIfaceMgrMsg();

--- a/Sources/Plasma/PubUtilLib/plMessage/plInterestingPing.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInterestingPing.h
@@ -51,9 +51,6 @@ class plInterestingModMsg : public plMessage
 
 public:
     plInterestingModMsg(){}
-    plInterestingModMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t){}
     ~plInterestingModMsg() { }
 
     CLASSNAME_REGISTER( plInterestingModMsg );
@@ -78,9 +75,6 @@ class plInterestingPing : public plMessage
 public:
     plInterestingPing(){SetBCastFlag(plMessage::kBCastByExactType);}
     plInterestingPing(const plKey &s) {SetBCastFlag(plMessage::kBCastByExactType);SetSender(s);}  
-    plInterestingPing(const plKey &s, 
-                    const plKey &r, 
-                    const double* t){SetBCastFlag(plMessage::kBCastByExactType);}
     ~plInterestingPing() { }
 
     CLASSNAME_REGISTER( plInterestingPing );

--- a/Sources/Plasma/PubUtilLib/plMessage/plMatrixUpdateMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMatrixUpdateMsg.h
@@ -51,9 +51,6 @@ class plMatrixUpdateMsg : public plMessage
 
 public:
     plMatrixUpdateMsg(){SetBCastFlag(plMessage::kPropagateToModifiers);}
-    plMatrixUpdateMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t){SetBCastFlag(plMessage::kPropagateToModifiers);}
     ~plMatrixUpdateMsg() { }
 
     CLASSNAME_REGISTER( plMatrixUpdateMsg );

--- a/Sources/Plasma/PubUtilLib/plMessage/plPickedMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plPickedMsg.h
@@ -61,11 +61,6 @@ public:
     {
         SetBCastFlag(plMessage::kPropagateToModifiers);
     }
-    plPickedMsg(const plKey &s, const plKey &r, const double* t)
-        : fPicked(true)
-    {
-        SetBCastFlag(plMessage::kPropagateToModifiers);
-    }
 
     CLASSNAME_REGISTER( plPickedMsg );
     GETINTERFACE_ANY( plPickedMsg, plMessage );

--- a/Sources/Plasma/PubUtilLib/plMessage/plPlayerMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plPlayerMsg.h
@@ -59,9 +59,6 @@ protected:
 
 public:
     plPlayerMsg() { SetBCastFlag(plMessage::kBCastByExactType); }
-    plPlayerMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t){ SetBCastFlag(plMessage::kBCastByExactType);    }
     ~plPlayerMsg() { }
 
     CLASSNAME_REGISTER( plPlayerMsg );

--- a/Sources/Plasma/PubUtilLib/plMessage/plSpawnModMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plSpawnModMsg.h
@@ -56,9 +56,6 @@ class plSpawnModMsg : public plMessage
 
 public:
     plSpawnModMsg() { }
-    plSpawnModMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t) { }
     ~plSpawnModMsg() { }
 
     CLASSNAME_REGISTER( plSpawnModMsg );

--- a/Sources/Plasma/PubUtilLib/plMessage/plSpawnRequestMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plSpawnRequestMsg.h
@@ -54,9 +54,6 @@ class plSpawnRequestMsg : public plMessage
 
 public:
     plSpawnRequestMsg(){SetBCastFlag(plMessage::kBCastByExactType);}
-    plSpawnRequestMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t){SetBCastFlag(plMessage::kBCastByExactType);}
     ~plSpawnRequestMsg() { }
 
     CLASSNAME_REGISTER( plSpawnRequestMsg );

--- a/Sources/Plasma/PubUtilLib/plMessage/plTimerCallbackMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plTimerCallbackMsg.h
@@ -48,7 +48,6 @@ class plTimerCallbackMsg : public plMessage
 {
 public:
     plTimerCallbackMsg() { }
-    plTimerCallbackMsg(const plKey &s, const plKey &r, const double* t) { }
     plTimerCallbackMsg(const plKey &r, int32_t id = 0) { AddReceiver(r); fID = id;}
     ~plTimerCallbackMsg() { }
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plTriggerMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plTriggerMsg.h
@@ -53,9 +53,6 @@ protected:
 public:
     
     plTriggerMsg(){SetBCastFlag(plMessage::kBCastByExactType | plMessage::kPropagateToModifiers);}
-    plTriggerMsg(const plKey &s, 
-                    const plKey &r, 
-                    const double* t){SetBCastFlag(plMessage::kBCastByExactType | plMessage::kPropagateToModifiers);}
     ~plTriggerMsg() { }
 
     CLASSNAME_REGISTER( plTriggerMsg );


### PR DESCRIPTION
Various message classes had alternative constructors that *looked* like a convenience constructor, but actually ignored all arguments and behaved exactly like the no-arg constructor. Thankfully, none of these broken constructors were used anywhere.

Along the way, I also fixed a few other small oddities in some message constructors.