### PR TITLE
Migrate `hsStatusMessage` and `hsDebugPrintToTerminal` to `ST::string`

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plBipedKiller.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plBipedKiller.cpp
@@ -274,7 +274,7 @@ int CompareKeys(ILinPoint3Key &a, ILinPoint3Key &b)
 {
     int result = a.val.Equals(b.val, .001f);
 #if 0
-    hsStatusMessageF("COMPAREKEYS(point): (%f %f %f) vs (%f, %f, %f) = %s", a.val.x, a.val.y, a.val.z, b.val.x, b.val.y, b.val.z, result ? "yes" : "no");
+    hsStatusMessage(ST::format("COMPAREKEYS(point): ({} {} {}) vs ({}, {}, {}) = {}", a.val.x, a.val.y, a.val.z, b.val.x, b.val.y, b.val.z, result ? "yes" : "no").c_str());
 #endif
     return result;
 }

--- a/Sources/MaxPlugin/MaxComponent/plBipedKiller.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plBipedKiller.cpp
@@ -274,7 +274,7 @@ int CompareKeys(ILinPoint3Key &a, ILinPoint3Key &b)
 {
     int result = a.val.Equals(b.val, .001f);
 #if 0
-    hsStatusMessage(ST::format("COMPAREKEYS(point): ({} {} {}) vs ({}, {}, {}) = {}", a.val.x, a.val.y, a.val.z, b.val.x, b.val.y, b.val.z, result ? "yes" : "no").c_str());
+    hsStatusMessageF("COMPAREKEYS(point): ({} {} {}) vs ({}, {}, {}) = {}", a.val.x, a.val.y, a.val.z, b.val.x, b.val.y, b.val.z, result ? "yes" : "no");
 #endif
     return result;
 }

--- a/Sources/MaxPlugin/MaxComponent/plDistribComponent.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plDistribComponent.cpp
@@ -140,10 +140,8 @@ protected:
     {
         return false;
 
-        char buff[256];
         IRollupWindow *rollup = GetCOREInterface()->GetCommandPanelRollup();
-        sprintf(buff, "%d\t%x\t%x", fRollup, rollup->GetPanelIndex(hWnd), msg);
-        hsStatusMessage(buff);
+        hsStatusMessage(ST::format("{}\t{x}\t{x}", fRollup, rollup->GetPanelIndex(hWnd), msg).c_str());
 
         if( msg == 0x18 )
         {

--- a/Sources/MaxPlugin/MaxComponent/plDistribComponent.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plDistribComponent.cpp
@@ -141,7 +141,7 @@ protected:
         return false;
 
         IRollupWindow *rollup = GetCOREInterface()->GetCommandPanelRollup();
-        hsStatusMessage(ST::format("{}\t{x}\t{x}", fRollup, rollup->GetPanelIndex(hWnd), msg).c_str());
+        hsStatusMessageF("{}\t{x}\t{x}", fRollup, rollup->GetPanelIndex(hWnd), msg);
 
         if( msg == 0x18 )
         {

--- a/Sources/MaxPlugin/MaxMain/plMaxNode.cpp
+++ b/Sources/MaxPlugin/MaxMain/plMaxNode.cpp
@@ -628,7 +628,7 @@ bool plMaxNode::MakePhysical(plErrorMsg *pErrMsg, plConvertSettings *settings)
     if (!physProps->IsUsed())
         return true;
 
-    //hsStatusMessageF("Making phys for %s", dbgNodeName);
+    //hsStatusMessage(ST::format("Making phys for {}", dbgNodeName).c_str());
 
     plSimDefs::Group group = (plSimDefs::Group)physProps->GetGroup();
     plSimDefs::Bounds bounds = (plSimDefs::Bounds)physProps->GetBoundsType();

--- a/Sources/MaxPlugin/MaxMain/plMaxNode.cpp
+++ b/Sources/MaxPlugin/MaxMain/plMaxNode.cpp
@@ -628,7 +628,7 @@ bool plMaxNode::MakePhysical(plErrorMsg *pErrMsg, plConvertSettings *settings)
     if (!physProps->IsUsed())
         return true;
 
-    //hsStatusMessage(ST::format("Making phys for {}", dbgNodeName).c_str());
+    //hsStatusMessageF("Making phys for {}", dbgNodeName);
 
     plSimDefs::Group group = (plSimDefs::Group)physProps->GetGroup();
     plSimDefs::Bounds bounds = (plSimDefs::Bounds)physProps->GetBoundsType();

--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -420,11 +420,11 @@ void plClient::ShutdownDLLs()
 #ifdef HS_BUILD_FOR_WIN32
         BOOL ret = FreeLibrary(mod);
         if (!ret)
-            hsStatusMessage(ST::format("Failed to free lib: {}", hsCOMError(hsLastWin32Error, GetLastError())).c_str());
+            hsStatusMessageF("Failed to free lib: {}", hsCOMError(hsLastWin32Error, GetLastError()));
 #else
         int ret = dlclose(mod);
         if (ret)
-            hsStatusMessage(ST::format("Failed to free lib: {}", dlerror()).c_str());
+            hsStatusMessageF("Failed to free lib: {}", dlerror());
 #endif
     }
 
@@ -827,10 +827,9 @@ bool plClient::MsgReceive(plMessage* msg)
     plEventCallbackMsg* callback = plEventCallbackMsg::ConvertNoRef(msg);
     if( callback )
     {
-        ST::string str = ST::format("Callback event from {}", callback->GetSender()
-                            ? callback->GetSender()->GetName()
-                            : ST_LITERAL("Unknown"));
-        hsStatusMessage(str.c_str());
+        hsStatusMessageF("Callback event from {}", callback->GetSender()
+                         ? callback->GetSender()->GetName()
+                         : ST_LITERAL("Unknown"));
         static int gotten = 0;
         if( ++gotten > 5 )
         {
@@ -1032,11 +1031,11 @@ void plClient::IQueueRoomLoad(const std::vector<plLocation>& locs, bool hold)
         {
             #ifdef HS_DEBUGGING
             if (!info)
-                hsStatusMessage(ST::format("Ignoring LoadRoom request for location {#x} because we can't find the location", loc.GetSequenceNumber()).c_str());
+                hsStatusMessageF("Ignoring LoadRoom request for location {#x} because we can't find the location", loc.GetSequenceNumber());
             else if (alreadyLoaded)
-                hsStatusMessage(ST::format("Ignoring LoadRoom request for {}-{}, since room is already loaded", info->GetAge(), info->GetPage()).c_str());
+                hsStatusMessageF("Ignoring LoadRoom request for {}-{}, since room is already loaded", info->GetAge(), info->GetPage());
             else if (isLoading)
-                hsStatusMessage(ST::format("Ignoring LoadRoom request for {}-{}, since room is currently loading", info->GetAge(), info->GetPage()).c_str());
+                hsStatusMessageF("Ignoring LoadRoom request for {}-{}, since room is currently loading", info->GetAge(), info->GetPage());
             #endif
 
             continue;
@@ -1049,7 +1048,7 @@ void plClient::IQueueRoomLoad(const std::vector<plLocation>& locs, bool hold)
         else
             allSameAge = false;
 
-        //hsStatusMessage(ST::format("+++ Loading room {}-{}", info.GetAge(), info.GetPage()).c_str());
+        //hsStatusMessageF("+++ Loading room {}-{}", info.GetAge(), info.GetPage());
         numRooms++;
     }
 
@@ -1272,7 +1271,7 @@ void plClient::IRoomLoaded(plSceneNode* node, bool hold)
         plgDispatch::MsgSend(loadmsg);
     }
     else
-        hsStatusMessage(ST::format("Done loading hold room {}, t={}", pRmKey->GetName(), hsTimer::GetSeconds()).c_str());
+        hsStatusMessageF("Done loading hold room {}, t={}", pRmKey->GetName(), hsTimer::GetSeconds());
 
     plLocation loc = pRmKey->GetUoid().GetLocation();
     for (auto it = fRoomsLoading.cbegin(); it != fRoomsLoading.cend(); ++it)

--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -1032,11 +1032,11 @@ void plClient::IQueueRoomLoad(const std::vector<plLocation>& locs, bool hold)
         {
             #ifdef HS_DEBUGGING
             if (!info)
-                hsStatusMessageF("Ignoring LoadRoom request for location 0x%x because we can't find the location", loc.GetSequenceNumber());
+                hsStatusMessage(ST::format("Ignoring LoadRoom request for location {#x} because we can't find the location", loc.GetSequenceNumber()).c_str());
             else if (alreadyLoaded)
-                hsStatusMessageF("Ignoring LoadRoom request for %s-%s, since room is already loaded", info->GetAge().c_str(), info->GetPage().c_str());
+                hsStatusMessage(ST::format("Ignoring LoadRoom request for {}-{}, since room is already loaded", info->GetAge(), info->GetPage()).c_str());
             else if (isLoading)
-                hsStatusMessageF("Ignoring LoadRoom request for %s-%s, since room is currently loading", info->GetAge().c_str(), info->GetPage().c_str());
+                hsStatusMessage(ST::format("Ignoring LoadRoom request for {}-{}, since room is currently loading", info->GetAge(), info->GetPage()).c_str());
             #endif
 
             continue;
@@ -1049,7 +1049,7 @@ void plClient::IQueueRoomLoad(const std::vector<plLocation>& locs, bool hold)
         else
             allSameAge = false;
 
-//      hsStatusMessageF("+++ Loading room %s-%s", info.GetAge(), info.GetPage());
+        //hsStatusMessage(ST::format("+++ Loading room {}-{}", info.GetAge(), info.GetPage()).c_str());
         numRooms++;
     }
 
@@ -1272,7 +1272,7 @@ void plClient::IRoomLoaded(plSceneNode* node, bool hold)
         plgDispatch::MsgSend(loadmsg);
     }
     else
-        hsStatusMessageF("Done loading hold room %s, t=%f", pRmKey->GetName().c_str(), hsTimer::GetSeconds());
+        hsStatusMessage(ST::format("Done loading hold room {}, t={}", pRmKey->GetName(), hsTimer::GetSeconds()).c_str());
 
     plLocation loc = pRmKey->GetUoid().GetLocation();
     for (auto it = fRoomsLoading.cbegin(); it != fRoomsLoading.cend(); ++it)

--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -474,7 +474,7 @@ void DeInitNetClientComm()
 //
 static plStatusLog* s_DebugLog = nullptr;
 
-static void _StatusMessageProc(const char* msg)
+static void _StatusMessageProc(const ST::string& msg)
 {
 #if defined(HS_DEBUGGING) || !defined(PLASMA_EXTERNAL_RELEASE)
     s_DebugLog->AddLine(msg);

--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -1181,7 +1181,7 @@ int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPWSTR lpCmdLine, int 
 
     // Redirect hsStatusMessage to plasmadbg.log
     DebugInit();
-    hsStatusMessage(ST::format("Plasma 2.0.{}.{} - {}", PLASMA2_MAJOR_VERSION, PLASMA2_MINOR_VERSION, plProduct::ProductString()).c_str());
+    hsStatusMessageF("Plasma 2.0.{}.{} - {}", PLASMA2_MAJOR_VERSION, PLASMA2_MINOR_VERSION, plProduct::ProductString());
 
     FILE *serverIniFile = plFileSystem::Open(serverIni, "rb");
     if (serverIniFile)

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -56,7 +56,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #endif
 
 #include <string_theory/format>
-
+#include <string_theory/stdio>
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -183,16 +183,16 @@ hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc)
 
 #ifndef PLASMA_EXTERNAL_RELEASE
 
-void hsStatusMessage(const char* message)
+void hsStatusMessage(const ST::string& message)
 {
     if (gHSStatusProc) {
         gHSStatusProc(message);
     } else {
 #if HS_BUILD_FOR_UNIX
-        printf("%s\n", message);
+        ST::printf("{}\n", message);
 #elif HS_BUILD_FOR_WIN32
-        OutputDebugString(message);
-        OutputDebugString("\n");
+        OutputDebugStringW(message.to_wchar().c_str());
+        OutputDebugStringW(L"\n");
 #endif
     }
 }

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -197,19 +197,4 @@ void hsStatusMessage(const char* message)
     }
 }
 
-void hsStatusMessageV(const char * fmt, va_list args)
-{
-    char  buffer[2000];
-    vsnprintf(buffer, std::size(buffer), fmt, args);
-    hsStatusMessage(buffer);
-}
-
-void hsStatusMessageF(const char * fmt, ...)
-{
-    va_list args;
-    va_start(args,fmt);
-    hsStatusMessageV(fmt,args);
-    va_end(args);
-}
-
 #endif

