### PR TITLE
Clean up assorted oddities/bugs around assert macros and `hsStatusMessage`

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plBipedKiller.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plBipedKiller.cpp
@@ -274,7 +274,7 @@ int CompareKeys(ILinPoint3Key &a, ILinPoint3Key &b)
 {
     int result = a.val.Equals(b.val, .001f);
 #if 0
-    hsStatusMessageF("COMPAREKEYS(point): (%f %f %f) vs (%f, %f, %f) = %s\n", a.val.x, a.val.y, a.val.z, b.val.x, b.val.y, b.val.z, result ? "yes" : "no");
+    hsStatusMessageF("COMPAREKEYS(point): (%f %f %f) vs (%f, %f, %f) = %s", a.val.x, a.val.y, a.val.z, b.val.x, b.val.y, b.val.z, result ? "yes" : "no");
 #endif
     return result;
 }

--- a/Sources/MaxPlugin/MaxComponent/plDistribComponent.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plDistribComponent.cpp
@@ -142,7 +142,7 @@ protected:
 
         char buff[256];
         IRollupWindow *rollup = GetCOREInterface()->GetCommandPanelRollup();
-        sprintf(buff, "%d\t%x\t%x\n", fRollup, rollup->GetPanelIndex(hWnd), msg);
+        sprintf(buff, "%d\t%x\t%x", fRollup, rollup->GetPanelIndex(hWnd), msg);
         hsStatusMessage(buff);
 
         if( msg == 0x18 )

