### PR TITLE
Start working on addressing the Y2038 problem.

### DIFF
--- a/Sources/Plasma/CoreLib/hsStream.cpp
+++ b/Sources/Plasma/CoreLib/hsStream.cpp
@@ -326,6 +326,21 @@ void hsStream::ReadLE32(size_t count, uint32_t values[])
         values[i] = hsToLE32(values[i]);
 }
 
+uint64_t hsStream::ReadLE64()
+{
+    uint64_t  value;
+    Read(sizeof(uint64_t), &value);
+    value = hsToLE64(value);
+    return value;
+}
+
+void hsStream::ReadLE64(size_t count, uint64_t values[])
+{
+    this->Read(count * sizeof(uint64_t), values);
+    for (size_t i = 0; i < count; i++)
+        values[i] = hsToLE64(values[i]);
+}
+
 double hsStream::ReadLEDouble()
 {
     double  value;
@@ -377,7 +392,7 @@ void hsStream::WriteByte(uint8_t value)
 void  hsStream::WriteLE16(uint16_t value)
 {
     value = hsToLE16(value);
-    this->Write(sizeof(int16_t), &value);
+    this->Write(sizeof(uint16_t), &value);
 }
 
 void  hsStream::WriteLE16(size_t count, const uint16_t values[])
@@ -389,13 +404,25 @@ void  hsStream::WriteLE16(size_t count, const uint16_t values[])
 void  hsStream::WriteLE32(uint32_t value)
 {
     value = hsToLE32(value);
-    this->Write(sizeof(int32_t), &value);
+    this->Write(sizeof(uint32_t), &value);
 }
 
 void  hsStream::WriteLE32(size_t count, const uint32_t values[])
 {
     for (size_t i = 0; i < count; i++)
         this->WriteLE32(values[i]);
+}
+
+void hsStream::WriteLE64(uint64_t value)
+{
+    value = hsToLE64(value);
+    this->Write(sizeof(uint64_t), &value);
+}
+
+void hsStream::WriteLE64(size_t count, const uint64_t values[])
+{
+    for (size_t i = 0; i < count; i++)
+        this->WriteLE64(values[i]);
 }
 
 void hsStream::WriteLEDouble(double value)

--- a/Sources/Plasma/CoreLib/hsStream.h
+++ b/Sources/Plasma/CoreLib/hsStream.h
@@ -95,6 +95,8 @@ public:
     void            ReadLE16(size_t count, uint16_t values[]);
     uint32_t        ReadLE32();
     void            ReadLE32(size_t count, uint32_t values[]);
+    uint64_t        ReadLE64();
+    void            ReadLE64(size_t count, uint64_t values[]);
 
     void            WriteBOOL(bool value);
     void            WriteBool(bool value);
@@ -104,6 +106,8 @@ public:
     void            WriteLE16(size_t count, const uint16_t values[]);
     void            WriteLE32(uint32_t value);
     void            WriteLE32(size_t count, const uint32_t values[]);
+    void            WriteLE64(uint64_t value);
+    void            WriteLE64(size_t count, const uint64_t values[]);
 
     float           ReadLEFloat();
     void            ReadLEFloat(size_t count, float values[]);
@@ -125,6 +129,9 @@ public:
     template <typename T> inline void ReadLE32(T*) = delete;
     void ReadLE32(uint32_t* v) { *v = ReadLE32(); }
     void ReadLE32(int32_t* v) { *v = (int32_t)ReadLE32(); }
+    template <typename T> inline void ReadLE64(T*) = delete;
+    void ReadLE64(uint64_t* v) { *v = ReadLE64(); }
+    void ReadLE64(int64_t* v) { *v = (int64_t)ReadLE64(); }
     template <typename T> inline void ReadLEFloat(T*) = delete;
     void ReadLEFloat(float* v) { *v = ReadLEFloat(); }
     template <typename T> inline void ReadLEDouble(T*) = delete;
@@ -137,6 +144,8 @@ public:
     void WriteLE16(int16_t v) { WriteLE16((uint16_t)v); }
     template <typename T> void WriteLE32(T) = delete;
     void WriteLE32(int32_t v) { WriteLE32((uint32_t)v); }
+    template <typename T> void WriteLE64(T) = delete;
+    void WriteLE64(int64_t v) { WriteLE64((uint64_t)v); }
     template <typename T> void WriteLEFloat(T) = delete;
     template <typename T> void WriteLEDouble(T) = delete;
 };

--- a/Sources/Plasma/CoreLib/plFileSystem.h
+++ b/Sources/Plasma/CoreLib/plFileSystem.h
@@ -278,10 +278,10 @@ public:
     int64_t FileSize() const { return fFileSize; }
 
     /** Returns the creation time of the file. */
