### PR TITLE
Add clickable links to journal books.

### DIFF
--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -87,7 +87,7 @@ LocalAvatar = None
 # a url by doing <a href="https://foo.com">, and this regex will
 # convert that to an integer id. It will do the same for any tag, but
 # only <img> and <movie> are useful.
-_URL_REGEX = re.compile(r"(?P<href>href\s*=\s*(?P<quote>[\"\']?)\s*?(?P<url>https?:\/\/[^\s>]+)\s*?(?P=quote))(?=[^<]*>)")
+_URL_REGEX = re.compile(r"(?P<href>href\s*=\s*(?P<quote>[\"\']?)\s*?(?P<url>https?:\/\/[^\s>]+)\s*?(?P=quote))(?=[^<]*>)", re.IGNORECASE)
 
 class xJournalBookGUIPopup(ptModifier):
     "The Journal Book GUI Popup python code"

--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -85,7 +85,8 @@ LocalAvatar = None
 # pfJournalBook's EsHTML will only allow links with integer events.
 # This isn't very friendly for age creators, so we'll let them specify
 # a url by doing <a href="https://foo.com">, and this regex will
-# convert that to an integer id.
+# convert that to an integer id. It will do the same for any tag, but
+# only <img> and <movie> are useful.
 _URL_REGEX = re.compile(r"(?P<href>href\s*=\s*(?P<quote>[\"\']?)\s*?(?P<url>https?:\/\/[^\s>]+)\s*?(?P=quote))(?=[^<]*>)")
 
 class xJournalBookGUIPopup(ptModifier):

--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -86,7 +86,7 @@ LocalAvatar = None
 # This isn't very friendly for age creators, so we'll let them specify
 # a url by doing <link href="https://foo.com">, and this regex will
 # convert that to an integer id.
-_URL_REGEX = re.compile(r"<link\s+href\s*=\s*(?P<quote>[\'\"]?)\s*(?P<url>https?:\/\/[\S]+|www\.[^\s.]+\.[^\s]+)\s*(?P=quote)\s*>")
+_URL_REGEX = re.compile(r"(?P<href>href\s*=\s*(?P<quote>[\"\']?)\s*?(?P<url>https?:\/\/[^\s>]+)\s*?(?P=quote))(?=[^<]*>)")
 
 class xJournalBookGUIPopup(ptModifier):
     "The Journal Book GUI Popup python code"
@@ -230,9 +230,15 @@ class xJournalBookGUIPopup(ptModifier):
 
             PtDebugPrint(f"xJournalBookGUIPopup.IPreprocessJournalContents(): Found {url=} {event=}")
             self.links.append(url)
-            return f"<link event={event}>"
+            return f"event={event}"
 
-        return _URL_REGEX.sub(replace_url, journalContents)
+        newContent = _URL_REGEX.sub(replace_url, journalContents)
+        PtDebugPrint(
+            "xJournalBookGuiPopup.IPreprocessJournalContents(): The journal content has been preprocessed to:",
+            newContent,
+            level=kDebugDumpLevel
+        )
+        return newContent
 
     def IsThereACover(self, bookHtml):
         # search the bookhtml string looking for a cover

--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -84,7 +84,7 @@ LocalAvatar = None
 
 # pfJournalBook's EsHTML will only allow links with integer events.
 # This isn't very friendly for age creators, so we'll let them specify
-# a url by doing <link href="https://foo.com">, and this regex will
+# a url by doing <a href="https://foo.com">, and this regex will
 # convert that to an integer id.
 _URL_REGEX = re.compile(r"(?P<href>href\s*=\s*(?P<quote>[\"\']?)\s*?(?P<url>https?:\/\/[^\s>]+)\s*?(?P=quote))(?=[^<]*>)")
 
@@ -230,7 +230,7 @@ class xJournalBookGUIPopup(ptModifier):
 
             PtDebugPrint(f"xJournalBookGUIPopup.IPreprocessJournalContents(): Found {url=} {event=}")
             self.links.append(url)
