### PR TITLE
Minor improvements to Darwin string tests

### DIFF
--- a/Sources/Tests/CoreTests/test_hsDarwin_CF.cpp
+++ b/Sources/Tests/CoreTests/test_hsDarwin_CF.cpp
@@ -46,17 +46,35 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 TEST(hsDarwin_CoreFoundation, converts_to_ST_string)
 {
-    CFStringRef str = CFSTR("Test ö");
+    CFStringRef str = CFSTR("Test 123");
     ST::string st = STStringFromCFString(str);
-    EXPECT_STREQ(st.c_str(), "Test \xc3\xb6");
+    EXPECT_STREQ(st.c_str(), "Test 123");
 }
 
 TEST(hsDarwin_CoreFoundation, converts_to_CFString)
 {
+    ST::string st = ST_LITERAL("Test 123");
+    CFStringRef cf = CFStringCreateWithSTString(st);
+    EXPECT_EQ(kCFCompareEqualTo, CFStringCompare(cf, CFSTR("Test 123"), 0));
+    CFRelease(cf);
+}
+
+TEST(hsDarwin_CoreFoundation, converts_to_ST_string_UTF8)
+{
+    CFStringRef str = CFStringCreateWithCString(nullptr, "Test ö", kCFStringEncodingUTF8);
+    ST::string st = STStringFromCFString(str);
+    EXPECT_STREQ(st.c_str(), "Test \xc3\xb6");
+    CFRelease(str);
+}
+
+TEST(hsDarwin_CoreFoundation, converts_to_CFString_UTF8)
+{
+    CFStringRef str = CFStringCreateWithCString(nullptr, "Test ö", kCFStringEncodingUTF8);
     ST::string st = ST_LITERAL("Test ö");
     CFStringRef cf = CFStringCreateWithSTString(st);
-    EXPECT_EQ(kCFCompareEqualTo, CFStringCompare(cf, CFSTR("Test ö"), 0));
+    EXPECT_EQ(kCFCompareEqualTo, CFStringCompare(cf, str, 0));
     CFRelease(cf);
+    CFRelease(str);
 }
 
 TEST(hsDarwin_CoreFoundation, returns_retained_CFString)

--- a/Sources/Tests/CoreTests/test_hsDarwin_NS.mm
+++ b/Sources/Tests/CoreTests/test_hsDarwin_NS.mm
@@ -47,21 +47,55 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 TEST(hsDarwin_Foundation, converts_to_ST_string)
 {
-    NSString* str = @"Test ö";
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+
+    NSString* str = @"Test 123";
     ST::string st = STStringFromNSString(str);
-    EXPECT_STREQ(st.c_str(), "Test \xc3\xb6");
+    EXPECT_STREQ(st.c_str(), "Test 123");
+
+    [pool drain];
 }
 
 TEST(hsDarwin_Foundation, converts_to_NSString)
 {
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+
+    ST::string st = ST_LITERAL("Test 123");
+    NSString* nstr = NSStringCreateWithSTString(st);
+    EXPECT_EQ(YES, [nstr isEqualToString:@"Test 123"]);
+
+    [pool drain];
+}
+
+TEST(hsDarwin_Foundation, converts_to_ST_string_UTF8)
+{
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+
+    NSString* str = [NSString stringWithUTF8String:"Test ö"];
+    ST::string st = STStringFromNSString(str);
+    EXPECT_STREQ(st.c_str(), "Test \xc3\xb6");
+
+    [pool drain];
+}
+
+TEST(hsDarwin_Foundation, converts_to_NSString_UTF8)
+{
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+
     ST::string st = ST_LITERAL("Test ö");
     NSString* nstr = NSStringCreateWithSTString(st);
-    EXPECT_EQ(YES, [nstr isEqualToString:@"Test ö"]);
+    EXPECT_EQ(YES, [nstr isEqualToString:[NSString stringWithUTF8String:"Test ö"]]);
+
+    [pool drain];
 }
 
 TEST(hsDarwin_Foundation, returns_retained_NSString)
 {
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+
     ST::string st = ST::format("{} Test {}", 12345, "Hello");
     NSString* nstr = NSStringCreateWithSTString(st);
     EXPECT_EQ(1, [nstr retainCount]);
+
+    [pool drain];
 }


### PR DESCRIPTION
It's apparently ill-advised to use non-ASCII characters in NSString `@`-literals or CFString `CFSTR` literals, so test those with pure ASCII strings and add separate tests with manually constructed strings for UTF8 testing.

Also wrap the NSString tests in autorelease pools to make sure nothing leaks.