### PR TITLE
Fixing Python path sensitivity

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -912,10 +912,10 @@ void PythonInterface::initPython()
 
     // Allow importing from the local python directory if and only if this is an internal client.
 #ifndef PLASMA_EXTERNAL_RELEASE
-    PyWideStringList_Append(&config.module_search_paths, L"./python");
-    PyWideStringList_Append(&config.module_search_paths, L"./python/plasma");
-    PyWideStringList_Append(&config.module_search_paths, L"./python/system");
-    PyWideStringList_Append(&config.module_search_paths, L"./python/system/lib-dynload");
+    PyWideStringList_Append(&config.module_search_paths, L"./Python");
+    PyWideStringList_Append(&config.module_search_paths, L"./Python/plasma");
+    PyWideStringList_Append(&config.module_search_paths, L"./Python/system");
+    PyWideStringList_Append(&config.module_search_paths, L"./Python/system/lib-dynload");
     config.module_search_paths_set = 1;
 #endif
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -372,8 +372,8 @@ bool plPythonFileMod::ILoadPythonCode()
 #ifndef PLASMA_EXTERNAL_RELEASE
     // get code from file and execute in module
     // see if the file exists first before trying to import it
-    plFileName pyfile = plFileName::Join(".", "python", ST::format("{}.py", fPythonFile));
-    plFileName gluefile = plFileName::Join(".", "python", "plasma", "glue.py");
+    plFileName pyfile = plFileName::Join(".", "Python", ST::format("{}.py", fPythonFile));
+    plFileName gluefile = plFileName::Join(".", "Python", "plasma", "glue.py");
     if (plFileInfo(pyfile).Exists() && plFileInfo(gluefile).Exists()) {
         // ok... we can't really use import because Python remembers too much where global variables came from
         // ...and using execfile make it sure that globals are defined in this module and not in the imported module


### PR DESCRIPTION
These paths do not work on case sensitive file systems (i.e. iOS APFS.) Fixing to match actual case.

Assuming the same problem could happen on case sensitive macOS or Linux (although case sensitive macOS installs are rare.)

I'm open to alternatives - but I'm not personally aware of a way to do a case incentive file load on a case sensitive system. Maybe someone else has ideas. I'm assuming the capital-P-Plasma is intentional in the installs.