### PR TITLE
Check for (and polyfill) strnlen API

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -80,6 +80,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfConsoleCore/pfConsoleEngine.h"
 #include "pfPython/cyPythonInterface.h"
 
+#ifdef HAVE_STRNLEN
+#   define pfStrnlen strnlen
+#else
+    static size_t pfStrnlen(const char* str, size_t max)
+    {
+        return static_cast<const char*>(memchr(str, '\0', max)) - str;
+    }
+#endif
 
 //// Static Class Stuff //////////////////////////////////////////////////////
 
@@ -548,7 +556,7 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
     }
     else if( msg->GetKeyCode() == KEY_END )
     {
-        fWorkingCursor = strnlen(fWorkingLine, std::size(fWorkingLine));
+        fWorkingCursor = pfStrnlen(fWorkingLine, std::size(fWorkingLine));
     }
     else if( msg->GetKeyCode() == KEY_HOME )
     {
@@ -638,7 +646,7 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
         {
             // FIXME: make the console unicode friendly.
             IHandleCharacter((char)key);
-            if (strnlen(fWorkingLine, std::size(fWorkingLine)) < kMaxCharsWide - 2 && key != 0) {
+            if (pfStrnlen(fWorkingLine, std::size(fWorkingLine)) < kMaxCharsWide - 2 && key != 0) {
                 findAgain = false;
                 findCounter = 0;
                 IUpdateTooltip();
@@ -657,7 +665,7 @@ void    pfConsole::IHandleCharacter(const char c)
         return;
     }
 
-    size_t i = strnlen(fWorkingLine, std::size(fWorkingLine));
+    size_t i = pfStrnlen(fWorkingLine, std::size(fWorkingLine));
 
     // The current working line is too long. Ignore this character.
     if (i >= kMaxCharsWide - 2 || c == '\0')

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -15,6 +15,13 @@ include(CheckCXXSymbolExists)
 check_cxx_symbol_exists("sysinfo" "sys/sysinfo.h" HAVE_SYSINFO)
 # Check for pthread setname_np API
 check_cxx_symbol_exists(pthread_setname_np pthread.h HAVE_PTHREAD_SETNAME_NP)
+# Check for strnlen
+check_cxx_symbol_exists(strnlen string.h HAVE_STRNLEN)
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "10.7")
+    # strnlen is not available on Mac < 10.7, so we can't use it if we're
+    # targeting a lower version
+    set(HAVE_STRNLEN FALSE)
+endif()
 
 # Check for BSD style sysctl.
 try_compile(HAVE_SYSCTL ${PROJECT_BINARY_DIR}

--- a/cmake/hsConfig.h.cmake
+++ b/cmake/hsConfig.h.cmake
@@ -68,5 +68,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #cmakedefine HAVE_SYSINFO
 #cmakedefine HAVE_SHELLSCALINGAPI
 #cmakedefine HAVE_PTHREAD_SETNAME_NP
+#cmakedefine HAVE_STRNLEN
 
 #endif


### PR DESCRIPTION
`strnlen` isn't available on Mac OS X pre-10.7, as well as some Solaris systems, so we'll check if it exists and do the counting loop ourselves otherwise.

If we ever convert the whole console over to ST::string, this problem likely goes away