### PR TITLE
Remove unused and unimplemented `VaultGetAgePublicAgesFolder`

### DIFF
--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -1211,10 +1211,6 @@ class ptAgeVault:
         """Returns a ptVaultPlayerInfoListNode of the players the Age knows about(?)."""
         ...
 
-    def getPublicAgesFolder(self):
-        """Returns a ptVaultFolderNode that contains all the public Ages"""
-        ...
-
     def getSubAgeLink(self, ageInfo):
         """Returns a ptVaultAgeLinkNode to 'ageInfo' (a ptAgeInfoStruct) for this Age."""
         ...

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.cpp
@@ -128,17 +128,6 @@ PyObject* pyAgeVault::GetPeopleIKnowAboutFolder()
     PYTHON_RETURN_NONE;
 }
 
-
-PyObject* pyAgeVault::GetPublicAgesFolder()
-{
-    hsRef<RelVaultNode> rvn = VaultGetAgePublicAgesFolder();
-    if (rvn)
-        return pyVaultFolderNode::New(rvn);
-
-    // just return a None object
-    PYTHON_RETURN_NONE;
-}
-
 PyObject* pyAgeVault::GetSubAgeLink( const pyAgeInfoStruct & info )
 {
     hsRef<RelVaultNode> rvn = VaultFindAgeSubAgeLink(info.GetAgeInfo());

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.h
@@ -98,8 +98,6 @@ public:
     PyObject*       GetPeopleIKnowAboutFolder(); // returns pyVaultPlayerInfoListNode
     // PERSONAL AGE SPECIFIC
     PyObject*       GetBookshelfFolder (); // returns pyVaultFolderNode
-    // NEXUS SPECIFIC
-    PyObject*       GetPublicAgesFolder(); // returns pyVaultFolderNode
     PyObject*       GetSubAgeLink( const pyAgeInfoStruct & info ); // returns pyVaultAgeLinkNode
     // AGE DEVICES. AKA IMAGERS, WHATEVER.
     // Add a new device.

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVaultGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVaultGlue.cpp
@@ -94,11 +94,6 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptAgeVault, getPeopleIKnowAboutFolder)
     return self->fThis->GetPeopleIKnowAboutFolder();
 }
 
-PYTHON_METHOD_DEFINITION_NOARGS(ptAgeVault, getPublicAgesFolder)
-{
-    return self->fThis->GetPublicAgesFolder();
-}
-
 PYTHON_METHOD_DEFINITION(ptAgeVault, getSubAgeLink, args)
 {
     PyObject* ageInfoObj = nullptr;
@@ -251,7 +246,6 @@ PYTHON_START_METHODS_TABLE(ptAgeVault)
     PYTHON_METHOD_NOARGS(ptAgeVault, getAgesIOwnFolder, "(depreciated, use getBookshelfFolder) Returns a ptVaultFolderNode that contain the Ages I own"),
     PYTHON_METHOD_NOARGS(ptAgeVault, getBookshelfFolder, "Personal age only: Returns a ptVaultFolderNode that contains the owning player's AgesIOwn age list"),
     PYTHON_METHOD_NOARGS(ptAgeVault, getPeopleIKnowAboutFolder, "Returns a ptVaultPlayerInfoListNode of the players the Age knows about(?)."),
-    PYTHON_METHOD_NOARGS(ptAgeVault, getPublicAgesFolder, "Returns a ptVaultFolderNode that contains all the public Ages"),
     PYTHON_METHOD(ptAgeVault, getSubAgeLink, "Params: ageInfo\nReturns a ptVaultAgeLinkNode to 'ageInfo' (a ptAgeInfoStruct) for this Age."),
     PYTHON_METHOD_NOARGS(ptAgeVault, getAgeGuid, "Returns the current Age's guid as a string."),
     PYTHON_METHOD(ptAgeVault, addDevice, "Params: deviceName,cb=None,cbContext=0\nAdds a device to the age"),

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -3623,12 +3623,6 @@ hsRef<RelVaultNode> VaultGetAgeSubAgesFolder () {
 }
 
 //============================================================================
-hsRef<RelVaultNode> VaultGetAgePublicAgesFolder () {
-    hsAssert(false, "eric, implement me");
-    return nullptr;
-}
-
-//============================================================================
 hsRef<RelVaultNode> VaultAgeGetBookshelfFolder () {
     if (hsRef<RelVaultNode> rvn = GetAgeNode())
         return rvn->GetChildAgeInfoListNode(plVault::kAgesIOwnFolder, 1);

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -393,7 +393,6 @@ hsRef<RelVaultNode> VaultGetAgeChildAgesFolder();
 hsRef<RelVaultNode> VaultGetAgeAgeOwnersFolder();
 hsRef<RelVaultNode> VaultGetAgeCanVisitFolder();
 hsRef<RelVaultNode> VaultGetAgePeopleIKnowAboutFolder();
-hsRef<RelVaultNode> VaultGetAgePublicAgesFolder();
 hsRef<RelVaultNode> VaultAgeGetBookshelfFolder();
 hsRef<RelVaultNode> VaultFindAgeSubAgeLink(const plAgeInfoStruct * info);
 hsRef<RelVaultNode> VaultFindAgeChildAgeLink(const plAgeInfoStruct * info);


### PR DESCRIPTION
A vault Age node doesn't contain a PublicAgesFolder, so it's not obvious how this API was supposed to behave.

The correct current API for getting the list of public ages is `NetCommGetPublicAgeList`/`PtGetPublicAgeList`.