### PR TITLE
Remove last non-Asio socket/internet API calls

### DIFF
--- a/Sources/Plasma/NucleusLib/pnNetCommon/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/CMakeLists.txt
@@ -37,8 +37,6 @@ target_link_libraries(
     PRIVATE
         pnMessage
         pnSceneObject
-        $<$<PLATFORM_ID:SunOS>:socket>
-        $<$<PLATFORM_ID:Windows>:ws2_32>
 )
 
 source_group("Header Files" FILES ${pnNetCommon_HEADERS})

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
@@ -41,20 +41,27 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <array>
+#include <string_theory/format>
 #include <string_theory/string_stream>
 
 #include "plNetAddress.h"
-#include "pnNetCommon.h"
+
+ST::string plNetAddress::GetIPv4AddressAsString(uint32_t ip4addr)
+{
+    static_assert(sizeof(ip4addr) == 4*sizeof(uint8_t));
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&ip4addr);
+    return ST::format("{}.{}.{}.{}", bytes[0], bytes[1], bytes[2], bytes[3]);
+}
 
 ST::string plNetAddress::GetHostString() const
 {
-    return pnNetCommon::GetTextAddr(fHost);
+    return GetIPv4AddressAsString(fHost);
 }
 
 ST::string plNetAddress::GetHostWithPort() const
 {
     ST::string_stream ss;
-    ss << pnNetCommon::GetTextAddr(fHost) << ":" << fPort;
+    ss << GetIPv4AddressAsString(fHost) << ":" << fPort;
     return ss.to_string();
 }
 
@@ -75,7 +82,7 @@ void plNetAddress::SetHost(const std::array<uint8_t, 4>& addr)
 ST::string plNetAddress::AsString() const
 {
     ST::string_stream ss;
-    ss << "IP:" << pnNetCommon::GetTextAddr(fHost);
+    ss << "IP:" << GetIPv4AddressAsString(fHost);
     ss << ":" << fPort;
 
     return ss.to_string();

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
@@ -66,11 +66,6 @@ std::array<uint8_t, 4> plNetAddress::GetHostBytes() const
     return bytes;
 }
 
-void plNetAddress::SetHost(const ST::string& hostname)
-{
-    fHost = pnNetCommon::GetBinAddr(hostname);
-}
-
 void plNetAddress::SetHost(const std::array<uint8_t, 4>& addr)
 {
     static_assert(sizeof(fHost) == sizeof(addr));

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
@@ -42,7 +42,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <array>
 #include <string_theory/format>
-#include <string_theory/string_stream>
 
 #include "plNetAddress.h"
 
@@ -60,9 +59,7 @@ ST::string plNetAddress::GetHostString() const
 
 ST::string plNetAddress::GetHostWithPort() const
 {
-    ST::string_stream ss;
-    ss << GetIPv4AddressAsString(fHost) << ":" << fPort;
-    return ss.to_string();
+    return ST::format("{}:{}", GetIPv4AddressAsString(fHost), fPort);
 }
 
 std::array<uint8_t, 4> plNetAddress::GetHostBytes() const
@@ -81,11 +78,7 @@ void plNetAddress::SetHost(const std::array<uint8_t, 4>& addr)
 
 ST::string plNetAddress::AsString() const
 {
-    ST::string_stream ss;
-    ss << "IP:" << GetIPv4AddressAsString(fHost);
-    ss << ":" << fPort;
-
-    return ss.to_string();
+    return ST::format("IP:{}:{}", GetIPv4AddressAsString(fHost), fPort);
 }
 
 void plNetAddress::Read(hsStream * s)

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.cpp
@@ -40,7 +40,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#include <array>
 #include <string_theory/format>
 
 #include "plNetAddress.h"

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.h
@@ -45,6 +45,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
+#include <array>
+
 #include "hsStream.h"
 
 #ifdef SetPort

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.h
@@ -163,6 +163,15 @@ public:
     void SetHost(const std::array<uint8_t, 4>& ip4addr);
 
     /**
+     * Returns the given IPv4 address as a string in 4-octet dotted
+     * notation.
+     *
+     * @param ip4addr The IPv4 address to convert, in network byte order.
+     * @return A string of the given IPv4 address.
+     */
+    static ST::string GetIPv4AddressAsString(uint32_t ip4addr);
+
+    /**
      * Returns the IPv4 address of the host as a string in 4-octet dotted
      * notation.
      *

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.h
@@ -100,10 +100,10 @@ public:
     }
 
     /**
-     * Initializes a new network address from the given hostname and port
+     * Initializes a new network address from the given IPv4 address and port
      * number.
      *
-     * @param addr The DNS hostname of the host.
+     * @param addr The IPv4 address as a string in 4-octet dotted notation.
      * @param port The port number as a 16-bit host order integer.
      */
     plNetAddress(const ST::string& addr, uint16_t port)
@@ -160,9 +160,10 @@ public:
     std::array<uint8_t, 4> GetHostBytes() const;
 
     /**
-     * Sets the IPv4 address of the host from a DNS name.
+     * Sets the IPv4 address of the host from a string in 4-octet dotted
+     * notation.
      *
-     * @param hostname The DNS name of the host.
+     * @param hostname The IPv4 host address.
      */
     void SetHost(const ST::string& hostname);
 

--- a/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/plNetAddress.h
@@ -99,19 +99,6 @@ public:
         SetHost(addr);
     }
 
