### PR TITLE
Adding dedicated hsDisplayHndl type

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -199,7 +199,7 @@ static void* const DeviceDidChangeContext = (void*)&DeviceDidChangeContext;
     [window setDelegate:self];
     
     gClient.SetClientWindow((__bridge void *)view.layer);
-    gClient.SetClientDisplay([window.screen.deviceDescription[@"NSScreenNumber"] intValue]);
+    gClient.SetClientDisplay([window.screen.deviceDescription[@"NSScreenNumber"] unsignedIntValue]);
 
     self = [super initWithWindow:window];
     self.window.acceptsMouseMovedEvents = YES;

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -199,7 +199,7 @@ static void* const DeviceDidChangeContext = (void*)&DeviceDidChangeContext;
     [window setDelegate:self];
     
     gClient.SetClientWindow((__bridge void *)view.layer);
-    gClient.SetClientDisplay((hsWindowHndl)NULL);
+    gClient.SetClientDisplay([window.screen.deviceDescription[@"NSScreenNumber"] intValue]);
 
     self = [super initWithWindow:window];
     self.window.acceptsMouseMovedEvents = YES;

--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -476,7 +476,7 @@ void plClient::ISetGraphicsDefaults()
     plDynamicCamMap::SetEnabled(plPipeline::fDefaultPipeParams.PlanarReflections ? true : false);
 }
 