--- a/Sources/MaxPlugin/MaxConvert/hsControlConverter.cpp
+++ b/Sources/MaxPlugin/MaxConvert/hsControlConverter.cpp
@@ -497,7 +497,7 @@ plController *hsControlConverter::MakeRotController(Control *control, plMaxNode 
                 TimeValue startTime = interval.Start(); // in ticks
                 TimeValue endTime = interval.End();     // in ticks
 
-                hsStatusMessage("Fixing up euler controller due to missing subcontrollers\n");
+                hsStatusMessage("Fixing up euler controller due to missing subcontrollers");
                 for(i=0; i<3; i++)
                 {
                     if (!rc->GetController(i))

--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -190,7 +190,7 @@ plClient::plClient()
     bPythonDebugConnected = false;
 #endif
 
-    hsStatusMessage("Constructing client\n");
+    hsStatusMessage("Constructing client");
     plClient::SetInstance(this);
     // gNextRoom[0] = '\0';
 
@@ -228,7 +228,7 @@ plClient::plClient()
 
 plClient::~plClient()
 {
-    hsStatusMessage("Destructing client\n");
+    hsStatusMessage("Destructing client");
 
     plClient::SetInstance(nullptr);
 
@@ -274,7 +274,7 @@ bool plClient::Shutdown()
     if (plAVIWriter::IsInitialized())
         plAVIWriter::Instance().Shutdown();
 
-    hsStatusMessage( "Shutting down client...\n" );
+    hsStatusMessage("Shutting down client...");
 
     // First, before anybody else goes away, write out our key mappings
     if( plInputInterfaceMgr::GetInstance() )
@@ -378,7 +378,7 @@ bool plClient::Shutdown()
 }
 
 void plClient::InitDLLs() {
-    hsStatusMessage("Init dlls client\n");
+    hsStatusMessage("Init dlls client");
 
     std::vector<plFileName> dlls = plFileSystem::ListDir("ModDLL",
 #if defined(HS_BUILD_FOR_WIN32)
@@ -440,7 +440,7 @@ void plClient::InitAuxInits()
 
 void plClient::InitInputs()
 {
-    hsStatusMessage("InitInputs client\n");
+    hsStatusMessage("InitInputs client");
     fInputManager = new plInputManager( fWindowHndl );
     fInputManager->CreateInterfaceMod(fPipeline);
     fInputManager->RegisterAs( kInput_KEY );
@@ -500,7 +500,7 @@ plPipeline* plClient::ICreatePipeline(hsDisplayHndl disp, hsWindowHndl hWnd, con
 
 bool plClient::InitPipeline(hsDisplayHndl display, uint32_t devType)
 {
-    hsStatusMessage("InitPipeline client\n");
+    hsStatusMessage("InitPipeline client");
 
     hsG3DDeviceModeRecord dmr;
     hsG3DDeviceSelector devSel;
@@ -827,7 +827,7 @@ bool plClient::MsgReceive(plMessage* msg)
     plEventCallbackMsg* callback = plEventCallbackMsg::ConvertNoRef(msg);
     if( callback )
     {
-        ST::string str = ST::format("Callback event from {}\n", callback->GetSender()
+        ST::string str = ST::format("Callback event from {}", callback->GetSender()
                             ? callback->GetSender()->GetName()
                             : ST_LITERAL("Unknown"));
         hsStatusMessage(str.c_str());
@@ -854,7 +854,7 @@ bool plClient::MsgReceive(plMessage* msg)
                 plgDispatch::MsgSend(cmd);
                 hsRefCnt_SafeUnRef(callback);
             }
-            hsStatusMessage("Removed\n");
+            hsStatusMessage("Removed");
             gotten = 0;
         }
         return true;
@@ -1272,7 +1272,7 @@ void plClient::IRoomLoaded(plSceneNode* node, bool hold)
         plgDispatch::MsgSend(loadmsg);
     }
     else
-        hsStatusMessageF("Done loading hold room %s, t=%f\n", pRmKey->GetName().c_str(), hsTimer::GetSeconds());
+        hsStatusMessageF("Done loading hold room %s, t=%f", pRmKey->GetName().c_str(), hsTimer::GetSeconds());
 
     plLocation loc = pRmKey->GetUoid().GetLocation();
     for (auto it = fRoomsLoading.cbegin(); it != fRoomsLoading.cend(); ++it)
@@ -1407,7 +1407,7 @@ void    plClient::IStopProgress()
 //============================================================================
 bool plClient::StartInit()
 {
-    hsStatusMessage("Init client\n");
+    hsStatusMessage("Init client");
     fFlags.SetBit( kFlagIniting );
 
     pfLocalizationMgr::Initialize("dat");

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -69,14 +69,9 @@ void hsDebugEnableGuiAsserts(bool enabled)
 #if !defined(HS_DEBUGGING)
 [[noreturn]]
 #endif // defined(HS_DEBUGGING)
-void hsDebugAssertionFailed(int line, const char* file, const char* fmt, ...)
+void hsDebugAssertionFailed(int line, const char* file, const char* msg)
 {
 #if defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
-    char msg[1024];
-    va_list args;
-    va_start(args, fmt);
-    vsnprintf(msg, std::size(msg), fmt, args);
-    va_end(args);
 #if defined(HS_DEBUGGING)
 #if defined(_MSC_VER)
     if (s_GuiAsserts)

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -71,7 +71,6 @@ void hsDebugEnableGuiAsserts(bool enabled)
 #endif // defined(HS_DEBUGGING)
 void hsDebugAssertionFailed(int line, const char* file, const char* msg)
 {
-#if defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
 #if defined(HS_DEBUGGING)
 #if defined(_MSC_VER)
     if (s_GuiAsserts)
@@ -89,13 +88,9 @@ void hsDebugAssertionFailed(int line, const char* file, const char* msg)
 
         hsDebugBreakAlways();
     }
-#endif // HS_DEBUGGING
 #else
     hsDebugBreakIfDebuggerPresent();
-#endif // defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
-
     // If no debugger break occurred, just crash.
-#if !defined(HS_DEBUGGING)
     std::abort();
 #endif // defined(HS_DEBUGGING)
 }

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -75,7 +75,7 @@ void hsDebugAssertionFailed(int line, const char* file, const char* msg)
 #if defined(_MSC_VER)
     if (s_GuiAsserts)
     {
-        if (_CrtDbgReport(_CRT_ASSERT, file, line, nullptr, msg))
+        if (_CrtDbgReport(_CRT_ASSERT, file, line, nullptr, "%s", msg))
             hsDebugBreakAlways();
 
         // All handling was done by the GUI, so bail.

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -189,15 +189,10 @@ void hsStatusMessage(const char* message)
         gHSStatusProc(message);
     } else {
 #if HS_BUILD_FOR_UNIX
-        printf("%s",message);
-        size_t len = strlen(message);
-        if (len>0 && message[len-1]!='\n')
-            printf("\n");
+        printf("%s\n", message);
 #elif HS_BUILD_FOR_WIN32
         OutputDebugString(message);
-        size_t len = strlen(message);
-        if (len>0 && message[len-1]!='\n')
-            OutputDebugString("\n");
+        OutputDebugString("\n");
 #endif
     }
 }

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -83,7 +83,7 @@ void hsDebugAssertionFailed(int line, const char* file, const char* msg)
     } else
 #endif // _MSC_VER
     {
-        hsDebugPrintToTerminal("-------\nASSERTION FAILED:\nFile: %s   Line: %i\nMessage: %s\n-------", file, line, msg);
+        hsDebugPrintToTerminal(ST::format("-------\nASSERTION FAILED:\nFile: {}   Line: {}\nMessage: {}\n-------", file, line, msg).c_str());
         fflush(stderr);
 
         hsDebugBreakAlways();
@@ -154,13 +154,8 @@ void hsDebugBreakAlways()
 #endif // _MSC_VER
 }
 
-void hsDebugPrintToTerminal(const char* fmt, ...)
+void hsDebugPrintToTerminal(const char* msg)
 {
-    char msg[1024];
-    va_list args;
-    va_start(args, fmt);
-    vsnprintf(msg, std::size(msg), fmt, args);
-    va_end(args);
     fprintf(stderr, "%s\n", msg);
 
 #ifdef _MSC_VER

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -317,10 +317,9 @@ void hsDebugBreakAlways();
  * Please use hsDebugPrintToTerminal ONLY for debugging messages aimed at developers
  * that must not go to a log file for some reason.
  *
- * @param fmt printf-style format string for the log message
- * @param ... format string arguments
+ * @param msg message to print
  */
-void hsDebugPrintToTerminal(const char* fmt, ...);
+void hsDebugPrintToTerminal(const char* msg);
 
 #ifdef HS_DEBUGGING
     

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -302,7 +302,7 @@ void hsDebugEnableGuiAsserts(bool enabled);
 #ifndef HS_DEBUGGING
 [[noreturn]]
 #endif
-void hsDebugAssertionFailed(int line, const char* file, const char* fmt, ...);
+void hsDebugAssertionFailed(int line, const char* file, const char* msg);
 
 bool hsDebugIsDebuggerPresent();
 void hsDebugBreakIfDebuggerPresent();
@@ -324,15 +324,15 @@ void hsDebugPrintToTerminal(const char* fmt, ...);
 
 #ifdef HS_DEBUGGING
     
-    #define hsAssert(expr, ...)                 (void)( (!!(expr)) || (hsDebugAssertionFailed(__LINE__, __FILE__, __VA_ARGS__), 0) )
+    #define hsAssert(expr, message)             (void)( (!!(expr)) || (hsDebugAssertionFailed(__LINE__, __FILE__, (message)), 0) )
     #define ASSERT(expr)                        (void)( (!!(expr)) || (hsDebugAssertionFailed(__LINE__, __FILE__, #expr), 0) )
-    #define FATAL(...)                          hsDebugAssertionFailed(__LINE__, __FILE__, __VA_ARGS__)
+    #define FATAL(message)                      hsDebugAssertionFailed(__LINE__, __FILE__, (message))
     
 #else   /* Not debugging */
 
-    #define hsAssert(expr, ...)                 ((void)0)
+    #define hsAssert(expr, message)             ((void)0)
     #define ASSERT(expr)                        ((void)0)
-    #define FATAL(...)                          ((void)0)
+    #define FATAL(message)                      ((void)0)
 
 #endif  // HS_DEBUGGING
 

--- a/Sources/Plasma/CoreLib/hsRefCnt.cpp
+++ b/Sources/Plasma/CoreLib/hsRefCnt.cpp
@@ -130,9 +130,9 @@ void hsRefCnt::UnRef(const char* tag)
 
 #if (REFCOUNT_DEBUGGING == REFCOUNT_DBG_REFS) || (REFCOUNT_DEBUGGING == REFCOUNT_DBG_ALL)
     if (tag)
-        hsDebugPrintToTerminal("Dec %p %s: %u", this, tag, fRefCnt - 1);
+        hsDebugPrintToTerminal(ST::format("Dec {#x} {}: {}", reinterpret_cast<uintptr_t>(this), tag, fRefCnt - 1).c_str());
     else
-        hsDebugPrintToTerminal("Dec %p: %u", this, fRefCnt - 1);
+        hsDebugPrintToTerminal(ST::format("Dec {#x}: {}", reinterpret_cast<uintptr_t>(this), fRefCnt - 1).c_str());
 #endif
 
     if (fRefCnt == 1)   // don't decrement if we call delete
@@ -145,9 +145,9 @@ void hsRefCnt::Ref(const char* tag)
 {
 #if (REFCOUNT_DEBUGGING == REFCOUNT_DBG_REFS) || (REFCOUNT_DEBUGGING == REFCOUNT_DBG_ALL)
     if (tag)
-        hsDebugPrintToTerminal("Inc %p %s: %u", this, tag, fRefCnt + 1);
+        hsDebugPrintToTerminal(ST::format("Inc {#x} {}: {}", reinterpret_cast<uintptr_t>(this), tag, fRefCnt + 1).c_str());
     else
-        hsDebugPrintToTerminal("Inc %p: %u", this, fRefCnt + 1);
+        hsDebugPrintToTerminal(ST::format("Inc {#x}: {}", reinterpret_cast<uintptr_t>(this), fRefCnt + 1).c_str());
 #endif
 
     ++fRefCnt;
@@ -156,7 +156,7 @@ void hsRefCnt::Ref(const char* tag)
 void hsRefCnt::TransferRef(const char* oldTag, const char* newTag)
 {
 #if (REFCOUNT_DEBUGGING == REFCOUNT_DBG_REFS) || (REFCOUNT_DEBUGGING == REFCOUNT_DBG_ALL)
-    hsDebugPrintToTerminal("Inc %p %s: (xfer)", this, newTag);
-    hsDebugPrintToTerminal("Dec %p %s: (xfer)", this, oldTag);
+    hsDebugPrintToTerminal(ST::format("Inc {#x} {}: (xfer)", reinterpret_cast<uintptr_t>(this), newTag).c_str());
+    hsDebugPrintToTerminal(ST::format("Dec {#x} {}: (xfer)", reinterpret_cast<uintptr_t>(this), oldTag).c_str());
 #endif
 }

--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -897,7 +897,7 @@ uint32_t hsQueueStream::Write(uint32_t byteCount, const void* buffer)
     {
 #if 0
         if (fReadCursor < fWriteCursor+length+1)
-            hsStatusMessage("ReadCursor wrapped\n");
+            hsStatusMessage("ReadCursor wrapped");
 #endif
         fReadCursor = std::min(fReadCursor, fWriteCursor+length+1);
         fReadCursor %= fSize;

--- a/Sources/Plasma/FeatureLib/pfAnimation/plRandomCommandMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plRandomCommandMod.cpp
@@ -224,7 +224,7 @@ bool plRandomCommandMod::MsgReceive(plMessage* msg)
         if( anim->GetSender() != GetKey() )
         {
 #if 0
-            hsStatusMessageF("someone triggered me, remote=%d\n", 
+            hsStatusMessageF("someone triggered me, remote=%d", 
                 msg->HasBCastFlag(plMessage::kNetNonLocal));
 #endif
             if( anim->Cmd(plAnimCmdMsg::kContinue) )
@@ -243,7 +243,7 @@ bool plRandomCommandMod::MsgReceive(plMessage* msg)
         {
             
 #if 0
-            hsStatusMessageF("play next if master, remote=%d\n", 
+            hsStatusMessageF("play next if master, remote=%d", 
                 msg->HasBCastFlag(plMessage::kNetNonLocal));
 #endif
             IPlayNextIfMaster();

--- a/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
@@ -1022,7 +1022,7 @@ void plCameraBrain1_Avatar::Update(bool forced)
     if (fFlags.IsBitSet(kIsTransitionCamera))
     {
         if (GetKey())
-            hsStatusMessageF("%s thinks it's the transition camera\n", GetKeyName().c_str());
+            hsStatusMessageF("%s thinks it's the transition camera", GetKeyName().c_str());
     }
     else
     {

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
@@ -2196,7 +2196,7 @@ void    plDXPipeline::Resize( uint32_t width, uint32_t height )
     {
         /// Direct3D is reporting that we lost the device but are unable to reset
         /// it yet, so ignore.
-        hsStatusMessage( "Received Resize() request at an invalid time. Ignoring...\n" );
+        hsStatusMessage("Received Resize() request at an invalid time. Ignoring...");
         return;
     }
     if( !width && !height )
@@ -2240,7 +2240,7 @@ void    plDXPipeline::Resize( uint32_t width, uint32_t height )
     else
     {
         // Just for debug
-        hsStatusMessage( "Recreating the pipeline...\n" );
+        hsStatusMessage("Recreating the pipeline...");
     }
 
     // Recreate

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.cpp
@@ -204,7 +204,7 @@ void    pfGUIListBoxMod::IUpdate()
 
     if( fLocked )
     {
-        hsStatusMessage( "WARNING: Forcing unlock on GUI list box due to call to IUpdate()\n" );
+        hsStatusMessage("WARNING: Forcing unlock on GUI list box due to call to IUpdate()");
         UnlockList();
     }
 

--- a/Sources/Plasma/FeatureLib/pfGameMgr/pfGameMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameMgr/pfGameMgr.cpp
@@ -42,6 +42,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pfGameMgr.h"
 
+#include <string_theory/format>
+
 #include "pfGameCli.h"
 #include "pfGameMgrTrans.h"
 
@@ -128,7 +130,7 @@ void pfGameMgr::RecvGameMgrMsg(GameMsgHeader* msg)
         gameIt->second->RecvGameMgrMsg(msg);
         return;
     } else if (msg->recvGameId) {
-        hsAssert(0, "Got a message for an unknown game client %u", msg->recvGameId);
+        hsAssert(0, ST::format("Got a message for an unknown game client {}", msg->recvGameId).c_str());
         return;
     }
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -757,7 +757,7 @@ void plMetalPipeline::Resize(uint32_t width, uint32_t height)
         fDevice.GetOutputLayer()->setDrawableSize(CGSizeMake(width, height));
     } else {
         // Just for debug
-        hsStatusMessage("Recreating the pipeline...\n");
+        hsStatusMessage("Recreating the pipeline...");
     }
 
     ICreateDeviceObjects();

--- a/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMoviePlayer/plMoviePlayer.cpp
@@ -345,7 +345,7 @@ void plMoviePlayer::IProcessVideoFrame(const std::vector<blkbuf_t>& frames)
             plPlanarImage::Yuv420ToRgba(fLastImg->d_w, fLastImg->d_h, fLastImg->stride, fLastImg->planes, reinterpret_cast<uint8_t*>(fTexture->GetImage()));
             break;
 
-        DEFAULT_FATAL("image format");
+        DEFAULT_FATAL(fLastImg->fmt);
         }
 
         // Flush new data to the device

--- a/Sources/Plasma/FeatureLib/pfSurface/plLayerMovie.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plLayerMovie.cpp
@@ -72,7 +72,7 @@ bool plLayerMovie::ISetFault(const char* errStr)
 {
 #ifdef HS_DEBUGGING
     char buff[256];
-    sprintf(buff, "ERROR %s: %s\n", fMovieName.AsString().c_str(), errStr);
+    sprintf(buff, "ERROR %s: %s", fMovieName.AsString().c_str(), errStr);
     hsStatusMessage(buff);
 #endif // HS_DEBUGGING
     fMovieName = "";

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/hsKeyedObject.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/hsKeyedObject.cpp
@@ -148,11 +148,9 @@ void hsKeyedObject::UnRegisterAsManual(plUoid& inUoid)
         plUoid myUoid = fpKey->GetUoid();
         if (!(inUoid == myUoid))
         {
-#if !HS_BUILD_FOR_UNIX      // disable for unix servers
             hsAssert(false,
                 ST::format("Request to Unregister wrong FixedKey, keyName={}, inUoid={}, myUoid={}",
                            fpKey->GetName(), inUoid, myUoid).c_str());
-#endif
         }
         plKeyImp::GetFromKey(fpKey)->UnRegister();
     }

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.cpp
@@ -78,7 +78,7 @@ static int IsTracked(const plKeyData* keyData)
 {
     if( mlfTrack && keyData )
     {
-        if( !keyData->GetUoid().GetObjectName().CompareI(keyNameToLookFor)
+        if( !keyData->GetUoid().GetObjectName().compare_i(keyNameToLookFor)
             && (keyData->GetUoid().GetClassType() == CLASS_TO_TRACK) )
         {
             if( (kCloneID < 0)

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
@@ -136,7 +136,7 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
                 fCallbacks[event] = fc;
 
 #if 0
-                hsStatusMessageF("Adding CBMsg, eventSender=%s, eventRemoteMsg=%d\n",                   
+                hsStatusMessageF("Adding CBMsg, eventSender=%s, eventRemoteMsg=%d",
                     event->GetSender() ? event->GetSender()->GetName().c_str() : "nil", fc->fNetPropogate);
 #endif
             }
@@ -161,7 +161,7 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
             plForwardCallback *fc = it->second;
             if (--fc->fNumCallbacks == 0)
             {
-                hsStatusMessageF("plEventCallbackMsg received, erasing, sender=%s, remoteMsg=%d\n",
+                hsStatusMessageF("plEventCallbackMsg received, erasing, sender=%s, remoteMsg=%d",
                     msg->GetSender() ? msg->GetSender()->GetName().c_str() : "nil", msg->HasBCastFlag(plMessage::kNetNonLocal));
 
                 fCallbacks.erase(eventMsg);
@@ -184,7 +184,7 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
         }
         else
         {
-            hsStatusMessageF("! Unknown plEventCallbackMsg received, sender=%s, remoteMsg=%d\n",
+            hsStatusMessageF("! Unknown plEventCallbackMsg received, sender=%s, remoteMsg=%d",
                 msg->GetSender() ? msg->GetSender()->GetName().c_str() : "nil", msg->HasBCastFlag(plMessage::kNetNonLocal));
             hsAssert(0, "Unknown plEventCallbackMsg received");
         }

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
@@ -207,8 +207,7 @@ bool plAgeLoader::ILoadAge(const ST::string& ageName)
     nc->DebugMsg( "Net: Loading age {}", fAgeName);
 
     if ((fFlags & kLoadMask) != 0)
-        hsDebugAssertionFailed(__LINE__, __FILE__, "Fatal Error:\nAlready loading or unloading an age.\n%s will now exit.",
-                               plProduct::ShortName().c_str());
+        hsDebugAssertionFailed(__LINE__, __FILE__, ST::format("Fatal Error:\nAlready loading or unloading an age.\n{} will now exit.", plProduct::ShortName()).c_str());
 
     fFlags |= kLoadingAge;
     

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
@@ -607,7 +607,7 @@ void plAGMasterMod::DumpCurrentAnims(const char *header)
         ST::string name = inst->GetName();
         float blend = inst->GetBlend();
 
-        hsStatusMessageF("%d: %s with blend of %f\n", i, name.c_str(), blend);
+        hsStatusMessageF("%d: %s with blend of %f", i, name.c_str(), blend);
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.cpp
@@ -70,7 +70,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define SND_INDEX_CHECK( index, ret )           \
     if ((size_t)index >= fSoundObjs.size())     \
     {                                           \
-        hsStatusMessageF("ERROR: Sound index out of range (index %d, count %zu)\n", index, fSoundObjs.size()); \
+        hsStatusMessageF("ERROR: Sound index out of range (index %d, count %zu)", index, fSoundObjs.size()); \
         return ret;                             \
     }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAnimStage.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAnimStage.cpp
@@ -521,7 +521,7 @@ bool plAnimStage::ITryAdvance(plArmatureMod *avMod)
     bool stageDone = false;
 
 
-    // hsStatusMessageF("Sending advance message for stage <%s>\n", fAnimName.c_str());
+    // hsStatusMessageF("Sending advance message for stage <%s>", fAnimName.c_str());
     if(fAdvanceType == kAdvanceAuto || fAdvanceType == kAdvanceOnMove) {
         stageDone = true;
     }
@@ -548,7 +548,7 @@ bool plAnimStage::ITryRegress(plArmatureMod *avMod)
     // we may want to rename this to "ReachedStageEnd"
     ISendNotify(kNotifyRegress, proEventData::kRegressPrevStage, avMod, fBrain);
 
-    // hsStatusMessageF("Sending regress message for stage <%s>\n", fAnimName.c_str());
+    // hsStatusMessageF("Sending regress message for stage <%s>", fAnimName.c_str());
     if(fRegressType == kRegressAuto) {
         stageDone = true;
     }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
@@ -627,7 +627,7 @@ bool plAvBrainHuman::IHandleTaskMsg(plAvTaskMsg *msg)
         plAvTask *task = taskM->GetTask();
         QueueTask(task);
     } else {
-        hsStatusMessageF("Couldn't recognize task message type.\n");
+        hsStatusMessageF("Couldn't recognize task message type.");
         return plArmatureBrain::IHandleTaskMsg(msg);
     }
     return true;

--- a/Sources/Plasma/PubUtilLib/plContainer/plConfigInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plContainer/plConfigInfo.cpp
@@ -911,7 +911,7 @@ bool plDebugConfigSource::WriteOutOf(plConfigInfo & configInfo)
     fConfigInfo->GetSectionIterators(si,se);
     for (; si!=se; ++si)
     {
-        sprintf(buf,"\n[%s]\n",si->first.c_str());
+        sprintf(buf,"\n[%s]",si->first.c_str());
         hsStatusMessage(buf);
         if (fConfigInfo->GetKeyIterators(si->first, ki, ke))
             for (; ki!=ke; ++ki)
@@ -919,7 +919,7 @@ bool plDebugConfigSource::WriteOutOf(plConfigInfo & configInfo)
                 if (fConfigInfo->GetValueIterators(si->first, ki->first, vi, ve))
                     for (; vi!=ve; ++vi)
                     {
-                        sprintf(buf,"%s=%s\n",ki->first.c_str(),vi->c_str());
+                        sprintf(buf,"%s=%s",ki->first.c_str(),vi->c_str());
                         hsStatusMessage(buf);
                     }
             }

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGeometrySpan.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGeometrySpan.cpp
@@ -935,7 +935,7 @@ void    plGeometrySpan::EndCreate()
             case kSkin1Weight: numWeights = 1; break;
             case kSkin2Weights: numWeights = 2; break;
             case kSkin3Weights: numWeights = 3; break;
-            default: hsAssert(false, "Garbage for weight format"); break;
+            DEFAULT_FATAL(fFormat & kSkinWeightMask);
             }
             memcpy( tempPtr, &fVertAccum[ i ].fWeights[ 0 ], numWeights * sizeof(float) );
             tempPtr += numWeights * sizeof(float);
@@ -1118,7 +1118,7 @@ void    plGeometrySpan::ExtractWeights( uint32_t vIdx, float *weightArray, uint3
         case kSkin1Weight: numWeights = 1; break;
         case kSkin2Weights: numWeights = 2; break;
         case kSkin3Weights: numWeights = 3; break;
-        default: hsAssert( false, "Bad number of weights in ExtractWeights()" );
+        DEFAULT_FATAL(fFormat & kSkinWeightMask);
     }
 
     memcpy( weightArray, fPtr, sizeof( float ) * numWeights );

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
@@ -4197,7 +4197,7 @@ void plWaveSet7::ISetupShoreLayers(hsGMaterial* mat)
     // Make sure the state is correct for each layer.
     // And set the textures up to point at the render targets
     plLayer* lay = plLayer::ConvertNoRef(mat->GetLayer(0)->BottomOfStack());
-    hsAssert(lay, "Bad first layer on material %s. Animated?");
+    hsAssert(lay, ST::format("Bad first layer on material {}. Animated?", mat->GetKeyName()).c_str());
 //  lay->SetBlendFlags(hsGMatState::kBlendAlpha | hsGMatState::kBlendInvertFinalAlpha | hsGMatState::kBlendAlphaAlways);
     lay->SetBlendFlags(hsGMatState::kBlendAlpha);
     lay->SetClampFlags(hsGMatState::kClampTextureV);
@@ -4211,7 +4211,7 @@ void plWaveSet7::ISetupShoreLayers(hsGMaterial* mat)
     lay->SetUVWSrc(0);
 
     lay = plLayer::ConvertNoRef(mat->GetLayer(1));
-    hsAssert(lay, "Bad second layer on material %s. Animated?");
+    hsAssert(lay, ST::format("Bad second layer on material {}. Animated?", mat->GetKeyName()).c_str());
     lay->SetBlendFlags(hsGMatState::kBlendAlpha);
     lay->SetClampFlags(hsGMatState::kClampTextureV);
     lay->SetShadeFlags(hsGMatState::kShadeNoProjectors
@@ -4224,7 +4224,7 @@ void plWaveSet7::ISetupShoreLayers(hsGMaterial* mat)
     lay->SetUVWSrc(1);
 
     lay = plLayer::ConvertNoRef(mat->GetLayer(2));
-    hsAssert(lay, "Bad third layer on material %s. Animated?");
+    hsAssert(lay, ST::format("Bad third layer on material {}. Animated?", mat->GetKeyName()).c_str());
     lay->SetBlendFlags(hsGMatState::kBlendAlpha);
     lay->SetClampFlags(hsGMatState::kClampTextureV);
     lay->SetShadeFlags(hsGMatState::kShadeNoProjectors

--- a/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
@@ -2212,7 +2212,7 @@ void    plMipmap::IReportLeaks()
     uint32_t      size;
 
 
-    hsStatusMessage( "--- plMipmap Leaks ---\n" );
+    hsStatusMessage("--- plMipmap Leaks ---");
     for (record = fRecords; record != nullptr; )
     {
         size = record->fHeight * record->fRowBytes;
@@ -2232,12 +2232,12 @@ void    plMipmap::IReportLeaks()
 
         switch( record->fCreationMethod )
         {
-            case plRecord::kViaCreate: strcat( msg, " via Create\n" ); break;
-            case plRecord::kViaRead: strcat( msg, " via Read\n" ); break;
-            case plRecord::kViaClipToMaxSize: strcat( msg, " via ClipToMaxSize\n" ); break;
-            case plRecord::kViaDetailMapConstructor: strcat( msg, " via DetailMapConstructor\n" ); break;
-            case plRecord::kViaCopyFrom: strcat( msg, " via CopyFrom\n" ); break;
-            case plRecord::kViaResize: strcat( msg, " via Resize\n" ); break;
+            case plRecord::kViaCreate: strcat(msg, " via Create"); break;
+            case plRecord::kViaRead: strcat(msg, " via Read"); break;
+            case plRecord::kViaClipToMaxSize: strcat(msg, " via ClipToMaxSize"); break;
+            case plRecord::kViaDetailMapConstructor: strcat(msg, " via DetailMapConstructor"); break;
+            case plRecord::kViaCopyFrom: strcat(msg, " via CopyFrom"); break;
+            case plRecord::kViaResize: strcat(msg, " via Resize"); break;
         }
 
         hsStatusMessage( msg );
@@ -2247,7 +2247,7 @@ void    plMipmap::IReportLeaks()
         delete record;
         record = next;
     }
-    hsStatusMessage( "--- End of plMipmap Leaks ---\n" );
+    hsStatusMessage("--- End of plMipmap Leaks ---");
 }
 
 #endif

--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
@@ -760,7 +760,7 @@ float plAnimTimeConvert::GetBestStopDist(float min, float max, float norm, float
         }
     }
     
-    hsStatusMessageF("found stop point %f\n", bestTime);
+    hsStatusMessageF("found stop point %f", bestTime);
 
     if (bestTime == -1)
         bestTime = norm;

--- a/Sources/Plasma/PubUtilLib/plModifier/plSimpleModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plSimpleModifier.cpp
@@ -167,16 +167,16 @@ bool plSimpleModifier::IHandleCmd(plAnimCmdMsg* modMsg)
 
 #if 0   // debug
     char str[256];
-        sprintf(str, "ModHandleCmd: time=%f, ts=%f FWD=%d, BWD=%d, SpeedChange=%d sp=%f, CONT=%d, STOP=%d",
-            hsTimer::GetSysSeconds(),
-            modMsg->GetTimeStamp(),
-            modMsg->Cmd(plAnimCmdMsg::kSetForewards),
-            modMsg->Cmd(plAnimCmdMsg::kSetBackwards),
-            modMsg->Cmd(plAnimCmdMsg::kSetSpeed),
-            modMsg->fSpeed,
-            modMsg->Cmd(plAnimCmdMsg::kContinue),
-            modMsg->Cmd(plAnimCmdMsg::kStop));
-        hsStatusMessage(str);
+    sprintf(str, "ModHandleCmd: time=%f, ts=%f FWD=%d, BWD=%d, SpeedChange=%d sp=%f, CONT=%d, STOP=%d",
+        hsTimer::GetSysSeconds(),
+        modMsg->GetTimeStamp(),
+        modMsg->Cmd(plAnimCmdMsg::kSetForewards),
+        modMsg->Cmd(plAnimCmdMsg::kSetBackwards),
+        modMsg->Cmd(plAnimCmdMsg::kSetSpeed),
+        modMsg->fSpeed,
+        modMsg->Cmd(plAnimCmdMsg::kContinue),
+        modMsg->Cmd(plAnimCmdMsg::kStop));
+    hsStatusMessage(str);
 #endif
     return true;
 }   

--- a/Sources/Plasma/PubUtilLib/plModifier/plSimpleModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plSimpleModifier.cpp
@@ -167,7 +167,7 @@ bool plSimpleModifier::IHandleCmd(plAnimCmdMsg* modMsg)
 
 #if 0   // debug
     char str[256];
-        sprintf(str, "ModHandleCmd: time=%f, ts=%f FWD=%d, BWD=%d, SpeedChange=%d sp=%f, CONT=%d, STOP=%d\n",
+        sprintf(str, "ModHandleCmd: time=%f, ts=%f FWD=%d, BWD=%d, SpeedChange=%d sp=%f, CONT=%d, STOP=%d",
             hsTimer::GetSysSeconds(),
             modMsg->GetTimeStamp(),
             modMsg->Cmd(plAnimCmdMsg::kSetForewards),

--- a/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.cpp
@@ -217,7 +217,7 @@ void plLinkEffectsMgr::ISendAllReadyCallbacks()
             hsRefCnt_SafeUnRef(fLinks[i]);
             fLinks.erase(fLinks.begin() + i);
 
-            hsStatusMessage("Done - removing link FX msg\n");
+            hsStatusMessage("Done - removing link FX msg");
         }
     }
 }
@@ -346,9 +346,9 @@ bool plLinkEffectsMgr::MsgReceive(plMessage *msg)
         }
         
         if (pTriggerMsg->IsLeavingAge())
-            hsStatusMessage("Starting LinkOut FX\n");
+            hsStatusMessage("Starting LinkOut FX");
         else
-            hsStatusMessage("Starting LinkIn FX\n");
+            hsStatusMessage("Starting LinkIn FX");
         
         plLinkEffectBCMsg *BCMsg = new plLinkEffectBCMsg();
         BCMsg->fLinkKey = linkKey;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglTrans.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglTrans.cpp
@@ -125,7 +125,7 @@ NetTrans::NetTrans (ENetProtocol protocol, ETransType transType)
 {
     ++s_perf[kPerfCurrTransactions];
     ++s_perfTransCount[m_transType];
-//  hsDebugPrintToTerminal("%s@%p created", s_transTypes[m_transType], this);
+//  hsDebugPrintToTerminal(ST::format("{}@{#x} created", s_transTypes[m_transType], reinterpret_cast<uintptr_t>(this)).c_str());
 }
 
 //============================================================================
@@ -141,7 +141,7 @@ NetTrans::~NetTrans () {
 #endif
     --s_perfTransCount[m_transType];
     --s_perf[kPerfCurrTransactions];
-//  hsDebugPrintToTerminal("%s@%p destroyed", s_transTypes[m_transType], this);
+//  hsDebugPrintToTerminal(ST::format("{}@{#x} destroyed", s_transTypes[m_transType], reinterpret_cast<uintptr_t>(this)).c_str());
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysX/plPXSimulation.cpp
@@ -115,12 +115,12 @@ public:
         case physx::PxErrorCode::eABORT:
             log->AddLineF(plStatusLog::kRed, "PhysX ABORT: '{}' File: {} Line: {}",
                           message, file, line);
-            hsDebugAssertionFailed(line, file, "PhysX ABORT: %s", message);
+            hsDebugAssertionFailed(line, file, ST::format("PhysX ABORT: {}", message).c_str());
             break;
         case physx::PxErrorCode::eINTERNAL_ERROR:
             log->AddLineF(plStatusLog::kRed, "PhysX INTERNAL ERROR: '{}' File: {} Line: {}",
                           message, file, line);
-            hsDebugAssertionFailed(line, file, "PhysX INTERNAL ERROR: %s", message);
+            hsDebugAssertionFailed(line, file, ST::format("PhysX INTERNAL ERROR: {}", message).c_str());
             break;
         case physx::PxErrorCode::eINVALID_OPERATION:
             log->AddLineF(plStatusLog::kRed, "PhysX INVALID OPERATION: '{}' File: {} Line: {}",

--- a/Sources/Plasma/PubUtilLib/plPhysical/plPickingDetector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plPickingDetector.cpp
@@ -97,7 +97,7 @@ bool plPickingDetector::MsgReceive(plMessage* msg)
 
             pMsg->SetSender(GetKey());
             pMsg->Send();
-            hsStatusMessageF("%s sending activate message to %s\n",GetKey()->GetName().c_str(), receiver->GetName().c_str());
+            hsStatusMessageF("%s sending activate message to %s",GetKey()->GetName().c_str(), receiver->GetName().c_str());
         }
     }
 

--- a/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/hsG3DDeviceSelector.cpp
@@ -609,12 +609,12 @@ void    hsG3DDeviceSelector::IFudgeDirectXDevice( hsG3DDeviceRecord &record,
             if (res.ok()) {
                 if( (series >= 8000) && (series < 9000) )
                 {
-                    hsStatusMessage( "== Using fudge factors for ATI Radeon 8X00 chipset ==\n" );
+                    hsStatusMessage("== Using fudge factors for ATI Radeon 8X00 chipset ==");
                     ISetFudgeFactors( kATIR8X00Chipset, record );
                 }
                 else if (series >= 9000)
                 {
-                    hsStatusMessage("== Using fudge factors for ATI Radeon 9X00 chipset ==\n");
+                    hsStatusMessage("== Using fudge factors for ATI Radeon 9X00 chipset ==");
                     ISetFudgeFactors(kATIRadeonChipset, record);
                 }
                 else
@@ -625,7 +625,7 @@ void    hsG3DDeviceSelector::IFudgeDirectXDevice( hsG3DDeviceRecord &record,
         }
         if (series == 0)
         {
-            hsStatusMessage("== Using fudge factors for ATI/AMD Radeon X/HD/R chipset ==\n");
+            hsStatusMessage("== Using fudge factors for ATI/AMD Radeon X/HD/R chipset ==");
             ISetFudgeFactors(kDefaultChipset, record);
         }
     }
@@ -635,18 +635,18 @@ void    hsG3DDeviceSelector::IFudgeDirectXDevice( hsG3DDeviceRecord &record,
     else if( deviceID == 0x00007125 &&
                 (driverString.compare_i("i81xdd.dll") == 0
                   || (descString.find("intel") >= 0 && descString.find("810") >= 0))) {
-        hsStatusMessage( "== Using fudge factors for an Intel i810 chipset ==\n" );
+        hsStatusMessage("== Using fudge factors for an Intel i810 chipset ==");
         ISetFudgeFactors( kIntelI810Chipset, record );
     }
     /// Detect for a GeForc FX card. We only need to nerf the really low end one.
     else if (descString.find("nvidia") >= 0 && descString.find("geforce fx 5200") >= 0) {
-        hsStatusMessage( "== Using fudge factors for an NVidia GeForceFX-based chipset ==\n" );
+        hsStatusMessage("== Using fudge factors for an NVidia GeForceFX-based chipset ==");
         ISetFudgeFactors( kNVidiaGeForceFXChipset, record );
     }
     /// Default fudge values
     else
     {
-        hsStatusMessage( "== Using default fudge factors ==\n" );
+        hsStatusMessage("== Using default fudge factors ==");
         ISetFudgeFactors( kDefaultChipset, record );
     }
 }

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
@@ -1040,14 +1040,14 @@ void plResManager::LoadAgeKeys(const ST::string& age)
     if (it != fHeldAgeKeys.end())
     {
         kResMgrLog(1, ILog(1, "Reffing age keys for age {}", age));
-        hsStatusMessageF("*** Reffing age keys for age %s ***\n", age.c_str());
+        hsStatusMessageF("*** Reffing age keys for age %s ***", age.c_str());
         plResAgeHolder* holder = it->second;
         holder->Ref();
     }
     else
     {
         kResMgrLog(1, ILog(1, "Loading age keys for age {}", age));
-        hsStatusMessageF("*** Loading age keys for age %s ***\n", age.c_str());
+        hsStatusMessageF("*** Loading age keys for age %s ***", age.c_str());
 
         plResAgeHolder* holder = new plResAgeHolder(age);
         fHeldAgeKeys[age] = holder;
@@ -1544,7 +1544,7 @@ static void sIReportLeak(plKeyImp* key, plRegistryPageNode* page)
     if (!alreadyDone)
     {
         // Print out page header
-        hsStatusMessageF("\tLeaks in page %s>%s[%08x]:\n", lastPage->GetPageInfo().GetAge().c_str(), lastPage->GetPageInfo().GetPage().c_str(), lastPage->GetPageInfo().GetLocation().GetSequenceNumber());
+        hsStatusMessageF("\tLeaks in page %s>%s[%08x]:", lastPage->GetPageInfo().GetAge().c_str(), lastPage->GetPageInfo().GetPage().c_str(), lastPage->GetPageInfo().GetLocation().GetSequenceNumber());
         alreadyDone = true;
     }
 

--- a/Sources/Tools/plResBrowser/plWinRegistryTools.cpp
+++ b/Sources/Tools/plResBrowser/plWinRegistryTools.cpp
@@ -76,7 +76,7 @@ static bool ISetRegKey(const QString &keyName, const QString &value, const QStri
                           nullptr, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS,
                           nullptr, &regKey, &result) != ERROR_SUCCESS)
     {
-        hsStatusMessageF("Warning: Registry database open failed for key '%s'.\n", qPrintable(keyName));
+        hsStatusMessageF("Warning: Registry database open failed for key '%s'.", qPrintable(keyName));
         return false;
     }
 
@@ -89,7 +89,7 @@ static bool ISetRegKey(const QString &keyName, const QString &value, const QStri
     if (::RegCloseKey(regKey) == ERROR_SUCCESS && lResult == ERROR_SUCCESS)
         return true;
 
-    hsStatusMessageF("Warning: Registry database update failed for key '%s'.\n", qPrintable(keyName));
+    hsStatusMessageF("Warning: Registry database update failed for key '%s'.", qPrintable(keyName));
     return false;
 }
 
@@ -173,7 +173,7 @@ QString plWinRegistryTools::GetCurrentFileExtensionAssociation(const QString &ex
     {
         char msg[512];
         FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, retVal, 0, msg, std::size(msg), nullptr);
-        hsStatusMessageF("Error querying registry key '%s' : %s\n", qPrintable(extension), msg);
+        hsStatusMessageF("Error querying registry key '%s' : %s", qPrintable(extension), msg);
         return QString();
     }
 


### PR DESCRIPTION
While preparing to `ST::string`-ify these APIs, I came across a bunch of oddities and small bugs. The main changes are:

* The assert macros no longer accept `printf`-style varargs. (This was very rarely used and caused issues for literal `%` characters in the message.)
* The assert macros now reliably support literal `%` characters in the message. (There was another format string confusion bug here, unrelated to the previous point!)
* `hsStatusMessage` now always adds a newline after the message. (Previously, there was a special case for messages that already ended in a newline.)

The other things are boring minor fixes - see commit messages for details.