### PR TITLE
Don't define `MAX_PATH` on non-Windows

### DIFF
--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -286,10 +286,6 @@ template <> inline double hsToLE(double value) { return hsToLEDouble(value); }
 #   ifndef fileno
 #       define fileno(__F) _fileno(__F)
 #   endif
-#else
-    // This is for Unix, Linux, OSX, etc.
-#   include <limits.h>
-#   define MAX_PATH PATH_MAX
 #endif
 
 // Useful floating point utilities

--- a/Sources/Plasma/PubUtilLib/plFile/plBrowseFolder.h
+++ b/Sources/Plasma/PubUtilLib/plFile/plBrowseFolder.h
@@ -50,14 +50,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 // Gets a directory using the "Browse for Folder" dialog.
 //
-// path:        Buffer to recieve the path.  Should be MAX_PATH characters.
 // startPath:   Initial path.
 // title:       Not really the title of the dialog, but it's displayed above the
 //              folder list.  Could be used to give instructions.
 // hwndOwner:   Owner window for dialog box.
 //
-// Returns true if path contains a valid path, false otherwise (error or user
-// clicked cancel.
+// Returns the directory selected by the user,
+// or an empty plFileName if the user clicked cancel or on error.
 //
 
 class plBrowseFolder


### PR DESCRIPTION
The current Plasma code uses `MAX_PATH` only in Windows-specific code. All Unix-specific code already uses the native spelling `PATH_MAX`. None of our cross-platform code needs `MAX_PATH`, and we should keep it that way to avoid arbitrary platform-specific path length limits.