### PR TITLE
Remove incorrect unreachable declaration in `DEFAULT_FATAL`

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -338,7 +338,7 @@ void hsDebugPrintToTerminal(const char* fmt, ...);
 
 #endif  // HS_DEBUGGING
 
-#define  DEFAULT_FATAL(var)  default: FATAL("No valid case for switch variable '" #var "'"); break;
+#define DEFAULT_FATAL(var) default: FATAL("No valid case for switch variable '" #var "'"); break
 
 typedef void (*hsStatusMessageProc)(const char message[]);
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglFile.cpp
@@ -694,7 +694,7 @@ void CliFileConn::Dispatch (Cli2File_MsgHeader * msg) {
         DISPATCH(BuildIdUpdate);
         DISPATCH(ManifestReply);
         DISPATCH(FileDownloadReply);
-        DEFAULT_FATAL(msg->messageId)
+        DEFAULT_FATAL(msg->messageId);
     }
 #undef DISPATCH
 }

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXPhysical.cpp
@@ -283,7 +283,7 @@ bool plPXPhysical::InitActor()
     }
     break;
 
-    DEFAULT_FATAL(fBounds)
+    DEFAULT_FATAL(fBounds);
     }
 
     fActor->userData = new plPXActorData(this);
@@ -735,7 +735,7 @@ plDrawableSpans* plPXPhysical::CreateProxy(hsGMaterial* mat, std::vector<uint32_
         return IGenerateProxy(addTo, idx, shape, geometry, l2w, mat, blended);
     }
 
-    DEFAULT_FATAL(shape->getGeometryType())
+    DEFAULT_FATAL(shape->getGeometryType());
     }
 
     return myDraw;

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
@@ -138,7 +138,7 @@ public:
             log->AddLineF(plStatusLog::kYellow, "PhysX WARNING: '{}' File: {} Line: {}",
                           message, file, line);
             break;
-        DEFAULT_FATAL(PxErrorCode)
+        DEFAULT_FATAL(PxErrorCode);
         }
     }
 } static gPxErrorCallback;


### PR DESCRIPTION
In debug builds, the code after `FATAL` is in fact reachable, because the failed assertion dialog offers the user the option to ignore the failure.

`hsDebugAssertionFailed` is already declared as `[[noreturn]]` where appropriate (i. e. in non-debug builds). This should be enough for compilers to figure out when the code after the call is unreachable.

Alternatively, if we want `DEFAULT_FATAL` to truly never continue execution, even in debug builds if the user asks for it, we could replace the unreachable declarations with an `abort()` call or similar.