-plPipeline* plClient::ICreatePipeline(hsWindowHndl disp, hsWindowHndl hWnd, const hsG3DDeviceModeRecord* devMode)
+plPipeline* plClient::ICreatePipeline(hsDisplayHndl disp, hsWindowHndl hWnd, const hsG3DDeviceModeRecord* devMode)
 {
     uint32_t renderer = devMode->GetDevice()->GetG3DDeviceType();
 
@@ -498,7 +498,7 @@ plPipeline* plClient::ICreatePipeline(hsWindowHndl disp, hsWindowHndl hWnd, cons
     return new plNullPipeline(disp, hWnd, devMode);
 }
 
-bool plClient::InitPipeline(hsWindowHndl display, uint32_t devType)
+bool plClient::InitPipeline(hsDisplayHndl display, uint32_t devType)
 {
     hsStatusMessage("InitPipeline client\n");
 

--- a/Sources/Plasma/Apps/plClient/plClient.h
+++ b/Sources/Plasma/Apps/plClient/plClient.h
@@ -201,7 +201,7 @@ protected:
     void    IIncProgress( float byHowMuch, const char *text );
     void    IStopProgress();
 
-    static plPipeline* ICreatePipeline(hsWindowHndl disp, hsWindowHndl hWnd, const hsG3DDeviceModeRecord* devMode);
+    static plPipeline* ICreatePipeline(hsDisplayHndl disp, hsWindowHndl hWnd, const hsG3DDeviceModeRecord* devMode);
 
     static void IDispatchMsgReceiveCallback();
     static void IReadKeyedObjCallback(const plKey& key);
@@ -241,7 +241,7 @@ public:
     
     bool MsgReceive(plMessage* msg) override;
     
-    bool        InitPipeline(hsWindowHndl display, uint32_t devType = hsG3DDeviceSelector::kDevTypeUnknown);
+    bool        InitPipeline(hsDisplayHndl display, uint32_t devType = hsG3DDeviceSelector::kDevTypeUnknown);
 
     void        InitInputs();
 

--- a/Sources/Plasma/Apps/plClient/plClientLoader.h
+++ b/Sources/Plasma/Apps/plClient/plClientLoader.h
@@ -48,7 +48,7 @@ class plClientLoader : private hsThread
 {
     class plClient* fClient;
     hsWindowHndl fWindow;
-    hsWindowHndl fDisplay;
+    hsDisplayHndl fDisplay;
     uint32_t fDevType;
 
     void OnQuit() override
@@ -85,7 +85,7 @@ public:
     /**
      * Sets the client display handle.
      */
-    void SetClientDisplay(hsWindowHndl hDC) { fDisplay = hDC; }
+    void SetClientDisplay(hsDisplayHndl hDC) { fDisplay = hDC; }
 
     /**
      * Sets the preferred rendering backend for the client pipeline.

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -69,17 +69,29 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     struct HINSTANCE__; typedef struct HINSTANCE__ *HINSTANCE;
 
     typedef HWND hsWindowHndl;
+    typedef HWND hsDisplayHndl;
     typedef HINSTANCE hsWindowInst;
     typedef HINSTANCE HMODULE;
     typedef HMODULE hsLibraryHndl;
     typedef long HRESULT;
     typedef void* HANDLE;
-#elif HS_BUILD_FOR_MACOS
+#elif HS_BUILD_FOR_APPLE
+    // Same note as Windows above - would rather not forward declare but I don't want to
+    // import Foundation or CoreGraphics
+#if HS_BUILD_FOR_IOS
+    // Exception - iOS doesn't support CGDirectDisplayID.
+    // It has UIScreen but that's a Cocoa type.
+    typedef void* hsDisplayHndl;
+#else
+    typedef uint32_t CGDirectDisplayID;
+    typedef CGDirectDisplayID hsDisplayHndl;
+#endif
     typedef void* hsWindowHndl;
     typedef void* hsWindowInst;
     typedef void* hsLibraryHndl;
 #else
     typedef int32_t* hsWindowHndl;
+    typedef int32_t* hsDisplayHndl;
     typedef int32_t* hsWindowInst;
     typedef void* hsLibraryHndl;
 #endif // HS_BUILD_FOR_WIN32

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -78,7 +78,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #elif HS_BUILD_FOR_APPLE
     // Same note as Windows above - would rather not forward declare but I don't want to
     // import Foundation or CoreGraphics
-#if HS_BUILD_FOR_IOS
+#ifdef HS_BUILD_FOR_IOS
     // Exception - iOS doesn't support CGDirectDisplayID.
     // It has UIScreen but that's a Cocoa type.
     typedef void* hsDisplayHndl;

--- a/Sources/Plasma/FeatureLib/pfGLPipeline/plGLPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfGLPipeline/plGLPipeline.cpp
@@ -62,7 +62,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 plGLEnumerate plGLPipeline::enumerator;
 
-plGLPipeline::plGLPipeline(hsWindowHndl display, hsWindowHndl window, const hsG3DDeviceModeRecord *devMode)
+plGLPipeline::plGLPipeline(hsDisplayHndl display, hsWindowHndl window, const hsG3DDeviceModeRecord *devMode)
     : pl3DPipeline(devMode)
 {
     fPlateMgr = new plGLPlateManager(this);

--- a/Sources/Plasma/FeatureLib/pfGLPipeline/plGLPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfGLPipeline/plGLPipeline.h
@@ -62,7 +62,7 @@ class plGLPipeline : public pl3DPipeline<plGLDevice>
     friend class plGLPlateManager;
 
 public:
-    plGLPipeline(hsWindowHndl display, hsWindowHndl window, const hsG3DDeviceModeRecord *devMode);
+    plGLPipeline(hsDisplayHndl display, hsWindowHndl window, const hsG3DDeviceModeRecord *devMode);
     virtual ~plGLPipeline() = default;
 
     CLASSNAME_REGISTER(plGLPipeline);

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -159,7 +159,7 @@ bool plRenderTriListFunc::RenderPrims() const
     fDevice->CurrentRenderCommandEncoder()->drawIndexedPrimitives(MTL::PrimitiveTypeTriangle, fNumTris * 3, MTL::IndexTypeUInt16, fDevice->fCurrentIndexBuffer, (sizeof(uint16_t) * fIStart));
 }
 
-plMetalPipeline::plMetalPipeline(hsWindowHndl display, hsWindowHndl window, const hsG3DDeviceModeRecord* devMode) : pl3DPipeline(devMode),
+plMetalPipeline::plMetalPipeline(hsDisplayHndl display, hsWindowHndl window, const hsG3DDeviceModeRecord* devMode) : pl3DPipeline(devMode),
                                                                                                                     fRenderTargetRefList(),
                                                                                                                     fMatRefList(),
                                                                                                                     fCurrentRenderPassUniforms(),

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
@@ -101,7 +101,7 @@ protected:
     plMetalRenderTargetRef*   fRenderTargetRefList;
 
 public:
-    plMetalPipeline(hsWindowHndl display, hsWindowHndl window, const hsG3DDeviceModeRecord* devMode);
+    plMetalPipeline(hsDisplayHndl display, hsWindowHndl window, const hsG3DDeviceModeRecord* devMode);
     ~plMetalPipeline();
 
     CLASSNAME_REGISTER(plMetalPipeline);

--- a/Sources/Plasma/PubUtilLib/plPipeline/plNullPipeline.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plNullPipeline.h
@@ -65,7 +65,7 @@ public:
 class plNullPipeline : public pl3DPipeline<plNullPipelineDevice>
 {
 public:
-    plNullPipeline(hsWindowHndl display, hsWindowHndl window, const hsG3DDeviceModeRecord *devModeRec)
+    plNullPipeline(hsDisplayHndl display, hsWindowHndl window, const hsG3DDeviceModeRecord *devModeRec)
         : pl3DPipeline(devModeRec) { }
 
     CLASSNAME_REGISTER(plNullPipeline);


### PR DESCRIPTION
This PR is in preparation for further macOS resolution work. I thought I'd ask for review for just this chunk to lighten the load in the next PR.

Plasma uses hsWindowHndl for both the window and display types. This worked under Windows because both displays and windows are HWND types. (That's technically not true, under Windows the display should be an HMONITOR type. Was this refactored at some point?)

I'd added the dedicated type and made it a CGDirectDisplayID on macOS.