### PR TITLE
Namespace some system-conflicting enum values

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plAnimEventComponent.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plAnimEventComponent.cpp
@@ -199,12 +199,12 @@ bool plAnimEventComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     if (fCompPB->GetInt(kAnimBegin))
     {
         plEventCallbackMsg *eventMsg = CreateCallbackMsg(animMsg, modKey);
-        eventMsg->fEvent = kBegin;
+        eventMsg->fEvent = plEventCallbackMsg::kBegin;
     }
     if (fCompPB->GetInt(kAnimEnd))
     {
         plEventCallbackMsg *eventMsg = CreateCallbackMsg(animMsg, modKey);
-        eventMsg->fEvent = kEnd;
+        eventMsg->fEvent = plEventCallbackMsg::kEnd;
     }
     if (fCompPB->Count(kAnimMarkers) > 0)
     {
@@ -218,7 +218,7 @@ bool plAnimEventComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
             float time = info.GetMarkerTime(marker);
 
             plEventCallbackMsg *eventMsg = CreateCallbackMsg(animMsg, modKey);
-            eventMsg->fEvent = kTime;
+            eventMsg->fEvent = plEventCallbackMsg::kTime;
             eventMsg->fEventTime = time;
         }
     }
@@ -505,12 +505,12 @@ bool plMtlEventComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     if (fCompPB->GetInt(kMtlBegin))
     {
         plEventCallbackMsg *eventMsg = CreateCallbackMsg(animMsg, modKey);
-        eventMsg->fEvent = kBegin;
+        eventMsg->fEvent = plEventCallbackMsg::kBegin;
     }
     if (fCompPB->GetInt(kMtlEnd))
     {
         plEventCallbackMsg *eventMsg = CreateCallbackMsg(animMsg, modKey);
-        eventMsg->fEvent = kEnd;
+        eventMsg->fEvent = plEventCallbackMsg::kEnd;
     }
     if (fCompPB->Count(kMtlMarkers) > 0)
     {
@@ -524,7 +524,7 @@ bool plMtlEventComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
             float time = info.GetMarkerTime(marker);
 
             plEventCallbackMsg *eventMsg = CreateCallbackMsg(animMsg, modKey);
-            eventMsg->fEvent = kTime;
+            eventMsg->fEvent = plEventCallbackMsg::kTime;
             eventMsg->fEventTime = time;
         }
     }

--- a/Sources/MaxPlugin/MaxComponent/plClickDragComponent.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plClickDragComponent.cpp
@@ -461,12 +461,12 @@ bool plClickDragComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
 
         // add callbacks for beginning and end of animation
         plEventCallbackMsg* pCall1 = new plEventCallbackMsg;
-        pCall1->fEvent = kBegin;
+        pCall1->fEvent = plEventCallbackMsg::kBegin;
         pCall1->fRepeats = -1;
         pCall1->AddReceiver(axisKey);
         
         plEventCallbackMsg* pCall2 = new plEventCallbackMsg;
-        pCall2->fEvent = kEnd;
+        pCall2->fEvent = plEventCallbackMsg::kEnd;
         pCall2->fRepeats = -1;
         pCall2->AddReceiver(axisKey);
 

--- a/Sources/MaxPlugin/MaxComponent/plResponderAnim.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plResponderAnim.cpp
@@ -524,11 +524,11 @@ void plResponderCmdAnim::CreateWait(plMaxNode* node, plErrorMsg* pErrMsg, IParam
         plNotetrackAnim notetrackAnim(animComp, nullptr);
         plAnimInfo info = notetrackAnim.GetAnimInfo(animName);
 
-        eventMsg->fEvent = kTime;
+        eventMsg->fEvent = plEventCallbackMsg::kTime;
         eventMsg->fEventTime = info.GetMarkerTime(waitInfo.point);
     }
     else