-    /**
-     * Initializes a new network address from the given IPv4 address and port
-     * number.
-     *
-     * @param addr The IPv4 address as a string in 4-octet dotted notation.
-     * @param port The port number as a 16-bit host order integer.
-     */
-    plNetAddress(const ST::string& addr, uint16_t port)
-        : fHost(), fPort(port)
-    {
-        SetHost(addr);
-    }
-
     bool operator==(const plNetAddress& other) const {
         return (GetHost() == other.GetHost()) && (GetPort() == other.GetPort());
     }
@@ -158,14 +145,6 @@ public:
      * @return The IPv4 host address
      */
     std::array<uint8_t, 4> GetHostBytes() const;
-
-    /**
-     * Sets the IPv4 address of the host from a string in 4-octet dotted
-     * notation.
-     *
-     * @param hostname The IPv4 host address.
-     */
-    void SetHost(const ST::string& hostname);
 
     /**
      * Sets the IPv4 address of the host from an unsigned 32-bit integer in

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
@@ -42,21 +42,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnNetCommon.h"
 
-#include <string_theory/format>
-
-namespace pnNetCommon
-{
-
-ST::string GetTextAddr(uint32_t binAddr)
-{
-    static_assert(sizeof(binAddr) == 4*sizeof(uint8_t));
-    const auto* bytes = reinterpret_cast<const uint8_t*>(&binAddr);
-    return ST::format("{}.{}.{}.{}", bytes[0], bytes[1], bytes[2], bytes[3]);
-}
-
-} // pnNetCommon namespace
-
-
 
 ////////////////////////////////////////////////////////////////////
 

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
@@ -43,8 +43,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnNetCommon.h"
 
 
-////////////////////////////////////////////////////////////////////
-
 void plCreatableStream::Write( hsStream* stream, hsResMgr* mgr )
 {
     fStream.Rewind();
@@ -73,6 +71,3 @@ void plCreatableStream::Read( hsStream* stream, hsResMgr* mgr )
     fStream.Rewind();
     delete[] buf;
 }
-
-////////////////////////////////////////////////////////////////////
-// End.

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
@@ -65,23 +65,6 @@ ST::string GetTextAddr(uint32_t binAddr)
     return ST::string::from_utf8(inet_ntop(AF_INET, &in, text_addr, sizeof(text_addr)));
 }
 
-// NOTE: On Win32, WSAStartup() must be called before GetBinAddr() will work.
-uint32_t GetBinAddr(const ST::string& textAddr)
-{
-    uint32_t addr = 0;
-    if (textAddr.empty())
-        return addr;
-
-    in_addr in;
-    int result = inet_pton(AF_INET, textAddr.c_str(), &in);
-    hsAssert(result >= 0, "inet_pton failed");
-    if (result) {
-        addr = in.s_addr;
-    }
-
-    return addr;
-}
-
 } // pnNetCommon namespace
 
 

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
@@ -39,30 +39,19 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
       Mead, WA   99021
 
 *==LICENSE==*/
