### PR TITLE
Remove `ptAgeVault.getAgesIOwnFolder` in favor of `.getBookshelfFolder`

### DIFF
--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -1187,10 +1187,6 @@ class ptAgeVault:
         """Returns the age's SDL (ptSDLStateDataRecord)"""
         ...
 
-    def getAgesIOwnFolder(self):
-        """(depreciated, use getBookshelfFolder) Returns a ptVaultFolderNode that contain the Ages I own"""
-        ...
-
     def getBookshelfFolder(self):
         """Personal age only: Returns a ptVaultFolderNode that contains the owning player's AgesIOwn age list"""
         ...

--- a/Scripts/Python/psnlBahroPoles.py
+++ b/Scripts/Python/psnlBahroPoles.py
@@ -941,7 +941,7 @@ class psnlBahroPoles(ptModifier):
 
     def IsVolatile(self, age):
         ageVault = ptAgeVault()
-        PAL = ageVault.getAgesIOwnFolder()
+        PAL = ageVault.getBookshelfFolder()
         contents = PAL.getChildNodeRefList()
         for content in contents:
             link = content.getChild()
@@ -966,7 +966,7 @@ class psnlBahroPoles(ptModifier):
             return 0
         
         ageVault = ptAgeVault()
-        PAL = ageVault.getAgesIOwnFolder()
+        PAL = ageVault.getBookshelfFolder()
         contents = PAL.getChildNodeRefList()
         for content in contents:
             link = content.getChild()
@@ -1079,9 +1079,9 @@ class psnlBahroPoles(ptModifier):
 
     def UpdateToState2(self):
         vault = ptAgeVault()
-        myAges = vault.getAgesIOwnFolder()
-        myAges = myAges.getChildNodeRefList()
-        for ageInfo in myAges:
+        PAL = vault.getBookshelfFolder()
+        contents = PAL.getChildNodeRefList()
+        for ageInfo in contents:
             link = ageInfo.getChild()
             link = link.upcastToAgeLinkNode()
             info = link.getAgeInfo()

--- a/Scripts/Python/psnlBookshelf.py
+++ b/Scripts/Python/psnlBookshelf.py
@@ -424,7 +424,7 @@ class psnlBookshelf(ptModifier):
                             link = self.IGetLinkFromBook()
                             bookAge = self.IGetAgeFromBook()
                             if bookAge in kHardcodedInstances:
-                                link = self.GetOwnedAgeLink(ptAgeVault(), bookAge)
+                                link = self.GetOwnedAgeLink(bookAge)
 
                             if bookAge == "Ahnonay" or bookAge == "AhnonayCathedral":
                                 ageVault = ptAgeVault()
@@ -583,9 +583,8 @@ class psnlBookshelf(ptModifier):
                         return
 
                     if ageName == "city" and PtIsSinglePlayerMode():
-                        ageVault = ptAgeVault()
-                        citylink = self.GetOwnedAgeLink(ageVault, "city")
-                        bcolink = self.GetOwnedAgeLink(ageVault, "BaronCityOffice")
+                        citylink = self.GetOwnedAgeLink("city")
+                        bcolink = self.GetOwnedAgeLink("BaronCityOffice")
                         
                         citylinklocked = citylink and citylink.getLocked()
                         bcolinklocked = bcolink and bcolink.getLocked()
@@ -672,7 +671,7 @@ class psnlBookshelf(ptModifier):
                     link = self.IGetLinkFromBook()
                     # Do not use the age link node of a Hood child age for the city book clasp!
                     if IsChildLink or ageName in kHardcodedInstances:
-                        link = self.GetOwnedAgeLink(ptAgeVault(), ageName)
+                        link = self.GetOwnedAgeLink(ageName)
                     if link is None:
                         return
                     if not isinstance(link, ptVaultAgeLinkNode) or link.getLocked():
@@ -723,9 +722,8 @@ class psnlBookshelf(ptModifier):
         if id==respShelveBook.id:
             ageName = self.IGetAgeFromBook()
             if ageName == "city" and PtIsSinglePlayerMode():
-                ageVault = ptAgeVault()
-                citylink = self.GetOwnedAgeLink(ageVault, "city")
-                bcolink = self.GetOwnedAgeLink(ageVault, "BaronCityOffice")
+                citylink = self.GetOwnedAgeLink("city")
+                bcolink = self.GetOwnedAgeLink("BaronCityOffice")
                 
                 citylinklocked = citylink and citylink.getLocked()
                 bcolinklocked = bcolink and bcolink.getLocked()