--- a/Sources/Plasma/CoreLib/HeadSpin.cpp
+++ b/Sources/Plasma/CoreLib/HeadSpin.cpp
@@ -83,7 +83,7 @@ void hsDebugAssertionFailed(int line, const char* file, const char* msg)
     } else
 #endif // _MSC_VER
     {
-        hsDebugPrintToTerminal(ST::format("-------\nASSERTION FAILED:\nFile: {}   Line: {}\nMessage: {}\n-------", file, line, msg).c_str());
+        hsDebugPrintToTerminal(ST::format("-------\nASSERTION FAILED:\nFile: {}   Line: {}\nMessage: {}\n-------", file, line, msg));
         fflush(stderr);
 
         hsDebugBreakAlways();
@@ -154,16 +154,16 @@ void hsDebugBreakAlways()
 #endif // _MSC_VER
 }
 
-void hsDebugPrintToTerminal(const char* msg)
+void hsDebugPrintToTerminal(const ST::string& msg)
 {
-    fprintf(stderr, "%s\n", msg);
+    ST::printf(stderr, "{}\n", msg);
 
 #ifdef _MSC_VER
     if (hsDebugIsDebuggerPresent())
     {
         // Also print to the MSVC Output window
-        OutputDebugStringA(msg);
-        OutputDebugStringA("\n");
+        OutputDebugStringW(msg.to_wchar().c_str());
+        OutputDebugStringW(L"\n");
     }
 #endif
 }

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -348,6 +348,9 @@ hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc);
     void hsStatusMessage(const char* message);
 #endif // PLASMA_EXTERNAL_RELEASE
 
+// Defined as a macro instead of a template function to avoid globally including <string_theory/format>.
+#define hsStatusMessageF(message, ...) (hsStatusMessage(ST::format((message), __VA_ARGS__).c_str()))
+
 #if defined(__clang__) || defined(__GNUC__)
 #   define _COMPILER_WARNING_NAME(warning) "-W" warning
 

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -344,10 +344,8 @@ hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc);
 
 #ifdef PLASMA_EXTERNAL_RELEASE
 #   define hsStatusMessage(x) ((void)0)
-#   define hsStatusMessageF(x, ...) ((void)0)
 #else
     void hsStatusMessage(const char* message);
-    void hsStatusMessageF(const char* fmt, ...);
 #endif // PLASMA_EXTERNAL_RELEASE
 
 #if defined(__clang__) || defined(__GNUC__)

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -319,7 +319,7 @@ void hsDebugBreakAlways();
  *
  * @param msg message to print
  */
-void hsDebugPrintToTerminal(const char* msg);
+void hsDebugPrintToTerminal(const ST::string& msg);
 
 #ifdef HS_DEBUGGING
     

--- a/Sources/Plasma/CoreLib/HeadSpin.h
+++ b/Sources/Plasma/CoreLib/HeadSpin.h
@@ -337,7 +337,7 @@ void hsDebugPrintToTerminal(const char* msg);
 
 #define DEFAULT_FATAL(var) default: FATAL("No valid case for switch variable '" #var "'"); break
 
-typedef void (*hsStatusMessageProc)(const char message[]);
+typedef void (*hsStatusMessageProc)(const ST::string& message);
 
 extern hsStatusMessageProc gHSStatusProc;
 hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc);
@@ -345,11 +345,11 @@ hsStatusMessageProc hsSetStatusMessageProc(hsStatusMessageProc newProc);
 #ifdef PLASMA_EXTERNAL_RELEASE
 #   define hsStatusMessage(x) ((void)0)
 #else
-    void hsStatusMessage(const char* message);
+    void hsStatusMessage(const ST::string& message);
 #endif // PLASMA_EXTERNAL_RELEASE
 
 // Defined as a macro instead of a template function to avoid globally including <string_theory/format>.
-#define hsStatusMessageF(message, ...) (hsStatusMessage(ST::format((message), __VA_ARGS__).c_str()))
+#define hsStatusMessageF(message, ...) (hsStatusMessage(ST::format((message), __VA_ARGS__)))
 
 #if defined(__clang__) || defined(__GNUC__)
 #   define _COMPILER_WARNING_NAME(warning) "-W" warning

--- a/Sources/Plasma/CoreLib/hsRefCnt.cpp
+++ b/Sources/Plasma/CoreLib/hsRefCnt.cpp
@@ -68,14 +68,14 @@ struct _RefCountLeakCheck
         hsLockGuard(m_mutex);
 
         hsDebugPrintToTerminal(ST::format("Refs tracked:  {} created, {} destroyed\n",
-                                          m_added, m_removed).c_str());
+                                          m_added, m_removed));
         if (m_refs.empty())
             return;
 
-        hsDebugPrintToTerminal(ST::format("    {} objects leaked...\n", m_refs.size()).c_str());
+        hsDebugPrintToTerminal(ST::format("    {} objects leaked...\n", m_refs.size()));
         for (hsRefCnt *ref : m_refs) {
             hsDebugPrintToTerminal(ST::format("    {#08x} {}: {} refs remain\n",
-                                              (uintptr_t)ref, typeid(*ref).name(), ref->RefCnt()).c_str());
+                                              (uintptr_t)ref, typeid(*ref).name(), ref->RefCnt()));
         }
     }
 
@@ -130,9 +130,9 @@ void hsRefCnt::UnRef(const char* tag)
 
 #if (REFCOUNT_DEBUGGING == REFCOUNT_DBG_REFS) || (REFCOUNT_DEBUGGING == REFCOUNT_DBG_ALL)
     if (tag)
-        hsDebugPrintToTerminal(ST::format("Dec {#x} {}: {}", reinterpret_cast<uintptr_t>(this), tag, fRefCnt - 1).c_str());
+        hsDebugPrintToTerminal(ST::format("Dec {#x} {}: {}", reinterpret_cast<uintptr_t>(this), tag, fRefCnt - 1));
     else
-        hsDebugPrintToTerminal(ST::format("Dec {#x}: {}", reinterpret_cast<uintptr_t>(this), fRefCnt - 1).c_str());
+        hsDebugPrintToTerminal(ST::format("Dec {#x}: {}", reinterpret_cast<uintptr_t>(this), fRefCnt - 1));
 #endif
 
     if (fRefCnt == 1)   // don't decrement if we call delete
