### PR TITLE
Display a proper error for too long avatar names

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -54,6 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsLockGuard.h"
 #include <mutex>
 #include <string>
+#include <string_theory/format>
 #include <utility>
 
 #ifdef HS_DEBUGGING
@@ -320,7 +321,7 @@ static void BufferedSendData (
                 // Use less-than instead of less-or-equal because
                 // we reserve one space for the NULL terminator
                 const uint16_t length = (uint16_t) std::char_traits<char16_t>::length((const char16_t *) *msg);
-                ASSERT_MSG_VALID(length < cmd->count);
+                hsAssert(length < cmd->count, ST::format("String of {} characters was passed into a message field that only allows {} characters", length, cmd->count - 1).c_str());
 
                 // Write actual string length
                 uint16_t size = hsToLE16(length);

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -273,7 +273,6 @@ static void BufferedSendData (
     const uint16_t msgId = hsToLE16((uint16_t)msg[0]);
     AddToSendBuffer(cli, sizeof(uint16_t), (const void*)&msgId);
     ++msg;
-    ASSERT(msg < msgEnd);
 
     // insert fields into command stream
     uint32_t varCount  = 0;
@@ -281,6 +280,7 @@ static void BufferedSendData (
     const NetMsgField * cmd     = sendMsg->msg->fields;
     const NetMsgField * cmdEnd  = cmd + sendMsg->msg->count;
     for (; cmd < cmdEnd; ++msg, ++cmd) {
+        ASSERT(msg < msgEnd);
         switch (cmd->type) {
             case kNetMsgFieldInteger: {
                 const unsigned count = cmd->count ? cmd->count : 1;

--- a/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCli/pnNcCli.cpp
@@ -256,9 +256,6 @@ static void BufferedSendData (
     const uintptr_t  msg[], 
     unsigned            fieldCount
 ) {
-    #define ASSERT_MSG_VALID(expr)          \
-        ASSERTMSG(expr, "Invalid message definition");
-
     ASSERT(cli);
     ASSERT(msg);
     ASSERT(fieldCount);
@@ -276,7 +273,7 @@ static void BufferedSendData (
     const uint16_t msgId = hsToLE16((uint16_t)msg[0]);
     AddToSendBuffer(cli, sizeof(uint16_t), (const void*)&msgId);
     ++msg;
-    ASSERT_MSG_VALID(msg < msgEnd);
+    ASSERT(msg < msgEnd);
 
     // insert fields into command stream
     uint32_t varCount  = 0;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -1287,8 +1287,11 @@ static ENetError FixupPlayerName (ST::string& name) {
 
     // Now, check to see if we have the appropriate length
     // We could count the characters, but lazy...
-    if (name.replace(" ", "").size() < 3)
+    if (name.replace(" ", "").size() < 3) {
         return kNetErrPlayerNameInvalid;
+    } else if (name.to_wchar().size() >= kMaxPlayerNameLength) {
+        return kNetErrPlayerNameInvalid;
+    }
     return kNetSuccess;
 }
 


### PR DESCRIPTION
Previously, this caused an assertion failure in the low-level network message code.

Also improved a few related asserts.