-            return f"event={event}"
+            return f"link={event}"
 
         newContent = _URL_REGEX.sub(replace_url, journalContents)
         PtDebugPrint(

--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -88,6 +88,7 @@ LocalAvatar = None
 # convert that to an integer id. It will do the same for any tag, but
 # only <img> and <movie> are useful.
 _URL_REGEX = re.compile(r"(?P<href>href\s*=\s*(?P<quote>[\"\']?)\s*?(?P<url>https?:\/\/[^\s>]+)\s*?(?P=quote))(?=[^<]*>)", re.IGNORECASE)
+_HOST_REGEX = re.compile(R"(?:https?:\/\/)?(?:www\.)?([^\/?#]+).*", re.IGNORECASE)
 
 class xJournalBookGUIPopup(ptModifier):
     "The Journal Book GUI Popup python code"
@@ -140,8 +141,13 @@ class xJournalBookGUIPopup(ptModifier):
                         except IndexError:
                             pass
                         else:
-                            PtDebugPrint(f"xJournalBookGUIPopup: NotifyImageLink: opening {url=} {event[2]=}", level=kWarningLevel)
-                            webbrowser.open_new_tab(url)
+                            def open_url(result):
+                                if result == PtConfirmationResult.Yes:
+                                    webbrowser.open_new_tab(url)
+
+                            hostname = _HOST_REGEX.sub(R"\1", url)
+                            PtDebugPrint(f"xJournalBookGUIPopup: NotifyImageLink: Prompting user to open {hostname=} {url=} {event[2]=}", level=kWarningLevel)
+                            PtLocalizedYesNoDialog(open_url, "KI.Messages.OpenHyperlink", hostname)
                     elif event[1] == PtBookEventTypes.kNotifyShow:
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyShow",level=kDebugDumpLevel)
                         # disable the KI

--- a/Sources/Plasma/FeatureLib/pfConsole/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfConsole/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(
         pfAudio
         pfAnimation
         pfCamera
+        pfJournalBook
         pfMessage
         pfPython
         pfSurface

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -167,6 +167,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfCamera/plVirtualCamNeu.h"
 #include "pfConsoleCore/pfConsoleCmd.h"
 #include "pfConsoleCore/pfConsoleContext.h"
+#include "pfJournalBook/pfJournalBook.h"
 #include "pfMessage/pfBackdoorMsg.h"
 #include "pfMessage/plClothingMsg.h"
 #include "pfMessage/pfKIMsg.h"
@@ -464,6 +465,33 @@ PF_CONSOLE_BASE_CMD( DumpLogs, "string folderName", "Dumps all current logs to t
 {
     plStatusLogMgr::GetInstance().DumpLogs(params[0]);
 }
+
+//////////////////////////////////////////////////////////////////////////////
+//// Journal Commands ////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef LIMIT_CONSOLE_COMMANDS
+
+PF_CONSOLE_GROUP(Journal)
+
+PF_CONSOLE_CMD(
+    Journal, ShowLinkRect,
+    "bool on",
+    ""
+)
+{
+    if (numParams != 1)
+        return;
+
+    pfJournalBook::ShowLinkRect((bool)params[0]);
+    if ((bool)params[0]) {
+        PrintString("Journals will now have link rects.");
+    } else {
+        PrintString("Journals will no longer have link rects.");
+    }
+}
+
+#endif
 
 
 //////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -2136,10 +2136,10 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                     break;
 
                 case pfEsHTMLChunk::kTextLink:
-                    c += 5;
+                    c += 2;
                     chunk = new pfEsHTMLChunk(pfEsHTMLChunk::TextLink);
                     while (IGetNextOption(c, end, name, option)) {
-                        if (name.compare_i("event") == 0) {
+                        if (name.compare_i("link") == 0) {
                             ST::conversion_result result;
                             chunk->fEventID = option.to_uint(result);
                             // Ideally, we'd do something like event=clear, but we'll just
@@ -2211,7 +2211,7 @@ uint8_t   pfJournalBook::IGetTagType( const char *string, const char *end )
                 { ST_LITERAL("decal"), pfEsHTMLChunk::kDecal },
                 { ST_LITERAL("movie"), pfEsHTMLChunk::kMovie },
                 { ST_LITERAL("editable"), pfEsHTMLChunk::kEditable },
-                { ST_LITERAL("link"), pfEsHTMLChunk::kTextLink },
+                { ST_LITERAL("a"), pfEsHTMLChunk::kTextLink },
     };
 
     for (const auto& tag : tags)

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -2413,18 +2413,24 @@ void    pfJournalBook::IRenderPage( uint32_t page, uint32_t whichDTMap, bool sup
                 case pfEsHTMLChunk::kParagraph:             
                     if( ( chunk->fFlags & pfEsHTMLChunk::kAlignMask ) == pfEsHTMLChunk::kLeft )
                     {
-                        dtMap->SetJustify( plDynamicTextMap::kLeftJustify );
-                        x = (uint16_t)fPageLMargin; // reset X if our justification changes
+                        if (dtMap->GetFontJustify() != plDynamicTextMap::kLeftJustify) {
+                            dtMap->SetJustify(plDynamicTextMap::kLeftJustify);
+                            x = (uint16_t)fPageLMargin; // reset X if our justification changes
+                        }
                     }
                     else if( ( chunk->fFlags & pfEsHTMLChunk::kAlignMask ) == pfEsHTMLChunk::kRight )
                     {
-                        dtMap->SetJustify( plDynamicTextMap::kRightJustify );
-                        x = (uint16_t)fPageLMargin; // reset X if our justification changes
+                        if (dtMap->GetFontJustify() != plDynamicTextMap::kRightJustify) {
+                            dtMap->SetJustify(plDynamicTextMap::kRightJustify);
+                            x = (uint16_t)fPageLMargin; // reset X if our justification changes
+                        }
                     }
                     else if( ( chunk->fFlags & pfEsHTMLChunk::kAlignMask ) == pfEsHTMLChunk::kCenter )
                     {
-                        dtMap->SetJustify( plDynamicTextMap::kCenter );
-                        x = (uint16_t)fPageLMargin; // reset X if our justification changes
+                        if (dtMap->GetFontJustify() != plDynamicTextMap::kCenter) {
+                            dtMap->SetJustify(plDynamicTextMap::kCenter);
+                            x = (uint16_t)fPageLMargin; // reset X if our justification changes
+                        }
                     }
 
                     dtMap->SetFirstLineIndent( (int16_t)(x - fPageLMargin) );

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -109,12 +109,26 @@ static hsColorRGBA s_LinkRectColor{ 0.f, 0.f, 1.f, 1.f };
 class pfEsHTMLChunk
 {
     public:
+        enum Type : uint8_t
+        {
+            kEmpty = 0,
+            kParagraph,
+            kImage,
+            kPageBreak,
+            kFontChange,
+            kMargin,
+            kCover, // Just a placeholder, never actually used after compile time
+            kBook,  // another placeholder
+            kDecal,
+            kMovie,
+            kEditable // placeholder, ver 3.0
+        };
 
         ST::string fText; // Paragraph text, or face name
         plKey   fImageKey;  // Key of image
         uint8_t   fFontSize;
         uint32_t  fFlags;
-        uint8_t   fType;
+        Type   fType;
         uint32_t  fEventID;
 
         hsColorRGBA fColor;
@@ -159,21 +173,6 @@ class pfEsHTMLChunk
                                         // is "on opacity"
             kChecked    = 0x00000080,   // Only for kActAsCB, set if it's currently "checked"
             kTranslucent= 0x00000100    // is the image translucent? if so, use fCurrOpacity
-        };
-
-        enum Types
-        {
-            kEmpty = 0,
-            kParagraph,
-            kImage,
-            kPageBreak,
-            kFontChange,
-            kMargin,
-            kCover,         // Just a placeholder, never actually used after compile time
-            kBook,          // another placeholder
-            kDecal,
-            kMovie,
-            kEditable       // placeholder, ver 3.0
         };
 
         // Paragraph constructor

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -50,7 +50,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pfJournalBook.h"
 
-#include <memory>
 #include <cwchar>
 
 #include "HeadSpin.h"
@@ -2911,7 +2910,7 @@ void    pfJournalBook::IMoveMovies( hsGMaterial *source, hsGMaterial *dest )
 
 void    pfJournalBook::IDrawMipmap( pfEsHTMLChunk *chunk, uint16_t x, uint16_t y, plMipmap *mip, plDynamicTextMap *dtMap, uint32_t whichDTMap, bool dontRender )
 {
-    auto copy = std::make_unique<plMipmap>();
+    hsRef<plMipmap> copy(new plMipmap(), hsStealRef);
     copy->CopyFrom(mip);
     if (chunk->fNoResizeImg)
     {
@@ -2986,7 +2985,7 @@ void    pfJournalBook::IDrawMipmap( pfEsHTMLChunk *chunk, uint16_t x, uint16_t y
                 opts.fFlags = ( chunk->fFlags & pfEsHTMLChunk::kBlendAlpha ) ? plMipmap::kCopySrcAlpha : plMipmap::kForceOpaque;
             opts.fOpacity = (uint8_t)(chunk->fCurrOpacity * 255.f);
         }
-        dtMap->Composite( copy.get(), x, y, &opts );
+        dtMap->Composite(copy.Get(), x, y, &opts);
     }
 
     if( chunk->fFlags & pfEsHTMLChunk::kCanLink )

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -2578,7 +2578,7 @@ void    pfJournalBook::IMoveMovies( hsGMaterial *source, hsGMaterial *dest )
 
 void    pfJournalBook::IDrawMipmap( pfEsHTMLChunk *chunk, uint16_t x, uint16_t y, plMipmap *mip, plDynamicTextMap *dtMap, uint32_t whichDTMap, bool dontRender )
 {
-    plMipmap *copy = new plMipmap();
+    auto copy = std::make_unique<plMipmap>();
     copy->CopyFrom(mip);
     if (chunk->fNoResizeImg)
     {
@@ -2653,7 +2653,7 @@ void    pfJournalBook::IDrawMipmap( pfEsHTMLChunk *chunk, uint16_t x, uint16_t y
                 opts.fFlags = ( chunk->fFlags & pfEsHTMLChunk::kBlendAlpha ) ? plMipmap::kCopySrcAlpha : plMipmap::kForceOpaque;
             opts.fOpacity = (uint8_t)(chunk->fCurrOpacity * 255.f);
         }
-        dtMap->Composite( copy, x, y, &opts );
+        dtMap->Composite( copy.get(), x, y, &opts );
     }
 
     if( chunk->fFlags & pfEsHTMLChunk::kCanLink )
@@ -2667,7 +2667,6 @@ void    pfJournalBook::IDrawMipmap( pfEsHTMLChunk *chunk, uint16_t x, uint16_t y
             chunk->fLinkRect.Set( x, y, (int16_t)(copy->GetWidth()), (int16_t)(copy->GetHeight()) );
         fVisibleLinks.emplace_back(chunk);
     }
-    delete copy;
 }
 
 pfJournalBook::loadedMovie *pfJournalBook::IMovieAlreadyLoaded(pfEsHTMLChunk *chunk)

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -2154,7 +2154,7 @@ uint8_t   pfJournalBook::IGetTagType( const char *string, const char *end )
                 { ST_LITERAL("editable"), pfEsHTMLChunk::kEditable },
     };
 
-    for (auto tag : tags)
+    for (const auto& tag : tags)
     {
         if (string + tag.fTag.size() < end && tag.fTag.compare_ni(string, tag.fTag.size()) == 0)
         {

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -1747,6 +1747,7 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
     IFreeSource();
 
     pfEsHTMLChunk *chunk, *lastParChunk = new pfEsHTMLChunk(ST::string());
+    pfEsHTMLChunk *lastLinkChunk = nullptr;
     const char *c, *start;
     ST::string name;
     ST::string option;
@@ -1869,6 +1870,13 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                             chunk->fNoResizeImg = (option.compare_i("no") == 0);
                         }
                     }
+
+                    // Inherit link
+                    if (!hsCheckBits(chunk->fFlags, pfEsHTMLChunk::kCanLink) && lastLinkChunk) {
+                        hsSetBits(chunk->fFlags, pfEsHTMLChunk::kCanLink);
+                        chunk->fEventID = lastLinkChunk->fEventID;
+                    }
+
                     if (chunk->fImageKey)
                         fHTMLSource.emplace_back(chunk);
                     else
@@ -2090,6 +2098,13 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                             chunk->fLoopMovie = option.compare_i("no") != 0;
                         }
                     }
+
+                    // Inherit link
+                    if (!hsCheckBits(chunk->fFlags, pfEsHTMLChunk::kCanLink) && lastLinkChunk) {
+                        hsSetBits(chunk->fFlags, pfEsHTMLChunk::kCanLink);
+                        chunk->fEventID = lastLinkChunk->fEventID;
+                    }
+
                     chunk->fMovieIndex = movieIndex;
                     movieIndex++;
                     if (chunk->fOnCover) {
@@ -2135,6 +2150,12 @@ bool    pfJournalBook::ICompileSource(const ST::string& source, const plLocation
                         }
                     }
                     fHTMLSource.emplace_back(chunk);
+
+                    // For other interactable bits to inherit the link.
+                    if (hsTestBits(chunk->fFlags, pfEsHTMLChunk::kCanLink))
+                        lastLinkChunk = chunk;
+                    else
+                        lastLinkChunk = nullptr;
 
                     lastParChunk = new pfEsHTMLChunk(ST::string());
                     lastParChunk->fFlags = IFindLastAlignment();

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -95,6 +95,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfMessage/pfGUINotifyMsg.h"
 #include "pfSurface/plLayerAVI.h"
 
+//////////////////////////////////////////////////////////////////////////////
+//// Do we show linking rects? ///////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+static bool s_ShowLinkRects = false;
+static hsColorRGBA s_LinkRectColor{ 0.f, 0.f, 1.f, 1.f };
 
 //////////////////////////////////////////////////////////////////////////////
 //// pfEsHTMLChunk Class /////////////////////////////////////////////////////
@@ -1172,6 +1178,11 @@ void    pfJournalBook::UnloadAllGUIs()
         names.emplace_back(name); // store a list of keys
     for (const ST::string& name : names)
         UnloadGUI(name); // UnloadGUI won't unload BkBook
+}
+
+void     pfJournalBook::ShowLinkRect(bool on)
+{
+    s_ShowLinkRects = on;
 }
 
 //// Constructor /////////////////////////////////////////////////////////////
@@ -2705,14 +2716,17 @@ void    pfJournalBook::IDrawMipmap( pfEsHTMLChunk *chunk, uint16_t x, uint16_t y
 
     if( chunk->fFlags & pfEsHTMLChunk::kCanLink )
     {
+        int16_t xOffs = 0;
         if( whichDTMap == pfJournalDlgProc::kTagRightDTMap || whichDTMap == pfJournalDlgProc::kTagTurnFrontDTMap )
-            x += (uint16_t)(dtMap->GetWidth());   // Right page rects are offsetted to differentiate
+            xOffs = (int16_t)(dtMap->GetWidth());   // Right page rects are offsetted to differentiate
 
         // if we aren't rendering then this link isn't visible, but the index still needs to be valid, so give it a rect of 0,0,0,0
         if (dontRender) {
             fVisibleLinks.emplace_back(chunk, 0, 0, 0, 0);
         } else {
-            fVisibleLinks.emplace_back(chunk, x, y, (int16_t)(copy->GetWidth()), (int16_t)(copy->GetHeight()));
+            fVisibleLinks.emplace_back(chunk, x + xOffs, y, (int16_t)(copy->GetWidth()), (int16_t)(copy->GetHeight()));
+            if (s_ShowLinkRects)
+                dtMap->FrameRect(x, y, (int16_t)(copy->GetWidth()), (int16_t)(copy->GetHeight()), s_LinkRectColor);
         }
     }
 }

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -552,6 +552,9 @@ class pfJournalBook : public hsKeyedObject
         // font properties at that point, or assigns defaults if none were specified
         void    IFindFontProps( uint32_t chunkIdx, ST::string &face, uint8_t &size, uint8_t &flags, hsColorRGBA &color, int16_t &spacing );
 
+        // Starting at the given chunk, works backward to determine the current text link ID
+        pfEsHTMLChunk* IFindTextLink(uint32_t chunkIdx) const;
+
         // Find the last paragraph chunk and thus the last par alignment settings
         uint8_t   IFindLastAlignment() const;
 

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -152,6 +152,16 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //                              defaults to yes                             //
 //      <editable> - Marks this book as editable (if the GUI supports it)   //
 //                                                                          //
+//      <a> - Places a link inline with the text. Images and movies will    //
+//            inherit the link's event if they do not have one set.         //
+//            Options are:                                                  //
+//          link=<eventID>    - Defines the text as clickable. When the     //
+//                              user clicks the text, it will generate an   //
+//                              events with the given event ID and send it  //
+//                              to the calling python handler. If the       //
+//                              eventID is not a valid integer, any active  //
+//                              text link is cleared.                       //
+//          color=rrggbb      - Hex color                                   //
 //  The pages don't render until displayed. As a result, jumping to a given //
 //  page requires each page from the current position to the destination    //
 //  to be rendered. Normally, this won't be a problem, because by default   //

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -169,6 +169,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <map>
 #include <string>
 #include <string_theory/string>
+#include <vector>
 
 #include "hsColorRGBA.h"
 

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -150,17 +150,23 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //                              to be ignored since cover movies can't link //
 //          loop=yes/no       - Defines whether the movie will loop or not  //
 //                              defaults to yes                             //
+//          href=#<name>      - Flips to the page the named anchor is on    //
+//                              when the user clicks it.                    //
 //      <editable> - Marks this book as editable (if the GUI supports it)   //
 //                                                                          //
 //      <a> - Places a link inline with the text. Images and movies will    //
 //            inherit the link's event if they do not have one set.         //
 //            Options are:                                                  //
+//          href=#<name>      - Flips to the page the named anchor is on    //
+//                              when the user clicks it.                    //
 //          link=<eventID>    - Defines the text as clickable. When the     //
 //                              user clicks the text, it will generate an   //
 //                              events with the given event ID and send it  //
 //                              to the calling python handler. If the       //
 //                              eventID is not a valid integer, any active  //
 //                              text link is cleared.                       //
+//          name=<foo>        - Defines a named anchor that can be linked   //
+//                              to using <a href=#foo>                      //
 //          color=rrggbb      - Hex color                                   //
 //  The pages don't render until displayed. As a result, jumping to a given //
 //  page requires each page from the current position to the destination    //
@@ -583,6 +589,12 @@ class pfJournalBook : public hsKeyedObject
 
         // Find the current moused link, if any
         hsSsize_t IFindCurrVisibleLink(bool rightNotLeft, bool hoverNotUp);
+
+        // Find the chunk matching the named anchor, if any
+        hsSsize_t IFindAnchor(const ST::string& anchor) const;
+
+        // Flip to the page with this named text link
+        void IFlipToAnchor(const ST::string &anchor);
 
         // Ensures that all the page starts are calced up to the given page (but not including it)
         void    IRecalcPageStarts( uint32_t upToPage );

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -401,6 +401,9 @@ class pfJournalBook : public hsKeyedObject
         // unloads all GUIs except for the default
         static void UnloadAllGUIs();
 
+        // show a rectangle around links
+        static void ShowLinkRect(bool on);
+
         void    SetGUI( const ST::string &guiName );
 
         // Shows the book, optionally starting open or closed

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -195,6 +195,7 @@ class pfGUIMultiLineEditCtrl;
 
 class pfJournalBook;
 class pfBookMultiLineEditProc;
+class pfJournalVisibleLink;
 
 class pfBookData : public hsKeyedObject
 {
@@ -514,8 +515,9 @@ class pfJournalBook : public hsKeyedObject
         // Some animation keys we use
         plKey   fPageTurnAnimKey;
 
-        // Current list of linkable image chunks we have visible on the screen, for quick hit testing
-        std::vector<pfEsHTMLChunk *> fVisibleLinks;
+        // Current list of visible link hotspots for quick hit testing.
+        // Can be images or lines of text.
+        std::vector<pfJournalVisibleLink> fVisibleLinks;
 
         static std::map<ST::string,pfBookData*> fBookGUIs;
         ST::string fCurBookGUI;

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.h
@@ -250,6 +250,7 @@ class plFont : public hsKeyedObject
         uint32_t    GetFlags() const { return fFlags; }
         float       GetDescent() const { return (float)fFontDescent; }
         float       GetAscent() const { return (float)fFontAscent; }
+        float       GetMaxCharHeight() const { return (float)fMaxCharHeight; }
 
         uint32_t      GetBitmapWidth() const { return fWidth; }
         uint32_t      GetBitmapHeight() const { return fHeight; }


### PR DESCRIPTION
This adds clickable links to journals. Links already somewhat existed in journals in that you could have an image or movie with a `link=[event ID]` attribute on the tag that fired a notification to the host Python script. This pull request extends that in a number of ways, rather creatively in some respects by:
- adding named anchors to journals
- adding the ability to link to named anchors using text, images, or movies
- adding the ability to link to URLs using text, images, or movies

Text based links can be created using `<a link=[event ID]>`. So, if you want some text to fire event 1 in the host script, use `<a link=1>`. EsHTML does not use closing tags, so to stop making text a link, use `<a link=clear>`. This is mostly consistent with `<img link=1>` and `<movie link=1>`. By default, links will be colored solid blue, but this can be controlled using the `color` attribute, which accepts a hex color.

To add an anchor named `foo` into a journal, use `<a name=foo>`. You can then link to that anchor by using `<a href=#foo>`  This also works with images and movies, eg `<img src=bar.hsm href=#foo>` and `<movie href=#foo>`. Alternatively, any images or movies added to a journal while a link is "active" will inherit that link unless they define their own links.

URL support was a bit more tricky. The existing KI URL support uses the Python `webbrowser` module. This module does a good job of opening URLs in browsers in a cross platform way. Unfortunately, it weighs in at approximately 24 KB. I have no interest in reimplementing that in C++, so that means Python needs to open URLs. Even more unfortunately, the book notification message only sends out an integer event ID. So, I decided to have the journal book Python script inspect all `href` attributes for URLs. If one is found, it translates that to an integer ID, and dispatches any events that come back from the book.

As part of this pull request, I identified some already existing issues with how journals work. Specifically, if using center or right alignment, any attempt to continue an already in progress paragraph will cause the paragraph text to overlap. A trivial way to do this would be to change the font color or style without starting a new paragraph, eg:
```
<p align=center>This is an example <font color=FF00FF0000>of the brokenness!
```
This means that using links in a center or right aligned paragraph may yield disappointing results. The entire paragraph will need to be a link in those cases because any uses of the `<a>` tag cause a new continuation paragraph to start internally.

For reference, [check out this video](https://www.youtube.com/watch?v=evyGFLz3GmE) or try the [sample Age](https://github.com/user-attachments/files/21338748/KormanGUI.zip) attached to this pull request.

