### PR TITLE
Ahnoying GameMgr Redux

### DIFF
--- a/Scripts/Python/ahnyQuabs.py
+++ b/Scripts/Python/ahnyQuabs.py
@@ -51,7 +51,6 @@ from dataclasses import dataclass, field
 import enum
 import itertools
 import random
-import re
 from typing import *
 import weakref
 
@@ -71,10 +70,6 @@ kQuabAvatarName = "Quab"
 # Silly behavior name constants
 kQuabIdleBehNames = ("Idle02", "Idle03",)
 kQuabRunBehNames  = ("Run02", "Run03",)
-
-# Regexes for variable notifications
-goalRegex = re.compile(r"^QuabGP(?P<axis>[XYZ])(?P<quabNum>\d+)$")
-runRegex = re.compile(r"^QuabRun(?P<quabNum>\d+)$")
 
 @dataclass
 class _QuabVar:

--- a/Scripts/Python/ahnyQuabs.py
+++ b/Scripts/Python/ahnyQuabs.py
@@ -47,7 +47,7 @@ from PlasmaGame import *
 from PlasmaTypes import *
 
 import abc
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import enum
 import itertools
 import random
@@ -80,31 +80,23 @@ runRegex = re.compile(r"^QuabRun(?P<quabNum>\d+)$")
 class _QuabVar:
     name: str
     varID: Optional[int] = None
-    value: float = 0.0
-    dirty: bool = False
-    lastUpdate: float = 0.0
-
-    def __hash__(self):
-        return hash((self.name, self.varID))
-
-    def __eq__(self, other):
-        if not isinstance(other, _QuabVar):
-            return False
-        return (self.name, self.varID) == (other.name, other.varID)
+    value: float = field(default=0.0, compare=False)
+    dirty: bool = field(default=False, compare=False)
+    lastUpdate: float = field(default=0.0, compare=False)
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class _QuabState:
     name: str
-    runningVar: _QuabVar
-    goalVarX: _QuabVar
-    goalVarY: _QuabVar
-    goalVarZ: _QuabVar
-    brain: Optional[ptCritterBrain]
-    lastXform: ptMatrix44
-    lastW2L: ptMatrix44
-    respawn: bool
-    pending: bool
+    runningVar: _QuabVar = field(compare=False)
+    goalVarX: _QuabVar = field(compare=False)
+    goalVarY: _QuabVar = field(compare=False)
+    goalVarZ: _QuabVar = field(compare=False)
+    brain: Optional[ptCritterBrain] = field(compare=False)
+    lastXform: ptMatrix44 = field(compare=False)
+    lastW2L: ptMatrix44 = field(compare=False)
+    respawn: bool = field(compare=False)
+    pending: bool = field(compare=False)
 
     def __init__(self, num: int):
         # Argh, Cyan's code offsets the quab name and variable indices!
@@ -121,14 +113,6 @@ class _QuabState:
         self.lastXform = ptMatrix44()
         self.respawn = False
         self.pending = False
-
-    def __hash__(self):
-        return hash(self.name)
-
-    def __eq__(self, other: _QuabState):
-        if not isinstance(other, _QuabState):
-            return False
-        return self.name == other.name
 
     @property
     def avatarListSorted(self) -> List[ptSceneobject]:

--- a/Scripts/Python/ahnyQuabs.py
+++ b/Scripts/Python/ahnyQuabs.py
@@ -225,7 +225,7 @@ class _QuabGameBrain(abc.ABC):
         # Make sure that the adjustment is actually enough to trigger some movement.
         if not quab.isRunning:
             distSq = goal.distanceSq(quab.goal)
-            if distSq < pow(quab.brain.getStopDistance(), 2):
+            if distSq < quab.brain.getStopDistance()**2:
                 return
 
         # Set and dirty any dimensions that have a non-trivial delta.

--- a/Scripts/Python/ahnyQuabs.py
+++ b/Scripts/Python/ahnyQuabs.py
@@ -170,7 +170,7 @@ class _QuabState:
     def isRunningDirty(self) -> bool:
         return self.runningVar.dirty
 
-    def itervars(self) -> Generator[_QuabVar]:
+    def itervars(self) -> Iterable[_QuabVar]:
         yield self.runningVar
         yield self.goalVarX
         yield self.goalVarY
@@ -178,7 +178,7 @@ class _QuabState:
 
     @property
     def lastGoalUpdate(self) -> float:
-        return max((i.lastUpdate for i in (self.goalVarX, self.goalVarY, self.goalVarZ)))
+        return max(i.lastUpdate for i in (self.goalVarX, self.goalVarY, self.goalVarZ))
 
     def runAway(self, run: bool = True, goal: Optional[ptPoint3] = None):
         beh = self.brain.runBehaviorName() if run else self.brain.idleBehaviorName()
@@ -248,7 +248,7 @@ class _QuabGameBrain(abc.ABC):
     def currentTime(self) -> int:
         ...
 
-    def iterAllVars(self) -> Generator[Tuple[_QuabState, _QuabVar]]:
+    def iterAllVars(self) -> Iterable[Tuple[_QuabState, _QuabVar]]:
         for quab in self.quabState:
             for var in quab.itervars():
                 yield quab, var
@@ -268,7 +268,7 @@ class _QuabGameBrain(abc.ABC):
         ...
 
     @property
-    def quabs(self) -> Generator[_QuabState]:
+    def quabs(self) -> Iterable[_QuabState]:
         for i in self.quabState:
             if i.brain is not None:
                 yield i
@@ -323,7 +323,7 @@ class _QuabVarSyncBrain(_QuabGameBrain):
             PtDebugPrint("_QuabVarSyncBrain.ICheckGameReady(): The initial var sync is NOT complete, we are clearly not ready", level=kDebugDumpLevel)
             return
 
-        if not self.ready and all((i.varsReady for i in self.quabState)):
+        if not self.ready and all(i.varsReady for i in self.quabState):
             PtDebugPrint("_QuabVarSyncBrain.ICheckGameReady(): All variables created!", level=kWarningLevel)
             self.gameState |= GameState.kAllVarsCreated
 

--- a/Scripts/Python/ahnyQuabs.py
+++ b/Scripts/Python/ahnyQuabs.py
@@ -192,7 +192,7 @@ class _QuabState:
         return all(i.varID is not None for i in self.itervars())
 
 
-class GameState(enum.IntFlag):
+class GameState(enum.Flag):
     kNotReady = 0
     kInitialSyncComplete = enum.auto()
     kVarCreateRequested = enum.auto()
@@ -283,7 +283,7 @@ class _QuabGameBrain(abc.ABC):
 
     @property
     def ready(self) -> bool:
-        return self.gameState & GameState.kReady == GameState.kReady
+        return GameState.kReady in self.gameState
 
     @abc.abstractmethod
     def ISendVars(self, *vars: _QuabVar):
@@ -319,7 +319,7 @@ class _QuabVarSyncBrain(_QuabGameBrain):
         PtDebugPrint(f"_QuabVarSyncBrain.OnNotify(): Unhandled {events=}")
 
     def ICheckGameReady(self) -> None:
-        if not self.gameState & GameState.kInitialSyncComplete:
+        if GameState.kInitialSyncComplete not in self.gameState:
             PtDebugPrint("_QuabVarSyncBrain.ICheckGameReady(): The initial var sync is NOT complete, we are clearly not ready", level=kDebugDumpLevel)
             return
 
@@ -332,7 +332,7 @@ class _QuabVarSyncBrain(_QuabGameBrain):
             return
 
         # The initial state is available, but not all variables are known. Therefore, we must create them.
-        if self.gameState & GameState.kVarCreateRequested:
+        if GameState.kVarCreateRequested in self.gameState:
             return
 
         for _, var in self.iterAllVars():

--- a/Scripts/Python/ahnyQuabs.py
+++ b/Scripts/Python/ahnyQuabs.py
@@ -40,10 +40,20 @@
 #
 # *==LICENSE==*/
 
+from __future__ import annotations
+
 from Plasma import *
+from PlasmaGame import *
 from PlasmaTypes import *
-import math
+
+import abc
+from dataclasses import dataclass
+import enum
+import itertools
 import random
+import re
+from typing import *
+import weakref
 
 # define the attributes that will be entered in max
 deadZone                    = ptAttribActivator(1, "detector for dead zone")
@@ -53,8 +63,7 @@ SDLQuabs                    = ptAttribString(3, "SDL: quabs")
 # How long does it take for more quabs to be born? Eight hours, evidently...
 kQuabGestationTime = 8 * 60 * 60
 
-# Stupid konstants the stupid Cyan tech artists didn't add in max...
-# Did I mention how STUPID this is?
+# Stupid konstants Cyan's tech artists didn't add in max...
 kLastQuabUpdate = "ahnyQuabsLastUpdate"
 kMaxNumQuabs = 20
 kQuabAvatarName = "Quab"
@@ -63,152 +72,737 @@ kQuabAvatarName = "Quab"
 kQuabIdleBehNames = ("Idle02", "Idle03",)
 kQuabRunBehNames  = ("Run02", "Run03",)
 