@@ -145,9 +145,9 @@ void hsRefCnt::Ref(const char* tag)
 {
 #if (REFCOUNT_DEBUGGING == REFCOUNT_DBG_REFS) || (REFCOUNT_DEBUGGING == REFCOUNT_DBG_ALL)
     if (tag)
-        hsDebugPrintToTerminal(ST::format("Inc {#x} {}: {}", reinterpret_cast<uintptr_t>(this), tag, fRefCnt + 1).c_str());
+        hsDebugPrintToTerminal(ST::format("Inc {#x} {}: {}", reinterpret_cast<uintptr_t>(this), tag, fRefCnt + 1));
     else
-        hsDebugPrintToTerminal(ST::format("Inc {#x}: {}", reinterpret_cast<uintptr_t>(this), fRefCnt + 1).c_str());
+        hsDebugPrintToTerminal(ST::format("Inc {#x}: {}", reinterpret_cast<uintptr_t>(this), fRefCnt + 1));
 #endif
 
     ++fRefCnt;
@@ -156,7 +156,7 @@ void hsRefCnt::Ref(const char* tag)
 void hsRefCnt::TransferRef(const char* oldTag, const char* newTag)
 {
 #if (REFCOUNT_DEBUGGING == REFCOUNT_DBG_REFS) || (REFCOUNT_DEBUGGING == REFCOUNT_DBG_ALL)
-    hsDebugPrintToTerminal(ST::format("Inc {#x} {}: (xfer)", reinterpret_cast<uintptr_t>(this), newTag).c_str());
-    hsDebugPrintToTerminal(ST::format("Dec {#x} {}: (xfer)", reinterpret_cast<uintptr_t>(this), oldTag).c_str());
+    hsDebugPrintToTerminal(ST::format("Inc {#x} {}: (xfer)", reinterpret_cast<uintptr_t>(this), newTag));
+    hsDebugPrintToTerminal(ST::format("Dec {#x} {}: (xfer)", reinterpret_cast<uintptr_t>(this), oldTag));
 #endif
 }

--- a/Sources/Plasma/FeatureLib/pfAnimation/plRandomCommandMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plRandomCommandMod.cpp
@@ -224,8 +224,8 @@ bool plRandomCommandMod::MsgReceive(plMessage* msg)
         if( anim->GetSender() != GetKey() )
         {
 #if 0
-            hsStatusMessage(ST::format("someone triggered me, remote={}", 
-                msg->HasBCastFlag(plMessage::kNetNonLocal)).c_str());
+            hsStatusMessageF("someone triggered me, remote={}", 
+                msg->HasBCastFlag(plMessage::kNetNonLocal));
 #endif
             if( anim->Cmd(plAnimCmdMsg::kContinue) )
                 IStart();
@@ -243,8 +243,8 @@ bool plRandomCommandMod::MsgReceive(plMessage* msg)
         {
             
 #if 0
-            hsStatusMessage(ST::format("play next if master, remote={}", 
-                msg->HasBCastFlag(plMessage::kNetNonLocal)).c_str());
+            hsStatusMessageF("play next if master, remote={}", 
+                msg->HasBCastFlag(plMessage::kNetNonLocal));
 #endif
             IPlayNextIfMaster();
         }

--- a/Sources/Plasma/FeatureLib/pfAnimation/plRandomCommandMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfAnimation/plRandomCommandMod.cpp
@@ -224,8 +224,8 @@ bool plRandomCommandMod::MsgReceive(plMessage* msg)
         if( anim->GetSender() != GetKey() )
         {
 #if 0
-            hsStatusMessageF("someone triggered me, remote=%d", 
-                msg->HasBCastFlag(plMessage::kNetNonLocal));
+            hsStatusMessage(ST::format("someone triggered me, remote={}", 
+                msg->HasBCastFlag(plMessage::kNetNonLocal)).c_str());
 #endif
             if( anim->Cmd(plAnimCmdMsg::kContinue) )
                 IStart();
@@ -243,8 +243,8 @@ bool plRandomCommandMod::MsgReceive(plMessage* msg)
         {
             
 #if 0
-            hsStatusMessageF("play next if master, remote=%d", 
-                msg->HasBCastFlag(plMessage::kNetNonLocal));
+            hsStatusMessage(ST::format("play next if master, remote={}", 
+                msg->HasBCastFlag(plMessage::kNetNonLocal)).c_str());
 #endif
             IPlayNextIfMaster();
         }

--- a/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
@@ -49,6 +49,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsTimer.h"
 
 #include <cmath>
+#include <string_theory/format>
 
 #include "plCameraModifier.h"
 #include "plVirtualCamNeu.h"
@@ -1022,7 +1023,7 @@ void plCameraBrain1_Avatar::Update(bool forced)
     if (fFlags.IsBitSet(kIsTransitionCamera))
     {
         if (GetKey())
-            hsStatusMessageF("%s thinks it's the transition camera", GetKeyName().c_str());
+            hsStatusMessage(ST::format("{} thinks it's the transition camera", GetKeyName()).c_str());
     }
     else
     {

--- a/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plCameraBrain.cpp
@@ -1023,7 +1023,7 @@ void plCameraBrain1_Avatar::Update(bool forced)
     if (fFlags.IsBitSet(kIsTransitionCamera))
     {
         if (GetKey())
-            hsStatusMessage(ST::format("{} thinks it's the transition camera", GetKeyName()).c_str());
+            hsStatusMessageF("{} thinks it's the transition camera", GetKeyName());
     }
     else
     {

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
@@ -127,7 +127,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfCamera/plVirtualCamNeu.h"
 
 #include <algorithm>
-#include <string_theory/string>
+#include <string_theory/format>
 #include <utility>
 
 //#define MF_TOSSER
@@ -1727,7 +1727,7 @@ void    plDXPipeline::IReleaseDeviceObjects()
         LONG ret;
         while( ret = fD3DDevice->Release() )
         {
-            hsStatusMessageF("%d - Error releasing device", ret);
+            hsStatusMessage(ST::format("{} - Error releasing device", ret).c_str());
         }
         fD3DDevice = nullptr;
     }
@@ -8646,7 +8646,7 @@ void plDXPipeline::IEndAllocUnManaged()
 // a new age.
 void plDXPipeline::LoadResources()
 {
-    hsStatusMessageF("Begin Device Reload t=%f",hsTimer::GetSeconds());
+    hsStatusMessage(ST::format("Begin Device Reload t={}", hsTimer::GetSeconds()).c_str());
     plNetClientApp::StaticDebugMsg("Begin Device Reload");
 
     // Just to be safe.
@@ -8704,7 +8704,7 @@ void plDXPipeline::LoadResources()
 
     plProfile_IncCount(PipeReload, 1);
 
-    hsStatusMessageF("End Device Reload t=%f",hsTimer::GetSeconds());
+    hsStatusMessage(ST::format("End Device Reload t={}", hsTimer::GetSeconds()).c_str());
     plNetClientApp::StaticDebugMsg("End Device Reload");
 }
 

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
@@ -1347,7 +1347,7 @@ bool plDXPipeline::ICreateDevice(bool windowed)
 #ifdef DBG_WRITE_FORMATS
     for (D3DFORMAT fmt : fCurrentMode->fDepthFormats)
     {
-        hsStatusMessage(ST::format("-- Valid depth buffer format: {}", IGetDXFormatName(fmt)).c_str());
+        hsStatusMessageF("-- Valid depth buffer format: {}", IGetDXFormatName(fmt));
     }
 #endif
 
@@ -1381,13 +1381,13 @@ bool plDXPipeline::ICreateDevice(bool windowed)
         fSettings.fD3DCaps &= ~kCapsZBias;
 
 #ifdef DBG_WRITE_FORMATS
-    hsStatusMessage(ST::format("-- Requesting depth buffer format: {}", IGetDXFormatName(params.AutoDepthStencilFormat)).c_str());
+    hsStatusMessageF("-- Requesting depth buffer format: {}", IGetDXFormatName(params.AutoDepthStencilFormat));
 #endif
 
 
     params.BackBufferFormat = dispMode.Format;
 #ifdef DBG_WRITE_FORMATS
-    hsStatusMessage(ST::format("-- Requesting back buffer format: {}", IGetDXFormatName(params.BackBufferFormat)).c_str());
+    hsStatusMessageF("-- Requesting back buffer format: {}", IGetDXFormatName(params.BackBufferFormat));
 #endif
 
     params.hDeviceWindow = fDevice.fHWnd;
@@ -1727,7 +1727,7 @@ void    plDXPipeline::IReleaseDeviceObjects()
         LONG ret;
         while( ret = fD3DDevice->Release() )
         {
-            hsStatusMessage(ST::format("{} - Error releasing device", ret).c_str());
+            hsStatusMessageF("{} - Error releasing device", ret);
         }
         fD3DDevice = nullptr;
     }
@@ -8646,7 +8646,7 @@ void plDXPipeline::IEndAllocUnManaged()
 // a new age.
 void plDXPipeline::LoadResources()
 {
-    hsStatusMessage(ST::format("Begin Device Reload t={}", hsTimer::GetSeconds()).c_str());
+    hsStatusMessageF("Begin Device Reload t={}", hsTimer::GetSeconds());
     plNetClientApp::StaticDebugMsg("Begin Device Reload");
 
     // Just to be safe.
@@ -8704,7 +8704,7 @@ void plDXPipeline::LoadResources()
 
     plProfile_IncCount(PipeReload, 1);
 
-    hsStatusMessage(ST::format("End Device Reload t={}", hsTimer::GetSeconds()).c_str());
+    hsStatusMessageF("End Device Reload t={}", hsTimer::GetSeconds());
     plNetClientApp::StaticDebugMsg("End Device Reload");
 }
 

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXShader.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXShader.cpp
@@ -79,7 +79,7 @@ HRESULT plDXShader::IOnError(HRESULT hr, ST::string errStr)
 
     fOwner->Invalidate();
 
-    hsStatusMessage(fErrorString.c_str());
+    hsStatusMessage(fErrorString);
 
     return hr;
 }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -786,7 +786,7 @@ void plMetalPipeline::IReleaseDeviceObjects()
 
 void plMetalPipeline::LoadResources()
 {
-    hsStatusMessageF("Begin Device Reload t=%f", hsTimer::GetSeconds());
+    hsStatusMessage(ST::format("Begin Device Reload t={}", hsTimer::GetSeconds()).c_str());
     plNetClientApp::StaticDebugMsg("Begin Device Reload");
 
     if (fFragFunction == nil) {
@@ -823,7 +823,7 @@ void plMetalPipeline::LoadResources()
 
     plProfile_IncCount(PipeReload, 1);
 
-    hsStatusMessageF("End Device Reload t=%f", hsTimer::GetSeconds());
+    hsStatusMessage(ST::format("End Device Reload t={}", hsTimer::GetSeconds()).c_str());
     plNetClientApp::StaticDebugMsg("End Device Reload");
 }
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -786,7 +786,7 @@ void plMetalPipeline::IReleaseDeviceObjects()
 
 void plMetalPipeline::LoadResources()
 {
-    hsStatusMessage(ST::format("Begin Device Reload t={}", hsTimer::GetSeconds()).c_str());
+    hsStatusMessageF("Begin Device Reload t={}", hsTimer::GetSeconds());
     plNetClientApp::StaticDebugMsg("Begin Device Reload");
 
     if (fFragFunction == nil) {
@@ -823,7 +823,7 @@ void plMetalPipeline::LoadResources()
 
     plProfile_IncCount(PipeReload, 1);
 
-    hsStatusMessage(ST::format("End Device Reload t={}", hsTimer::GetSeconds()).c_str());
+    hsStatusMessageF("End Device Reload t={}", hsTimer::GetSeconds());
     plNetClientApp::StaticDebugMsg("End Device Reload");
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -320,10 +320,10 @@ plPythonFileMod::~plPythonFileMod()
         PyObject* m;
         PyObject* modules = PyImport_GetModuleDict();
         if (modules && (m = PyDict_GetItemString(modules, fModuleName.c_str())) && PyModule_Check(m)) {
-            hsStatusMessage(ST::format("Module {} removed from python dictionary", fModuleName).c_str());
+            hsStatusMessageF("Module {} removed from python dictionary", fModuleName);
             PyDict_DelItemString(modules, fModuleName.c_str());
         } else {
-            hsStatusMessage(ST::format("Module {} not found in python dictionary. Already removed?", fModuleName).c_str());
+            hsStatusMessageF("Module {} not found in python dictionary. Already removed?", fModuleName);
         }
     }
 }

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -320,10 +320,10 @@ plPythonFileMod::~plPythonFileMod()
         PyObject* m;
         PyObject* modules = PyImport_GetModuleDict();
         if (modules && (m = PyDict_GetItemString(modules, fModuleName.c_str())) && PyModule_Check(m)) {
-            hsStatusMessageF("Module %s removed from python dictionary", fModuleName.c_str());
+            hsStatusMessage(ST::format("Module {} removed from python dictionary", fModuleName).c_str());
             PyDict_DelItemString(modules, fModuleName.c_str());
         } else {
-            hsStatusMessageF("Module %s not found in python dictionary. Already removed?",fModuleName.c_str());
+            hsStatusMessage(ST::format("Module {} not found in python dictionary. Already removed?", fModuleName).c_str());
         }
     }
 }

--- a/Sources/Plasma/FeatureLib/pfSurface/plLayerMovie.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plLayerMovie.cpp
@@ -71,9 +71,7 @@ plLayerMovie::~plLayerMovie()
 bool plLayerMovie::ISetFault(const char* errStr)
 {
 #ifdef HS_DEBUGGING
-    char buff[256];
-    sprintf(buff, "ERROR %s: %s", fMovieName.AsString().c_str(), errStr);
-    hsStatusMessage(buff);
+    hsStatusMessage(ST::format("ERROR {}: {}", fMovieName, errStr).c_str());
 #endif // HS_DEBUGGING
     fMovieName = "";
     return true;

--- a/Sources/Plasma/FeatureLib/pfSurface/plLayerMovie.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plLayerMovie.cpp
@@ -71,7 +71,7 @@ plLayerMovie::~plLayerMovie()
 bool plLayerMovie::ISetFault(const char* errStr)
 {
 #ifdef HS_DEBUGGING
-    hsStatusMessage(ST::format("ERROR {}: {}", fMovieName, errStr).c_str());
+    hsStatusMessageF("ERROR {}: {}", fMovieName, errStr);
 #endif // HS_DEBUGGING
     fMovieName = "";
     return true;

--- a/Sources/Plasma/NucleusLib/inc/plProfileManager.cpp
+++ b/Sources/Plasma/NucleusLib/inc/plProfileManager.cpp
@@ -308,7 +308,7 @@ void plProfileLaps::EndFrame()
         fLapTimes[i].EndFrame();
         if (!fLapTimes[i].fUsedThisFrame)
         {
-            hsStatusMessage(ST::format("Dropping unused lap {}", fLapTimes[i].GetName()).c_str());
+            hsStatusMessageF("Dropping unused lap {}", fLapTimes[i].GetName());
             fLapTimes.erase(fLapTimes.begin()+i);
             i--;
         }

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKey.cpp
@@ -123,7 +123,7 @@ plKey::plKey(const plKey& rhs) : fKeyData(rhs.fKeyData)
     {
         ST::string msg = ST::format("C: Key {} {} is being constructed using the plKey(plKey&) constructor", keyNameToLookFor, CloneString(fKeyData));
         //hsAssert(false, msg.c_str());
-        hsStatusMessage(msg.c_str());
+        hsStatusMessage(msg);
     }
 #endif
     IIncRef();
@@ -136,7 +136,7 @@ plKey::plKey(plKeyData* data) : fKeyData(data)
     {
         ST::string msg = ST::format("C: Key {} {} is being constructed using the plKey(plKeyData*) constructor", keyNameToLookFor, CloneString(fKeyData));
         //hsAssert(false, msg.c_str());
-        hsStatusMessage(msg.c_str());
+        hsStatusMessage(msg);
     }
 #endif
     IIncRef();
@@ -149,7 +149,7 @@ plKey::~plKey()
     {
         ST::string msg = ST::format("D: Key {} {} is being destructed", keyNameToLookFor, CloneString(fKeyData));
         //hsAssert(false, msg.c_str());
-        hsStatusMessage(msg.c_str());
+        hsStatusMessage(msg);
     }
 #endif
     IDecRef();
@@ -171,7 +171,7 @@ plKey &plKey::operator=( const plKey &rhs )
                     keyNameToLookFor, CloneString(rhs.fKeyData),
                     fKeyData->GetUoid().GetObjectName());
             //hsAssert(false, msg.c_str());
-            hsStatusMessage(msg.c_str());
+            hsStatusMessage(msg);
         }
         if( IsTracked(fKeyData) )
         {
@@ -184,7 +184,7 @@ plKey &plKey::operator=( const plKey &rhs )
                     fKeyData->GetUoid().GetObjectName(),
                     CloneString(fKeyData), keyNameToLookFor);
             //hsAssert(false, msg.c_str());
-            hsStatusMessage(msg.c_str());
+            hsStatusMessage(msg);
         }
     }
 #endif
@@ -205,7 +205,7 @@ plKey &plKey::operator=(std::nullptr_t)
     {
         ST::string msg = ST::format("D: Key {} {} is being nilified", keyNameToLookFor, CloneString(fKeyData));
         //hsAssert(false, msg.c_str());
-        hsStatusMessage(msg.c_str());
+        hsStatusMessage(msg);
     }
 #endif
 
@@ -246,7 +246,7 @@ void plKey::IIncRef()
         lastData = fKeyData;
         msg = ST::format("+: Key {} {} is being reffed! Refcount: {}", keyNameToLookFor, CloneString(fKeyData), fKeyData->fRefCount);
         //hsAssert(false, msg.c_str());
-        hsStatusMessage(msg.c_str());
+        hsStatusMessage(msg);
     }
 #endif
 
@@ -275,7 +275,7 @@ void plKey::IDecRef()
         lastData = fKeyData;
         msg = ST::format("-: Key {} {} is being de-reffed! Refcount: {}", keyNameToLookFor, CloneString(fKeyData), fKeyData->fRefCount);
         //hsAssert(false, msg.c_str());
-        hsStatusMessage(msg.c_str());
+        hsStatusMessage(msg);
         if( fKeyData->fRefCount == 0 )
             msg.clear();
     }

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
@@ -236,7 +236,7 @@ hsKeyedObject* plKeyImp::RefObject(plRefFlags::Type flags)
 
 #ifdef LOG_ACTIVE_REFS
     if (IsTrackedKey(this))
-        hsStatusMessageF("@@@ RefObject adding active ref to %s (%d total)", kObjName, fNumActiveRefs+1);
+        hsStatusMessage(ST::format("@@@ RefObject adding active ref to {} ({} total)", kObjName, fNumActiveRefs+1).c_str());
 #endif // LOG_ACTIVE_REFS
 
     IncActiveRefs();
@@ -253,7 +253,7 @@ void plKeyImp::UnRefObject(plRefFlags::Type flags)
 
 #ifdef LOG_ACTIVE_REFS
     if (IsTrackedKey(this))
-        hsStatusMessageF("@@@ UnRefObject releasing active ref to %s (%d total)", kObjName, fNumActiveRefs-1);
+        hsStatusMessage(ST::format("@@@ UnRefObject releasing active ref to {} ({} total)", kObjName, fNumActiveRefs-1).c_str());
 #endif // LOG_ACTIVE_REFS
     DecActiveRefs();
 
