### PR TITLE
Use prefixes and suffixes for manifest names to indicate platform.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,9 @@ if(PLASMA_EXTERNAL_RELEASE)
     add_definitions(-DPLASMA_EXTERNAL_RELEASE)
 endif(PLASMA_EXTERNAL_RELEASE)
 
+# Should the client use manifest names that differ based on the target platform?
+option(USE_PLATFORM_MANIFESTS "Use client manifest names based on the target platform" ON)
+
 # Pipeline Renderers
 cmake_dependent_option(PLASMA_PIPELINE_DX "Enable DirectX rendering pipeline?" ON "DirectX_FOUND" OFF)
 cmake_dependent_option(PLASMA_PIPELINE_GL "Enable OpenGL rendering pipeline?" ON "TARGET epoxy::epoxy" OFF)

--- a/Sources/Plasma/FeatureLib/pfPatcher/plManifests.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/plManifests.cpp
@@ -41,6 +41,8 @@ Mead, WA   99021
 *==LICENSE==*/
 
 #include "plManifests.h"
+
+#include "hsConfig.h"
 #include "plFileSystem.h"
 
 #include <string_theory/string>
@@ -62,7 +64,9 @@ Mead, WA   99021
 #   define EXECUTABLE_SUFFIX ""
 #endif
 
-#if (defined(__GNUC__) && defined(__x86_64__)) || (defined(_MSC_VER) && defined(_M_X64))
+#if !defined(USE_PLATFORM_MANIFESTS)
+#   define MANIFEST_SUFFIX ""
+#elif (defined(__GNUC__) && defined(__x86_64__)) || (defined(_MSC_VER) && defined(_M_X64))
 #   define MANIFEST_SUFFIX "AMD64"
 #elif (defined(__GNUC__) && defined(__i386__)) || (defined(_MSC_VER) && defined(_M_IX86))
 #   define MANIFEST_SUFFIX ""
@@ -78,7 +82,9 @@ Mead, WA   99021
 #   error "Unknown architecture in plManifest"
 #endif
 
-#if defined(HS_BUILD_FOR_WIN32)
+#if !defined(USE_PLATFORM_MANIFESTS)
+#   define MANIFEST_PREFIX ""
+#elif defined(HS_BUILD_FOR_WIN32)
 #   define MANIFEST_PREFIX ""
 #elif defined(HS_BUILD_FOR_MACOS)
     // "mac" was used by the old Cider wrappers. To prevent silently overwriting these clients,

--- a/Sources/Plasma/FeatureLib/pfPatcher/plManifests.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/plManifests.cpp
@@ -48,8 +48,10 @@ Mead, WA   99021
 // Helper that returns the appropriate string per build
 #ifdef PLASMA_EXTERNAL_RELEASE
 #   define MANIFEST(in, ex) ex
+#   define MANIFEST_RELEASE_TYPE "External"
 #else
 #   define MANIFEST(in, ex) in
+#   define MANIFEST_RELEASE_TYPE "Internal"
 #endif // PLASMA_EXTERNAL_RELEASE
 
 #if defined(HS_BUILD_FOR_APPLE)
@@ -60,41 +62,75 @@ Mead, WA   99021
 #   define EXECUTABLE_SUFFIX ""
 #endif
 
