### PR TITLE
Reduce copy-paste in console command implementation code

### DIFF
--- a/Sources/MaxPlugin/MaxMain/GlobalUtility.cpp
+++ b/Sources/MaxPlugin/MaxMain/GlobalUtility.cpp
@@ -94,14 +94,6 @@ public:
 static PlasmaMaxClassDesc PlasmaMaxCD;
 ClassDesc* GetGUPDesc() { return &PlasmaMaxCD; }
 
-//////////////////////////////////////////
-
-// This function is from the console.  This dummy version is here so that plNetLinkingMgr will build.
-plKey FindSceneObjectByName(const ST::string& name, const ST::string& ageName, char* statusStr, bool subString)
-{
-    return nullptr;
-}
-
 
 /*===========================================================================*\
  |  Global Utility interface (start/stop/control)

--- a/Sources/Plasma/FeatureLib/pfConsole/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfConsole/CMakeLists.txt
@@ -2,6 +2,7 @@ set(pfConsole_SOURCES
     pfAudioConsoleCommands.cpp
     pfAvatarConsoleCommands.cpp
     pfConsole.cpp
+    pfConsoleCommandUtilities.cpp
     pfConsoleCommands.cpp
     pfConsoleCommandsNet.cpp
     pfConsoleDirSrc.cpp
@@ -11,6 +12,7 @@ set(pfConsole_SOURCES
 
 set(pfConsole_HEADERS
     pfConsole.h
+    pfConsoleCommandUtilities.h
     pfConsoleCreatable.h
     pfConsoleDirSrc.h
     pfDispatchLog.h

--- a/Sources/Plasma/FeatureLib/pfConsole/pfAudioConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfAudioConsoleCommands.cpp
@@ -45,10 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //                                                                          //
 //////////////////////////////////////////////////////////////////////////////
 
-#ifdef PLASMA_EXTERNAL_RELEASE
-#define LIMIT_CONSOLE_COMMANDS 1
-#endif
-
 #include <string_theory/format>
 #include <string_theory/string>
 
@@ -70,8 +66,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pfAudio/plListener.h"
 #include "pfConsoleCore/pfConsoleCmd.h"
-
-#define PF_SANITY_CHECK( cond, msg ) { if( !( cond ) ) { PrintString( msg ); return; } }
 
 //// DO NOT REMOVE!!!!
 //// This is here so Microsoft VC won't decide to "optimize" this file out

--- a/Sources/Plasma/FeatureLib/pfConsole/pfAudioConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfAudioConsoleCommands.cpp
@@ -55,6 +55,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plgDispatch.h"
 #include "hsResMgr.h"
 
+#include "pfConsoleCommandUtilities.h"
+
 #include "pnKeyedObject/plFixedKey.h"
 #include "pnMessage/plAudioSysMsg.h"
 #include "pnMessage/plSoundMsg.h"
@@ -82,12 +84,6 @@ PF_CONSOLE_FILE_DUMMY(Audio)
 // how to add console commands.
 //
 /////////////////////////////////////////////////////////////////
-
-// External Helpers (see pfConsoleCommands.cpp)
-plKey FindSceneObjectByName(const ST::string& name, const ST::string& ageName, ST::string& statusStr, bool subString=false);
-plKey FindObjectByName(const ST::string& name, int type, const ST::string& ageName, ST::string& statusStr, bool subString=false);
-plKey FindObjectByNameAndType(const ST::string& name, const char* typeName, const ST::string& ageName,
-                              ST::string& statusStr, bool subString=false);
 
 PF_CONSOLE_GROUP(Audio)
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfAvatarConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfAvatarConsoleCommands.cpp
@@ -57,6 +57,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsTimer.h"
 
 #include "pfConsole.h"
+#include "pfConsoleCommandUtilities.h"
 
 #include "pnMessage/plNotifyMsg.h"
 #include "pnNetCommon/plNetApp.h"
@@ -104,19 +105,6 @@ PF_CONSOLE_FILE_DUMMY(Avatar)
 // how to add console commands.
 //
 /////////////////////////////////////////////////////////////////
-
-
-
-/////////////////////////////////////////////////////////////////
-//
-// UTILITIES - LOCAL AND OTHERWISE
-//
-/////////////////////////////////////////////////////////////////
-
-plKey FindSceneObjectByName(const ST::string& name, const ST::string& ageName, ST::string& statusStr, bool subString=false);
-plKey FindObjectByName(const ST::string& name, int type, const ST::string& ageName, ST::string& statusStr, bool subString=false);
-plKey FindObjectByNameAndType(const ST::string& name, const char* typeName, const ST::string& ageName,
-                              ST::string& statusStr, bool subString=false);
 
 PF_CONSOLE_GROUP( Avatar )
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfAvatarConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfAvatarConsoleCommands.cpp
@@ -45,10 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //                                                                          //
 //////////////////////////////////////////////////////////////////////////////
 
-#ifdef PLASMA_EXTERNAL_RELEASE
-#define LIMIT_CONSOLE_COMMANDS 1
-#endif
-
 #include <string_theory/format>
 #include <string_theory/string>
 
@@ -91,8 +87,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pfConsoleCore/pfConsoleCmd.h"
 #include "pfMessage/plArmatureEffectMsg.h"
-
-#define PF_SANITY_CHECK( cond, msg ) { if( !( cond ) ) { PrintString( msg ); return; } }
 
 //// DO NOT REMOVE!!!!
 //// This is here so Microsoft VC won't decide to "optimize" this file out

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandUtilities.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandUtilities.cpp
@@ -1,0 +1,130 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "pfConsoleCommandUtilities.h"
+
+#include <string_theory/string>
+
+#include "pnFactory/plFactory.h"
+#include "pnKeyedObject/plKey.h"
+#include "pnSceneObject/plSceneObject.h"
+
+#include "plAgeLoader/plAgeLoader.h"
+#include "plNetClient/plNetClientMgr.h"
+#include "plResMgr/plKeyFinder.h"
+
+plKey FindObjectByName(const ST::string& name, int type, const ST::string& ageName,
+                       ST::string& statusStr, bool subString)
+{
+    if (name.empty())
+    {
+        statusStr = ST_LITERAL("Object name is nil");
+        return nullptr;
+    }
+    
+    if (type<0 || type>=plFactory::GetNumClasses())
+    {
+        statusStr = ST_LITERAL("Illegal class type val");
+        return nullptr;
+    }
+
+    plKey key;
+    // Try restricted to our age first, if we're not given an age name. This works
+    // around most of the problems associated with unused keys in pages causing the pages to be marked
+    // as not loaded and thus screwing up our searches
+    if (ageName.empty() && plNetClientMgr::GetInstance() != nullptr)
+    {
+        ST::string thisAge = plAgeLoader::GetInstance()->GetCurrAgeDesc().GetAgeName();
+        if (!thisAge.empty())
+        {
+            key = plKeyFinder::Instance().StupidSearch(thisAge, ST::string(), type, name, subString);
+            if (key != nullptr)
+            {
+                statusStr = ST_LITERAL("Found Object");
+                return key;
+            }
+        }
+    }
+    // Fallback
+    key = plKeyFinder::Instance().StupidSearch(ageName, ST::string(), type, name, subString);
+
+    if (!key)
+    {
+        statusStr = ST_LITERAL("Can't find object");
+        return nullptr;
+    }
+    
+    if (!key->ObjectIsLoaded())
+    {
+        statusStr = ST_LITERAL("Object is not loaded");
+    }
+
+    statusStr = ST_LITERAL("Found Object");
+
+    return key;
+}
+
+plKey FindSceneObjectByName(const ST::string& name, const ST::string& ageName,
+                            ST::string& statusStr, bool subString)
+{
+    plKey key=FindObjectByName(name, plSceneObject::Index(), ageName, statusStr, subString);
+
+    if (!plSceneObject::ConvertNoRef(key ? key->ObjectIsLoaded() : nullptr))
+    {
+        statusStr = ST_LITERAL("Can't find SceneObject");
+        return nullptr;
+    }
+
+    return key;
+}
+
+plKey FindObjectByNameAndType(const ST::string& name, const char* typeName, const ST::string& ageName,
+                              ST::string& statusStr, bool subString)
+{
+    if (!typeName)
+    {
+        statusStr = ST_LITERAL("TypeName is nil");
+        return nullptr;
+    }
+    
+    return FindObjectByName(name, plFactory::FindClassIndex(typeName), ageName, statusStr, subString);
+}

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandUtilities.h
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandUtilities.h
@@ -1,0 +1,66 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef _pfConsoleCommandUtilities_h
+#define _pfConsoleCommandUtilities_h
+
+// Utility functions shared across multiple console commands.
+
+#include "HeadSpin.h"
+
+class plKey;
+
+// Find an object from name, type (int), and optionally age.
+// Name can be an alias specified by saying $foo.
+plKey FindSceneObjectByName(const ST::string& name, const ST::string& ageName, ST::string& statusStr, bool subString=false);
+
+// Find a SCENEOBJECT from name, and optionally age.
+// Name can be an alias specified by saying $foo.
+// Will load the object if necessary.
+plKey FindObjectByName(const ST::string& name, int type, const ST::string& ageName, ST::string& statusStr, bool subString=false);
+
+// Find an object from name, type (string) and optionally age.
+// Name can be an alias specified by saying $foo.
+plKey FindObjectByNameAndType(const ST::string& name, const char* typeName, const ST::string& ageName,
+                              ST::string& statusStr, bool subString=false);
+
+#endif // _pfConsoleCommandUtilities_h

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandUtilities.h
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandUtilities.h
@@ -49,6 +49,23 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plKey;
 
+// If LIMIT_CONSOLE_COMMANDS is defined, only console commands needed during
+// normal gameplay will be built. This includes commands called by:
+// * age .fni scripts
+// * user .ini settings
+// * assorted engine code (via plConsoleMsg)
+// * key bindings (via Keyboard.BindConsoleCmd and plControlEventMsg::SetCmdString)
+// * GUI controls (via pfGUIConsoleCmdProc)
+// * Python scripts (via PtConsole/PtConsoleNet)
+// Most developer-oriented commands will be compiled out if this macro is defined.
+#ifdef PLASMA_EXTERNAL_RELEASE
+#define LIMIT_CONSOLE_COMMANDS 1
+#endif
+
+// Ensure that the given condition is true.
+// If it isn't, print the given message to the console and return from the command.
+#define PF_SANITY_CHECK( cond, msg ) { if( !( cond ) ) { PrintString( msg ); return; } }
+
 // Find an object from name, type (int), and optionally age.
 // Name can be an alias specified by saying $foo.
 plKey FindSceneObjectByName(const ST::string& name, const ST::string& ageName, ST::string& statusStr, bool subString=false);

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -218,7 +218,7 @@ PF_CONSOLE_FILE_DUMMY(Main)
 //        name isn't obvious (i.e. SetFogColor doesn't really need one)
 //  
 //  The actual C code prototype looks like:
-//      void pfConsoleCmd_groupName_functionName(int32_t numParams, pfConsoleCmdParam *params, void (*PrintString)(const ST::string&));
+//      void pfConsoleCmd_groupName_functionName(int32_t numParams, pfConsoleCmdParam* params, pfConsolePrintFunc PrintString);
 //
 //  numParams is exactly what it sounds like. params is an array of console
 //  parameter objects, each of which are rather nifty in that they can be cast
@@ -2498,7 +2498,7 @@ class pfConsoleActiveRefPeeker
 };
 
 // Not static so others can call it - making it even handier
-void MyHandyPrintFunction(const plKey &obj, void (*PrintString)(const ST::string&))
+void MyHandyPrintFunction(const plKey& obj, pfConsolePrintFunc PrintString)
 {
     if (obj->GetUoid().IsClone())
         PrintString(ST::format("{} refs on {}, clone {}:{}: loaded={}",
@@ -3982,12 +3982,10 @@ namespace plWaveCmd {
     };
 };
 
-typedef void PrintFunk(const ST::string& str);
-
 static constexpr float FracToPercent(float f) { return 100.f * f; }
 static constexpr float PercentToFrac(float f) { return f / 100.f; }
 
-static void IDisplayWaveVal(PrintFunk PrintString, plWaveSet7* wave, plWaveCmd::Cmd cmd)
+static void IDisplayWaveVal(pfConsolePrintFunc PrintString, plWaveSet7* wave, plWaveCmd::Cmd cmd)
 {
     if( !wave )
         return;
@@ -4112,7 +4110,7 @@ static void IDisplayWaveVal(PrintFunk PrintString, plWaveSet7* wave, plWaveCmd::
     PrintString(msg);
 }
 
-static plWaveSet7* IGetWaveSet(PrintFunk PrintString, const ST::string& name)
+static plWaveSet7* IGetWaveSet(pfConsolePrintFunc PrintString, const ST::string& name)
 {
     ST::string status;
     plKey waveKey = FindObjectByName(name, plWaveSet7::Index(), {}, status, false);
@@ -4128,7 +4126,7 @@ static plWaveSet7* IGetWaveSet(PrintFunk PrintString, const ST::string& name)
     return waveSet;
 }
 
-static plWaveSet7* ICheckWaveParams(PrintFunk PrintString, const ST::string& name, int numParams, int n, plWaveCmd::Cmd cmd)
+static plWaveSet7* ICheckWaveParams(pfConsolePrintFunc PrintString, const ST::string& name, int numParams, int n, plWaveCmd::Cmd cmd)
 {
     if( !numParams )
     {
@@ -4144,7 +4142,7 @@ static plWaveSet7* ICheckWaveParams(PrintFunk PrintString, const ST::string& nam
     return waveSet;
 }
 
-static bool ISendWaveCmd1f(PrintFunk PrintString, pfConsoleCmdParam* params, int numParams, plWaveCmd::Cmd cmd)
+static bool ISendWaveCmd1f(pfConsolePrintFunc PrintString, pfConsoleCmdParam* params, int numParams, plWaveCmd::Cmd cmd)
 {
     plWaveSet7* wave = ICheckWaveParams(PrintString, params[0], numParams, 2, cmd);
     if( !wave )
@@ -4223,7 +4221,7 @@ static bool ISendWaveCmd1f(PrintFunk PrintString, pfConsoleCmdParam* params, int
     return true;
 }
 
-static bool ISendWaveCmd2f(PrintFunk PrintString, pfConsoleCmdParam* params, int numParams, plWaveCmd::Cmd cmd)
+static bool ISendWaveCmd2f(pfConsolePrintFunc PrintString, pfConsoleCmdParam* params, int numParams, plWaveCmd::Cmd cmd)
 {
     plWaveSet7* wave = ICheckWaveParams(PrintString, params[0], numParams, 3, cmd);
     if( !wave )
@@ -4265,7 +4263,7 @@ static bool ISendWaveCmd2f(PrintFunk PrintString, pfConsoleCmdParam* params, int
     return true;
 }
 
-static bool ISendWaveCmd3f(PrintFunk PrintString, pfConsoleCmdParam* params, int numParams, plWaveCmd::Cmd cmd)
+static bool ISendWaveCmd3f(pfConsolePrintFunc PrintString, pfConsoleCmdParam* params, int numParams, plWaveCmd::Cmd cmd)
 {
     plWaveSet7* wave = ICheckWaveParams(PrintString, params[0], numParams, 4, cmd);
     if( !wave )
@@ -4303,7 +4301,7 @@ static bool ISendWaveCmd3f(PrintFunk PrintString, pfConsoleCmdParam* params, int
     return true;
 }
 
-static bool ISendWaveCmd4c(PrintFunk PrintString, pfConsoleCmdParam* params, int numParams, plWaveCmd::Cmd cmd)
+static bool ISendWaveCmd4c(pfConsolePrintFunc PrintString, pfConsoleCmdParam* params, int numParams, plWaveCmd::Cmd cmd)
 {
     plWaveSet7* wave = ICheckWaveParams(PrintString, params[0], numParams, 4, cmd);
     if( !wave )
@@ -5264,7 +5262,7 @@ PF_CONSOLE_CMD( Age, SetSDLBool, "string varName, bool value, int index", "Set t
 
 PF_CONSOLE_GROUP( ParticleSystem ) // Defines a main command group
 
-void UpdateParticleParam(const ST::string &objName, int32_t paramID, float value, void (*PrintString)(const ST::string&))
+void UpdateParticleParam(const ST::string& objName, int32_t paramID, float value, pfConsolePrintFunc PrintString)
 {
     ST::string status;
     plKey key = FindSceneObjectByName(objName, {}, status);

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -45,10 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //                                                                          //
 //////////////////////////////////////////////////////////////////////////////
 
-#ifdef PLASMA_EXTERNAL_RELEASE
-#define LIMIT_CONSOLE_COMMANDS 1
-#endif
-
 #include <string_theory/format>
 #include <string_theory/stdio>
 
@@ -181,8 +177,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 // FIXME
 #include "../../Apps/plClient/plClient.h"
-
-#define PF_SANITY_CHECK( cond, msg ) { if( !( cond ) ) { PrintString( msg ); return; } }
 
 //// DO NOT REMOVE!!!!
 //// This is here so Microsoft VC won't decide to "optimize" this file out

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -63,6 +63,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsTimer.h"
 
 #include "pfConsole.h"
+#include "pfConsoleCommandUtilities.h"
 #include "pfDispatchLog.h"
 
 #include "pnFactory/plFactory.h"
@@ -270,101 +271,6 @@ PF_CONSOLE_FILE_DUMMY(Main)
 //  the 
 //
 //////////////////////////////////////////////////////////////////////////////
-
-//
-// utility functions
-//
-//////////////////////////////////////////////////////////////////////////////
-
-//
-// Find an object from name, type (int), and optionally age.
-// Name can be an alias specified by saying $foo
-//
-plKey FindObjectByName(const ST::string& name, int type, const ST::string& ageName,
-                       ST::string& statusStr, bool subString = false)
-{
-    if (name.empty())
-    {
-        statusStr = ST_LITERAL("Object name is nil");
-        return nullptr;
-    }
-    
-    if (type<0 || type>=plFactory::GetNumClasses())
-    {
-        statusStr = ST_LITERAL("Illegal class type val");
-        return nullptr;
-    }
-
-    plKey key;
-    // Try restricted to our age first, if we're not given an age name. This works
-    // around most of the problems associated with unused keys in pages causing the pages to be marked
-    // as not loaded and thus screwing up our searches
-    if (ageName.empty() && plNetClientMgr::GetInstance() != nullptr)
-    {
-        ST::string thisAge = plAgeLoader::GetInstance()->GetCurrAgeDesc().GetAgeName();
-        if (!thisAge.empty())
-        {
-            key = plKeyFinder::Instance().StupidSearch(thisAge, ST::string(), type, name, subString);
-            if (key != nullptr)
-            {
-                statusStr = ST_LITERAL("Found Object");
-                return key;
-            }
-        }
-    }
-    // Fallback
-    key = plKeyFinder::Instance().StupidSearch(ageName, ST::string(), type, name, subString);
-
-    if (!key)
-    {
-        statusStr = ST_LITERAL("Can't find object");
-        return nullptr;
-    }
-    
-    if (!key->ObjectIsLoaded())
-    {
-        statusStr = ST_LITERAL("Object is not loaded");
-    }
-
-    statusStr = ST_LITERAL("Found Object");
-
-    return key;
-}
-
-//
-// Find a SCENEOBJECT from name, and optionally age.
-// Name can be an alias specified by saying $foo.
-// Will load the object if necessary.
-//
-plKey FindSceneObjectByName(const ST::string& name, const ST::string& ageName,
-                            ST::string& statusStr, bool subString = false)
-{
-    plKey key=FindObjectByName(name, plSceneObject::Index(), ageName, statusStr, subString);
-
-    if (!plSceneObject::ConvertNoRef(key ? key->ObjectIsLoaded() : nullptr))
-    {
-        statusStr = ST_LITERAL("Can't find SceneObject");
-        return nullptr;
-    }
-
-    return key;
-}
-
-//
-// Find an object from name, type (string) and optionally age.
-// Name can be an alias specified by saying $foo
-//
-plKey FindObjectByNameAndType(const ST::string& name, const char* typeName, const ST::string& ageName,
-                              ST::string& statusStr, bool subString = false)
-{
-    if (!typeName)
-    {
-        statusStr = ST_LITERAL("TypeName is nil");
-        return nullptr;
-    }
-    
-    return FindObjectByName(name, plFactory::FindClassIndex(typeName), ageName, statusStr, subString);
-}
 
 //////////////////////////////////////////////////////////////////////////////
 //// Base Commands ///////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
@@ -128,7 +128,7 @@ PF_CONSOLE_FILE_DUMMY(Net)
 //        name isn't obvious (i.e. SetFogColor doesn't really need one)
 //  
 //  The actual C code prototype looks like:
-//      void pfConsoleCmd_groupName_functionName(int32_t numParams, pfConsoleCmdParam *params, void (*PrintString)(const ST::string&));
+//      void pfConsoleCmd_groupName_functionName(int32_t numParams, pfConsoleCmdParam* params, pfConsolePrintFunc PrintString);
 //
 //  numParams is exactly what it sounds like. params is an array of console
 //  parameter objects, each of which are rather nifty in that they can be cast

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
@@ -188,7 +188,7 @@ PF_CONSOLE_FILE_DUMMY(Net)
 plKey FindSceneObjectByName(const ST::string& name, const ST::string& ageName, ST::string& statusStr, bool subString=false);
 plKey FindObjectByName(const ST::string& name, int type, const ST::string& ageName, ST::string& statusStr, bool subString=false);
 plKey FindObjectByNameAndType(const ST::string& name, const char* typeName, const ST::string& ageName,
-                              ST::string statusStr, bool subString=false);
+                              ST::string& statusStr, bool subString=false);
 
 //////////////////////////////////////////////////////////////////////////////
 //// Network Group Commands //////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
@@ -45,10 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //                                                                          //
 //////////////////////////////////////////////////////////////////////////////
 
-#ifdef PLASMA_EXTERNAL_RELEASE
-#define LIMIT_CONSOLE_COMMANDS 1
-#endif
-
 #include <string_theory/format>
 
 #include "plgDispatch.h"
@@ -91,8 +87,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 // FIXME FIXME
 #include "../../Apps/plClient/plClient.h"
-
-#define PF_SANITY_CHECK( cond, msg ) { if( !( cond ) ) { PrintString( msg ); return; } }
 
 //// DO NOT REMOVE!!!!
 //// This is here so Microsoft VC won't decide to "optimize" this file out

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
@@ -93,88 +93,12 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 PF_CONSOLE_FILE_DUMMY(Net)
 //// DO NOT REMOVE!!!!
 
-//// Defining Console Commands ///////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
 //
-//  You define console commands by using the PF_CONSOLE_CMD macro. The format
-//  of the macro is:
+// Please see pfConsoleCommands.cpp for detailed instructions on
+// how to add console commands.
 //
-//      PF_CONSOLE_CMD( groupName, functionName, "paramList", "Help string" )
-//
-//  Where:
-//      - groupName is a string representing what command group the command
-//        is in. Subgroups are specified by an underscore, i.e. to put a command
-//        in the Draw subgroup of the Graphics group, you would specify
-//        "Graphics_Draw". Specifying "" means to put the command in the base
-//        command group--i.e. it has no group.
-//      - functionName is required; it specifies the function name (really?!?!).
-//        Function names must be globally unique, so you can't have a Draw
-//        function in both the Graphics and SceneAPI groups. Sorry. :(
-//      - paramList specifies the parameters and types to the function.
-//        The smallest list you can have is "", which means "no parameters".
-//        If you have parameters, it must be in a comma-delimited string.
-//        You can either specify types or labels and types, so you can say
-//        "int, float" or "int x, float value". Currently, the labels are only
-//        used when printing out usage strings, but they will be used later
-//        for auto-labeling GUI elements, so please put them in where viable.
-//
-//        White space does not matter. Valid types are int, float, char, string
-//        bool (auto-conversion of "true"/"false" strings to 1 or 0) and "...".
-//        "..." is a special type that means the same as the C equivalent:
-//        "there can be zero or more parameters here and I don't care what the
-//        type is" is the gist of it.
-//      - helpString is a short description of the function, which currently
-//        isn't used, but will be used in the future when implementing help
-//        (could you have guessed it? :) Please fill it in when the function
-//        name isn't obvious (i.e. SetFogColor doesn't really need one)
-//  
-//  The actual C code prototype looks like:
-//      void pfConsoleCmd_groupName_functionName(int32_t numParams, pfConsoleCmdParam* params, pfConsolePrintFunc PrintString);
-//
-//  numParams is exactly what it sounds like. params is an array of console
-//  parameter objects, each of which are rather nifty in that they can be cast
-//  immediately to whatever type you asked for in your parameter list
-//  ("paramList" above). So if your paramList was "int", then params[ 0 ]
-//  can be cast to an int immediately, such as int x = params[ 0 ];
-//  If you attempt to cast a parameter to a type other than the one specified
-//  in the paramList, you get an hsAssert saying so, so don't do it! Any
-//  parameters that fall under "..." are automagically strings, but they can
-//  be cast to any valid type without an assert. So basically, if you want
-//  to still do your own conversion, just specify "..." as the entire paramList
-//  and treat the params array as if it were an array of strings.
-//
-//  Thus, the net result of the paramList is that it lets the console engine
-//  do the parameter parsing for you. If the paramters given to the function
-//  do not match the list (this includes too many or too few parameters), a
-//  usage string is printed out and the function is not called. Thus, the
-//  ONLY parameter error you can possibly have is casting a parameter object
-//  to a type other than you asked for. So don't do it!
-//
-//  (Note: this makes numParams almost obsolete; the only reason it still has
-//  a use is for "...", which of course allows variable number of parameters.)
-//
-//  PrintString is a function that lets you print output to the on-screen
-//  console. It is guaranteed to be non-null. Worst case is that it points
-//  to a dummy function that does nothing, but it will *always* be valid.
-//
-//  To define console command groups, you use the macro:
-//
-//      PF_CONSOLE_GROUP( group )
-//
-//  where "group" is the name without quotes of the group you want to create.
-//  To create a subgroup inside a group, use:
-//
-//      PF_CONSOLE_SUBGROUP( parent, group )
-//
-//  where "parent" is the parent group for the subgroup. "parent" can have
-//  underscores in it just like the group of a CONSOLE_CMD, so you can say
-//
-//      PF_CONSOLE_SUBGROUP( Graphics_Render, Drawing )
-//
-//  to create the Graphics_Render_Drawing subgroup. All groups must be
-//  defined before any commands that are in that group. Note that although
-//  the 
-//
-//////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
 //// Network Group Commands //////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
@@ -57,6 +57,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsTimer.h"
 
 #include "pfConsole.h"
+#include "pfConsoleCommandUtilities.h"
 
 #include "pnKeyedObject/plFixedKey.h"
 #include "pnKeyedObject/plKey.h"
@@ -180,15 +181,6 @@ PF_CONSOLE_FILE_DUMMY(Net)
 //  the 
 //
 //////////////////////////////////////////////////////////////////////////////
-
-//
-// utility functions
-//
-//////////////////////////////////////////////////////////////////////////////
-plKey FindSceneObjectByName(const ST::string& name, const ST::string& ageName, ST::string& statusStr, bool subString=false);
-plKey FindObjectByName(const ST::string& name, int type, const ST::string& ageName, ST::string& statusStr, bool subString=false);
-plKey FindObjectByNameAndType(const ST::string& name, const char* typeName, const ST::string& ageName,
-                              ST::string& statusStr, bool subString=false);
 
 //////////////////////////////////////////////////////////////////////////////
 //// Network Group Commands //////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfConsole/pfGameConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfGameConsoleCommands.cpp
@@ -64,14 +64,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //                                                                          //
 //////////////////////////////////////////////////////////////////////////////
 
-#ifdef PLASMA_EXTERNAL_RELEASE
-#define LIMIT_CONSOLE_COMMANDS 1
-#endif
-
 #include "plgDispatch.h"
 #include "plPipeline.h"
 
 #include "pfConsole.h"
+#include "pfConsoleCommandUtilities.h"
 
 #include "pnKeyedObject/plFixedKey.h"
 
@@ -86,8 +83,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfConsoleCore/pfConsoleCmd.h"
 #include "pfMessage/pfGameGUIMsg.h"
 #include "pfMessage/pfKIMsg.h"
-
-#define PF_SANITY_CHECK( cond, msg ) { if( !( cond ) ) { PrintString( msg ); return; } }
 
 //// DO NOT REMOVE!!!!
 //// This is here so Microsoft VC won't decide to "optimize" this file out

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.cpp
@@ -429,7 +429,7 @@ void    pfConsoleCmd::Unregister()
 //// Execute /////////////////////////////////////////////////////////////////
 //  Run da thing!
 
-void pfConsoleCmd::Execute(int32_t numParams, pfConsoleCmdParam *params, void (*PrintFn)(const ST::string&))
+void pfConsoleCmd::Execute(int32_t numParams, pfConsoleCmdParam* params, pfConsolePrintFunc PrintFn)
 {
     fFunction( numParams, params, PrintFn );
 }

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleCmd.h
@@ -213,7 +213,8 @@ class pfConsoleCmdParam
 
 //// pfConsoleCmd Class Definition ///////////////////////////////////////////
 
-typedef void (*pfConsoleCmdPtr)(int32_t numParams, pfConsoleCmdParam *params, void (*PrintString)(const ST::string&));
+using pfConsolePrintFunc = void (*)(const ST::string& str);
+using pfConsoleCmdPtr = void (*)(int32_t numParams, pfConsoleCmdParam *params, pfConsolePrintFunc PrintString);
 
 class pfConsoleCmd
 {
@@ -256,7 +257,7 @@ class pfConsoleCmd
 
         void Register(const ST::string& group);
         void    Unregister();
-        void    Execute(int32_t numParams, pfConsoleCmdParam *params, void (*PrintFn)(const ST::string&) = nullptr);
+        void    Execute(int32_t numParams, pfConsoleCmdParam *params, pfConsolePrintFunc PrintFn = nullptr);
 
         void    Link( pfConsoleCmd **prevPtr );
         void    Unlink();
@@ -295,14 +296,14 @@ public:
 
 
 #define PF_CONSOLE_BASE_CMD( name, p, help ) \
-    void pfConsoleCmd_##name##_proc(int32_t numParams, pfConsoleCmdParam *params, void (*PrintString)(const ST::string&)); \
+    void pfConsoleCmd_##name##_proc(int32_t numParams, pfConsoleCmdParam* params, pfConsolePrintFunc PrintString); \
     pfConsoleCmd conCmd_##name({}, ST_LITERAL(#name), ST_LITERAL(p), ST_LITERAL(help), pfConsoleCmd_##name##_proc); \
-    void pfConsoleCmd_##name##_proc(int32_t numParams, pfConsoleCmdParam *params, void (*PrintString)(const ST::string&))
+    void pfConsoleCmd_##name##_proc(int32_t numParams, pfConsoleCmdParam* params, pfConsolePrintFunc PrintString)
 
 #define PF_CONSOLE_CMD( grp, name, p, help ) \
-    void pfConsoleCmd_##grp##_##name##_proc(int32_t numParams, pfConsoleCmdParam *params, void (*PrintString)(const ST::string&)); \
+    void pfConsoleCmd_##grp##_##name##_proc(int32_t numParams, pfConsoleCmdParam* params, pfConsolePrintFunc PrintString); \
     pfConsoleCmd conCmd_##grp##_##name(ST_LITERAL(#grp), ST_LITERAL(#name), ST_LITERAL(p), ST_LITERAL(help), pfConsoleCmd_##grp##_##name##_proc); \
-    void pfConsoleCmd_##grp##_##name##_proc(int32_t numParams, pfConsoleCmdParam *params, void (*PrintString)(const ST::string&))
+    void pfConsoleCmd_##grp##_##name##_proc(int32_t numParams, pfConsoleCmdParam* params, pfConsolePrintFunc PrintString)
 
 //// pfConsoleCmdGroup Creation Macro ////////////////////////////////////////
 

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.cpp
@@ -69,7 +69,7 @@ pfConsoleEngine::~pfConsoleEngine()
 
 //// PrintCmdHelp ////////////////////////////////////////////////////////////
 
-bool pfConsoleEngine::PrintCmdHelp(const ST::string& name, void (*PrintFn)(const ST::string&))
+bool pfConsoleEngine::PrintCmdHelp(const ST::string& name, pfConsolePrintFunc PrintFn)
 {
     pfConsoleParser parser(name);
     auto [group, token] = parser.ParseGroupAndName();
@@ -171,7 +171,7 @@ bool pfConsoleEngine::ExecuteFile(const plFileName &fileName)
 //  requires tokenizing the entire line and searching the tokens one by one,
 //  parsing them first as groups, then commands and then params.
 
-bool pfConsoleEngine::RunCommand(const ST::string& line, void (*PrintFn)(const ST::string&))
+bool pfConsoleEngine::RunCommand(const ST::string& line, pfConsolePrintFunc PrintFn)
 {
     pfConsoleParser parser(line);
     pfConsoleCmd* cmd = parser.ParseCommand();

--- a/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
+++ b/Sources/Plasma/FeatureLib/pfConsoleCore/pfConsoleEngine.h
@@ -68,6 +68,8 @@ class plFileName;
 class pfConsoleCmd;
 class pfConsoleCmdParam;
 class pfConsoleCmdGroup;
+using pfConsolePrintFunc = void (*)(const ST::string& str);
+
 class pfConsoleEngine
 {
     private:
@@ -86,10 +88,10 @@ class pfConsoleEngine
         ST::string GetCmdSignature(const ST::string& name);
 
         // Prints out the help for a given command (or group)
-        bool PrintCmdHelp(const ST::string& name, void (*PrintFn)(const ST::string&));
+        bool PrintCmdHelp(const ST::string& name, pfConsolePrintFunc PrintFn);
 
         // Breaks the given line into a command and parameters and runs the command
-        bool RunCommand(const ST::string& line, void (*PrintFn)(const ST::string&));
+        bool RunCommand(const ST::string& line, pfConsolePrintFunc PrintFn);
 
         // Executes the given file as a sequence of console commands
         bool    ExecuteFile( const plFileName &fileName );


### PR DESCRIPTION
A few declarations and macros were copy-pasted into each console command implementation file. This PR pulls them out into a proper shared header.

Also finally adds a named type for the `PrintFunc`s that get passed all around the console code.