### PR TITLE
Support for Metal renderer on iOS

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -190,6 +190,15 @@ public:
     MTL::PixelFormat GetFramebufferFormat() const { return fFramebufferFormat; };
     
     MTL::Library* GetShaderLibrary() const { return fShaderLibrary; }
+    
+    static constexpr MTL::StorageMode GetDefaultStorageMode()
+    {
+#if HS_BUILD_FOR_MACOS
+        return MTL::StorageModeManaged;
+#else
+        return MTL::StorageModeShared;
+#endif
+    }
 
 private:
     struct plMetalPipelineRecord

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
@@ -252,7 +252,7 @@ void plMetalMaterialShaderRef::ILoopOverLayers()
         // a lot of the render state, it will be on the GPU already.
         // I'd like to encode more data here, and use a heap. The heap hasn't happened yet because heaps are
         // private memory, and we don't have a window yet for a blit phase into private memory.
-        MTL::Buffer* argumentBuffer = fDevice->newBuffer(sizeof(plMetalFragmentShaderArgumentBuffer), MTL::ResourceStorageModeManaged);
+        MTL::Buffer* argumentBuffer = fDevice->newBuffer(sizeof(plMetalFragmentShaderArgumentBuffer), plMetalDevice::GetDefaultStorageMode());
 
         plMetalFragmentShaderArgumentBuffer* layerBuffer = (plMetalFragmentShaderArgumentBuffer*)argumentBuffer->contents();
 
@@ -287,7 +287,9 @@ void plMetalMaterialShaderRef::ILoopOverLayers()
 
         fPasses.push_back(layers);
 
-        argumentBuffer->didModifyRange(NS::Range(0, argumentBuffer->length()));
+        if (argumentBuffer->storageMode() == MTL::StorageModeManaged) {
+            argumentBuffer->didModifyRange(NS::Range(0, argumentBuffer->length()));
+        }
 
         fPassArgumentBuffers.push_back(argumentBuffer);
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPlateManager.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPlateManager.cpp
@@ -77,9 +77,9 @@ void plMetalPlateManager::ICreateGeometry()
 
         uint16_t indices[6] = {0, 1, 2, 1, 2, 3};
 
-        fVtxBuffer = pipeline->fDevice.fMetalDevice->newBuffer(&vertexBuffer, sizeof(plateVertexBuffer), MTL::StorageModeManaged);
+        fVtxBuffer = pipeline->fDevice.fMetalDevice->newBuffer(&vertexBuffer, sizeof(plateVertexBuffer), plMetalDevice::GetDefaultStorageMode());
         fVtxBuffer->retain();
-        idxBuffer = pipeline->fDevice.fMetalDevice->newBuffer(&indices, sizeof(indices), MTL::StorageModeManaged);
+        idxBuffer = pipeline->fDevice.fMetalDevice->newBuffer(&indices, sizeof(indices), plMetalDevice::GetDefaultStorageMode());
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalTextFont.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalTextFont.cpp
@@ -144,7 +144,7 @@ void plMetalTextFont::IDrawPrimitive(uint32_t count, plFontVertex* array)
     
     uint drawn = 0;
     while (count > 0) {
-        uint drawCount = MIN(maxCount, count);
+        uint drawCount = std::min(uint(maxCount), uint(count));
         fPipeline->fDevice.CurrentRenderCommandEncoder()->setVertexBytes(array + (drawn * 3), drawCount * 3 * sizeof(plFontVertex), 0);
 
         fPipeline->fDevice.CurrentRenderCommandEncoder()->drawPrimitives(MTL::PrimitiveTypeTriangle, NS::UInteger(0), drawCount * 3);


### PR DESCRIPTION
Only using storage mode managed on Mac - shared elsewhere. See: https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/ResourceOptions.html

Fixes for a few other compile issues when building for iPad OS.