-class ahnyQuabs(ptModifier, object):
+# Regexes for variable notifications
+goalRegex = re.compile(r"^QuabGP(?P<axis>[XYZ])(?P<quabNum>\d+)$")
+runRegex = re.compile(r"^QuabRun(?P<quabNum>\d+)$")
+
+@dataclass
+class _QuabVar:
+    name: str
+    varID: Optional[int] = None
+    value: float = 0.0
+    dirty: bool = False
+    lastUpdate: float = 0.0
+
+    def __hash__(self):
+        return hash((self.name, self.varID))
+
+    def __eq__(self, other):
+        if not isinstance(other, _QuabVar):
+            return False
+        return (self.name, self.varID) == (other.name, other.varID)
+
+
+@dataclass
+class _QuabState:
+    name: str
+    runningVar: _QuabVar
+    goalVarX: _QuabVar
+    goalVarY: _QuabVar
+    goalVarZ: _QuabVar
+    brain: Optional[ptCritterBrain]
+    lastXform: ptMatrix44
+    lastW2L: ptMatrix44
+    respawn: bool
+    pending: bool
+
+    def __init__(self, num: int):
+        # Argh, Cyan's code offsets the quab name and variable indices!
+        self.name = f"Quab {num}"
+        self.runningVar = _QuabVar(f"QuabRun{num + 1}")
+        # These variables are offset by the maximum number of quabs because the legacy
+        # ahnyQuabs script lops off the first 7 characters of the variable name and uses
+        # the remainder as a Python long (sigh) to index into a dict. Offsetting these
+        # variables will prevent them from blowing away the legacy stuff.
+        self.goalVarX = _QuabVar(f"QuabGPX{kMaxNumQuabs + num + 1}")
+        self.goalVarY = _QuabVar(f"QuabGPY{kMaxNumQuabs + num + 1}")
+        self.goalVarZ = _QuabVar(f"QuabGPZ{kMaxNumQuabs + num + 1}")
+        self.brain = None
+        self.lastXform = ptMatrix44()
+        self.respawn = False
+        self.pending = False
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __eq__(self, other: _QuabState):
+        if not isinstance(other, _QuabState):
+            return False
+        return self.name == other.name
+
+    @property
+    def avatarListSorted(self) -> List[ptSceneobject]:
+        players = PtGetPlayerList()
+        players.append(PtGetLocalPlayer())
+        avatars = [PtGetAvatarKeyFromClientID(i.getPlayerID()).getSceneObject() for i in players]
+        if self.brain is not None:
+            myPos = self.brain.getSceneObject().position()
+        else:
+            myPos = self.lastXform.getTranslate()
+            # Grrr... myPos is a ptVector3
+            myPos = ptPoint3(
+                myPos.getX(),
+                myPos.getY(),
+                myPos.getZ()
+            )
+        return sorted(
+            avatars,
+            key=lambda x: x.position().distanceSq(myPos)
+        )
+
+    @property
+    def goal(self) -> ptPoint3:
+        return ptPoint3(
+            self.goalVarX.value,
+            self.goalVarY.value,
+            self.goalVarZ.value
+        )
+
+    @property
+    def isDirty(self) -> bool:
+        return any(i.dirty for i in self.itervars())
+
+    @property
+    def isGoalDirty(self) -> bool:
+        return any(i.dirty for i in (self.goalVarX, self.goalVarY, self.goalVarZ))
+
+    @property
+    def isIdleBehActive(self) -> bool:
+        if brain := self.brain:
+            return brain.runningBehavior(brain.idleBehaviorName())
+        return False
+
+    @property
+    def isRunningBehActive(self) -> bool:
+        if brain := self.brain:
+            return brain.runningBehavior(brain.runBehaviorName())
+        return False
+
+    @property
+    def isRunning(self) -> bool:
+        return self.runningVar.value
+
+    @property
+    def isRunningDirty(self) -> bool:
+        return self.runningVar.dirty
+
+    def itervars(self) -> Generator[_QuabVar]:
+        yield self.runningVar
+        yield self.goalVarX
+        yield self.goalVarY
+        yield self.goalVarZ
+
+    @property
+    def lastGoalUpdate(self) -> float:
+        return max((i.lastUpdate for i in (self.goalVarX, self.goalVarY, self.goalVarZ)))
+
+    def runAway(self, run: bool = True, goal: Optional[ptPoint3] = None):
+        beh = self.brain.runBehaviorName() if run else self.brain.idleBehaviorName()
+        if not self.brain.runningBehavior(beh):
+            self.brain.startBehavior(beh)
+            if run and goal:
+                self.brain.goToGoal(goal, True)
+
+    @property
+    def varsReady(self) -> bool:
+        return all(i.varID is not None for i in self.itervars())
+
+
+class GameState(enum.IntFlag):
+    kNotReady = 0
+    kInitialSyncComplete = enum.auto()
+    kVarCreateRequested = enum.auto()
+    kAllVarsCreated = enum.auto()
+    kReady = (kInitialSyncComplete | kAllVarsCreated)
+
+
+class _QuabGameBrain(abc.ABC):
+    def __init__(self, parent: ahnyQuabs):
+        self.quabState = [_QuabState(i) for i in range(kMaxNumQuabs)]
+        self.gameState = GameState.kNotReady
+        self._parent = weakref.ref(parent)
+
+    @property
+    @abc.abstractmethod
+    def amOwner(self) -> bool:
+        ...
+
+    def changeQuabState(self, quab: _QuabState, running: bool, *, sync: bool = False):
+        if quab.runningVar.value == running:
+            return
+
+        quab.runningVar.value = running
+        quab.runningVar.dirty = True
+
+        if sync:
+            self.ISendVars(quab.runningVar)
+
+    def changeQuabGoal(self, quab: _QuabState, goal: ptPoint3, *, sync: bool = False):
+        # Make sure that the adjustment is actually enough to trigger some movement.
+        if not quab.isRunning:
+            distSq = goal.distanceSq(quab.goal)
+            if distSq < pow(quab.brain.getStopDistance(), 2):
+                return
+
+        # Set and dirty any dimensions that have a non-trivial delta.
+        goalVars = (quab.goalVarX, quab.goalVarY, quab.goalVarZ)
+        goalDims = (goal.getX(), goal.getY(), goal.getZ())
+        for var, value in zip(goalVars, goalDims):
+            if abs(var.value - value) > 0.01:
+                var.value = value
+                var.dirty = True
+
+        if not any(i.dirty for i in goalVars):
+            return
+
+        self.changeQuabState(quab, True)
+        if sync:
+            self.sync(quab.itervars())
+
+    @property
+    @abc.abstractmethod
+    def currentTime(self) -> int:
+        ...
+
+    def iterAllVars(self) -> Generator[Tuple[_QuabState, _QuabVar]]:
+        for quab in self.quabState:
+            for var in quab.itervars():
+                yield quab, var
+
+    def findQuab(self, name: str) -> Optional[_QuabState]:
+        return next((i for i in self.quabState if name == i.name), None)
+
+    def findQuabVar(self, varIdent: Union[int, str]) -> Tuple[_QuabState, _QuabVar]:
+        for quab in self.quabState:
+            for var in quab.itervars():
+                if (isinstance(varIdent, str) and var.name == varIdent) or (isinstance(varIdent, int) and var.varID == varIdent):
+                    return quab, var
+        raise LookupError
+
+    @abc.abstractmethod
+    def OnNotify(self, events):
+        ...
+
+    @property
+    def quabs(self) -> Generator[_QuabState]:
+        for i in self.quabState:
+            if i.brain is not None:
+                yield i
+
+    @property
+    def numQuabs(self) -> int:
+        return len([i for i in self.quabState if i.brain is not None or i.pending])
+
+    @property
+    def parent(self) -> ahnyQuabs:
+        return self._parent()
+
+    @property
+    def ready(self) -> bool:
+        return self.gameState & GameState.kReady == GameState.kReady
+
+    @abc.abstractmethod
+    def ISendVars(self, *vars: _QuabVar):
+        ...
+
+    def sync(self, quabs: Optional[Iterable[_QuabState]] = None, *, force: bool = False):
+        if quabs is None:
+            quabs = self.quabState
+        dirtyvars = [var for quab in quabs for var in quab.itervars() if var.dirty or force]
+        self.ISendVars(*dirtyvars)
+
+
+class _QuabVarSyncBrain(_QuabGameBrain):
+    @property
+    def amOwner(self) -> bool:
+        if self.gameCli is not None:
+            return self.gameCli.isLocallyOwned
+        return False
+
+    @property
+    def currentTime(self) -> int:
+        # This is vulnerable to DST shennanigans, but we have to use this time
+        # to retain compatibility with legacy clients.
+        return PtGetDniTime()
+
+    def OnOwnerChanged(self, newOwnerID: int):
+        amOwner = self.gameCli.isLocallyOwned
+        PtDebugPrint(f"_QuabVarSyncBrain.OnOwnerChanged(): Ownership of VarSync has changed {amOwner=} {newOwnerID=}", level=kWarningLevel)
+        if amOwner:
+            self.parent.HandleOwnershipChange()
+
+    def OnNotify(self, events):
+        PtDebugPrint(f"_QuabVarSyncBrain.OnNotify(): Unhandled {events=}")
+
+    def ICheckGameReady(self) -> None:
+        if not self.gameState & GameState.kInitialSyncComplete:
+            PtDebugPrint("_QuabVarSyncBrain.ICheckGameReady(): The initial var sync is NOT complete, we are clearly not ready", level=kDebugDumpLevel)
+            return
+
+        if not self.ready and all((i.varsReady for i in self.quabState)):
+            PtDebugPrint("_QuabVarSyncBrain.ICheckGameReady(): All variables created!", level=kWarningLevel)
+            self.gameState |= GameState.kAllVarsCreated
+
+        if self.ready:
+            self.parent.SpawnQuabs()
+            return
+
+        # The initial state is available, but not all variables are known. Therefore, we must create them.
+        if self.gameState & GameState.kVarCreateRequested:
+            return
+
+        for _, var in self.iterAllVars():
+            PtDebugPrint(f"_QuabVarSyncBrain.ICheckGameReady(): Checking variable '{var.name=}'...", level=kDebugDumpLevel)
+            if var.varID is None:
+                PtDebugPrint(f"_QuabVarSyncBrain.ICheckGameReady(): Creating variable '{var.name=}'", level=kWarningLevel)
+                self.gameCli.createVariable(var.name, var.value)
+        self.gameState |= GameState.kVarCreateRequested
+
+    def OnAllVarsSent(self):
+        PtDebugPrint(f"_QuabVarSyncBrain.OnAllVarsSent(): All variables received", level=kWarningLevel)
+        self.gameState |= GameState.kInitialSyncComplete
+        self.ICheckGameReady()
+
+    def OnVarCreated(self, varName: str, varID: int, varValue: Union[float, str]):
+        PtDebugPrint(f"_QuabVarSyncBrain.OnVarCreated(): [{varID=}], [{varName=}], [{varValue=}]", level=kDebugDumpLevel)
+        try:
+            # We need to lookup the variable by name because we don't actually know
+            # what the ID is yet.
+            quab, var = self.findQuabVar(varName)
+        except LookupError:
+            PtDebugPrint(f"_QuabVarSyncBrain.OnVarCreated(): [{varID=}], [{varName=}], [{varValue=}] variable not found")
+        else:
+            var.varID = varID
+            var.value = varValue
+            var.lastUpdate = PtGetGameTime()
+            self.parent.OnQuabVarUpdate(quab)
+        self.ICheckGameReady()
+
+    def OnVarChanged(self, varID: int, varValue: Union[float, str]):
+        PtDebugPrint(f"_QuabVarSyncBrain.OnVarChanged(): [{varID=}], [{varValue=}]", level=kDebugDumpLevel)
+        try:
+            quab, var = self.findQuabVar(varID)
+        except LookupError:
+            PtDebugPrint(f"_QuabVarSyncBrain.OnVarChanged(): [{varID=}], [{varValue=}] variable not found")
+        else:
+            var.value = varValue
+            var.lastUpdate = PtGetGameTime()
+            self.parent.OnQuabVarUpdate(quab)
+
+    def ISendVars(self, *vars: _QuabVar):
+        cli = self.gameCli
+        for var in vars:
+            # The GameMgr will notify us once this variable is set on the server.
+            cli.setVariable(var.varID, var.value)
+            var.dirty = False
+
+    def sync(self, quabs: Optional[Iterable[_QuabState]] = None, *, force: bool = False):
+        if force:
+            PtDebugPrint("_QuabVarSyncBrain.sync(): Force syncs are not allowed. Suppressing.", level=kDebugDumpLevel)
+            return
+        super().sync(quabs)
+
+
+class _QuabPyNotifyBrain(_QuabGameBrain):
+    def __init__(self, parent: ahnyQuabs):
+        _QuabGameBrain.__init__(self, parent)
+        if self.amOwner:
+            self.gameState |= GameState.kReady
+
+    @property
+    def amOwner(self) -> bool:
+        return self.parent.sceneobject.isLocallyOwned()
+
+    @property
+    def currentTime(self) -> int:
+        return PtGetServerTime()
+
+    def OnNotify(self, events):
+        PtDebugPrint(f"_QuabPyNotifyBrain.OnNotify(): {events=}", level=kDebugDumpLevel)
+
+        wasReady = self.ready
+        secs = PtGetGameTime()
+        updatedQuabs = set()
+
+        for i, event in enumerate(events):
+            if event[0] != kVariableEvent:
+                PtDebugPrint(f"_QuabPyNotifyBrain.OnNotify(): Event {i} is not a variable event!", level=kDebugDumpLevel)
+                continue
+            try:
+                quab, var = self.findQuabVar(event[1])
+            except LookupError:
+                PtDebugPrint(f"_QuabPyNotifyBrain.OnNotify(): Could not find variable {event[1]=}")
+                continue
+            else:
+                if event[2] not in {PtNotifyDataType.kFloat, PtNotifyDataType.kInt}:
+                    eventDataType = PtNotifyDataType.reverseLookup.get(event[2], f"<UNKNOWN: {event[2]}>")
+                    PtDebugPrint(f"_QuabPyNotifyBrain.OnNotify(): Invalid data type {event[1]=} {eventDataType=}")
+                    continue
+
+                var.value = event[3]
+                var.lastUpdate = secs
+                updatedQuabs.add(quab)
+
+                # It's probably best to just assume that receiving a valid variable notification
+                # is enough to be a state init.
+                self.gameState |= (GameState.kInitialSyncComplete | GameState.kAllVarsCreated)
+
+        # We strictly speaking don't need to guard this, but I find that the log messages are
+        # VERY spammy if we don't.
+        if not wasReady and self.ready:
+            PtDebugPrint("_QuabPyNotifyBrain.OnNotify(): Got initial state sync. Brain is now ready!", level=kWarningLevel)
+            self.parent.SpawnQuabs()
+
+        for quab in updatedQuabs:
+            self.parent.OnQuabVarUpdate(quab)
+
+    def ISendVars(self, *vars: _QuabVar):
+        # Don't send out empty (ie spam) messages
+        if not vars:
+            return
+
+        note = ptNotify(self.parent.key)
+        note.addReceiver(self.parent.key)
+        note.netForce(True)
+        note.netPropagate(True)
+        note.setActivate(1.0)
+        for var in vars:
+            note.addVarFloat(var.name, var.value)
+            var.dirty = False
+        note.send()
+
+
+class ahnyQuabs(ptModifier):
     def __init__(self):
         ptModifier.__init__(self)
         self.id = 5946
         self.version = 2
