### PR TITLE
Windows/ARM support

### DIFF
--- a/Scripts/Ports/physx/fix-compiler-flag.patch
+++ b/Scripts/Ports/physx/fix-compiler-flag.patch
@@ -1,0 +1,75 @@
+diff --git a/physx/compiler/public/CMakeLists.txt b/physx/compiler/public/CMakeLists.txt
+index 77776ca7..bd7b496d 100644
+--- a/physx/compiler/public/CMakeLists.txt
++++ b/physx/compiler/public/CMakeLists.txt
+@@ -33,6 +33,8 @@ ENDIF()
+ 
+ project(PhysXSDK C CXX)
+ 
++SET(PHYSX_CXX_FLAGS "${CMAKE_CXX_FLAGS}" CACHE INTERNAL "PhysX Debug CXX Flags")
++
+ OPTION(PX_BUILDSNIPPETS "Generate the snippets" OFF)
+ OPTION(PX_BUILDPUBLICSAMPLES "Generate the samples" OFF)
+ OPTION(PX_CMAKE_SUPPRESS_REGENERATION "Disable zero_check projects" OFF)
+diff --git a/physx/source/compiler/cmake/uwp/CMakeLists.txt b/physx/source/compiler/cmake/uwp/CMakeLists.txt
+index 20dcb6ae..c7e03c3e 100644
+--- a/physx/source/compiler/cmake/uwp/CMakeLists.txt
++++ b/physx/source/compiler/cmake/uwp/CMakeLists.txt
+@@ -39,11 +39,13 @@ ELSE()
+ ENDIF()
+ 
+ # Cache the CXX flags so the other CMakeLists.txt can use them if needed
+-SET(PHYSX_CXX_FLAGS "/Wall /d2Zi+ /MP /WX /W4 /GF /GS- /GR- /Gd ${PHYSX_FP_MODE} ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")
++SET(PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS} ${PHYSX_FP_MODE} ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")
++if(FALSE)
+ SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /Zi" CACHE INTERNAL "PhysX Debug CXX Flags")
+ SET(PHYSX_CXX_FLAGS_CHECKED "/O2 ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Checked CXX Flags")
+ SET(PHYSX_CXX_FLAGS_PROFILE "/O2 ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Profile CXX Flags")
+ SET(PHYSX_CXX_FLAGS_RELEASE "/O2 ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Release CXX Flags")
++endif()
+ 
+ # These flags are local to the directory the CMakeLists.txt is in, so don't get carried over to OTHER CMakeLists.txt (thus the CACHE variables above)
+ SET(CMAKE_CXX_FLAGS ${PHYSX_CXX_FLAGS})
+diff --git a/physx/source/compiler/cmake/windows/CMakeLists.txt b/physx/source/compiler/cmake/windows/CMakeLists.txt
+index a1ab3596..dbd20fb0 100644
+--- a/physx/source/compiler/cmake/windows/CMakeLists.txt
++++ b/physx/source/compiler/cmake/windows/CMakeLists.txt
+@@ -41,17 +41,19 @@ ELSE()
+ 	SET(PHYSX_FP_MODE "/fp:fast")	
+ ENDIF()
+ IF(CMAKE_CL_64)
+-	SET(PHYSX_CXX_FLAGS "/d2Zi+ /MP /WX /W4 /GF /GS- /GR- /Gd ${PHYSX_FP_MODE} /Oy ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")
++	SET(PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS} ${PHYSX_FP_MODE} ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")
+ ELSE()
+-	SET(PHYSX_CXX_FLAGS "/arch:SSE2 /d2Zi+ /MP /WX /W4 /GF /GS- /GR- /Gd ${PHYSX_FP_MODE} /Oy ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")	
++	SET(PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS} /arch:SSE2 ${PHYSX_FP_MODE} ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")
+ ENDIF()
+ 
++if(FALSE)
+ SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /RTCu /Zi" CACHE INTERNAL "PhysX Debug CXX Flags")
+ # PT: changed /Ox to /O2 because "the /Ox compiler option enables only a subset of the speed optimization options enabled by /O2."
+ # See https://docs.microsoft.com/en-us/cpp/build/reference/ox-full-optimization?view=vs-2019
+ SET(PHYSX_CXX_FLAGS_CHECKED "/O2 ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Checked CXX Flags")
+ SET(PHYSX_CXX_FLAGS_PROFILE "/O2 ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Profile CXX Flags")
+ SET(PHYSX_CXX_FLAGS_RELEASE "/O2 ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Release CXX Flags")
++endif()
+ 
+ # cache lib type defs
+ IF(PX_GENERATE_STATIC_LIBRARIES)	
+diff --git a/physx/source/compiler/cmake/linux/CMakeLists.txt b/physx/source/compiler/cmake/linux/CMakeLists.txt
+index 6246e488..7bf0cc30 100644
+--- a/physx/source/compiler/cmake/linux/CMakeLists.txt
++++ b/physx/source/compiler/cmake/linux/CMakeLists.txt
+@@ -36,6 +36,11 @@ IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        SET(PHYSX_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -fno-exceptions -ffunction-sections -fdata-sections -fstrict-aliasing ${CLANG_WARNINGS}" CACHE INTERNAL "PhysX CXX")
+ ELSEIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        SET(PHYSX_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -fno-exceptions -ffunction-sections -fdata-sections -fno-strict-aliasing ${GCC_WARNINGS}" CACHE INTERNAL "PhysX CXX")
++
++       # Enable SSE2 and fix double alignment for 32-bit x86 builds
++       IF (CMAKE_SYSTEM_PROCESSOR MATCHES "i686.*|i386.*|x86.*")
++               STRING(APPEND PHYSX_CXX_FLAGS " -malign-double -msse2")
++       ENDIF()
+ ENDIF()
+ 
+ # Build debug info for all configurations
+

--- a/Scripts/Ports/physx/portfile.cmake
+++ b/Scripts/Ports/physx/portfile.cmake
@@ -1,0 +1,166 @@
+vcpkg_download_distfile(
+    patch1
+    URLS "https://github.com/NVIDIAGameWorks/PhysX/commit/ada4fccf04e5a5832af1353d6d1f91de691aa47d.patch"
+    FILENAME "physx-PR569-ada4fccf.patch"
+    SHA512 ec2fc2fce0b5aab4d42b77f21373bf067f129543e672516477513419241c56b99f2d663b992cb29d296933440e7e7cc31a57198f6fcc78d6eac26b7706c1e937
+)
+
+vcpkg_download_distfile(
+    patch2
+    URLS "https://github.com/NVIDIAGameWorks/PhysX/commit/d590c88e3cbf0fb682726abf7d7c16417855084f.patch"
+    FILENAME "physx-PR569-d590c88e.patch"
+    SHA512 4eb7630db1cb10b2372220c3706dfe255075f466c6b2b12654c9fbc3b17c4df69d7b91e6f0d798c92a4cb8806e1c34b66bb52b46d9358d643ca62ec0de321fd2
+)
+
+vcpkg_download_distfile(
+    patch3
+    URLS "https://github.com/NVIDIAGameWorks/PhysX/commit/cdbfc0f1283829c71b07e332ddd6ce2e5aa7d467.patch"
+    FILENAME "physx-PR569-cdbfc0f.patch"
+    SHA512 2d9d4d30d923b0e006ae1a5c413993325bb4ce5c130fe655242611e87dab945cb220776f112b6cf96b1f06c83a6cec475314a11649bf03304083f5068e282ef2
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIAGameWorks/PhysX
+    REF 93c6dd21b545605185f2febc8eeacebe49a99479
+    SHA512 c9f50255ca9e0f1ebdb9926992315a62b77e2eea3addd4e65217283490714e71e24f2f687717dd8eb155078a1a6b25c9fadc123ce8bc4c5615f7ac66cd6b11aa
+    HEAD_REF master
+    PATCHES
+        fix-compiler-flag.patch
+        "${patch1}"
+        "${patch2}"
+        "${patch3}"
+	win-arm64.patch
+        remove-werror.patch
+)
+
+if(NOT DEFINED RELEASE_CONFIGURATION)
+    set(RELEASE_CONFIGURATION "release")
+endif()
+set(DEBUG_CONFIGURATION "debug")
+
+set(OPTIONS
+    "-DPHYSX_ROOT_DIR=${SOURCE_PATH}/physx"
+    "-DPXSHARED_PATH=${SOURCE_PATH}/pxshared"
+    "-DPXSHARED_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}"
+    "-DCMAKEMODULES_PATH=${SOURCE_PATH}/externals/cmakemodules"
+    "-DCMAKEMODULES_NAME=CMakeModules"
+    "-DCMAKE_MODULES_VERSION=1.27"
+    "-DPX_BUILDSNIPPETS=OFF"
+    "-DPX_BUILDPUBLICSAMPLES=OFF"
+    "-DPX_FLOAT_POINT_PRECISE_MATH=OFF"
+    "-DPX_COPY_EXTERNAL_DLL=OFF"
+    "-DGPU_DLL_COPIED=ON"
+)
+
+set(OPTIONS_RELEASE
+    "-DPX_OUTPUT_BIN_DIR=${CURRENT_PACKAGES_DIR}"
+    "-DPX_OUTPUT_LIB_DIR=${CURRENT_PACKAGES_DIR}"
+)
+set(OPTIONS_DEBUG
+    "-DPX_OUTPUT_BIN_DIR=${CURRENT_PACKAGES_DIR}/debug"
+    "-DPX_OUTPUT_LIB_DIR=${CURRENT_PACKAGES_DIR}/debug"
+    "-DNV_USE_DEBUG_WINCRT=ON"
+)
+
+if(VCPKG_TARGET_IS_UWP)
+    list(APPEND OPTIONS "-DTARGET_BUILD_PLATFORM=uwp")
+    set(configure_options WINDOWS_USE_MSBUILD)
+elseif(VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND OPTIONS "-DTARGET_BUILD_PLATFORM=windows")
+elseif(VCPKG_TARGET_IS_OSX)
+    list(APPEND OPTIONS "-DTARGET_BUILD_PLATFORM=mac")
+elseif(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_FREEBSD)
+    list(APPEND OPTIONS "-DTARGET_BUILD_PLATFORM=linux")
+elseif(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND OPTIONS "-DTARGET_BUILD_PLATFORM=android")
+else()
+    message(FATAL_ERROR "Unhandled or unsupported target platform.")
+endif()
+
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+    list(APPEND OPTIONS "-DNV_FORCE_64BIT_SUFFIX=ON" "-DNV_FORCE_32BIT_SUFFIX=OFF")
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    list(APPEND OPTIONS "-DPX_GENERATE_STATIC_LIBRARIES=OFF")
+else()
+    list(APPEND OPTIONS "-DPX_GENERATE_STATIC_LIBRARIES=ON")
+endif()
+
+if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+    list(APPEND OPTIONS "-DNV_USE_STATIC_WINCRT=OFF")
+else()
+    list(APPEND OPTIONS "-DNV_USE_STATIC_WINCRT=ON")
+endif()
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    list(APPEND OPTIONS "-DPX_OUTPUT_ARCH=arm")
+else()
+    list(APPEND OPTIONS "-DPX_OUTPUT_ARCH=x86")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/physx/compiler/public"
+    ${configure_options}
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS ${OPTIONS}
+    OPTIONS_DEBUG ${OPTIONS_DEBUG}
+    OPTIONS_RELEASE ${OPTIONS_RELEASE}
+)
+vcpkg_cmake_install()
+
+# NVIDIA Gameworks release structure is generally something like <compiler>/<configuration>/[artifact]
+# It would be nice to patch this out, but that directory structure is hardcoded over many cmake files.
+# So, we have this helpful helper to copy the bins and libs out.
+function(fixup_physx_artifacts)
+    macro(_fixup _IN_DIRECTORY _OUT_DIRECTORY)
+        foreach(_SUFFIX IN LISTS _fpa_SUFFIXES)
+            file(GLOB_RECURSE _ARTIFACTS
+                LIST_DIRECTORIES false
+                "${CURRENT_PACKAGES_DIR}/${_IN_DIRECTORY}/*${_SUFFIX}"
+            )
+            if(_ARTIFACTS)
+                file(COPY ${_ARTIFACTS} DESTINATION "${CURRENT_PACKAGES_DIR}/${_OUT_DIRECTORY}")
+            endif()
+        endforeach()
+    endmacro()
+
+    cmake_parse_arguments(_fpa "" "DIRECTORY" "SUFFIXES" ${ARGN})
+    _fixup("bin" ${_fpa_DIRECTORY})
+    _fixup("debug/bin" "debug/${_fpa_DIRECTORY}")
+endfunction()
+
+fixup_physx_artifacts(
+    DIRECTORY "lib"
+    SUFFIXES ${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${VCPKG_TARGET_IMPORT_LIBRARY_SUFFIX}
+)
+fixup_physx_artifacts(
+    DIRECTORY "bin"
+    SUFFIXES ${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX} ".pdb"
+)
+
+# Remove compiler directory and descendents.
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/bin/"
+        "${CURRENT_PACKAGES_DIR}/debug/bin/"
+    )
+else()
+    file(GLOB PHYSX_ARTIFACTS LIST_DIRECTORIES true
+        "${CURRENT_PACKAGES_DIR}/bin/*"
+        "${CURRENT_PACKAGES_DIR}/debug/bin/*"
+    )
+    foreach(_ARTIFACT IN LISTS PHYSX_ARTIFACTS)
+        if(IS_DIRECTORY ${_ARTIFACT})
+            file(REMOVE_RECURSE ${_ARTIFACT})
+        endif()
+    endforeach()
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/source"
+    "${CURRENT_PACKAGES_DIR}/source"
+)
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/Scripts/Ports/physx/remove-werror.patch
+++ b/Scripts/Ports/physx/remove-werror.patch
@@ -1,0 +1,52 @@
+diff --git a/physx/source/compiler/cmake/android/CMakeLists.txt b/physx/source/compiler/cmake/android/CMakeLists.txt
+index 06e0d98..2e5454d 100644
+--- a/physx/source/compiler/cmake/android/CMakeLists.txt
++++ b/physx/source/compiler/cmake/android/CMakeLists.txt
+@@ -52,6 +52,8 @@ SET(PHYSX_CXX_FLAGS_RELEASE "-O3 -g" CACHE INTERNAL "PhysX Release CXX Flags")
+ 
+ 
+ # These flags are local to the directory the CMakeLists.txt is in
++string(REPLACE " -Werror " " " PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS}")
++set(PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS}" CACHE INTERNAL "PhysX CXX")
+ SET(CMAKE_CXX_FLAGS ${PHYSX_CXX_FLAGS})
+ 
+ SET(CMAKE_CXX_FLAGS_DEBUG   ${PHYSX_CXX_FLAGS_DEBUG})
+diff --git a/physx/source/compiler/cmake/ios/CMakeLists.txt b/physx/source/compiler/cmake/ios/CMakeLists.txt
+index 5605e9a..b40500b 100644
+--- a/physx/source/compiler/cmake/ios/CMakeLists.txt
++++ b/physx/source/compiler/cmake/ios/CMakeLists.txt
+@@ -39,6 +39,8 @@ SET(PHYSX_CXX_FLAGS_PROFILE "-O3 -g" CACHE INTERNAL "PhysX Profile CXX Flags")
+ SET(PHYSX_CXX_FLAGS_RELEASE "-O3 -g" CACHE INTERNAL "PhysX Release CXX Flags")
+ 
+ # These flags are local to the directory the CMakeLists.txt is in
++string(REPLACE " -Werror " " " PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS}")
++set(PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS}" CACHE INTERNAL "PhysX CXX")
+ SET(CMAKE_CXX_FLAGS ${PHYSX_CXX_FLAGS})
+ 
+ SET(CMAKE_CXX_FLAGS_DEBUG   ${PHYSX_CXX_FLAGS_DEBUG})
+diff --git a/physx/source/compiler/cmake/linux/CMakeLists.txt b/physx/source/compiler/cmake/linux/CMakeLists.txt
+index aba5336..fd5f813 100644
+--- a/physx/source/compiler/cmake/linux/CMakeLists.txt
++++ b/physx/source/compiler/cmake/linux/CMakeLists.txt
+@@ -45,6 +45,8 @@ SET(PHYSX_CXX_FLAGS_PROFILE "-O3" CACHE INTERNAL "PhysX Profile CXX Flags")
+ SET(PHYSX_CXX_FLAGS_RELEASE "-O3" CACHE INTERNAL "PhysX Release CXX Flags")
+ 
+ # These flags are local to the directory the CMakeLists.txt is in, so don't get carried over to OTHER CMakeLists.txt (thus the CACHE variables above)
++string(REPLACE " -Werror " " " PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS}")
++set(PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS}" CACHE INTERNAL "PhysX CXX")
+ SET(CMAKE_CXX_FLAGS ${PHYSX_CXX_FLAGS})
+ 
+ SET(CMAKE_CXX_FLAGS_DEBUG   ${PHYSX_CXX_FLAGS_DEBUG})
+diff --git a/physx/source/compiler/cmake/mac/CMakeLists.txt b/physx/source/compiler/cmake/mac/CMakeLists.txt
+index bfd1357..cffb090 100644
+--- a/physx/source/compiler/cmake/mac/CMakeLists.txt
++++ b/physx/source/compiler/cmake/mac/CMakeLists.txt
+@@ -49,6 +49,8 @@ SET(PHYSX_CXX_FLAGS_PROFILE "-O3 -g" CACHE INTERNAL "PhysX Profile CXX Flags")
+ SET(PHYSX_CXX_FLAGS_RELEASE "-O3 -g" CACHE INTERNAL "PhysX Release CXX Flags")
+ 
+ # These flags are local to the directory the CMakeLists.txt is in
++string(REPLACE " -Werror " " " PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS}")
++set(PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS}" CACHE INTERNAL "PhysX CXX")
+ SET(CMAKE_CXX_FLAGS ${PHYSX_CXX_FLAGS})
+ 
+ SET(CMAKE_CXX_FLAGS_DEBUG   ${PHYSX_CXX_FLAGS_DEBUG})