-    uint64_t CreateTime() const { return fCreateTime; }
+    int64_t CreateTime() const { return fCreateTime; }
 
     /** Returns the last modification time of the file. */
-    uint64_t ModifyTime() const { return fModifyTime; }
+    int64_t ModifyTime() const { return fModifyTime; }
 
     /** Returns \p true if this file is a directory. */
     bool IsDirectory() const { return (fFlags & kIsDirectory) != 0; }
@@ -292,7 +292,7 @@ public:
 private:
     plFileName fName;
     int64_t fFileSize;
-    uint64_t fCreateTime, fModifyTime;
+    int64_t fCreateTime, fModifyTime;
 
     enum {
         kEntryExists    = (1<<0),

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.cpp
@@ -199,7 +199,7 @@ PyObject* pyVaultNode::GetOwnerNode()
     PYTHON_RETURN_NONE;
 }
 
-uint32_t pyVaultNode::GetModifyTime()
+int64_t pyVaultNode::GetModifyTime()
 {
     if (fNode)
         return fNode->GetModifyTime();
@@ -229,14 +229,14 @@ PyObject* pyVaultNode::GetCreatorNode()
     PYTHON_RETURN_NONE;
 }
 
-uint32_t pyVaultNode::GetCreateTime()
+int64_t pyVaultNode::GetCreateTime()
 {
     if (fNode)
         return fNode->GetCreateTime();
     return 0;
 }
 
-uint32_t pyVaultNode::GetCreateAgeTime()
+int64_t pyVaultNode::GetCreateAgeTime()
 {
     hsAssert(false, "eric, port?");
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNode.h
@@ -117,11 +117,11 @@ public:
     uint32_t GetType();
     uint32_t  GetOwnerNodeID();
     PyObject* GetOwnerNode(); // returns pyVaultPlayerInfoNode
-    uint32_t GetModifyTime();
+    int64_t GetModifyTime();
     uint32_t GetCreatorNodeID();
     PyObject* GetCreatorNode(); // returns pyVaultPlayerInfoNode
-    uint32_t GetCreateTime();
-    uint32_t GetCreateAgeTime();
+    int64_t GetCreateTime();
+    int64_t GetCreateAgeTime();
     ST::string GetCreateAgeName() const;
     plUUID    GetCreateAgeGuid() const;
     PyObject* GetCreateAgeCoords ();

--- a/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyVaultNodeGlue.cpp
@@ -122,7 +122,7 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultNode, getOwnerNode)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultNode, getModifyTime)
 {
-    return PyLong_FromUnsignedLong(self->fThis->GetModifyTime());
+    return PyLong_FromLongLong(self->fThis->GetModifyTime());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultNode, getCreatorNodeID)
@@ -137,12 +137,12 @@ PYTHON_METHOD_DEFINITION_NOARGS(ptVaultNode, getCreatorNode)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultNode, getCreateTime)
 {
-    return PyLong_FromUnsignedLong(self->fThis->GetCreateTime());
+    return PyLong_FromLongLong(self->fThis->GetCreateTime());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultNode, getCreateAgeTime)
 {
-    return PyLong_FromUnsignedLong(self->fThis->GetCreateAgeTime());
+    return PyLong_FromLongLong(self->fThis->GetCreateAgeTime());
 }
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptVaultNode, getCreateAgeName)

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.h
@@ -256,8 +256,8 @@ private:
     plUUID fRevision;
 
     uint32_t fNodeId;
-    uint32_t fCreateTime;
-    uint32_t fModifyTime;
+    int64_t  fCreateTime;
+    int64_t  fModifyTime;
     ST::string fCreateAgeName;
     plUUID   fCreateAgeUuid;
     plUUID   fCreatorAcct;
@@ -351,8 +351,8 @@ public:
     void GenerateRevision() { fRevision = plUUID::Generate(); }
 
     uint32_t GetNodeId() const { return fNodeId; }
-    uint32_t GetCreateTime() const { return fCreateTime; }
-    uint32_t GetModifyTime() const { return fModifyTime; }
+    int64_t GetCreateTime() const { return fCreateTime; }
+    int64_t GetModifyTime() const { return fModifyTime; }
     ST::string GetCreateAgeName() const { return fCreateAgeName; }
     plUUID GetCreateAgeUuid() const { return fCreateAgeUuid; }
     plUUID GetCreatorAcct() const { return fCreatorAcct; }
