### PR TITLE
Journal Page Remembering (Part Deux)

### DIFF
--- a/Scripts/Python/plasma/PlasmaConstants.py
+++ b/Scripts/Python/plasma/PlasmaConstants.py
@@ -103,6 +103,7 @@ class PtBookEventTypes:
     kNotifyPreviousPage = 4
     kNotifyCheckUnchecked = 5
     kNotifyClose = 6
+    kNotifyOpen = 7
 
 class PtBrainModes:
     kGeneric = 0

--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -236,8 +236,4 @@ class xJournalBookGUIPopup(ptModifier):
         return newContent
 
     def IsThereACover(self, bookHtml):
-        # search the bookhtml string looking for a cover
-        idx = bookHtml.find('<cover')
-        if idx >= 0:
-            return 1
-        return 0
+        return "<cover" in bookHtml

--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -189,26 +189,14 @@ class xJournalBookGUIPopup(ptModifier):
         journalContents = ""
         if Dynamic.value:
             inbox = ptVault().getGlobalInbox()
-            inboxChildList = inbox.getChildNodeRefList()
-            for child in inboxChildList:
-                PtDebugPrint("xJournalBookGUIPopupDyn: looking at node " + str(child), level=kDebugDumpLevel)
-                node = child.getChild()
-                folderNode = node.upcastToFolderNode()
-                if folderNode:
-                    PtDebugPrint("xJournalBookGUIPopupDyn: node is named %s" % (folderNode.getFolderName()), level=kDebugDumpLevel)
-                    if folderNode.getFolderName() == "Journals":
-                        folderNodeChildList = folderNode.getChildNodeRefList()
-                        for folderChild in folderNodeChildList:
-                            PtDebugPrint("xJournalBookGUIPopupDyn: looking at child node " + str(folderChild), level=kDebugDumpLevel)
-                            childNode = folderChild.getChild()
-                            textNode = childNode.upcastToTextNoteNode()
-                            if textNode:
-                                PtDebugPrint("xJournalBookGUIPopupDyn: child node is named %s" % (textNode.getTitle()), level=kDebugDumpLevel)
-                                # TODO: Convert this to use LocPath.value and migrate node values in DB if necessary once all PFMs
-                                #  are converted to use LocalizationPaths
-                                if textNode.getTitle() == JournalIdent:
-                                    journalContents = textNode.getText()
-                                    PtDebugPrint("xJournalBookGUIPopupDyn: journal contents are '%s'" % (journalContents), level=kDebugDumpLevel)
+            journalTemplate = ptVaultFolderNode(0)
+            journalTemplate.setFolderName("Journals")
+            if journalFolderNode := inbox.findNode(journalTemplate):
+                textTemplate = ptVaultTextNoteNode(0)
+                textTemplate.setTitle(JournalIdent)
+                if textNoteNode := journalFolderNode.findNode(textTemplate):
+                    textNoteNode = textNoteNode.upcastToTextNoteNode()
+                    journalContents = textNoteNode.getText()
         else:
             journalContents = PtGetLocalizedString(LocPath.value)
 

--- a/Scripts/Python/xJournalBookGUIPopup.py
+++ b/Scripts/Python/xJournalBookGUIPopup.py
@@ -62,7 +62,9 @@ from PlasmaTypes import *
 from PlasmaKITypes import *
 
 import re
+from typing import *
 import webbrowser
+import zlib
 
 import xJournalBookDefs
 
@@ -82,6 +84,9 @@ GUIType             = ptAttribString(14,"Book GUI Type",default="bkBook")
 # globals
 LocalAvatar = None
 
+# Konstants
+kJournalPageChronName = "LastJournalPage"
+
 # pfJournalBook's EsHTML will only allow links with integer events.
 # This isn't very friendly for age creators, so we'll let them specify
 # a url by doing <a href="https://foo.com">, and this regex will
@@ -90,12 +95,21 @@ LocalAvatar = None
 _URL_REGEX = re.compile(r"(?P<href>href\s*=\s*(?P<quote>[\"\']?)\s*?(?P<url>https?:\/\/[^\s>]+)\s*?(?P=quote))(?=[^<]*>)", re.IGNORECASE)
 _HOST_REGEX = re.compile(R"(?:https?:\/\/)?(?:www\.)?([^\/?#]+).*", re.IGNORECASE)
 
+class JournalPageCache(NamedTuple):
+    JournalHash: str
+    PageNum: Union[int, str]
+
+
 class xJournalBookGUIPopup(ptModifier):
     "The Journal Book GUI Popup python code"
     def __init__(self):
         ptModifier.__init__(self)
         self.id = 203
         self.version = 1