--- a/Scripts/Ports/physx/vcpkg.json
+++ b/Scripts/Ports/physx/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "physx",
+  "version": "4.1.2",
+  "port-version": 6,
+  "description": "The NVIDIA PhysX SDK is a scalable multi-platform physics solution supporting a wide range of devices, from smartphones to high-end multicore CPUs and GPUs",
+  "homepage": "https://github.com/NVIDIAGameWorks/PhysX",
+  "license": null,
+  "supports": "!mingw",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/Scripts/Ports/physx/win-arm64.patch
+++ b/Scripts/Ports/physx/win-arm64.patch
@@ -1,0 +1,72 @@
+﻿diff --git a/physx/source/foundation/include/PsVecMath.h b/physx/source/foundation/include/PsVecMath.h
+index 2718de2a..b12a762d 100644
+--- a/physx/source/foundation/include/PsVecMath.h
++++ b/physx/source/foundation/include/PsVecMath.h
+@@ -54,5 +54,7 @@
+ #define COMPILE_VECTOR_INTRINSICS 1
+ #elif PX_UWP && PX_NEON
+ #define COMPILE_VECTOR_INTRINSICS 1
++#elif PX_WINDOWS_FAMILY && PX_NEON
++#define COMPILE_VECTOR_INTRINSICS 1
+ #elif PX_IOS && PX_NEON
+ #define COMPILE_VECTOR_INTRINSICS 1
+diff --git a/physx/source/geomutils/include/GuSIMDHelpers.h b/physx/source/geomutils/include/GuSIMDHelpers.h
+index caa8e5a6..039ba1e4 100644
+--- a/physx/source/geomutils/include/GuSIMDHelpers.h
++++ b/physx/source/geomutils/include/GuSIMDHelpers.h
+@@ -72,7 +72,7 @@ namespace Gu
+ 			const QuatV qV = V4LoadU(&q.x);
+ 			Vec3V column0V, column1V, column2V;
+ 			QuatGetMat33V(qV, column0V, column1V, column2V);
+-#if defined(PX_SIMD_DISABLED) || PX_ANDROID || (PX_LINUX && (PX_ARM || PX_A64)) || (PX_UWP && (PX_ARM || PX_A64)) || (PX_OSX && PX_A64)
++#if defined(PX_SIMD_DISABLED) || PX_ANDROID || (PX_LINUX && (PX_ARM || PX_A64)) || (PX_UWP && (PX_ARM || PX_A64)) || (PX_OSX && PX_A64) || (PX_WINDOWS_FAMILY && (PX_ARM || PX_A64))
+ 			V3StoreU(column0V, column0);
+ 			V3StoreU(column1V, column1);
+ 			V3StoreU(column2V, column2);
+diff --git a/pxshared/include/foundation/PxPreprocessor.h b/pxshared/include/foundation/PxPreprocessor.h
+index 12d6147f..ac1168f4 100644
+--- a/pxshared/include/foundation/PxPreprocessor.h
++++ b/pxshared/include/foundation/PxPreprocessor.h
+@@ -523,7 +523,7 @@ protected:
+ 
+ #ifndef DISABLE_CUDA_PHYSX
+ //CUDA is currently supported only on windows 
+-#define PX_SUPPORT_GPU_PHYSX ((PX_WINDOWS_FAMILY) || (PX_LINUX && PX_X64))
++#define PX_SUPPORT_GPU_PHYSX ((PX_WINDOWS_FAMILY && PX_X64) || (PX_LINUX && PX_X64))
+ #else
+ #define PX_SUPPORT_GPU_PHYSX 0
+ #endif
+diff --git a/physx/source/physxextensions/src/serialization/SnSerialUtils.cpp b/physx/source/physxextensions/src/serialization/SnSerialUtils.cpp
+index 282b9810..29fbbd09 100644
+--- a/physx/source/physxextensions/src/serialization/SnSerialUtils.cpp
++++ b/physx/source/physxextensions/src/serialization/SnSerialUtils.cpp
+@@ -39,7 +39,7 @@ using namespace physx;
+ namespace
+ {
+ 
+-#define SN_NUM_BINARY_PLATFORMS 17
++#define SN_NUM_BINARY_PLATFORMS 18
+ const PxU32 sBinaryPlatformTags[SN_NUM_BINARY_PLATFORMS] =
+ {
+ 	PX_MAKE_FOURCC('W','_','3','2'),
+@@ -79,7 +79,8 @@ const char* sBinaryPlatformNames[SN_NUM_BINARY_PLATFORMS] =
+ 	"linuxaarch64",
+ 	"uwparm",
+ 	"uwparm64",
+-	"macaarch64"
++	"macaarch64",
++    "winARM64"
+ };
+ 
+ }
+@@ -121,7 +122,9 @@ PxU32 getBinaryPlatformTag()
+ #elif PX_UWP && PX_A64
+ 	return sBinaryPlatformTags[15];
+ #elif PX_OSX && PX_A64
+-	return sBinaryPlatformTags[16];
++    return sBinaryPlatformTags[16];
++#elif PX_WINDOWS_FAMILY && PX_A64
++    return sBinaryPlatformTags[17];
+ #else
+ 	#error Unknown binary platform
+ #endif