@@ -386,8 +386,8 @@ public:
 public:
     void SetNodeId(uint32_t value) { ISetVaultField(kNodeId, fNodeId, value); }
     void SetNodeId_NoDirty(uint32_t value) { ISetVaultField_NoDirty(kNodeId, fNodeId, value); }
-    void SetCreateTime(uint32_t value) { ISetVaultField(kCreateTime, fCreateTime, value); }
-    void SetModifyTime(uint32_t value) { ISetVaultField(kModifyTime, fModifyTime, value); }
+    void SetCreateTime(int64_t value) { ISetVaultField(kCreateTime, fCreateTime, value); }
+    void SetModifyTime(int64_t value) { ISetVaultField(kModifyTime, fModifyTime, value); }
     void SetCreateAgeName(const ST::string& value) { ISetVaultField(kCreateAgeName, fCreateAgeName, value); }
     void SetCreateAgeUuid(const plUUID& value) { ISetVaultField(kCreateAgeUuid, fCreateAgeUuid, value); }
     void SetCreatorAcct(const plUUID& value) { ISetVaultField(kCreatorAcct, fCreatorAcct, value); }

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plTimeSpan.h
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plTimeSpan.h
@@ -49,7 +49,7 @@ class plTimeSpan : public plUnifiedTime
 public:
     plTimeSpan():plUnifiedTime() {}
     plTimeSpan(const struct timespec& ts) : plUnifiedTime(ts) {}
-    plTimeSpan(time_t t):plUnifiedTime(t) {}
+    plTimeSpan(int64_t t):plUnifiedTime(t) {}
     plTimeSpan(int year, int month, int day, int hour, int min, int sec, unsigned long usec=0, int dst=-1):plUnifiedTime(year, month, day, hour, min, sec, usec, dst) {}
     plTimeSpan(const plUnifiedTime & src):plUnifiedTime(src) {}
 

--- a/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.h
+++ b/Sources/Plasma/PubUtilLib/plUnifiedTime/plUnifiedTime.h
@@ -65,9 +65,9 @@ public:
     };
 
 protected:
-    time_t  fSecs;
+    int64_t   fSecs;
     uint32_t  fMicros;
-    Mode    fMode;
+    Mode      fMode;
 
     static int32_t    fLocalTimeZoneOffset;
 
@@ -80,13 +80,13 @@ public:
     plUnifiedTime(double secsDouble) : fMode(kGmt) { SetSecsDouble(secsDouble); }
     plUnifiedTime(const struct timespec& tv);
     plUnifiedTime(Mode mode, struct tm src);
-    plUnifiedTime(time_t t);
+    plUnifiedTime(int64_t t);
     plUnifiedTime(int year, int month, int day, int hour, int min, int sec, unsigned long usec=0, int dst=-1);
 
     static plUnifiedTime GetCurrent(Mode mode=kGmt);
 
     // getters
-    time_t GetSecs() const { return fSecs; }
+    int64_t GetSecs() const { return fSecs; }
     uint32_t GetMicros() const { return fMicros; }
     double GetSecsDouble() const;  // get the secs and micros as a double floating point value
     bool GetTime(short &year, short &month, short &day, short &hour, short &minute, short &second) const;
@@ -102,7 +102,7 @@ public:
     Mode GetMode() const { return fMode; } // local or gmt.
 
     // setters
-    void SetSecs(const time_t secs) { fSecs = secs; }
+    void SetSecs(int64_t secs) { fSecs = secs; }
     void SetSecsDouble(double secs);
     void SetMicros(const uint32_t micros) { fMicros = micros; }
     bool SetTime(short year, short month, short day, short hour, short minute, short second, unsigned long usec=0, int dst=-1);
@@ -136,7 +136,6 @@ public:
 
 
     // casting
-    operator time_t() const { return fSecs;}
     operator struct timespec() const;
     operator struct tm() const;
 


### PR DESCRIPTION
Plasma uses 32-bit timestamps in a few places, which will start causing problems in a little over 12 years...  However, we don't want to break backwards compatibility with the wire or file protocol, so this introduces a new encoding which remains backwards-compatible until Jan 2038:

* For timestamps before max(int32), the same 32-bit encoding is used.
* For timestamps greater than max(int32), a dummy `0xFFFFFFFF` value is written, immediately followed by a 64-bit (signed) timestamp.  This is compatible with the definition of `time_t` on systems that use a 64-bit timestamp.

This means things will continue to work even with unpatched servers and clients until the rollover point, which should hopefully give enough time for everything to be updated and patched before crashing and burning.

This change specifically addresses the 32-bit timestamps everywhere `plUnifiedTime` is used, and in the Vault nodes.  There are other 32-bit timestamps left to convert (such as the server ping timers, and probably others I'm forgetting about), but it's a start.