### PR TITLE
Setting LocalData on Mac client when NoSelfPatch is set

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -378,7 +378,7 @@ dispatch_queue_t loadingQueue = dispatch_queue_create("", DISPATCH_QUEUE_SERIAL)
     NetCommConnect();
     [[PLSServerStatus sharedStatus] loadServerStatus];
 
-    BOOL skipPatch = cmdParser.IsSpecified(kArgNoSelfPatch);
+    BOOL skipPatch = cmdParser.IsSpecified(kArgNoSelfPatch) ||  cmdParser.IsSpecified(kArgLocalData);
     if (gDataServerLocal || skipPatch) {
         [self initializeClient];
     } else {


### PR DESCRIPTION
I think what happened here is that Windows has the separate patcher and client. I would guess servers like Destiny don't even bother including the launcher.

I'm hard coding this inference on the Mac client.

(While I'm here - I'm happy with how the Mac client was setup but I'm not sure if there is any reason to have a separate Mac launcher. Always open to suggestions - but it's at least aligned with how an iOS client could work.)