### PR TITLE
Lambda-ify the high-level vault API callbacks

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -2673,12 +2673,7 @@ void cyMisc::ForceVaultNodeUpdate(unsigned nodeId)
 
 void cyMisc::VaultDownload(unsigned nodeId)
 {
-    VaultDownloadAndWait(
-        "PyVaultDownload",
-        nodeId,
-        nullptr,
-        nullptr
-    );
+    VaultDownloadAndWait("PyVaultDownload", nodeId, nullptr);
 }
 
 PyObject* cyMisc::CloneKey(pyKey* object, bool loading) {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.cpp
@@ -486,13 +486,6 @@ void pyVault::UnRegisterVisitAge(const ST::string& guidstr)
     VaultUnregisterVisitAge(&info);
 }
 
-//============================================================================
-void _InvitePlayerToAge(ENetError result, void* state, void* param, hsWeakRef<RelVaultNode> node)
-{
-    if (result == kNetSuccess)
-        VaultSendNode(node, (uint32_t)((uintptr_t)param));
-}
-
 void pyVault::InvitePlayerToAge( const pyAgeLinkStruct & link, uint32_t playerID )
 {
     NetVaultNode templateNode;
@@ -500,14 +493,10 @@ void pyVault::InvitePlayerToAge( const pyAgeLinkStruct & link, uint32_t playerID
     VaultTextNoteNode visitAcc(&templateNode);
     visitAcc.SetNoteType(plVault::kNoteType_Visit);
     visitAcc.SetVisitInfo(*link.GetAgeLink()->GetAgeInfo());
-    VaultCreateNode(&templateNode, (FVaultCreateNodeCallback)_InvitePlayerToAge, nullptr, (void*)(uintptr_t)playerID);
-}
-
-//============================================================================
-void _UninvitePlayerToAge(ENetError result, void* state, void* param, hsWeakRef<RelVaultNode> node)
-{
-    if (result == kNetSuccess)
-        VaultSendNode(node, (uint32_t)((uintptr_t)param));
+    VaultCreateNode(&templateNode, [playerID](auto result, auto node) {
+        if (result == kNetSuccess)
+            VaultSendNode(node, playerID);
+    });
 }
 
 void pyVault::UnInvitePlayerToAge(const ST::string& str, uint32_t playerID)
@@ -528,7 +517,10 @@ void pyVault::UnInvitePlayerToAge(const ST::string& str, uint32_t playerID)
     VaultTextNoteNode visitAcc(&templateNode);
     visitAcc.SetNoteType(plVault::kNoteType_UnVisit);
     visitAcc.SetVisitInfo(info);
-    VaultCreateNode(&templateNode, (FVaultCreateNodeCallback)_UninvitePlayerToAge, nullptr, (void*)(uintptr_t)playerID);
+    VaultCreateNode(&templateNode, [playerID](auto result, auto node) {
+        if (result == kNetSuccess)
+            VaultSendNode(node, playerID);
+    });
 }
 
 //============================================================================

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
@@ -77,15 +77,6 @@ bool pyVaultPlayerInfoListNode::HasPlayer( uint32_t playerID )
     return rvn != nullptr;
 }
 
-//==================================================================
-
-static void IAddPlayer_NodesFound(ENetError result, void* param, unsigned nodeIdCount, const unsigned nodeIds[])
-{
-    hsWeakRef<NetVaultNode> parent = static_cast<NetVaultNode*>(param);
-    if (nodeIdCount)
-        VaultAddChildNode(parent->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr);
-}
-
 void pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
 {
     if (HasPlayer(playerID) || !fNode)
@@ -103,7 +94,11 @@ void pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
     if (!nodeIds.empty())
         VaultAddChildNode(fNode->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr);
     else
-        VaultFindNodes(&templateNode, IAddPlayer_NodesFound, fNode.Get());
+        VaultFindNodes(&templateNode, [parentId = fNode->GetNodeId()](auto result, auto nodeIdCount, auto nodeIds) {
+            if (nodeIdCount) {
+                VaultAddChildNode(parentId, nodeIds[0], VaultGetPlayerId(), nullptr);
+            }
+        });
 }
 
 void pyVaultPlayerInfoListNode::RemovePlayer( uint32_t playerID )

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoListNode.cpp
@@ -83,7 +83,7 @@ static void IAddPlayer_NodesFound(ENetError result, void* param, unsigned nodeId
 {
     hsWeakRef<NetVaultNode> parent = static_cast<NetVaultNode*>(param);
     if (nodeIdCount)
-        VaultAddChildNode(parent->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr, nullptr);
+        VaultAddChildNode(parent->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr);
 }
 
 void pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
@@ -101,7 +101,7 @@ void pyVaultPlayerInfoListNode::AddPlayer( uint32_t playerID )
 
     // So, if we know about this node, we can take it easy. If not, we lazy load it.
     if (!nodeIds.empty())
-        VaultAddChildNode(fNode->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr, nullptr);
+        VaultAddChildNode(fNode->GetNodeId(), nodeIds[0], VaultGetPlayerId(), nullptr);
     else
         VaultFindNodes(&templateNode, IAddPlayer_NodesFound, fNode.Get());
 }
@@ -117,7 +117,7 @@ void pyVaultPlayerInfoListNode::RemovePlayer( uint32_t playerID )
     access.SetPlayerId(playerID);
 
     if (hsRef<RelVaultNode> rvn = fNode->GetChildNode(&templateNode, 1))
