### PR TITLE
Make `plNetObjectDebugger` usable in non-debug builds

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetCliAgeJoiner.cpp
@@ -458,7 +458,13 @@ bool plNCAgeJoiner::MsgReceive (plMessage * msg) {
     //========================================================================
     plInitialAgeStateLoadedMsg * stateMsg = plInitialAgeStateLoadedMsg::ConvertNoRef(msg);
     if(stateMsg) {
-        plNetObjectDebugger::GetInstance()->LogMsg(ST_LITERAL("OnServerInitComplete"));
+        if (plNetObjectDebugger::GetInstance()->GetNumDebugObjects() != 0) {
+            // Log this only if the debugger is actually in use.
+            // Avoids creating a NetObject.log file with only OnServerInitComplete messages
+            // if no objects are added to the debugger (which is the usual case for non-debug builds).
+            plNetObjectDebugger::GetInstance()->LogMsg(ST_LITERAL("OnServerInitComplete"));
+        }
+
         nc->SetFlagsBit(plNetClientApp::kLoadingInitialAgeState, false);
 
         const plArmatureMod *avMod = plAvatarMgr::GetInstance()->GetLocalAvatar();

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -914,12 +914,14 @@ bool plNetClientMgr::MsgReceive( plMessage* msg )
     plClientMsg* clientMsg = plClientMsg::ConvertNoRef(msg);
     if (clientMsg && clientMsg->GetClientMsgFlag()==plClientMsg::kInitComplete)
     {
+#ifdef HS_DEBUGGING
         // add 1 debug object for age sdl
         if (plNetObjectDebugger::GetInstance())
         {
             plNetObjectDebugger::GetInstance()->RemoveDebugObject(ST_LITERAL("AgeSDLHook"));
             plNetObjectDebugger::GetInstance()->AddDebugObject(ST_LITERAL("AgeSDLHook"));
         }
+#endif
 
         // if we're linking to startup we don't need (or want) a player set
         ST::string ageName = NetCommGetStartupAge()->ageDatasetName;

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.cpp
@@ -117,7 +117,12 @@ bool plNetObjectDebugger::DebugObject::ObjectMatches(const hsKeyedObject* obj)
 /////////////////////////////////////////////////////////////////
 // plNetObjectDebugger
 /////////////////////////////////////////////////////////////////
-plNetObjectDebugger::plNetObjectDebugger() : fStatusLog(), fDebugging()
+plNetObjectDebugger::plNetObjectDebugger()
+    : fStatusLog(plStatusLogMgr::GetInstance().CreateStatusLog(
+          40, "NetObject.log",
+          plStatusLog::kFilledBackground | plStatusLog::kAlignToTop | plStatusLog::kTimestamp
+      )),
+      fDebugging()
 {
 }
 
@@ -138,18 +143,6 @@ plNetObjectDebugger* plNetObjectDebugger::GetInstance()
         plNetObjectDebuggerBase::SetInstance(&gNetObjectDebugger);
 
     return &gNetObjectDebugger;
-}
-
-//
-// create StatusLog if necessary
-//
-void plNetObjectDebugger::ICreateStatusLog() const
-{
-    if (!fStatusLog)
-    {
-        fStatusLog = plStatusLogMgr::GetInstance().CreateStatusLog(40, "NetObject.log",
-            plStatusLog::kFilledBackground | plStatusLog::kAlignToTop | plStatusLog::kTimestamp );
-    }
 }
 
 bool plNetObjectDebugger::AddDebugObject(ST::string objName, const ST::string& pageName)
@@ -197,8 +190,6 @@ bool plNetObjectDebugger::AddDebugObject(ST::string objName, const ST::string& p
     }
 
     fDebugObjects.push_back(new DebugObject(std::move(objName), loc, flags));
-
-    ICreateStatusLog();
 
     return true;
 }
@@ -274,7 +265,7 @@ void plNetObjectDebugger::LogMsgIfMatch(const ST::string& msg) const
 
 void plNetObjectDebugger::LogMsg(const ST::string& msg) const
 {
-    DEBUG_MSG(msg.c_str());
+    fStatusLog->AddLine(msg);
 }
 
 bool plNetObjectDebugger::IsDebugObject(const hsKeyedObject* obj) const

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetObjectDebugger.h
@@ -75,10 +75,9 @@ private:
     };
     typedef std::vector<DebugObject*> DebugObjectList;
     DebugObjectList fDebugObjects;
-    mutable plStatusLog* fStatusLog;
+    plStatusLog* fStatusLog;
     bool    fDebugging;
 
-    void ICreateStatusLog() const;
 public:
     plNetObjectDebugger();
     ~plNetObjectDebugger();


### PR DESCRIPTION
The console commands `Net.DebugObject.AddObject`, etc. already existed in both debug and release builds, but only had a visible effect in debug builds. In release builds, the `DEBUG_MSG` macro call got compiled out, so the output couldn't be seen anywhere.

The output now instead goes to a log file (NetObject.log) and can also be viewed in the in-game log viewer, regardless of build type. Release builds don't add any objects to the debugger by default (to match the previous behavior), but objects can now be added manually via the in-game console.