@@ -318,8 +318,8 @@ void plKeyImp::AddNotifyCreated(plRefMsg* msg, plRefFlags::Type flags)
 #ifdef LOG_ACTIVE_REFS
         if (IsTrackedKey(this))
         {
-            hsStatusMessageF("@@@ %s(%s) adding active ref to %s (%d total)", msg->GetReceiver(0)->GetName().c_str(),
-                plFactory::GetNameOfClass(msg->GetReceiver(0)->GetUoid().GetClassType()), kObjName, fNumActiveRefs+1);
+            hsStatusMessage(ST::format("@@@ {}({}) adding active ref to {} ({} total)", msg->GetReceiver(0)->GetName(),
+                plFactory::GetNameOfClass(msg->GetReceiver(0)->GetUoid().GetClassType()), kObjName, fNumActiveRefs+1).c_str());
         }
 #endif // LOG_ACTIVE_REFS
 
@@ -603,8 +603,8 @@ void plKeyImp::IRelease(plKeyImp* iTargetKey)
     // it has been notified it is going away.
 #ifdef LOG_ACTIVE_REFS
     if (isActive && IsTrackedKey(iTargetKey))
-        hsStatusMessageF("@@@ %s(%s) releasing active ref on %s (%d total)", GetName().c_str(),
-                         plFactory::GetNameOfClass(GetUoid().GetClassType()), kObjName, iTargetKey->fNumActiveRefs-1);
+        hsStatusMessage(ST::format("@@@ {}({}) releasing active ref on {} ({} total)", GetName(),
+            plFactory::GetNameOfClass(GetUoid().GetClassType()), kObjName, iTargetKey->fNumActiveRefs-1).c_str());
 #endif // LOG_ACTIVE_REFS
 
     if (isActive && iTargetKey->GetActiveRefs() && !iTargetKey->DecActiveRefs())

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
@@ -236,7 +236,7 @@ hsKeyedObject* plKeyImp::RefObject(plRefFlags::Type flags)
 
 #ifdef LOG_ACTIVE_REFS
     if (IsTrackedKey(this))
-        hsStatusMessage(ST::format("@@@ RefObject adding active ref to {} ({} total)", kObjName, fNumActiveRefs+1).c_str());
+        hsStatusMessageF("@@@ RefObject adding active ref to {} ({} total)", kObjName, fNumActiveRefs+1);
 #endif // LOG_ACTIVE_REFS
 
     IncActiveRefs();
@@ -253,7 +253,7 @@ void plKeyImp::UnRefObject(plRefFlags::Type flags)
 
 #ifdef LOG_ACTIVE_REFS
     if (IsTrackedKey(this))
-        hsStatusMessage(ST::format("@@@ UnRefObject releasing active ref to {} ({} total)", kObjName, fNumActiveRefs-1).c_str());
+        hsStatusMessageF("@@@ UnRefObject releasing active ref to {} ({} total)", kObjName, fNumActiveRefs-1);
 #endif // LOG_ACTIVE_REFS
     DecActiveRefs();
 
@@ -318,8 +318,8 @@ void plKeyImp::AddNotifyCreated(plRefMsg* msg, plRefFlags::Type flags)
 #ifdef LOG_ACTIVE_REFS
         if (IsTrackedKey(this))
         {
-            hsStatusMessage(ST::format("@@@ {}({}) adding active ref to {} ({} total)", msg->GetReceiver(0)->GetName(),
-                plFactory::GetNameOfClass(msg->GetReceiver(0)->GetUoid().GetClassType()), kObjName, fNumActiveRefs+1).c_str());
+            hsStatusMessageF("@@@ {}({}) adding active ref to {} ({} total)", msg->GetReceiver(0)->GetName(),
+                plFactory::GetNameOfClass(msg->GetReceiver(0)->GetUoid().GetClassType()), kObjName, fNumActiveRefs+1);
         }
 #endif // LOG_ACTIVE_REFS
 
@@ -603,8 +603,8 @@ void plKeyImp::IRelease(plKeyImp* iTargetKey)
     // it has been notified it is going away.
 #ifdef LOG_ACTIVE_REFS
     if (isActive && IsTrackedKey(iTargetKey))
-        hsStatusMessage(ST::format("@@@ {}({}) releasing active ref on {} ({} total)", GetName(),
-            plFactory::GetNameOfClass(GetUoid().GetClassType()), kObjName, iTargetKey->fNumActiveRefs-1).c_str());
+        hsStatusMessageF("@@@ {}({}) releasing active ref on {} ({} total)", GetName(),
+            plFactory::GetNameOfClass(GetUoid().GetClassType()), kObjName, iTargetKey->fNumActiveRefs-1);
 #endif // LOG_ACTIVE_REFS
 
     if (isActive && iTargetKey->GetActiveRefs() && !iTargetKey->DecActiveRefs())

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
@@ -52,6 +52,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnNetCommon/plNetApp.h"
 #include "pnNetCommon/plSynchedObject.h"
 
+#include <string_theory/format>
+
 struct plForwardCallback
 {
     std::vector<plKey> fOrigReceivers;
@@ -136,14 +138,14 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
                 fCallbacks[event] = fc;
 
 #if 0
-                hsStatusMessageF("Adding CBMsg, eventSender=%s, eventRemoteMsg=%d",
-                    event->GetSender() ? event->GetSender()->GetName().c_str() : "nil", fc->fNetPropogate);
+                hsStatusMessage(ST::format("Adding CBMsg, eventSender={}, eventRemoteMsg={}",
+                    event->GetSender() ? event->GetSender()->GetName() : ST_LITERAL("nil"), fc->fNetPropogate).c_str());
 #endif
             }
         }
 #if 0
-        hsStatusMessageF("Fwding CBMsg, sender=%s, remoteMsg=%d",
-            msg->GetSender() ? msg->GetSender()->GetName().c_str() : "nil", msg->HasBCastFlag(plMessage::kNetNonLocal));
+        hsStatusMessage(ST::format("Fwding CBMsg, sender={}, remoteMsg={}",
+            msg->GetSender() ? msg->GetSender()->GetName() : ST_LITERAL("nil"), msg->HasBCastFlag(plMessage::kNetNonLocal)).c_str());
 #endif
         IForwardMsg(callbackMsg);
         
@@ -161,8 +163,8 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
             plForwardCallback *fc = it->second;
             if (--fc->fNumCallbacks == 0)
             {
-                hsStatusMessageF("plEventCallbackMsg received, erasing, sender=%s, remoteMsg=%d",
-                    msg->GetSender() ? msg->GetSender()->GetName().c_str() : "nil", msg->HasBCastFlag(plMessage::kNetNonLocal));
+                hsStatusMessage(ST::format("plEventCallbackMsg received, erasing, sender={}, remoteMsg={}",
+                    msg->GetSender() ? msg->GetSender()->GetName() : ST_LITERAL("nil"), msg->HasBCastFlag(plMessage::kNetNonLocal)).c_str());
 
                 fCallbacks.erase(eventMsg);
 
@@ -184,8 +186,8 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
         }
         else
         {
-            hsStatusMessageF("! Unknown plEventCallbackMsg received, sender=%s, remoteMsg=%d",
-                msg->GetSender() ? msg->GetSender()->GetName().c_str() : "nil", msg->HasBCastFlag(plMessage::kNetNonLocal));
+            hsStatusMessage(ST::format("! Unknown plEventCallbackMsg received, sender={}, remoteMsg={}",
+                msg->GetSender() ? msg->GetSender()->GetName() : ST_LITERAL("nil"), msg->HasBCastFlag(plMessage::kNetNonLocal)).c_str());
             hsAssert(0, "Unknown plEventCallbackMsg received");
         }
         return true;

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
@@ -138,14 +138,14 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
                 fCallbacks[event] = fc;
 
 #if 0
-                hsStatusMessage(ST::format("Adding CBMsg, eventSender={}, eventRemoteMsg={}",
-                    event->GetSender() ? event->GetSender()->GetName() : ST_LITERAL("nil"), fc->fNetPropogate).c_str());
+                hsStatusMessageF("Adding CBMsg, eventSender={}, eventRemoteMsg={}",
+                    event->GetSender() ? event->GetSender()->GetName() : ST_LITERAL("nil"), fc->fNetPropogate);
 #endif
             }
         }
 #if 0
-        hsStatusMessage(ST::format("Fwding CBMsg, sender={}, remoteMsg={}",
-            msg->GetSender() ? msg->GetSender()->GetName() : ST_LITERAL("nil"), msg->HasBCastFlag(plMessage::kNetNonLocal)).c_str());
+        hsStatusMessageF("Fwding CBMsg, sender={}, remoteMsg={}",
+            msg->GetSender() ? msg->GetSender()->GetName() : ST_LITERAL("nil"), msg->HasBCastFlag(plMessage::kNetNonLocal));
 #endif
         IForwardMsg(callbackMsg);
         
@@ -163,8 +163,8 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
             plForwardCallback *fc = it->second;
             if (--fc->fNumCallbacks == 0)
             {
-                hsStatusMessage(ST::format("plEventCallbackMsg received, erasing, sender={}, remoteMsg={}",
-                    msg->GetSender() ? msg->GetSender()->GetName() : ST_LITERAL("nil"), msg->HasBCastFlag(plMessage::kNetNonLocal)).c_str());
+                hsStatusMessageF("plEventCallbackMsg received, erasing, sender={}, remoteMsg={}",
+                    msg->GetSender() ? msg->GetSender()->GetName() : ST_LITERAL("nil"), msg->HasBCastFlag(plMessage::kNetNonLocal));
 
                 fCallbacks.erase(eventMsg);
 
@@ -186,8 +186,8 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
         }
         else
         {
-            hsStatusMessage(ST::format("! Unknown plEventCallbackMsg received, sender={}, remoteMsg={}",
-                msg->GetSender() ? msg->GetSender()->GetName() : ST_LITERAL("nil"), msg->HasBCastFlag(plMessage::kNetNonLocal)).c_str());
+            hsStatusMessageF("! Unknown plEventCallbackMsg received, sender={}, remoteMsg={}",
+                msg->GetSender() ? msg->GetSender()->GetName() : ST_LITERAL("nil"), msg->HasBCastFlag(plMessage::kNetNonLocal));
             hsAssert(0, "Unknown plEventCallbackMsg received");
         }
         return true;

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnim.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnim.cpp
@@ -55,6 +55,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsResMgr.h"
 #include "hsStream.h"
 
+#include <string_theory/format>
+
 // other
 #include "plInterp/plAnimEaseTypes.h"
 #include "plMessage/plAnimCmdMsg.h"