--- a/Sources/Plasma/FeatureLib/pfCrashHandler/plWindowsStackWalker.cpp
+++ b/Sources/Plasma/FeatureLib/pfCrashHandler/plWindowsStackWalker.cpp
@@ -83,6 +83,10 @@ struct plWindowsStackFrame : plStackFrame
         fFrame.AddrPC.Offset = ctx->Rip;
         fFrame.AddrStack.Offset = ctx->Rsp;
         fFrame.AddrFrame.Offset = ctx->Rbp;
+#elif _M_ARM64
+        fFrame.AddrPC.Offset = ctx->Pc;
+        fFrame.AddrStack.Offset = ctx->Sp;
+        fFrame.AddrFrame.Offset = ctx->Fp;
 #else
         fFrame.AddrPC.Offset = ctx->Eip;
         fFrame.AddrStack.Offset = ctx->Esp;

--- a/cmake/check_cpuid.cpp
+++ b/cmake/check_cpuid.cpp
@@ -1,11 +1,16 @@
 #if defined(_MSC_VER) || ((defined(_WIN32) || defined(_WIN64)) && defined(__INTEL_COMPILER))
 #  include <intrin.h>
+#  define MSC_COMPATIBLE
 #elif defined(__GNUC__)
 #  include <cpuid.h>
 #endif
 
