### PR TITLE
Fix #1705.

### DIFF
--- a/Scripts/Python/nxusBookMachine.py
+++ b/Scripts/Python/nxusBookMachine.py
@@ -750,6 +750,7 @@ class nxusBookMachine(ptModifier):
         respKISlotReturn.run(self.key)
         self.controlsEnabled = True
         self.animCount = 0
+        self.dialogVisible = False
 
         if self.presentedBookAls is not None:
             self.IBookRetract()


### PR DESCRIPTION
The Nexus dialog never marks that it is closed. This causes the open-dialog init to only run once. The dialog is fairly resilient and is able to cope with that not happening, with the exception of the Neighborhood button not being cleared out properly on exit. This fixes the state tracking so that the button is reinitialized correctly.