### PR TITLE
Fix builds for Xcode 16.3

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.h
@@ -121,7 +121,7 @@ private:
 
     void                                                 IBuildLayerTexture(MTL::RenderCommandEncoder* encoder, const uint32_t offsetFromRootLayer, plLayerInterface* layer);
     void                                                 EncodeTransform(const plLayerInterface* layer, UVOutDescriptor *transform);
-    std::vector<const std::vector<plLayerInterface*>>    fPasses;
+    std::vector<std::vector<plLayerInterface*>>          fPasses;
     std::vector<struct plMetalFragmentShaderDescription> fFragmentShaderDescriptions;
 };
 


### PR DESCRIPTION
Vectors of const types are not allowed. Clang now aligns with the cpp spec.

The Xcode 16.3 release notes describe this change:

> libc++ no longer supports `std::allocator<const T>` and containers of const-qualified element type, such as `std::vector<const T>` and `std::list<const T>`. This used to be supported as an undocumented extension. If you were using `std::vector<const T>`, replace it with `std::vector<T>` instead. The `_LIBCPP_ENABLE_REMOVED_ALLOCATOR_CONST` macro can be defined to temporarily re-enable this extension. This compatibility macro will be removed in a future release. To assist with the clean-up process, consider running your code through Clang Tidy, with `std-allocator-const` enabled.