@@ -754,7 +752,7 @@ class psnlBookshelf(ptModifier):
             link = self.IGetLinkFromBook()
             # Do not use the age link node of a Hood child age for the city book clasp!
             if IsChildLink or ageName in kHardcodedInstances:
-                link = self.GetOwnedAgeLink(ptAgeVault(), ageName)
+                link = self.GetOwnedAgeLink(ageName)
             if link is None:
                 return
                 
@@ -834,9 +832,8 @@ class psnlBookshelf(ptModifier):
                     agename = self.IGetAgeFromBook()
 
                     if agename == "city" and PtIsSinglePlayerMode():
-                        agevault = ptAgeVault()
-                        citylink = self.GetOwnedAgeLink(agevault, "city")
-                        bcolink = self.GetOwnedAgeLink(agevault, "BaronCityOffice")
+                        citylink = self.GetOwnedAgeLink("city")
+                        bcolink = self.GetOwnedAgeLink("BaronCityOffice")
 
                         citylinklocked = citylink and citylink.getLocked()
                         bcolinklocked = bcolink and bcolink.getLocked()
@@ -871,7 +868,7 @@ class psnlBookshelf(ptModifier):
                     link = self.IGetLinkFromBook()
                     # Do not use the age link node of a Hood child age for the city book clasp!
                     if IsChildLink or agename in kHardcodedInstances:
-                        link = self.GetOwnedAgeLink(ptAgeVault(), agename)
+                        link = self.GetOwnedAgeLink(agename)
                     if link is None:
                         return
                     lockName = objLockPicked.getName()
@@ -1019,7 +1016,7 @@ class psnlBookshelf(ptModifier):
             bookAge = self.IGetAgeFromBook()
 
             if bookAge in kHardcodedInstances:
-                link = self.GetOwnedAgeLink(ptAgeVault(), bookAge)
+                link = self.GetOwnedAgeLink(bookAge)
 
             if bookAge == "Ahnonay" or bookAge == "AhnonayCathedral":
                 ageVault = ptAgeVault()
@@ -1203,7 +1200,7 @@ class psnlBookshelf(ptModifier):
             ageInfo = ptAgeInfoStruct()
             ageInfo.setAgeFilename(ageName)
             ageInfo.setAgeInstanceName(ageName)
-            link = self.GetOwnedAgeLink(ptAgeVault(), ageName)
+            link = self.GetOwnedAgeLink(ageName)
             if link is None:
                 link = self.IGetHoodChildLink(ageName)
             if link is not None:
@@ -1253,8 +1250,8 @@ class psnlBookshelf(ptModifier):
 
         # check for the dang city book and do stuff
         if self.HasCityBook():
-            citylink = self.GetOwnedAgeLink(ageVault, "city")
-            #bcolink = self.GetOwnedAgeLink(ageVault, "BaronCityOffice")
+            citylink = self.GetOwnedAgeLink("city")
+            #bcolink = self.GetOwnedAgeLink("BaronCityOffice")
             bcolink = self.IGetHoodChildLink("BaronCityOffice")
             
             citylinklocked = citylink and citylink.getLocked()
@@ -1427,9 +1424,8 @@ class psnlBookshelf(ptModifier):
 
         # check for the dang city book and do stuff
         if self.HasCityBook():
-            ageVault = ptAgeVault()
-            citylink = self.GetOwnedAgeLink(ageVault, "city")
-            #bcolink = self.GetOwnedAgeLink(ageVault, "BaronCityOffice")
+            citylink = self.GetOwnedAgeLink("city")
+            #bcolink = self.GetOwnedAgeLink("BaronCityOffice")
             bcolink = self.IGetHoodChildLink("BaronCityOffice")
 
             citylinklocked = citylink and citylink.getLocked()
@@ -1932,10 +1928,9 @@ class psnlBookshelf(ptModifier):
             PtDebugPrint("can't find CityBookLinks chron entry")
         return 0
 
-        vault = ptAgeVault()
         # look for city book age links
         for age, splist in CityBookAges.items():
