### PR TITLE
Remove special case for plain IP addresses when connecting to servers

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -4674,28 +4674,17 @@ void NetCliAuthStartConnect (
     authAddrCount = std::min(authAddrCount, 1u);
 
     for (unsigned i = 0; i < authAddrCount; ++i) {
-        // Do we need to lookup the address?
         const ST::string& name = authAddrList[i];
-        const char* pos;
-        for (pos = name.begin(); pos != name.end(); ++pos) {
-            if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {
-                AsyncAddressLookupName(name, GetClientPort(), [name](auto addrs) {
-                    if (addrs.empty()) {
-                        ReportNetError(kNetProtocolCli2Auth, kNetErrNameLookupFailed);
-                        return;
-                    }
-
-                    for (const plNetAddress& addr : addrs) {
-                        Connect(name, addr);
-                    }
-                });
-                break;
+        AsyncAddressLookupName(name, GetClientPort(), [name](auto addrs) {
+            if (addrs.empty()) {
+                ReportNetError(kNetProtocolCli2Auth, kNetErrNameLookupFailed);
+                return;
             }
-        }
-        if (pos == name.end()) {
-            plNetAddress addr(name, GetClientPort());
-            Connect(name, addr);
-        }
+
+            for (const plNetAddress& addr : addrs) {
+                Connect(name, addr);
+            }
+        });
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -1295,28 +1295,17 @@ void NetCliFileStartConnect (
     s_serverType = kSrvTypeNone;
 
     for (unsigned i = 0; i < fileAddrCount; ++i) {
-        // Do we need to lookup the address?
         const ST::string& name = fileAddrList[i];
-        const char* pos;
-        for (pos = name.begin(); pos != name.end(); ++pos) {
-            if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {
-                AsyncAddressLookupName(name, GetClientPort(), [name](auto addrs) {
-                    if (addrs.empty()) {
-                        ReportNetError(kNetProtocolCli2File, kNetErrNameLookupFailed);
-                        return;
-                    }
-
-                    for (const plNetAddress& addr : addrs) {
-                        Connect(name, addr);
-                    }
-                });
-                break;
+        AsyncAddressLookupName(name, GetClientPort(), [name](auto addrs) {
+            if (addrs.empty()) {
+                ReportNetError(kNetProtocolCli2File, kNetErrNameLookupFailed);
+                return;
             }
-        }
-        if (pos == name.end()) {
-            plNetAddress addr(name, GetClientPort());
-            Connect(name, addr);
-        }
+
+            for (const plNetAddress& addr : addrs) {
+                Connect(name, addr);
+            }
+        });
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -904,28 +904,17 @@ void NetCliGateKeeperStartConnect (
     gateKeeperAddrCount = std::min(gateKeeperAddrCount, 1u);
 
     for (unsigned i = 0; i < gateKeeperAddrCount; ++i) {
-        // Do we need to lookup the address?
         const ST::string& name = gateKeeperAddrList[i];
-        const char* pos;
-        for (pos = name.begin(); pos != name.end(); ++pos) {
-            if (!(isdigit(*pos) || *pos == '.' || *pos == ':')) {
-                AsyncAddressLookupName(name, GetClientPort(), [name](auto addrs) {
-                    if (addrs.empty()) {
-                        ReportNetError(kNetProtocolCli2GateKeeper, kNetErrNameLookupFailed);
-                        return;
-                    }
-
-                    for (const plNetAddress& addr : addrs) {
-                        Connect(name, addr);
-                    }
-                });
-                break;
+        AsyncAddressLookupName(name, GetClientPort(), [name](auto addrs) {
+            if (addrs.empty()) {
+                ReportNetError(kNetProtocolCli2GateKeeper, kNetErrNameLookupFailed);
+                return;
             }
-        }
-        if (pos == name.end()) {
-            plNetAddress addr(name, GetClientPort());
-            Connect(name, addr);
-        }
+
+            for (const plNetAddress& addr : addrs) {
+                Connect(name, addr);
+            }
+        });
     }
 }
 


### PR DESCRIPTION
`AsyncAddressLookupName` can handle plain IP addresses just as well as host names, so there's no need for this special case.

This fixes the client being unable to connect to server addresses that contain a plain IP address with a port number (either in server.ini or when returned by the gatekeeper server). Cyan's original code supported this, but it was apparently broken by accident way back as part of some `plNetAddress` cleanup in #182 (3ea3473d1397d54322bbff177ca8ae6a36e46856).

This is relevant at least for MOSS, where the gatekeeper server returns addresses with an explicit port number if the server is running on a port other than the default 14617.

Server addresses consisting of a host name with a port number have always worked fine. Only the plain IP address case was broken.