### PR TITLE
Ensure functions with `DEFAULT_FATAL` return a value.

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyEnum.cpp
@@ -283,6 +283,8 @@ PYTHON_RICH_COMPARE_DEFINITION(EnumValue, v, w, compareType)
         PYTHON_RETURN_BOOL(i >= j);
     DEFAULT_FATAL(compareType);
     }
+
+    PYTHON_RETURN_NOT_IMPLEMENTED;
 }
 
 PYTHON_NO_INIT_DEFINITION(EnumValue)

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglMisc.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglMisc.cpp
@@ -81,6 +81,9 @@ unsigned ConnGetId (ENetProtocol protocol) {
         case kNetProtocolCli2GateKeeper: return GateKeeperGetConnId();
         DEFAULT_FATAL(protocol);
     }
+
+    // ConnId 0 means no connection
+    return 0;
 }
 
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglTrans.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglTrans.cpp
@@ -153,6 +153,8 @@ bool NetTrans::CanStart () const {
         case kNetProtocolCli2GateKeeper: return GateKeeperQueryConnected();
         DEFAULT_FATAL(m_protocol);
     }
+
+    return false;
 }
 
 


### PR DESCRIPTION
#1745 made it possible to return from `DEFAULT_FATAL()`. This means we now need to return values from functions whose switch cases return values and terminate with `DEFAULT_FATAL()`. I'm tired of seeing these warnings fly by.