-#include <string>
+
 #include "pnNetCommon.h"
 
-#if defined(HS_BUILD_FOR_UNIX)
-# include <sys/socket.h>
-# include <arpa/inet.h>
-#elif defined(HS_BUILD_FOR_WIN32)
-#include "hsWindows.h"
-#include <ws2tcpip.h>
-#else
-#error "Not implemented for this platform"
-#endif
+#include <string_theory/format>
 
 namespace pnNetCommon
 {
 
-// NOTE: On Win32, WSAStartup() must be called before GetTextAddr() will work.
 ST::string GetTextAddr(uint32_t binAddr)
 {
-    in_addr in;
-    in.s_addr = binAddr;
-
-    char text_addr[INET_ADDRSTRLEN];
-    return ST::string::from_utf8(inet_ntop(AF_INET, &in, text_addr, sizeof(text_addr)));
+    static_assert(sizeof(binAddr) == 4*sizeof(uint8_t));
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&binAddr);
+    return ST::format("{}.{}.{}.{}", bytes[0], bytes[1], bytes[2], bytes[3]);
 }
 
 } // pnNetCommon namespace

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.cpp
@@ -44,9 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #if defined(HS_BUILD_FOR_UNIX)
 # include <sys/socket.h>
-# include <netinet/in.h>
 # include <arpa/inet.h>
-# include <netdb.h>
 #elif defined(HS_BUILD_FOR_WIN32)
 #include "hsWindows.h"
 #include <ws2tcpip.h>
@@ -79,19 +77,6 @@ uint32_t GetBinAddr(const ST::string& textAddr)
     hsAssert(result >= 0, "inet_pton failed");
     if (result) {
         addr = in.s_addr;
-    } else {
-        struct addrinfo* ai = nullptr;
-        struct addrinfo hints = {};
-        hints.ai_family = PF_INET;
-        hints.ai_flags  = AI_CANONNAME;
-        if (getaddrinfo(textAddr.c_str(), nullptr, &hints, &ai) != 0)
-        {
-            hsAssert(false, "getaddrinfo failed");
-            return addr;
-        }
-
-        addr = reinterpret_cast<sockaddr_in *>(ai->ai_addr)->sin_addr.s_addr;
-        freeaddrinfo(ai);
     }
 
     return addr;

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
@@ -73,8 +73,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define Int2Bool(value) ((value)?true:false)
 
 
-///////////////////////////////////////////////////////////////////
-
 class plCreatableStream : public plCreatable
 {
     hsRAMStream fStream;
@@ -90,6 +88,3 @@ public:
 };
 
 #endif // pnNetCommon_h_inc
-
-///////////////////////////////////////////////////////////////////
-// End.

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
@@ -75,13 +75,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 ///////////////////////////////////////////////////////////////////
 
