### PR TITLE
Lambda-ify the gatekeeper and game server callbacks

### DIFF
--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.cpp
@@ -389,9 +389,9 @@ void plClientLauncher::InitializeNetCore()
     uint32_t num = GetGateKeeperSrvHostnames(addrs);
 
     NetCliGateKeeperStartConnect(addrs, num);
-    NetCliGateKeeperFileSrvIpAddressRequest([this](auto result, auto addr) {
+    NetCliGateKeeperFileSrvIpAddressRequest(true, [this](auto result, auto addr) {
         IGotFileServIPs(result, addr);
-    }, true);
+    });
 
     // Windows is getting a little unreliable about reporting its own state, so we keep
     // track of whether or not we are active now.

--- a/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
+++ b/Sources/Plasma/Apps/plUruLauncher/plClientLauncher.h
@@ -95,6 +95,7 @@ private:
 
     void IOnPatchComplete(ENetError result, const ST::string& msg);
     bool IApproveDownload(const plFileName& file);
+    void IGotFileServIPs(ENetError result, const ST::string& addr);
 
 public:
     plClientLauncher();

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -601,7 +601,6 @@ static void INetCliAuthSendFriendInviteCallback (
 //============================================================================
 static void AuthSrvIpAddressCallback (
     ENetError       result,
-    void *          param,
     const ST::string& addr
 ) {
     s_authSrvAddr = addr;
@@ -611,7 +610,6 @@ static void AuthSrvIpAddressCallback (
 //============================================================================
 static void FileSrvIpAddressCallback (
     ENetError       result,
-    void *          param,
     const ST::string& addr
 ) {
     s_fileSrvAddr = addr;
@@ -770,7 +768,7 @@ void NetCommConnect () {
         connectedToKeeper = true;
 
         // request an auth server ip address
-        NetCliGateKeeperAuthSrvIpAddressRequest(AuthSrvIpAddressCallback, nullptr);
+        NetCliGateKeeperAuthSrvIpAddressRequest(AuthSrvIpAddressCallback);
 
         while(!s_hasAuthSrvIpAddress && !s_netError) {
             NetClientUpdate();
@@ -799,7 +797,7 @@ void NetCommConnect () {
             }
 
             // request a file server ip address
-            NetCliGateKeeperFileSrvIpAddressRequest(FileSrvIpAddressCallback, nullptr, false);
+            NetCliGateKeeperFileSrvIpAddressRequest(FileSrvIpAddressCallback, false);
 
             while(!s_hasFileSrvIpAddress && !s_netError) {
                 NetClientUpdate();

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -548,8 +548,9 @@ static void INetCliAuthAgeRequestCallback (
             ageMcpId,
             s_account.accountUuid,
             s_player->playerInt,
-            INetCliGameJoinAgeRequestCallback,
-            param
+            [param](auto result) {
+                INetCliGameJoinAgeRequestCallback(result, param);
+            }
         );
     }
     else {

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -798,7 +798,7 @@ void NetCommConnect () {
             }
 
             // request a file server ip address
-            NetCliGateKeeperFileSrvIpAddressRequest(FileSrvIpAddressCallback, false);
+            NetCliGateKeeperFileSrvIpAddressRequest(false, FileSrvIpAddressCallback);
 
             while(!s_hasFileSrvIpAddress && !s_netError) {
                 NetClientUpdate();

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.cpp
@@ -91,7 +91,6 @@ struct CliGmConn : hsRefCnt, AsyncNotifySocketCallbacks {
 //============================================================================
 struct JoinAgeRequestTrans : NetGameTrans {
     FNetCliGameJoinAgeRequestCallback   m_callback;
-    void *                              m_param;
     // sent
     unsigned                            m_ageMcpId;
     plUUID                              m_accountUuid;
@@ -101,8 +100,7 @@ struct JoinAgeRequestTrans : NetGameTrans {
         unsigned                            ageMcpId,
         const plUUID&                       accountUuid,
         unsigned                            playerInt,
-        FNetCliGameJoinAgeRequestCallback   callback,
-        void *                              param
+        FNetCliGameJoinAgeRequestCallback   callback
     );
 
     bool Send() override;
@@ -526,11 +524,9 @@ JoinAgeRequestTrans::JoinAgeRequestTrans (
     unsigned                            ageMcpId,
     const plUUID&                       accountUuid,
     unsigned                            playerInt,
-    FNetCliGameJoinAgeRequestCallback   callback,
-    void *                              param
+    FNetCliGameJoinAgeRequestCallback   callback
 ) : NetGameTrans(kJoinAgeRequestTrans)
-,   m_callback(callback)
-,   m_param(param)
+,   m_callback(std::move(callback))
 ,   m_ageMcpId(ageMcpId)
 ,   m_accountUuid(accountUuid)
 ,   m_playerInt(playerInt)
@@ -557,10 +553,7 @@ bool JoinAgeRequestTrans::Send () {
 
 //============================================================================
 void JoinAgeRequestTrans::Post () {
-    m_callback(
-        m_result,
-        m_param
-    );
+    m_callback(m_result);
 }
 
 //============================================================================
@@ -757,15 +750,13 @@ void NetCliGameJoinAgeRequest (
     unsigned                            ageMcpId,
     const plUUID&                       accountUuid,
     unsigned                            playerInt,
-    FNetCliGameJoinAgeRequestCallback   callback,
-    void *                              param
+    FNetCliGameJoinAgeRequestCallback   callback
 ) {
     JoinAgeRequestTrans * trans = new JoinAgeRequestTrans(
         ageMcpId,
         accountUuid,
         playerInt,
-        callback,
-        param
+        std::move(callback)
     );
     NetTransSend(trans);
 }
@@ -774,7 +765,7 @@ void NetCliGameJoinAgeRequest (
 void NetCliGameSetRecvBufferHandler (
     FNetCliGameRecvBufferHandler    handler
 ) {
-    s_bufHandler = handler;
+    s_bufHandler = std::move(handler);
 }
 
 //============================================================================
@@ -802,7 +793,7 @@ void NetCliGamePropagateBuffer (
 //============================================================================
 void NetCliGameSetRecvGameMgrMsgHandler(FNetCliGameRecvGameMgrMsgHandler handler)
 {
-    s_gameMgrMsgHandler = handler;
+    s_gameMgrMsgHandler = std::move(handler);
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGame.h
@@ -50,6 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #endif
 #define PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETGAMELIB_PRIVATE_PLNGLGAME_H
 
+#include <functional>
 
 /*****************************************************************************
 *
@@ -72,26 +73,22 @@ void NetCliGameDisconnect ();
 //============================================================================
 // Join Age
 //============================================================================
-typedef void (*FNetCliGameJoinAgeRequestCallback)(
-    ENetError       result,
-    void *          param
-);
+using FNetCliGameJoinAgeRequestCallback = std::function<void(ENetError result)>;
 void NetCliGameJoinAgeRequest (
     unsigned                            ageMcpId,
     const plUUID&                       accountUuid,
     unsigned                            playerInt,
-    FNetCliGameJoinAgeRequestCallback   callback,
-    void *                              param
+    FNetCliGameJoinAgeRequestCallback   callback
 );
 
 //============================================================================
 // Propagate app-specific data
 //============================================================================
-typedef void (*FNetCliGameRecvBufferHandler)(
+using FNetCliGameRecvBufferHandler = std::function<void(
     unsigned                        type,
     unsigned                        bytes,
     const uint8_t                      buffer[]
-);
+)>;
 void NetCliGameSetRecvBufferHandler (
     FNetCliGameRecvBufferHandler    handler
 );
@@ -104,6 +101,6 @@ void NetCliGamePropagateBuffer (
 //============================================================================
 // GameMgrMsg
 //============================================================================
-typedef void (*FNetCliGameRecvGameMgrMsgHandler)(struct GameMsgHeader* msg);
+using FNetCliGameRecvGameMgrMsgHandler = std::function<void(struct GameMsgHeader* msg)>;
 void NetCliGameSetRecvGameMgrMsgHandler(FNetCliGameRecvGameMgrMsgHandler handler);
 void NetCliGameSendGameMgrMsg(const struct GameMsgHeader* msg);

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -931,8 +931,8 @@ void NetCliGateKeeperPingRequest (
 
 //============================================================================
 void NetCliGateKeeperFileSrvIpAddressRequest (
-    FNetCliGateKeeperFileSrvIpAddressRequestCallback    callback,
-    bool                                                isPatcher
+    bool                                                isPatcher,
+    FNetCliGateKeeperFileSrvIpAddressRequestCallback    callback
 ) {
     FileSrvIpAddressRequestTrans * trans = new FileSrvIpAddressRequestTrans(std::move(callback), isPatcher);
     NetTransSend(trans);

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -739,7 +739,7 @@ bool FileSrvIpAddressRequestTrans::Recv (
 
 //============================================================================
 AuthSrvIpAddressRequestTrans::AuthSrvIpAddressRequestTrans (
-    FNetCliGateKeeperFileSrvIpAddressRequestCallback    callback,
+    FNetCliGateKeeperAuthSrvIpAddressRequestCallback    callback,
     void *                                              param
 ) : NetGateKeeperTrans(kGkAuthSrvIpAddressRequestTrans)
 ,   m_callback(callback)

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.cpp
@@ -108,14 +108,12 @@ struct CliGkConn : hsRefCnt, AsyncNotifySocketCallbacks {
 //============================================================================
 struct PingRequestTrans : NetGateKeeperTrans {
     FNetCliGateKeeperPingRequestCallback    m_callback;
-    void *                                  m_param;
     unsigned                                m_pingAtMs;
     unsigned                                m_replyAtMs;
     std::vector<uint8_t>                    m_payload;
     
     PingRequestTrans (
         FNetCliGateKeeperPingRequestCallback    callback,
-        void *                                  param,
         unsigned                                pingAtMs,
         unsigned                                payloadBytes,
         const void *                            payload
@@ -134,13 +132,11 @@ struct PingRequestTrans : NetGateKeeperTrans {
 //============================================================================
 struct FileSrvIpAddressRequestTrans : NetGateKeeperTrans {
     FNetCliGateKeeperFileSrvIpAddressRequestCallback    m_callback;
-    void *                                              m_param;
     ST::string                                          m_addr;
     bool                                                m_isPatcher;
     
     FileSrvIpAddressRequestTrans (
         FNetCliGateKeeperFileSrvIpAddressRequestCallback    callback,
-        void *                                              param,
         bool                                                isPatcher
     );
 
@@ -157,12 +153,10 @@ struct FileSrvIpAddressRequestTrans : NetGateKeeperTrans {
 //============================================================================
 struct AuthSrvIpAddressRequestTrans : NetGateKeeperTrans {
     FNetCliGateKeeperAuthSrvIpAddressRequestCallback    m_callback;
-    void *                                              m_param;
     ST::string                                          m_addr;
 
     AuthSrvIpAddressRequestTrans (
-        FNetCliGateKeeperAuthSrvIpAddressRequestCallback    callback,
-        void *                                              param
+        FNetCliGateKeeperAuthSrvIpAddressRequestCallback    callback
     );
 
     bool Send() override;
@@ -609,13 +603,11 @@ static NetMsgInitRecv s_recv[] = {
 //============================================================================
 PingRequestTrans::PingRequestTrans (
     FNetCliGateKeeperPingRequestCallback    callback,
-    void *                          param,
     unsigned                        pingAtMs,
     unsigned                        payloadBytes,
     const void *                    payload
 ) : NetGateKeeperTrans(kPingRequestTrans)
-,   m_callback(callback)
-,   m_param(param)
+,   m_callback(std::move(callback))
 ,   m_pingAtMs(pingAtMs)
 ,   m_payload((const uint8_t *)payload, (const uint8_t *)payload + payloadBytes)
 {
@@ -645,7 +637,6 @@ void PingRequestTrans::Post () {
 
     m_callback(
         m_result,
-        m_param,
         m_pingAtMs,
         m_replyAtMs,
         m_payload.size(),
@@ -678,11 +669,9 @@ bool PingRequestTrans::Recv (
 //============================================================================
 FileSrvIpAddressRequestTrans::FileSrvIpAddressRequestTrans (
     FNetCliGateKeeperFileSrvIpAddressRequestCallback    callback,
-    void *                                              param,
     bool                                                isPatcher
 ) : NetGateKeeperTrans(kGkFileSrvIpAddressRequestTrans)
-,   m_callback(callback)
-,   m_param(param)
+,   m_callback(std::move(callback))
 ,   m_isPatcher(isPatcher)
 {
 }
@@ -710,7 +699,6 @@ void FileSrvIpAddressRequestTrans::Post () {
 
     m_callback(
         m_result,
-        m_param,
         m_addr
     );
 }
@@ -739,11 +727,9 @@ bool FileSrvIpAddressRequestTrans::Recv (
 
 //============================================================================
 AuthSrvIpAddressRequestTrans::AuthSrvIpAddressRequestTrans (
-    FNetCliGateKeeperAuthSrvIpAddressRequestCallback    callback,
-    void *                                              param
+    FNetCliGateKeeperAuthSrvIpAddressRequestCallback    callback
 ) : NetGateKeeperTrans(kGkAuthSrvIpAddressRequestTrans)
-,   m_callback(callback)
-,   m_param(param)
+,   m_callback(std::move(callback))
 {
 }
 
@@ -768,7 +754,6 @@ void AuthSrvIpAddressRequestTrans::Post () {
 
     m_callback(
         m_result,
-        m_param,
         m_addr
     );
 }
@@ -933,12 +918,10 @@ void NetCliGateKeeperPingRequest (
     unsigned                                pingTimeMs,
     unsigned                                payloadBytes,
     const void *                            payload,
-    FNetCliGateKeeperPingRequestCallback    callback,
-    void *                                  param
+    FNetCliGateKeeperPingRequestCallback    callback
 ) {
     PingRequestTrans * trans = new PingRequestTrans(
-        callback,
-        param,
+        std::move(callback),
         pingTimeMs, 
         payloadBytes,
         payload
@@ -949,18 +932,16 @@ void NetCliGateKeeperPingRequest (
 //============================================================================
 void NetCliGateKeeperFileSrvIpAddressRequest (
     FNetCliGateKeeperFileSrvIpAddressRequestCallback    callback,
-    void *                                              param,
     bool                                                isPatcher
 ) {
-    FileSrvIpAddressRequestTrans * trans = new FileSrvIpAddressRequestTrans(callback, param, isPatcher);
+    FileSrvIpAddressRequestTrans * trans = new FileSrvIpAddressRequestTrans(std::move(callback), isPatcher);
     NetTransSend(trans);
 }
 
 //============================================================================
 void NetCliGateKeeperAuthSrvIpAddressRequest (
-    FNetCliGateKeeperAuthSrvIpAddressRequestCallback    callback,
-    void *                                              param
+    FNetCliGateKeeperAuthSrvIpAddressRequestCallback    callback
 ) {
-    AuthSrvIpAddressRequestTrans * trans = new AuthSrvIpAddressRequestTrans(callback, param);
+    AuthSrvIpAddressRequestTrans * trans = new AuthSrvIpAddressRequestTrans(std::move(callback));
     NetTransSend(trans);
 }

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.h
@@ -101,8 +101,8 @@ using FNetCliGateKeeperFileSrvIpAddressRequestCallback = std::function<void(
 )>;
 
 void NetCliGateKeeperFileSrvIpAddressRequest (
-    FNetCliGateKeeperFileSrvIpAddressRequestCallback    callback,
-    bool                                                isPatcher
+    bool                                                isPatcher,
+    FNetCliGateKeeperFileSrvIpAddressRequestCallback    callback
 );
 
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.h
@@ -66,21 +66,11 @@ void NetCliGateKeeperStartConnect (
     uint32_t         gateKeeperAddrCount
 );
 
-bool NetCliGateKeeperQueryConnected ();
-void NetCliGateKeeperAutoReconnectEnable (bool enable); // is enabled by default
-
-// Called after the gatekeeper/client connection is encrypted
-typedef void (*FNetCliGateKeeperConnectCallback)();
-void NetCliGateKeeperSetConnectCallback (
-    FNetCliGateKeeperConnectCallback callback
-);
-
 
 //============================================================================
 // Disconnect
 //============================================================================
 void NetCliGateKeeperDisconnect ();
-void NetCliGateKeeperUnexpectedDisconnect ();
 
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglGateKeeper.h
@@ -50,6 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #endif
 #define PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETGAMELIB_PRIVATE_PLNGLGATEKEEPER_H
 
+#include <functional>
 
 /*****************************************************************************
 *
@@ -76,35 +77,31 @@ void NetCliGateKeeperDisconnect ();
 //============================================================================
 // Ping
 //============================================================================
-typedef void (*FNetCliGateKeeperPingRequestCallback)(
+using FNetCliGateKeeperPingRequestCallback = std::function<void(
     ENetError   result,
-    void *      param,
     unsigned    pingAtMs,
     unsigned    replyAtMs,
     unsigned    payloadBytes,
     const uint8_t  payload[]
-);
+)>;
 void NetCliGateKeeperPingRequest (
     unsigned                                pingTimeMs,
     unsigned                                payloadBytes,   // max 64k (pnNetCli enforced upon send)
     const void *                            payload,
-    FNetCliGateKeeperPingRequestCallback    callback,
-    void *                                  param
+    FNetCliGateKeeperPingRequestCallback    callback
 );
 
 
 //============================================================================
 // FileSrvIpAddress
 //============================================================================
-typedef void (*FNetCliGateKeeperFileSrvIpAddressRequestCallback)(
+using FNetCliGateKeeperFileSrvIpAddressRequestCallback = std::function<void(
     ENetError       result,
-    void *          param,
     const ST::string& addr
-);
+)>;
 
 void NetCliGateKeeperFileSrvIpAddressRequest (
     FNetCliGateKeeperFileSrvIpAddressRequestCallback    callback,
-    void *                                              param,
     bool                                                isPatcher
 );
 
@@ -112,15 +109,13 @@ void NetCliGateKeeperFileSrvIpAddressRequest (
 //============================================================================
 // AuthSrvIpAddress
 //============================================================================
-typedef void (*FNetCliGateKeeperAuthSrvIpAddressRequestCallback)(
+using FNetCliGateKeeperAuthSrvIpAddressRequestCallback = std::function<void(
     ENetError       result,
-    void *          param,
     const ST::string& addr
-);
+)>;
 
 void NetCliGateKeeperAuthSrvIpAddressRequest (
-    FNetCliGateKeeperAuthSrvIpAddressRequestCallback    callback,
-    void *                                              param
+    FNetCliGateKeeperAuthSrvIpAddressRequestCallback    callback
 );
 
 

--- a/Sources/Tools/plFilePatcher/plFilePatcher.cpp
+++ b/Sources/Tools/plFilePatcher/plFilePatcher.cpp
@@ -115,9 +115,9 @@ void plFilePatcher::IRequestFileSrvInfo()
     uint32_t num = GetGateKeeperSrvHostnames(addrs);
     NetCliGateKeeperStartConnect(addrs, num);
 
-    NetCliGateKeeperFileSrvIpAddressRequest([](ENetError result, void* param, const ST::string& addr) {
-        static_cast<plFilePatcher*>(param)->IHandleFileSrvInfo(result, addr);
-    }, this, true);
+    NetCliGateKeeperFileSrvIpAddressRequest([this](auto result, auto addr) {
+        IHandleFileSrvInfo(result, addr);
+    }, true);
 }
 
 void plFilePatcher::IHandleFileSrvInfo(ENetError result, const ST::string& addr)

--- a/Sources/Tools/plFilePatcher/plFilePatcher.cpp
+++ b/Sources/Tools/plFilePatcher/plFilePatcher.cpp
@@ -115,9 +115,9 @@ void plFilePatcher::IRequestFileSrvInfo()
     uint32_t num = GetGateKeeperSrvHostnames(addrs);
     NetCliGateKeeperStartConnect(addrs, num);
 
-    NetCliGateKeeperFileSrvIpAddressRequest([this](auto result, auto addr) {
+    NetCliGateKeeperFileSrvIpAddressRequest(true, [this](auto result, auto addr) {
         IHandleFileSrvInfo(result, addr);
-    }, true);
+    });
 }
 
 void plFilePatcher::IHandleFileSrvInfo(ENetError result, const ST::string& addr)


### PR DESCRIPTION
To allow passing extra context into the callbacks without any `void*` casting. Follow-up to #1539.

I plan to give all the other NetGameLib calls the same treatment too. These two servers are the easiest ones to start with.