### PR TITLE
Make `plVault` not use `pfKIMsg`

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
+++ b/Sources/Plasma/FeatureLib/pfMessage/pfKIMsg.h
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class pfKIMsg : public plMessage
 {
-#ifndef KI_CONSTANTS_ONLY
     protected:
 
         uint8_t   fCommand;
@@ -84,8 +83,6 @@ class pfKIMsg : public plMessage
             fDelay = 0.0;
             fValue = 0;
         }
-
-#endif // def KI_CONSTANTS_ONLY
 
     public:
         enum 
@@ -177,8 +174,6 @@ class pfKIMsg : public plMessage
             kNormalKI = 2
         };
 
-#ifndef KI_CONSTANTS_ONLY
-
         pfKIMsg() : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); IInit(); }
         pfKIMsg(uint8_t command) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); IInit(); fCommand = command; }
         pfKIMsg(const plKey& receiver, uint8_t command) : plMessage(nullptr, receiver, nullptr) { IInit(); fCommand = command; }
@@ -227,8 +222,6 @@ class pfKIMsg : public plMessage
 
         void        SetIntValue( int32_t value ) { fValue = value; }
         int32_t     GetIntValue() { return fValue; }
-
-#endif // def KI_CONSTANTS_ONLY
 };
 
 #endif // _pfKIMsg_h

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgHandler.cpp
@@ -68,8 +68,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plSDL/plSDL.h"
 #include "plVault/plVault.h"
 
-#include "pfMessage/pfKIMsg.h"      // Should be moved to PubUtil level
-
 ////////////////////////////////////////////////////////////////////////
 
 plNetClientMsgHandler::plNetClientMsgHandler(plNetClientMgr * mgr)

--- a/Sources/Plasma/PubUtilLib/plVault/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plVault/CMakeLists.txt
@@ -38,12 +38,9 @@ target_link_libraries(
         plSDL
         plStatusLog
         plUnifiedTime
-        pfMessage # For pfKIMsg
     INTERFACE
         pnFactory
 )
-
-target_include_directories(plVault PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
 
 source_group("Source Files" FILES ${plVault_SOURCES})
 source_group("Header Files" FILES ${plVault_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plVault/Pch.h
+++ b/Sources/Plasma/PubUtilLib/plVault/Pch.h
@@ -61,6 +61,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <unordered_map>
 
 #include "hsGeometry3.h"
+#include "hsStream.h"
 #include "hsTimer.h"
 
 #include "pnDispatch/plDispatch.h"
@@ -77,9 +78,5 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plSDL/plSDL.h"
 #include "plStatusLog/plStatusLog.h"
 #include "plUnifiedTime/plUnifiedTime.h"
-
-#define KI_CONSTANTS_ONLY
-#include "pfMessage/pfKIMsg.h"  // for KI level constants =(
-#undef KI_CONSTANTS_ONLY
 
 #endif

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.cpp
@@ -2742,12 +2742,6 @@ bool VaultAmIgnoringPlayer (unsigned playerId) {
 }
 
 //============================================================================
-unsigned VaultGetKILevel () {
-    hsAssert(false, "eric, implement me");
-    return pfKIMsg::kNanoKI;
-}
-
-//============================================================================
 bool VaultGetCCRStatus () {
     bool retval = false;
     if (hsRef<RelVaultNode> rvnSystem = VaultGetSystemNode()) {

--- a/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plVaultClientApi.h
@@ -339,7 +339,6 @@ void            VaultAddChronicleEntryAndWait (
     const ST::string& entryValue
 );
 bool        VaultAmIgnoringPlayer (unsigned playerId);
-unsigned    VaultGetKILevel ();
 bool        VaultGetCCRStatus ();               // true=online, false=away
 bool        VaultSetCCRStatus (bool online);    // true=online, false=away
 void        VaultDump (const ST::string& tag, unsigned vaultId);


### PR DESCRIPTION
Was only used in an unused, stubbed out function (`VaultGetKILevel`).