### PR TITLE
Lambda-ify patcher-related net callbacks

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -192,6 +192,13 @@ struct pfPatcherWorker : public hsThread
 
     void OnQuit() override;
 
+    void IAuthThingDownloadCB(ENetError result, const plFileName& filename, hsStream* writer);
+    void IGotAuthFileList(ENetError result, const NetCliAuthFileInfo infoArr[], unsigned infoCount);
+    void IHandleManifestDownload(const ST::string& group, const NetCliFileManifestEntry manifest[], unsigned entryCount);
+    void IPreloaderManifestDownloadCB(ENetError result, const ST::string& group, const NetCliFileManifestEntry manifest[], unsigned entryCount);
+    void IFileManifestDownloadCB(ENetError result, const ST::string& group, const NetCliFileManifestEntry manifest[], unsigned entryCount);
+    void IFileThingDownloadCB(ENetError result, const plFileName& filename, pfPatcherStream* stream);
+
     void EndPatch(ENetError result, const ST::string& msg={});
     bool IssueRequest();
     void Run() override;
@@ -304,30 +311,30 @@ public:
 
 // ===================================================
 
-static void IAuthThingDownloadCB(pfPatcherWorker* patcher, ENetError result, const plFileName& filename, hsStream* writer)
+void pfPatcherWorker::IAuthThingDownloadCB(ENetError result, const plFileName& filename, hsStream* writer)
 {
     if (IS_NET_SUCCESS(result)) {
         PatcherLogGreen("\tDownloaded Legacy File '{}'", filename);
-        patcher->IssueRequest();
+        IssueRequest();
 
         // Now, we pass our RAM-backed file to the game code handlers. In the main client,
         // this will trickle down and add a new friend to plStreamSource. This should never
         // happen in any other app...
         writer->Rewind();
-        patcher->WhitelistFile(filename, true, writer);
+        WhitelistFile(filename, true, writer);
     } else {
         PatcherLogRed("\tDownloaded Failed: File '{}'", filename);
-        patcher->EndPatch(result, filename.AsString());
+        EndPatch(result, filename.AsString());
     }
 }
 
