### PR TITLE
Replace `MAX_EXT` with a netcode-specific constant

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -299,7 +299,6 @@ template <> inline double hsToLE(double value) { return hsToLEDouble(value); }
 #   include <limits.h>
 #   define MAX_PATH PATH_MAX
 #endif
-#define MAX_EXT     (256)
 
 // Useful floating point utilities
 constexpr float hsDegreesToRadians(float deg) { return deg * (hsConstants::pi<float> / 180.f); }

--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbConst.h
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbConst.h
@@ -84,6 +84,7 @@ const unsigned kMaxGTOSIdLength                 = 8;
 const unsigned kMaxGameScoreNameLength          = 64;
 const unsigned kMaxEmailAddressLength           = 64;
 const unsigned kMaxTracebackLength              = 1024;
+const unsigned kMaxFileExtensionLength          = 256;
 
 // For string lengths that were formerly set to MAX_PATH,
 // which is 260 on Windows, but generally different on other OSes.

--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbConst.h
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbConst.h
@@ -53,7 +53,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // Network constants
 //============================================================================
 const unsigned kMaxTcpPacketSize                = 1460;
-const unsigned kNetDefaultStringSize            = 260;
 const unsigned kDefaultClientPort = 14617;
 
 //============================================================================
@@ -85,6 +84,10 @@ const unsigned kMaxGTOSIdLength                 = 8;
 const unsigned kMaxGameScoreNameLength          = 64;
 const unsigned kMaxEmailAddressLength           = 64;
 const unsigned kMaxTracebackLength              = 1024;
+
+// For string lengths that were formerly set to MAX_PATH,
+// which is 260 on Windows, but generally different on other OSes.
+const unsigned kNetDefaultStringSize            = 260;
 
 /*****************************************************************************
 *

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.cpp
@@ -150,8 +150,8 @@ static const NetMsgField kAcctActivateRequestFields[] = {
 
 static const NetMsgField kFileListRequestFields[] = {
     kNetMsgFieldTransId,                                // transId
-    NET_MSG_FIELD_STRING(kNetDefaultStringSize),       // directory
-    NET_MSG_FIELD_STRING(MAX_EXT),                      // ext
+    NET_MSG_FIELD_STRING(kNetDefaultStringSize),        // directory
+    NET_MSG_FIELD_STRING(kMaxFileExtensionLength),      // ext
 };
 
 static const NetMsgField kFileDownloadRequestFields[] = {

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/Private/Protocols/Cli2Auth/pnNpCli2Auth.h
@@ -393,7 +393,7 @@ struct Cli2Auth_FileListRequest {
     uint32_t       messageId;
     uint32_t       transId;
     char16_t       directory[kNetDefaultStringSize];
-    char16_t       ext[MAX_EXT];
+    char16_t       ext[kMaxFileExtensionLength];
 };
 
 // FileDownloadRequest

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAuth.cpp
@@ -505,7 +505,7 @@ struct FileListRequestTrans : NetAuthTrans {
     FNetCliAuthFileListRequestCallback  m_callback;
 
     char16_t                            m_directory[kNetDefaultStringSize];
-    char16_t                            m_ext[MAX_EXT];
+    char16_t                            m_ext[kMaxFileExtensionLength];
 
     std::vector<NetCliAuthFileInfo>       m_fileInfoArray;
 


### PR DESCRIPTION
Nothing else uses this constant anymore, so it doesn't need to be in HeadSpin.h. This also makes it clearer that this value can't be changed.