-        self.brains = []
+
+        self._ageUnLoading = False
+        self._brain = None
+        self._aiMsgHandlers = {
+            PtAIMsgType.kBrainCreated: self.OnAIMsg_BrainCreated,
+            PtAIMsgType.kArrivedAtGoal: self.OnAIMsg_ArrivedAtGoal,
+            PtAIMsgType.kBrainDestroyed: self.OnAIMsg_BrainDestroyed,
+            PtAIMsgType.kGoToGoal: self.OnAIMsg_GoToGoal,
+        }
+
         random.seed()
         PtDebugPrint(f"__init__ahnyQuabs v{self.version} ")
 
     @property
-    def last_update(self) -> int:
+    def _LastUpdate(self) -> int:
         """Gets the last time a quab was killed/born"""
         ageSDL = PtGetAgeSDL()
         return ageSDL[kLastQuabUpdate][0]
 
     @property
-    def quabs(self) -> int:
+    def _NumQuabs(self) -> int:
         """Gets the number of quabs alive"""
         ageSDL = PtGetAgeSDL()
         return ageSDL[SDLQuabs.value][0]
 
-    @quabs.setter
-    def quabs(self, value: int) -> None:
+    @_NumQuabs.setter
+    def _NumQuabs(self, value: int) -> None:
         ageSDL = PtGetAgeSDL()
         ageSDL[SDLQuabs.value] = (value,)
-        ageSDL[kLastQuabUpdate] = (PtGetServerTime(),)
+        ageSDL[kLastQuabUpdate] = (self._brain.currentTime,)
 
     def OnServerInitComplete(self):
-        PtDebugPrint("ahnyQuabs.OnServerInitComplete():\tWhen I got here...", level=kWarningLevel)
-        PtDebugPrint(f"ahnyQuabs.OnServerInitComplete():\t... there were already {self.quabs} quabs", level=kWarningLevel)
-        self.brains = PtGetAIAvatarsByModelName(kQuabAvatarName)
+        if ptGmVarSync.isSupported():
+            PtDebugPrint("ahnyQuabs.OnServerInitComplete(): Legacy VarSync Quab game", level=kWarningLevel)
+            self._brain = _QuabVarSyncBrain(self)
+            ptGmVarSync.join(self._brain)
+        else:
+            PtDebugPrint("ahnyQuabs.OnServerInitComplete(): PyNotify Quab game", level=kWarningLevel)
+            self._brain = _QuabPyNotifyBrain(self)
 
