### PR TITLE
Remove `hsDebugMessage` in favor of `hsStatusMessage`

### DIFF
--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -481,14 +481,6 @@ static void _StatusMessageProc(const char* msg)
 #endif // defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
 }
 
-template<typename... _Args>
-static void DebugMsg(const char* format, _Args&&... args)
-{
-#if defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
-    s_DebugLog->AddLineF(plStatusLog::kYellow, format, std::forward<_Args>(args)...);
-#endif // defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
-}
-
 static void DebugInit()
 {
 #if defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
@@ -1189,7 +1181,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
 
     // Redirect hsStatusMessage to plasmadbg.log
     DebugInit();
-    DebugMsg("Plasma 2.0.{}.{} - {}", PLASMA2_MAJOR_VERSION, PLASMA2_MINOR_VERSION, plProduct::ProductString());
+    hsStatusMessage(ST::format("Plasma 2.0.{}.{} - {}", PLASMA2_MAJOR_VERSION, PLASMA2_MINOR_VERSION, plProduct::ProductString()).c_str());
 
     FILE *serverIniFile = plFileSystem::Open(serverIni, "rb");
     if (serverIniFile)

--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -473,12 +473,6 @@ void DeInitNetClientComm()
 // For error logging
 //
 static plStatusLog* s_DebugLog = nullptr;
-static void _DebugMessageProc(const char* msg)
-{
-#if defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
-    s_DebugLog->AddLine(plStatusLog::kRed, msg);
-#endif // defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
-}
 
 static void _StatusMessageProc(const char* msg)
 {
@@ -501,7 +495,6 @@ static void DebugInit()
     plStatusLogMgr& mgr = plStatusLogMgr::GetInstance();
     s_DebugLog = mgr.CreateStatusLog(30, "plasmadbg.log", plStatusLog::kFilledBackground |
                  plStatusLog::kDeleteForMe | plStatusLog::kAlignToTop | plStatusLog::kTimestamp);
-    hsSetDebugMessageProc(_DebugMessageProc);
     hsSetStatusMessageProc(_StatusMessageProc);
 #endif // defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
 }
@@ -1194,7 +1187,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
     }
 #endif
 
-    // Set up to log errors by using hsDebugMessage
+    // Redirect hsStatusMessage to plasmadbg.log
     DebugInit();
     DebugMsg("Plasma 2.0.{}.{} - {}", PLASMA2_MAJOR_VERSION, PLASMA2_MINOR_VERSION, plProduct::ProductString());
 

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -58,20 +58,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <string_theory/format>
 
 
-///////////////////////////////////////////////////////////////////////////
-/////////////////// For Status Messages ///////////////////////////////////
-///////////////////////////////////////////////////////////////////////////
-hsStatusMessageProc gHSStatusProc = nullptr;
-
-hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc)
-{
-    hsStatusMessageProc oldProc = gHSStatusProc;
-
-    gHSStatusProc = newProc;
-
-    return oldProc;
-}
-
 //////////////////////////////////////////////////////////////////////////
 
 static bool s_GuiAsserts = true;
@@ -198,6 +184,17 @@ void hsDebugPrintToTerminal(const char* fmt, ...)
 }
 
 ////////////////////////////////////////////////////////////////////////////
+
+hsStatusMessageProc gHSStatusProc = nullptr;
+
+hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc)
+{
+    hsStatusMessageProc oldProc = gHSStatusProc;
+
+    gHSStatusProc = newProc;
+
+    return oldProc;
+}
 
 #ifndef PLASMA_EXTERNAL_RELEASE
 

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -61,11 +61,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 ///////////////////////////////////////////////////////////////////////////
 /////////////////// For Status Messages ///////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////
-hsDebugMessageProc gHSStatusProc = nullptr;
+hsStatusMessageProc gHSStatusProc = nullptr;
 
