### PR TITLE
Allow longer duration KI light and randomization

### DIFF
--- a/Scripts/Python/dsntKILightMachine.py
+++ b/Scripts/Python/dsntKILightMachine.py
@@ -76,8 +76,6 @@ lightOn = 0
 #----------
 # constants
 #----------
-kLightTimeShort = intKILightTimeShort.value
-kLightTimeLong = intKILightTimeLong.value
 listLightResps = ["respKILightOff","respKILightOn"]
 kLightStopID = 1
 kKILightShortSFXRespName = "respSFX-KILight-Short"
@@ -166,11 +164,11 @@ class dsntKILightMachine(ptModifier):
         if not byteKILightFunc:
             return
         elif byteKILightFunc == 1:
-            lightStop = (lightStart + kLightTimeShort)
+            lightStop = (lightStart + intKILightTimeShort.value)
         elif byteKILightFunc == 2:
-            lightStop = (lightStart + kLightTimeLong)
+            lightStop = (lightStart + intKILightTimeLong.value)
         elif byteKILightFunc == 3:
-            lightStop = (lightStart + random.randint(kLightTimeShort,kLightTimeLong))
+            lightStop = (lightStart + random.randint(intKILightTimeShort.value,intKILightTimeLong.value))
 
         timeRemaining = (lightStop - lightStart)
         PtDebugPrint("timer set, light will shut off in ",timeRemaining," seconds; lightStop = ",lightStop)
@@ -241,7 +239,7 @@ class dsntKILightMachine(ptModifier):
                         self.SetKILightChron(remaining)
                         lightOn = 0
                         PtSetLightAnimStart(avatarKey, KILightObjectName, False)
-                elif resp.getName() == kKILightShortSFXRespName and remaining == kLightTimeShort:
+                elif resp.getName() == kKILightShortSFXRespName and remaining == intKILightTimeShort.value:
                     PtDebugPrint("dsntKILightMachine.DoKILight():\tRunning short KI Light SFX")
                     sndResp = ptAttribResponder(43)
                     sndResp.__setvalue__(resp)


### PR DESCRIPTION
Allows longer duration KI Light and randomizing the time for puzzles

Python File Mod #5 is an Integer that sets the duration of the light when unrepaired, default of 5 seconds
Python File Mod #6 is an Integer that sets the duration of the light when repaired, default of 60 seconds

byteKILightFunc now has a third option for random light time between the short and long time