### PR TITLE
CI: Update Windows CI builds to use Windows 2022 / MSVC 17.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,14 @@ jobs:
           MACHINE_USER_TOKEN: ${{ secrets.MACHINE_USER_REPO_READ }}
 
   windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: ${{ matrix.platform.str }}-${{ matrix.cfg.str }}
     needs: ["max-secrets"]
     strategy:
       matrix:
         platform:
-          - { generator: Visual Studio 16 2019, max-version: 7, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2,  str: windows-x86 }
-          - { generator: Visual Studio 16 2019, max-version: 2022, arch: x64, qt-arch: win64_msvc2019_64, qt-version: 5.15.2,  str: windows-x64 }
+          - { generator: Visual Studio 17 2022, max-version: 7, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2,  str: windows-x86 }
+          - { generator: Visual Studio 17 2022, max-version: 2022, arch: x64, qt-arch: win64_msvc2019_64, qt-version: 5.15.2,  str: windows-x64 }
         cfg:
           - { external: OFF, type: RelWithPDB, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -112,20 +112,20 @@ jobs:
     needs: ["max-secrets"]
     if: github.event_name == 'push' && needs.max-secrets.outputs.HAS_MACHINE_USER_TOKEN == 'true'
 
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: maxplugin-${{ matrix.cfg.str }}-${{ matrix.cfg.sdk-version }}
     strategy:
       matrix:
         cfg:
           # Max 7 and 2022 are tested in the x86 and x64 windows build jobs, respectively.
-          - { sdk-version: 2008, generator: Visual Studio 16 2019, arch: Win32, str: windows-x86 }
-          - { sdk-version: 2012, generator: Visual Studio 16 2019, arch: Win32, str: windows-x86 }
-          - { sdk-version: 2013, generator: Visual Studio 16 2019, arch: x64, str: windows-x64 }
-          - { sdk-version: 2017, generator: Visual Studio 16 2019, arch: x64, str: windows-x64 }
-          - { sdk-version: 2019, generator: Visual Studio 16 2019, arch: x64, str: windows-x64 }
-          - { sdk-version: 2020, generator: Visual Studio 16 2019, arch: x64, str: windows-x64 }
-          - { sdk-version: 2023, generator: Visual Studio 16 2019, arch: x64, str: windows-x64 }
-          - { sdk-version: 2024, generator: Visual Studio 16 2019, arch: x64, str: windows-x64 }
+          - { sdk-version: 2008, generator: Visual Studio 17 2022, arch: Win32, str: windows-x86 }
+          - { sdk-version: 2012, generator: Visual Studio 17 2022, arch: Win32, str: windows-x86 }
+          - { sdk-version: 2013, generator: Visual Studio 17 2022, arch: x64, str: windows-x64 }
+          - { sdk-version: 2017, generator: Visual Studio 17 2022, arch: x64, str: windows-x64 }
+          - { sdk-version: 2019, generator: Visual Studio 17 2022, arch: x64, str: windows-x64 }
+          - { sdk-version: 2020, generator: Visual Studio 17 2022, arch: x64, str: windows-x64 }
+          - { sdk-version: 2023, generator: Visual Studio 17 2022, arch: x64, str: windows-x64 }
+          - { sdk-version: 2024, generator: Visual Studio 17 2022, arch: x64, str: windows-x64 }
 
     steps:
       - name: Checkout Plasma


### PR DESCRIPTION
Windows 2019 runners will be unsupported next month.  Fortunately, MSVC 17 is ABI-compatible with MSVC 16.