-hsDebugMessageProc hsSetStatusMessageProc(hsDebugMessageProc newProc)
+hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc)
 {
-    hsDebugMessageProc oldProc = gHSStatusProc;
+    hsStatusMessageProc oldProc = gHSStatusProc;
 
     gHSStatusProc = newProc;
 

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -74,43 +74,6 @@ hsDebugMessageProc hsSetStatusMessageProc(hsDebugMessageProc newProc)
 
 //////////////////////////////////////////////////////////////////////////
 
-hsDebugMessageProc gHSDebugProc = nullptr;
-
-hsDebugMessageProc hsSetDebugMessageProc(hsDebugMessageProc newProc)
-{
-    hsDebugMessageProc oldProc = gHSDebugProc;
-
-    gHSDebugProc = newProc;
-
-    return oldProc;
-}
-
-#ifdef HS_DEBUGGING
-void hsDebugMessage (const char* message, long val)
-{
-    char    s[1024];
-
-    if (val)
-        s[0] = snprintf(&s[1], 1022, "%s: %ld", message, val);
-    else
-        s[0] = snprintf(&s[1], 1022, "%s", message);
-
-    if (gHSDebugProc)
-        gHSDebugProc(&s[1]);
-    else
-#if HS_BUILD_FOR_WIN32
-    {
-        OutputDebugString(&s[1]);
-        OutputDebugString("\n");
-    }
-#else
-    {
-        fprintf(stderr, "%s\n", &s[1]);
-    }
-#endif
-}
-#endif
-
 static bool s_GuiAsserts = true;
 void hsDebugEnableGuiAsserts(bool enabled)
 {

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -307,10 +307,10 @@ constexpr float hsInvert(float a) { return 1.f / a; }
 
 /************************ Debug/Error Macros **************************/
 
-typedef void (*hsDebugMessageProc)(const char message[]);
+typedef void (*hsStatusMessageProc)(const char message[]);
 
-extern hsDebugMessageProc gHSStatusProc;
-hsDebugMessageProc hsSetStatusMessageProc(hsDebugMessageProc newProc);
+extern hsStatusMessageProc gHSStatusProc;
+hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc);
 
 void hsDebugEnableGuiAsserts(bool enabled);
 

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -262,14 +262,6 @@ template <> inline double hsToLE(double value) { return hsToLEDouble(value); }
 ***/
 #define IS_POW2(val) (!((val) & ((val) - 1)))
 
-#ifdef PLASMA_EXTERNAL_RELEASE
-#   define hsStatusMessage(x)                  ((void)0)
-#   define hsStatusMessageF(x, ...)            ((void)0)
-#else
-    void    hsStatusMessage(const char* message);
-    void    hsStatusMessageF(const char * fmt, ...);
-#endif // PLASMA_EXTERNAL_RELEASE
-
 // Use "correct" non-standard string functions based on the
 // selected compiler / library
 #if HS_BUILD_FOR_WIN32
@@ -306,11 +298,6 @@ constexpr float hsRadiansToDegrees(float rad) { return rad * (180.f / hsConstant
 constexpr float hsInvert(float a) { return 1.f / a; }
 
 /************************ Debug/Error Macros **************************/
-
-typedef void (*hsStatusMessageProc)(const char message[]);
-
-extern hsStatusMessageProc gHSStatusProc;
-hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc);
 
 void hsDebugEnableGuiAsserts(bool enabled);
 
@@ -359,6 +346,19 @@ void hsDebugPrintToTerminal(const char* fmt, ...);
 #else
 #define  DEFAULT_FATAL(var)  default: FATAL("No valid case for switch variable '" #var "'"); break;
 #endif
+
+typedef void (*hsStatusMessageProc)(const char message[]);
+
+extern hsStatusMessageProc gHSStatusProc;
+hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc);
+
+#ifdef PLASMA_EXTERNAL_RELEASE
+#   define hsStatusMessage(x) ((void)0)
+#   define hsStatusMessageF(x, ...) ((void)0)
+#else
+    void hsStatusMessage(const char* message);
+    void hsStatusMessageF(const char* fmt, ...);
+#endif // PLASMA_EXTERNAL_RELEASE
 
 #if defined(__clang__) || defined(__GNUC__)
 #   define _COMPILER_WARNING_NAME(warning) "-W" warning

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -308,9 +308,6 @@ constexpr float hsInvert(float a) { return 1.f / a; }
 /************************ Debug/Error Macros **************************/
 
 typedef void (*hsDebugMessageProc)(const char message[]);
-extern hsDebugMessageProc gHSDebugProc;
-#define HSDebugProc(m)  { if (gHSDebugProc) gHSDebugProc(m); }
-hsDebugMessageProc hsSetDebugMessageProc(hsDebugMessageProc newProc);
 
 extern hsDebugMessageProc gHSStatusProc;
 hsDebugMessageProc hsSetStatusMessageProc(hsDebugMessageProc newProc);
@@ -328,7 +325,7 @@ void hsDebugBreakAlways();
 
 /**
  * Print a message to stderr (and to the Windows debugger output, if on Windows with a debugger attached).
- * This function's output is never redirected to a log file (unlike hsStatusMessage and hsDebugMessage).
+ * This function's output is never redirected to a log file (unlike hsStatusMessage).
  *
  * Be aware that this function's output is impossible to see for the average player/tester.
  * Prefer using other logging functions instead.
@@ -342,16 +339,12 @@ void hsDebugPrintToTerminal(const char* fmt, ...);
 
 #ifdef HS_DEBUGGING
     
-    void    hsDebugMessage(const char* message, long refcon);
-    #define hsIfDebugMessage(expr, msg, ref)    (void)( (!!(expr)) || (hsDebugMessage(msg, ref), 0) )
     #define hsAssert(expr, ...)                 (void)( (!!(expr)) || (hsDebugAssertionFailed(__LINE__, __FILE__, __VA_ARGS__), 0) )
     #define ASSERT(expr)                        (void)( (!!(expr)) || (hsDebugAssertionFailed(__LINE__, __FILE__, #expr), 0) )
     #define FATAL(...)                          hsDebugAssertionFailed(__LINE__, __FILE__, __VA_ARGS__)
     
 #else   /* Not debugging */
 
-    #define hsDebugMessage(message, refcon)     ((void)0)
-    #define hsIfDebugMessage(expr, msg, ref)    ((void)0)
     #define hsAssert(expr, ...)                 ((void)0)
     #define ASSERT(expr)                        ((void)0)
     #define FATAL(...)                          ((void)0)

--- a/Sources/Plasma/CoreLib/hsGeometry3.h
+++ b/Sources/Plasma/CoreLib/hsGeometry3.h
@@ -196,7 +196,7 @@ struct hsVector3 : public hsScalarTriple {
     void Normalize()
     {
         float length = this->Magnitude();
-        // hsIfDebugMessage(length == 0, "Err: Normalizing hsVector3 of length 0", 0);
+        // hsAssert(length == 0, "Err: Normalizing hsVector3 of length 0");
         if (length == 0)
             return;
         float invMag = hsInvert(length);
@@ -209,7 +209,7 @@ struct hsVector3 : public hsScalarTriple {
     inline void Renormalize() // if the vector is already close to unit length
     {
         float mag2 = *this * *this;
-        hsIfDebugMessage(mag2 == 0, "Err: Renormalizing hsVector3 of length 0", 0);
+        hsAssert(mag2 == 0, "Err: Renormalizing hsVector3 of length 0");
         if (mag2 == 0)
             return;
         float invMag = hsInvSqrt(mag2);

--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -447,10 +447,7 @@ uint32_t hsUNIXStream::Read(uint32_t bytes,  void* buffer)
     fPosition += numItems;
     if (numItems < bytes)
     {
-        if (!feof(fRef))
-        {
-            hsDebugMessage("Error on UNIX Read", ferror(fRef));
-        }
+        hsAssert(feof(fRef), ST::format("Error on UNIX Read (ferror = {})", ferror(fRef)).c_str());
     }
     return numItems;
 }

--- a/Sources/Plasma/CoreLib/hsThread.cpp
+++ b/Sources/Plasma/CoreLib/hsThread.cpp
@@ -50,18 +50,17 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 void hsThread::Start()
 {
-    if (!fThread.joinable()) {
-        fThread = std::thread([this]() {
-            hsThread::SetThisThreadName(ST_LITERAL("hsNoNameThread"));
+    hsAssert(!fThread.joinable(), "Calling hsThread::Start() more than once");
+
+    fThread = std::thread([this]() {
+        hsThread::SetThisThreadName(ST_LITERAL("hsNoNameThread"));
 #ifdef USE_VLD
-            // Needs to be enabled for each thread except the WinMain
-            VLDEnable();
+        // Needs to be enabled for each thread except the WinMain
+        VLDEnable();
 #endif
-            Run();
-            OnQuit();
-        });
-    } else
-        hsDebugMessage("Calling hsThread::Start() more than once", 0);
+        Run();
+        OnQuit();
+    });
 }
 
 void hsThread::Stop()

--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -353,7 +353,7 @@ bool plFileSystem::CreateDir(const plFileName &dir, bool checkParents)
 {
     plFileName fdir = dir;
     if (fdir.GetFileName().empty()) {
-        hsDebugMessage("WARNING: CreateDir called with useless trailing slash", 0);
+        hsStatusMessage("WARNING: CreateDir called with useless trailing slash");
         fdir = fdir.StripFileName();
     }
 

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
@@ -1347,7 +1347,7 @@ bool plDXPipeline::ICreateDevice(bool windowed)
 #ifdef DBG_WRITE_FORMATS
     for (D3DFORMAT fmt : fCurrentMode->fDepthFormats)
     {
-        hsDebugMessage(ST::format("-- Valid depth buffer format: {}", IGetDXFormatName(fmt)).c_str(), 0);
+        hsStatusMessage(ST::format("-- Valid depth buffer format: {}", IGetDXFormatName(fmt)).c_str());
     }
 #endif
 
@@ -1381,13 +1381,13 @@ bool plDXPipeline::ICreateDevice(bool windowed)
         fSettings.fD3DCaps &= ~kCapsZBias;
 
 #ifdef DBG_WRITE_FORMATS
-    hsDebugMessage(ST::format("-- Requesting depth buffer format: {}", IGetDXFormatName(params.AutoDepthStencilFormat)).c_str(), 0);
+    hsStatusMessage(ST::format("-- Requesting depth buffer format: {}", IGetDXFormatName(params.AutoDepthStencilFormat)).c_str());
 #endif
 
 
     params.BackBufferFormat = dispMode.Format;
 #ifdef DBG_WRITE_FORMATS
-    hsDebugMessage(ST::format("-- Requesting back buffer format: {}", IGetDXFormatName(params.BackBufferFormat)).c_str(), 0);
+    hsStatusMessage(ST::format("-- Requesting back buffer format: {}", IGetDXFormatName(params.BackBufferFormat)).c_str());
 #endif
 
     params.hDeviceWindow = fDevice.fHWnd;

--- a/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
@@ -175,9 +175,9 @@ uint32_t plEncryptedStream::IRead(uint32_t bytes, void* buffer)
 {
     if (!fRef)
         return 0;
-    int numItems = (int)(::fread(buffer, 1 /*size*/, bytes /*count*/, fRef));
+    size_t numItems = fread(buffer, 1 /*size*/, bytes /*count*/, fRef);
     fPosition += numItems;
-    if ((unsigned)numItems < bytes) {
+    if (numItems < bytes) {
         if (feof(fRef)) {
             hsAssert(false, ST::format("Hit EOF on UNIX Read, only read {} out of requested {} bytes", numItems, bytes).c_str());
         } else {

--- a/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
@@ -42,6 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plEncryptedStream.h"
 
 #include <ctime>
+#include <string_theory/format>
 #include <wchar.h>
 #include <algorithm>
 
@@ -178,13 +179,9 @@ uint32_t plEncryptedStream::IRead(uint32_t bytes, void* buffer)
     fPosition += numItems;
     if ((unsigned)numItems < bytes) {
         if (feof(fRef)) {
-            // EOF ocurred
-            char str[128];
-            sprintf(str, "Hit EOF on UNIX Read, only read %d out of requested %d bytes\n", numItems, bytes);
-            hsDebugMessage(str, 0);
-        }
-        else {
-            hsDebugMessage("Error on UNIX Read", ferror(fRef));
+            hsAssert(false, ST::format("Hit EOF on UNIX Read, only read {} out of requested {} bytes", numItems, bytes).c_str());
+        } else {
+            hsAssert(false, ST::format("Error on UNIX Read (ferror = {})", ferror(fRef)).c_str());
         }
     }
     return numItems;

--- a/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
@@ -284,15 +284,17 @@ uint32_t plSecureStream::IRead(uint32_t bytes, void* buffer)
 {
     if (fRef == INVALID_HANDLE_VALUE)
         return 0;
-    uint32_t numItems = 0;
+    size_t numItems = 0;
 #if HS_BUILD_FOR_WIN32
-    bool success = (ReadFile(fRef, buffer, bytes, (LPDWORD)&numItems, nullptr) != 0);
+    DWORD numItemsDword = 0;
+    bool success = ReadFile(fRef, buffer, bytes, &numItemsDword, nullptr);
+    numItems = numItemsDword;
 #elif HS_BUILD_FOR_UNIX
     numItems = fread(buffer, bytes, 1, fRef);
     bool success = numItems != 0;
 #endif
     fPosition += numItems;
-    if ((unsigned)numItems < bytes)
+    if (numItems < bytes)
     {
         if (success)
         {

--- a/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
@@ -40,6 +40,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 #include <string>
+#include <string_theory/format>
 #include <ctime>
 
 #include "plSecureStream.h"
@@ -295,17 +296,14 @@ uint32_t plSecureStream::IRead(uint32_t bytes, void* buffer)
     {
         if (success)
         {
-            // EOF ocurred
-            char str[128];
-            sprintf(str, "Hit EOF on Windows read, only read %d out of requested %d bytes\n", numItems, bytes);
-            hsDebugMessage(str, 0);
+            hsAssert(false, ST::format("Hit EOF on Windows read, only read {} out of requested {} bytes", numItems, bytes).c_str());
         }
         else
         {
 #if HS_BUILD_FOR_WIN32
-            hsDebugMessage("Error on Windows read", GetLastError());
+            hsAssert(false, ST::format("Error on Windows read (GetLastError = {})", GetLastError()).c_str());
 #else
-            hsDebugMessage("Error on POSIX read", errno);
+            hsAssert(false, ST::format("Error on POSIX read (errno = {})", errno).c_str());
 #endif
         }
     }

--- a/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
@@ -749,9 +749,7 @@ void    plMipmap::SetConfig( unsigned config )
             fSpace  = kGraySpace;
             fFlags  = kNoFlag;
             break;
-        default:
-            hsDebugMessage( "unknown config", config );
-            break;
+        DEFAULT_FATAL(config);
     }
 }
 


### PR DESCRIPTION
The two functions behaved almost identically, except that `hsDebugMessage` is conditionally enabled only in debug builds (whereas `hsStatusMessage` is enabled in all internal builds), and there were minimal differences in the printing logic if no custom handler was set.

Practically speaking, these differences don't matter. Of the two functions, `hsStatusMessage` was by far more commonly used, so this removes `hsDebugMessage`.

I've replaced some of the former `hsDebugMessage` calls with assertions where appropriate (i. e. things that seem to be clear error conditions and not just warning/debug messages). There is a small chance that this will crash the game somewhere by surfacing an error that was silently ignored before, but I think it's unlikely.

Also includes a couple of small cleanups in the code touched by these changes.