### PR TITLE
Fixing Metal validation error around lighting

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -1681,9 +1681,9 @@ void plMetalPipeline::IBindLights()
     if (!(fState.fBoundLights.has_value() && memcmp(&fState.fBoundLights, &fLights, lightSize) == 0)) {
         memcpy(&fState.fBoundLights, &fLights, lightSize);
         if (fLightingPerPixel) {
-            fDevice.CurrentRenderCommandEncoder()->setFragmentBytes(&fLights, lightSize, FragmentShaderArgumentLights);
+            fDevice.CurrentRenderCommandEncoder()->setFragmentBytes(&fLights, sizeof(plMetalLights), FragmentShaderArgumentLights);
         } else {
-            fDevice.CurrentRenderCommandEncoder()->setVertexBytes(&fLights, lightSize, VertexShaderArgumentLights);
+            fDevice.CurrentRenderCommandEncoder()->setVertexBytes(&fLights, sizeof(plMetalLights), VertexShaderArgumentLights);
         }
     }
     


### PR DESCRIPTION
The Metal validator has started complaining that we’re passing a buffer that’s smaller than the argument size. This validation is tripped even if I change the argument in the shader to a pointer.

The idea was that I could pass a partial structure of lights to save on bandwidth costs - but Metal no longer seems to like that. I’ll have to pass the full array of lights whenever they are updated.

This came up after the merge of the Metal per pixel lighting code. I'm not sure why the validator has decided to complain now - but I've done an Xcode upgrade since then.