### PR TITLE
Rename global `DebugMsg` function (and others) to avoid name collisions/confusion

### DIFF
--- a/Sources/MaxPlugin/MaxExport/plExportErrorMsg.cpp
+++ b/Sources/MaxPlugin/MaxExport/plExportErrorMsg.cpp
@@ -129,7 +129,7 @@ void plExportErrorMsg::Quit()
 void plExportErrorMsg::IDebugThrow()
 {
     try {
-        DebugBreakIfDebuggerPresent();
+        hsDebugBreakIfDebuggerPresent();
     }
     catch(...)
     {

--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -1569,7 +1569,7 @@ bool plClient::MainLoop()
 #endif
 
 #ifdef PLASMA_EXTERNAL_RELEASE
-    if (DebugIsDebuggerPresent())
+    if (hsDebugIsDebuggerPresent())
     {
         NetCliAuthLogClientDebuggerConnect();
         SetDone(true);

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -140,8 +140,7 @@ void ErrorAssert(int line, const char* file, const char* fmt, ...)
     } else
 #endif // _MSC_VER
     {
-        DebugMsg("-------\nASSERTION FAILED:\nFile: %s   Line: %i\nMessage: %s\n-------",
-                 file, line, msg);
+        hsDebugPrintToTerminal("-------\nASSERTION FAILED:\nFile: %s   Line: %i\nMessage: %s\n-------", file, line, msg);
         fflush(stderr);
 
         DebugBreakAlways();
@@ -216,7 +215,7 @@ void DebugBreakAlways()
 #endif // _MSC_VER
 }
 
-void DebugMsg(const char* fmt, ...)
+void hsDebugPrintToTerminal(const char* fmt, ...)
 {
     char msg[1024];
     va_list args;

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -112,7 +112,7 @@ void hsDebugMessage (const char* message, long val)
 #endif
 
 static bool s_GuiAsserts = true;
-void ErrorEnableGui(bool enabled)
+void hsDebugEnableGuiAsserts(bool enabled)
 {
     s_GuiAsserts = enabled;
 }
@@ -120,7 +120,7 @@ void ErrorEnableGui(bool enabled)
 #if !defined(HS_DEBUGGING)
 [[noreturn]]
 #endif // defined(HS_DEBUGGING)
-void ErrorAssert(int line, const char* file, const char* fmt, ...)
+void hsDebugAssertionFailed(int line, const char* file, const char* fmt, ...)
 {
 #if defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
     char msg[1024];
@@ -133,7 +133,7 @@ void ErrorAssert(int line, const char* file, const char* fmt, ...)
     if (s_GuiAsserts)
     {
         if (_CrtDbgReport(_CRT_ASSERT, file, line, nullptr, msg))
-            DebugBreakAlways();
+            hsDebugBreakAlways();
 
         // All handling was done by the GUI, so bail.
         return;
@@ -143,11 +143,11 @@ void ErrorAssert(int line, const char* file, const char* fmt, ...)
         hsDebugPrintToTerminal("-------\nASSERTION FAILED:\nFile: %s   Line: %i\nMessage: %s\n-------", file, line, msg);
         fflush(stderr);
 
-        DebugBreakAlways();
+        hsDebugBreakAlways();
     }
 #endif // HS_DEBUGGING
 #else
-    DebugBreakIfDebuggerPresent();
+    hsDebugBreakIfDebuggerPresent();
 #endif // defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
 
     // If no debugger break occurred, just crash.
@@ -156,7 +156,7 @@ void ErrorAssert(int line, const char* file, const char* fmt, ...)
 #endif // defined(HS_DEBUGGING)
 }
 
-bool DebugIsDebuggerPresent()
+bool hsDebugIsDebuggerPresent()
 {
 #if defined(HS_BUILD_FOR_WIN32)
     return IsDebuggerPresent();
@@ -185,7 +185,7 @@ bool DebugIsDebuggerPresent()
 #endif
 }
 
-void DebugBreakIfDebuggerPresent()
+void hsDebugBreakIfDebuggerPresent()
 {
 #if defined(_MSC_VER)
     __try
@@ -196,14 +196,14 @@ void DebugBreakIfDebuggerPresent()
         // Whatever. Don't crash here.
     }
 #elif defined(HS_BUILD_FOR_UNIX)
-    if (DebugIsDebuggerPresent())
+    if (hsDebugIsDebuggerPresent())
         raise(SIGTRAP);
 #else
     // FIXME
 #endif // _MSC_VER
 }
 
-void DebugBreakAlways()
+void hsDebugBreakAlways()
 {
 #if defined(_MSC_VER)
     DebugBreak();
@@ -225,7 +225,7 @@ void hsDebugPrintToTerminal(const char* fmt, ...)
     fprintf(stderr, "%s\n", msg);
 
 #ifdef _MSC_VER
-    if (DebugIsDebuggerPresent())
+    if (hsDebugIsDebuggerPresent())
     {
         // Also print to the MSVC Output window
         OutputDebugStringA(msg);

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -315,16 +315,16 @@ hsDebugMessageProc hsSetDebugMessageProc(hsDebugMessageProc newProc);
 extern hsDebugMessageProc gHSStatusProc;
 hsDebugMessageProc hsSetStatusMessageProc(hsDebugMessageProc newProc);
 
-void ErrorEnableGui (bool enabled);
+void hsDebugEnableGuiAsserts(bool enabled);
 
 #ifndef HS_DEBUGGING
 [[noreturn]]
 #endif
-void ErrorAssert (int line, const char* file, const char* fmt, ...);
+void hsDebugAssertionFailed(int line, const char* file, const char* fmt, ...);
 
-bool DebugIsDebuggerPresent();
-void DebugBreakIfDebuggerPresent();
-void DebugBreakAlways();
+bool hsDebugIsDebuggerPresent();
+void hsDebugBreakIfDebuggerPresent();
+void hsDebugBreakAlways();
 
 /**
  * Print a message to stderr (and to the Windows debugger output, if on Windows with a debugger attached).
@@ -344,9 +344,9 @@ void hsDebugPrintToTerminal(const char* fmt, ...);
     
     void    hsDebugMessage(const char* message, long refcon);
     #define hsIfDebugMessage(expr, msg, ref)    (void)( (!!(expr)) || (hsDebugMessage(msg, ref), 0) )
-    #define hsAssert(expr, ...)                 (void)( (!!(expr)) || (ErrorAssert(__LINE__, __FILE__, __VA_ARGS__), 0) )
-    #define ASSERT(expr)                        (void)( (!!(expr)) || (ErrorAssert(__LINE__, __FILE__, #expr), 0) )
-    #define FATAL(...)                          ErrorAssert(__LINE__, __FILE__, __VA_ARGS__)
+    #define hsAssert(expr, ...)                 (void)( (!!(expr)) || (hsDebugAssertionFailed(__LINE__, __FILE__, __VA_ARGS__), 0) )
+    #define ASSERT(expr)                        (void)( (!!(expr)) || (hsDebugAssertionFailed(__LINE__, __FILE__, #expr), 0) )
+    #define FATAL(...)                          hsDebugAssertionFailed(__LINE__, __FILE__, __VA_ARGS__)
     
 #else   /* Not debugging */
 

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -325,7 +325,20 @@ void ErrorAssert (int line, const char* file, const char* fmt, ...);
 bool DebugIsDebuggerPresent();
 void DebugBreakIfDebuggerPresent();
 void DebugBreakAlways();
-void DebugMsg(const char* fmt, ...);
+
+/**
+ * Print a message to stderr (and to the Windows debugger output, if on Windows with a debugger attached).
+ * This function's output is never redirected to a log file (unlike hsStatusMessage and hsDebugMessage).
+ *
+ * Be aware that this function's output is impossible to see for the average player/tester.
+ * Prefer using other logging functions instead.
+ * Please use hsDebugPrintToTerminal ONLY for debugging messages aimed at developers
+ * that must not go to a log file for some reason.
+ *
+ * @param fmt printf-style format string for the log message
+ * @param ... format string arguments
+ */
+void hsDebugPrintToTerminal(const char* fmt, ...);
 
 #ifdef HS_DEBUGGING
     

--- a/Sources/Plasma/CoreLib/hsRefCnt.cpp
+++ b/Sources/Plasma/CoreLib/hsRefCnt.cpp
@@ -67,15 +67,15 @@ struct _RefCountLeakCheck
     {
         hsLockGuard(m_mutex);
 
-        DebugMsg(ST::format("Refs tracked:  {} created, {} destroyed\n",
-                            m_added, m_removed).c_str());
+        hsDebugPrintToTerminal(ST::format("Refs tracked:  {} created, {} destroyed\n",
+                                          m_added, m_removed).c_str());
         if (m_refs.empty())
             return;
 
-        DebugMsg(ST::format("    {} objects leaked...\n", m_refs.size()).c_str());
+        hsDebugPrintToTerminal(ST::format("    {} objects leaked...\n", m_refs.size()).c_str());
         for (hsRefCnt *ref : m_refs) {
-            DebugMsg(ST::format("    {#08x} {}: {} refs remain\n",
-                                (uintptr_t)ref, typeid(*ref).name(), ref->RefCnt()).c_str());
+            hsDebugPrintToTerminal(ST::format("    {#08x} {}: {} refs remain\n",
+                                              (uintptr_t)ref, typeid(*ref).name(), ref->RefCnt()).c_str());
         }
     }
 
@@ -130,9 +130,9 @@ void hsRefCnt::UnRef(const char* tag)
 
 #if (REFCOUNT_DEBUGGING == REFCOUNT_DBG_REFS) || (REFCOUNT_DEBUGGING == REFCOUNT_DBG_ALL)
     if (tag)
-        DebugMsg("Dec %p %s: %u", this, tag, fRefCnt - 1);
+        hsDebugPrintToTerminal("Dec %p %s: %u", this, tag, fRefCnt - 1);
     else
-        DebugMsg("Dec %p: %u", this, fRefCnt - 1);
+        hsDebugPrintToTerminal("Dec %p: %u", this, fRefCnt - 1);
 #endif
 
     if (fRefCnt == 1)   // don't decrement if we call delete
@@ -145,9 +145,9 @@ void hsRefCnt::Ref(const char* tag)
 {
 #if (REFCOUNT_DEBUGGING == REFCOUNT_DBG_REFS) || (REFCOUNT_DEBUGGING == REFCOUNT_DBG_ALL)
     if (tag)
-        DebugMsg("Inc %p %s: %u", this, tag, fRefCnt + 1);
+        hsDebugPrintToTerminal("Inc %p %s: %u", this, tag, fRefCnt + 1);
     else
-        DebugMsg("Inc %p: %u", this, fRefCnt + 1);
+        hsDebugPrintToTerminal("Inc %p: %u", this, fRefCnt + 1);
 #endif
 
     ++fRefCnt;
@@ -156,7 +156,7 @@ void hsRefCnt::Ref(const char* tag)
 void hsRefCnt::TransferRef(const char* oldTag, const char* newTag)
 {
 #if (REFCOUNT_DEBUGGING == REFCOUNT_DBG_REFS) || (REFCOUNT_DEBUGGING == REFCOUNT_DBG_ALL)
-    DebugMsg("Inc %p %s: (xfer)", this, newTag);
-    DebugMsg("Dec %p %s: (xfer)", this, oldTag);
+    hsDebugPrintToTerminal("Inc %p %s: (xfer)", this, newTag);
+    hsDebugPrintToTerminal("Dec %p %s: (xfer)", this, oldTag);
 #endif
 }

--- a/Sources/Plasma/NucleusLib/pnDispatch/plDispatch.cpp
+++ b/Sources/Plasma/NucleusLib/pnDispatch/plDispatch.cpp
@@ -362,7 +362,7 @@ void plDispatch::IMsgDispatch()
 
                 #ifdef HS_DEBUGGING
                 if (msg->GetBreakBeforeDispatch())
-                    DebugBreakIfDebuggerPresent();
+                    hsDebugBreakIfDebuggerPresent();
                 #endif
                     
                 plProfile_BeginTiming(MsgReceive);

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
@@ -207,8 +207,8 @@ bool plAgeLoader::ILoadAge(const ST::string& ageName)
     nc->DebugMsg( "Net: Loading age {}", fAgeName);
 
     if ((fFlags & kLoadMask) != 0)
-        ErrorAssert(__LINE__, __FILE__, "Fatal Error:\nAlready loading or unloading an age.\n%s will now exit.",
-                                        plProduct::ShortName().c_str());
+        hsDebugAssertionFailed(__LINE__, __FILE__, "Fatal Error:\nAlready loading or unloading an age.\n%s will now exit.",
+                               plProduct::ShortName().c_str());
 
     fFlags |= kLoadingAge;
     

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plWavFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plWavFile.cpp
@@ -50,7 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 static inline HRESULT DXTrace(const TCHAR* msg, const char* file, int line, HRESULT hr)
 {
     ST::string error = ST::format("Error Calling: {}\n{}", msg, (hsCOMError)hr);
-    ErrorAssert(line, file, error.c_str());
+    hsDebugAssertionFailed(line, file, error.c_str());
     return hr;
 }
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglTrans.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglTrans.cpp
@@ -125,7 +125,7 @@ NetTrans::NetTrans (ENetProtocol protocol, ETransType transType)
 {
     ++s_perf[kPerfCurrTransactions];
     ++s_perfTransCount[m_transType];
-//  DebugMsg("%s@%p created", s_transTypes[m_transType], this);
+//  hsDebugPrintToTerminal("%s@%p created", s_transTypes[m_transType], this);
 }
 
 //============================================================================
@@ -141,7 +141,7 @@ NetTrans::~NetTrans () {
 #endif
     --s_perfTransCount[m_transType];
     --s_perf[kPerfCurrTransactions];
-//  DebugMsg("%s@%p destroyed", s_transTypes[m_transType], this);
+//  hsDebugPrintToTerminal("%s@%p destroyed", s_transTypes[m_transType], this);
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
@@ -115,12 +115,12 @@ public:
         case physx::PxErrorCode::eABORT:
             log->AddLineF(plStatusLog::kRed, "PhysX ABORT: '{}' File: {} Line: {}",
                           message, file, line);
-            ErrorAssert(line, file, "PhysX ABORT: %s", message);
+            hsDebugAssertionFailed(line, file, "PhysX ABORT: %s", message);
             break;
         case physx::PxErrorCode::eINTERNAL_ERROR:
             log->AddLineF(plStatusLog::kRed, "PhysX INTERNAL ERROR: '{}' File: {} Line: {}",
                           message, file, line);
-            ErrorAssert(line, file, "PhysX INTERNAL ERROR: %s", message);
+            hsDebugAssertionFailed(line, file, "PhysX INTERNAL ERROR: %s", message);
             break;
         case physx::PxErrorCode::eINVALID_OPERATION:
             log->AddLineF(plStatusLog::kRed, "PhysX INVALID OPERATION: '{}' File: {} Line: {}",


### PR DESCRIPTION
Renames the following global functions in HeadSpin.h that were missing the usual `hs` prefix, and also adjusts some names for clarity (bikeshedding welcome 😉):

| previously | with this PR |
|---|---|
| `ErrorEnableGui` | `hsDebugEnableGuiAsserts` |
| `ErrorAssert` | `hsDebugAssertionFailed` |
| `DebugIsDebuggerPresent` | `hsDebugIsDebuggerPresent` |
| `DebugBreakIfDebuggerPresent` | `hsDebugBreakIfDebuggerPresent` |
| `DebugBreakAlways` | `hsDebugBreakAlways` |
| `DebugMsg` | `hsDebugPrintToTerminal` |

`DebugMsg` is the main motivation for this change, because there are multiple other functions/methods named `DebugMsg` elsewhere in the codebase, e. g. in `plLoggable`, `plSDLParser`, and `plClient`. This made it very difficult to tell if a call to `DebugMsg` went to the global function or one of the local variants.

The other renames are to avoid possible confusion about whether a function is from Plasma or from Win32. For example, the Win32 functions [`DebugBreak`](https://learn.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-debugbreak) and [`IsDebuggerPresent`](https://learn.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-isdebuggerpresent) look dangerously similar to some of the previous HeadSpin.h functions.