### PR TITLE
Fix #1208

### DIFF
--- a/Scripts/Python/grsnNexusBookMachine.py
+++ b/Scripts/Python/grsnNexusBookMachine.py
@@ -88,7 +88,6 @@ class grsnNexusBookMachine(ptResponder):
         PtDebugPrint("book machine init")
         self.id = 53624
         self.version = 2
-        self.serverInitDone = False
 
     def IAmMaster(self):
         return (self.sceneobject.isLocallyOwned())
@@ -105,7 +104,6 @@ class grsnNexusBookMachine(ptResponder):
         return plyrList
 
     def OnServerInitComplete(self):
-        self.serverInitDone = True
         bookPillarSpinning.run(self.key,netPropagate=False)
         if not PtIsSolo():
             return
@@ -152,8 +150,6 @@ class grsnNexusBookMachine(ptResponder):
         global elevatorStatus
 
         #PtDebugPrint("id ",id)
-        if not self.serverInitDone:
-            return
 
         avatar=PtFindAvatar(events)
         local = PtGetLocalAvatar()

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -818,14 +818,18 @@ void plArmatureMod::SpawnAt(int spawnNum, double time)
         l2w = spawnObj->GetLocalToWorld();
         w2l = spawnObj->GetWorldToLocal();
     }
-    
-    if (fController)
-        fController->ResetAchievedLinearVelocity();
+
     plCoordinateInterface* ci = (plCoordinateInterface*)GetTarget(0)->GetCoordinateInterface();
     l2w.RemoveScale();
     w2l.RemoveScale();
     ci->SetTransform(l2w, w2l);
     ci->FlushTransform();
+
+    // Force the issue with the character controller
+    if (fController) {
+        fController->ResetAchievedLinearVelocity();
+        fController->SetGlobalLoc(l2w, false);
+    }
 
     if (IsLocalAvatar() && plVirtualCam1::Instance())
         plVirtualCam1::Instance()->SetCutNext();

--- a/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plPhysicalControllerCore.h
@@ -140,7 +140,7 @@ public:
 
     // Global location
     virtual const hsMatrix44& GetLastGlobalLoc() { return fLastGlobalLoc; }
-    virtual void SetGlobalLoc(const hsMatrix44& l2w) = 0;
+    virtual void SetGlobalLoc(const hsMatrix44& l2w, bool kinematic = true) = 0;
 
     // Local sim position
     virtual void GetPositionSim(hsPoint3& pos) = 0;

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.h
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysicalControllerCore.h
@@ -90,7 +90,7 @@ public:
     void SetMovementStrategy(plMovementStrategy* strategy) override;
 
     // Global location
-    void SetGlobalLoc(const hsMatrix44& l2w) override;
+    void SetGlobalLoc(const hsMatrix44& l2w, bool kinematic = true) override;
 
     // Local Sim Position
     void GetPositionSim(hsPoint3& pos) override;


### PR DESCRIPTION
Properly fixes #1208 by preventing the CCT's underlying kinematic actor from moving from the link out point to the link in point in space during the link. This reverts #1469 because the hack is no longer needed.