-            #agelink = self.GetOwnedAgeLink(vault, age)
+            #agelink = self.GetOwnedAgeLink(age)
             agelink = self.IGetHoodChildLink(age)
             PtDebugPrint("age = ",age)
             PtDebugPrint("agelink = ",agelink)
@@ -1952,7 +1947,7 @@ class psnlBookshelf(ptModifier):
                         return 1
 
         # look for a city treasure link, but it's a Hood childage now
-        #agelink = self.GetOwnedAgeLink(vault, "city")
+        #agelink = self.GetOwnedAgeLink("city")
         agelink = self.IGetHoodChildLink(age)
         PtDebugPrint("age = the city")
         PtDebugPrint("agelink = ",agelink)
@@ -1973,7 +1968,8 @@ class psnlBookshelf(ptModifier):
         return 0
 
 
-    def GetOwnedAgeLink(self, vault, age):
+    def GetOwnedAgeLink(self, age):
+        vault = ptAgeVault()
         PAL = vault.getAgesIOwnFolder()
         if PAL is not None:
             contents = PAL.getChildNodeRefList()

--- a/Scripts/Python/psnlBookshelf.py
+++ b/Scripts/Python/psnlBookshelf.py
@@ -456,7 +456,7 @@ class psnlBookshelf(ptModifier):
                                 note.send()
                                 
                                 ageVault = ptAgeVault()
-                                PAL = ageVault.getAgesIOwnFolder()
+                                PAL = ageVault.getBookshelfFolder()
                                 contents = PAL.getChildNodeRefList()
                                 for content in contents:
                                     link = content.getChild()
@@ -1056,7 +1056,7 @@ class psnlBookshelf(ptModifier):
                     note.send()
 
                     ageVault = ptAgeVault()
-                    PAL = ageVault.getAgesIOwnFolder()
+                    PAL = ageVault.getBookshelfFolder()
                     contents = PAL.getChildNodeRefList()
                     for content in contents:
                         link = content.getChild()
@@ -1213,7 +1213,7 @@ class psnlBookshelf(ptModifier):
             return ageLink
 
         ageVault = ptAgeVault()
-        PAL = ageVault.getAgesIOwnFolder()
+        PAL = ageVault.getBookshelfFolder()
         contents = PAL.getChildNodeRefList()
         for content in contents:
             link = content.getChild()
@@ -1245,7 +1245,7 @@ class psnlBookshelf(ptModifier):
         global CityBookAges
         
         ageVault = ptAgeVault()
-        PAL = ageVault.getAgesIOwnFolder()
+        PAL = ageVault.getBookshelfFolder()
         contents = PAL.getChildNodeRefList()
 
         # check for the dang city book and do stuff
@@ -1457,7 +1457,7 @@ class psnlBookshelf(ptModifier):
                             break
         
         ageVault = ptAgeVault()
-        PAL = ageVault.getAgesIOwnFolder()
+        PAL = ageVault.getBookshelfFolder()
         if PAL is not None:
             contents = PAL.getChildNodeRefList()
 
@@ -1970,7 +1970,7 @@ class psnlBookshelf(ptModifier):
 
     def GetOwnedAgeLink(self, age):
         vault = ptAgeVault()
-        PAL = vault.getAgesIOwnFolder()
+        PAL = vault.getBookshelfFolder()
         if PAL is not None:
             contents = PAL.getChildNodeRefList()
             for content in contents:

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -736,7 +736,7 @@ class xLinkingBookGUIPopup(ptModifier):
         
         # citybook links have been changed to Hood childages, so we search there now
         #vault = ptAgeVault()
-        #OwnedAges = vault.getAgesIOwnFolder().getChildNodeRefList()
+        #OwnedAges = vault.getBookshelfFolder().getChildNodeRefList()
         childAgeFolder = self.IGetHoodInfoNode().getChildAgesFolder()
         HoodChildAges = childAgeFolder.getChildNodeRefList()
         spawnPoints = []
@@ -878,7 +878,7 @@ class xLinkingBookGUIPopup(ptModifier):
         
         # Step 1: Find this age's spawnPoints
         vault = ptAgeVault()
-        OwnedAges = vault.getAgesIOwnFolder().getChildNodeRefList()
+        OwnedAges = vault.getBookshelfFolder().getChildNodeRefList()
         spawnPoints = None
         for NodeRef in OwnedAges:
             tmpLink = NodeRef.getChild().upcastToAgeLinkNode()