-        # Sanity Check: Before we think about doing any processing, make sure there are no quabs
-        #               already loaded. We may have arrived after the last man left but before the
-        #               server shut down. Therefore, we will already have quabs... So we don't want
-        #               to spawn another 20 or so dupe avatar clones.
-        if self.brains:
-            PtDebugPrint("ahnyQuabs.OnServerInitComplete():\t... and they were already spawned!", level=kWarningLevel)
-            for brain in self.brains:
-                self._PrepCritterBrain(brain[0])
-            return
-
-        if self.sceneobject.isLocallyOwned():
-            delta = PtGetServerTime() - self.last_update
-            toSpawn = delta // kQuabGestationTime
+        PtDebugPrint("ahnyQuabs.OnServerInitComplete(): When I got here...", level=kWarningLevel)
+        PtDebugPrint(f"ahnyQuabs.OnServerInitComplete(): ... there were already {self._NumQuabs} quabs", level=kWarningLevel)
+        if PtIsSolo():
+            delta = self._brain.currentTime - self._LastUpdate
+            toSpawn = min((kMaxNumQuabs - self._NumQuabs, delta // kQuabGestationTime))
             if toSpawn:
-                PtDebugPrint(f"ahnyQuabs.OnServerInitComplete():\t... and I need {toSpawn=} more", level=kWarningLevel)
-                self.quabs += toSpawn
-            if self.quabs > kMaxNumQuabs:
-                PtDebugPrint(f"ahnyQuabs.OnServerInitComplete():\t... woah,  {self.quabs=}?!", level=kWarningLevel)
-                self.quabs = kMaxNumQuabs
+                PtDebugPrint(f"ahnyQuabs.OnServerInitComplete(): ... and I need {toSpawn=} more", level=kWarningLevel)
+                self._NumQuabs += toSpawn
 
-            # Shuffle the spawn points around so we don't get the same quabs appearing
-            # every single time. That would be quite boring.
-            qSpawns = list(quabObjects.value)
-            random.shuffle(qSpawns)
+        PtDebugPrint("ahnyQuabs.OnServerInitComplete(): Trying to handle quab brains...", level=kWarningLevel)
+        brains = PtGetAIAvatarsByModelName(kQuabAvatarName)
+        for brain, name in brains:
+            quab = self._brain.findQuab(name)
+            if quab is None:
+                PtDebugPrint(f"ahnyQuabs.OnServerInitComplete(): Invalid quab clone on server {name=}")
+                continue
 
-            # On quab spawning...
-            # We will load the avatar clones manually if we are the first one in.
-            # We will obtain the ptCritterBrains in an OnAIMsg callback.
-            for i in range(self.quabs):
-                PtLoadAvatarModel(kQuabAvatarName, qSpawns[i].getKey(), f"Quab {i}")
+            PtDebugPrint(f"ahnyQuabs.OnServerInitComplete(): Got a brain for quab {name=}", level=kDebugDumpLevel)
+            self._PrepCritterBrain(quab, brain)
 
-    def OnAIMsg(self, brain, msgType, userStr, args):
-        if msgType == PtAIMsgType.kBrainCreated:
-            # Init the brain and push it into our collection
-            PtDebugPrint(f"ahnyQuabs.OnAIMsg():\t{userStr} created", level=kDebugDumpLevel)
-            self._PrepCritterBrain(brain)
-            self.brains.append((brain, userStr,))
-            return
+        # Maybe we're ready to do this, maybe not.
+        self.SpawnQuabs()
 
-        if msgType == PtAIMsgType.kArrivedAtGoal:
-            # Not really important, but useful for debugging
-            PtDebugPrint(f"ahnyQuabs.OnAIMsg():\t{userStr} arrived at goal", level=kDebugDumpLevel)
-            return
+    def BeginAgeUnLoad(self, localAv: ptSceneobject):
+        PtDebugPrint("ahnyQuabs.BeginAgeUnLoad(): Taking note of this.", level=kWarningLevel)
+        self._ageUnLoading = True
+
+    def OnOwnershipChanged(self):
+        PtDebugPrint(f"ahnyQuabs.OnOwnershipChanged(): {self.sceneobject.isLocallyOwned()=} {self._brain.amOwner=}", level=kWarningLevel)
+        if self._brain.amOwner:
+            self.HandleOwnershipChange()
+
+    def HandleOwnershipChange(self):
+        # Reassign ownership for brains that are valid. Or, at least, that's what we would LIKE to do.
+        # In practice, Cyan's server seems to have a bit of a challenge here. When a player disconnects from
+        # the game server, all of the clones it spawned are pitched. The bug is that Cyan's server only ever seems
+        # to send us the unload for a single quab - probably the last one spawned in. That means we respawn a single quab
+        # and see the the other n-1 quabs. When someone else links in, though, they only see the ONE quab.
+        # Or, at worst, no quabs. So, to fix that, completely despawn and respawn all quabs.
+        for quab in (i for i in self._brain.quabs if not i.brain.getLocallyControlled()):
+            PtDebugPrint(f"ahnyQuabs.HandlerOwnershipChange(): Despawning {quab.name=}", level=kWarningLevel)
+            PtUnLoadAvatarModel(quab.brain.getSceneObject().getKey())
+
+        # The underlying sceneobject has changed ownership, so the previous owner of the game might be gone. This could mean that
+        # quab brains have been thrown out from under us. Respawn any that should still be alive. This will NOT cause the
+        # ones despawned above to be respawned. They will be respawned after the brains get tossed.
+        self.SpawnQuabs(respawn=True)
+
+    def AvatarPage(self, avatar: ptSceneobject, loading: bool, lastOut: bool):
+        PtDebugPrint(
+            f"ahnyQuabs.AvatarPage(): PlayerID:{PtGetClientIDFromAvatarKey(avatar.getKey())} "
+            f"is {'joining' if loading else 'leaving'} us!",
+            level=kDebugDumpLevel
+        )
+        if loading:
+            if brain := self._brain:
+                brain.sync(force=True)
 
     def OnNotify(self, state, id, events):
         if id == deadZone.id:
             # Make sure this isn't the player jumping into the water for a quick swim
-            # Musing: Ideally, we would despawn the clone here since it's now useless,
-            #         but removing the brain without causing rampant issues might be problematic...
             colso = PtFindAvatar(events)
             if colso.isAvatar() and not colso.isHuman():
-                self.quabs -= 1
-                PtDebugPrint(f"ahnyQuabs.OnNotify():\tQuabs remaining: {self.quabs}", level=kWarningLevel)
+                self._NumQuabs -= 1
+                PtDebugPrint(f"ahnyQuabs.OnNotify():\tQuabs remaining: {self._NumQuabs}", level=kWarningLevel)
                 return
 
-    def OnUpdate(self, seconds, delta):
-        for brain, name in self.brains:
-            # Meh, I'm tired of huge indentation levels
-            # If you think running this every frame is a bad idea, remember how
-            # badly the quab AI sucked in MOUL. This won't kill you.
-            self._Think(brain, name)
-
-    def _Think(self, brain, name):
-        """Basic quab thought logic (scurry, scurry, scurry)"""
-        running = self._IsRunningAway(brain)
-
-        # Quabs spook very easily. They are also stupid like dogs--they run
-        # in a straight line away from whatever is chasing them. Fun fact: alligators
-        # can catch dogs because they do the same thing. The mammalian adaptation is the
-        # ability to turn quickly (which the dog does not actually do)...
-        # This evolutionary biology lesson is thanks to Hoikas, the Mammalogy drop-out
-        monsters = brain.playersICanHear()
-        if not monsters:
-            if running:
-                PtDebugPrint(f"ahnyQuabs._Think():\t{name} is now safe.", level=kDebugDumpLevel)
-                self._RunAway(brain, False)
+        if id == -1:
+            if brain := self._brain:
+                brain.OnNotify(events)
             return
+
+    def OnAIMsg(self, brain: ptCritterBrain, msgType, userStr: str, args):
+        PtDebugPrint(f"ahnyQuabs.OnAIMsg(): {brain=} {msgType=} {userStr=} {args=}", level=kDebugDumpLevel)
+        if handler := self._aiMsgHandlers.get(msgType):
+            args = () if args is None else args
+            handler(brain, userStr, *args)
+        else:
+            PtDebugPrint(f"ahnyQuabs.OnAIMsg(): Unhandled message {msgType=} {userStr=} {args=}")
+
+    def OnAIMsg_BrainCreated(self, brain: ptCritterBrain, userStr: str):
+        PtDebugPrint(f"ahnyQuabs.OnAIMsg_BrainCreated(): {userStr=}", level=kDebugDumpLevel)
+        if quab := self._brain.findQuab(userStr):
+            self._PrepCritterBrain(quab, brain)
+
+            if self._brain.amOwner:
+                if quab.respawn:
+                    PtDebugPrint(f"ahnyQuabs.OnAIMsg_BrainCreated(): {userStr=} was respawned, moving to previous location", level=kWarningLevel)
+
+                    # We requested that the quab spawn into a specific spawn point (because we have to). Spawning is done by sending a WarpMsg
+                    # after the avatar is loaded. That means to override the spawn point, we need to send a WarpMsg from Python, otherwise any direct
+                    # transform settings we apply will simply be blown away by the WarpMsg. The only way to do this is to use the pPhysics.warp() functions.
+                    quabSO = brain.getSceneObject()
+                    quabSO.physics.netForce(True)
+                    quabSO.physics.warp(quab.lastXform)
+                    quab.respawn = False
+                if self._brain.ready:
+                    self._UpdateQuabGoal(quab, force=True, sync=True)
+
+    def OnAIMsg_ArrivedAtGoal(self, brain: ptCritterBrain, userStr: str, goal: ptPoint3):
+        PtDebugPrint(f"ahnyQuabs.OnAIMsg_ArrivedAtGoal(): {userStr=} {goal=}", level=kDebugDumpLevel)
+        quab = self._brain.findQuab(userStr)
+        if quab is None:
+            PtDebugPrint(f"ahnyQuabs.OnAIMsg_ArrivedAtGoal(): Hmmm... {userStr=} is not a known quab")
+            return
+
+        if self._brain.amOwner:
+            PtDebugPrint(f"ahnyQuabs.OnAIMsg_ArrivedAtGoal(): {userStr=} telling everyone we are no longer running.", level=kDebugDumpLevel)
+            self._brain.changeQuabState(quab, False, sync=True)
+        elif quab.isRunning:
+            PtDebugPrint(f"ahnyQuabs.OnAIMsg_ArrivedAtGoal(): {userStr=} is now at our goal, but the owner thinks it should still be running.", level=kDebugDumpLevel)
+        else:
+            PtDebugPrint(f"ahnyQuabs.OnAIMsg_ArrivedAtGoal(): {userStr=} is now at our goal, and the owner has stopped it.", level=kDebugDumpLevel)
+
+    def OnAIMsg_BrainDestroyed(self, brain: ptCritterBrain, userStr: str):
+        PtDebugPrint(f"ahnyQuabs.OnAIMsg_BrainDestroyed(): {userStr=}", level=kDebugDumpLevel)
+        quab = self._brain.findQuab(userStr)
+        if quab is None:
+            PtDebugPrint(f"ahnyQuabs.OnAIMsg_BrainDestroyed(): Hmmm... {userStr=} is not a known quab")
+            return
+
+        # IMPORTANT: Do *NOT* hold on to the quab's brain any longer. Bad things will happen!
+        quab.brain = None
+
+        if not self._ageUnLoading and self._brain.amOwner:
+            PtDebugPrint(f"ahnyQuabs.OnAIMsg_BrainDestroyed(): I need to respawn {quab.name=}!", level=kWarningLevel)
+            quab.respawn = True
+            quab.pending = True
+            PtLoadAvatarModel(kQuabAvatarName, quabObjects.value[0].getKey(), userStr)
+        elif not self._ageUnLoading and not self._brain.amOwner:
+            PtDebugPrint(f"ahnyQuabs.OnAIMsg_BrainDestroyed(): {quab.name=} needs to be respawned, but I'm not the owner!", level=kWarningLevel)
+        else:
+            PtDebugPrint(f"ahnyQuabs.OnAIMsg_BrainDestroyed(): {quab.name=} says, 'Goodbye, cruel world!'", level=kWarningLevel)
+
+    def OnAIMsg_GoToGoal(self, brain: ptCritterBrain, userStr: str, goal: ptPoint3, avoid: bool):
+        PtDebugPrint(f"ahnyQuabs.OnAIMsg_GoToGoal(): {userStr=} {goal=} {avoid=}", level=kDebugDumpLevel)
+
+    def OnUpdate(self, secs, delta):
+        if self._brain is None:
+            return
+
+        # Stash the current transform of each quab, just in case we need to respawn it.
+        for quab, so in ((i, i.brain.getSceneObject()) for i in self._brain.quabs if not i.pending):
+            quab.lastXform = so.getLocalToWorld()
+        self._UpdateQuabs(sync=True)
+
+    def _UpdateQuabs(self, *, sync: bool = False):
+        if not self._brain.ready:
+            return
+        if not self._brain.amOwner:
+            return
+
+        quabs = list(self._brain.quabs)
+        for quab in quabs:
+            self._UpdateQuabGoal(quab)
+        if sync:
+            self._brain.sync(quabs)
+
+    def _CalcQuabGoal(self, quab: _QuabState) -> Optional[ptPoint3]:
+        """Calculates the goal position for the quab based on the players it can hear."""
+        monsters = quab.brain.playersICanHear()
+        if not monsters:
+            return None
+
         runaway  = None
         for monster in monsters:
-            vec = brain.vectorToPlayer(monster)
+            vec = quab.brain.vectorToPlayer(monster)
             vec.normalize()
             if runaway:
                 runaway = runaway.add(vec)
             else:
                 runaway = vec
         runaway = runaway.scale(100) # so we don't just move a centimeter away
-        curPos = brain.getSceneObject().position()
-        endPos = ptPoint3(curPos.getX() + runaway.getX(), curPos.getY() + runaway.getY(), curPos.getZ() + runaway.getZ())
+        curPos = quab.brain.getSceneObject().position()
+        return ptPoint3(
+            curPos.getX() + runaway.getX(),
+            curPos.getY() + runaway.getY(),
+            curPos.getZ() + runaway.getZ()
+        )
 
-        # Now, actually make the quab run away
-        if not running:
-            # Note: low level brain will make the quab play the run behavior
-            #       no need to court a race condition by playing it here
-            PtDebugPrint(f"ahnyQuabs._Think():\tTime for {name} to run away!", level=kDebugDumpLevel)
-        brain.goToGoal(endPos)
+    def _CalcCrappyGoal(self, quab: _QuabState) -> ptPoint3:
+        """Calculates a crappy quab goal so it has somewhere to go."""
+        closestAv = next(iter(quab.avatarListSorted), PtGetLocalAvatar())
+        vec = quab.brain.vectorToPlayer(
+            PtGetClientIDFromAvatarKey(closestAv.getKey())
+        ).scale(100)
+        curPos = quab.brain.getSceneObject().position()
+        return ptPoint3(
+            curPos.getX() + vec.getX(),
+            curPos.getY() + vec.getY(),
+            curPos.getZ() + vec.getZ()
+        )
 
-    def _PrepCritterBrain(self, brain):
-        """Attaches quab behaviors to newly initialized/fetched critter brains"""
+    def _UpdateQuabGoal(self, quab: _QuabState, *, force: bool = False, sync: bool = False):
+        # We only want to update the goal every 3 seconds while a quab is running.
+        # If the quab is not running, we need to evaluate every frame to be responsive
+        # to some pesky avatar getting all up in our grill. To do so, we need to use
+        # PtGetGameTime(), a monotonic clock, which we can rely on to always count forward
+        # in a steady manner, independent of user visible clocks, but consistent.
+        # PtGetServerTime() moves with whatever is going on with the server's wall clock
+        # and is subject to nonsense like leap seconds and moving backwards. Don't use that.
+        if not force and quab.isRunning and PtGetGameTime() - quab.lastGoalUpdate < 3.0:
+            return
+
+        if goal := self._CalcQuabGoal(quab):
+            self._brain.changeQuabGoal(quab, goal, sync=sync)
+        else:
+            self._brain.changeQuabState(quab, False, sync=sync)
+
+    def OnQuabVarUpdate(self, quab: _QuabState):
+        if quab.brain is None:
+            PtDebugPrint(f"ahnyQuabs.OnQuabVarUpdate(): {quab.name=} AI is not ready.", level=kDebugDumpLevel)
+            return
+        if not quab.isRunning:
+            quab.runAway(False)
+            return
+
+        # At best, the game manager brain is going to receive the goal position
+        # in three messages. Those messages might be coming in *after* the start
+        # running message. At worst, the legacy client simply won't send anything at all.
+        # So, if the quab is supposedly running, we haven't had a goal update in the
+        # last second, then we need to compute some kind of phony goal. We *have*
+        # to do it this fiddly way because quabs can be halted before they reach their
+        # previous "goal" position because their little pea brain was no longer able
+        # to hear or see an avatar.
+        delVars = abs(quab.lastGoalUpdate - quab.runningVar.lastUpdate)
+        if delVars > 1.0:
+            PtDebugPrint(f"ahnyQuabs.OnQuabVarUpdate(): Spurious goal! {delVars=}", level=kDebugDumpLevel)
+            phonyGoal = self._CalcQuabGoal(quab)
+            if phonyGoal is None:
+                PtDebugPrint("ahnyQuabs.OnQuabVarUpdate(): Ah, crap, we couldn't even make a phony goal! Brute force time.", level=kDebugDumpLevel)
+                phonyGoal = self._CalcCrappyGoal(quab)
+            quab.runAway(True, phonyGoal)
+        else:
+            PtDebugPrint(f"ahnyQuabs.OnQuabVarUpdate(): Valid goal {delVars=} {quab.brain.atGoal()=} {quab.goal=}", level=kDebugDumpLevel)
+            quab.runAway(True, quab.goal)
+
+    def SpawnQuabs(self, *, respawn: bool = False):
+        if not self._brain.ready:
+            PtDebugPrint(f"ahnyQuabs.SpawnQuabs(): {self._brain.__class__.__name__} is not ready!", level=kWarningLevel)
+            return
+        if not self._brain.amOwner:
+            PtDebugPrint("ahnyQuabs.SpawnQuabs(): I'm not the game owner!", level=kWarningLevel)
+            return
+        if self._NumQuabs <= self._brain.numQuabs:
+            return
+
+        # Shuffle the spawn points around so we don't get the same quabs appearing
+        # every single time. That would be quite boring.
+        qSpawns = list(quabObjects.value)
+        random.shuffle(qSpawns)
+
+        # Count up from however many quabs there are (should be zero) to the
+        # final number. Also, pair it with a non-spawned quab.
+        PtDebugPrint(f"ahnyQuabs.SpawnQuabs(): Spawning... {self._NumQuabs=} {self._brain.numQuabs=} {respawn=}", level=kWarningLevel)
+        counter = range(self._brain.numQuabs, self._NumQuabs)
+        quabs = itertools.takewhile(lambda x: x.brain is None and not x.pending, self._brain.quabState)
+        for i, quab in zip(counter, quabs):
+            # We'll get him in OnAIMsg_OnBrainCreated()
+            PtDebugPrint(f"ahnyQuabs.SpawnQuabs(): Spawning... {quab.name=}", level=kDebugDumpLevel)
+            PtLoadAvatarModel(kQuabAvatarName, qSpawns[i].getKey(), quab.name)
+            # We can't move him now - he's not actually loaded yet.
+            quab.respawn = respawn
+            quab.pending = True
+
+    def _PrepCritterBrain(self, quab: _QuabState, brain: ptCritterBrain):
+        quab.brain = brain
+        quab.pending = False
+
         brain.addReceiver(self.key)
+        brain.setLocallyControlled(self._brain.amOwner)
         for beh in kQuabIdleBehNames:
             brain.addBehavior(beh, brain.idleBehaviorName())
         for beh in kQuabRunBehNames:
             brain.addBehavior(beh, brain.runBehaviorName(), randomStartPos=0)
 
-    def _IsRunningAway(self, brain):
-        if brain.runningBehavior(brain.runBehaviorName()):
-            return True
-        if brain.runningBehavior(brain.idleBehaviorName()):
-            return False
-        raise RuntimeError("Quab brain running neither the idle nor the run behavior. WTF?")
+    def OnBackdoorMsg(self, target: str, param: str):
+        if not self._brain.amOwner:
+            PtDebugPrint(f"ahnyQuabs.OnBackdoorMsg(): {target=} {param=} You're joking, right?")
+            return
 
-    def _RunAway(self, brain, runAway=True):
-        """Quick helper because I'm lazy and the behavior apis are really stupid"""
-        if runAway:
-            brain.startBehavior(brain.runBehaviorName())
-        else:
-            brain.startBehavior(brain.idleBehaviorName())
+        args = (target.lower(), param.lower())
+        if args == ("quabs", "reset"):
+            self._NumQuabs = kMaxNumQuabs
+            self.SpawnQuabs()
+        elif args == ("quabs", "respawn"):
+            for i in self._brain.quabs:
+                PtDebugPrint(f"ahnyQuabs.OnBackdoorMsg(): Despawning {i.name=}",)
+                PtUnLoadAvatarModel(i.brain.getSceneObject().getKey())

--- a/Scripts/Python/ahnyQuabs.py
+++ b/Scripts/Python/ahnyQuabs.py
@@ -429,7 +429,7 @@ class _QuabPyNotifyBrain(_QuabGameBrain):
 
                 # It's probably best to just assume that receiving a valid variable notification
                 # is enough to be a state init.
-                self.gameState |= (GameState.kInitialSyncComplete | GameState.kAllVarsCreated)
+                self.gameState |= GameState.kReady
 
         # We strictly speaking don't need to guard this, but I find that the log messages are
         # VERY spammy if we don't.

--- a/Scripts/Python/ahnyQuabs.py
+++ b/Scripts/Python/ahnyQuabs.py
@@ -261,7 +261,7 @@ class _QuabGameBrain(abc.ABC):
             for var in quab.itervars():
                 if (isinstance(varIdent, str) and var.name == varIdent) or (isinstance(varIdent, int) and var.varID == varIdent):
                     return quab, var
-        raise LookupError
+        raise LookupError(varIdent)
 
     @abc.abstractmethod
     def OnNotify(self, events):

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -2079,6 +2079,10 @@ class ptCritterBrain:
         """Returns how far away the brain can hear."""
         ...
 
+    def getLocallyControlled(self):
+        """Are we the one making AI decisions? NOTE: Not set automatically, some python script needs to tell the brain this using setLocallyControlled()."""
+        ...
+
     def getSceneObject(self):
         """Returns the ptSceneObject this brain controls."""
         ...
@@ -2129,6 +2133,10 @@ class ptCritterBrain:
 
     def setHearingDistance(self, dist):
         """Set how far away the brain can hear (360 degree field of hearing)."""
+        ...
+
+    def setLocallyControlled(self, local):
+        """Tells the brain that we are the ones making all the AI decisions, and to prop location and other information to the server."""
         ...
 
     def setSightCone(self, radians):

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -2079,7 +2079,7 @@ class ptCritterBrain:
         """Returns how far away the brain can hear."""
         ...
 
-    def getLocallyControlled(self):
+    def getLocallyControlled(self) -> bool:
         """Are we the one making AI decisions? NOTE: Not set automatically, some python script needs to tell the brain this using setLocallyControlled()."""
         ...
 
@@ -2135,7 +2135,7 @@ class ptCritterBrain:
         """Set how far away the brain can hear (360 degree field of hearing)."""
         ...
 
-    def setLocallyControlled(self, local):
+    def setLocallyControlled(self, local: bool) -> None:
         """Tells the brain that we are the ones making all the AI decisions, and to prop location and other information to the server."""
         ...
 

--- a/Scripts/Python/plasma/PlasmaConstants.py
+++ b/Scripts/Python/plasma/PlasmaConstants.py
@@ -64,6 +64,7 @@ class PtAIMsgType:
     kBrainCreated = 1
     kArrivedAtGoal = 2
     kBrainDestroyed = 3
+    kGoToGoal = 4
 
 class PtAccountUpdateType:
     kCreatePlayer = 1

--- a/Scripts/Python/plasma/PlasmaConstants.py
+++ b/Scripts/Python/plasma/PlasmaConstants.py
@@ -63,6 +63,7 @@ class PtAIMsgType:
     kUnknown = 0
     kBrainCreated = 1
     kArrivedAtGoal = 2
+    kBrainDestroyed = 3
 
 class PtAccountUpdateType:
     kCreatePlayer = 1

--- a/Scripts/Python/plasma/PlasmaGame.py
+++ b/Scripts/Python/plasma/PlasmaGame.py
@@ -149,20 +149,20 @@ class ptGmMarker(ptGameCli):
 class ptGmVarSync(ptGameCli):
     """Legacy var sync game client."""
 
-    def createVariable(self):
+    def createVariable(self, varName: str, value: Union[float, str]) -> None:
         """Create a new variable on the server."""
         ...
 
     @staticmethod
-    def isSupported():
+    def isSupported() -> bool:
         """Checks for the presence of a server-side var sync game manager."""
         ...
 
     @staticmethod
-    def join():
+    def join(handler: Any) -> None:
         """Join the common var sync game in the current Age."""
         ...
 
-    def setVariable(self):
+    def setVariable(self, varID: int, value: Union[float, str]) -> None:
         """Change the value of a variable on the server."""
         ...

--- a/Scripts/Python/plasma/PlasmaGame.py
+++ b/Scripts/Python/plasma/PlasmaGame.py
@@ -145,3 +145,24 @@ class ptGmMarker(ptGameCli):
     def startGame(self) -> None:
         """Request for the server to start the marker game."""
         ...
+
+class ptGmVarSync(ptGameCli):
+    """Legacy var sync game client."""
+
+    def createVariable(self):
+        """Create a new variable on the server."""
+        ...
+
+    @staticmethod
+    def isSupported():
+        """Checks for the presence of a server-side var sync game manager."""
+        ...
+
+    @staticmethod
+    def join():
+        """Join the common var sync game in the current Age."""
+        ...
+
+    def setVariable(self):
+        """Change the value of a variable on the server."""
+        ...

--- a/Sources/Plasma/FeatureLib/pfGameMgr/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/CMakeLists.txt
@@ -5,6 +5,7 @@ set(pfGameMgr_HEADERS
     pfGameMgrTrans.h
     pfGmBlueSpiral.h
     pfGmMarker.h
+    pfGmVarSync.h
 )
 
 set(pfGameMgr_SOURCES
@@ -13,6 +14,7 @@ set(pfGameMgr_SOURCES
     pfGameMgrTrans.cpp
     pfGmBlueSpiral.cpp
     pfGmMarker.cpp
+    pfGmVarSync.cpp
 )
 
 plasma_library(pfGameMgr

--- a/Sources/Plasma/FeatureLib/pfGameMgr/pfGmVarSync.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/pfGmVarSync.cpp
@@ -1,0 +1,245 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "pfGmVarSync.h"
+#include "pfGameMgrTrans.h"
+
+#include <type_traits>
+
+#include "pnGameMgr/pnGmVarSync.h"
+#include "pnUtils/pnUtStr.h"
+
+#include "plNetGameLib/plNetGameLib.h"
+
+// ===========================================================================
+
+constexpr uint32_t kVarSyncTableID = 255;
+
+// ===========================================================================
+
+template<>
+void pfGmVarSync::Recv(const Srv2Cli_VarSync_StringVarChanged& msg)
+{
+    if (GetHandler()) {
+        GetHandler()->OnVarChanged(
+            msg.varID,
+            ST::string::from_utf16(msg.varValue)
+        );
+    }
+}
+
+template<>
+void pfGmVarSync::Recv(const Srv2Cli_VarSync_NumericVarChanged& msg)
+{
+    if (GetHandler())
+        GetHandler()->OnVarChanged(msg.varID, msg.varValue);
+}
+
+template<>
+void pfGmVarSync::Recv(const Srv2Cli_VarSync_AllVarsSent&)
+{
+    if (GetHandler())
+        GetHandler()->OnAllVarsSent();
+}
+
+template<>
+void pfGmVarSync::Recv(const Srv2Cli_VarSync_StringVarCreated& msg)
+{
+    if (GetHandler()) {
+        GetHandler()->OnVarCreated(
+            ST::string::from_utf16(msg.varName),
+            msg.varID,
+            ST::string::from_utf16(msg.varValue)
+        );
+    }
+}
+
+template<>
+void pfGmVarSync::Recv(const Srv2Cli_VarSync_NumericVarCreated& msg)
+{
+    if (GetHandler()) {
+        GetHandler()->OnVarCreated(
+            ST::string::from_utf16(msg.varName),
+            msg.varID,
+            msg.varValue
+        );
+    }
+}
+
+bool pfGmVarSync::RecvGameMgrMsg(const GameMsgHeader* msg)
+{
+    if (pfGameCli::RecvGameMgrMsg(msg))
+        return true;
+
+#define DISPATCH(x)                                                 \
+    case kSrv2Cli_VarSync_##x: {                                    \
+        const auto& msgFinal = *(const Srv2Cli_VarSync_##x*)msg;    \
+        Recv(msgFinal);                                             \
+        return true;                                                \
+    };
+
+    switch (msg->messageId) {
+        DISPATCH(StringVarChanged);
+        DISPATCH(NumericVarChanged);
+        DISPATCH(AllVarsSent);
+        DISPATCH(StringVarCreated);
+        DISPATCH(NumericVarCreated);
+        default:
+            return false;
+    }
+
+#undef DISPATCH
+}
+
+// ===========================================================================
+
+#define VARSYNC_MSG(x, name)                  \
+    Cli2Srv_VarSync_##x name;                 \
+    name.messageId = kCli2Srv_VarSync_##x;    \
+    name.transId = 0;                         \
+    name.recvGameId = GetGameID();            \
+    name.messageBytes = sizeof(name);         //
+
+#define VARSYNC_SEND(name)                    \
+    NetCliGameSendGameMgrMsg(&name);          //
+
+void pfGmVarSync::SetVariable(
+    uint32_t varID,
+    const pfGmVarSyncValue& varValue
+) const
+{
+    std::visit(
+        [this, varID](auto&& value) {
+            using _VarT = std::decay_t<decltype(value)>;
+            if constexpr (std::is_same_v<_VarT, double>) {
+                VARSYNC_MSG(SetNumericVar, msg)
+                msg.varID = varID;
+                msg.varValue = value;
+                VARSYNC_SEND(msg)
+            } else if constexpr (std::is_same_v<_VarT, ST::string>) {
+                VARSYNC_MSG(SetStringVar, msg)
+                msg.varID = varID;
+                StrCopy(msg.varValue, value.to_utf16().data(), std::size(msg.varValue));
+                VARSYNC_SEND(msg)
+            } else {
+                static_assert(
+                    std::is_same_v<_VarT, double> || std::is_same_v<_VarT, ST::string>,
+                    "Non-exhaustive visitor"
+                );
+            }
+        }, varValue
+    );
+}
+
+void pfGmVarSync::CreateVariable(
+    const ST::string& varName,
+    const pfGmVarSyncValue& varValue
+) const
+{
+    std::visit(
+        [this, &varName](auto&& value) {
+            using _VarT = std::decay_t<decltype(value)>;
+            if constexpr (std::is_same_v<_VarT, double>) {
+                VARSYNC_MSG(CreateNumericVar, msg)
+                StrCopy(msg.varName, varName.to_utf16().data(), std::size(msg.varName));
+                msg.varValue = value;
+                VARSYNC_SEND(msg)
+            } else if constexpr (std::is_same_v<_VarT, ST::string>) {
+                VARSYNC_MSG(CreateStringVar, msg)
+                StrCopy(msg.varName, varName.to_utf16().data(), std::size(msg.varName));
+                StrCopy(msg.varValue, value.to_utf16().data(), std::size(msg.varValue));
+                VARSYNC_SEND(msg)
+            } else {
+                static_assert(
+                    std::is_same_v<_VarT, double> || std::is_same_v<_VarT, ST::string>,
+                    "Non-exhaustive visitor"
+                );
+            }
+        }, varValue
+    );
+}
+
+#undef VARSYNC_SEND
+#undef VARSYNC_MSG
+
+// ===========================================================================
+
+class pfGmVarSyncCreateTrans : public pfGameCliCreateTrans
+{
+public:
+    pfGmVarSyncCreateTrans(pfGmVarSync* self, pfGmVarSyncHandler* handler)
+        : pfGameCliCreateTrans(self, handler)
+    {
+    }
+
+    void Send() override
+    {
+        VarSync_CreateParam param{};
+        constexpr size_t bufsz = sizeof(Cli2Srv_GameMgr_JoinGame) + sizeof(param) - sizeof(Cli2Srv_GameMgr_CreateGame::createData);
+        uint8_t msgbuf[bufsz];
+
+        Cli2Srv_GameMgr_JoinGame& msg = *reinterpret_cast<Cli2Srv_GameMgr_JoinGame*>(msgbuf);
+        msg.messageId = kCli2Srv_GameMgr_JoinGame;
+        msg.newGameId = kVarSyncTableID;
+        msg.createOptions = kGameJoinCommon;
+        msg.gameTypeId = kGameTypeId_VarSync;
+        msg.createDataBytes = sizeof(param);
+        memcpy(msg.createData, &param, sizeof(param));
+        ISend(&msg, bufsz);
+    }
+};
+
+void pfGmVarSync::Join(pfGmVarSyncHandler* handler)
+{
+    pfGmVarSync* game = new pfGmVarSync();
+    game->SendTransaction<pfGmVarSyncCreateTrans>(
+        game,
+        handler
+    );
+}
+
+// ===========================================================================
+
+bool pfGmVarSync::IsSupported()
+{
+    return NetCliAuthCheckCap(kCapsGameMgrVarSync);
+}

--- a/Sources/Plasma/FeatureLib/pfGameMgr/pfGmVarSync.h
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/pfGmVarSync.h
@@ -1,0 +1,143 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef _pfGmVarSync_h_
+#define _pfGmVarSync_h_
+
+#include "pfGameCli.h"
+
+#include <string_theory/string>
+#include <variant>
+
+class pfGmVarSync;
+
+using pfGmVarSyncValue = std::variant<ST::string, double>;
+
+/**
+ * Abstract base class declaring the event handler methods
+ * for legacy var sync.
+ */
+class pfGmVarSyncHandler : public pfGameHandler
+{
+public:
+    /**
+     * Gets a weak reference to the var sync game client that posts
+     * notifications to this handler.
+     */
+    pfGmVarSync* GetGameCli() const
+    {
+        return (pfGmVarSync*)pfGameHandler::GetGameCli();
+    }
+
+public:
+    /**
+     * Called when the server sends us an updated value for a synchronized variable.
+     */
+    virtual void OnVarChanged(uint32_t varID, pfGmVarSyncValue varValue) {}
+
+    /**
+     * Called when the server has sent us all of the variables that have been
+     * syncrhonized before we joined the game.
+     */
+    virtual void OnAllVarsSent() {}
+
+    /**
+     * Called when a new variable has been synchronized or as part of the initial
+     * state broadcast.
+     */
+    virtual void OnVarCreated(
+        ST::string varName,
+        uint32_t varID,
+        pfGmVarSyncValue value
+    ) {}
+};
+
+class pfGmVarSync : public pfGameCli
+{
+public:
+    CLASSNAME_REGISTER(pfGmVarSync);
+    GETINTERFACE_ANY(pfGmVarSync, pfGameCli);
+
+private:
+    template <typename _MsgT>
+    void Recv(const _MsgT& msg) = delete;
+
+protected:
+    bool RecvGameMgrMsg(const struct GameMsgHeader* msg) override;
+
+public:
+    pfGmVarSyncHandler* GetHandler() const
+    {
+        return static_cast<pfGmVarSyncHandler*>(pfGameCli::GetHandler());
+    }
+
+public:
+    /**
+     * Change the value of a variable on the server.
+     */
+    void SetVariable(uint32_t varID, const pfGmVarSyncValue& varValue) const;
+
+    /**
+     * Create a new variable on the server.
+     */
+    void CreateVariable(const ST::string& varName, const pfGmVarSyncValue& varValue) const;
+
+public:
+    /**
+     * Join a common var sync game in the current Age.
+     * \param[in] handler
+     * \parblock
+     * The var sync game event handler.
+     *
+     * This should be a weak reference to a subclass of `pfGmVarSyncHandler` that implements
+     * your blue spiral gameplay logic.
+     * \endparblock
+     */
+    static void Join(pfGmVarSyncHandler* handler);
+
+    /**
+     * Checks for the presence of a server-side var sync game manager.
+     */
+    static bool IsSupported();
+};
+
+#endif

--- a/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfPython/CMakeLists.txt
@@ -33,6 +33,7 @@ set(pfPython_SOURCES
     pyGlueHelpers.cpp
     pyGmBlueSpiral.cpp
     pyGmMarker.cpp
+    pyGmVarSync.cpp
     pyGrassShader.cpp
     pyGUIControl.cpp
     pyGUIControlButton.cpp
@@ -126,6 +127,7 @@ set(pfPython_HEADERS
     pyGeometry3.h
     pyGmBlueSpiral.h
     pyGmMarker.h
+    pyGmVarSync.h
     pyGrassShader.h
     pyGUIControl.h
     pyGUIControlButton.h
@@ -215,6 +217,7 @@ set(pfPython_GLUE
     pyGlueHelpers.h
     pyGmBlueSpiralGlue.cpp
     pyGmMarkerGlue.cpp
+    pyGmVarSyncGlue.cpp
     pyGrassShaderGlue.cpp
     pyGUIControlButtonGlue.cpp
     pyGUIControlCheckBoxGlue.cpp

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -89,6 +89,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGameMgr.h"
 #include "pyGmBlueSpiral.h"
 #include "pyGmMarker.h"
+#include "pyGmVarSync.h"
 
 // GUIDialog and its controls
 #include "pyGUIDialog.h"
@@ -1214,6 +1215,7 @@ void PythonInterface::AddPlasmaGameClasses(PyObject* plasmaGameMod)
     pyGameCli::AddPlasmaGameClasses(plasmaGameMod);
     pyGmBlueSpiral::AddPlasmaGameClasses(plasmaGameMod);
     pyGmMarker::AddPlasmaGameClasses(plasmaGameMod);
+    pyGmVarSync::AddPlasmaGameClasses(plasmaGameMod);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -1552,13 +1552,14 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
         int msgType = plAIMsg::kAIMsg_Unknown;
         pyObjectRef args;
 
-        if (plAIBrainCreatedMsg::ConvertNoRef(aiMsg))
+        if (plAIBrainCreatedMsg::ConvertNoRef(aiMsg)) {
             msgType = plAIMsg::kAIMsg_BrainCreated;
-        plAIArrivedAtGoalMsg* arrivedMsg = plAIArrivedAtGoalMsg::ConvertNoRef(aiMsg);
-        if (arrivedMsg) {
+        } else if (auto* arrivedMsg = plAIArrivedAtGoalMsg::ConvertNoRef(aiMsg)) {
             msgType = plAIMsg::kAIMsg_ArrivedAtGoal;
             args = PyTuple_New(1);
             PyTuple_SetItem(args.Get(), 0, pyPoint3::New(arrivedMsg->Goal()));
+        } else if (plAIBrainDestroyedMsg::ConvertNoRef(aiMsg)) {
+            msgType = plAIMsg::kAIMsg_BrainDestroyed;
         }
 
         // if no args were set, simply set to none

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -1560,6 +1560,13 @@ bool plPythonFileMod::MsgReceive(plMessage* msg)
             PyTuple_SetItem(args.Get(), 0, pyPoint3::New(arrivedMsg->Goal()));
         } else if (plAIBrainDestroyedMsg::ConvertNoRef(aiMsg)) {
             msgType = plAIMsg::kAIMsg_BrainDestroyed;
+        } else if (auto* goToMsg = plAIGoToGoalMsg::ConvertNoRef(aiMsg)) {
+            msgType = plAIMsg::kAIMsg_GoToGoal;
+            args = plPython::ConvertFrom(
+                plPython::ToTuple,
+                pyPoint3::New(goToMsg->Goal()),
+                goToMsg->AvoidingAvatars()
+            );
         }
 
         // if no args were set, simply set to none

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrain.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrain.cpp
@@ -74,6 +74,19 @@ void pyCritterBrain::RemoveReceiver(pyKey& oldReceiver)
     fBrain->RemoveReceiver(oldReceiver.getKey());
 }
 
+void pyCritterBrain::LocallyControlled(bool local)
+{
+    if (fBrain)
+        fBrain->LocallyControlled(local);
+}
+
+bool pyCritterBrain::LocallyControlled() const
+{
+    if (fBrain)
+        return fBrain->LocallyControlled();
+    return false;
+}
+
 PyObject* pyCritterBrain::GetSceneObject()
 {
     if (fBrain)

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrain.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrain.h
@@ -80,6 +80,9 @@ public:
     void AddReceiver(pyKey& newReceiver);
     void RemoveReceiver(pyKey& oldReceiver);
 
+    void LocallyControlled(bool local);
+    bool LocallyControlled() const;
+
     PyObject* GetSceneObject();
 
     void AddBehavior(const ST::string& animationName, const ST::string& behaviorName, bool loop = true, bool randomStartPos = true,

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
@@ -61,6 +61,7 @@ void pyAIMsg::AddPlasmaConstantsClasses(PyObject *m)
     PYTHON_ENUM_ELEMENT(PtAIMsgType, kUnknown, plAIMsg::kAIMsg_Unknown)
     PYTHON_ENUM_ELEMENT(PtAIMsgType, kBrainCreated, plAIMsg::kAIMsg_BrainCreated)
     PYTHON_ENUM_ELEMENT(PtAIMsgType, kArrivedAtGoal, plAIMsg::kAIMsg_ArrivedAtGoal)
+    PYTHON_ENUM_ELEMENT(PtAIMsgType, kBrainDestroyed, plAIMsg::kAIMsg_BrainDestroyed)
     PYTHON_ENUM_END(m, PtAIMsgType)
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
@@ -408,10 +408,11 @@ PYTHON_METHOD_DEFINITION(ptCritterBrain, vectorToPlayer, args)
 PYTHON_START_METHODS_TABLE(ptCritterBrain)
     PYTHON_METHOD(ptCritterBrain, addReceiver, "Params: key\nTells the brain that the specified key wants AI messages"),
     PYTHON_METHOD(ptCritterBrain, removeReceiver, "Params: key\nTells the brain that the specified key no longer wants AI messages"),
-    PYTHON_METHOD(ptCritterBrain, setLocallyControlled, "Params: local\n"
+    PYTHON_METHOD(ptCritterBrain, setLocallyControlled, "Type: (local: bool) -> None\n"
         "Tells the brain that we are the ones making all the AI decisions, and to prop location and other information to the server."),
     PYTHON_METHOD(ptCritterBrain, getSceneObject, "Returns the ptSceneObject this brain controls."),
-    PYTHON_METHOD_NOARGS(ptCritterBrain, getLocallyControlled, "Are we the one making AI decisions? NOTE: Not set automatically, some python script needs to "
+    PYTHON_METHOD_NOARGS(ptCritterBrain, getLocallyControlled, "Type: () -> bool\n"
+        "Are we the one making AI decisions? NOTE: Not set automatically, some python script needs to "
         "tell the brain this using setLocallyControlled()."),
     PYTHON_METHOD_WKEY(ptCritterBrain, addBehavior, "Params: animName, behaviorName, loop = 1, randomStartPos = 1, fadeInLen = 2.0, fadeOutLen = 2.0\n"
         "Adds a new animation to the brain as a behavior with the specified name and parameters. If multiple animations are assigned to the same behavior, "

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
@@ -62,6 +62,7 @@ void pyAIMsg::AddPlasmaConstantsClasses(PyObject *m)
     PYTHON_ENUM_ELEMENT(PtAIMsgType, kBrainCreated, plAIMsg::kAIMsg_BrainCreated)
     PYTHON_ENUM_ELEMENT(PtAIMsgType, kArrivedAtGoal, plAIMsg::kAIMsg_ArrivedAtGoal)
     PYTHON_ENUM_ELEMENT(PtAIMsgType, kBrainDestroyed, plAIMsg::kAIMsg_BrainDestroyed)
+    PYTHON_ENUM_ELEMENT(PtAIMsgType, kGoToGoal, plAIMsg::kAIMsg_GoToGoal)
     PYTHON_ENUM_END(m, PtAIMsgType)
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyCritterBrainGlue.cpp
@@ -46,6 +46,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plMessage/plAIMsg.h"
 
+#include "plPythonConvert.h"
 #include "pyEnum.h"
 #include "pyGeometry3.h"
 #include "pyGlueHelpers.h"
@@ -143,6 +144,23 @@ PYTHON_METHOD_DEFINITION(ptCritterBrain, removeReceiver, args)
     pyKey* key = pyKey::ConvertFrom(keyObj);
     self->fThis->RemoveReceiver(*key);
     PYTHON_RETURN_NONE;
+}
+
+PYTHON_METHOD_DEFINITION(ptCritterBrain, setLocallyControlled, args)
+{
+    char local;
+    if (!PyArg_ParseTuple(args, "b", &local)) {
+        PyErr_SetString(PyExc_TypeError, "setLocallyControlled expects a boolean");
+        PYTHON_RETURN_ERROR;
+    }
+
+    self->fThis->LocallyControlled(local != 0);
+    PYTHON_RETURN_NONE;
+}
+
+PYTHON_METHOD_DEFINITION_NOARGS(ptCritterBrain, getLocallyControlled)
+{
+    return plPython::ConvertFrom(self->fThis->LocallyControlled());
 }
 
 PYTHON_METHOD_DEFINITION(ptCritterBrain, getSceneObject, GetSceneObject)
@@ -390,7 +408,11 @@ PYTHON_METHOD_DEFINITION(ptCritterBrain, vectorToPlayer, args)
 PYTHON_START_METHODS_TABLE(ptCritterBrain)
     PYTHON_METHOD(ptCritterBrain, addReceiver, "Params: key\nTells the brain that the specified key wants AI messages"),
     PYTHON_METHOD(ptCritterBrain, removeReceiver, "Params: key\nTells the brain that the specified key no longer wants AI messages"),
+    PYTHON_METHOD(ptCritterBrain, setLocallyControlled, "Params: local\n"
+        "Tells the brain that we are the ones making all the AI decisions, and to prop location and other information to the server."),
     PYTHON_METHOD(ptCritterBrain, getSceneObject, "Returns the ptSceneObject this brain controls."),
+    PYTHON_METHOD_NOARGS(ptCritterBrain, getLocallyControlled, "Are we the one making AI decisions? NOTE: Not set automatically, some python script needs to "
+        "tell the brain this using setLocallyControlled()."),
     PYTHON_METHOD_WKEY(ptCritterBrain, addBehavior, "Params: animName, behaviorName, loop = 1, randomStartPos = 1, fadeInLen = 2.0, fadeOutLen = 2.0\n"
         "Adds a new animation to the brain as a behavior with the specified name and parameters. If multiple animations are assigned to the same behavior, "
         "they will be randomly picked from when started."),

--- a/Sources/Plasma/FeatureLib/pfPython/pyGmVarSync.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGmVarSync.cpp
@@ -1,0 +1,136 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "pyGmVarSync.h"
+
+#include <type_traits>
+
+#include "pfGameMgr/pfGmVarSync.h"
+
+#include "plPythonCallable.h"
+#include "pyGameHandler.h"
+#include "pyObjectRef.h"
+
+// ===========================================================================
+
+void pyGmVarSync::SetVariable(uint32_t varID, const pfGmVarSyncValue& varValue) const
+{
+    GetGameCli()->SetVariable(varID, varValue);
+}
+
+void pyGmVarSync::CreateVariable(const ST::string& varName, const pfGmVarSyncValue& varValue) const
+{
+    GetGameCli()->CreateVariable(varName, varValue);
+}
+
+// ===========================================================================
+
+namespace plPython
+{
+    template<>
+    PyObject* ConvertFrom(pfGmVarSyncValue&& value)
+    {
+        return std::visit(
+            [](auto&& value) -> PyObject* {
+                using _ValueT = std::decay_t<decltype(value)>;
+                if constexpr (std::is_same_v<_ValueT, ST::string>) {
+                    return PyUnicode_FromSTString(value);
+               } else if constexpr (std::is_same_v<_ValueT, double>) {
+                    return PyFloat_FromDouble(value);
+               } else {
+                    static_assert(
+                        std::is_same_v<_ValueT, double> || std::is_same_v<_ValueT, ST::string>,
+                        "Non-exhaustive visitor"
+                    );
+               }
+            }, value
+        );
+    }
+}
+
+// ===========================================================================
+
+class pyGmVarSyncHandler : public pyGameHandler<pfGmVarSyncHandler, pyGmVarSync>
+{
+public:
+    pyGmVarSyncHandler(PyObject* obj)
+        : pyGameHandler(obj)
+    {
+    }
+
+public:
+    void OnVarChanged(uint32_t varID, pfGmVarSyncValue varValue) override
+    {
+        ICallMethod("OnVarChanged", varID, std::move(varValue));
+    }
+
+    void OnAllVarsSent() override
+    {
+        ICallMethod("OnAllVarsSent");
+    }
+
+    void OnVarCreated(
+        ST::string varName,
+        uint32_t varID,
+        pfGmVarSyncValue value
+    ) override
+    {
+        ICallMethod(
+            "OnVarCreated",
+            std::move(varName),
+            varID,
+            std::move(value)
+        );
+    }
+};
+
+// ===========================================================================
+
+void pyGmVarSync::Join(PyObject* handler)
+{
+    pfGmVarSync::Join(new pyGmVarSyncHandler(handler));
+}
+
+bool pyGmVarSync::IsSupported()
+{
+    return pfGmVarSync::IsSupported();
+}

--- a/Sources/Plasma/FeatureLib/pfPython/pyGmVarSync.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGmVarSync.h
@@ -40,21 +40,41 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#ifndef _pfGameMgrCreatable_h_
-#define _pfGameMgrCreatable_h_
+#ifndef _pyGmVarSync_h_
+#define _pyGmVarSync_h_
 
-#include "pnFactory/plCreator.h"
+#include "pyGameCli.h"
 
-#include "pfGameCli.h"
-REGISTER_NONCREATABLE(pfGameCli);
+#include <variant>
 
-#include "pfGmBlueSpiral.h"
-REGISTER_NONCREATABLE(pfGmBlueSpiral);
+using pfGmVarSyncValue = std::variant<ST::string, double>;
 
-#include "pfGmMarker.h"
-REGISTER_NONCREATABLE(pfGmMarker);
+class pfGmVarSync;
 
-#include "pfGmVarSync.h"
-REGISTER_NONCREATABLE(pfGmVarSync);
+class pyGmVarSync : public pyGameCli
+{
+public:
+    // required functions for PyObject interoperability
+    PYTHON_CLASS_NEW_FRIEND(ptGmVarSync);
+    PYTHON_CLASS_GMCLI_NEW_DEFINITION(pfGmVarSync);
+    PYTHON_CLASS_CHECK_DEFINITION;                        // returns true if the PyObject is a pyGmVarSync object
+    PYTHON_CLASS_CONVERT_FROM_DEFINITION(pyGmVarSync); // converts a PyObject to a pyGmVarSync (throws error if not correct type)
+
+protected:
+    pfGmVarSync* GetGameCli() const { return (pfGmVarSync*)fCli; }
+
+public:
+    void SetVariable(uint32_t varID, const pfGmVarSyncValue& varValue) const;
+
+    void CreateVariable(const ST::string& varName, const pfGmVarSyncValue& varValue) const;
+
+public:
+    static void Join(PyObject* handler);
+
+    static bool IsSupported();
+
+public:
+    static void AddPlasmaGameClasses(PyObject* m);
+};
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfPython/pyGmVarSyncGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGmVarSyncGlue.cpp
@@ -116,10 +116,22 @@ PYTHON_METHOD_DEFINITION_STATIC_NOARGS(ptGmVarSync, isSupported)
 }
 
 PYTHON_START_METHODS_TABLE(ptGmVarSync)
-    PYTHON_METHOD_STATIC(ptGmVarSync, join, "Join the common var sync game in the current Age."),
-    PYTHON_METHOD_STATIC_NOARGS(ptGmVarSync, isSupported, "Checks for the presence of a server-side var sync game manager."),
-    PYTHON_METHOD(ptGmVarSync, setVariable, "Change the value of a variable on the server."),
-    PYTHON_METHOD(ptGmVarSync, createVariable, "Create a new variable on the server."),
+    PYTHON_METHOD_STATIC(ptGmVarSync, join,
+        "Type: (handler: Any) -> None\n"
+        "Join the common var sync game in the current Age."
+    ),
+    PYTHON_METHOD_STATIC_NOARGS(ptGmVarSync, isSupported,
+        "Type: () -> bool\n"
+        "Checks for the presence of a server-side var sync game manager."
+    ),
+    PYTHON_METHOD(ptGmVarSync, setVariable,
+        "Type: (varID: int, value: Union[float, str]) -> None\n"
+        "Change the value of a variable on the server."
+    ),
+    PYTHON_METHOD(ptGmVarSync, createVariable,
+        "Type: (varName: str, value: Union[float, str]) -> None\n"
+        "Create a new variable on the server."
+    ),
 PYTHON_END_METHODS_TABLE;
 
 // Type structure definition

--- a/Sources/Plasma/FeatureLib/pfPython/pyGmVarSyncGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGmVarSyncGlue.cpp
@@ -1,0 +1,140 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "plPythonConvert.h"
+#include "pyGameCli.h"
+#include "pyGlueHelpers.h"
+#include "pyGmVarSync.h"
+
+// ===========================================================================
+
+PYTHON_CLASS_DEFINITION(ptGmVarSync, pyGmVarSync);
+
+PYTHON_DEFAULT_NEW_DEFINITION(ptGmVarSync, pyGmVarSync)
+PYTHON_DEFAULT_DEALLOC_DEFINITION(ptGmVarSync)
+
+PYTHON_NO_INIT_DEFINITION(ptGmVarSync)
+
+PYTHON_METHOD_DEFINITION(ptGmVarSync, setVariable, args)
+{
+    unsigned int varID;
+    PyObject* varValueObj;
+    if (!PyArg_ParseTuple(args, "IO", &varID, &varValueObj)) {
+        PyErr_SetString(PyExc_TypeError, "setVariable expects an unsigned integer and a number or string");
+        PYTHON_RETURN_ERROR;
+    }
+
+    if (PyUnicode_Check(varValueObj)) {
+        self->fThis->SetVariable(varID, PyUnicode_AsSTString(varValueObj));
+        PYTHON_RETURN_NONE;
+    } else if (PyNumber_Check(varValueObj)) {
+        pyObjectRef varFloatObj = PyNumber_Float(varValueObj);
+        self->fThis->SetVariable(varID, PyFloat_AsDouble(varFloatObj.Get()));
+        PYTHON_RETURN_NONE;
+    }
+
+    PyErr_SetString(PyExc_TypeError, "setVariable expects an unsigned integer and a number or string");
+    PYTHON_RETURN_ERROR;
+}
+
+PYTHON_METHOD_DEFINITION(ptGmVarSync, createVariable, args)
+{
+    ST::string varName;
+    PyObject* varValueObj;
+    if (!PyArg_ParseTuple(args, "O&O", &PyUnicode_STStringConverter, &varName, &varValueObj)) {
+        PyErr_SetString(PyExc_TypeError, "createVariable expects a string and a number or string");
+        PYTHON_RETURN_ERROR;
+    }
+
+    if (PyUnicode_Check(varValueObj)) {
+        self->fThis->CreateVariable(varName, PyUnicode_AsSTString(varValueObj));
+        PYTHON_RETURN_NONE;
+    } else if (PyNumber_Check(varValueObj)) {
+        pyObjectRef varFloatObj = PyNumber_Float(varValueObj);
+        self->fThis->CreateVariable(varName, PyFloat_AsDouble(varFloatObj.Get()));
+        PYTHON_RETURN_NONE;
+    }
+
+    PyErr_SetString(PyExc_TypeError, "createVariable expects a string and a number or string");
+    PYTHON_RETURN_ERROR;
+}
+
+PYTHON_METHOD_DEFINITION_STATIC(ptGmVarSync, join, args)
+{
+    PyObject* handler;
+    if (!PyArg_ParseTuple(args, "O", &handler)) {
+        PyErr_SetString(PyExc_TypeError, "ptGmVarSync.join() expects an object");
+        PYTHON_RETURN_ERROR;
+    }
+
+    pyGmVarSync::Join(handler);
+    PYTHON_RETURN_NONE;
+}
+
+PYTHON_METHOD_DEFINITION_STATIC_NOARGS(ptGmVarSync, isSupported)
+{
+    return plPython::ConvertFrom(self->fThis->IsSupported());
+}
+
+PYTHON_START_METHODS_TABLE(ptGmVarSync)
+    PYTHON_METHOD_STATIC(ptGmVarSync, join, "Join the common var sync game in the current Age."),
+    PYTHON_METHOD_STATIC_NOARGS(ptGmVarSync, isSupported, "Checks for the presence of a server-side var sync game manager."),
+    PYTHON_METHOD(ptGmVarSync, setVariable, "Change the value of a variable on the server."),
+    PYTHON_METHOD(ptGmVarSync, createVariable, "Create a new variable on the server."),
+PYTHON_END_METHODS_TABLE;
+
+// Type structure definition
+PLASMA_DEFAULT_TYPE_WBASE(ptGmVarSync, pyGameCli, "Legacy var sync game client.");
+
+// required functions for PyObject interoperability
+PYTHON_CLASS_GMCLI_NEW_IMPL(ptGmVarSync, pyGmVarSync, pfGmVarSync)
+PYTHON_CLASS_CHECK_IMPL(ptGmVarSync, pyGmVarSync)
+PYTHON_CLASS_CONVERT_FROM_IMPL(ptGmVarSync, pyGmVarSync)
+
+// ===========================================================================
+
+void pyGmVarSync::AddPlasmaGameClasses(PyObject* m)
+{
+    PYTHON_CLASS_IMPORT_START(m);
+    PYTHON_CLASS_IMPORT(m, ptGmVarSync);
+    PYTHON_CLASS_IMPORT_END(m);
+}

--- a/Sources/Plasma/NucleusLib/inc/plCreatableIndex.h
+++ b/Sources/Plasma/NucleusLib/inc/plCreatableIndex.h
@@ -963,6 +963,7 @@ CLASS_INDEX_LIST_START
     CLASS_INDEX(plDisplayScaleChangedMsg),
     CLASS_INDEX(plMetalPipeline),
     CLASS_INDEX(plAIBrainDestroyedMsg),
+    CLASS_INDEX(plAIGoToGoalMsg),
 CLASS_INDEX_LIST_END
 
 #endif // plCreatableIndex_inc

--- a/Sources/Plasma/NucleusLib/inc/plCreatableIndex.h
+++ b/Sources/Plasma/NucleusLib/inc/plCreatableIndex.h
@@ -962,6 +962,7 @@ CLASS_INDEX_LIST_START
     CLASS_INDEX(plSubtitleMsg),
     CLASS_INDEX(plDisplayScaleChangedMsg),
     CLASS_INDEX(plMetalPipeline),
+    CLASS_INDEX(plAIBrainDestroyedMsg),
 CLASS_INDEX_LIST_END
 
 #endif // plCreatableIndex_inc

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -1945,10 +1945,10 @@ bool plArmatureMod::IsLocalAvatar()
 
 bool plArmatureMod::IsLocalAI() const
 {
-    // Formerly a lot of silly cached rigamaroll... Now, we'll just rely
-    // on the fact that one player is the game master. HACK TURD if net groups
-    // are ever brought back.
-    return plNetClientApp::GetInstance()->IsLocallyOwned(this);
+    plAvBrainCritter* ai = plAvBrainCritter::ConvertNoRef(FindBrainByClass(plAvBrainCritter::Index()));
+    if (ai)
+        return ai->LocallyControlled();
+    return false; // not an AI, obviously not local
 }
 
 void plArmatureMod::SynchIfLocal(double timeNow, int force)

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
@@ -184,6 +184,11 @@ bool plAvBrainCritter::Apply(double time, float elapsed)
 
 bool plAvBrainCritter::MsgReceive(plMessage* msg)
 {
+    if (auto* pGoToMsg = plAIGoToGoalMsg::ConvertNoRef(msg)) {
+        GoToGoal(pGoToMsg->Goal(), pGoToMsg->AvoidingAvatars());
+        return true;
+    }
+
     return plArmatureBrain::MsgReceive(msg);
 }
 
@@ -339,6 +344,13 @@ void plAvBrainCritter::GoToGoal(hsPoint3 newGoal, bool avoidingAvatars /* = fals
     if(!RunningBehavior(RunBehaviorName()))
         fNextMode = IPickBehavior(kRun);
     // Missing TODO Turd: Pathfinding.
+
+    // Let everyone who's listending know that we're going somewhere.
+    plAIGoToGoalMsg* pMsg = new plAIGoToGoalMsg(fArmature->GetKey(), nullptr);
+    pMsg->AddReceivers(fReceivers);
+    pMsg->Goal(newGoal);
+    pMsg->AvoidingAvatars(avoidingAvatars);
+    pMsg->Send();
 }
 
 bool plAvBrainCritter::AtGoal() const

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
@@ -134,7 +134,7 @@ protected:
 ///////////////////////////////////////////////////////////////////////////////
 
 plAvBrainCritter::plAvBrainCritter()
-    : fWalkingStrategy(), fCurMode(kIdle), fNextMode(kIdle),
+    : fLocallyControlled(), fWalkingStrategy(), fCurMode(kIdle), fNextMode(kIdle),
       fFadingNextBehavior(true), fAvoidingAvatars(), fDotGoal(),
       fAngRight()
 {

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
@@ -213,6 +213,12 @@ void plAvBrainCritter::Activate(plArmatureModBase* avMod)
 
 void plAvBrainCritter::Deactivate()
 {
+    // Although "destroyed" is in the past tense, this is really a warning message.
+    // The brain is about to go away, so save anything you need to and toss it!
+    plAIBrainDestroyedMsg* brainDestroyed = new plAIBrainDestroyedMsg(fArmature->GetKey(), nullptr);
+    brainDestroyed->AddReceivers(fReceivers);
+    brainDestroyed->Send();
+
     plArmatureBrain::Deactivate();
 }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.cpp
@@ -642,12 +642,10 @@ void plAvBrainCritter::IEvalGoal()
             fNextMode = IPickBehavior(kIdle);
 
             // tell everyone who cares that we have arrived
-            for (unsigned i = 0; i < fReceivers.size(); ++i)
-            {
-                plAIArrivedAtGoalMsg* msg = new plAIArrivedAtGoalMsg(fArmature->GetKey(), fReceivers[i]);
-                msg->Goal(fFinalGoalPos);
-                msg->Send();
-            }
+            plAIArrivedAtGoalMsg* msg = new plAIArrivedAtGoalMsg(fArmature->GetKey(), nullptr);
+            msg->AddReceivers(fReceivers);
+            msg->Goal(fFinalGoalPos);
+            msg->Send();
         }
     }
 }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainCritter.h
@@ -106,6 +106,9 @@ public:
     void StartBehavior(const ST::string& behaviorName, bool fade = true);
     bool RunningBehavior(const ST::string& behaviorName) const;
 
+    void LocallyControlled(bool local) { fLocallyControlled = local; }
+    bool LocallyControlled() const { return fLocallyControlled; }
+
     ST::string BehaviorName(int behavior) const;
     ST::string AnimationName(int behavior) const;
     int CurBehavior() const {return fCurMode;}
@@ -169,6 +172,8 @@ protected:
     int fCurMode; // current behavior we are running
     int fNextMode; // the next behavior to run (-1 if we aren't switching on next eval)
     bool fFadingNextBehavior; // is the next behavior supposed to blend?
+
+    bool fLocallyControlled; // is our local AI script the one making all the choices?
 
     bool fAvoidingAvatars; // are we avoiding avatars to the best of our ability when pathfinding?
     hsPoint3 fFinalGoalPos; // the location we are pathfinding to

--- a/Sources/Plasma/PubUtilLib/plMessage/plAIMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAIMsg.cpp
@@ -86,3 +86,19 @@ void plAIArrivedAtGoalMsg::Write(hsStream* stream, hsResMgr* mgr)
     plAIMsg::Write(stream, mgr);
     fGoal.Write(stream);
 }
+
+///////////////////////////////////////////////////////////////////////////////
+
+void plAIGoToGoalMsg::Read(hsStream* stream, hsResMgr* mgr)
+{
+    plAIMsg::Read(stream, mgr);
+    fGoal.Read(stream);
+    fAvoidingAvatars = stream->ReadBool();
+}
+
+void plAIGoToGoalMsg::Write(hsStream* stream, hsResMgr* mgr)
+{
+    plAIMsg::Write(stream, mgr);
+    fGoal.Write(stream);
+    fAvoidingAvatars = stream->ReadBool();
+}

--- a/Sources/Plasma/PubUtilLib/plMessage/plAIMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAIMsg.h
@@ -71,6 +71,7 @@ public:
         kAIMsg_Unknown,
         kAIMsg_BrainCreated,
         kAIMsg_ArrivedAtGoal,
+        kAIMsg_BrainDestroyed,
     };
 
 private:
@@ -111,6 +112,26 @@ public:
 
 private:
     hsPoint3 fGoal;
+};
+
+/**
+ * Message spammed to anyone listening so they can discard the brain's key
+ * does NOT get net-propped
+ */
+class plAIBrainDestroyedMsg : public plAIMsg
+{
+public:
+    plAIBrainDestroyedMsg() : plAIMsg() { SetBCastFlag(plMessage::kBCastByExactType); }
+    plAIBrainDestroyedMsg(const plKey& sender, const plKey& receiver)
+        : plAIMsg(sender, receiver)
+    {
+    }
+
+    CLASSNAME_REGISTER(plAIBrainDestroyedMsg);
+    GETINTERFACE_ANY(plAIBrainDestroyedMsg, plAIMsg);
+
+    void Read(hsStream* stream, hsResMgr* mgr) override { plAIMsg::Read(stream, mgr); }
+    void Write(hsStream* stream, hsResMgr* mgr) override { plAIMsg::Write(stream, mgr); }
 };
 
 #endif // plAIMsg_inc

--- a/Sources/Plasma/PubUtilLib/plMessage/plAIMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAIMsg.h
@@ -72,6 +72,7 @@ public:
         kAIMsg_BrainCreated,
         kAIMsg_ArrivedAtGoal,
         kAIMsg_BrainDestroyed,
+        kAIMsg_GoToGoal,
     };
 
 private:
@@ -132,6 +133,37 @@ public:
 
     void Read(hsStream* stream, hsResMgr* mgr) override { plAIMsg::Read(stream, mgr); }
     void Write(hsStream* stream, hsResMgr* mgr) override { plAIMsg::Write(stream, mgr); }
+};
+
+/**
+ * Message sent to the AI brain to force it to go to a specific goal
+ * might get net-proppped
+ */
+class plAIGoToGoalMsg : public plAIMsg
+{
+    hsPoint3 fGoal;
+    bool     fAvoidingAvatars;
+
+public:
+    plAIGoToGoalMsg() : plAIMsg() {}
+    plAIGoToGoalMsg(const plKey& sender, const plKey& receiver)
+        : plAIMsg(sender, receiver),
+          fAvoidingAvatars()
+    {
+        // Only gets sent to specific receivers
+    }
+
+    CLASSNAME_REGISTER(plAIGoToGoalMsg);
+    GETINTERFACE_ANY(plAIGoToGoalMsg, plAIMsg);
+
+    void Read(hsStream* stream, hsResMgr* mgr) override;
+    void Write(hsStream* stream, hsResMgr* mgr) override;
+
+    void     Goal(const hsPoint3& goal) { fGoal = goal; }
+    hsPoint3 Goal() const { return fGoal; }
+
+    bool AvoidingAvatars() const { return fAvoidingAvatars; }
+    void AvoidingAvatars(bool value) { fAvoidingAvatars = value; }
 };
 
 #endif // plAIMsg_inc

--- a/Sources/Plasma/PubUtilLib/plMessage/plAIMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAIMsg.h
@@ -116,8 +116,8 @@ private:
 };
 
 /**
- * Message spammed to anyone listening so they can discard the brain's key
- * does NOT get net-propped
+ * Message spammed to anyone listening so they can discard the brain's key.
+ * Does NOT get net-propped.
  */
 class plAIBrainDestroyedMsg : public plAIMsg
 {
@@ -136,8 +136,8 @@ public:
 };
 
 /**
- * Message sent to the AI brain to force it to go to a specific goal
- * might get net-proppped
+ * Message sent to the AI brain to force it to go to a specific goal.
+ * Might get net-propped.
  */
 class plAIGoToGoalMsg : public plAIMsg
 {

--- a/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
@@ -325,6 +325,7 @@ REGISTER_CREATABLE(plVaultNotifyMsg);
 REGISTER_CREATABLE(plAIArrivedAtGoalMsg);
 REGISTER_CREATABLE(plAIBrainCreatedMsg);
 REGISTER_CREATABLE(plAIBrainDestroyedMsg);
+REGISTER_CREATABLE(plAIGoToGoalMsg);
 REGISTER_CREATABLE(plAIMsg);
 
 #include "plAvCoopMsg.h"

--- a/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plMessageCreatable.h
@@ -324,6 +324,7 @@ REGISTER_CREATABLE(plVaultNotifyMsg);
 #include "plAIMsg.h"
 REGISTER_CREATABLE(plAIArrivedAtGoalMsg);
 REGISTER_CREATABLE(plAIBrainCreatedMsg);
+REGISTER_CREATABLE(plAIBrainDestroyedMsg);
 REGISTER_CREATABLE(plAIMsg);
 
 #include "plAvCoopMsg.h"


### PR DESCRIPTION
This continues the game manager restore compatibility work by bringing back the VarSync quab game. The non-game manager version has been rewritten simultaneously to improve ownership and synchronization. This changeset has been in progress for over a year, so there are some remnants of ideas about how to improve synchronizing critter AI in the code that has been somewhat left by the wayside, specifically around the whole GoToGoal aspect. A lot of the commit messages are aspirational in that regard.

Notes:
- Fixed the client crash on Cyan's server when the owner of the VarSync game links out AND retains the quabs in their previous location.
- When the game owner is running this implementation, the "goal position" of the quabs will be synchronized to other clients, improving the behavior of the quabs on remote clients (e.g. they should run in the same general direction now). Older clients will safely ignore this information.
- This will not work 100% correctly on MOSS because MOSS "knows" that the quab game is broken and refuses to correctly reassign ownership when the owner leaves. This could probably be mitigated with a special case, but I have elected to not do this in the hope that MOSS will be fixed instead of me needing to add yet another hack.