### PR TITLE
Fix missing AI user strings.

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -1283,6 +1283,9 @@ bool plArmatureMod::MsgReceive(plMessage* msg)
             }
         }
 
+        // copy the user string over
+        fUserStr = avLoadMsg->GetUserStr();
+
         // We also want to use the trigger msg when loading an avatar
         MsgReceive(avLoadMsg->GetTriggerMsg());
 


### PR DESCRIPTION
This was accidentally removed in 7e66aee38276d7043be590b2bcb16ec0de5f689b and prevents the VarSync compatible quab game implementation I'm writing from working correctly. I'm kind of surprised that our ahnyQuabs.py that's currently in repo works correctly, considering how long this has been broken.