### PR TITLE
Adding scroll wheel support to macOS

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
@@ -128,6 +128,30 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     [self updateClientMouseLocation:event];
 }
 
+// MARK: Mouse scroll
+- (void)scrollWheel:(NSEvent *)event
+{
+    plMouseEventMsg* pMsg = new plMouseEventMsg;
+    float zDelta = [event scrollingDeltaY];
+    pMsg->SetWheelDelta(zDelta);
+    if (zDelta < 0)
+        pMsg->SetButton(kWheelNeg);
+    else
+        pMsg->SetButton(kWheelPos);
+
+    CGPoint windowLocation = [event locationInWindow];
+    CGPoint viewLocation = [self convertPoint:windowLocation fromView:nil];
+
+    NSRect windowViewBounds = self.bounds;
+    CGFloat xNormal = (windowLocation.x) / windowViewBounds.size.width;
+    CGFloat yNormal =
+        (windowViewBounds.size.height - windowLocation.y) / windowViewBounds.size.height;
+    pMsg->SetXPos(xNormal);
+    pMsg->SetYPos(yNormal);
+
+    pMsg->Send();
+}
+
 // MARK: Mouse movement
 - (void)mouseMoved:(NSEvent*)event
 {


### PR DESCRIPTION
This addresses #1655.

I'm hoping macOS provides the same scroll values at Windows. I did a quick comparison and it seemed to be the same scroll velocities on both platforms.

There is some code duplication here but it seems like all the different events are using types. I borrowed this code from the Win32 client and just replaced the relevant calls with the Cocoa ones.