### PR TITLE
Fix #1714.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -139,10 +139,9 @@ void    pfGUIEditBoxMod::IUpdate()
         else if( 4 + cursorPos < 4 )
         {
             fScrollPos -= 4 - ( 4 + cursorPos );
-            if( fScrollPos < 0 )
-                fScrollPos = 0;
         }
 
+        fScrollPos = std::max(0, fScrollPos);
         cursorPos = (int16_t)(oldCursorPos - fScrollPos);
     }
 


### PR DESCRIPTION
I'm not really sure what's happened - the code is basically identical between the source drop and here, but, for some reason, we are getting a negative scrolling position, which throws everything off. It looks like Cyan anticipated that in one code path, but not the other. Debounce it everywhere.