@@ -308,7 +310,7 @@ void plAGAnim::DumpAnimationRegistry()
     do {
         plAGAnim *anim = (*i).second;
         ST::string name = anim->GetName();
-        hsStatusMessageF("GLOBAL ANIMS [%d]: <%s>", j++, name.c_str());
+        hsStatusMessage(ST::format("GLOBAL ANIMS [{}]: <{}>", j++, name).c_str());
     } while(++i != fAllAnims.end());
 }
 

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnim.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnim.cpp
@@ -310,7 +310,7 @@ void plAGAnim::DumpAnimationRegistry()
     do {
         plAGAnim *anim = (*i).second;
         ST::string name = anim->GetName();
-        hsStatusMessage(ST::format("GLOBAL ANIMS [{}]: <{}>", j++, name).c_str());
+        hsStatusMessageF("GLOBAL ANIMS [{}]: <{}>", j++, name);
     } while(++i != fAllAnims.end());
 }
 

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -128,7 +128,7 @@ plAGAnimInstance::plAGAnimInstance(plAGAnim * anim, plAGMasterMod * master,
     fCleanupChannels.push_back(timeChan);
 
 #ifdef SHOW_AG_CHANGES
-    hsStatusMessageF("\nAbout to Attach anim <%s>", GetName().c_str());
+    hsStatusMessage(ST::format("\nAbout to Attach anim <{}>", GetName()).c_str());
     fMaster->DumpAniGraph("bone_pelvis", false, hsTimer::GetSysSeconds());
 #endif
 
@@ -315,7 +315,7 @@ void plAGAnimInstance::Detach()
 void plAGAnimInstance::DetachChannels()
 {
 #ifdef SHOW_AG_CHANGES
-    hsStatusMessageF("\nAbout to DETACH anim <%s>", GetName().c_str());
+    hsStatusMessage(ST::format("\nAbout to DETACH anim <{}>", GetName()).c_str());
     fMaster->DumpAniGraph("bone_pelvis", false, hsTimer::GetSysSeconds());
 #endif
     plDetachMap::iterator i = fManualDetachChannels.begin();
@@ -346,7 +346,7 @@ void plAGAnimInstance::DetachChannels()
     fCleanupChannels.clear();
 
 #ifdef SHOW_AG_CHANGES
-    hsStatusMessageF("\nFinished DETACHING anim <%s>", GetName().c_str());
+    hsStatusMessage(ST::format("\nFinished DETACHING anim <{}>", GetName()).c_str());
     fMaster->DumpAniGraph("bone_pelvis", false, hsTimer::GetSysSeconds());
 #endif
 }

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -128,7 +128,7 @@ plAGAnimInstance::plAGAnimInstance(plAGAnim * anim, plAGMasterMod * master,
     fCleanupChannels.push_back(timeChan);
 
 #ifdef SHOW_AG_CHANGES
-    hsStatusMessage(ST::format("\nAbout to Attach anim <{}>", GetName()).c_str());
+    hsStatusMessageF("\nAbout to Attach anim <{}>", GetName());
     fMaster->DumpAniGraph("bone_pelvis", false, hsTimer::GetSysSeconds());
 #endif
 
@@ -315,7 +315,7 @@ void plAGAnimInstance::Detach()
 void plAGAnimInstance::DetachChannels()
 {
 #ifdef SHOW_AG_CHANGES
-    hsStatusMessage(ST::format("\nAbout to DETACH anim <{}>", GetName()).c_str());
+    hsStatusMessageF("\nAbout to DETACH anim <{}>", GetName());
     fMaster->DumpAniGraph("bone_pelvis", false, hsTimer::GetSysSeconds());
 #endif
     plDetachMap::iterator i = fManualDetachChannels.begin();
@@ -346,7 +346,7 @@ void plAGAnimInstance::DetachChannels()
     fCleanupChannels.clear();
 
 #ifdef SHOW_AG_CHANGES
-    hsStatusMessage(ST::format("\nFinished DETACHING anim <{}>", GetName()).c_str());
+    hsStatusMessageF("\nFinished DETACHING anim <{}>", GetName());
     fMaster->DumpAniGraph("bone_pelvis", false, hsTimer::GetSysSeconds());
 #endif
 }
@@ -651,7 +651,7 @@ void DumpAGAllocs()
 
         uint16_t realClassIndex = al->fObject->ClassIndex();
 
-        hsStatusMessage(ST::format("agAlloc: an: {} ch: {}, cl: {}", al->fAnimName, al->fChannelName, plFactory::GetNameOfClass(realClassIndex)).c_str());
+        hsStatusMessageF("agAlloc: an: {} ch: {}, cl: {}", al->fAnimName, al->fChannelName, plFactory::GetNameOfClass(realClassIndex));
 
     }
     // it's not fast but it's safe and simple..

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
@@ -52,6 +52,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsResMgr.h"
 #include "plgDispatch.h"
 
+#include <string_theory/format>
+
 // other
 #include "plInterp/plAnimEaseTypes.h"
 #include "plInterp/plAnimTimeConvert.h"
@@ -313,7 +315,7 @@ void plAGMasterMod::DumpAniGraph(const char *justThisChannel, bool optimized, do
                     plMatrixChannel *topChannel = plMatrixChannel::ConvertNoRef(channel);
                     if(topChannel)
                     {
-                        hsStatusMessageF("AGModifier: <%s>", mod->GetChannelName().c_str());
+                        hsStatusMessage(ST::format("AGModifier: <{}>", mod->GetChannelName()).c_str());
                         topChannel->Dump(1, optimized, time);
                     }
                 }
@@ -599,7 +601,7 @@ void plAGMasterMod::DetachAnimation(const ST::string &name)
 void plAGMasterMod::DumpCurrentAnims(const char *header)
 {
     if(header)
-        hsStatusMessageF("Dumping Armature Anim Stack: %s", header);
+        hsStatusMessage(ST::format("Dumping Armature Anim Stack: {}", header).c_str());
     int nAnims = fAnimInstances.size();
     for(int i = nAnims - 1; i >= 0; i--)
     {
@@ -607,7 +609,7 @@ void plAGMasterMod::DumpCurrentAnims(const char *header)
         ST::string name = inst->GetName();
         float blend = inst->GetBlend();
 
-        hsStatusMessageF("%d: %s with blend of %f", i, name.c_str(), blend);
+        hsStatusMessage(ST::format("{}: {} with blend of {}", i, name, blend).c_str());
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
@@ -315,7 +315,7 @@ void plAGMasterMod::DumpAniGraph(const char *justThisChannel, bool optimized, do
                     plMatrixChannel *topChannel = plMatrixChannel::ConvertNoRef(channel);
                     if(topChannel)
                     {
-                        hsStatusMessage(ST::format("AGModifier: <{}>", mod->GetChannelName()).c_str());
+                        hsStatusMessageF("AGModifier: <{}>", mod->GetChannelName());
                         topChannel->Dump(1, optimized, time);
                     }
                 }
@@ -601,7 +601,7 @@ void plAGMasterMod::DetachAnimation(const ST::string &name)
 void plAGMasterMod::DumpCurrentAnims(const char *header)
 {
     if(header)
-        hsStatusMessage(ST::format("Dumping Armature Anim Stack: {}", header).c_str());
+        hsStatusMessageF("Dumping Armature Anim Stack: {}", header);
     int nAnims = fAnimInstances.size();
     for(int i = nAnims - 1; i >= 0; i--)
     {
@@ -609,7 +609,7 @@ void plAGMasterMod::DumpCurrentAnims(const char *header)
         ST::string name = inst->GetName();
         float blend = inst->GetBlend();
 
-        hsStatusMessage(ST::format("{}: {} with blend of {}", i, name, blend).c_str());
+        hsStatusMessageF("{}: {} with blend of {}", i, name, blend);
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAnimation/plMatrixChannel.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plMatrixChannel.cpp
@@ -51,6 +51,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //#include <hkmath/quaternion.h>
 
 #include <cmath>
+#include <string_theory/format>
+#include <string_theory/string_stream>
 
 // singular
 #include "plMatrixChannel.h"
@@ -167,12 +169,12 @@ plAGChannel * plMatrixChannel::MakeTimeScale(plScalarChannel *timeSource)
 // -----
 void plMatrixChannel::Dump(int indent, bool optimized, double time)
 {
-    std::string indentStr;
+    ST::string_stream indentStr;
     for(int i = 0; i < indent; i++)
     {
-        indentStr += "- ";
+        indentStr << "- ";
     }
-    hsStatusMessageF("%s matChan<%s>", indentStr.c_str(), fName.c_str());
+    hsStatusMessage(ST::format("{} matChan<{}>", indentStr.to_string(), fName).c_str());
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -297,12 +299,12 @@ plAGChannel * plMatrixTimeScale::Detach(plAGChannel * detach)
 // -----
 void plMatrixTimeScale::Dump(int indent, bool optimized, double time)
 {
-    std::string indentStr;
+    ST::string_stream indentStr;
     for(int i = 0; i < indent; i++)
     {
-        indentStr += "- ";
+        indentStr << "- ";
     }
-    hsStatusMessageF("%s matTimeScale <%s> at time <%f>", indentStr.c_str(), fName.c_str(), fTimeSource->Value(time, true));
+    hsStatusMessage(ST::format("{} matTimeScale <{}> at time <{}>", indentStr.to_string(), fName, fTimeSource->Value(time, true)).c_str());
     fChannelIn->Dump(indent + 1, optimized, time);
 
 }
@@ -470,12 +472,12 @@ plAGChannel *plMatrixBlend::Optimize(double time)
 // -----
 void plMatrixBlend::Dump(int indent, bool optimized, double time)
 {
-    std::string indentStr;
+    ST::string_stream indentStr;
     for(int i = 0; i < indent; i++)
     {
-        indentStr += "- ";
+        indentStr << "- ";
     }
-    hsStatusMessageF("%s matBlend<%s>, bias:<%f>", indentStr.c_str(), fName.c_str(), fChannelBias->Value(time, true));
+    hsStatusMessage(ST::format("{} matBlend<{}>, bias:<{}>", indentStr.to_string(), fName, fChannelBias->Value(time, true)).c_str());
     if(optimized)
     {
         fOptimizedB->Dump(indent + 1, optimized, time);
@@ -569,12 +571,12 @@ plAGChannel *plMatrixControllerChannel::MakeCacheChannel(plAnimTimeConvert *atc)
 
 void plMatrixControllerChannel::Dump(int indent, bool optimized, double time)
 {
-    std::string indentStr;
+    ST::string_stream indentStr;
     for(int i = 0; i < indent; i++)
     {
-        indentStr += "- ";
+        indentStr << "- ";
     }
-    hsStatusMessageF("%s MatController<%s>", indentStr.c_str(), fName.c_str());
+    hsStatusMessage(ST::format("{} MatController<{}>", indentStr.to_string(), fName).c_str());
 }
 
 // Write -------------------------------------------------------------

--- a/Sources/Plasma/PubUtilLib/plAnimation/plMatrixChannel.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plMatrixChannel.cpp
@@ -174,7 +174,7 @@ void plMatrixChannel::Dump(int indent, bool optimized, double time)
     {
         indentStr << "- ";
     }
-    hsStatusMessage(ST::format("{} matChan<{}>", indentStr.to_string(), fName).c_str());
+    hsStatusMessageF("{} matChan<{}>", indentStr.to_string(), fName);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -304,7 +304,7 @@ void plMatrixTimeScale::Dump(int indent, bool optimized, double time)
     {
         indentStr << "- ";
     }
-    hsStatusMessage(ST::format("{} matTimeScale <{}> at time <{}>", indentStr.to_string(), fName, fTimeSource->Value(time, true)).c_str());
+    hsStatusMessageF("{} matTimeScale <{}> at time <{}>", indentStr.to_string(), fName, fTimeSource->Value(time, true));
     fChannelIn->Dump(indent + 1, optimized, time);
 
 }
@@ -477,7 +477,7 @@ void plMatrixBlend::Dump(int indent, bool optimized, double time)
     {
         indentStr << "- ";
     }
-    hsStatusMessage(ST::format("{} matBlend<{}>, bias:<{}>", indentStr.to_string(), fName, fChannelBias->Value(time, true)).c_str());
+    hsStatusMessageF("{} matBlend<{}>, bias:<{}>", indentStr.to_string(), fName, fChannelBias->Value(time, true));
     if(optimized)
     {
         fOptimizedB->Dump(indent + 1, optimized, time);
@@ -576,7 +576,7 @@ void plMatrixControllerChannel::Dump(int indent, bool optimized, double time)
     {
         indentStr << "- ";
     }
-    hsStatusMessage(ST::format("{} MatController<{}>", indentStr.to_string(), fName).c_str());
+    hsStatusMessageF("{} MatController<{}>", indentStr.to_string(), fName);
 }
 
 // Write -------------------------------------------------------------

--- a/Sources/Plasma/PubUtilLib/plAnimation/plQuatChannel.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plQuatChannel.cpp
@@ -106,7 +106,7 @@ plAGChannel *plQuatChannel::MakeBlend(plAGChannel *channelB, plScalarChannel *ch
     {
         return new plQuatBlend(this, chanB, chanBias);
     } else {
-        hsStatusMessageF("Blend operation failed.");
+        hsStatusMessage("Blend operation failed.");
         return this;
     }
 }

--- a/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.cpp
@@ -64,13 +64,15 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnSceneObject/plSceneObject.h"
 #include "plStatusLog/plStatusLog.h"
 
+#include <string_theory/format>
+
 // Visualization
 #include "plWinAudibleProxy.h"
 
 #define SND_INDEX_CHECK( index, ret )           \
     if ((size_t)index >= fSoundObjs.size())     \
     {                                           \
-        hsStatusMessageF("ERROR: Sound index out of range (index %d, count %zu)", index, fSoundObjs.size()); \
+        hsStatusMessage(ST::format("ERROR: Sound index out of range (index {}, count {})", index, fSoundObjs.size()).c_str()); \
         return ret;                             \
     }
 

--- a/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudible/plWinAudible.cpp
@@ -72,7 +72,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define SND_INDEX_CHECK( index, ret )           \
     if ((size_t)index >= fSoundObjs.size())     \
     {                                           \
-        hsStatusMessage(ST::format("ERROR: Sound index out of range (index {}, count {})", index, fSoundObjs.size()).c_str()); \
+        hsStatusMessageF("ERROR: Sound index out of range (index {}, count {})", index, fSoundObjs.size()); \
         return ret;                             \
     }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAnimStage.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAnimStage.cpp
@@ -323,7 +323,7 @@ bool plAnimStage::Detach(plArmatureMod *armature)
     snprintf(sbuf, std::size(sbuf), "AnimStage::Detach - detaching stage %s", fAnimName.c_str());
     plAvatarMgr::GetInstance()->GetLog()->AddLine(sbuf);
 #endif
-    // hsStatusMessage(ST::format("Detaching plAnimStage {}>", fAnimName).c_str());
+    // hsStatusMessageF("Detaching plAnimStage {}>", fAnimName);
     if(fArmature) {
         fArmature = nullptr;
 
@@ -521,7 +521,7 @@ bool plAnimStage::ITryAdvance(plArmatureMod *avMod)
     bool stageDone = false;
 
 
-    // hsStatusMessage(ST::format("Sending advance message for stage <{}>", fAnimName).c_str());
+    // hsStatusMessageF("Sending advance message for stage <{}>", fAnimName);
     if(fAdvanceType == kAdvanceAuto || fAdvanceType == kAdvanceOnMove) {
         stageDone = true;
     }
@@ -548,7 +548,7 @@ bool plAnimStage::ITryRegress(plArmatureMod *avMod)
     // we may want to rename this to "ReachedStageEnd"
     ISendNotify(kNotifyRegress, proEventData::kRegressPrevStage, avMod, fBrain);
 
-    // hsStatusMessage(ST::format("Sending regress message for stage <{}>", fAnimName).c_str());
+    // hsStatusMessageF("Sending regress message for stage <{}>", fAnimName);
     if(fRegressType == kRegressAuto) {
         stageDone = true;
     }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAnimStage.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAnimStage.cpp
@@ -323,7 +323,7 @@ bool plAnimStage::Detach(plArmatureMod *armature)
     snprintf(sbuf, std::size(sbuf), "AnimStage::Detach - detaching stage %s", fAnimName.c_str());
     plAvatarMgr::GetInstance()->GetLog()->AddLine(sbuf);
 #endif
-//  hsStatusMessageF("Detaching plAnimStage <%s>", fAnimName.c_str());
+    // hsStatusMessage(ST::format("Detaching plAnimStage {}>", fAnimName).c_str());
     if(fArmature) {
         fArmature = nullptr;
 
@@ -336,7 +336,7 @@ bool plAnimStage::Detach(plArmatureMod *armature)
     } else {
         plAvatarMgr::GetInstance()->GetLog()->AddLine("AnimStage::Detach: stage already detached");
 #endif
-//      hsStatusMessageF("Detach: stage already detached.");
+        // hsStatusMessage("Detach: stage already detached.");
     }
     
     fBrain = nullptr;
@@ -521,7 +521,7 @@ bool plAnimStage::ITryAdvance(plArmatureMod *avMod)
     bool stageDone = false;
 
 
-    // hsStatusMessageF("Sending advance message for stage <%s>", fAnimName.c_str());
+    // hsStatusMessage(ST::format("Sending advance message for stage <{}>", fAnimName).c_str());
     if(fAdvanceType == kAdvanceAuto || fAdvanceType == kAdvanceOnMove) {
         stageDone = true;
     }
@@ -548,7 +548,7 @@ bool plAnimStage::ITryRegress(plArmatureMod *avMod)
     // we may want to rename this to "ReachedStageEnd"
     ISendNotify(kNotifyRegress, proEventData::kRegressPrevStage, avMod, fBrain);
 
-    // hsStatusMessageF("Sending regress message for stage <%s>", fAnimName.c_str());
+    // hsStatusMessage(ST::format("Sending regress message for stage <{}>", fAnimName).c_str());
     if(fRegressType == kRegressAuto) {
         stageDone = true;
     }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainClimb.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainClimb.cpp
@@ -420,7 +420,7 @@ bool plAvBrainClimb::IAdvanceCurrentStage(double time, float elapsed, float &ove
 // ITRYSTAGETRANSITION
 bool plAvBrainClimb::ITryStageTransition(double time, float overage)
 {
-    //hsStatusMessage(ST::format("Got overage {}", overage).c_str());
+    //hsStatusMessageF("Got overage {}", overage);
     IChooseNextMode();
 
     bool result = true;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainClimb.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainClimb.cpp
@@ -420,7 +420,7 @@ bool plAvBrainClimb::IAdvanceCurrentStage(double time, float elapsed, float &ove
 // ITRYSTAGETRANSITION
 bool plAvBrainClimb::ITryStageTransition(double time, float overage)
 {
-//  hsStatusMessageF("Got overage %f", overage);
+    //hsStatusMessage(ST::format("Got overage {}", overage).c_str());
     IChooseNextMode();
 
     bool result = true;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
@@ -318,7 +318,7 @@ void plAvBrainHuman::IInitBoneMap()
             fAvMod->AddBoneMapping(id, bone);
         }
         else
-            hsStatusMessage(ST::format("Couldn't find standard bone {}.", name).c_str());
+            hsStatusMessageF("Couldn't find standard bone {}.", name);
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvBrainHuman.cpp
@@ -64,6 +64,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plPhysicalControllerCore.h"
 
 #include <cmath>
+#include <string_theory/format>
 #include <vector>
 
 #include "pnEncryption/plRandom.h"
@@ -317,7 +318,7 @@ void plAvBrainHuman::IInitBoneMap()
             fAvMod->AddBoneMapping(id, bone);
         }
         else
-            hsStatusMessageF("Couldn't find standard bone %s.", name.c_str());
+            hsStatusMessage(ST::format("Couldn't find standard bone {}.", name).c_str());
     }
 }
 
@@ -627,7 +628,7 @@ bool plAvBrainHuman::IHandleTaskMsg(plAvTaskMsg *msg)
         plAvTask *task = taskM->GetTask();
         QueueTask(task);
     } else {
-        hsStatusMessageF("Couldn't recognize task message type.");
+        hsStatusMessage("Couldn't recognize task message type.");
         return plArmatureBrain::IHandleTaskMsg(msg);
     }
     return true;

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
@@ -54,6 +54,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "plgDispatch.h"
 
+#include <string_theory/format>
+
 // other
 #include "pnKeyedObject/plKey.h"
 #include "pnMessage/plCameraMsg.h"
@@ -407,7 +409,7 @@ bool plAvAnimTask::Start(plArmatureMod *avatar, plArmatureBrain *brain, double t
         }
         else
         {
-            hsStatusMessageF("Couldn't find animation <%s> for plAvAnimTask: will try again", fAnimName.c_str());
+            hsStatusMessage(ST::format("Couldn't find animation <{}> for plAvAnimTask: will try again", fAnimName).c_str());
         }
     }
     else

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
@@ -409,7 +409,7 @@ bool plAvAnimTask::Start(plArmatureMod *avatar, plArmatureBrain *brain, double t
         }
         else
         {
-            hsStatusMessage(ST::format("Couldn't find animation <{}> for plAvAnimTask: will try again", fAnimName).c_str());
+            hsStatusMessageF("Couldn't find animation <{}> for plAvAnimTask: will try again", fAnimName);
         }
     }
     else

--- a/Sources/Plasma/PubUtilLib/plContainer/plConfigInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plContainer/plConfigInfo.cpp
@@ -907,20 +907,17 @@ bool plDebugConfigSource::WriteOutOf(plConfigInfo & configInfo)
     plConfigInfo::Keys::const_iterator      ki, ke;
     plConfigInfo::Values::const_iterator    vi, ve;
 
-    char buf[1024];
     fConfigInfo->GetSectionIterators(si,se);
     for (; si!=se; ++si)
     {
-        sprintf(buf,"\n[%s]",si->first.c_str());
-        hsStatusMessage(buf);
+        hsStatusMessage(ST::format("\n[{}]", si->first).c_str());
         if (fConfigInfo->GetKeyIterators(si->first, ki, ke))
             for (; ki!=ke; ++ki)
             {
                 if (fConfigInfo->GetValueIterators(si->first, ki->first, vi, ve))
                     for (; vi!=ve; ++vi)
                     {
-                        sprintf(buf,"%s=%s",ki->first.c_str(),vi->c_str());
-                        hsStatusMessage(buf);
+                        hsStatusMessage(ST::format("{}={}", ki->first, *vi).c_str());
                     }
             }
     }

--- a/Sources/Plasma/PubUtilLib/plContainer/plConfigInfo.cpp
+++ b/Sources/Plasma/PubUtilLib/plContainer/plConfigInfo.cpp
@@ -910,14 +910,14 @@ bool plDebugConfigSource::WriteOutOf(plConfigInfo & configInfo)
     fConfigInfo->GetSectionIterators(si,se);
     for (; si!=se; ++si)
     {
-        hsStatusMessage(ST::format("\n[{}]", si->first).c_str());
+        hsStatusMessageF("\n[{}]", si->first);
         if (fConfigInfo->GetKeyIterators(si->first, ki, ke))
             for (; ki!=ke; ++ki)
             {
                 if (fConfigInfo->GetValueIterators(si->first, ki->first, vi, ve))
                     for (; vi!=ve; ++vi)
                     {
-                        hsStatusMessage(ST::format("{}={}", ki->first, *vi).c_str());
+                        hsStatusMessageF("{}={}", ki->first, *vi);
                     }
             }
     }

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
@@ -441,7 +441,7 @@ void    plDynamicTextMap::SetFont( const ST::string &face, uint16_t size, uint8_
     if (fCurrFont == nullptr)
     {
         if (!fCurrFont)
-            hsStatusMessage(ST::format("Font missing - {}. Using Arial", fFontFace).c_str());
+            hsStatusMessageF("Font missing - {}. Using Arial", fFontFace);
 
         fFontFace = "Arial";
         // lets try again with Arial

--- a/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plDynamicTextMap.cpp
@@ -54,6 +54,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "HeadSpin.h"
 #include "plDynamicTextMap.h"
 
+#include <string_theory/format>
+
 #include "hsStream.h"
 #include "hsExceptions.h"
 
@@ -439,7 +441,7 @@ void    plDynamicTextMap::SetFont( const ST::string &face, uint16_t size, uint8_
     if (fCurrFont == nullptr)
     {
         if (!fCurrFont)
-            hsStatusMessageF("Font missing - %s. Using Arial", fFontFace.c_str("nil"));
+            hsStatusMessage(ST::format("Font missing - {}. Using Arial", fFontFace).c_str());
 
         fFontFace = "Arial";
         // lets try again with Arial

--- a/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
@@ -2240,7 +2240,7 @@ void    plMipmap::IReportLeaks()
             case plRecord::kViaResize: creationMethodStr = ST_LITERAL("Resize"); break;
         }
 
-        hsStatusMessage(ST::format(
+        hsStatusMessageF(
             "{}, {}: \t{}x{}, {} levels, {} bpr {} via {}",
             record->fKeyName,
             sizeStr,
@@ -2249,7 +2249,7 @@ void    plMipmap::IReportLeaks()
             record->fRowBytes,
             compressionStr,
             creationMethodStr
-        ).c_str());
+        );
 
         next = record->fNext;
         record->Unlink();

--- a/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plMipmap.cpp
@@ -64,6 +64,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plPNG.h"
 #include <cmath>
 #include <algorithm>
+#include <string_theory/format>
+#include <string_theory/string_stream>
 
 plProfile_CreateMemCounter("Mipmaps", "Memory", MemMipmaps);
 
@@ -2208,39 +2210,38 @@ void    plMipmap::IRemoveFromMemRecord( uint8_t *image )
 void    plMipmap::IReportLeaks()
 {
     plRecord    *record, *next;
-    static char msg[ 512 ], m2[ 128 ];
     uint32_t      size;
 
 
     hsStatusMessage("--- plMipmap Leaks ---");
     for (record = fRecords; record != nullptr; )
     {
+        ST::string_stream msg;
         size = record->fHeight * record->fRowBytes;
         if (size >= 1024) {
-            sprintf(msg, "%s, %4.1f kB: \t%dx%d, %d levels, %d bpr", record->fKeyName.c_str(),
-                    size / 1024.f, record->fWidth, record->fHeight, record->fNumLevels, record->fRowBytes);
+            msg << ST::format("{}, {4.1f} kB: \t{}x{}, {} levels, {} bpr", record->fKeyName,
+                size / 1024.f, record->fWidth, record->fHeight, record->fNumLevels, record->fRowBytes);
         } else {
-            sprintf(msg, "%s, %u bytes: \t%dx%d, %d levels, %d bpr", record->fKeyName.c_str(),
-                    size, record->fWidth, record->fHeight, record->fNumLevels, record->fRowBytes);
+            msg << ST::format("{}, {} bytes: \t{}x{}, {} levels, {} bpr", record->fKeyName,
+                size, record->fWidth, record->fHeight, record->fNumLevels, record->fRowBytes);
         }
 
         if( record->fCompressionType != kDirectXCompression )
-            sprintf( m2, " UType: %d", record->fUncompressedInfo.fType );
+            msg << ST::format(" UType: {}", record->fUncompressedInfo.fType);
         else
-            sprintf( m2, " DXT%d BSz: %d", record->fDirectXInfo.fCompressionType, record->fDirectXInfo.fBlockSize );
-        strcat( msg, m2 );
+            msg << ST::format(" DXT{} BSz: {}", record->fDirectXInfo.fCompressionType, record->fDirectXInfo.fBlockSize);
 
         switch( record->fCreationMethod )
         {
-            case plRecord::kViaCreate: strcat(msg, " via Create"); break;
-            case plRecord::kViaRead: strcat(msg, " via Read"); break;
-            case plRecord::kViaClipToMaxSize: strcat(msg, " via ClipToMaxSize"); break;
-            case plRecord::kViaDetailMapConstructor: strcat(msg, " via DetailMapConstructor"); break;
-            case plRecord::kViaCopyFrom: strcat(msg, " via CopyFrom"); break;
-            case plRecord::kViaResize: strcat(msg, " via Resize"); break;
+            case plRecord::kViaCreate: msg << " via Create"; break;
+            case plRecord::kViaRead: msg << " via Read"; break;
+            case plRecord::kViaClipToMaxSize: msg << " via ClipToMaxSize"; break;
+            case plRecord::kViaDetailMapConstructor: msg << " via DetailMapConstructor"; break;
+            case plRecord::kViaCopyFrom: msg << " via CopyFrom"; break;
+            case plRecord::kViaResize: msg << " via Resize"; break;
         }
 
-        hsStatusMessage( msg );
+        hsStatusMessage(msg.to_string().c_str());
 
         next = record->fNext;
         record->Unlink();

--- a/Sources/Plasma/PubUtilLib/plInterp/hsInterp.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/hsInterp.cpp
@@ -299,7 +299,7 @@ void hsInterp::LinInterp(const hsAffineParts* k1, const hsAffineParts* k2, float
     }
     
     if(k1->fF!=k2->fF)
-        hsStatusMessageF("WARNING: Inequality in affine parts flip value.");
+        hsStatusMessage("WARNING: Inequality in affine parts flip value.");
 
 //  hsAssert(k1->fF==k2->fF, "inequality in affine parts flip value");
     if (!(flags & kIgnorePartsPos))

--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
@@ -41,6 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 #include "HeadSpin.h"
 #include <cmath>
+#include <string_theory/format>
 
 #include "plAnimEaseTypes.h"
 #include "plAnimTimeConvert.h"
@@ -760,7 +761,7 @@ float plAnimTimeConvert::GetBestStopDist(float min, float max, float norm, float
         }
     }
     
-    hsStatusMessageF("found stop point %f", bestTime);
+    hsStatusMessage(ST::format("found stop point {}", bestTime).c_str());
 
     if (bestTime == -1)
         bestTime = norm;

--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
@@ -761,7 +761,7 @@ float plAnimTimeConvert::GetBestStopDist(float min, float max, float norm, float
         }
     }
     
-    hsStatusMessage(ST::format("found stop point {}", bestTime).c_str());
+    hsStatusMessageF("found stop point {}", bestTime);
 
     if (bestTime == -1)
         bestTime = norm;

--- a/Sources/Plasma/PubUtilLib/plMessageBox/hsMessageBox.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessageBox/hsMessageBox.cpp
@@ -54,7 +54,7 @@ hsMessageBoxResult hsMessageBox(const ST::string& message, const ST::string& cap
     if (hsMessageBox_SuppressPrompts)
         return hsMBoxOk;
 
-    hsStatusMessage(ST::format("{}\n{}", message, caption).c_str());
+    hsStatusMessageF("{}\n{}", message, caption);
     return hsMBoxCancel;
 }
 #endif

--- a/Sources/Plasma/PubUtilLib/plModifier/plSimpleModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plSimpleModifier.cpp
@@ -166,7 +166,7 @@ bool plSimpleModifier::IHandleCmd(plAnimCmdMsg* modMsg)
     }
 
 #if 0   // debug
-    hsStatusMessage(ST::format("ModHandleCmd: time={}, ts={} FWD={}, BWD={}, SpeedChange={} sp={}, CONT={}, STOP={}",
+    hsStatusMessageF("ModHandleCmd: time={}, ts={} FWD={}, BWD={}, SpeedChange={} sp={}, CONT={}, STOP={}",
         hsTimer::GetSysSeconds(),
         modMsg->GetTimeStamp(),
         modMsg->Cmd(plAnimCmdMsg::kSetForewards),
@@ -175,7 +175,7 @@ bool plSimpleModifier::IHandleCmd(plAnimCmdMsg* modMsg)
         modMsg->fSpeed,
         modMsg->Cmd(plAnimCmdMsg::kContinue),
         modMsg->Cmd(plAnimCmdMsg::kStop)
-    ).c_str());
+    );
 #endif
     return true;
 }   

--- a/Sources/Plasma/PubUtilLib/plModifier/plSimpleModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plSimpleModifier.cpp
@@ -166,8 +166,7 @@ bool plSimpleModifier::IHandleCmd(plAnimCmdMsg* modMsg)
     }
 
 #if 0   // debug
-    char str[256];
-    sprintf(str, "ModHandleCmd: time=%f, ts=%f FWD=%d, BWD=%d, SpeedChange=%d sp=%f, CONT=%d, STOP=%d",
+    hsStatusMessage(ST::format("ModHandleCmd: time={}, ts={} FWD={}, BWD={}, SpeedChange={} sp={}, CONT={}, STOP={}",
         hsTimer::GetSysSeconds(),
         modMsg->GetTimeStamp(),
         modMsg->Cmd(plAnimCmdMsg::kSetForewards),
@@ -175,8 +174,8 @@ bool plSimpleModifier::IHandleCmd(plAnimCmdMsg* modMsg)
         modMsg->Cmd(plAnimCmdMsg::kSetSpeed),
         modMsg->fSpeed,
         modMsg->Cmd(plAnimCmdMsg::kContinue),
-        modMsg->Cmd(plAnimCmdMsg::kStop));
-    hsStatusMessage(str);
+        modMsg->Cmd(plAnimCmdMsg::kStop)
+    ).c_str());
 #endif
     return true;
 }   

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -1196,7 +1196,7 @@ bool plNetClientMgr::IHandlePlayerPageMsg(plPlayerPageMsg *playerMsg)
         plSceneObject *playerSO = plSceneObject::ConvertNoRef(playerKey->ObjectIsLoaded());
         if (!playerSO)
         {
-            hsStatusMessageF("Ignoring player page message for non-existant player.");
+            hsStatusMessage("Ignoring player page message for non-existant player.");
         }
         else
         if(playerMsg->fPlayer)

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -262,7 +262,7 @@ bool plNetClientMgr::Log(const ST::string& str) const
     ST::string buf2 = ST::format("{.2f} {}", hsTimer::GetSeconds(), ProcessTab(str.c_str()));
 
     if ( GetConsoleOutput() )
-        hsStatusMessage(buf2.c_str());
+        hsStatusMessage(buf2);
 
     GetLog();
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglTrans.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Private/plNglTrans.cpp
@@ -125,7 +125,7 @@ NetTrans::NetTrans (ENetProtocol protocol, ETransType transType)
 {
     ++s_perf[kPerfCurrTransactions];
     ++s_perfTransCount[m_transType];
-//  hsDebugPrintToTerminal(ST::format("{}@{#x} created", s_transTypes[m_transType], reinterpret_cast<uintptr_t>(this)).c_str());
+    //hsDebugPrintToTerminal(ST::format("{}@{#x} created", s_transTypes[m_transType], reinterpret_cast<uintptr_t>(this)));
 }
 
 //============================================================================
@@ -141,7 +141,7 @@ NetTrans::~NetTrans () {
 #endif
     --s_perfTransCount[m_transType];
     --s_perf[kPerfCurrTransactions];
-//  hsDebugPrintToTerminal(ST::format("{}@{#x} destroyed", s_transTypes[m_transType], reinterpret_cast<uintptr_t>(this)).c_str());
+    //hsDebugPrintToTerminal(ST::format("{}@{#x} destroyed", s_transTypes[m_transType], reinterpret_cast<uintptr_t>(this)));
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
@@ -441,7 +441,7 @@ void plObjectInVolumeAndFacingDetector::ICheckForTrigger()
         objView.Normalize();
 
         float dot = playerView * objView;
-//      hsStatusMessageF("Dot: %f Tolerance: %f", dot, fFacingTolerance);
+        //hsStatusMessage(ST::format("Dot: {} Tolerance: {}", dot, fFacingTolerance).c_str());
         bool facing = dot >= fFacingTolerance;
 
         bool movingForward = false;

--- a/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plCollisionDetector.cpp
@@ -441,7 +441,7 @@ void plObjectInVolumeAndFacingDetector::ICheckForTrigger()
         objView.Normalize();
 
         float dot = playerView * objView;
-        //hsStatusMessage(ST::format("Dot: {} Tolerance: {}", dot, fFacingTolerance).c_str());
+        //hsStatusMessageF("Dot: {} Tolerance: {}", dot, fFacingTolerance);
         bool facing = dot >= fFacingTolerance;
 
         bool movingForward = false;

--- a/Sources/Plasma/PubUtilLib/plPhysical/plPickingDetector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plPickingDetector.cpp
@@ -42,6 +42,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plPickingDetector.h"
 
+#include <string_theory/format>
+
 #include "pnKeyedObject/plKey.h"
 #include "pnMessage/plObjRefMsg.h"
 #include "pnNetCommon/plNetApp.h"
@@ -97,7 +99,7 @@ bool plPickingDetector::MsgReceive(plMessage* msg)
 
             pMsg->SetSender(GetKey());
             pMsg->Send();
-            hsStatusMessageF("%s sending activate message to %s",GetKey()->GetName().c_str(), receiver->GetName().c_str());
+            hsStatusMessage(ST::format("{} sending activate message to {}", GetKey()->GetName(), receiver->GetName()).c_str());
         }
     }
 

--- a/Sources/Plasma/PubUtilLib/plPhysical/plPickingDetector.cpp
+++ b/Sources/Plasma/PubUtilLib/plPhysical/plPickingDetector.cpp
@@ -99,7 +99,7 @@ bool plPickingDetector::MsgReceive(plMessage* msg)
 
             pMsg->SetSender(GetKey());
             pMsg->Send();
-            hsStatusMessage(ST::format("{} sending activate message to {}", GetKey()->GetName(), receiver->GetName()).c_str());
+            hsStatusMessageF("{} sending activate message to {}", GetKey()->GetName(), receiver->GetName());
         }
     }
 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
@@ -340,11 +340,9 @@ void plRegistryPageNode::AddKey(plKeyImp* key)
     // Error check
     if (keys->FindKey(key->GetUoid().GetObjectName()) != nullptr)
     {
-        //char str[512], tempStr[128];
-        //sprintf(str, "Attempting to add a key with a duplicate name. Not allowed."
-        //          "\n\n(Key name: %s, Class: %s, Loc: %s)", key->GetUoid().GetObjectName(), 
-        //          plFactory::GetNameOfClass(classType), key->GetUoid().GetLocation().StringIze(tempStr));
-        //hsStatusMessage(str);
+        //hsStatusMessage(ST::format("Attempting to add a key with a duplicate name. Not allowed."
+        //          "\n\n(Key name: {}, Class: {}, Loc: {})", key->GetUoid().GetObjectName(), 
+        //          plFactory::GetNameOfClass(classType), key->GetUoid().GetLocation()).c_str());
         bool recovered = false;
 
         // Attempt recovery

--- a/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plRegistryNode.cpp
@@ -340,9 +340,9 @@ void plRegistryPageNode::AddKey(plKeyImp* key)
     // Error check
     if (keys->FindKey(key->GetUoid().GetObjectName()) != nullptr)
     {
-        //hsStatusMessage(ST::format("Attempting to add a key with a duplicate name. Not allowed."
+        //hsStatusMessageF("Attempting to add a key with a duplicate name. Not allowed."
         //          "\n\n(Key name: {}, Class: {}, Loc: {})", key->GetUoid().GetObjectName(), 
-        //          plFactory::GetNameOfClass(classType), key->GetUoid().GetLocation()).c_str());
+        //          plFactory::GetNameOfClass(classType), key->GetUoid().GetLocation());
         bool recovered = false;
 
         // Attempt recovery

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
@@ -1559,7 +1559,7 @@ static void sIReportLeak(plKeyImp* key, plRegistryPageNode* page)
         ss << "- " << key->GetDataLen() << " bytes - " << refsLeft << " refs left";
     else
         ss << "(key only, " << refsLeft << " refs left)";
-    hsStatusMessage(ss.to_string().c_str());
+    hsStatusMessage(ss.to_string());
 }
 
 //// UnloadPageObjects ///////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
@@ -709,7 +709,7 @@ plKey plResManager::ReadKeyNotifyMe(hsStream* stream, plRefMsg* msg, plRefFlags:
     }
     if(key->GetUoid().GetLoadMask().DontLoad())
     {
-        hsStatusMessageF("%s being skipped because of load mask", key->GetName().c_str());
+        hsStatusMessage(ST::format("{} being skipped because of load mask", key->GetName()).c_str());
         hsRefCnt_SafeUnRef(msg);
         return nullptr;
     }
@@ -1040,14 +1040,14 @@ void plResManager::LoadAgeKeys(const ST::string& age)
     if (it != fHeldAgeKeys.end())
     {
         kResMgrLog(1, ILog(1, "Reffing age keys for age {}", age));
-        hsStatusMessageF("*** Reffing age keys for age %s ***", age.c_str());
+        hsStatusMessage(ST::format("*** Reffing age keys for age {} ***", age).c_str());
         plResAgeHolder* holder = it->second;
         holder->Ref();
     }
     else
     {
         kResMgrLog(1, ILog(1, "Loading age keys for age {}", age));
-        hsStatusMessageF("*** Loading age keys for age %s ***", age.c_str());
+        hsStatusMessage(ST::format("*** Loading age keys for age {} ***", age).c_str());
 
         plResAgeHolder* holder = new plResAgeHolder(age);
         fHeldAgeKeys[age] = holder;
@@ -1544,7 +1544,7 @@ static void sIReportLeak(plKeyImp* key, plRegistryPageNode* page)
     if (!alreadyDone)
     {
         // Print out page header
-        hsStatusMessageF("\tLeaks in page %s>%s[%08x]:", lastPage->GetPageInfo().GetAge().c_str(), lastPage->GetPageInfo().GetPage().c_str(), lastPage->GetPageInfo().GetLocation().GetSequenceNumber());
+        hsStatusMessage(ST::format("\tLeaks in page {}>{}[{08x}]:", lastPage->GetPageInfo().GetAge(), lastPage->GetPageInfo().GetPage(), lastPage->GetPageInfo().GetLocation().GetSequenceNumber()).c_str());
         alreadyDone = true;
     }
 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManager.cpp
@@ -709,7 +709,7 @@ plKey plResManager::ReadKeyNotifyMe(hsStream* stream, plRefMsg* msg, plRefFlags:
     }
     if(key->GetUoid().GetLoadMask().DontLoad())
     {
-        hsStatusMessage(ST::format("{} being skipped because of load mask", key->GetName()).c_str());
+        hsStatusMessageF("{} being skipped because of load mask", key->GetName());
         hsRefCnt_SafeUnRef(msg);
         return nullptr;
     }
@@ -1040,14 +1040,14 @@ void plResManager::LoadAgeKeys(const ST::string& age)
     if (it != fHeldAgeKeys.end())
     {
         kResMgrLog(1, ILog(1, "Reffing age keys for age {}", age));
-        hsStatusMessage(ST::format("*** Reffing age keys for age {} ***", age).c_str());
+        hsStatusMessageF("*** Reffing age keys for age {} ***", age);
         plResAgeHolder* holder = it->second;
         holder->Ref();
     }
     else
     {
         kResMgrLog(1, ILog(1, "Loading age keys for age {}", age));
-        hsStatusMessage(ST::format("*** Loading age keys for age {} ***", age).c_str());
+        hsStatusMessageF("*** Loading age keys for age {} ***", age);
 
         plResAgeHolder* holder = new plResAgeHolder(age);
         fHeldAgeKeys[age] = holder;
@@ -1544,7 +1544,7 @@ static void sIReportLeak(plKeyImp* key, plRegistryPageNode* page)
     if (!alreadyDone)
     {
         // Print out page header
-        hsStatusMessage(ST::format("\tLeaks in page {}>{}[{08x}]:", lastPage->GetPageInfo().GetAge(), lastPage->GetPageInfo().GetPage(), lastPage->GetPageInfo().GetLocation().GetSequenceNumber()).c_str());
+        hsStatusMessageF("\tLeaks in page {}>{}[{08x}]:", lastPage->GetPageInfo().GetAge(), lastPage->GetPageInfo().GetPage(), lastPage->GetPageInfo().GetLocation().GetSequenceNumber());
         alreadyDone = true;
     }
 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.cpp
@@ -189,9 +189,7 @@ void plResManagerHelper::LoadAndHoldPageKeys( plRegistryPageNode *page )
 
     // Load and ref the keys
 #ifdef HS_DEBUGGING
-    char msg[ 256 ];
-    sprintf( msg, "*** Temporarily loading keys for room %s>%s based on FindKey() query, will drop in 1 sec ***", page->GetPageInfo().GetAge().c_str(), page->GetPageInfo().GetPage().c_str());
-    hsStatusMessage( msg );
+    hsStatusMessage(ST::format("*** Temporarily loading keys for room {}>{} based on FindKey() query, will drop in 1 sec ***", page->GetPageInfo().GetAge(), page->GetPageInfo().GetPage()).c_str());
 #endif
     kResMgrLogF(2, 0xff80ff80, "Temporarily loading keys for room {}>{}, will drop in 1 sec", page->GetPageInfo().GetAge(), page->GetPageInfo().GetPage());
         

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.cpp
@@ -189,7 +189,7 @@ void plResManagerHelper::LoadAndHoldPageKeys( plRegistryPageNode *page )
 
     // Load and ref the keys
 #ifdef HS_DEBUGGING
-    hsStatusMessage(ST::format("*** Temporarily loading keys for room {}>{} based on FindKey() query, will drop in 1 sec ***", page->GetPageInfo().GetAge(), page->GetPageInfo().GetPage()).c_str());
+    hsStatusMessageF("*** Temporarily loading keys for room {}>{} based on FindKey() query, will drop in 1 sec ***", page->GetPageInfo().GetAge(), page->GetPageInfo().GetPage());
 #endif
     kResMgrLogF(2, 0xff80ff80, "Temporarily loading keys for room {}>{}, will drop in 1 sec", page->GetPageInfo().GetAge(), page->GetPageInfo().GetPage());
         

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDLMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDLMgr.cpp
@@ -201,7 +201,7 @@ int plSDLMgr::Read(hsStream* s, plSDL::DescriptorList* dl)
         }
         else
         {
-            hsStatusMessage(ST::format("Something bad happened while reading SDLMgr data: {}", e.what()).c_str());
+            hsStatusMessageF("Something bad happened while reading SDLMgr data: {}", e.what());
         }
         return 0;
     }

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDLParser.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDLParser.cpp
@@ -381,7 +381,7 @@ bool plSDLParser::IReadDescriptors() const
             if (netApp)
                 netApp->ErrorMsg("Error loading SDL file {}", files[i]);
             else
-                hsStatusMessageF("Error loading SDL file %s", files[i].AsString().c_str());
+                hsStatusMessage(ST::format("Error loading SDL file {}", files[i]).c_str());
             ret=false;
         }
         else

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDLParser.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDLParser.cpp
@@ -59,7 +59,7 @@ void plSDLParser::DebugMsg(const ST::string& msg) const
     if (netApp)
         hsLogEntry(netApp->DebugMsg(msg));
     else
-        hsStatusMessage(msg.c_str());
+        hsStatusMessage(msg);
 }
 
 //