+
+        self.JournalBook: Optional[ptBook] = None
+        self._JournalHash: Optional[str] = None
+        self._OpenToPage: Optional[int] = None
 
     def OnFirstUpdate(self):
         pass
@@ -152,6 +166,11 @@ class xJournalBookGUIPopup(ptModifier):
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyShow",level=kDebugDumpLevel)
                         # disable the KI
                         PtSendKIMessage(kDisableKIandBB,0)
+                        # open to requested page
+                        # use an explicit test against None because the walrus tests for truthiness
+                        if self._OpenToPage is not None:
+                            PtDebugPrint(f"xJournalBookGUIPopup:Book: NotifyShow - opening to page {self._OpenToPage}", level=kWarningLevel)
+                            self.JournalBook.open(self._OpenToPage)
                     elif event[1] == PtBookEventTypes.kNotifyHide:
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyHide",level=kDebugDumpLevel)
                         # re-enable KI
@@ -160,11 +179,22 @@ class xJournalBookGUIPopup(ptModifier):
                         PtToggleAvatarClickability(True)
                     elif event[1] == PtBookEventTypes.kNotifyNextPage:
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyNextPage",level=kDebugDumpLevel)
+                        self.ISavePage(self.JournalBook.getCurrentPage())
                     elif event[1] == PtBookEventTypes.kNotifyPreviousPage:
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyPreviousPage",level=kDebugDumpLevel)
+                        self.ISavePage(self.JournalBook.getCurrentPage())
                     elif event[1] == PtBookEventTypes.kNotifyCheckUnchecked:
                         PtDebugPrint("xJournalBookGUIPopup:Book: NotifyCheckUncheck",level=kDebugDumpLevel)
-                        pass
+                    elif event[1] == PtBookEventTypes.kNotifyClose:
+                        PtDebugPrint("xJournalBookGUIPopup:Book: NotifyClose", level=kDebugDumpLevel)
+                        # if we're closing but not hiding, that means the user manually went to the
+                        # cover, so clear out the saved page such that the next "show" of this book
+                        # will open to the cover.
+                        if not event[2]:
+                            self.ISavePage(page=None)
+                    elif event[1] == PtBookEventTypes.kNotifyOpen:
+                        PtDebugPrint("xJournalBookGUIPopup:Book: NotifyOpen", level=kDebugDumpLevel)
+                        self.ISavePage(self.JournalBook.getCurrentPage())
 
     def IShowBook(self):
         self.JournalBook = None
@@ -206,16 +236,19 @@ class xJournalBookGUIPopup(ptModifier):
         # hide the KI
         PtSendKIMessage(kDisableKIandBB, 0)
 
+        # update the hash for automatic page flipping
+        self._JournalHash = f"{zlib.crc32(JournalIdent.encode()):08x},{zlib.crc32(journalContents.encode()):08x}"
+        PtDebugPrint(f"xJournalBookGUIPopup.IShowBook(): {self._JournalHash=}", level=kDebugDumpLevel)
+        self._OpenToPage = self._CachedPage
+
         # now build the book
         self.JournalBook = ptBook(self.IPreprocessJournalContents(journalContents), self.key)
         self.JournalBook.setSize(BookWidth.value, BookHeight.value)
         self.JournalBook.setGUI(GUIType.value)
 
         # make sure there is a cover to show
-        if not StartOpen.value and not self.IsThereACover(journalContents):
-            self.JournalBook.show(1)
-        else:
-            self.JournalBook.show(StartOpen.value)
+        startOpen = StartOpen.value or not self.IsThereACover(journalContents)
+        self.JournalBook.show(startOpen)
 
     def IPreprocessJournalContents(self, journalContents: str):
         self.links = []
@@ -237,3 +270,49 @@ class xJournalBookGUIPopup(ptModifier):
 
     def IsThereACover(self, bookHtml):
         return "<cover" in bookHtml