+#if (defined(__GNUC__) && defined(__x86_64__)) || (defined(_MSC_VER) && defined(_M_X64))
+#   define MANIFEST_SUFFIX "AMD64"
+#elif (defined(__GNUC__) && defined(__i386__)) || (defined(_MSC_VER) && defined(_M_IX86))
+#   define MANIFEST_SUFFIX ""
+#elif (defined(__GNUC__) && defined(__arm__)) || (defined(_MSC_VER) && defined(_M_ARM))
+#   define MANIFEST_SUFFIX "ARM"
+#elif (defined(__GNUC__) && defined(__aarch64__)) || (defined(_MSC_VER) && defined(_M_ARM64))
+#   define MANIFEST_SUFFIX "ARM64"
+#elif (defined(__GNUC__) && defined(__powerpc64__))
+#   define MANIFEST_SUFFIX "PPC64"
+#elif (defined(__GNUC__) && defined(__ppc__))
+#   define MANIFEST_SUFFIX "PPC"
+#else
+#   error "Unknown architecture in plManifest"
+#endif
+
+#if defined(HS_BUILD_FOR_WIN32)
+#   define MANIFEST_PREFIX ""
+#elif defined(HS_BUILD_FOR_MACOS)
+    // "mac" was used by the old Cider wrappers. To prevent silently overwriting these clients,
+    // we won't use that as our mac prefix.
+#   define MANIFEST_PREFIX "macos"
+#elif defined(HS_BUILD_FOR_LINUX)
+#   define MANIFEST_PREFIX "linux"
+#else
+#   error "Unknown OS in plManifest"
+#endif
+
 plFileName plManifest::ClientExecutable()
 {
-    return MANIFEST("plClient" EXECUTABLE_SUFFIX, "UruExplorer" EXECUTABLE_SUFFIX);
+    return ST_LITERAL(
+        MANIFEST("plClient", "UruExplorer")
+        EXECUTABLE_SUFFIX
+    );
 }
 
 plFileName plManifest::PatcherExecutable()
 {
+    // On macOS, due to the chaos of .app bundles, the client and
+    // patcher are the same executable at this time.
 #ifdef HS_BUILD_FOR_MACOS
-    return MANIFEST("plClient" EXECUTABLE_SUFFIX, "UruExplorer" EXECUTABLE_SUFFIX);
+    return ClientExecutable();
 #else
-    return MANIFEST("plUruLauncher" EXECUTABLE_SUFFIX, "UruLauncher" EXECUTABLE_SUFFIX);
+    return ST_LITERAL(
+        MANIFEST("plUruLauncher", "UruLauncher")
+        EXECUTABLE_SUFFIX
+    );
 #endif
 }
 
 ST::string plManifest::ClientManifest()
 {
-#ifdef HS_BUILD_FOR_MACOS
-    return MANIFEST("macThinInternal", "macThinExternal");
-#else
-    return MANIFEST("ThinInternal", "ThinExternal");
-#endif
+    return ST_LITERAL(
+        MANIFEST_PREFIX "Thin" MANIFEST_RELEASE_TYPE MANIFEST_SUFFIX
+    );
 }
 
 ST::string plManifest::ClientImageManifest()
 {
-#ifdef HS_BUILD_FOR_MACOS
-    return MANIFEST("macInternal", "macExternal");
-#else
-    return MANIFEST("Internal", "External");
-#endif
+    return ST_LITERAL(
+        MANIFEST_PREFIX MANIFEST_RELEASE_TYPE MANIFEST_SUFFIX
+    );
 }
 
 ST::string plManifest::PatcherManifest()
 {
-    return MANIFEST("InternalPatcher", "ExternalPatcher");
+    return ST_LITERAL(
+        MANIFEST_PREFIX MANIFEST_RELEASE_TYPE "Patcher" MANIFEST_SUFFIX
+    );
 }
 
 std::vector<ST::string> plManifest::EssentialGameManifests()

--- a/cmake/hsConfig.h.cmake
+++ b/cmake/hsConfig.h.cmake
@@ -74,4 +74,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #cmakedefine HAVE_PTHREAD_SETNAME_NP
 #cmakedefine HAVE_STRNLEN
 
+/* User settings */
+#cmakedefine USE_PLATFORM_MANIFESTS
+
 #endif


### PR DESCRIPTION
This formalizes a system of prefixing and suffixing manifest names to indicate the platform. Given that the current examples of production manifests are:

`External` -> external client, windows, 32-bit
`macExternal` -> external client, macOS cider wrapper, 32-bit Intel

The baseline rule is that no prefix means Windows and no suffix means 32-bit intel. Therefore, all other operating systems and architectures must be suffixed. I included PowerPC suffixes for @dpogue whom I know is tinkering with PowerPC macs. Here is what I came up with:

Suffixes:
- ` `: (no suffix) x86
- `AMD64`: AMD64/x86_64
- `ARM`: 32-bit arm (eg NVIDIA Tegra)
- `ARM64`: 64-bit arm (eg Apple Silicon, Snapdragon X)
- `PPC`: 32-bit PowerPC (eg iMac G4)
- `PPC64`: 64-bit PowerPC (eg PowerMac G5)

Prefixes:
- ` `: (no prefix) Windows
- `macos`: macOS (**not** `mac` because this conflicts with the old cider wrapper)
- `linux`: Linux (presumably glibc based)

So, some sample manifests:
- `External64`: x64 Windows external client image manifest
- `linuxThinInternal`: x86 Linux internal client manifest
- `macosInternalPatcherARM64`: Apple Silicon macOS internal release patcher manifest

Currently, we do not build any universal/fat binaries for macOS, therefore nothing has been added for any kind of universal mac binary. I'm somewhat concerned about the UX if/when an architecture gets dropped and a user on that architecture downloads a new fat binary without that architecture. Aside from that, the best way to handle universal binaries, IMO, would be to add a `Universal` or `Fat` suffix (remember, no suffix is already established as 32-bit intel) and detect if the current binary is fat. If so, use the fat binary. If not, use the arch-specific one. This would match the Windows behavior where anyone running a 32-bit client on 64-bit Windows will continue to receive 32-bit clients, even though they can run a 64-bit client. However, as stated previously, we currently do not build universal binaries, so this is currently only a tangential point.

~~This proposal matches what I'm already doing in UruManifest - it assumes that amd64 windows binaries should go into a manifest suffixed with `64`.~~ The proposed mac changes to UruManifest will need adjustments because it wrongly reassigns the meaning of `macExternal` to "64-bit intel". There's also some other oddness in there about a mac bundle manifest that doesn't make any sense. All client files should go into the client manifest.