### PR TITLE
Remove uses of `_PyModule_Clear()`.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -180,6 +180,8 @@ bool    PythonInterface::IsInShutdown = false;           // whether we are _real
 PyObject* PythonInterface::stdOut = nullptr;            // python object of the stdout file
 PyObject* PythonInterface::stdErr = nullptr;            // python object of the err file
 
+PyObject* PythonInterface::builtInModuleName = nullptr;
+
 bool      PythonInterface::debug_initialized = false;   // has the debug been initialized yet?
 PyObject* PythonInterface::dbgMod = nullptr;            // display module for stdout and stderr
 PyObject* PythonInterface::dbgOut = nullptr;
@@ -930,6 +932,10 @@ void PythonInterface::initPython()
     if (!ICheckedInit<PyConfig, Py_InitializeFromConfig, PyConfig_Clear>(config, dbgLog, "Main init failed!"))
         return;
 
+    // Create an interned string for __builtins__ so we don't have to keep converting the string over and over.
+    // Python LIKELY already has this string interned.
+    builtInModuleName = PyUnicode_InternFromString("__builtins__");
+
     // Initialize built-in Plasma modules. For some reason, when using the append-inittab thingy,
     // we get complaints about these modules being leaked :(
     // Note: If you add a new built-in module,
@@ -1265,6 +1271,9 @@ void PythonInterface::finiPython()
         if (usePythonDebugger)
             debugServer.Disconnect();
 #endif
+
+        Py_CLEAR(builtInModuleName);
+
         // let Python clean up after itself
         if (Py_FinalizeEx() != 0)
             dbgLog->AddLine("Hmm... Errors during Python shutdown.");
@@ -1447,7 +1456,7 @@ PyObject* PythonInterface::CreateModule(const char* module)
     {
         // clear it
         hsAssert(false, ST::format("ERROR! Creating a python module of the same name - {}", module).c_str());
-        _PyModule_Clear(m);
+        ClearModule(m);
     }
 
     // create the module
@@ -1457,12 +1466,12 @@ PyObject* PythonInterface::CreateModule(const char* module)
     d = PyModule_GetDict(m);
     // add in the built-ins
     // first make sure that we don't already have the builtins
-    if (PyDict_GetItemString(d, "__builtins__") == nullptr)
+    if (PyDict_GetItem(d, builtInModuleName) == nullptr)
     {
         // if we need the builtins then find the builtin module
         PyObject *bimod = PyImport_ImportModule("builtins");
         // then add the builtin dicitionary to our module's dictionary
-        if (bimod == nullptr || PyDict_SetItemString(d, "__builtins__", bimod) != 0) {
+        if (bimod == nullptr || PyDict_SetItem(d, builtInModuleName, bimod) != 0) {
             getOutputAndReset();
             return nullptr;
         }
@@ -1471,6 +1480,42 @@ PyObject* PythonInterface::CreateModule(const char* module)
     return m;
 }
 
+void PythonInterface::ClearModule(PyObject* m)
+{
+    hsAssert(PyModule_Check(m), "PythonInterface::ClearModule() called on a non-module object");
+    PyObject* dict = PyModule_GetDict(m);
+
+    // This is basically a reimplementation of the _PyModule_ClearDict function. It's been
+    // "private" forever but was finally removed from Python's public API as of 3.13. So,
+    // here we are.
+    Py_ssize_t pos = 0;
+    PyObject* key;
+    PyObject* value;
+
+    // First, clear everything that begins with a single underscore.
+    while (PyDict_Next(dict, &pos, &key, &value)) {
+        if (value == Py_None && !PyUnicode_Check(key))
+            continue;
+        if (!(PyUnicode_READ_CHAR(key, 0) == '_' && PyUnicode_READ_CHAR(key, 1) != '_'))
+            continue;
+        if (PyDict_SetItem(dict, key, Py_None) != 0)
+            PyErr_Print();
+    }
+
+    // Finally, clear everything except __builtins__
+    pos = 0;
+    while (PyDict_Next(dict, &pos, &key, &value)) {
+        if (value == Py_None || !PyUnicode_Check(key))
+            continue;
+        if (PyUnicode_Compare(key, builtInModuleName) != 0) {
+            if (PyErr_Occurred())
+                PyErr_Print();
+            continue;
+        }
+        if (PyDict_SetItem(dict, key, Py_None) != 0)
+            PyErr_Print();
+    }
+}
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
@@ -71,6 +71,8 @@ private:
     static PyObject* stdOut;    // python object of the stdout file
     static PyObject* stdErr;    // python object of the err file
 
+    static PyObject* builtInModuleName;
+
     static bool debug_initialized;    // has the debug been initialized yet?
     static PyObject* dbgMod;    // display module for stdout and stderr
     static PyObject* dbgOut;
@@ -142,6 +144,9 @@ public:
 
     // create a new module with built-ins
     static PyObject* CreateModule(const char* module);
+
+    /** Clears the dict of a Python module. Analagous to `_PyModule_Clear()`. */
+    static void ClearModule(PyObject* m);
 
     // Determine if the module name is unique
     static bool IsModuleNameUnique(const ST::string& module);

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -316,7 +316,7 @@ plPythonFileMod::~plPythonFileMod()
     // then get rid of this module
     // NOTE: fModule shouldn't be made in the plugin, only at runtime
     if (!fModuleName.empty() && fModule) {
-        //_PyModule_Clear(fModule);
+        //PythonInterface::ClearModule(fModule);
         PyObject* m;
         PyObject* modules = PyImport_GetModuleDict();
         if (modules && (m = PyDict_GetItemString(modules, fModuleName.c_str())) && PyModule_Check(m)) {


### PR DESCRIPTION
Fixes #1649 by implementing `_PyModule_ClearDict()` in our code.