### PR TITLE
Various compiler warning fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,17 @@ if(POLICY CMP0127)
     cmake_policy(SET CMP0127 OLD)
 endif()
 
-
 # When cross-compiling, we want CMake to find the host system's Python interpreter
 if(POLICY CMP0190)
     cmake_policy(SET CMP0190 NEW)
+endif()
+
+# Deduplicate libraries on linker commands
+if(POLICY CMP0156)
+    cmake_policy(SET CMP0156 NEW)
+    if(POLICY CMP0179)
+        cmake_policy(SET CMP0179 NEW)
+    endif()
 endif()
 
 include(CheckLanguage)

--- a/Sources/Plasma/CoreLib/hsBounds.cpp
+++ b/Sources/Plasma/CoreLib/hsBounds.cpp
@@ -2203,7 +2203,7 @@ bool hsBounds3Ext::ISectBoxBS(const hsBounds3Ext &other, const hsVector3 &myVel,
     hsAssert(fBounds3Flags & kCenterValid, "Sphere set but not center (BoxBS(vel))");
 
     hsVector3 minAxis;
-    float minDepth;
+    float minDepth = -1.f;
     bool haveAxis = false;
     hsVector3 tstAxis;
     float tstDepth;

--- a/Sources/Plasma/CoreLib/hsMatrix44.cpp
+++ b/Sources/Plasma/CoreLib/hsMatrix44.cpp
@@ -320,7 +320,7 @@ hsMatrix44&     hsMatrix44::SetRotate(int axis, float radians)
 {
     float s = sin(radians);
     float c = cos(radians);
-    int c1,c2;
+    int c1 = 0, c2 = 0;
     switch (axis)
     {
     case 0:

--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -201,9 +201,8 @@ bool hsStream::IsTokenSeparator(char c)
 
 bool hsStream::GetToken(char *s, uint32_t maxLen, const char beginComment, const char endComment)
 {
-    char c;
-    char endCom;
-        endCom = endComment;
+    char c = 0;
+    char endCom = endComment;
 
     while( true )
     {
@@ -235,9 +234,8 @@ bool hsStream::GetToken(char *s, uint32_t maxLen, const char beginComment, const
 
 bool hsStream::ReadLn(char *s, uint32_t maxLen, const char beginComment, const char endComment)
 {
-    char c;
-    char endCom;
-        endCom = endComment;
+    char c = 0;
+    char endCom = endComment;
 
     while( true )
     {
@@ -270,7 +268,7 @@ bool hsStream::ReadLn(char *s, uint32_t maxLen, const char beginComment, const c
 bool hsStream::ReadLn(ST::string& s, const char beginComment, const char endComment)
 {
     ST::string_stream ss;
-    char c;
+    char c = 0;
     char endCom = endComment;
 
     while (true) {

--- a/Sources/Plasma/CoreLib/hsSystemInfo.cpp
+++ b/Sources/Plasma/CoreLib/hsSystemInfo.cpp
@@ -122,8 +122,8 @@ static inline ST::string IGetAppleCPUVendor()
     ST::string result;
 
 #ifdef HAVE_SYSCTL
-    size_t bufsize = 100;
-    char buffer[bufsize];
+    char buffer[100];
+    size_t bufsize = sizeof(buffer);
 
     if (sysctlbyname("machdep.cpu.brand_string", &buffer, &bufsize, nullptr, 0) == 0) {
         result = buffer;

--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -471,7 +471,7 @@ plFileName plFileSystem::GetUserDataPath()
 #if HS_BUILD_FOR_WIN32
         wchar_t path[MAX_PATH];
         if (!SHGetSpecialFolderPathW(nullptr, path, CSIDL_LOCAL_APPDATA, TRUE))
-            return "";
+            return {};
 
         _userData = plFileName::Join(ST::string::from_wchar(path), plProduct::LongName());
 #elif HS_BUILD_FOR_APPLE
@@ -481,6 +481,8 @@ plFileName plFileSystem::GetUserDataPath()
             sysdir_search_path_enumeration_state state;
             state = sysdir_start_search_path_enumeration(SYSDIR_DIRECTORY_APPLICATION_SUPPORT, SYSDIR_DOMAIN_MASK_USER);
             state = sysdir_get_next_search_path_enumeration(state, path);
+            if (state == 0)
+                return {};
         }
         else
 #endif
@@ -490,13 +492,19 @@ plFileName plFileSystem::GetUserDataPath()
             NSSearchPathEnumerationState state;
             state = NSStartSearchPathEnumeration(NSApplicationSupportDirectory, NSUserDomainMask);
             state = NSGetNextSearchPathEnumeration(state, path);
+            if (state == 0)
+                return {};
 
             IGNORE_WARNINGS_END
         }
 
         if (path[0] == '~') {
+            const char* homedir = getenv("HOME");
+            if (!homedir)
+                return {};
+
             char home[PATH_MAX] {};
-            strlcat(home, getenv("HOME"), sizeof(home));
+            strlcat(home, homedir, sizeof(home));
             strlcat(home, &path[1], sizeof(home));
 
             _userData = plFileName::Join(home, plProduct::LongName());
@@ -510,7 +518,7 @@ plFileName plFileSystem::GetUserDataPath()
         } else {
             homedir = getenv("HOME");
             if (!homedir)
-                return "";
+                return {};
 
             _userData = plFileName::Join(homedir, ".config", plProduct::LongName());
         }

--- a/Sources/Plasma/CoreLib/plFileSystem.cpp
+++ b/Sources/Plasma/CoreLib/plFileSystem.cpp
@@ -262,10 +262,10 @@ plFileName plFileSystem::GetCWD()
         cwd = ST::string::from_wchar(cwd_sm);
     }
 #else
-    char *cwd_a = getcwd(nullptr, 0);
-    hsAssert(cwd_a, "Failure to get working directory (unsupported libc?)");
+    char cwd_a[PATH_MAX];
+    const char* res = getcwd(cwd_a, sizeof(cwd_a));
+    hsAssert(res, "Failure to get working directory (unsupported libc?)");
     cwd = cwd_a;
-    free(cwd_a);
 #endif
 
     return cwd;

--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -2237,47 +2237,42 @@ PyObject* cyMisc::RebuildCameraStack(const ST::string& name, const ST::string& a
     if (name.compare("empty") == 0)
         PYTHON_RETURN_NONE;
 
-    if ( !name.empty() )
-    {
-        key=plKeyFinder::Instance().StupidSearch("", "", plSceneObject::Index(), name, false);
-    }
-    if (key == nullptr)
-    {
+    if (!name.empty())
+        key = plKeyFinder::Instance().StupidSearch("", "", plSceneObject::Index(), name, false);
+
+    if (key == nullptr) {
         // try and use this new hack method to find it
-        if (!plVirtualCam1::Instance()->RestoreFromName(name))
-        {
+        if (!plVirtualCam1::Instance()->RestoreFromName(name)) {
             // give up and force built in 3rd person
             plVirtualCam1::Instance()->PushThirdPerson();
             ST::string errmsg = ST::format("Sceneobject {} not found", name);
             PyErr_SetString(PyExc_NameError, errmsg.c_str());
             PYTHON_RETURN_ERROR;
         }
-    }
-    else
-    {
+
+        PYTHON_RETURN_NONE;
+    } else {
         // now we have the scene object, look for it's camera modifier
         const plCameraModifier1* pMod = nullptr;
         plSceneObject* pObj = plSceneObject::ConvertNoRef(key->ObjectIsLoaded());
-        if (pObj)
-        {
-            for (size_t i = 1; i < pObj->GetNumModifiers(); i++)
-            {
+        if (pObj) {
+            for (size_t i = 1; i < pObj->GetNumModifiers(); i++) {
                 pMod = plCameraModifier1::ConvertNoRef(pObj->GetModifier(i));
                 if (pMod)
                     break;
             }
-            if (pMod)
-            {   
+
+            if (pMod) {
                 plVirtualCam1::Instance()->RebuildStack(pMod->GetKey());
                 PYTHON_RETURN_NONE;
             }
         }
+
         plVirtualCam1::Instance()->PushThirdPerson();
         ST::string errmsg = ST::format("Sceneobject {} has no camera modifier", name);
         PyErr_SetString(PyExc_NameError, errmsg.c_str());
         PYTHON_RETURN_ERROR;
     }
-    
 }
 
 void cyMisc::PyClearCameraStack()

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeInfoStruct.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeInfoStruct.cpp
@@ -135,7 +135,7 @@ void pyAgeInfoStruct::SetAgeInstanceGuid(const ST::string& guid)
         hash.AddTo(y.size(), (uint8_t*)y.c_str());
         hash.Finish();
 
-        const char* md5sum = hash.GetAsHexString();
+        ST::string md5sum = hash.GetAsHexString();
         ST::string_stream ss;
         for (size_t i = 0; i < 16; i++) {
             ss << md5sum[2*i];

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -45,6 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsStream.h"
 
 #include <cstring>
+#include <string_theory/codecs>
 
 struct _InitOpenSSL
 {
@@ -217,23 +218,11 @@ void plMD5Checksum::Finish()
     fContext = nullptr;
 }
 
-const char* plMD5Checksum::GetAsHexString() const
+ST::string plMD5Checksum::GetAsHexString() const
 {
-    const int   kHexStringSize = (2 * MD5_DIGEST_LENGTH) + 1;
-    static char tempString[kHexStringSize];
-
-    int     i;
-    char    *ptr;
-
-
     hsAssert(fValid, "Trying to get string version of invalid checksum");
 
-    for (i = 0, ptr = tempString; i < sizeof(fChecksum); i++, ptr += 2)
-        sprintf(ptr, "%02x", fChecksum[i]);
-
-    *ptr = 0;
-
-    return tempString;
+    return ST::hex_encode(fChecksum, sizeof(fChecksum));
 }
 
 void plMD5Checksum::SetFromHexString(const char* string)
@@ -370,22 +359,11 @@ void plSHAChecksum::Finish()
     fValid = true;
 }
 
-const char* plSHAChecksum::GetAsHexString() const
+ST::string plSHAChecksum::GetAsHexString() const
 {
-    const int kHexStringSize = (2 * SHA_DIGEST_LENGTH) + 1;
-    static char tempString[kHexStringSize];
-
-    int i;
-    char* ptr;
-
     hsAssert(fValid, "Trying to get string version of invalid checksum");
 
-    for (i = 0, ptr = tempString; i < sizeof(fChecksum); i++, ptr += 2)
-        sprintf(ptr, "%02x", fChecksum[i]);
-
-    *ptr = 0;
-
-    return tempString;
+    return ST::hex_encode(fChecksum, sizeof(fChecksum));
 }
 
 void plSHAChecksum::SetFromHexString(const char* string)
@@ -512,22 +490,11 @@ void plSHA1Checksum::Finish()
     fContext = nullptr;
 }
 
-const char* plSHA1Checksum::GetAsHexString() const
+ST::string plSHA1Checksum::GetAsHexString() const
 {
-    const int kHexStringSize = (2 * SHA_DIGEST_LENGTH) + 1;
-    static char tempString[kHexStringSize];
-
-    int i;
-    char* ptr;
-
     hsAssert(fValid, "Trying to get string version of invalid checksum");
 
-    for (i = 0, ptr = tempString; i < sizeof(fChecksum); i++, ptr += 2)
-        sprintf(ptr, "%02x", fChecksum[i]);
-
-    *ptr = 0;
-
-    return tempString;
+    return ST::hex_encode(fChecksum, sizeof(fChecksum));
 }
 
 void plSHA1Checksum::SetFromHexString(const char* string)

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -96,9 +96,7 @@ class plMD5Checksum
         // Backdoor for cached checksums (ie, if you loaded it off disk)
         void SetValue(uint8_t* checksum);
 
-        // Note: GetAsHexString() returns a pointer to a static string;
-        // do not rely on the contents of this string between calls!
-        const char* GetAsHexString() const;
+        ST::string GetAsHexString() const;
         void SetFromHexString(const char* string);
 
         bool operator==(const plMD5Checksum& rhs) const;
@@ -142,9 +140,7 @@ class plSHAChecksum
         // Backdoor for cached checksums (ie, if you loaded it off disk)
         void SetValue(uint8_t* checksum);
 
-        // Note: GetAsHexString() returns a pointer to a static string;
-        // do not rely on the contents of this string between calls!
-        const char* GetAsHexString() const;
+        ST::string GetAsHexString() const;
         void SetFromHexString(const char* string);
 
         bool operator==(const plSHAChecksum& rhs) const;
@@ -182,9 +178,7 @@ class plSHA1Checksum
         // Backdoor for cached checksums (ie, if you loaded it off disk)
         void SetValue(uint8_t* checksum);
 
-        // Note: GetAsHexString() returns a pointer to a static string;
-        // do not rely on the contents of this string between calls!
-        const char* GetAsHexString() const;
+        ST::string GetAsHexString() const;
         void SetFromHexString(const char* string);
 
         bool operator==(const plSHA1Checksum& rhs) const;

--- a/Sources/Plasma/PubUtilLib/plDrawable/plVertCoder.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plVertCoder.cpp
@@ -458,6 +458,6 @@ plVertCoder::~plVertCoder()
 
 void plVertCoder::Clear()
 {
-    memset(this, 0, sizeof(*this));
+    memset(static_cast<void*>(this), 0, sizeof(*this));
 }
 

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plMD5Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plMD5Checksum.cpp
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <cstring>
 #include <gtest/gtest.h>
 #include "pnEncryption/plChecksum.h"
+#include <string_theory/string>
 
 TEST(plMD5Checksum, ctor_with_buffer)
 {
@@ -55,7 +56,7 @@ TEST(plMD5Checksum, ctor_with_buffer)
 
     EXPECT_EQ(sizeof(value), sum.GetSize());
     EXPECT_EQ(0, memcmp(sum.GetValue(), value, 16));
-    EXPECT_STREQ(hexStr, sum.GetAsHexString());
+    EXPECT_STREQ(hexStr, sum.GetAsHexString().c_str());
 }
 
 TEST(plMD5Checksum, update)
@@ -73,7 +74,7 @@ TEST(plMD5Checksum, update)
 
     EXPECT_EQ(sizeof(value), sum.GetSize());
     EXPECT_EQ(0, memcmp(sum.GetValue(), value, 16));
-    EXPECT_STREQ(hexStr, sum.GetAsHexString());
+    EXPECT_STREQ(hexStr, sum.GetAsHexString().c_str());
 }
 
 TEST(plMD5Checksum, well_known_hashes)
@@ -82,23 +83,23 @@ TEST(plMD5Checksum, well_known_hashes)
     const char case0_text[] = "";
     const char case0_digest[] = "d41d8cd98f00b204e9800998ecf8427e";
     plMD5Checksum case0(strlen(case0_text), (const uint8_t*)case0_text);
-    EXPECT_STREQ(case0_digest, case0.GetAsHexString());
+    EXPECT_STREQ(case0_digest, case0.GetAsHexString().c_str());
 
     const char case1_text[] = "abc";
     const char case1_digest[] = "900150983cd24fb0d6963f7d28e17f72";
     plMD5Checksum case1(strlen(case1_text), (const uint8_t*)case1_text);
-    EXPECT_STREQ(case1_digest, case1.GetAsHexString());
+    EXPECT_STREQ(case1_digest, case1.GetAsHexString().c_str());
 
     const char case2_text[] = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
     const char case2_digest[] = "8215ef0796a20bcaaae116d3876c664a";
     plMD5Checksum case2(strlen(case2_text), (const uint8_t*)case2_text);
-    EXPECT_STREQ(case2_digest, case2.GetAsHexString());
+    EXPECT_STREQ(case2_digest, case2.GetAsHexString().c_str());
 
     const char case3_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
                               "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
     const char case3_digest[] = "03dd8807a93175fb062dfb55dc7d359c";
     plMD5Checksum case3(strlen(case3_text), (const uint8_t*)case3_text);
-    EXPECT_STREQ(case3_digest, case3.GetAsHexString());
+    EXPECT_STREQ(case3_digest, case3.GetAsHexString().c_str());
 
     // 1,000,000 copies of 'a'
     uint8_t onek_a[1000];
@@ -109,7 +110,7 @@ TEST(plMD5Checksum, well_known_hashes)
     for (size_t i = 0; i < 1000; ++i)
         case4.AddTo(sizeof(onek_a), onek_a);
     case4.Finish();
-    EXPECT_STREQ(case4_digest, case4.GetAsHexString());
+    EXPECT_STREQ(case4_digest, case4.GetAsHexString().c_str());
 
     // case5_text repeated 16,777,216 times
     const char case5_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno";
@@ -120,5 +121,5 @@ TEST(plMD5Checksum, well_known_hashes)
     for (size_t i = 0; i < 16777216; ++i)
         case5.AddTo(case5_text_len, (const uint8_t*)case5_text);
     case5.Finish();
-    EXPECT_STREQ(case5_digest, case5.GetAsHexString());
+    EXPECT_STREQ(case5_digest, case5.GetAsHexString().c_str());
 }

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA1Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA1Checksum.cpp
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <cstring>
 #include <gtest/gtest.h>
 #include "pnEncryption/plChecksum.h"
+#include <string_theory/string>
 
 TEST(plSHA1Checksum, ctor_with_buffer)
 {
@@ -58,7 +59,7 @@ TEST(plSHA1Checksum, ctor_with_buffer)
 
     EXPECT_EQ(sizeof(value), sum.GetSize());
     EXPECT_EQ(0, memcmp(sum.GetValue(), value, 20));
-    EXPECT_STREQ(hexStr, sum.GetAsHexString());
+    EXPECT_STREQ(hexStr, sum.GetAsHexString().c_str());
 }
 
 TEST(plSHA1Checksum, update)
@@ -79,7 +80,7 @@ TEST(plSHA1Checksum, update)
 
     EXPECT_EQ(sizeof(value), sum.GetSize());
     EXPECT_EQ(0, memcmp(sum.GetValue(), value, 20));
-    EXPECT_STREQ(hexStr, sum.GetAsHexString());
+    EXPECT_STREQ(hexStr, sum.GetAsHexString().c_str());
 }
 
 TEST(plSHA1Checksum, well_known_hashes)
@@ -88,23 +89,23 @@ TEST(plSHA1Checksum, well_known_hashes)
     const char case0_text[] = "";
     const char case0_digest[] = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
     plSHA1Checksum case0(strlen(case0_text), (const uint8_t*)case0_text);
-    EXPECT_STREQ(case0_digest, case0.GetAsHexString());
+    EXPECT_STREQ(case0_digest, case0.GetAsHexString().c_str());
 
     const char case1_text[] = "abc";
     const char case1_digest[] = "a9993e364706816aba3e25717850c26c9cd0d89d";
     plSHA1Checksum case1(strlen(case1_text), (const uint8_t*)case1_text);
-    EXPECT_STREQ(case1_digest, case1.GetAsHexString());
+    EXPECT_STREQ(case1_digest, case1.GetAsHexString().c_str());
 
     const char case2_text[] = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
     const char case2_digest[] = "84983e441c3bd26ebaae4aa1f95129e5e54670f1";
     plSHA1Checksum case2(strlen(case2_text), (const uint8_t*)case2_text);
-    EXPECT_STREQ(case2_digest, case2.GetAsHexString());
+    EXPECT_STREQ(case2_digest, case2.GetAsHexString().c_str());
 
     const char case3_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
                               "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
     const char case3_digest[] = "a49b2446a02c645bf419f995b67091253a04a259";
     plSHA1Checksum case3(strlen(case3_text), (const uint8_t*)case3_text);
-    EXPECT_STREQ(case3_digest, case3.GetAsHexString());
+    EXPECT_STREQ(case3_digest, case3.GetAsHexString().c_str());
 
     // 1,000,000 copies of 'a'
     uint8_t onek_a[1000];
@@ -115,7 +116,7 @@ TEST(plSHA1Checksum, well_known_hashes)
     for (size_t i = 0; i < 1000; ++i)
         case4.AddTo(sizeof(onek_a), onek_a);
     case4.Finish();
-    EXPECT_STREQ(case4_digest, case4.GetAsHexString());
+    EXPECT_STREQ(case4_digest, case4.GetAsHexString().c_str());
 
     // case5_text repeated 16,777,216 times
     const char case5_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno";
@@ -126,5 +127,5 @@ TEST(plSHA1Checksum, well_known_hashes)
     for (size_t i = 0; i < 16777216; ++i)
         case5.AddTo(case5_text_len, (const uint8_t*)case5_text);
     case5.Finish();
-    EXPECT_STREQ(case5_digest, case5.GetAsHexString());
+    EXPECT_STREQ(case5_digest, case5.GetAsHexString().c_str());
 }

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
@@ -43,6 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <cstring>
 #include <gtest/gtest.h>
 #include "pnEncryption/plChecksum.h"
+#include <string_theory/string>
 
 TEST(plSHAChecksum, ctor_with_buffer)
 {
@@ -58,7 +59,7 @@ TEST(plSHAChecksum, ctor_with_buffer)
 
     EXPECT_EQ(sizeof(value), sum.GetSize());
     EXPECT_EQ(0, memcmp(sum.GetValue(), value, 20));
-    EXPECT_STREQ(hexStr, sum.GetAsHexString());
+    EXPECT_STREQ(hexStr, sum.GetAsHexString().c_str());
 }
 
 TEST(plSHAChecksum, update)
@@ -79,7 +80,7 @@ TEST(plSHAChecksum, update)
 
     EXPECT_EQ(sizeof(value), sum.GetSize());
     EXPECT_EQ(0, memcmp(sum.GetValue(), value, 20));
-    EXPECT_STREQ(hexStr, sum.GetAsHexString());
+    EXPECT_STREQ(hexStr, sum.GetAsHexString().c_str());
 }
 
 TEST(plSHAChecksum, well_known_hashes)
@@ -88,23 +89,23 @@ TEST(plSHAChecksum, well_known_hashes)
     const char case0_text[] = "";
     const char case0_digest[] = "f96cea198ad1dd5617ac084a3d92c6107708c0ef";
     plSHAChecksum case0(strlen(case0_text), (const uint8_t*)case0_text);
-    EXPECT_STREQ(case0_digest, case0.GetAsHexString());
+    EXPECT_STREQ(case0_digest, case0.GetAsHexString().c_str());
 
     const char case1_text[] = "abc";
     const char case1_digest[] = "0164b8a914cd2a5e74c4f7ff082c4d97f1edf880";
     plSHAChecksum case1(strlen(case1_text), (const uint8_t*)case1_text);
-    EXPECT_STREQ(case1_digest, case1.GetAsHexString());
+    EXPECT_STREQ(case1_digest, case1.GetAsHexString().c_str());
 
     const char case2_text[] = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
     const char case2_digest[] = "d2516ee1acfa5baf33dfc1c471e438449ef134c8";
     plSHAChecksum case2(strlen(case2_text), (const uint8_t*)case2_text);
-    EXPECT_STREQ(case2_digest, case2.GetAsHexString());
+    EXPECT_STREQ(case2_digest, case2.GetAsHexString().c_str());
 
     const char case3_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
                               "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
     const char case3_digest[] = "459f83b95db2dc87bb0f5b513a28f900ede83237";
     plSHAChecksum case3(strlen(case3_text), (const uint8_t*)case3_text);
-    EXPECT_STREQ(case3_digest, case3.GetAsHexString());
+    EXPECT_STREQ(case3_digest, case3.GetAsHexString().c_str());
 
     // 1,000,000 copies of 'a'
     uint8_t onek_a[1000];
@@ -115,7 +116,7 @@ TEST(plSHAChecksum, well_known_hashes)
     for (size_t i = 0; i < 1000; ++i)
         case4.AddTo(sizeof(onek_a), onek_a);
     case4.Finish();
-    EXPECT_STREQ(case4_digest, case4.GetAsHexString());
+    EXPECT_STREQ(case4_digest, case4.GetAsHexString().c_str());
 
 #if 0
     // case5_text repeated 16,777,216 times
@@ -129,6 +130,6 @@ TEST(plSHAChecksum, well_known_hashes)
     for (size_t i = 0; i < 16777216; ++i)
         case5.AddTo(case5_text_len, (const uint8_t*)case5_text);
     case5.Finish();
-    EXPECT_STREQ(case5_digest, case5.GetAsHexString());
+    EXPECT_STREQ(case5_digest, case5.GetAsHexString().c_str());
 #endif
 }


### PR DESCRIPTION
Fixes various warnings (mostly in CoreLib) from Xcode and Visual Studio around uninitialized local variables, unused values, improper use of `getcwd`, and some (but not all) signed/unsigned and int sizing warnings in hsStream.

This also enables [CMP0156](https://cmake.org/cmake/help/latest/policy/CMP0156.html) which is supposed to deduplicate linked libraries to avoid warnings from Xcode.

I've tried to keep each commit reasonably self-contained, so we can drop anything that we don't have agreement on.