### PR TITLE
Fix `BIPDRIVEN_CONTROL_CLASS_ID` macro redef warning with 3ds Max 2022 SDK

### DIFF
--- a/Sources/MaxPlugin/MaxMain/MaxCompat.h
+++ b/Sources/MaxPlugin/MaxMain/MaxCompat.h
@@ -291,10 +291,14 @@ public:
 
 // Old versions of Max define this as an integer, not a Class_ID
 #define XREFOBJ_COMPAT_CLASS_ID Class_ID(0x92aab38c, 0)
+
 // This definition is removed in later versions of the sdk
+#if MAX_VERSION_MAJOR < 24
+#   define BIPDRIVEN_CONTROL_CLASS_ID BIPSLAVE_CONTROL_CLASS_ID
+#endif
+
 // In newer versions of the sdk Progress returns an enum value of KeyReduceResult
 #if MAX_VERSION_MAJOR <= 25
-#   define BIPDRIVEN_CONTROL_CLASS_ID BIPSLAVE_CONTROL_CLASS_ID
     using KeyReduceResult = int;
 #endif
 

--- a/Sources/MaxPlugin/MaxMain/MaxCompat.h
+++ b/Sources/MaxPlugin/MaxMain/MaxCompat.h
@@ -292,7 +292,8 @@ public:
 // Old versions of Max define this as an integer, not a Class_ID
 #define XREFOBJ_COMPAT_CLASS_ID Class_ID(0x92aab38c, 0)
 
-// This definition is removed in later versions of the sdk
+// The new name BIPDRIVEN_CONTROL_CLASS_ID was added in Max 2022.
+// The old name was removed later (Max 2023?).
 #if MAX_VERSION_MAJOR < 24
 #   define BIPDRIVEN_CONTROL_CLASS_ID BIPSLAVE_CONTROL_CLASS_ID
 #endif


### PR DESCRIPTION
Building the Max plugins locally using the 2022 SDK gives me this warning many times:

```
C:\Program Files\Autodesk\3ds Max 2022 SDK\maxsdk\include\CS/bipexp.h(42): warning C4005: 'BIPDRIVEN_CONTROL_CLASS_ID': macro redefinition
...\Plasma\Sources\MaxPlugin\MaxMain/MaxCompat.h(297): note: see previous definition of 'BIPDRIVEN_CONTROL_CLASS_ID'
```

This PR fixes that by only defining the macro for versions that don't already define it themselves. According to the comments in the BIPEXP.H header, the old name was deprecated in Max 2022 (`MAX_VERSION_MAJOR` 24), so I assume all Max versions older than that don't have the new name yet.

I think this was caused by #1532, but apparently I didn't notice for a long while.