### PR TITLE
Make macOS intro video handling more consistent with Windows.

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSKeyboardEventMonitor.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSKeyboardEventMonitor.mm
@@ -105,15 +105,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
         switch (event.type) {
             case NSEventTypeKeyDown:
             case NSEventTypeKeyUp:
-            case NSEventTypeFlagsChanged: {
-                if (self.gClient->GetQuitIntro() == false) {
-                    self.gClient->SetQuitIntro(true);
-                    return true;
-                } else {
-                    return [self processKeyEvent:event];
-                }
-                break;
-            }
+            case NSEventTypeFlagsChanged:
+                self.gClient->SetQuitIntro(true);
+                return [self processKeyEvent:event];
             default:
                 NSLog(@"Unexpected unhandled event type %@", event);
                 return NO;

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.h
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.h
@@ -41,7 +41,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #import <Cocoa/Cocoa.h>
-#include "plInputCore/plInputManager.h"
+
+class plClientLoader;
+class plInputManager;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -49,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PLSView : NSView
 
+@property plClientLoader* _gClient;
 @property plInputManager* inputManager;
 @property(weak) id<PLSViewDelegate> delegate;
 

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.h
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.h
@@ -51,7 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PLSView : NSView
 
-@property plClientLoader* _gClient;
+- (id)initWithFrame:(NSRect)frameRect NS_UNAVAILABLE;
+- (instancetype)initWithFrame:(NSRect)frameRect client:(plClientLoader*)gClient;
+- (plClientLoader&)gClient;
 @property plInputManager* inputManager;
 @property(weak) id<PLSViewDelegate> delegate;
 

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
@@ -41,9 +41,15 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #import "PLSView.h"
+
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h>
+
+#include "plInputCore/plInputManager.h"
 #include "plMessage/plInputEventMsg.h"
+
+#include "plClient/plClient.h"
+#include "plClient/plClientLoader.h"
 
 /*
  Plasma view for Cocoa
@@ -70,6 +76,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 @end
 
 @implementation PLSView
+
+- (plClientLoader&)gClient
+{
+    return *self._gClient;
+}
 
 // MARK: View setup
 - (id)initWithFrame:(NSRect)frameRect
@@ -194,15 +205,25 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
     if (event.type == NSEventTypeLeftMouseUp) {
         pBMsg->fButton |= kLeftButtonUp;
-        if (event.clickCount == 2)
+        if (event.clickCount == 2) {
+            if (self.gClient)
+                self.gClient->SetQuitIntro(true);
             pBMsg->fButton |= kLeftButtonDblClk;
+        }
     } else if (event.type == NSEventTypeRightMouseUp) {
         pBMsg->fButton |= kRightButtonUp;
-        if (event.clickCount == 2)
+        if (event.clickCount == 2) {
+            if (self.gClient)
+                self.gClient->SetQuitIntro(true);
             pBMsg->fButton |= kRightButtonDblClk;
+        }
     } else if (event.type == NSEventTypeLeftMouseDown) {
+        if (self.gClient)
+            self.gClient->SetQuitIntro(true);
         pBMsg->fButton |= kLeftButtonDown;
     } else if (event.type == NSEventTypeRightMouseDown) {
+        if (self.gClient)
+            self.gClient->SetQuitIntro(true);
         pBMsg->fButton |= kRightButtonDown;
     }
 

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSView.mm
@@ -67,6 +67,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
  */
 
 @interface PLSView ()
+{
+    plClientLoader* _gClient;
+}
 
 @property NSTrackingArea* mouseTrackingArea;
 #if PLASMA_PIPELINE_METAL
@@ -79,11 +82,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 - (plClientLoader&)gClient
 {
-    return *self._gClient;
+    return *_gClient;
 }
 
 // MARK: View setup
-- (id)initWithFrame:(NSRect)frameRect
+- (instancetype)initWithFrame:(NSRect)frameRect client:(plClientLoader*)gClient
 {
     self = [super initWithFrame:frameRect];
 #if PLASMA_PIPELINE_METAL
@@ -94,6 +97,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
     self.layer = self.metalLayer = layer;
 #endif
     self.layer.backgroundColor = NSColor.blackColor.CGColor;
+    _gClient = gClient;
     return self;
 }
 

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -320,6 +320,7 @@ static void* const DeviceDidChangeContext = (void*)&DeviceDidChangeContext;
     window.backgroundColor = NSColor.blackColor;
 
     PLSView* view = [[PLSView alloc] init];
+    view._gClient = &gClient;
     self.plsView = view;
     window.contentView = view;
     self.gameWindow = window;

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -319,8 +319,7 @@ static void* const DeviceDidChangeContext = (void*)&DeviceDidChangeContext;
                                                        defer:NO];
     window.backgroundColor = NSColor.blackColor;
 
-    PLSView* view = [[PLSView alloc] init];
-    view._gClient = &gClient;
+    PLSView* view = [[PLSView alloc] initWithFrame:windowRect client:&gClient];
     self.plsView = view;
     window.contentView = view;
     self.gameWindow = window;


### PR DESCRIPTION
Fixes two issues with the intro video handling on macOS:
- Mouse downs and mouse double clicks should cause the intro videos to terminate.
- On Windows, input events are always passed through to the engine, even if they cause an intro video to terminate.