-        VaultRemoveChildNode(fNode->GetNodeId(), rvn->GetNodeId(), nullptr, nullptr);
+        VaultRemoveChildNode(fNode->GetNodeId(), rvn->GetNodeId(), nullptr);
 }
 
 PyObject * pyVaultPlayerInfoListNode::GetPlayer( uint32_t playerID )

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.cpp
@@ -147,13 +147,6 @@ PyObject * pyVaultTextNoteNode::GetDeviceInbox() const
         PYTHON_RETURN_NONE;
 }
 
-static void _SetDeviceInboxCallback(ENetError result, hsRef<RelVaultNode> inbox, void* param)
-{
-    auto cb = static_cast<pyVaultNode::pyVaultNodeOperationCallback*>(param);
-    cb->SetNode(std::move(inbox));
-    cb->VaultOperationComplete(result);
-}
-
 void pyVaultTextNoteNode::SetDeviceInbox(const ST::string& devName, PyObject * cbObject, uint32_t cbContext)
 {
     if (!fNode)
@@ -162,5 +155,8 @@ void pyVaultTextNoteNode::SetDeviceInbox(const ST::string& devName, PyObject * c
     pyVaultNode::pyVaultNodeOperationCallback * cb = new pyVaultNode::pyVaultNodeOperationCallback( cbObject );
     cb->VaultOperationStarted( cbContext );
 
-    VaultAgeSetDeviceInbox(devName, DEFAULT_DEVICE_INBOX, _SetDeviceInboxCallback, cb);
+    VaultAgeSetDeviceInbox(devName, DEFAULT_DEVICE_INBOX, [cb](auto result, auto inbox) {
+        cb->SetNode(std::move(inbox));
+        cb->VaultOperationComplete(result);
+    });
 }

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.cpp
@@ -810,7 +810,6 @@ void plNetLinkingMgr::IPostProcessLink()
                             fldr->GetNodeId(),
                             info->GetNodeId(),
                             NetCommGetPlayer()->playerInt,
-                            nullptr,
                             nullptr
                         );
             }
@@ -832,7 +831,6 @@ void plNetLinkingMgr::IPostProcessLink()
                             fldr->GetNodeId(),
                             info->GetNodeId(),
                             NetCommGetPlayer()->playerInt,
-                            nullptr,
                             nullptr
                         );
             }

--- a/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientComm/plNetClientComm.cpp
@@ -270,9 +270,9 @@ static void INetCliAuthSetPlayerRequestCallback (
         VaultDownloadNoCallbacks(
             "SetActivePlayer",
             s_player->playerInt,
-            PlayerInitCallback,
-            param,
-            nullptr,
+            [param](auto result) {
+                PlayerInitCallback(result, param);
+            },
             nullptr
         );
     }