-static void IGotAuthFileList(pfPatcherWorker* patcher, ENetError result, const NetCliAuthFileInfo infoArr[], unsigned infoCount)
+void pfPatcherWorker::IGotAuthFileList(ENetError result, const NetCliAuthFileInfo infoArr[], unsigned infoCount)
 {
     if (IS_NET_SUCCESS(result)) {
         // so everything goes directly into the Requests deque because AuthSrv lists
         // don't have any hashes attached. WHY did eap think this was a good idea?!?!
         {
-            hsLockGuard(patcher->fRequestMut);
+            hsLockGuard(fRequestMut);
             for (unsigned i = 0; i < infoCount; ++i) {
                 PatcherLogYellow("\tEnqueuing Legacy File '{}'", infoArr[i].filename);
 
@@ -336,50 +343,50 @@ static void IGotAuthFileList(pfPatcherWorker* patcher, ENetError result, const N
 
                 // We purposefully do NOT Open this stream! This uses a special auth-file constructor that
                 // utilizes a backing hsRAMStream. This will be fed to plStreamSource later...
-                pfPatcherStream* s = new pfPatcherStream(patcher, fn, infoArr[i].filesize);
-                patcher->fRequests.emplace_back(fn.AsString(), pfPatcherWorker::Request::kAuthFile, s);
+                pfPatcherStream* s = new pfPatcherStream(this, fn, infoArr[i].filesize);
+                fRequests.emplace_back(fn.AsString(), Request::kAuthFile, s);
             }
         }
-        patcher->IssueRequest();
+        IssueRequest();
     } else {
         PatcherLogRed("\tSHIT! Some legacy manifest phailed");
-        patcher->EndPatch(result, "SecurePreloader failed");
+        EndPatch(result, "SecurePreloader failed");
     }
 }
 
-static void IHandleManifestDownload(pfPatcherWorker* patcher, const ST::string& group, const NetCliFileManifestEntry manifest[], unsigned entryCount)
+void pfPatcherWorker::IHandleManifestDownload(const ST::string& group, const NetCliFileManifestEntry manifest[], unsigned entryCount)
 {
     PatcherLogGreen("\tDownloaded Manifest '{}'", group);
     {
-        hsLockGuard(patcher->fFileMut);
+        hsLockGuard(fFileMut);
         for (unsigned i = 0; i < entryCount; ++i)
-            patcher->fQueuedFiles.emplace_back(pfPatcherQueuedFile::Type::kManifestHash, manifest[i]);
-        patcher->fFileSignal.Signal();
+            fQueuedFiles.emplace_back(pfPatcherQueuedFile::Type::kManifestHash, manifest[i]);
+        fFileSignal.Signal();
     }
-    patcher->IssueRequest();
+    IssueRequest();
 }
 
-static void IPreloaderManifestDownloadCB(pfPatcherWorker* patcher, ENetError result, const ST::string& group, const NetCliFileManifestEntry manifest[], unsigned entryCount)
+void pfPatcherWorker::IPreloaderManifestDownloadCB(ENetError result, const ST::string& group, const NetCliFileManifestEntry manifest[], unsigned entryCount)
 {
     if (IS_NET_SUCCESS(result)) {
-        IHandleManifestDownload(patcher, group, manifest, entryCount);
+        IHandleManifestDownload(group, manifest, entryCount);
     } else {
-        patcher->EnqueuePreloaderLists();
-        patcher->IssueRequest();
+        EnqueuePreloaderLists();
+        IssueRequest();
     }
 }
 
-static void IFileManifestDownloadCB(pfPatcherWorker* patcher, ENetError result, const ST::string& group, const NetCliFileManifestEntry manifest[], unsigned entryCount)
+void pfPatcherWorker::IFileManifestDownloadCB(ENetError result, const ST::string& group, const NetCliFileManifestEntry manifest[], unsigned entryCount)
 {
     if (IS_NET_SUCCESS(result))
-        IHandleManifestDownload(patcher, group, manifest, entryCount);
+        IHandleManifestDownload(group, manifest, entryCount);
     else {
         PatcherLogRed("\tDownload Failed: Manifest '{}'", group);
-        patcher->EndPatch(result, group);
+        EndPatch(result, group);
     }
 }
 
-static void IFileThingDownloadCB(pfPatcherWorker* patcher, ENetError result, const plFileName& filename, pfPatcherStream* stream)
+void pfPatcherWorker::IFileThingDownloadCB(ENetError result, const plFileName& filename, pfPatcherStream* stream)
 {
     // We need to explicitly close any underlying streams NOW because we
     // might be about to signal the client that this file needs to be acted
@@ -391,24 +398,23 @@ static void IFileThingDownloadCB(pfPatcherWorker* patcher, ENetError result, con
 
     if (IS_NET_SUCCESS(result)) {
         PatcherLogGreen("\tDownloaded File '{}'", stream->GetFileName());
-        patcher->WhitelistFile(stream->GetFileName(), true);
-        if (patcher->fSelfPatch && stream->IsSelfPatch())
-            patcher->fSelfPatch(stream->GetFileName());
-        if (patcher->fRedistUpdateDownloaded && stream->IsRedistUpdate())
-            patcher->fRedistUpdateDownloaded(stream->GetFileName());
+        WhitelistFile(stream->GetFileName(), true);
+        if (fSelfPatch && stream->IsSelfPatch())
+            fSelfPatch(stream->GetFileName());
+        if (fRedistUpdateDownloaded && stream->IsRedistUpdate())
+            fRedistUpdateDownloaded(stream->GetFileName());
 
         // Punt the SFX decompression to the patcher thread (this is the main/draw thread)
         if (stream->RequiresSfxCache()) {
-            hsLockGuard(patcher->fFileMut);
-            patcher->fQueuedFiles.emplace_back(pfPatcherQueuedFile::Type::kSoundDecompress,
-                                               stream->GetFileName(), stream->GetFlags());
-            patcher->fFileSignal.Signal();
+            hsLockGuard(fFileMut);
+            fQueuedFiles.emplace_back(pfPatcherQueuedFile::Type::kSoundDecompress, stream->GetFileName(), stream->GetFlags());
+            fFileSignal.Signal();
         }
-        patcher->IssueRequest();
+        IssueRequest();
     } else {
         PatcherLogRed("\tDownloaded Failed: File '{}'", stream->GetFileName());
         stream->Unlink();
-        patcher->EndPatch(result, filename.AsString());
+        EndPatch(result, filename.AsString());
     }
 
     delete stream;
@@ -484,19 +490,19 @@ bool pfPatcherWorker::IssueRequest()
                 fFileBeginDownload(req.fStream->GetFileName());
 
             NetCliFileDownloadRequest(req.fName, req.fStream, 0, [this, filename = req.fName, stream = req.fStream](auto result) {
-                IFileThingDownloadCB(this, result, filename, stream);
+                IFileThingDownloadCB(result, filename, stream);
             });
             break;
         case Request::kManifest:
             NetCliFileManifestRequest(req.fName.to_utf16().data(), 0, [this, group = req.fName](auto result, auto manifest, auto entryCount) {
-                IFileManifestDownloadCB(this, result, group, manifest, entryCount);
+                IFileManifestDownloadCB(result, group, manifest, entryCount);
             });
             break;
         case Request::kSecurePreloader:
             // so, yeah, this is usually the "SecurePreloader" manifest on the file server...
             // except on legacy servers, this may not exist, so we need to fall back without nuking everything!
             NetCliFileManifestRequest(req.fName.to_utf16().data(), 0, [this, group = req.fName](auto result, auto manifest, auto entryCount) {
-                IPreloaderManifestDownloadCB(this, result, group, manifest, entryCount);
+                IPreloaderManifestDownloadCB(result, group, manifest, entryCount);
             });
             break;
         case Request::kAuthFile:
@@ -506,17 +512,17 @@ bool pfPatcherWorker::IssueRequest()
                 fFileBeginDownload(req.fStream->GetFileName());
 
             NetCliAuthFileRequest(req.fName, req.fStream, [this, filename = req.fName, writer = req.fStream](auto result) {
-                IAuthThingDownloadCB(this, result, filename, writer);
+                IAuthThingDownloadCB(result, filename, writer);
             });
             break;
         case Request::kPythonList:
             NetCliAuthFileListRequest(u"Python", u"pak", [this](auto result, auto infoArr, auto infoCount) {
-                IGotAuthFileList(this, result, infoArr, infoCount);
+                IGotAuthFileList(result, infoArr, infoCount);
             });
             break;
         case Request::kSdlList:
             NetCliAuthFileListRequest(u"SDL", u"sdl", [this](auto result, auto infoArr, auto infoCount) {
-                IGotAuthFileList(this, result, infoArr, infoCount);
+                IGotAuthFileList(result, infoArr, infoCount);
             });
             break;
         DEFAULT_FATAL(req.fType);

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -483,21 +483,21 @@ bool pfPatcherWorker::IssueRequest()
             if (fFileBeginDownload)
                 fFileBeginDownload(req.fStream->GetFileName());
 
-            NetCliFileDownloadRequest(req.fName, req.fStream, [this, filename = req.fName, stream = req.fStream](auto result) {
+            NetCliFileDownloadRequest(req.fName, req.fStream, 0, [this, filename = req.fName, stream = req.fStream](auto result) {
                 IFileThingDownloadCB(this, result, filename, stream);
             });
             break;
         case Request::kManifest:
-            NetCliFileManifestRequest([this, group = req.fName](auto result, auto manifest, auto entryCount) {
+            NetCliFileManifestRequest(req.fName.to_utf16().data(), 0, [this, group = req.fName](auto result, auto manifest, auto entryCount) {
                 IFileManifestDownloadCB(this, result, group, manifest, entryCount);
-            }, req.fName.to_utf16().data());
+            });
             break;
         case Request::kSecurePreloader:
             // so, yeah, this is usually the "SecurePreloader" manifest on the file server...
             // except on legacy servers, this may not exist, so we need to fall back without nuking everything!
-            NetCliFileManifestRequest([this, group = req.fName](auto result, auto manifest, auto entryCount) {
+            NetCliFileManifestRequest(req.fName.to_utf16().data(), 0, [this, group = req.fName](auto result, auto manifest, auto entryCount) {
                 IPreloaderManifestDownloadCB(this, result, group, manifest, entryCount);
-            }, req.fName.to_utf16().data());
+            });
             break;
         case Request::kAuthFile:
             // ffffffuuuuuu

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -2957,7 +2957,7 @@ bool FileListRequestTrans::Send () {
 
 //============================================================================
 void FileListRequestTrans::Post () {
-    m_callback(m_result, m_fileInfoArray.data(), m_fileInfoArray.size());
+    m_callback(m_result, m_fileInfoArray);
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -535,7 +535,6 @@ struct AccountActivateRequestTrans : NetAuthTrans {
 //============================================================================
 struct FileListRequestTrans : NetAuthTrans {
     FNetCliAuthFileListRequestCallback  m_callback;
-    void *                              m_param;
 
     char16_t                            m_directory[kNetDefaultStringSize];
     char16_t                            m_ext[MAX_EXT];
@@ -544,7 +543,6 @@ struct FileListRequestTrans : NetAuthTrans {
 
     FileListRequestTrans (
         FNetCliAuthFileListRequestCallback  callback,
-        void *                              param,
         const char16_t                      directory[],
         const char16_t                      ext[]
     );
@@ -562,14 +560,12 @@ struct FileListRequestTrans : NetAuthTrans {
 //============================================================================
 struct FileDownloadRequestTrans : NetAuthTrans {
     FNetCliAuthFileRequestCallback  m_callback;
-    void *                          m_param;
 
     plFileName                      m_filename;
     hsStream *                      m_writer;
 
     FileDownloadRequestTrans (
         FNetCliAuthFileRequestCallback  callback,
-        void *                          param,
         const plFileName &              filename,
         hsStream *                      writer
     );
@@ -2933,12 +2929,10 @@ bool AccountActivateRequestTrans::Recv (
 //============================================================================
 FileListRequestTrans::FileListRequestTrans (
     FNetCliAuthFileListRequestCallback  callback,
-    void *                              param,
     const char16_t                      directory[],
     const char16_t                      ext[]
 ) : NetAuthTrans(kFileListRequestTrans)
-,   m_callback(callback)
-,   m_param(param)
+,   m_callback(std::move(callback))
 {
     StrCopy(m_directory, directory, std::size(m_directory));
     StrCopy(m_ext, ext, std::size(m_ext));
@@ -2963,7 +2957,7 @@ bool FileListRequestTrans::Send () {
 
 //============================================================================
 void FileListRequestTrans::Post () {
-    m_callback(m_result, m_param, m_fileInfoArray.data(), m_fileInfoArray.size());
+    m_callback(m_result, m_fileInfoArray.data(), m_fileInfoArray.size());
 }
 
 //============================================================================
@@ -3046,12 +3040,10 @@ bool FileListRequestTrans::Recv (
 //============================================================================
 FileDownloadRequestTrans::FileDownloadRequestTrans (
     FNetCliAuthFileRequestCallback  callback,
-    void *                          param,
     const plFileName &              filename,
     hsStream *                      writer
 ) : NetAuthTrans(kFileDownloadRequestTrans)
-,   m_callback(callback)
-,   m_param(param)
+,   m_callback(std::move(callback))
 ,   m_filename(filename)
 ,   m_writer(writer)
 {
@@ -3082,7 +3074,7 @@ bool FileDownloadRequestTrans::Send () {
 
 //============================================================================
 void FileDownloadRequestTrans::Post () {
-    m_callback(m_result, m_param, m_filename, m_writer);
+    m_callback(m_result);
 }
 
 //============================================================================
@@ -5038,12 +5030,10 @@ void NetCliAuthAccountActivateRequest (
 void NetCliAuthFileListRequest (
     const char16_t                      dir[],
     const char16_t                      ext[],
-    FNetCliAuthFileListRequestCallback  callback,
-    void *                              param
+    FNetCliAuthFileListRequestCallback  callback
 ) {
     FileListRequestTrans * trans = new FileListRequestTrans(
-        callback,
-        param,
+        std::move(callback),
         dir,
         ext
     );
@@ -5054,12 +5044,10 @@ void NetCliAuthFileListRequest (
 void NetCliAuthFileRequest (
     const plFileName &              filename,
     hsStream *                      writer,
-    FNetCliAuthFileRequestCallback  callback,
-    void *                          param
+    FNetCliAuthFileRequestCallback  callback
 ) {
     FileDownloadRequestTrans * trans = new FileDownloadRequestTrans(
-        callback,
-        param,
+        std::move(callback),
         filename,
         writer
     );

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
@@ -50,6 +50,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #endif
 #define PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETGAMELIB_PRIVATE_PLNGLAUTH_H
 
+#include <functional>
+
 #include "pnEncryption/plChecksum.h"
 
 /*****************************************************************************
@@ -358,33 +360,25 @@ struct NetCliAuthFileInfo {
     char16_t    filename[kNetDefaultStringSize];
     unsigned    filesize;
 };
-typedef void (*FNetCliAuthFileListRequestCallback)(
+using FNetCliAuthFileListRequestCallback = std::function<void(
     ENetError                   result,
-    void *                      param,
     const NetCliAuthFileInfo    infoArr[],
     unsigned                    infoCount
-);
+)>;
 void NetCliAuthFileListRequest (
     const char16_t                      dir[],
     const char16_t                      ext[],
-    FNetCliAuthFileListRequestCallback  callback,
-    void *                              param
+    FNetCliAuthFileListRequestCallback  callback
 );
 
 //============================================================================
 // File Download
 //============================================================================
-typedef void (*FNetCliAuthFileRequestCallback)(
-    ENetError           result,
-    void *              param,
-    const plFileName &  filename,
-    hsStream *          writer
-);
+using FNetCliAuthFileRequestCallback = std::function<void(ENetError result)>;
 void NetCliAuthFileRequest (
     const plFileName &              filename,
     hsStream *                      writer,
-    FNetCliAuthFileRequestCallback  callback,
-    void *                          param
+    FNetCliAuthFileRequestCallback  callback
 );
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.h
@@ -51,6 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETGAMELIB_PRIVATE_PLNGLAUTH_H
 
 #include <functional>
+#include <vector>
 
 #include "pnEncryption/plChecksum.h"
 
@@ -362,8 +363,7 @@ struct NetCliAuthFileInfo {
 };
 using FNetCliAuthFileListRequestCallback = std::function<void(
     ENetError                   result,
-    const NetCliAuthFileInfo    infoArr[],
-    unsigned                    infoCount
+    const std::vector<NetCliAuthFileInfo>& infos
 )>;
 void NetCliAuthFileListRequest (
     const char16_t                      dir[],

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -1325,9 +1325,9 @@ void NetCliFileRegisterBuildIdUpdate (FNetCliFileBuildIdUpdateCallback callback)
 
 //============================================================================
 void NetCliFileManifestRequest (
-    FNetCliFileManifestRequestCallback  callback,
     const char16_t                      group[],
-    unsigned                            buildId /* = 0 */
+    unsigned                            buildId,
+    FNetCliFileManifestRequestCallback  callback
 ) {
     ManifestRequestTrans * trans = new ManifestRequestTrans(
         std::move(callback),
@@ -1341,8 +1341,8 @@ void NetCliFileManifestRequest (
 void NetCliFileDownloadRequest (
     const plFileName &                  filename,
     hsStream *                          writer,
-    FNetCliFileDownloadRequestCallback  callback,
-    unsigned                            buildId /* = 0 */
+    unsigned                            buildId,
+    FNetCliFileDownloadRequestCallback  callback
 ) {
     DownloadRequestTrans * trans = new DownloadRequestTrans(
         std::move(callback),

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -867,7 +867,7 @@ bool ManifestRequestTrans::Send () {
 
 //============================================================================
 void ManifestRequestTrans::Post () {
-    m_callback(m_result, m_manifest.data(), m_manifest.size());
+    m_callback(m_result, m_manifest);
 }
 
 // Neither char_traits nor C's string library have a "strnlen" equivalent for

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -137,14 +137,10 @@ struct CliFileConn : hsRefCnt, AsyncNotifySocketCallbacks {
 //============================================================================
 struct BuildIdRequestTrans : NetFileTrans {
     FNetCliFileBuildIdRequestCallback   m_callback;
-    void *                              m_param;
 
     unsigned                            m_buildId;
-    
-    BuildIdRequestTrans (
-        FNetCliFileBuildIdRequestCallback   callback,
-        void *                              param
-    );
+
+    BuildIdRequestTrans(FNetCliFileBuildIdRequestCallback callback);
 
     bool Send() override;
     void Post() override;
@@ -159,7 +155,6 @@ struct BuildIdRequestTrans : NetFileTrans {
 //============================================================================
 struct ManifestRequestTrans : NetFileTrans {
     FNetCliFileManifestRequestCallback  m_callback;
-    void *                              m_param;
     char16_t                            m_group[kNetDefaultStringSize];
     unsigned                            m_buildId;
 
@@ -168,7 +163,6 @@ struct ManifestRequestTrans : NetFileTrans {
 
     ManifestRequestTrans (
         FNetCliFileManifestRequestCallback  callback,
-        void *                              param,
         const char16_t                      group[],
         unsigned                            buildId
     );
@@ -186,7 +180,6 @@ struct ManifestRequestTrans : NetFileTrans {
 //============================================================================
 struct DownloadRequestTrans : NetFileTrans {
     FNetCliFileDownloadRequestCallback  m_callback;
-    void *                              m_param;
 
     plFileName                          m_filename;
     hsStream *                          m_writer;
@@ -196,7 +189,6 @@ struct DownloadRequestTrans : NetFileTrans {
 
     DownloadRequestTrans (
         FNetCliFileDownloadRequestCallback  callback,
-        void *                              param,
         const plFileName &                  filename,
         hsStream *                          writer,
         unsigned                            buildId
@@ -247,7 +239,7 @@ static std::atomic<long>            s_perf[kNumPerf];
 static unsigned                     s_connectBuildId;
 static unsigned                     s_serverType;
 
-static FNetCliFileBuildIdUpdateCallback s_buildIdCallback = nullptr;
+static FNetCliFileBuildIdUpdateCallback s_buildIdCallback;
 
 const unsigned kMinValidConnectionMs                = 25 * 1000;
 
@@ -785,10 +777,9 @@ bool CliFileConn::Recv_FileDownloadReply (
 ***/
 
 //============================================================================
-BuildIdRequestTrans::BuildIdRequestTrans(
-        FNetCliFileBuildIdRequestCallback callback, void* param)
+BuildIdRequestTrans::BuildIdRequestTrans(FNetCliFileBuildIdRequestCallback callback)
     : NetFileTrans(kBuildIdRequestTrans),
-      m_callback(callback), m_param(param), m_buildId()
+      m_callback(std::move(callback)), m_buildId()
 { }
 
 //============================================================================
@@ -808,7 +799,7 @@ bool BuildIdRequestTrans::Send () {
 
 //============================================================================
 void BuildIdRequestTrans::Post () {
-    m_callback(m_result, m_param, m_buildId);
+    m_callback(m_result, m_buildId);
 }
 
 //============================================================================
@@ -844,12 +835,10 @@ bool BuildIdRequestTrans::Recv (
 //============================================================================
 ManifestRequestTrans::ManifestRequestTrans (
     FNetCliFileManifestRequestCallback  callback,
-    void *                              param,
     const char16_t                      group[],
     unsigned                            buildId
 ) : NetFileTrans(kManifestRequestTrans)
-,   m_callback(callback)
-,   m_param(param)
+,   m_callback(std::move(callback))
 ,   m_numEntriesReceived(0)
 ,   m_buildId(buildId)
 {
@@ -878,7 +867,7 @@ bool ManifestRequestTrans::Send () {
 
 //============================================================================
 void ManifestRequestTrans::Post () {
-    m_callback(m_result, m_param, m_group, m_manifest.data(), m_manifest.size());
+    m_callback(m_result, m_manifest.data(), m_manifest.size());
 }
 
 // Neither char_traits nor C's string library have a "strnlen" equivalent for
@@ -1080,13 +1069,11 @@ bool ManifestRequestTrans::Recv (
 //============================================================================
 DownloadRequestTrans::DownloadRequestTrans (
     FNetCliFileDownloadRequestCallback  callback,
-    void *                              param,
     const plFileName &                  filename,
     hsStream *                          writer,
     unsigned                            buildId
 ) : NetFileTrans(kDownloadRequestTrans)
-,   m_callback(callback)
-,   m_param(param)
+,   m_callback(std::move(callback))
 ,   m_filename(filename)
 ,   m_writer(writer)
 ,   m_totalBytesReceived(0)
@@ -1117,7 +1104,7 @@ bool DownloadRequestTrans::Send () {
 
 //============================================================================
 void DownloadRequestTrans::Post () {
-    m_callback(m_result, m_param, m_filename, m_writer);
+    m_callback(m_result);
 }
 
 //============================================================================
@@ -1325,32 +1312,25 @@ void NetCliFileDisconnect () {
 }
 
 //============================================================================
-void NetCliFileBuildIdRequest (
-    FNetCliFileBuildIdRequestCallback   callback,
-    void *                              param
-) {
-    BuildIdRequestTrans * trans = new BuildIdRequestTrans(
-        callback,
-        param
-    );
+void NetCliFileBuildIdRequest(FNetCliFileBuildIdRequestCallback callback)
+{
+    BuildIdRequestTrans* trans = new BuildIdRequestTrans(std::move(callback));
     NetTransSend(trans);
 }
 
 //============================================================================
 void NetCliFileRegisterBuildIdUpdate (FNetCliFileBuildIdUpdateCallback callback) {
-    s_buildIdCallback = callback;
+    s_buildIdCallback = std::move(callback);
 }
 
 //============================================================================
 void NetCliFileManifestRequest (
     FNetCliFileManifestRequestCallback  callback,
-    void *                              param,
     const char16_t                      group[],
     unsigned                            buildId /* = 0 */
 ) {
     ManifestRequestTrans * trans = new ManifestRequestTrans(
-        callback,
-        param,
+        std::move(callback),
         group,
         buildId
     );
@@ -1362,12 +1342,10 @@ void NetCliFileDownloadRequest (
     const plFileName &                  filename,
     hsStream *                          writer,
     FNetCliFileDownloadRequestCallback  callback,
-    void *                              param,
     unsigned                            buildId /* = 0 */
 ) {
     DownloadRequestTrans * trans = new DownloadRequestTrans(
-        callback,
-        param,
+        std::move(callback),
         filename,
         writer,
         buildId

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
@@ -51,6 +51,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETGAMELIB_PRIVATE_PLNGLFILE_H
 
 #include <functional>
+#include <vector>
 
 /*****************************************************************************
 *
@@ -100,8 +101,7 @@ struct NetCliFileManifestEntry {
 };
 using FNetCliFileManifestRequestCallback = std::function<void(
     ENetError                       result,
-    const NetCliFileManifestEntry   manifest[],
-    unsigned                        entryCount
+    const std::vector<NetCliFileManifestEntry>& manifest
 )>;
 void NetCliFileManifestRequest (
     const char16_t                      group[], // the group of files you want (empty or nil = all)

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
@@ -104,9 +104,9 @@ using FNetCliFileManifestRequestCallback = std::function<void(
     unsigned                        entryCount
 )>;
 void NetCliFileManifestRequest (
-    FNetCliFileManifestRequestCallback  callback,
     const char16_t                      group[], // the group of files you want (empty or nil = all)
-    unsigned                            buildId = 0 // 0 = get latest, other = get particular build (servers only)
+    unsigned                            buildId, // 0 = get latest, other = get particular build (servers only)
+    FNetCliFileManifestRequestCallback  callback
 );
 
 //============================================================================
@@ -116,6 +116,6 @@ using FNetCliFileDownloadRequestCallback = std::function<void(ENetError result)>
 void NetCliFileDownloadRequest (
     const plFileName &                  filename,
     hsStream *                          writer,
-    FNetCliFileDownloadRequestCallback  callback,
-    unsigned                            buildId = 0 // 0 = get latest, other = get particular build (servers only)
+    unsigned                            buildId, // 0 = get latest, other = get particular build (servers only)
+    FNetCliFileDownloadRequestCallback  callback
 );

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.h
@@ -50,6 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #endif
 #define PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETGAMELIB_PRIVATE_PLNGLFILE_H
 
+#include <functional>
 
 /*****************************************************************************
 *
@@ -76,16 +77,13 @@ void NetCliFileDisconnect ();
 //============================================================================
 // File server related messages
 //============================================================================
-typedef void (*FNetCliFileBuildIdRequestCallback)(
+using FNetCliFileBuildIdRequestCallback = std::function<void(
     ENetError       result,
-    void *          param,
     unsigned        buildId
-);
-void NetCliFileBuildIdRequest (
-    FNetCliFileBuildIdRequestCallback   callback,
-    void *                              param
-);
-typedef void (*FNetCliFileBuildIdUpdateCallback)(unsigned buildId);
+)>;
+void NetCliFileBuildIdRequest(FNetCliFileBuildIdRequestCallback callback);
+
+using FNetCliFileBuildIdUpdateCallback = std::function<void(unsigned buildId)>;
 void NetCliFileRegisterBuildIdUpdate (FNetCliFileBuildIdUpdateCallback callback);
 
 //============================================================================
@@ -100,16 +98,13 @@ struct NetCliFileManifestEntry {
     unsigned    zipSize;
     unsigned    flags;
 };
-typedef void (*FNetCliFileManifestRequestCallback)(
+using FNetCliFileManifestRequestCallback = std::function<void(
     ENetError                       result,
-    void *                          param,
-    const char16_t                  group[],
     const NetCliFileManifestEntry   manifest[],
     unsigned                        entryCount
-);
+)>;
 void NetCliFileManifestRequest (
     FNetCliFileManifestRequestCallback  callback,
-    void *                              param,
     const char16_t                      group[], // the group of files you want (empty or nil = all)
     unsigned                            buildId = 0 // 0 = get latest, other = get particular build (servers only)
 );
@@ -117,16 +112,10 @@ void NetCliFileManifestRequest (
 //============================================================================
 // File Download
 //============================================================================
-typedef void (*FNetCliFileDownloadRequestCallback)(
-    ENetError           result,
-    void *              param,
-    const plFileName &  filename,
-    hsStream *          writer
-);
+using FNetCliFileDownloadRequestCallback = std::function<void(ENetError result)>;
 void NetCliFileDownloadRequest (
     const plFileName &                  filename,
     hsStream *                          writer,
     FNetCliFileDownloadRequestCallback  callback,
-    void *                              param,
     unsigned                            buildId = 0 // 0 = get latest, other = get particular build (servers only)
 );


### PR DESCRIPTION
Follow-up to #1539, part 2. This covers all file server callbacks and a few related auth server callbacks.

While I was here, I also cleaned up the callback signatures: removed redundant parameters and replaced C-style array parameters (pointer and count) with `std::vector`.