-        eventMsg->fEvent = kStop;
+        eventMsg->fEvent = plEventCallbackMsg::kStop;
 
     plMessageWithCallbacks *callbackMsg = plMessageWithCallbacks::ConvertNoRef(waitInfo.msg);
     callbackMsg->AddCallback(eventMsg);

--- a/Sources/MaxPlugin/MaxComponent/plResponderMtl.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plResponderMtl.cpp
@@ -458,7 +458,7 @@ void plResponderCmdMtl::CreateWait(plMaxNode* node, plErrorMsg* pErrMsg, IParamB
     plEventCallbackMsg *eventMsg = new plEventCallbackMsg;
     eventMsg->AddReceiver(waitInfo.receiver);
     eventMsg->fRepeats = 0;
-    eventMsg->fEvent = kStop;
+    eventMsg->fEvent = plEventCallbackMsg::kStop;
     eventMsg->fUser = waitInfo.callbackUser;
 
     if (!waitInfo.point.empty())
@@ -470,12 +470,12 @@ void plResponderCmdMtl::CreateWait(plMaxNode* node, plErrorMsg* pErrMsg, IParamB
         plNotetrackAnim notetrackAnim(mtl, nullptr);
         plAnimInfo info = notetrackAnim.GetAnimInfo(animName);
 
-        eventMsg->fEvent = kTime;
+        eventMsg->fEvent = plEventCallbackMsg::kTime;
         eventMsg->fEventTime = info.GetMarkerTime(waitInfo.point);
     }
     else
     {
-        eventMsg->fEvent = kStop;
+        eventMsg->fEvent = plEventCallbackMsg::kStop;
     }
 
     plMessageWithCallbacks *callbackMsg = plMessageWithCallbacks::ConvertNoRef(waitInfo.msg);

--- a/Sources/MaxPlugin/MaxConvert/hsControlConverter.cpp
+++ b/Sources/MaxPlugin/MaxConvert/hsControlConverter.cpp
@@ -2129,7 +2129,7 @@ void hsControlConverter::IExportAnimatedCameraFOV(plMaxNode* node, std::vector<h
         pFOVMsg->AddReceiver(pCamMod->GetKey());
         
         plEventCallbackMsg* pCall = new plEventCallbackMsg;
-        pCall->fEvent = kTime;
+        pCall->fEvent = plEventCallbackMsg::kTime;
         pCall->fEventTime = (*kfArray)[i].fFrame / MAX_FRAMES_PER_SEC;
         pCall->fIndex = i;
         pCall->AddReceiver(pCamMod->GetKey());

--- a/Sources/Plasma/FeatureLib/pfConditional/plAnimationEventConditionalObject.cpp
+++ b/Sources/Plasma/FeatureLib/pfConditional/plAnimationEventConditionalObject.cpp
@@ -65,7 +65,7 @@ bool plAnimationEventConditionalObject::MsgReceive(plMessage* msg)
 }
     
 
-void plAnimationEventConditionalObject::SetEvent(const CallbackEvent b, float time)
+void plAnimationEventConditionalObject::SetEvent(const plEventCallbackMsg::CallbackEvent b, float time)
 {
     plAnimCmdMsg* pMsg = new plAnimCmdMsg;
     pMsg->AddReceiver(fTarget);
@@ -83,7 +83,7 @@ void plAnimationEventConditionalObject::Read(hsStream* stream, hsResMgr* mgr)
 {
     plConditionalObject::Read(stream, mgr);
     fTarget = mgr->ReadKey(stream);
-    fAction = (CallbackEvent)stream->ReadLE32();
+    fAction = (plEventCallbackMsg::CallbackEvent)stream->ReadLE32();
 }
 
 void plAnimationEventConditionalObject::Write(hsStream* stream, hsResMgr* mgr)

--- a/Sources/Plasma/FeatureLib/pfConditional/plAnimationEventConditionalObject.h
+++ b/Sources/Plasma/FeatureLib/pfConditional/plAnimationEventConditionalObject.h
@@ -50,13 +50,13 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plAnimationEventConditionalObject : public plConditionalObject
 {
 protected:
-    CallbackEvent   fAction;
+    plEventCallbackMsg::CallbackEvent   fAction;
     plKey           fTarget;
 public:
     
     
     plAnimationEventConditionalObject() : fAction(), fTarget() { }
-    plAnimationEventConditionalObject(plKey pTargetModifier) : fTarget(std::move(pTargetModifier)), fAction(kEventEnd) { }
+    plAnimationEventConditionalObject(plKey pTargetModifier) : fTarget(std::move(pTargetModifier)), fAction(plEventCallbackMsg::kEventEnd) { }
     ~plAnimationEventConditionalObject() { }
     
     CLASSNAME_REGISTER( plAnimationEventConditionalObject );
@@ -70,7 +70,7 @@ public:
     void Evaluate() override { }
     void Reset() override { SetSatisfied(false); }
 
-    void SetEvent(const CallbackEvent b, float time = 0.0f);
+    void SetEvent(const plEventCallbackMsg::CallbackEvent b, float time = 0.0f);
     
 };
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -2108,13 +2108,13 @@ PF_CONSOLE_CMD( App,
     int reps = 1;
 
     const ST::string& eventStr = params[1];
-    CallbackEvent event;
+    plEventCallbackMsg::CallbackEvent event;
     if (eventStr.compare_i("Start") == 0) {
-        event = kStart;
+        event = plEventCallbackMsg::kStart;
     } else if (eventStr.compare_i("Stop") == 0) {
-        event = kStop;
+        event = plEventCallbackMsg::kStop;
     } else if (eventStr.compare_i("Time") == 0) {
-        event = kTime;
+        event = plEventCallbackMsg::kTime;
         if (numParams < 2) {
             PrintString("'Time' expects a timestamp (in seconds)");
             return;
@@ -2162,13 +2162,13 @@ PF_CONSOLE_CMD( App,
     int reps = -1;
 
     const ST::string& eventStr = params[1];
-    CallbackEvent event;
+    plEventCallbackMsg::CallbackEvent event;
     if (eventStr.compare_i("Start") == 0) {
-        event = kStart;
+        event = plEventCallbackMsg::kStart;
     } else if (eventStr.compare_i("Stop") == 0) {
-        event = kStop;
+        event = plEventCallbackMsg::kStop;
     } else if (eventStr.compare_i("Time") == 0) {
-        event = kTime;
+        event = plEventCallbackMsg::kTime;
         secs = params[2];
     }
 

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -467,7 +467,7 @@ bool pfBookData::MsgReceive(plMessage *pMsg)
             {
                 // Or actually maybe it's that we're done closing and should hide now,
                 // produced from a CloseAndHide()
-                if( callback->fEvent == kStop )
+                if( callback->fEvent == plEventCallbackMsg::kStop )
                     fCurrBook->Hide();
                 else
                     fCurrBook->IFinishShow( ( callback->fUser & 0x01 ) ? true : false );
@@ -827,12 +827,12 @@ void pfBookData::ITriggerPageFlip(bool flipBackwards, bool immediate)
     if (immediate)
     {
         eventMsg->fUser = ((!flipBackwards) ? 0x01 : 0x00) | 0x02;
-        eventMsg->fEvent = kSingleFrameAdjust;
+        eventMsg->fEvent = plEventCallbackMsg::kSingleFrameAdjust;
     }
     else
     {
         eventMsg->fUser = (flipBackwards ? 0x01 : 0x00);
-        eventMsg->fEvent = kStop;
+        eventMsg->fEvent = plEventCallbackMsg::kStop;
     }
     msg->SetCmd(plAnimCmdMsg::kAddCallbacks);
     msg->AddCallback(eventMsg);
@@ -846,7 +846,7 @@ void pfBookData::ITriggerPageFlip(bool flipBackwards, bool immediate)
         eventMsg->AddReceiver(GetKey());
         eventMsg->fRepeats = 0;
         eventMsg->fUser = !flipBackwards ? (0x04 | 0x01) : 0x04;
-        eventMsg->fEvent = kBegin;  // Should cause it to be triggered once it seeks at the start of the command
+        eventMsg->fEvent = plEventCallbackMsg::kBegin;  // Should cause it to be triggered once it seeks at the start of the command
         msg->AddCallback(eventMsg);
         hsRefCnt_SafeUnRef(eventMsg);
     }
@@ -1386,7 +1386,7 @@ void    pfJournalBook::ITriggerCloseWithNotify( bool closeNotOpen, bool immediat
     eventMsg->AddReceiver( fBookGUIs[fCurBookGUI]->GetKey() );
     eventMsg->fRepeats = 0;
     eventMsg->fUser = 0x08 | ( closeNotOpen ? 0x00 : 0x01 );    // So we know which this is for
-    eventMsg->fEvent = immediate ? ( kSingleFrameEval ) : kStop;
+    eventMsg->fEvent = immediate ? ( plEventCallbackMsg::kSingleFrameEval ) : plEventCallbackMsg::kStop;
     msg->SetCmd( plAnimCmdMsg::kAddCallbacks );
     msg->AddCallback( eventMsg );
     hsRefCnt_SafeUnRef( eventMsg );

--- a/Sources/Plasma/NucleusLib/pnMessage/plEventCallbackMsg.h
+++ b/Sources/Plasma/NucleusLib/pnMessage/plEventCallbackMsg.h
@@ -45,25 +45,23 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plMessage.h"
 
-enum CallbackEvent
-{
-    kStart = 0,
-    kStop,
-    kReverse,
-    kTime,
-    kLoop,
-    kBegin,
-    kEnd,
-    kEventEnd,
-    kSingleFrameAdjust,
-    kSingleFrameEval
-};
-
 class plEventCallbackMsg : public plMessage
 {
-protected:
-
 public:
+    enum CallbackEvent
+    {
+        kStart = 0,
+        kStop,
+        kReverse,
+        kTime,
+        kLoop,
+        kBegin,
+        kEnd,
+        kEventEnd,
+        kSingleFrameAdjust,
+        kSingleFrameEval
+    };
+
     float           fEventTime; // the time for time events
     CallbackEvent   fEvent;     // the event    
     int16_t         fIndex;     // the index of the object we want the event to come from

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -194,17 +194,17 @@ void plAGAnimInstance::IInitAnimTimeConvert(plAnimTimeConvert* atc, plATCAnim* a
     // Set up our eval callbacks
     plAGInstanceCallbackMsg* instMsg;
 
-    instMsg = new plAGInstanceCallbackMsg(master->GetKey(), kStart);
+    instMsg = new plAGInstanceCallbackMsg(master->GetKey(), plEventCallbackMsg::kStart);
     instMsg->fInstance = this;
     atc->AddCallback(instMsg);
     hsRefCnt_SafeUnRef(instMsg);
 
-    instMsg = new plAGInstanceCallbackMsg(master->GetKey(), kStop);
+    instMsg = new plAGInstanceCallbackMsg(master->GetKey(), plEventCallbackMsg::kStop);
     instMsg->fInstance = this;
     atc->AddCallback(instMsg);
     hsRefCnt_SafeUnRef(instMsg);
 
-    instMsg = new plAGInstanceCallbackMsg(master->GetKey(), kSingleFrameAdjust);
+    instMsg = new plAGInstanceCallbackMsg(master->GetKey(), plEventCallbackMsg::kSingleFrameAdjust);
     instMsg->fInstance = this;
     atc->AddCallback(instMsg);
     hsRefCnt_SafeUnRef(instMsg);
@@ -497,11 +497,11 @@ void plAGAnimInstance::AttachCallbacks(plOneShotCallbacks *callbacks)
                 float marker = anim->GetMarker(cb.fMarker);
                 hsAssert(marker != -1, "Bad marker name");
                 eventMsg->fEventTime = marker;
-                eventMsg->fEvent = kTime;
+                eventMsg->fEvent = plEventCallbackMsg::kTime;
             }
             else
             {
-                eventMsg->fEvent = kStop;
+                eventMsg->fEvent = plEventCallbackMsg::kStop;
             }
             
             animMsg.AddCallback(eventMsg);

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
@@ -451,7 +451,7 @@ void plAGMasterMod::PlaySimpleAnim(const ST::string &name)
         instance->SetLoop(false);
         instance->Start();
 
-        plAGDetachCallbackMsg *msg = new plAGDetachCallbackMsg(GetKey(), kStop); 
+        plAGDetachCallbackMsg *msg = new plAGDetachCallbackMsg(GetKey(), plEventCallbackMsg::kStop); 
         msg->SetAnimName(name);
         instance->GetTimeConvert()->AddCallback(msg);
         hsRefCnt_SafeUnRef(msg);
@@ -679,11 +679,11 @@ bool plAGMasterMod::MsgReceive(plMessage* msg)
     plAGInstanceCallbackMsg *agicMsg = plAGInstanceCallbackMsg::ConvertNoRef(msg);
     if (agicMsg)
     {
-        if (agicMsg->fEvent == kStart)
+        if (agicMsg->fEvent == plEventCallbackMsg::kStart)
         {
             IRegForEval(true);
         }
-        else if (agicMsg->fEvent == kStop)
+        else if (agicMsg->fEvent == plEventCallbackMsg::kStop)
         {
             if (!HasRunningAnims())
                 IRegForEval(false);

--- a/Sources/Plasma/PubUtilLib/plAudio/plSoundEvent.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSoundEvent.cpp
@@ -151,10 +151,10 @@ plSoundEvent::Types plSoundEvent::GetTypeFromCallbackMsg( plEventCallbackMsg *ms
 {
     switch( msg->fEvent )
     {
-        case ::kStart: return kStart;
-        case ::kTime:  return kTime;
-        case ::kStop:  return kStop;
-        case ::kLoop:  return kLoop;
+        case plEventCallbackMsg::kStart: return kStart;
+        case plEventCallbackMsg::kTime:  return kTime;
+        case plEventCallbackMsg::kStop:  return kStop;
+        case plEventCallbackMsg::kLoop:  return kLoop;
         default:       return kStop;
     }
 }

--- a/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plWin32Sound.cpp
@@ -425,7 +425,7 @@ bool plWin32Sound::MsgReceive( plMessage* pMsg )
     plEventCallbackMsg *e = plEventCallbackMsg::ConvertNoRef( pMsg );
     if (e != nullptr)
     {
-        if( e->fEvent == kStop )
+        if( e->fEvent == plEventCallbackMsg::kStop )
         {
             fPlaying = false;
             fPlayOnReactivate = false;  // Just to make sure...

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -2409,14 +2409,14 @@ void plArmatureMod::ISetupMarkerCallbacks(plATCAnim *anim, plAnimTimeConvert *at
         {
             plEventCallbackInterceptMsg *iMsg;
 
-            plArmatureEffectMsg *msg = new plArmatureEffectMsg(fEffects->GetKey(), kTime);
+            plArmatureEffectMsg *msg = new plArmatureEffectMsg(fEffects->GetKey(), plEventCallbackMsg::kTime);
             msg->fEventTime = time;
             msg->fTriggerIdx = AnimNameToIndex(anim->GetName());
             
             iMsg = new plEventCallbackInterceptMsg();
             iMsg->AddReceiver(fEffects->GetKey());
             iMsg->fEventTime = time;
-            iMsg->fEvent = kTime;
+            iMsg->fEvent = plEventCallbackMsg::kTime;
             iMsg->SetMessageRef(msg);
             atc->AddCallback(iMsg);
             hsRefCnt_SafeUnRef(msg);
@@ -2428,7 +2428,7 @@ void plArmatureMod::ISetupMarkerCallbacks(plATCAnim *anim, plAnimTimeConvert *at
             iMsg = new plEventCallbackInterceptMsg();
             iMsg->AddReceiver(fEffects->GetKey());
             iMsg->fEventTime = time;
-            iMsg->fEvent = kTime;
+            iMsg->fEvent = plEventCallbackMsg::kTime;
             iMsg->SetMessageRef(foot);
             atc->AddCallback(iMsg);
             hsRefCnt_SafeUnRef(foot);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainSwim.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainSwim.cpp
@@ -272,14 +272,14 @@ bool plAvBrainSwim::Apply(double time, float elapsed)
             if (huBrain && !huBrain->fWalkingStrategy->IsOnGround())
             {
                 // We're jumping in! Trigger splash effect (sound)              
-                plArmatureEffectMsg *msg = new plArmatureEffectMsg(fAvMod->GetArmatureEffects()->GetKey(), kTime);
+                plArmatureEffectMsg *msg = new plArmatureEffectMsg(fAvMod->GetArmatureEffects()->GetKey(), plEventCallbackMsg::kTime);
                 msg->fEventTime = (float)time;
                 msg->fTriggerIdx = plArmatureMod::kImpact;
 
                 plEventCallbackInterceptMsg *iMsg = new plEventCallbackInterceptMsg;
                 iMsg->AddReceiver(fAvMod->GetArmatureEffects()->GetKey());
                 iMsg->fEventTime = (float)time;
-                iMsg->fEvent = kTime;
+                iMsg->fEvent = plEventCallbackMsg::kTime;
                 iMsg->SetMessageRef(msg);
                 iMsg->Send();
             }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
@@ -581,7 +581,7 @@ bool plAvOneShotTask::Start(plArmatureMod *avatar, plArmatureBrain *brain, doubl
         {
             // Must do the physics re-enable through a callback so that it happens before the "done" callback and we don't
             // step over some script's attempt to disable physics again.
-            plAvatarPhysicsEnableCallbackMsg *epMsg = new plAvatarPhysicsEnableCallbackMsg(avatar->GetKey(), kStop, 0, 0, 0, 0);
+            plAvatarPhysicsEnableCallbackMsg *epMsg = new plAvatarPhysicsEnableCallbackMsg(avatar->GetKey(), plEventCallbackMsg::kStop, 0, 0, 0, 0);
             fAnimInstance->GetTimeConvert()->AddCallback(epMsg);
             hsRefCnt_SafeUnRef(epMsg);
         }   

--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
@@ -175,14 +175,14 @@ void plAnimTimeConvert::ICheckTimeCallbacks(float frameStart, float frameStop)
 {
     for (hsSsize_t i = fCallbackMsgs.size() - 1; i >= 0; --i)
     {
-        if (fCallbackMsgs[i]->fEvent == kTime)
+        if (fCallbackMsgs[i]->fEvent == plEventCallbackMsg::kTime)
         {
             if( ITimeInFrame(fCallbackMsgs[i]->fEventTime, frameStart, frameStop) )
                 ISendCallback(i);
         }
-        else if (fCallbackMsgs[i]->fEvent == kBegin && ITimeInFrame(fBegin, frameStart, frameStop) )
+        else if (fCallbackMsgs[i]->fEvent == plEventCallbackMsg::kBegin && ITimeInFrame(fBegin, frameStart, frameStop) )
             ISendCallback(i);
-        else if (fCallbackMsgs[i]->fEvent == kEnd && ITimeInFrame(fEnd, frameStart, frameStop) )
+        else if (fCallbackMsgs[i]->fEvent == plEventCallbackMsg::kEnd && ITimeInFrame(fEnd, frameStart, frameStop) )
             ISendCallback(i);
 
     }
@@ -267,7 +267,7 @@ plAnimTimeConvert& plAnimTimeConvert::IStop(double time, float animTime)
 
     for (hsSsize_t i = fCallbackMsgs.size() - 1; i >= 0; --i)
     {
-        if (fCallbackMsgs[i]->fEvent == kStop)
+        if (fCallbackMsgs[i]->fEvent == plEventCallbackMsg::kStop)
         {
             ISendCallback(i);
         }
@@ -416,7 +416,7 @@ float plAnimTimeConvert::WorldToAnimTime(double wSecs)
         {
             for (hsSsize_t i = fCallbackMsgs.size() - 1; i >= 0; --i)
             {
-                if (fCallbackMsgs[i]->fEvent == kSingleFrameEval)
+                if (fCallbackMsgs[i]->fEvent == plEventCallbackMsg::kSingleFrameEval)
                 {
                     ISendCallback(i);
                 }
@@ -665,7 +665,7 @@ void plAnimTimeConvert::SetCurrentAnimTime(float s, bool jump /* = false */)
     fCurrentAnimTime = s;
     for (hsSsize_t i = fCallbackMsgs.size() - 1; i >= 0; --i)
     {
-        if (fCallbackMsgs[i]->fEvent == kSingleFrameAdjust)
+        if (fCallbackMsgs[i]->fEvent == plEventCallbackMsg::kSingleFrameAdjust)
         {
             ISendCallback(i);
         }
@@ -958,7 +958,7 @@ plAnimTimeConvert& plAnimTimeConvert::Start(double startTime)
     // check for a start callback
     for (hsSsize_t i = fCallbackMsgs.size() - 1; i >= 0; --i)
     {
-        if (fCallbackMsgs[i]->fEvent == kStart)
+        if (fCallbackMsgs[i]->fEvent == plEventCallbackMsg::kStart)
         {
             ISendCallback(i);
         }
@@ -991,7 +991,7 @@ plAnimTimeConvert& plAnimTimeConvert::Backwards()
     // check for a reverse callback
     for (hsSsize_t i = fCallbackMsgs.size() - 1; i >= 0; --i)
     {
-        if (fCallbackMsgs[i]->fEvent == kReverse)
+        if (fCallbackMsgs[i]->fEvent == plEventCallbackMsg::kReverse)
         {
             ISendCallback(i);
         }
@@ -1013,7 +1013,7 @@ plAnimTimeConvert& plAnimTimeConvert::Forewards()
     // check for a reverse callback
     for (hsSsize_t i = fCallbackMsgs.size() - 1; i >= 0; --i)
     {
-        if (fCallbackMsgs[i]->fEvent == kReverse)
+        if (fCallbackMsgs[i]->fEvent == plEventCallbackMsg::kReverse)
         {
             ISendCallback(i);
         }

--- a/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
@@ -142,7 +142,7 @@ bool plAxisAnimModifier::MsgReceive(plMessage* msg)
     {
         // Send our notification to whomever cares;
         float time = 0.0f;
-        if (pCall->fEvent == kEnd)
+        if (pCall->fEvent == plEventCallbackMsg::kEnd)
             time = 1.0f;
         fNotify->ClearEvents();
         fNotify->SetSender(fNotificationKey); // so python can handle it.
@@ -285,12 +285,12 @@ bool plAxisAnimModifier::MsgReceive(plMessage* msg)
 
                 // add callbacks for beginning and end of animation
                 plEventCallbackMsg* pCall1 = new plEventCallbackMsg;
-                pCall1->fEvent = kBegin;
+                pCall1->fEvent = plEventCallbackMsg::kBegin;
                 pCall1->fRepeats = -1;
                 pCall1->AddReceiver(GetKey());
                 
                 plEventCallbackMsg* pCall2 = new plEventCallbackMsg;
-                pCall2->fEvent = kEnd;
+                pCall2->fEvent = plEventCallbackMsg::kEnd;
                 pCall2->fRepeats = -1;
                 pCall2->AddReceiver(GetKey());
 
@@ -313,12 +313,12 @@ bool plAxisAnimModifier::MsgReceive(plMessage* msg)
                 
                 // add callbacks for beginning and end of animation
                 plEventCallbackMsg* pCall1 = new plEventCallbackMsg;
-                pCall1->fEvent = kBegin;
+                pCall1->fEvent = plEventCallbackMsg::kBegin;
                 pCall1->fRepeats = -1;
                 pCall1->AddReceiver(GetKey());
                 
                 plEventCallbackMsg* pCall2 = new plEventCallbackMsg;
-                pCall2->fEvent = kEnd;
+                pCall2->fEvent = plEventCallbackMsg::kEnd;
                 pCall2->fRepeats = -1;
                 pCall2->AddReceiver(GetKey());
 

--- a/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
@@ -727,7 +727,7 @@ void plResponderModifier::IDebugPlayMsg(plAnimCmdMsg* msg)
     eventMsg->AddReceiver(GetKey());
     eventMsg->fRepeats = 0;
     eventMsg->fUser = -1;
-    eventMsg->fEvent = kStop;
+    eventMsg->fEvent = plEventCallbackMsg::kStop;
     msg->SetCmd(plAnimCmdMsg::kAddCallbacks);
     msg->AddCallback(eventMsg);
     hsRefCnt_SafeUnRef(eventMsg);

--- a/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.cpp
@@ -525,7 +525,7 @@ void plLinkEffectsMgr::WaitForEffect(plKey linkKey, float time)
 
     msg->fEffects++;
     plLinkCallbackMsg *callback = new plLinkCallbackMsg();
-    callback->fEvent = kStop;
+    callback->fEvent = plEventCallbackMsg::kStop;
     callback->fRepeats = 0;
     callback->fLinkKey = std::move(linkKey);
     double timeToDeliver = hsTimer::GetSysSeconds() + time;
@@ -545,7 +545,7 @@ plMessage *plLinkEffectsMgr::WaitForEffect(plKey linkKey)
     msg->fEffects++;
 
     plLinkCallbackMsg *callback = new plLinkCallbackMsg();
-    callback->fEvent = kStop;
+    callback->fEvent = plEventCallbackMsg::kStop;
     callback->fRepeats = 0;
     callback->fLinkKey = std::move(linkKey);
     callback->AddReceiver( GetKey() );

--- a/Sources/Plasma/PubUtilLib/plSurface/plLayerAnimation.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plLayerAnimation.cpp
@@ -418,7 +418,7 @@ plLayerLinkAnimation::plLayerLinkAnimation() :
     fFadeFlagsDirty()
 { 
     fIFaceCallback = new plEventCallbackMsg();
-    fIFaceCallback->fEvent = kTime;
+    fIFaceCallback->fEvent = plEventCallbackMsg::kTime;
     fIFaceCallback->fRepeats = 0;           
 }
 
@@ -517,7 +517,7 @@ uint32_t plLayerLinkAnimation::Eval(double wSecs, uint32_t frame, uint32_t ignor
             {
                 // Either we're going opaque, or we were opaque and now we're fading.
                 // Tell the armature to re-eval its opacity settings.
-                plAvatarOpacityCallbackMsg *opacityMsg = new plAvatarOpacityCallbackMsg(fLinkKey, kStop);
+                plAvatarOpacityCallbackMsg *opacityMsg = new plAvatarOpacityCallbackMsg(fLinkKey, plEventCallbackMsg::kStop);
                 opacityMsg->SetBCastFlag(plMessage::kPropagateToModifiers);
                 opacityMsg->Send();
             }               


### PR DESCRIPTION
Some of these enum key names in the global scope were conflicting with enums and other definitions in system header files, and it's easier to address it in our code than it is to change system files.