-/* Just needed to look for the headers -- this just makes the compiler happy. */
 int main(int argc, char *argv[])
 {
+#if defined(MSC_COMPATIBLE)
+    // We need to test - Windows ARM64 will have the headers but not the definition
+    unsigned int features[4] = {0, 0, 0, 0};
+    __cpuid(features, 0);
+#endif
     return 0;
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -61,7 +61,8 @@
         "dependencies": [
           {
             "name": "python3-cairosvg",
-            "host": true
+            "host": true,
+            "platform": "!(windows & arm64)"
           }
         ]
       }


### PR DESCRIPTION
This PR has been tested on Visual Studio on top of ARM Windows running in VMWare on a MacBook Pro. Requires Python 3.12 - so this PR is being opened post that merge. _This change only targets ARM64._

Changes were required:
- We have to take ownership of the PhysX port in since we have to patch it for ARM Windows. I've added the patch files necessary.
- I added the correct stack frame offsets for ARM64.
- I fixed the CPUID tests which were not behaving correctly on ARM.

Note that I did not add NEON acceleration - Plasma will currently fall back to software for matrix operations on ARM.

Also the CairoSVG wheel is not hosted already for Python 3.12 - and I had a lot of trouble getting it to compile locally. For now - I've disabled the CairoSVG dependency on ARM. I think later versions of Python have that wheel precompiled so I think that will be fixed in the future.