--- a/Sources/Plasma/PubUtilLib/plSDL/plSDLParser.cpp
+++ b/Sources/Plasma/PubUtilLib/plSDL/plSDLParser.cpp
@@ -381,7 +381,7 @@ bool plSDLParser::IReadDescriptors() const
             if (netApp)
                 netApp->ErrorMsg("Error loading SDL file {}", files[i]);
             else
-                hsStatusMessage(ST::format("Error loading SDL file {}", files[i]).c_str());
+                hsStatusMessageF("Error loading SDL file {}", files[i]);
             ret=false;
         }
         else

--- a/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
@@ -344,9 +344,9 @@ bool plAutoProfileImp::MsgReceive(plMessage* msg)
             fLinkTime = hsTimer::GetTicks() - fLinkTime;
             float ms = hsTimer::GetMilliSeconds<float>(fLinkTime);
 
-            hsStatusMessage(ST::format("Age {} finished load, took {.1f} ms",
+            hsStatusMessageF("Age {} finished load, took {.1f} ms",
                 fAges[fNextAge-1],
-                ms).c_str());
+                ms);
 
             plStatusLog::AddLineSF("agetimings.log", "Age {} took {.1f} ms",
                 fAges[fNextAge-1],

--- a/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatGather/plAutoProfile.cpp
@@ -344,9 +344,9 @@ bool plAutoProfileImp::MsgReceive(plMessage* msg)
             fLinkTime = hsTimer::GetTicks() - fLinkTime;
             float ms = hsTimer::GetMilliSeconds<float>(fLinkTime);
 
-            hsStatusMessageF("Age %s finished load, took %.1f ms",
-                fAges[fNextAge-1].c_str(),
-                ms);
+            hsStatusMessage(ST::format("Age {} finished load, took {.1f} ms",
+                fAges[fNextAge-1],
+                ms).c_str());
 
             plStatusLog::AddLineSF("agetimings.log", "Age {} took {.1f} ms",
                 fAges[fNextAge-1],

--- a/Sources/Tools/plResBrowser/plWinRegistryTools.cpp
+++ b/Sources/Tools/plResBrowser/plWinRegistryTools.cpp
@@ -76,7 +76,7 @@ static bool ISetRegKey(const QString &keyName, const QString &value, const QStri
                           nullptr, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS,
                           nullptr, &regKey, &result) != ERROR_SUCCESS)
     {
-        hsStatusMessage(ST::format("Warning: Registry database open failed for key '{}'.", qUtf8Printable(keyName)).c_str());
+        hsStatusMessageF("Warning: Registry database open failed for key '{}'.", qUtf8Printable(keyName));
         return false;
     }
 
@@ -89,7 +89,7 @@ static bool ISetRegKey(const QString &keyName, const QString &value, const QStri
     if (::RegCloseKey(regKey) == ERROR_SUCCESS && lResult == ERROR_SUCCESS)
         return true;
 
-    hsStatusMessage(ST::format("Warning: Registry database update failed for key '{}'.", qUtf8Printable(keyName)).c_str());
+    hsStatusMessageF("Warning: Registry database update failed for key '{}'.", qUtf8Printable(keyName));
     return false;
 }
 
@@ -173,7 +173,7 @@ QString plWinRegistryTools::GetCurrentFileExtensionAssociation(const QString &ex
     {
         wchar_t msg[512];
         FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, retVal, 0, msg, std::size(msg), nullptr);
-        hsStatusMessage(ST::format("Error querying registry key '{}' : {}", qUtf8Printable(extension), msg).c_str());
+        hsStatusMessageF("Error querying registry key '{}' : {}", qUtf8Printable(extension), msg);
         return QString();
     }
 

--- a/Sources/Tools/plResBrowser/plWinRegistryTools.cpp
+++ b/Sources/Tools/plResBrowser/plWinRegistryTools.cpp
@@ -76,7 +76,7 @@ static bool ISetRegKey(const QString &keyName, const QString &value, const QStri
                           nullptr, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS,
                           nullptr, &regKey, &result) != ERROR_SUCCESS)
     {
-        hsStatusMessageF("Warning: Registry database open failed for key '%s'.", qPrintable(keyName));
+        hsStatusMessage(ST::format("Warning: Registry database open failed for key '{}'.", qUtf8Printable(keyName)).c_str());
         return false;
     }
 
