### PR TITLE
Add missing double click handler for macOS.

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
@@ -194,8 +194,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
     if (event.type == NSEventTypeLeftMouseUp) {
         pBMsg->fButton |= kLeftButtonUp;
+        if (event.clickCount == 2)
+            pBMsg->fButton |= kLeftButtonDblClk;
     } else if (event.type == NSEventTypeRightMouseUp) {
         pBMsg->fButton |= kRightButtonUp;
+        if (event.clickCount == 2)
+            pBMsg->fButton |= kRightButtonDblClk;
     } else if (event.type == NSEventTypeLeftMouseDown) {
         pBMsg->fButton |= kLeftButtonDown;
     } else if (event.type == NSEventTypeRightMouseDown) {


### PR DESCRIPTION
These are needed to select a player in the StartUp Age by double clicking on its entry in the list.