### PR TITLE
Fixing vcpkg libffi builds on macOS

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -66,7 +66,7 @@
         ]
       }
     },
-    "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf",
+    "builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",
     "vcpkg-configuration": {
       "overlay-ports": ["./Scripts/Ports"],
       "overlay-triplets": ["./Scripts/Triplets"]


### PR DESCRIPTION
This fixes our vcpkg builds on macOS. There is a compile problem with libffi described here:
https://github.com/libffi/libffi/pull/857

I noticed this problem with Xcode 26 (which is in beta) on a fresh Mac install. The PR states it's been a compile issue since Xcode 15.2 (where Xcode 15 is the current release series for Xcode.) It's possible that everyone including the build system has been working off a cached libffi so it went unnoticed until I tried a fresh machine.

libffi is a dependency of Python - we don't directly declare it.

This updates vcpkg to the 2025.04.09 tag:
- **expat**
2.6.4 -> 2.7.1
- **openal-soft**
1.24.2 -> 1.24.3
- **openssl**
3.4.1 -> 3.5.0