@@ -326,9 +326,9 @@ static void INetCliAuthLoginSetPlayerRequestCallback (
         VaultDownloadNoCallbacks(
             "SetActivePlayer",
             s_player->playerInt,
-            LoginPlayerInitCallback,
-            param,
-            nullptr,
+            [param](auto result) {
+                LoginPlayerInitCallback(result, param);
+            },
             nullptr
         );
     }

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -146,15 +146,14 @@ struct VaultDownloadNoCallbacksTrans : VaultDownloadTrans {
 
 struct AddChildNodeFetchTrans {
     FVaultAddChildNodeCallback  callback;
-    void *                      cbParam;
     ENetError                   result;
     std::atomic<long>           opCount;
 
     AddChildNodeFetchTrans()
-        : callback(), cbParam(), result(kNetSuccess), opCount() { }
+        : callback(), result(kNetSuccess), opCount() {}
 
-    AddChildNodeFetchTrans(FVaultAddChildNodeCallback _callback, void * _param)
-        : callback(_callback), cbParam(_param), result(kNetSuccess), opCount() { }
+    AddChildNodeFetchTrans(FVaultAddChildNodeCallback _callback)
+        : callback(std::move(_callback)), result(kNetSuccess), opCount() {}
 
     void VaultNodeFetched(
         ENetError           res,
@@ -759,10 +758,7 @@ void AddChildNodeFetchTrans::VaultNodeRefsFetched (
     // Make the callback now if there are no nodes to fetch, or if error
     if (!(--opCount)) {
         if (callback)
-            callback(
-                result,
-                cbParam
-            );
+            callback(result);
         delete this;
     }
 }
@@ -779,10 +775,7 @@ void AddChildNodeFetchTrans::VaultNodeFetched (
 
     if (!(--opCount)) {
         if (callback)
-            callback(
-                result,
-                cbParam
-            );
+            callback(result);
         delete this;
     }
 }
@@ -1353,8 +1346,8 @@ void VaultAddChildNode (
     unsigned                    parentId,
     unsigned                    childId,
     unsigned                    ownerId,
-    FVaultAddChildNodeCallback  callback,
-    void *                      param
+    // TODO Make it so that the callback only needs to be moved and not copied
+    const FVaultAddChildNodeCallback& callback
 ) {
     // Make sure we only do the callback once
     bool madeCallback = false;
@@ -1388,13 +1381,13 @@ void VaultAddChildNode (
             s_log->AddLineF("Node relationship would be circular: p:{}, c:{}", parentId, childId);
             // callback now with error code
             if (callback)
-                callback(kNetErrCircularReference, param);
+                callback(kNetErrCircularReference);
         }
         else if (childNode->IsParentOf(parentId, 255)) {
             s_log->AddLineF("Node relationship would be circular: p:{}, c:{}", parentId, childId);
             // callback now with error code
             if (callback)
-                callback(kNetErrCircularReference, param);
+                callback(kNetErrCircularReference);
         }
         else {
             NetVaultNodeRef refs[] = {
@@ -1408,7 +1401,7 @@ void VaultAddChildNode (
         
             if (!childNode->GetNodeType() || !parentNode->GetNodeType()) {
                 // One or more nodes need to be fetched before the callback is made
-                AddChildNodeFetchTrans * trans = new AddChildNodeFetchTrans(callback, param);
+                AddChildNodeFetchTrans* trans = new AddChildNodeFetchTrans(callback);
                 if (!childNode->GetNodeType()) {
                     ++trans->opCount;
                     NetCliAuthVaultNodeFetch(childId, [trans](auto result, auto node) {
@@ -1433,7 +1426,7 @@ void VaultAddChildNode (
             else {
                 // We have both nodes already, so make the callback now.
                 if (callback) {
-                    callback(kNetSuccess, param);
+                    callback(kNetSuccess);
                     madeCallback = true;
                 }
             }
@@ -1442,7 +1435,7 @@ void VaultAddChildNode (
     else {
         // Parent doesn't exist locally (and we may not want it to), just make the callback now.
         if (callback) {
-            callback(kNetSuccess, param);
+            callback(kNetSuccess);
             madeCallback = true;
         }
     }
@@ -1455,9 +1448,9 @@ void VaultAddChildNode (
         parentId,
         childId,
         ownerId,
-        [callback, param, madeCallback](auto result) {
+        [callback, madeCallback](auto result) {
             if (callback && !madeCallback) {
-                callback(result, param);
+                callback(result);
             }
         }
     );
@@ -1472,9 +1465,8 @@ struct _AddChildNodeParam {
 };
 static void _AddChildNodeCallback (
     ENetError       result,
-    void *          vparam
+    _AddChildNodeParam* param
 ) {
-    _AddChildNodeParam * param = (_AddChildNodeParam *)vparam;
     param->result       = result;
     param->complete     = true;
 }
@@ -1492,13 +1484,9 @@ void VaultAddChildNodeAndWait (
     _AddChildNodeParam param;
     memset(&param, 0, sizeof(param));
     
-    VaultAddChildNode(
-        parentId,
-        childId,
-        ownerId,
-        _AddChildNodeCallback,
-        &param
-    );
+    VaultAddChildNode(parentId, childId, ownerId, [&param](auto result) {
+        _AddChildNodeCallback(result, &param);
+    });
 
     while (!param.complete) {
         NetClientUpdate();
@@ -1514,8 +1502,7 @@ void VaultAddChildNodeAndWait (
 void VaultRemoveChildNode (
     unsigned                        parentId,
     unsigned                        childId,
-    FVaultRemoveChildNodeCallback   callback,
-    void *                          param
+    FVaultRemoveChildNodeCallback   callback
 ) {
     for (;;) {
         // Unlink 'em locally, if we can
@@ -1546,9 +1533,9 @@ void VaultRemoveChildNode (
     }
     
     // Send it on up to the vault
-    NetCliAuthVaultNodeRemove(parentId, childId, [callback, param](auto result) {
+    NetCliAuthVaultNodeRemove(parentId, childId, [callback = std::move(callback)](auto result) {
         if (callback) {
-            callback(result, param);
+            callback(result);
         }
     });
 }
@@ -2188,9 +2175,8 @@ struct _AddChildNodeParam {
 };
 static void _AddChildNodeCallback (
     ENetError       result,
-    void *          vparam
+    _AddChildNodeParam* param
 ) {
-    _AddChildNodeParam * param = (_AddChildNodeParam *)vparam;
     param->result       = result;
     param->complete     = true;
 }
@@ -2323,29 +2309,17 @@ bool VaultRegisterOwnedAgeAndWait (const plAgeLinkStruct * link) {
             if (hsRef<RelVaultNode> rvnPlayerInfo = VaultGetPlayerInfoNode())
                 playerInfoId = rvnPlayerInfo->GetNodeId();
 
-            VaultAddChildNode(
-                agesIOwnId,
-                ageLinkId,
-                0,
-                _AddChildNodeCallback,
-                &param1
-            );
+            VaultAddChildNode(agesIOwnId, ageLinkId, 0, [&param1](auto result) {
+                _AddChildNodeCallback(result, &param1);
+            });
 
-            VaultAddChildNode(
-                ageLinkId,
-                ageInfoId,
-                0,
-                _AddChildNodeCallback,
-                &param2
-            );
+            VaultAddChildNode(ageLinkId, ageInfoId, 0, [&param2](auto result) {
+                _AddChildNodeCallback(result, &param2);
+            });
 
-            VaultAddChildNode(
-                ageOwnersId,
-                playerInfoId,
-                0,
-                _AddChildNodeCallback,
-                &param3
-            );
+            VaultAddChildNode(ageOwnersId, playerInfoId, 0, [&param3](auto result) {
+                _AddChildNodeCallback(result, &param3);
+            });
 
             while (!param1.complete && !param2.complete && !param3.complete) {
                 NetClientUpdate();
@@ -2402,17 +2376,20 @@ namespace _VaultRegisterOwnedAge {
         }
     };
 
-    void _AddAgeInfoNode(ENetError result, void* param) {
+    void _AddAgeInfoNode(ENetError result)
+    {
         if (IS_NET_ERROR(result))
             s_log->AddLine("VaultRegisterOwnedAge: Failed to add info to link (async)");
     }
 
-    void _AddAgeLinkNode(ENetError result, void* param) {
+    void _AddAgeLinkNode(ENetError result)
+    {
         if (IS_NET_ERROR(result))
             s_log->AddLine("VaultRegisterOwnedAge: Failed to add age to bookshelf (async)");
     }
 
-    void _AddPlayerInfoNode(ENetError result, void* param) {
+    void _AddPlayerInfoNode(ENetError result)
+    {
         if (IS_NET_ERROR(result))
             s_log->AddLine("VaultRegisterOwnedAge: Failed to add playerInfo to ageOwners (async)");
     }
@@ -2434,13 +2411,13 @@ namespace _VaultRegisterOwnedAge {
         // Make some refs
         hsRef<RelVaultNode> agesIOwn = VaultGetAgesIOwnFolder();
         hsRef<RelVaultNode> plyrInfo = VaultGetPlayerInfoNode();
-        VaultAddChildNode(agesIOwn->GetNodeId(), node->GetNodeId(), 0, (FVaultAddChildNodeCallback)_AddAgeLinkNode, nullptr);
-        VaultAddChildNode(node->GetNodeId(), (uint32_t)((uintptr_t)p->fAgeInfoId), 0, (FVaultAddChildNodeCallback)_AddAgeInfoNode, nullptr);
+        VaultAddChildNode(agesIOwn->GetNodeId(), node->GetNodeId(), 0, _AddAgeLinkNode);
+        VaultAddChildNode(node->GetNodeId(), (uint32_t)((uintptr_t)p->fAgeInfoId), 0, _AddAgeInfoNode);
 
         // Add our PlayerInfo to important places
         if (hsRef<RelVaultNode> rvnAgeInfo = VaultGetNode((uint32_t)((uintptr_t)p->fAgeInfoId))) {
             if (hsRef<RelVaultNode> rvnAgeOwners = rvnAgeInfo->GetChildPlayerInfoListNode(plVault::kAgeOwnersFolder, 1))
-                VaultAddChildNode(rvnAgeOwners->GetNodeId(), plyrInfo->GetNodeId(), 0, (FVaultAddChildNodeCallback)_AddPlayerInfoNode, nullptr);
+                VaultAddChildNode(rvnAgeOwners->GetNodeId(), plyrInfo->GetNodeId(), 0, _AddPlayerInfoNode);
         }
 
         // Fire off vault callbacks
@@ -2557,9 +2534,8 @@ struct _AddChildNodeParam {
 };
 static void _AddChildNodeCallback (
     ENetError       result,
-    void *          vparam
+    _AddChildNodeParam* param
 ) {
-    _AddChildNodeParam * param = (_AddChildNodeParam *)vparam;
     param->result       = result;
     param->complete     = true;
 }
@@ -2691,29 +2667,17 @@ bool VaultRegisterVisitAgeAndWait (const plAgeLinkStruct * link) {
             if (hsRef<RelVaultNode> rvnPlayerInfo = VaultGetPlayerInfoNode())
                 playerInfoId = rvnPlayerInfo->GetNodeId();
 
-            VaultAddChildNode(
-                agesICanVisitId,
-                ageLinkId,
-                0,
-                _AddChildNodeCallback,
-                &param1
-            );
+            VaultAddChildNode(agesICanVisitId, ageLinkId, 0, [&param1](auto result) {
+                _AddChildNodeCallback(result, &param1);
+            });
 
-            VaultAddChildNode(
-                ageLinkId,
-                ageInfoId,
-                0,
-                _AddChildNodeCallback,
-                &param2
-            );
+            VaultAddChildNode(ageLinkId, ageInfoId, 0, [&param2](auto result) {
+                _AddChildNodeCallback(result, &param2);
+            });
 
-            VaultAddChildNode(
-                ageVisitorsId,
-                playerInfoId,
-                0,
-                _AddChildNodeCallback,
-                &param3
-            );
+            VaultAddChildNode(ageVisitorsId, playerInfoId, 0, [&param3](auto result) {
+                _AddChildNodeCallback(result, &param3);
+            });
 
             while (!param1.complete && !param2.complete && !param3.complete) {
                 NetClientUpdate();
@@ -2784,13 +2748,13 @@ namespace _VaultRegisterVisitAge {
         // Add ourselves to the Can Visit folder of the age
         if (hsRef<RelVaultNode> playerInfo = VaultGetPlayerInfoNode()) {
             if (hsRef<RelVaultNode> canVisit = ageInfo->GetChildPlayerInfoListNode(plVault::kCanVisitFolder, 1))
-                VaultAddChildNode(canVisit->GetNodeId(), playerInfo->GetNodeId(), 0, nullptr, nullptr);
+                VaultAddChildNode(canVisit->GetNodeId(), playerInfo->GetNodeId(), 0, nullptr);
         }
 
         // Get our AgesICanVisit folder
         if (hsRef<RelVaultNode> iCanVisit = VaultGetAgesICanVisitFolder()) {
-            VaultAddChildNode(node->GetNodeId(), ageInfo->GetNodeId(), 0, nullptr, nullptr);
-            VaultAddChildNode(iCanVisit->GetNodeId(), node->GetNodeId(), 0, nullptr, nullptr);
+            VaultAddChildNode(node->GetNodeId(), ageInfo->GetNodeId(), 0, nullptr);
+            VaultAddChildNode(iCanVisit->GetNodeId(), node->GetNodeId(), 0, nullptr);
         }
 
         // Update the AgeLink with a spawn point
@@ -2897,10 +2861,10 @@ bool VaultUnregisterOwnedAge(const plAgeInfoStruct* info) {
             playerInfoId = rvnPlayerInfo->GetNodeId();
 
         // remove our playerInfo from the ageOwners folder
-        VaultRemoveChildNode(ageOwnersId, playerInfoId, nullptr, nullptr);
+        VaultRemoveChildNode(ageOwnersId, playerInfoId, nullptr);
         
         // remove the link from AgesIOwn folder 
-        VaultRemoveChildNode(agesIOwnId, ageLinkId, nullptr, nullptr);
+        VaultRemoveChildNode(agesIOwnId, ageLinkId, nullptr);
 
         // delete the link node since link nodes aren't shared with anyone else
     //  VaultDeleteNode(ageLinkId);
@@ -2955,10 +2919,10 @@ bool VaultUnregisterVisitAge(const plAgeInfoStruct* info) {
             playerInfoId = rvnPlayerInfo->GetNodeId();
 
         // remove our playerInfo from the ageVisitors folder
-        VaultRemoveChildNode(ageVisitorsId, playerInfoId, nullptr, nullptr);
+        VaultRemoveChildNode(ageVisitorsId, playerInfoId, nullptr);
 
         // remove the link from AgesICanVisit folder    
-        VaultRemoveChildNode(agesICanVisitId, ageLinkId, nullptr, nullptr);
+        VaultRemoveChildNode(agesICanVisitId, ageLinkId, nullptr);
         
         // delete the link node since link nodes aren't shared with anyone else
     //  VaultDeleteNode(ageLinkId);
@@ -3021,7 +2985,7 @@ void VaultAddChronicleEntryAndWait (
         chrnNode.SetEntryValue(entryValue);
         ENetError result;
         if (hsRef<RelVaultNode> rvnChrn = VaultCreateNodeAndWait(&templateNode, &result))
-            VaultAddChildNode(rvnFldr->GetNodeId(), rvnChrn->GetNodeId(), 0, nullptr, nullptr);
+            VaultAddChildNode(rvnFldr->GetNodeId(), rvnChrn->GetNodeId(), 0, nullptr);
     }
 }
 
@@ -3194,7 +3158,7 @@ void VaultProcessVisitNote(hsWeakRef<RelVaultNode> rvnVisit) {
             VaultRegisterVisitAge(&link);
         }
         // remove it from the inbox
-        VaultRemoveChildNode(rvnInbox->GetNodeId(), rvnVisit->GetNodeId(), nullptr, nullptr);
+        VaultRemoveChildNode(rvnInbox->GetNodeId(), rvnVisit->GetNodeId(), nullptr);
     }
 }
 
@@ -3208,7 +3172,7 @@ void VaultProcessUnvisitNote(hsWeakRef<RelVaultNode> rvnUnVisit) {
             VaultUnregisterVisitAge(&info);
         }
         // remove it from the inbox
-        VaultRemoveChildNode(rvnInbox->GetNodeId(), rvnUnVisit->GetNodeId(), nullptr, nullptr);
+        VaultRemoveChildNode(rvnInbox->GetNodeId(), rvnUnVisit->GetNodeId(), nullptr);
     }
 }
 
@@ -3231,7 +3195,7 @@ void VaultProcessPlayerInbox () {
                     VaultRegisterVisitAge(&link);
                 }
                 // remove it from the inbox
-                VaultRemoveChildNode(rvnInbox->GetNodeId(), rvnVisit->GetNodeId(), nullptr, nullptr);
+                VaultRemoveChildNode(rvnInbox->GetNodeId(), rvnVisit->GetNodeId(), nullptr);
             }
         }
         {   // Process new unvisit requests
@@ -3250,7 +3214,7 @@ void VaultProcessPlayerInbox () {
                     VaultUnregisterVisitAge(&info);
                 }
                 // remove it from the inbox
-                VaultRemoveChildNode(rvnInbox->GetNodeId(), rvnUnVisit->GetNodeId(), nullptr, nullptr);
+                VaultRemoveChildNode(rvnInbox->GetNodeId(), rvnUnVisit->GetNodeId(), nullptr);
             }
         }
     }
@@ -3401,9 +3365,8 @@ namespace _VaultAgeAddDevice
         hsRef<RelVaultNode> device;
     };
 
-    static void _AddFolderDeviceChildCallback(ENetError result, void* param)
+    static void _AddFolderDeviceChildCallback(ENetError result, _Params* p)
     {
-        _Params* p = static_cast<_Params*>(param);
         p->callback(result, IS_NET_SUCCESS(result) ? std::move(p->device) : nullptr, p->param);
         delete p;
     }
@@ -3417,7 +3380,9 @@ namespace _VaultAgeAddDevice
             access.SetNoteTitle(p->deviceName);
 
             p->device = node;
-            VaultAddChildNode(p->folder->GetNodeId(), node->GetNodeId(), 0, _AddFolderDeviceChildCallback, p);
+            VaultAddChildNode(p->folder->GetNodeId(), node->GetNodeId(), 0, [p](auto result) {
+                _AddFolderDeviceChildCallback(result, p);
+            });
         } else {
             p->callback(result, nullptr, p->param);
             delete p;
@@ -3452,7 +3417,7 @@ void VaultAgeRemoveDevice (const ST::string& deviceName) {
         VaultTextNoteNode access(&templateNode);
         access.SetNoteTitle(deviceName);
         if (hsRef<RelVaultNode> device = folder->GetChildNode(&templateNode, 1)) {
-            VaultRemoveChildNode(folder->GetNodeId(), device->GetNodeId(), nullptr, nullptr);
+            VaultRemoveChildNode(folder->GetNodeId(), device->GetNodeId(), nullptr);
 
             auto it = s_ageDeviceInboxes.find(deviceName);
             if (it != s_ageDeviceInboxes.end())
@@ -3500,9 +3465,8 @@ namespace _VaultAgeSetDeviceInbox
         hsRef<RelVaultNode> inbox;
     };
 
-    static void _AddDeviceInboxChildCallback(ENetError result, void* param)
+    static void _AddDeviceInboxChildCallback(ENetError result, _Params* p)
     {
-        _Params* p = static_cast<_Params*>(param);
         p->callback(result, IS_NET_SUCCESS(result) ? std::move(p->inbox) : nullptr, p->param);
         delete p;
     }
@@ -3516,7 +3480,9 @@ namespace _VaultAgeSetDeviceInbox
             access.SetFolderType(plVault::kDeviceInboxFolder);
 
             p->inbox = node;
-            VaultAddChildNode(p->device->GetNodeId(), node->GetNodeId(), 0, _AddDeviceInboxChildCallback, p);
+            VaultAddChildNode(p->device->GetNodeId(), node->GetNodeId(), 0, [p](auto result) {
+                _AddDeviceInboxChildCallback(result, p);
+            });
         } else {
             p->callback(result, nullptr, p->param);
             delete p;
@@ -3656,9 +3622,9 @@ namespace _VaultCreateSubAge {
         }
 
         // Add the children to the right places
-        VaultAddChildNode(node->GetNodeId(), (uint32_t)((uintptr_t)param), 0, nullptr, nullptr);
+        VaultAddChildNode(node->GetNodeId(), (uint32_t)((uintptr_t)param), 0, nullptr);
         if (hsRef<RelVaultNode> saFldr = VaultGetAgeSubAgesFolder())
-            VaultAddChildNode(saFldr->GetNodeId(), node->GetNodeId(), 0, nullptr, nullptr);
+            VaultAddChildNode(saFldr->GetNodeId(), node->GetNodeId(), 0, nullptr);
         else
             s_log->AddLine("CreateSubAge: Couldn't find SubAges folder (async)");
 
@@ -3744,8 +3710,8 @@ namespace _VaultCreateChildAge {
         _Params* p = (_Params*)param;
 
         // Add the children to the right places
-        VaultAddChildNode(node->GetNodeId(), (uint32_t)((uintptr_t)p->fAgeInfoId), 0, nullptr, nullptr);
-        VaultAddChildNode((uint32_t)((uintptr_t)p->fChildAgesFldr), node->GetNodeId(), 0, nullptr, nullptr);
+        VaultAddChildNode(node->GetNodeId(), (uint32_t)((uintptr_t)p->fAgeInfoId), 0, nullptr);
+        VaultAddChildNode((uint32_t)((uintptr_t)p->fChildAgesFldr), node->GetNodeId(), 0, nullptr);
 
         // Send the VaultNotify that the plNetLinkingMgr wants...
         plVaultNotifyMsg * msg = new plVaultNotifyMsg;

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -1684,12 +1684,11 @@ void VaultForceSaveNodeAndWait (
 //============================================================================
 void VaultFindNodes (
     hsWeakRef<NetVaultNode> templateNode,
-    FVaultFindNodeCallback  callback,
-    void *                  param
+    FVaultFindNodeCallback  callback
 ) {
-    NetCliAuthVaultNodeFind(templateNode.Get(), [callback, param](auto result, auto nodeIdCount, auto nodeIds) {
+    NetCliAuthVaultNodeFind(templateNode.Get(), [callback = std::move(callback)](auto result, auto nodeIdCount, auto nodeIds) {
         if (callback) {
-            callback(result, param, nodeIdCount, nodeIds);
+            callback(result, nodeIdCount, nodeIds);
         }
     });  
 }

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -3332,14 +3332,13 @@ namespace _VaultAgeAddDevice
     {
         ST::string deviceName;
         FVaultAgeAddDeviceCallback callback;
-        void* param;
         hsRef<RelVaultNode> folder;
         hsRef<RelVaultNode> device;
     };
 
     static void _AddFolderDeviceChildCallback(ENetError result, _Params* p)
     {
-        p->callback(result, IS_NET_SUCCESS(result) ? std::move(p->device) : nullptr, p->param);
+        p->callback(result, IS_NET_SUCCESS(result) ? std::move(p->device) : nullptr);
         delete p;
     }
 
@@ -3355,28 +3354,28 @@ namespace _VaultAgeAddDevice
                 _AddFolderDeviceChildCallback(result, p);
             });
         } else {
-            p->callback(result, nullptr, p->param);
+            p->callback(result, nullptr);
             delete p;
         }
     }
 }
 
-void VaultAgeAddDevice(const ST::string& deviceName, FVaultAgeAddDeviceCallback callback, void* param)
+void VaultAgeAddDevice(const ST::string& deviceName, FVaultAgeAddDeviceCallback callback)
 {
     using namespace _VaultAgeAddDevice;
 
     if (hsRef<RelVaultNode> existing = VaultAgeGetDevice(deviceName)) {
-        callback(kNetSuccess, std::move(existing), param);
+        callback(kNetSuccess, std::move(existing));
         return;
     }
 
     hsRef<RelVaultNode> folder = VaultGetAgeDevicesFolder();
     if (!folder) {
-        callback(kNetErrVaultNodeNotFound, nullptr, param);
+        callback(kNetErrVaultNodeNotFound, nullptr);
         return;
     }
 
-    _Params* p = new _Params {deviceName, callback, param, std::move(folder)};
+    _Params* p = new _Params {deviceName, std::move(callback), std::move(folder)};
     VaultCreateNode(plVault::kNodeType_TextNote, [p](auto result, auto node) {
         _CreateDeviceCallback(result, p, node);
     });
@@ -3433,14 +3432,13 @@ namespace _VaultAgeSetDeviceInbox
     {
         ST::string inboxName;
         FVaultAgeSetDeviceInboxCallback callback;
-        void* param;
         hsRef<RelVaultNode> device;
         hsRef<RelVaultNode> inbox;
     };
 
     static void _AddDeviceInboxChildCallback(ENetError result, _Params* p)
     {
-        p->callback(result, IS_NET_SUCCESS(result) ? std::move(p->inbox) : nullptr, p->param);
+        p->callback(result, IS_NET_SUCCESS(result) ? std::move(p->inbox) : nullptr);
         delete p;
     }
 
@@ -3456,13 +3454,13 @@ namespace _VaultAgeSetDeviceInbox
                 _AddDeviceInboxChildCallback(result, p);
             });
         } else {
-            p->callback(result, nullptr, p->param);
+            p->callback(result, nullptr);
             delete p;
         }
     }
 }
 
-void VaultAgeSetDeviceInbox(const ST::string& deviceName, const ST::string& inboxName, FVaultAgeSetDeviceInboxCallback callback, void* param)
+void VaultAgeSetDeviceInbox(const ST::string& deviceName, const ST::string& inboxName, FVaultAgeSetDeviceInboxCallback callback)
 {
     using namespace _VaultAgeSetDeviceInbox;
 
@@ -3472,20 +3470,20 @@ void VaultAgeSetDeviceInbox(const ST::string& deviceName, const ST::string& inbo
     // it wasn't found then continue on and create the inbox
     hsRef<RelVaultNode> existing = VaultAgeGetDeviceInbox(deviceName);
     if (existing) {
-        callback(kNetSuccess, std::move(existing), param);
+        callback(kNetSuccess, std::move(existing));
         return;
     } else if (inboxName != DEFAULT_DEVICE_INBOX) {
-        callback(kNetErrVaultNodeNotFound, nullptr, param);
+        callback(kNetErrVaultNodeNotFound, nullptr);
         return;
     }
 
     hsRef<RelVaultNode> device = VaultAgeGetDevice(deviceName);
     if (!device) {
-        callback(kNetErrVaultNodeNotFound, nullptr, param);
+        callback(kNetErrVaultNodeNotFound, nullptr);
         return;
     }
 
-    _Params* p = new _Params {inboxName, callback, param, std::move(device)};
+    _Params* p = new _Params {inboxName, std::move(callback), std::move(device)};
     VaultCreateNode(plVault::kNodeType_Folder, [p](auto result, auto node) {
         _CreateDefaultInboxCallback(result, p, node);
     });

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -241,23 +241,17 @@ void VaultSendNode (
     unsigned                dstPlayerId
 );
 
-typedef void (*FVaultCreateNodeCallback)(
+using FVaultCreateNodeCallback = std::function<void(
     ENetError       result,
-    void *          state,
-    void *          param,
     hsWeakRef<RelVaultNode> node
-);
+)>;
 void VaultCreateNode (          // non-blocking
     plVault::NodeTypes          nodeType,
-    FVaultCreateNodeCallback    callback,
-    void *                      state,
-    void *                      param
+    FVaultCreateNodeCallback    callback
 );
 void VaultCreateNode (          // non-blocking
     hsWeakRef<NetVaultNode>     templateNode,
-    FVaultCreateNodeCallback    callback,
-    void *                      state,
-    void *                      param
+    FVaultCreateNodeCallback    callback
 );
 hsRef<RelVaultNode> VaultCreateNodeAndWait (   // block until completion. returns node. nullptr --> failure
     plVault::NodeTypes          nodeType,

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -265,16 +265,14 @@ void VaultForceSaveNodeAndWait (
     hsWeakRef<NetVaultNode>     node
 );
 
-typedef void (*FVaultFindNodeCallback)(
+using FVaultFindNodeCallback = std::function<void(
     ENetError           result,
-    void *              param,
     unsigned            nodeIdCount,
     const unsigned      nodeIds[]
-);
+)>;
 void VaultFindNodes (
     hsWeakRef<NetVaultNode> templateNode,
-    FVaultFindNodeCallback  callback,
-    void *                  param
+    FVaultFindNodeCallback  callback
 );
 void VaultFindNodesAndWait (
     hsWeakRef<NetVaultNode> templateNode,

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -384,13 +384,13 @@ void           VaultAddAgeChronicleEntry (
     int               entryType,
     const ST::string& entryValue
 );
-typedef void (*FVaultAgeAddDeviceCallback)(ENetError result, hsRef<RelVaultNode> device, void* param);
-void VaultAgeAddDevice(const ST::string& deviceName, FVaultAgeAddDeviceCallback callback, void* param);
+using FVaultAgeAddDeviceCallback = std::function<void(ENetError result, hsRef<RelVaultNode> device)>;
+void VaultAgeAddDevice(const ST::string& deviceName, FVaultAgeAddDeviceCallback callback);
 void VaultAgeRemoveDevice (const ST::string& deviceName);
 bool VaultAgeHasDevice (const ST::string& deviceName);
 hsRef<RelVaultNode> VaultAgeGetDevice(const ST::string& deviceName);
-typedef void (*FVaultAgeSetDeviceInboxCallback)(ENetError result, hsRef<RelVaultNode> inbox, void* param);
-void VaultAgeSetDeviceInbox(const ST::string& deviceName, const ST::string& inboxName, FVaultAgeSetDeviceInboxCallback callback, void* param);
+using FVaultAgeSetDeviceInboxCallback = std::function<void(ENetError result, hsRef<RelVaultNode> inbox)>;
+void VaultAgeSetDeviceInbox(const ST::string& deviceName, const ST::string& inboxName, FVaultAgeSetDeviceInboxCallback callback);
 hsRef<RelVaultNode> VaultAgeGetDeviceInbox(const ST::string& deviceName);
 void VaultClearDeviceInboxMap ();
 

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -50,6 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #endif
 #define PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLVAULT_PLVAULTCLIENTAPI_H
 
+#include <functional>
 #include <list>
 
 /*****************************************************************************
@@ -210,31 +211,23 @@ hsRef<RelVaultNode> VaultGetNode(hsWeakRef<NetVaultNode> templateNode);
 
 // VaultAddChildNode will download the child node if necessary
 // the parent exists locally before making the callback.
-typedef void (*FVaultAddChildNodeCallback)(
-    ENetError       result,
-    void *          param
-);
+using FVaultAddChildNodeCallback = std::function<void(ENetError result)>;
 void VaultAddChildNode (
     unsigned                    parentId,
     unsigned                    childId,
     unsigned                    ownerId,
-    FVaultAddChildNodeCallback  callback,   // optional
-    void *                      param       // optional
+    const FVaultAddChildNodeCallback& callback // optional
 );
 void VaultAddChildNodeAndWait (
     unsigned                    parentId,
     unsigned                    childId,
     unsigned                    ownerId
 );
-typedef void (*FVaultRemoveChildNodeCallback)(
-    ENetError       result,
-    void *          param
-);
+using FVaultRemoveChildNodeCallback = std::function<void(ENetError result)>;
 void VaultRemoveChildNode (
     unsigned                        parentId,
     unsigned                        childId,
-    FVaultRemoveChildNodeCallback   callback,
-    void *                          param
+    FVaultRemoveChildNodeCallback   callback
 );
 void VaultSetNodeSeen (
     unsigned    nodeId,

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -287,19 +287,15 @@ void VaultFetchNodesAndWait (   // Use VaultGetNode to access the fetched nodes
     unsigned                count,
     bool                    force = false
 );
-typedef void (*FVaultInitAgeCallback)(
+using FVaultInitAgeCallback = std::function<void(
     ENetError       result,
-    void *          state,
-    void *          param,
     unsigned        ageVaultId,
     unsigned        ageInfoVaultId
-);
+)>;
 void VaultInitAge (
     const class plAgeInfoStruct *   info,
     const plUUID                    parentAgeInstId,
-    FVaultInitAgeCallback           callback,
-    void *                          state,
-    void *                          param
+    FVaultInitAgeCallback           callback
 );
 
 

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -431,37 +431,25 @@ void VaultCCRDumpPlayers();
 *
 ***/
 
-typedef void (*FVaultDownloadCallback)(
-    ENetError                   result,
-    void *                      param
-);
-typedef void (*FVaultProgressCallback)(
-    unsigned                    total,
-    unsigned                    curr,
-    void *                      param
-);
+using FVaultDownloadCallback = std::function<void(ENetError result)>;
+using FVaultProgressCallback = std::function<void(unsigned total, unsigned curr)>;
 
 void VaultDownload (
     const ST::string&           tag,
     unsigned                    vaultId,
     FVaultDownloadCallback      callback,
-    void *                      cbParam,
-    FVaultProgressCallback      progressCallback,
-    void *                      cbProgressParam
+    FVaultProgressCallback      progressCallback
 );
 void VaultDownloadNoCallbacks (
     const ST::string&           tag,
     unsigned                    vaultId,
     FVaultDownloadCallback      callback,
-    void *                      cbParam,
-    FVaultProgressCallback      progressCallback,
-    void *                      cbProgressParam
+    FVaultProgressCallback      progressCallback
 );
 void VaultDownloadAndWait (
     const ST::string&           tag,
     unsigned                    vaultId,
-    FVaultProgressCallback      progressCallback,
-    void *                      cbProgressParam
+    FVaultProgressCallback      progressCallback
 );
 
 void VaultCull (


### PR DESCRIPTION
Follow-up to #1703. As expected, this is another big diff because of lots of helper structs and functions being inlined (especially commit f5759534475496170b45ae9a83c1f9ab0f04ee68). But now you can read the async vault code internals without your brain catching fire immediately.