### PR TITLE
Resolve Max Textures During Export (Part Deux)

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plGUIComponents.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plGUIComponents.cpp
@@ -4793,6 +4793,7 @@ bool plGUISkinComp::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         PBBitmap *texture = layer->GetPBBitmap();
         if (texture != nullptr)
         {
+            BMMGetFullFilename(&texture->bi);
             plBitmap *bMap = plLayerConverter::Instance().CreateSimpleTexture( M2ST(texture->bi.Name()), fConvertedSkin->GetKey()->GetUoid().GetLocation(), 0, plMipmap::kForceNonCompressed | plMipmap::kAlphaChannelFlag | plMipmap::kNoMaxSize );
             if (bMap != nullptr && plMipmap::ConvertNoRef(bMap) != nullptr)
             {

--- a/Sources/MaxPlugin/MaxComponent/plGUIComponents.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plGUIComponents.cpp
@@ -4790,11 +4790,10 @@ bool plGUISkinComp::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     plLayerTex *layer= (plLayerTex *)fCompPB->GetTexmap( kRefBitmap );
     if (layer != nullptr)
     {
-        PBBitmap *texture = layer->GetPBBitmap();
-        if (texture != nullptr)
+        plFileName texturePath = layer->GetBitmapFileName();
+        if (texturePath.IsValid())
         {
-            BMMGetFullFilename(&texture->bi);
-            plBitmap *bMap = plLayerConverter::Instance().CreateSimpleTexture( M2ST(texture->bi.Name()), fConvertedSkin->GetKey()->GetUoid().GetLocation(), 0, plMipmap::kForceNonCompressed | plMipmap::kAlphaChannelFlag | plMipmap::kNoMaxSize );
+            plBitmap *bMap = plLayerConverter::Instance().CreateSimpleTexture( texturePath, fConvertedSkin->GetKey()->GetUoid().GetLocation(), 0, plMipmap::kForceNonCompressed | plMipmap::kAlphaChannelFlag | plMipmap::kNoMaxSize );
             if (bMap != nullptr && plMipmap::ConvertNoRef(bMap) != nullptr)
             {
                 hsgResMgr::ResMgr()->AddViaNotify( bMap->GetKey(), new plGenRefMsg( fConvertedSkin->GetKey(), 

--- a/Sources/MaxPlugin/MaxComponent/plMiscComponents.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plMiscComponents.cpp
@@ -2535,20 +2535,19 @@ bool pfImageLibComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         plLayerTex *layer = GetBitmap( i );
         if (layer != nullptr)
         {
-            PBBitmap *texture = layer->GetPBBitmap();
-            if (texture != nullptr)
+            plFileName texturePath = layer->GetBitmapFileName();
+            if (texturePath.IsValid())
             {
-                BMMGetFullFilename(&texture->bi);
                 uint32_t flags = plBitmap::kAlphaChannelFlag;
 
                 plBitmap *bMap;
                 if (fCompPB->GetInt(kCompressImage, 0, i) == 0)
                 {
                     flags |= plBitmap::kForceNonCompressed;
-                    bMap = plLayerConverter::Instance().CreateSimpleTexture( M2ST(texture->bi.Name()), lib->GetKey()->GetUoid().GetLocation(), 0, flags );
+                    bMap = plLayerConverter::Instance().CreateSimpleTexture( texturePath, lib->GetKey()->GetUoid().GetLocation(), 0, flags );
                 }
                 else // compress using PNG compression scheme
-                    bMap = plLayerConverter::Instance().CreateSimpleTexture( M2ST(texture->bi.Name()), lib->GetKey()->GetUoid().GetLocation(), 0, flags, true );
+                    bMap = plLayerConverter::Instance().CreateSimpleTexture( texturePath, lib->GetKey()->GetUoid().GetLocation(), 0, flags, true );
                 if (bMap != nullptr)
                 {
                     hsgResMgr::ResMgr()->AddViaNotify( bMap->GetKey(), new plGenRefMsg( lib->GetKey(), 

--- a/Sources/MaxPlugin/MaxComponent/plMiscComponents.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plMiscComponents.cpp
@@ -2538,6 +2538,7 @@ bool pfImageLibComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
             PBBitmap *texture = layer->GetPBBitmap();
             if (texture != nullptr)
             {
+                BMMGetFullFilename(&texture->bi);
                 uint32_t flags = plBitmap::kAlphaChannelFlag;
 
                 plBitmap *bMap;

--- a/Sources/MaxPlugin/MaxConvert/hsMaterialConverter.cpp
+++ b/Sources/MaxPlugin/MaxConvert/hsMaterialConverter.cpp
@@ -1957,6 +1957,7 @@ static plLayerInterface* IProcessLayerMovie(plPassMtlBase* mtl, plLayerTex* layT
     if( !bi || !bi->Name() || !*bi->Name() )
         return layerIFace;
 
+    BMMGetFullFilename(bi);
     plFileName fileName = bi->Name();
 
     plAnimStealthNode* stealth = IGetEntireAnimation(mtl);
@@ -4529,6 +4530,7 @@ plClothingItem *hsMaterialConverter::GenerateClothingItem(plClothingMtl *mtl, co
             if (layer == nullptr || layer->GetPBBitmap() == nullptr)
                 continue;
 
+            BMMGetFullFilename(&layer->GetPBBitmap()->bi);
             ST::string texName = M2ST(layer->GetPBBitmap()->bi.Name());
 
             for (clipLevels = 0, startWidth = layer->GetPBBitmap()->bi.Width(); 

--- a/Sources/MaxPlugin/MaxConvert/hsMaterialConverter.cpp
+++ b/Sources/MaxPlugin/MaxConvert/hsMaterialConverter.cpp
@@ -1947,18 +1947,12 @@ static plLayerInterface* IProcessLayerMovie(plPassMtlBase* mtl, plLayerTex* layT
     IParamBlock2* bitmapPB = layTex->GetParamBlockByID( plLayerTex::kBlkBitmap );
     if( !bitmapPB )
         return layerIFace;
-
-    PBBitmap    *pbbm = nullptr;
-
-    if( !bitmapPB->GetInt(kBmpUseBitmap) || !(pbbm = bitmapPB->GetBitmap(kBmpBitmap)) )
+    if (!bitmapPB->GetInt(kBmpUseBitmap))
         return layerIFace;
 
-    BitmapInfo  *bi = &pbbm->bi;
-    if( !bi || !bi->Name() || !*bi->Name() )
+    plFileName fileName = layTex->GetBitmapFileName(); // LayerTex always pulls from kBlkBitmap
+    if (!fileName.IsValid())
         return layerIFace;
-
-    BMMGetFullFilename(bi);
-    plFileName fileName = bi->Name();
 
     plAnimStealthNode* stealth = IGetEntireAnimation(mtl);
 
@@ -4530,8 +4524,7 @@ plClothingItem *hsMaterialConverter::GenerateClothingItem(plClothingMtl *mtl, co
             if (layer == nullptr || layer->GetPBBitmap() == nullptr)
                 continue;
 
-            BMMGetFullFilename(&layer->GetPBBitmap()->bi);
-            ST::string texName = M2ST(layer->GetPBBitmap()->bi.Name());
+            plFileName texName = layer->GetBitmapFileName();
 
             for (clipLevels = 0, startWidth = layer->GetPBBitmap()->bi.Width(); 
                  startWidth > tileset->fElements[i]->fWidth;

--- a/Sources/MaxPlugin/MaxConvert/plBitmapCreator.h
+++ b/Sources/MaxPlugin/MaxConvert/plBitmapCreator.h
@@ -72,7 +72,7 @@ public:
     float sig;
     bool    isStaticCubicEnvMap;
     bool    invertAlpha;
-    const MCHAR  *faceNames[ 6 ];
+    plFileName faceNames[ 6 ];
     uint32_t  maxDimension;
     uint8_t   clampFlags;
     bool    usePNG;
@@ -86,7 +86,6 @@ public:
         sig = 0;
         isStaticCubicEnvMap = false;
         invertAlpha = false;
-        faceNames[0] = faceNames[1] = faceNames[2] = faceNames[3] = faceNames[4] = faceNames[5] = nullptr;
         maxDimension = 0;
         clampFlags = 0;
         usePNG = false;

--- a/Sources/MaxPlugin/MaxConvert/plLayerConverter.cpp
+++ b/Sources/MaxPlugin/MaxConvert/plLayerConverter.cpp
@@ -323,6 +323,7 @@ plLayerInterface    *plLayerConverter::IConvertLayerTex( plPlasmaMAXLayer *layer
 
     // Setup the texture creation parameters
     plBitmapData bd;
+    BMMGetFullFilename(bi);
     bd.fileName = bi->Name();
 
     // Create texture and add it to list if unique
@@ -442,6 +443,7 @@ plLayerInterface    *plLayerConverter::IConvertStaticEnvLayer( plPlasmaMAXLayer 
 
     // Setup the texture creation parameters
     plBitmapData bd;
+    BMMGetFullFilename(bi);
     bd.fileName = bi->Name();
 
     // Create texture and add it to list if unique
@@ -474,6 +476,7 @@ plLayerInterface    *plLayerConverter::IConvertStaticEnvLayer( plPlasmaMAXLayer 
         PBBitmap *face = bitmapPB->GetBitmap( plStaticEnvLayer::kBmpFrontBitmap + i );
         if( !face )
             return (plLayerInterface *)plasmaLayer;
+        BMMGetFullFilename(&face->bi);
         bd.faceNames[ i ] = face->bi.Name();
     }
 

--- a/Sources/MaxPlugin/MaxConvert/plLayerConverter.cpp
+++ b/Sources/MaxPlugin/MaxConvert/plLayerConverter.cpp
@@ -292,6 +292,7 @@ plLayerInterface    *plLayerConverter::IConvertLayerTex( plPlasmaMAXLayer *layer
     plLayer *plasmaLayer = ICreateLayer( M2ST( layer->GetName() ), upperLayer, loc );
 
     // We're using a texture, try and get its info
+    plFileName fileName = layer->GetBitmapFileName();
     PBBitmap    *pbbm = nullptr;
     BitmapInfo  *bi = nullptr;
 
@@ -304,7 +305,7 @@ plLayerInterface    *plLayerConverter::IConvertLayerTex( plPlasmaMAXLayer *layer
     }
 
     // If the texture had bad info, assert and return the empty layer
-    if( !bi || !bi->Name() || _tcscmp(bi->Name(), _T("")) == 0 )
+    if( !fileName.IsValid() )
     {
         if( upperLayer )
         {
@@ -323,8 +324,7 @@ plLayerInterface    *plLayerConverter::IConvertLayerTex( plPlasmaMAXLayer *layer
 
     // Setup the texture creation parameters
     plBitmapData bd;
-    BMMGetFullFilename(bi);
-    bd.fileName = bi->Name();
+    bd.fileName = std::move(fileName);
 
     // Create texture and add it to list if unique
     int32_t texFlags = 0;//hsGTexture::kMipMap;
@@ -428,13 +428,14 @@ plLayerInterface    *plLayerConverter::IConvertStaticEnvLayer( plPlasmaMAXLayer 
     plLayer *plasmaLayer = ICreateLayer( M2ST( layer->GetName() ), upperLayer, loc );
 
     // Get the texture info
+    plFileName fileName = layer->GetBitmapFileName(); // the index==0 bitmap is the front face
     PBBitmap *pbbm = bitmapPB->GetBitmap( plStaticEnvLayer::kBmpFrontBitmap + 0 );
     BitmapInfo *bi = nullptr;
     if( pbbm )
         bi = &pbbm->bi;
 
     // If the texture had bad info, assert and return the empty layer
-    if (!bi || !bi->Name() || _tcscmp(bi->Name(), _T("")) == 0)
+    if (!fileName.IsValid())
     {
         // Or don't assert since it can get annoying when you are using someone
         // elses file and don't have all the textures.
@@ -443,8 +444,7 @@ plLayerInterface    *plLayerConverter::IConvertStaticEnvLayer( plPlasmaMAXLayer 
 
     // Setup the texture creation parameters
     plBitmapData bd;
-    BMMGetFullFilename(bi);
-    bd.fileName = bi->Name();
+    bd.fileName = std::move(fileName);
 
     // Create texture and add it to list if unique
     int32_t texFlags = 0;
@@ -476,8 +476,7 @@ plLayerInterface    *plLayerConverter::IConvertStaticEnvLayer( plPlasmaMAXLayer 
         PBBitmap *face = bitmapPB->GetBitmap( plStaticEnvLayer::kBmpFrontBitmap + i );
         if( !face )
             return (plLayerInterface *)plasmaLayer;
-        BMMGetFullFilename(&face->bi);
-        bd.faceNames[ i ] = face->bi.Name();
+        bd.faceNames[i] = layer->GetBitmapFileName(i);
     }
 
     // Get detail parameters

--- a/Sources/MaxPlugin/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.cpp
+++ b/Sources/MaxPlugin/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.cpp
@@ -400,6 +400,7 @@ bool    plPlasmaMAXLayer::GetBitmapFileName( TCHAR* destFilename, int maxLength,
     if (GetPBBitmap(index) == nullptr)
         return false;
 
+    BMMGetFullFilename(&GetPBBitmap(index)->bi);
     _tcsncpy( destFilename, GetPBBitmap( index )->bi.Name(), maxLength );
     return true;
 }

--- a/Sources/MaxPlugin/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.cpp
+++ b/Sources/MaxPlugin/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.cpp
@@ -56,6 +56,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <vector>
 
 #include "HeadSpin.h"
+#include "plFileSystem.h"
 #include "hsResMgr.h"
 
 #include "MaxMain/MaxAPI.h"
@@ -400,9 +401,33 @@ bool    plPlasmaMAXLayer::GetBitmapFileName( TCHAR* destFilename, int maxLength,
     if (GetPBBitmap(index) == nullptr)
         return false;
 
-    BMMGetFullFilename(&GetPBBitmap(index)->bi);
-    _tcsncpy( destFilename, GetPBBitmap( index )->bi.Name(), maxLength );
+#if MAX_VERSION_MAJOR >= 24
+    // 3ds Max 2022 and higher have an API to resolve the full path
+    // as a string. Earlier maxes (somewhere post-7) have one as well,
+    // but it's not safe.
+    return BMMGetFullFilename(GetPBBitmap(index)->bi.Name(), destFilename, maxLength);
+#else
+    // Make a copy of the bitmap info. Resolving the path may change it, and we
+    // would prefer for the bitmap info in the paramblock to remain unchanged to
+    // prevent the max file from being dirtied by the exporter.
+    BitmapInfo bi(GetPBBitmap(index)->bi);
+    BMMGetFullFilename(&bi);
+
+    _tcsncpy( destFilename, bi.Name(), maxLength );
     return true;
+#endif
+}
+
+plFileName plPlasmaMAXLayer::GetBitmapFileName(int index)
+{
+    // Yeah, this is a double copy, but it looks like the weird MAXASS code
+    // expects to be able to write to a buffer. If we're going to play nice,
+    // we have to do it this way and not just assume that we can parse the
+    // string from the BitmapInfo.
+    TCHAR filename[MAX_PATH];
+    if (GetBitmapFileName(filename, std::size(filename), index))
+        return ST::string(filename);
+    return {};
 }
 
 BOOL plPlasmaMAXLayer::HandleBitmapSelection(int index /* = 0 */)

--- a/Sources/MaxPlugin/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.h
+++ b/Sources/MaxPlugin/MaxPlasmaMtls/Layers/plPlasmaMAXLayer.h
@@ -89,6 +89,7 @@ class plLayerTargetContainer;
 class plLocation;
 class plMaxNode;
 class jvUniqueId;
+class plFileName;
 
 class plPlasmaMAXLayer : public plMaxMtlBase<Texmap>
 {
@@ -151,6 +152,7 @@ class plPlasmaMAXLayer : public plMaxMtlBase<Texmap>
         void RefreshBitmaps();
 
         bool    GetBitmapFileName( TCHAR* destFilename, int maxLength, int index = 0 );
+        plFileName GetBitmapFileName(int index = 0);
 
         // Virtual function called by plBMSampler to get various things while sampling the layer's image
         virtual bool    GetSamplerInfo( plBMSamplerData *samplerData ) { return false; }


### PR DESCRIPTION
Closes #1623 by either using the safer, new in Max 2022 `BMMGetFullFilename()` or by falling back to copying the `BitmapInfo` object in older versions of Max. I also centralized all of the conversions to `plPlasmaMAXLayer::GetBitmapFileName()`.