### PR TITLE
Fix #1761 stragglers.

### DIFF
--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -1051,7 +1051,7 @@ bool WinInit(HINSTANCE hInst)
     return true;
 }
 
-int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nCmdShow)
+int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPWSTR lpCmdLine, int nCmdShow)
 {
     PF_CONSOLE_INIT_ALL()
 
@@ -1061,7 +1061,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
     std::vector<ST::string> args;
     args.reserve(__argc);
     for (size_t i = 0; i < __argc; i++) {
-        args.push_back(ST::string::from_utf8(__argv[i]));
+        args.push_back(ST::string::from_wchar(__wargv[i]));
     }
 
     plCmdParser cmdParser(s_cmdLineArgs, std::size(s_cmdLineArgs));

--- a/Sources/Plasma/Apps/plUruLauncher/winmain.cpp
+++ b/Sources/Plasma/Apps/plUruLauncher/winmain.cpp
@@ -387,7 +387,7 @@ static pfPatcher* IPatcherFactory()
 
 // ===================================================
 
-int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLink, int nCmdShow)
+int __stdcall wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLink, int nCmdShow)
 {
     plWinDpi::Instance();
 


### PR DESCRIPTION
Fixes #1767 and fixes the plClient entrypoint on Windows to use UCS-2 as well.