### PR TITLE
Globally forward-declare `ST::string` in HeadSpin.h

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plMiscComponents.h
+++ b/Sources/MaxPlugin/MaxComponent/plMiscComponents.h
@@ -58,8 +58,6 @@ class plFileName;
 class plAgeDescription;
 class plComponentBase;
 
-namespace ST { class string; }
-
 const MCHAR* LocCompGetPage(plComponentBase* comp);
 
 namespace plPageInfoUtils

--- a/Sources/MaxPlugin/MaxConvert/hsMaterialConverter.h
+++ b/Sources/MaxPlugin/MaxConvert/hsMaterialConverter.h
@@ -87,8 +87,6 @@ class plClothingItem;
 class plClothingMtl;
 class hsBitVector;
 
-namespace ST { class string; }
-
 class plExportMaterialData
 {
 public:

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -58,6 +58,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <cstdint>
 #include <type_traits>
 
+namespace ST { class string; }
+
 //======================================
 // Winblows Hacks
 //======================================

--- a/Sources/Plasma/FeatureLib/pfAnimation/plAnimDebugList.h
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plAnimDebugList.h
@@ -46,8 +46,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnKeyedObject/plKey.h"
 
-namespace ST { class string; }
-
 // Simple debugging tool, everything is public
 // This class collects a list of keyed objects that deal with
 // animation, to report info on them when requested.

--- a/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.h
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfDispatchLog.h
@@ -49,7 +49,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plMessage;
 class plStatusLog;
-namespace ST { class string; }
 
 class plDispatchLog : public plDispatchLogBase
 {

--- a/Sources/Plasma/FeatureLib/pfCrashHandler/plCrashBase.h
+++ b/Sources/Plasma/FeatureLib/pfCrashHandler/plCrashBase.h
@@ -45,8 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsThread.h"
 
-namespace ST { class string; }
-
 class plCrashBase
 {
 protected:

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXDevice.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXDevice.h
@@ -54,7 +54,6 @@ class plDXPipeline;
 class plRenderTarget;
 struct IDirect3DDevice9;
 struct IDirect3DSurface9;
-namespace ST { class string; }
 
 class plDXDevice
 {

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.h
@@ -58,8 +58,6 @@ class pfGUIValueCtrl;
 class plMessage;
 class pfScrollProc;
 
-namespace ST { class string; }
-
 class pfGUIListBoxMod : public pfGUIControlMod
 {
     friend class pfScrollProc;

--- a/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationMgr.h
+++ b/Sources/Plasma/FeatureLib/pfLocalizationMgr/pfLocalizationMgr.h
@@ -52,7 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 
 class plFileName;
-namespace ST { class string; }
 
 class pfLocalizationMgr
 {

--- a/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.h
+++ b/Sources/Plasma/FeatureLib/pfPasswordStore/pfPasswordStore.h
@@ -45,8 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
-namespace ST { class string; }
-
 class pfPasswordStore
 {
 public:

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.h
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.h
@@ -55,8 +55,6 @@ class plMD5Checksum;
 class plStatusLog;
 class hsStream;
 
-namespace ST { class string; }
-
 /** Plasma File Patcher
  *  This is used to patch the client with one or many manifests at once. It assumes that
  *  we have permission to modify the game files, so be sure that you do! We memory manage

--- a/Sources/Plasma/FeatureLib/pfPython/cyAvatar.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyAvatar.h
@@ -63,7 +63,6 @@ class plMorphSequence;
 class pyColor;
 class pyKey;
 class pySceneObject;
-namespace ST { class string; }
 
 class cyAvatar
 {

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.h
@@ -64,7 +64,6 @@ class pyKey;
 class pyPlayer;
 class pyPoint3;
 class pySceneObject;
-namespace ST { class string; }
 
 typedef struct _object PyObject;
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeVault.h
@@ -66,7 +66,6 @@ class pyVaultFolderNode;
 class pyVaultNode;
 class pyVaultPlayerInfoListNode;
 class pyVaultTextNoteNode;
-namespace ST { class string; }
 
 class pyAgeVault
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyDynamicText.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyDynamicText.h
@@ -58,7 +58,6 @@ class plDynamicTextMsg;
 class pyColor;
 class pyImage;
 class pyKey;
-namespace ST { class string; }
 
 class pyDynamicText
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlEditBox.h
@@ -55,7 +55,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plKey;
 class pyColor;
 class pyKey;
-namespace ST { class string; }
 
 class pyGUIControlEditBox : public pyGUIControl
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlListBox.h
@@ -59,7 +59,6 @@ class plKey;
 class pyColor;
 class pyImage;
 class pyKey;
-namespace ST { class string; }
 
 class pyGUIControlListBox : public pyGUIControl
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlMultiLineEdit.h
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plKey;
 class pyColor;
 class pyKey;
-namespace ST { class string; }
 
 class pyGUIControlMultiLineEdit : public pyGUIControl
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.h
@@ -56,7 +56,6 @@ class pfGUIColorScheme;
 class plKey;
 class pyColor;
 class pyKey;
-namespace ST { class string; }
 
 class pyGUIControlTextBox : public pyGUIControl
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.h
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class pyColor;
 class pyKey;
-namespace ST { class string; }
 
 class pyGUIDialog
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.h
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class pfGUIPopUpMenu;
 class pyColor;
 class pyKey;
-namespace ST { class string; }
 
 class pyGUIPopUpMenu
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameScore.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameScore.h
@@ -55,7 +55,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class pfGameScore;
 class pyKey;
-namespace ST { class string; }
 
 class pyGameScore
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGameScoreMsg.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGameScoreMsg.h
@@ -46,8 +46,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pyGlueDefinitions.h"
 
-namespace ST { class string; }
-
 class pyGameScoreMsg
 {
 protected:

--- a/Sources/Plasma/FeatureLib/pfPython/pyGmMarker.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGmMarker.h
@@ -49,7 +49,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class pfGmMarker;
 class pyGmMarkerHandler;
-namespace ST { class string; }
 
 class pyGmMarker : public pyGameCli
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyImage.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyImage.h
@@ -62,7 +62,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plFileName;
 class pyColor;
 class pyKey;
-namespace ST { class string; }
 
 class pyImage
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyKey.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyKey.h
@@ -56,7 +56,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plPipeline;
 class plPythonFileMod;
-namespace ST { class string; }
 
 class pyKey
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyKeyMap.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyKeyMap.h
@@ -52,8 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pyGlueDefinitions.h"
 
-namespace ST { class string; }
-
 class pyKeyMap
 {
 protected:

--- a/Sources/Plasma/FeatureLib/pfPython/pyNetLinkingMgr.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyNetLinkingMgr.h
@@ -53,7 +53,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //////////////////////////////////////////////////////////////////////
 
 class pyAgeLinkStruct;
-namespace ST { class string; }
 
 class pyNetLinkingMgr
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyNotify.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyNotify.h
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class pyKey;
 class pyPoint3;
-namespace ST { class string; }
 
 class pyNotify
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pySDL.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pySDL.h
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plKey;
 class plSimpleStateVariable;
 class plStateDataRecord;
-namespace ST { class string; }
 
 // pySDL -- this thing really only exists for the constants
 class pySDL

--- a/Sources/Plasma/FeatureLib/pfPython/pySceneObject.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pySceneObject.h
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyKey.h"
 
 class pyMatrix44;
-namespace ST { class string; }
 
 class pySceneObject
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyStatusLog.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyStatusLog.h
@@ -55,7 +55,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plStatusLog;
 class pyColor;
-namespace ST { class string; }
 
 class pyStatusLog
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyStream.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyStream.h
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGlueDefinitions.h"
 
 class plFileName;
-namespace ST { class string; }
 
 class pyStream
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVault.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVault.h
@@ -57,7 +57,6 @@ class pyAgeLinkStruct;
 class pySDLStateDataRecord;
 class pyVaultAgeInfoNode;
 class pyVaultNode;
-namespace ST { class string; }
 
 class pyVault
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeInfoNode.h
@@ -54,7 +54,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyVaultNode.h"
 
 class plUUID;
-namespace ST { class string; }
 
 class pyVaultAgeInfoNode : public pyVaultNode
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultAgeLinkNode.h
@@ -57,7 +57,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class pySpawnPointInfo;
 class pySpawnPointInfoRef;
-namespace ST { class string; }
 
 class pyVaultAgeLinkNode : public pyVaultNode
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultChronicleNode.h
@@ -53,8 +53,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGlueDefinitions.h"
 #include "pyVaultNode.h"
 
-namespace ST { class string; }
-
 class pyVaultChronicleNode : public pyVaultNode
 {
 protected:

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultFolderNode.h
@@ -51,8 +51,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGlueDefinitions.h"
 #include "pyVaultNode.h"
 
-namespace ST { class string; }
-
 class pyVaultFolderNode : public pyVaultNode
 {
 protected:

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultImageNode.h
@@ -55,7 +55,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plMipmap;
 class pyImage;
-namespace ST { class string; }
 
 class pyVaultImageNode : public pyVaultNode
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultMarkerGameNode.h
@@ -55,7 +55,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plUUID;
 struct VaultMarker;
-namespace ST { class string; }
 
 class pyVaultMarkerGameNode : public pyVaultNode
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
@@ -58,7 +58,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 struct RelVaultNode;
 class plUUID;
-namespace ST { class string; }
 
 #define PYTHON_CLASS_VAULT_NODE_NEW_DEFINITION \
     static PyObject* New(hsRef<RelVaultNode> vaultNode=nullptr);

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerInfoNode.h
@@ -52,7 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyVaultNode.h"
 
 class plUUID;
-namespace ST { class string; }
 
 class pyVaultPlayerInfoNode : public pyVaultNode
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultPlayerNode.h
@@ -53,7 +53,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyVaultNode.h"
 
 class pyAgeInfoStruct;
-namespace ST { class string; }
 
 class pyVaultPlayerNode : public pyVaultNode
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultSDLNode.h
@@ -52,7 +52,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyVaultNode.h"
 
 class pySDLStateDataRecord;
-namespace ST { class string; }
 
 class pyVaultSDLNode : public pyVaultNode
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultTextNoteNode.h
@@ -53,8 +53,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGlueDefinitions.h"
 #include "pyVaultNode.h"
 
-namespace ST { class string; }
-
 class pyVaultTextNoteNode : public pyVaultNode
 {
 protected:

--- a/Sources/Plasma/NucleusLib/inc/hsResMgr.h
+++ b/Sources/Plasma/NucleusLib/inc/hsResMgr.h
@@ -47,8 +47,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plLoadMask.h"
 #include "plRefFlags.h"
 
-namespace ST { class string; }
-
 class hsStream;
 class plKey;
 class plKeyImp;

--- a/Sources/Plasma/NucleusLib/inc/plPipeline.h
+++ b/Sources/Plasma/NucleusLib/inc/plPipeline.h
@@ -92,8 +92,6 @@ class plVisMgr;
 
 class plViewTransform;
 
-namespace ST { class string; }
-
 struct PipelineParams
 {
     PipelineParams():

--- a/Sources/Plasma/NucleusLib/pnDispatch/plDispatchLogBase.h
+++ b/Sources/Plasma/NucleusLib/pnDispatch/plDispatchLogBase.h
@@ -49,7 +49,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 class plMessage;
 class plReceiver;
-namespace ST { class string; }
 
 class plDispatchLogBase
 {

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChallengeHash.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChallengeHash.h
@@ -45,8 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "plChecksum.h"
 
-namespace ST { class string; }
-
 void CryptCreateRandomSeed(size_t length, uint8_t* data);
 
 void CryptHashPassword(const ST::string& username, const ST::string& password, ShaDigest dest);

--- a/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.h
+++ b/Sources/Plasma/NucleusLib/pnInputCore/plInputMap.h
@@ -50,8 +50,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <map>
 #include <vector>
 
-namespace ST { class string; }
-
 class plInputMap
 {
 public:

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.h
@@ -49,7 +49,6 @@ class hsKeyedObject;
 class plRefMsg;
 class plUoid;
 class hsBitVector;
-namespace ST { class string; }
 
 //// plKey ///////////////////////////////////////////////////////////////////
 //  Pointer to a plKeyData struct, which is a handle to a keyedObject

--- a/Sources/Plasma/NucleusLib/pnNetBase/pnNbSrvs.h
+++ b/Sources/Plasma/NucleusLib/pnNetBase/pnNbSrvs.h
@@ -84,8 +84,6 @@ enum ESrvType {
 *
 ***/
 
-namespace ST { class string; }
-
 unsigned GetAuthSrvHostnames (const ST::string*& addrs); // returns addrCount
 void SetAuthSrvHostname (const ST::string& addr);
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plSound.h
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSound.h
@@ -73,7 +73,6 @@ class plGraphPlate;
 struct hsMatrix44;
 class plSceneObject;
 class plSoundVolumeApplicator;
-namespace ST { class string; }
 
 // Set this to 1 to do our own distance attenuation (model doesn't work yet tho)
 #define MCN_HACK_OUR_ATTEN  0

--- a/Sources/Plasma/PubUtilLib/plAudioCore/plOGGCodec.h
+++ b/Sources/Plasma/PubUtilLib/plAudioCore/plOGGCodec.h
@@ -55,7 +55,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //// Class Definition ////////////////////////////////////////////////////////
 
 struct OggVorbis_File;
-namespace ST { class string; }
 
 class plOGGCodec : public plAudioFileReader
 {

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.h
@@ -59,7 +59,6 @@ class plControlEventMsg;
 class plMatrixChannel;
 class plMatrixMultiplyApplicator;
 class plWalkingStrategy;
-namespace ST { class string; }
 
 class plAvBrainHuman : public plArmatureBrain
 {

--- a/Sources/Plasma/PubUtilLib/plContainer/plKeysAndValues.h
+++ b/Sources/Plasma/PubUtilLib/plContainer/plKeysAndValues.h
@@ -48,8 +48,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "hsStream.h"
 
-namespace ST { class string; }
-
 enum KAddValueMode
 {
     kAlwaysAdd,         // Add another value if key already exists

--- a/Sources/Plasma/PubUtilLib/plMessageBox/hsMessageBox.h
+++ b/Sources/Plasma/PubUtilLib/plMessageBox/hsMessageBox.h
@@ -45,8 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
-namespace ST { class string; }
-
 enum hsMessageBoxKind {              // Kind of MessageBox...passed to hsMessageBox
     hsMessageBoxAbortRetyIgnore,
     hsMessageBoxNormal,             // Just Ok

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetLinkingMgr.h
@@ -53,8 +53,6 @@ struct plNCAgeJoiner;
 struct plNCAgeLeaver;
 class plVaultNotifyMsg;
 
-namespace ST { class string; }
-
 class plNetLinkingMgr
 {
     static void NCAgeJoinerCallback (

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetCommonHelpers.h
@@ -50,8 +50,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnFactory/plCreatable.h"
 
-namespace ST { class string; }
-
 ////////////////////////////////////////////////////////////////////
 
 class plCreatableListHelper : public plCreatable

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetMember.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetMember.h
@@ -48,7 +48,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plNetApp;
 class plNetGenericServer;
-namespace ST { class string; }
 
 ////////////////////////////////
 // A participant (peer) who we can send and recv messages from/to

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetMsgScreener.h
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetMsgScreener.h
@@ -50,8 +50,6 @@ class plMessage;
 class plNetGameMember;
 class plNetMessage;
 
-namespace ST { class string; }
-
 //
 // Class which decides what game messages are allowed to be sent to the server.
 // Used both client and server-side.

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAllIncludes.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglAllIncludes.h
@@ -57,8 +57,6 @@ class plNetAddress;
 class hsStream;
 class plUUID;
 
-namespace ST { class string; }
-
 #include "plNglCore.h"
 #include "plNglAuth.h"
 #include "plNglGame.h"

--- a/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plKeyFinder.h
@@ -72,8 +72,6 @@ class plKey;
 class plPageInfo;
 class plRegistryPageNode;
 
-namespace ST { class string; }
-
 class plKeyFinder
 {
 public: 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryKeyList.h
@@ -51,8 +51,6 @@ class plRegistryKeyIterator;
 class hsStream;
 class plUoid;
 
-namespace ST { class string; }
-
 //
 //  List of keys for a single class type.
 //

--- a/Sources/Plasma/PubUtilLib/plScene/plRelevanceMgr.h
+++ b/Sources/Plasma/PubUtilLib/plScene/plRelevanceMgr.h
@@ -51,8 +51,6 @@ struct hsPoint3;
 class plRelevanceRegion;
 class hsStream;
 
-namespace ST { class string; }
-
 class plRelevanceMgr : public hsKeyedObject
 {
 protected:

--- a/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.h
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.h
@@ -44,8 +44,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnKeyedObject/hsKeyedObject.h"
 
-namespace ST { class string; }
-
 class plAutoProfile : public hsKeyedObject
 {
 public:

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.h
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.h
@@ -54,7 +54,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //
 
 class hsStream;
-namespace ST { class string; }
 
 class plUnifiedTime //
 {

--- a/Sources/Plasma/PubUtilLib/plVault/plDniCoordinateInfo.h
+++ b/Sources/Plasma/PubUtilLib/plVault/plDniCoordinateInfo.h
@@ -49,7 +49,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class hsStream;
 class hsResMgr;
-namespace ST { class string; }
 
 class plDniCoordinateInfo : public plCreatable
 {

--- a/Sources/Tools/plPythonPack/PythonInterface.h
+++ b/Sources/Tools/plPythonPack/PythonInterface.h
@@ -45,7 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <vector>
 
 class plFileName;
-namespace ST { class string; }
 
 namespace PythonInterface
 {


### PR DESCRIPTION
In preparation for `ST::string`-ifying some of the HeadSpin.h functions. `ST::string` is also used frequently enough that it makes sense to have it always forward-declared, IMO.