@@ -89,7 +89,7 @@ static bool ISetRegKey(const QString &keyName, const QString &value, const QStri
     if (::RegCloseKey(regKey) == ERROR_SUCCESS && lResult == ERROR_SUCCESS)
         return true;
 
-    hsStatusMessageF("Warning: Registry database update failed for key '%s'.", qPrintable(keyName));
+    hsStatusMessage(ST::format("Warning: Registry database update failed for key '{}'.", qUtf8Printable(keyName)).c_str());
     return false;
 }
 
@@ -171,9 +171,9 @@ QString plWinRegistryTools::GetCurrentFileExtensionAssociation(const QString &ex
     LONG retVal = ::RegQueryValueW(HKEY_CLASSES_ROOT, extension.toStdWString().c_str(), buffer, &dataLen);
     if (retVal != ERROR_SUCCESS)
     {
-        char msg[512];
-        FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, retVal, 0, msg, std::size(msg), nullptr);
-        hsStatusMessageF("Error querying registry key '%s' : %s", qPrintable(extension), msg);
+        wchar_t msg[512];
+        FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, retVal, 0, msg, std::size(msg), nullptr);
+        hsStatusMessage(ST::format("Error querying registry key '{}' : {}", qUtf8Printable(extension), msg).c_str());
         return QString();
     }
 


### PR DESCRIPTION
Haven't touched `hsAssert` yet, because there are just *so many* of them. If there are no complaints here, I'll repeat the same procedure for `hsAssert` later.