### PR TITLE
Remove `PtGetPublicAgeList` `cbObject` parameter that had no effect

### DIFF
--- a/Scripts/Python/Personal.py
+++ b/Scripts/Python/Personal.py
@@ -119,7 +119,7 @@ class Personal(ptResponder):
             if cityInfo:
                 if cityInfo.getAgeInstanceGuid()==kEmptyGuid:
                     # we don't have it yet, so make it! (the callback will make it for us)
-                    PtGetPublicAgeList('city',self)
+                    PtGetPublicAgeList('city')
             else:
                 PtDebugPrint("hmm. city link has no age info node")
         else:

--- a/Scripts/Python/nxusBookMachine.py
+++ b/Scripts/Python/nxusBookMachine.py
@@ -591,11 +591,11 @@ class nxusBookMachine(ptModifier):
 
     def IPublicAgeCreated(self, ageName):
         PtDebugPrint("IPublicAgeCreated: " + ageName)
-        PtGetPublicAgeList(ageName, self)
+        PtGetPublicAgeList(ageName)
 
     def IPublicAgeRemoved(self, ageName):
         PtDebugPrint("IPublicAgeRemoved: " + ageName)
-        PtGetPublicAgeList(ageName, self)
+        PtGetPublicAgeList(ageName)
 
     def IHoodCreated(self, ageInfo):
         PtDebugPrint("OnVaultNotify: Setting the new hood's language to %d " % PtGetLanguage())
@@ -707,8 +707,8 @@ class nxusBookMachine(ptModifier):
                         ageInfo.setAgeFilename(ageFilename)
                         ageInfo.setAgeInstanceGuid(hardcoded)
                         ageData.instances.append(AgeInstance((ageInfo, 0, 0)))
-                PtGetPublicAgeList(ageFilename, self)
-            PtGetPublicAgeList('Neighborhood', self)
+                PtGetPublicAgeList(ageFilename)
+            PtGetPublicAgeList('Neighborhood')
 
             # set up the camera so when the one shot returns it gets set up right (one shot was fighting with python for camera control)
             virtCam = ptCamera()

--- a/Scripts/Python/plasma/Plasma.py
+++ b/Scripts/Python/plasma/Plasma.py
@@ -570,9 +570,9 @@ def PtGetPrevAgeName():
     """Returns filename of previous age visited"""
     ...
 