-namespace pnNetCommon
-{
-    ST::string GetTextAddr(uint32_t binAddr);
-}
-
-///////////////////////////////////////////////////////////////////
-
 class plCreatableStream : public plCreatable
 {
     hsRAMStream fStream;

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
@@ -77,7 +77,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 namespace pnNetCommon
 {
-    uint32_t GetBinAddr(const ST::string& textAddr);
     ST::string GetTextAddr(uint32_t binAddr);
 }
 

--- a/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetCommon/pnNetCommon.h
@@ -69,9 +69,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 # endif
 #endif
 
-#define Bool2Int(value) ((value)?1:0)
-#define Int2Bool(value) ((value)?true:false)
-
 
 class plCreatableStream : public plCreatable
 {

--- a/Sources/Tests/NucleusTests/CMakeLists.txt
+++ b/Sources/Tests/NucleusTests/CMakeLists.txt
@@ -2,4 +2,5 @@ include_directories("${PLASMA_SOURCE_ROOT}/CoreLib")
 include_directories("${PLASMA_SOURCE_ROOT}/NucleusLib")
 
 add_subdirectory(pnEncryptionTest)
+add_subdirectory(pnNetCommonTest)
 add_subdirectory(pnUUIDTest)

--- a/Sources/Tests/NucleusTests/pnNetCommonTest/CMakeLists.txt
+++ b/Sources/Tests/NucleusTests/pnNetCommonTest/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(pnNetCommonTest_SOURCES
+    test_plNetAddress.cpp
+)
+
+plasma_test(test_pnNetCommon SOURCES ${pnNetCommonTest_SOURCES})
+target_link_libraries(
+    test_pnNetCommon
+    PRIVATE
+        CoreLib
+        pnNetCommon
+        gtest_main
+)

--- a/Sources/Tests/NucleusTests/pnNetCommonTest/test_plNetAddress.cpp
+++ b/Sources/Tests/NucleusTests/pnNetCommonTest/test_plNetAddress.cpp
@@ -40,7 +40,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#include <array>
 #include <gtest/gtest.h>
 #include <string_theory/string>
 

--- a/Sources/Tests/NucleusTests/pnNetCommonTest/test_plNetAddress.cpp
+++ b/Sources/Tests/NucleusTests/pnNetCommonTest/test_plNetAddress.cpp
@@ -1,0 +1,72 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <array>
+#include <gtest/gtest.h>
+#include <string_theory/string>
+
+#include "pnNetCommon/plNetAddress.h"
+
+using namespace ST::literals;
+
+TEST(plNetAddress, HostPortAsString)
+{
+    plNetAddress addr1({1, 2, 3, 4}, 80);
+    EXPECT_EQ(addr1.GetHostString(), "1.2.3.4"_st);
+    EXPECT_EQ(addr1.GetHostWithPort(), "1.2.3.4:80"_st);
+
+    plNetAddress addr2({10, 20, 30, 40}, 443);
+    EXPECT_EQ(addr2.GetHostString(), "10.20.30.40"_st);
+    EXPECT_EQ(addr2.GetHostWithPort(), "10.20.30.40:443"_st);
+
+    plNetAddress addr3({127, 0, 0, 1}, 8080);
+    EXPECT_EQ(addr3.GetHostString(), "127.0.0.1"_st);
+    EXPECT_EQ(addr3.GetHostWithPort(), "127.0.0.1:8080"_st);
+
+    plNetAddress addr4({184, 73, 198, 22}, 14617);
+    EXPECT_EQ(addr4.GetHostString(), "184.73.198.22"_st);
+    EXPECT_EQ(addr4.GetHostWithPort(), "184.73.198.22:14617"_st);
+
+    plNetAddress addr5({255, 254, 253, 252}, 65535);
+    EXPECT_EQ(addr5.GetHostString(), "255.254.253.252"_st);
+    EXPECT_EQ(addr5.GetHostWithPort(), "255.254.253.252:65535"_st);
+}


### PR DESCRIPTION
The code behind `plNetAddress` still used `inet_ntop`, `inet_pton`, and `getaddrinfo` instead of the corresponding Asio APIs. `getaddrinfo` is especially problematic, because it can block for an unpredictable amount of time because of DNS queries.

Thankfully, most of this code was already unused, except for the IPv4-to-string conversion. I reimplemented that part manually, because it seems overkill to depend on Asio just for a simple string conversion. (But at some point, we might want to properly reimplement `plNetAddress` based on `asio::ip::address`.)