@@ -1016,7 +1016,7 @@ class xLinkingBookGUIPopup(ptModifier):
 
     def GetOwnedAgeLink(self, age):
         vault = ptAgeVault()
-        PAL = vault.getAgesIOwnFolder()
+        PAL = vault.getBookshelfFolder()
         if PAL is not None:
             contents = PAL.getChildNodeRefList()
             for content in contents:

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -583,8 +583,7 @@ class xLinkingBookGUIPopup(ptModifier):
                 agePanel = SpawnPointTitle_Dict[xLinkingBookDefs.kFirstLinkPanelID]
                 PtDebugPrint("agePanel2 = ",agePanel)
             elif agePanel == "Neighborhood":
-                agevault = ptAgeVault()
-                nblink = self.GetOwnedAgeLink(agevault, "Neighborhood")
+                nblink = self.GetOwnedAgeLink("Neighborhood")
                 if not nblink:
                     SpawnPointTitle_Dict = {xLinkingBookDefs.kFirstLinkPanelID: 'Default'}
                     SpawnPointName_Dict = {xLinkingBookDefs.kFirstLinkPanelID: 'LinkInPointDefault'}
@@ -1015,7 +1014,8 @@ class xLinkingBookGUIPopup(ptModifier):
             cam.enableFirstPersonOverride()
 
 
-    def GetOwnedAgeLink(self, vault, age):
+    def GetOwnedAgeLink(self, age):
+        vault = ptAgeVault()
         PAL = vault.getAgesIOwnFolder()
         if PAL is not None:
             contents = PAL.getChildNodeRefList()

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVaultGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVaultGlue.cpp
@@ -79,11 +79,6 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptAgeVault, getChronicleFolder)
     return self->fThis->GetChronicleFolder();
 }
 
-PYTHON_METHOD_DEFINITION_NOARGS(ptAgeVault, getAgesIOwnFolder)
-{
-    return self->fThis->GetBookshelfFolder();
-}
-
 PYTHON_METHOD_DEFINITION_NOARGS(ptAgeVault, getBookshelfFolder)
 {
     return self->fThis->GetBookshelfFolder();
@@ -248,7 +243,6 @@ PYTHON_START_METHODS_TABLE(ptAgeVault)
     PYTHON_METHOD_NOARGS(ptAgeVault, getAgeDevicesFolder, "Returns a ptVaultFolderNode of the inboxes for the devices in this Age."),
     PYTHON_METHOD_NOARGS(ptAgeVault, getSubAgesFolder, "Returns a ptVaultFolderNode of sub Age's folder."),
     PYTHON_METHOD_NOARGS(ptAgeVault, getChronicleFolder, "Returns a ptVaultFolderNode"),
-    PYTHON_METHOD_NOARGS(ptAgeVault, getAgesIOwnFolder, "(depreciated, use getBookshelfFolder) Returns a ptVaultFolderNode that contain the Ages I own"),
     PYTHON_METHOD_NOARGS(ptAgeVault, getBookshelfFolder, "Personal age only: Returns a ptVaultFolderNode that contains the owning player's AgesIOwn age list"),
     PYTHON_METHOD_NOARGS(ptAgeVault, getPeopleIKnowAboutFolder, "Returns a ptVaultPlayerInfoListNode of the players the Age knows about(?)."),
     PYTHON_METHOD_NOARGS(ptAgeVault, getPublicAgesFolder, "Returns a ptVaultFolderNode that contains all the public Ages"),


### PR DESCRIPTION
The implementation of the two methods is identical, so this doesn't change any behavior.

However, the name `getBookshelfFolder` more accurately describes the method's behavior and avoids confusion with `ptVault.getAgesIOwnFolder`, which does *not* do the same thing as the `ptAgeVault` method:

* `ptVault.getAgesIOwnFolder` can be called in any age and returns the age   instances owned by the current avatar.
* `ptAgeVault.getBookshelfFolder` (formerly `ptAgeVault.getAgesIOwnFolder`) only succeeds when in an instance of Relto and returns the age instances owned by the avatar that owns the Relto instance (i. e. the books appearing in that Relto instance's bookshelf).

These two lists will be different if one avatar is visiting another avatar's Relto!