-def PtGetPublicAgeList(ageName, cbObject=None):
+def PtGetPublicAgeList(ageName):
     """Get list of public ages for the given age name.
-    cbObject, if supplied should have a method called gotPublicAgeList(self,ageList). ageList is a list of tuple(ptAgeInfoStruct,nPlayersInAge)
+    The age list will be delivered asynchronously through the callback method gotPublicAgeList(self,ageList). ageList is a list of tuple(ptAgeInfoStruct,nPlayersInAge)
     """
     ...
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -2169,17 +2169,15 @@ void cyMisc::ShootBulletFromObject(pyKey &selfkey, pySceneObject* sobj, float ra
 //////////////////////////////////////////////////////////////////////////////
 //
 // Function   : GetPublicAgeList
-// PARAMETERS : ageName, callback object
+// PARAMETERS : ageName
 //
 // PURPOSE    : Get the list of public ages for the given age name.
 //
-void cyMisc::GetPublicAgeList(const ST::string& ageName, PyObject * cbObject)
+void cyMisc::GetPublicAgeList(const ST::string& ageName)
 {
-    if (cbObject)
-        Py_XINCREF(cbObject);
     NetCommGetPublicAgeList(
         ageName,
-        cbObject,
+        nullptr,
         plNetCommReplyMsg::kParamTypePython
     );
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -2175,11 +2175,7 @@ void cyMisc::ShootBulletFromObject(pyKey &selfkey, pySceneObject* sobj, float ra
 //
 void cyMisc::GetPublicAgeList(const ST::string& ageName)
 {
-    NetCommGetPublicAgeList(
-        ageName,
-        nullptr,
-        plNetCommReplyMsg::kParamTypePython
-    );
+    NetCommGetPublicAgeList(ageName, nullptr);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -745,11 +745,11 @@ public:
     //////////////////////////////////////////////////////////////////////////////
     //
     // Function   : GetPublicAgeList
-    // PARAMETERS : ageName, callback object
+    // PARAMETERS : ageName
     //
     // PURPOSE    : Get the list of public ages for the given age name.
     //
-    static void GetPublicAgeList(const ST::string& ageName, PyObject * cbObject = nullptr);
+    static void GetPublicAgeList(const ST::string& ageName);
 
     //////////////////////////////////////////////////////////////////////////////
     //

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue4.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue4.cpp
@@ -230,17 +230,15 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtShootBulletFromObject, args, "Params: selfkey,
     PYTHON_RETURN_NONE;
 }
 
-PYTHON_GLOBAL_METHOD_DEFINITION(PtGetPublicAgeList, args, "Params: ageName, cbObject=None\nGet list of public ages for the given age name.\n"
-            "cbObject, if supplied should have a method called gotPublicAgeList(self,ageList). ageList is a list of tuple(ptAgeInfoStruct,nPlayersInAge)")
+PYTHON_GLOBAL_METHOD_DEFINITION(PtGetPublicAgeList, args, "Params: ageName\nGet list of public ages for the given age name.\n"
+            "The age list will be delivered asynchronously through the callback method gotPublicAgeList(self,ageList). ageList is a list of tuple(ptAgeInfoStruct,nPlayersInAge)")
 {
     ST::string ageName;
-    PyObject* cbObject = nullptr;
-    if (!PyArg_ParseTuple(args, "O&|O", PyUnicode_STStringConverter, &ageName, &cbObject))
-    {
-        PyErr_SetString(PyExc_TypeError, "PtGetPublicAgeList expects a string and an optional object with a gotPublicAgeList() method");
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_STStringConverter, &ageName)) {
+        PyErr_SetString(PyExc_TypeError, "PtGetPublicAgeList expects a string");
         PYTHON_RETURN_ERROR;
     }
-    cyMisc::GetPublicAgeList(ageName, cbObject);
+    cyMisc::GetPublicAgeList(ageName);
     PYTHON_RETURN_NONE;
 }
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plNetCommMsgs.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plNetCommMsgs.h
@@ -57,14 +57,8 @@ struct NetCliAuthFileInfo;
 
 class plNetCommReplyMsg : public plMessage {
 public:
-    enum EParamType {
-        kParamTypeOther = 0,
-        kParamTypePython,
-    };
-
     ENetError   result;
     void *      param;
-    EParamType  ptype;
 
     plNetCommReplyMsg () { SetBCastFlag(kBCastByExactType); }
 

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -475,13 +475,11 @@ static void INetCliAuthChangePasswordCallback(ENetError result)
 static void INetCliAuthGetPublicAgeListCallback (
     ENetError                   result,
     void *                      param,
-    plNetCommReplyMsg::EParamType ptype,
     std::vector<NetAgeInfo>     ages
 ) {
     plNetCommPublicAgeListMsg * msg = new plNetCommPublicAgeListMsg;
     msg->result     = result;
     msg->param      = param;
-    msg->ptype      = ptype;
     msg->ages       = std::move(ages);
     msg->Send();
 }
@@ -963,13 +961,12 @@ void NetCommDeletePlayer (  // --> plNetCommDeletePlayerMsg
 //============================================================================
 void NetCommGetPublicAgeList (//-> plNetCommPublicAgeListMsg
     const ST::string&               ageName,
-    void *                          param,
-    plNetCommReplyMsg::EParamType   ptype
+    void *                          param
 ) {
     NetCliAuthGetPublicAgeList(
         ageName,
-        [param, ptype](auto result, auto ages) {
-            INetCliAuthGetPublicAgeListCallback(result, param, ptype, std::move(ages));
+        [param](auto result, auto ages) {
+            INetCliAuthGetPublicAgeListCallback(result, param, std::move(ages));
         }
     );
 }

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.h
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.h
@@ -172,8 +172,7 @@ void NetCommDeletePlayer (  // --> plNetCommDeletePlayerMsg
 );
 void NetCommGetPublicAgeList (//-> plNetCommPublicAgeListMsg
     const ST::string&               ageName,
-    void *                          param,
-    plNetCommReplyMsg::EParamType   ptype = plNetCommReplyMsg::kParamTypeOther
+    void *                          param
 );
 void NetCommSetAgePublic (  // --> no msg
     unsigned                ageInfoId,


### PR DESCRIPTION
The `gotPublicAgeList` callback method is called on any PythonFileMod that has one, not on the particular object passed to `PtGetPublicAgeList`.

Alternatively, I could try to change the implementation so that it actually uses the `cbObject` argument for calling the callback method. It depends on which style of callback API we would prefer going forward.

(For reference, a while back in 9b8523cdf7493a2889e81f26abb884cb6a4d98c0 in #1486, I made a similar change for another Python function.)