+
+    def IIterateJournalCache(self, cache: str):
+        for i in cache.split():
+            entry = i.split(':')
+            if len(entry) < 2:
+                continue
+            yield JournalPageCache(entry[0], entry[1])
+
+    def IStringifyJournalCache(self, cache: Iterable[JournalPageCache]) -> str:
+        return ' '.join(f"{i.JournalHash}:{i.PageNum}" for i in cache)
+
+    @property
+    def _CachedPage(self) -> Optional[int]:
+        vault = ptVault()
+        if chron := vault.findChronicleEntry(kJournalPageChronName):
+            journals = self.IIterateJournalCache(chron.getValue())
+            if pageNum := next((i.PageNum for i in journals if i.JournalHash == self._JournalHash), None):
+                try:
+                    pageNum = int(pageNum)
+                except ValueError:
+                    PtDebugPrint(f"xJournalBookGUIPopup._CachedPage(): Unable to convert {pageNum=} to integer")
+                else:
+                    PtDebugPrint(f"xJournalBookGUIPopup._CachedPage(): {pageNum=}", level=kDebugDumpLevel)
+                    return pageNum
+
+    def ISavePage(self, page: Union[int, None]) -> None:
+        vault = ptVault()
+        if chron := vault.findChronicleEntry(kJournalPageChronName):
+            journals = [i for i in self.IIterateJournalCache(chron.getValue()) if i.JournalHash != self._JournalHash]
+            if page is not None:
+                journals.insert(0, JournalPageCache(self._JournalHash, page))
+
+            # Limit the chronicle to no more than 1024 characters due to some servers only allowing the
+            # Text_1 field to be that long.
+            chronValue = self.IStringifyJournalCache(journals)
+            while len(chronValue) > 1024 and journals:
+                journals.pop()
+                chronValue = self.IStringifyJournalCache(journals)
+
+            chron.setValue(chronValue)
+        elif page is not None:
+            journals = [JournalPageCache(self._JournalHash, page)]
+            chronValue = self.IStringifyJournalCache(journals)
+            vault.addChronicleEntry(kJournalPageChronName, 0, chronValue)
+        else:
+            PtDebugPrint("xJournalBookGUIPopup.ISavePage(): Got a request to remove the saved page, but the chronicle doesn't exist?")

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -1393,7 +1393,13 @@ void    pfJournalBook::Open( uint32_t startingPage /*= 0 */)
 {
     if( !fBookGUIs[fCurBookGUI]->CurrentlyOpen() )
     {
+        ISendNotify(kNotifyOpen);
+
         fBookGUIs[fCurBookGUI]->PlayBookCloseAnim( false );
+
+        // Make sure we actually know where the requested page is.
+        if (startingPage > fCurrentPage)
+            IRecalcPageStarts(startingPage);
 
         // Render initial pages
         fCurrentPage = startingPage;
@@ -1413,7 +1419,7 @@ void    pfJournalBook::Close()
     // don't allow them to close the book if the book started open
     if( !fBookGUIs[fCurBookGUI]->StartedOpen() && fBookGUIs[fCurBookGUI]->CurrentlyOpen() )
     {
-        ISendNotify( kNotifyClose );
+        ISendNotify( kNotifyClose, 0 );
         fBookGUIs[fCurBookGUI]->PlayBookCloseAnim( true );
     }
 }
@@ -1429,7 +1435,7 @@ void    pfJournalBook::CloseAndHide()
         // if we are flipping a book then kill the page flipping animation
         if ( fBookGUIs[fCurBookGUI]->CurrentlyTurning() )
             fBookGUIs[fCurBookGUI]->KillPageFlip();
-        ISendNotify( kNotifyClose );
+        ISendNotify( kNotifyClose, 1 );
 
         ITriggerCloseWithNotify( true, false );
 

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.h
@@ -387,6 +387,7 @@ class pfJournalBook : public hsKeyedObject
             kNotifyPreviousPage,
             kNotifyCheckUnchecked,
             kNotifyClose,
+            kNotifyOpen,
         };
 
         // The constructor takes in the esHTML source for the journal, along with

--- a/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyJournalBookGlue.cpp
@@ -335,5 +335,6 @@ void pyJournalBook::AddPlasmaConstantsClasses(PyObject *m)
     PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyPreviousPage,      pfJournalBook::kNotifyPreviousPage)
     PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyCheckUnchecked,    pfJournalBook::kNotifyCheckUnchecked)
     PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyClose,             pfJournalBook::kNotifyClose)
+    PYTHON_ENUM_ELEMENT(PtBookEventTypes, kNotifyOpen,              pfJournalBook::kNotifyOpen)
     PYTHON_ENUM_END(m, PtBookEventTypes)
 }


### PR DESCRIPTION
Superceeds and closes #1679 by addressing concerns I had and fixing some disclosed drawbacks with the previous implementation.

Journals should now remember their last position, for the most part. I've retained the 1024 character limit for the chronicle to ensure nothing bad happens. This PR does not use JSON at all and also hashes the journal content to ensure that we don't assume that page numbers from old journal contents correspond to the new contents. Further, with this PR, the auto turn mechanic can tell the difference between closing the journal on the cover (the cover reopens) or closing the journal on the first page (the first page reopens).

Amusingly, I didn't realize it was possible to turn back to the cover in a journal until I was looking at this. For posterity, you can turn back to the cover by clicking on where the left turn button should be on the first page.

As a bonus, you get some code cleanups in xJournalBookGUIPopup.