### PR TITLE
Fix #1708.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
@@ -123,6 +123,20 @@ bool plPXPhysical::IsTrigger() const
 
 // ==========================================================================
 
+void plPXPhysical::SetGroup(int group)
+{
+    fGroup = (plSimDefs::Group)group;
+    IUpdateShapeFlags();
+    ISyncFilterData();
+    if (fActor) {
+        // Invalidate character collision cache for exclude regions changing groups.
+        plPXPhysicalControllerCore::InvalidateCache(fWorldKey);
+        InitProxy();
+    }
+}
+
+// ==========================================================================
+
 void plPXPhysical::IUpdateShapeFlags()
 {
     physx::PxShape* shape;

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.h
@@ -213,14 +213,7 @@ public:
     void GetTransform(hsMatrix44& l2w, hsMatrix44& w2l) override;
 
     int GetGroup() const override { return fGroup; }
-    void SetGroup(int group) override
-    {
-        fGroup = (plSimDefs::Group)group;
-        IUpdateShapeFlags();
-        ISyncFilterData();
-        if (fActor)
-            InitProxy();
-    }
+    void SetGroup(int group) override;
 
     void AddLOSDB(uint16_t flag) override
     {

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.cpp
@@ -68,6 +68,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // ==========================================================================
 
 static std::vector<plPXPhysicalControllerCore*> gControllers;
+static std::set<plKey> gInvalidCacheWorlds;
 
 #ifndef PLASMA_EXTERNAL_RELEASE
 bool plPXPhysicalControllerCore::fDebugDisplay = false;
@@ -669,6 +670,8 @@ plDrawableSpans* plPXPhysicalControllerCore::CreateProxy(hsGMaterial* mat, std::
     return myDraw;
 }
 
+// ==========================================================================
+
 void plPXPhysicalControllerCore::Apply(float delSecs)
 {
     plPXPhysicalControllerCore* controller;
@@ -681,8 +684,14 @@ void plPXPhysicalControllerCore::Apply(float delSecs)
         controller->fDbgCollisionInfo.clear();
 #endif
 
+        auto findIt = gInvalidCacheWorlds.find(controller->fWorldKey);
+        if (findIt != gInvalidCacheWorlds.end())
+            controller->fController->invalidateCache();
+
         controller->IApply(delSecs);
     }
+
+    gInvalidCacheWorlds.clear();
 }
 
 void plPXPhysicalControllerCore::Update(int numSubSteps, float alpha)
@@ -720,6 +729,13 @@ void plPXPhysicalControllerCore::UpdateNonPhysical(float alpha)
 #endif
     }
 }
+
+void plPXPhysicalControllerCore::InvalidateCache(plKey world)
+{
+    gInvalidCacheWorlds.emplace(std::move(world));
+}
+
+// ==========================================================================
 
 void plPXPhysicalControllerCore::ISynchProxy()
 {

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.h
@@ -202,6 +202,9 @@ public:
     // Update controllers when not performing a physics step
     static void UpdateNonPhysical(float alpha);
 
+    /** Invalidates the collision cache for the specified subworld. */
+    static void InvalidateCache(plKey world = {});
+
 #ifndef PLASMA_EXTERNAL_RELEASE
     static bool fDebugDisplay;
 #endif


### PR DESCRIPTION
Exclude regions were in practice not clearing because the PhysX CCT was holding onto the collision so as long as the "details" of the collision are largely the same. According to empirical evidence, once the preFilter stage is passed, PhysX never questions an actor again unless there's a position change or something of that nature. So, changing from an exclude region group to a detector volume isn't enough. We actually have to invalidate the character controller's cache to force re-evaluation of the collision. This allows us to move through a released exclude region immediately.

I suppose we could destroy and recreate the actor, but that feels like a more expensive option than just telling the character controllers to reevaluate their lives. Ideally, we would only do this for characters in contact with an exclude region, but that starts to get complicated. It's probably better to go with this simple fix.