### PR TITLE
plEncryptedStream no longer asserts on EOF

### DIFF
--- a/Sources/Plasma/PubUtilLib/plFile/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plFile/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(
     PUBLIC
         CoreLib
     PRIVATE
-        plNetClient
         $<$<PLATFORM_ID:Windows>:shell32>
 )
 

--- a/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plEncryptedStream.cpp
@@ -40,8 +40,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 #include "plEncryptedStream.h"
-#include "pnNetCommon/plNetApp.h"
-#include "pnNetCommon/pnNetCommon.h"
 
 #include <ctime>
 #include <string_theory/format>
@@ -180,13 +178,11 @@ uint32_t plEncryptedStream::IRead(uint32_t bytes, void* buffer)
     size_t numItems = fread(buffer, 1 /*size*/, bytes /*count*/, fRef);
     fPosition += numItems;
     if (numItems < bytes) {
-        if (feof(fRef)) {
-            hsLogEntry(plNetApp::StaticDebugMsg(ST::format("Hit EOF on UNIX Read, only read {} out of requested {} bytes", numItems, bytes).c_str()));
-        } else {
+        if (!feof(fRef)) {
             hsAssert(false, ST::format("Error on UNIX Read (ferror = {})", ferror(fRef)).c_str());
         }
     }
-    return uint32_t(numItems);
+    return static_cast<uint32_t>(numItems);
 }
 
 void plEncryptedStream::IBufferFile()

--- a/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
+++ b/Sources/Plasma/PubUtilLib/plFile/plSecureStream.cpp
@@ -296,11 +296,7 @@ uint32_t plSecureStream::IRead(uint32_t bytes, void* buffer)
     fPosition += numItems;
     if (numItems < bytes)
     {
-        if (success)
-        {
-            hsAssert(false, ST::format("Hit EOF on Windows read, only read {} out of requested {} bytes", numItems, bytes).c_str());
-        }
-        else
+        if (!success)
         {
 #if HS_BUILD_FOR_WIN32
             hsAssert(false, ST::format("Error on Windows read (GetLastError = {})", GetLastError()).c_str());
@@ -309,7 +305,7 @@ uint32_t plSecureStream::IRead(uint32_t bytes, void* buffer)
 #endif
         }
     }
-    return numItems;
+    return static_cast<uint32_t>(numItems);
 }
 
 void plSecureStream::IBufferFile()


### PR DESCRIPTION
Returning EOF to a log event. Not sure if EOF shouldbe a log event either, but in the original engine it was. Reaching EOF before a buffer fills should be expected behavior.

Putting this up mostly as a way to kickstart the conversation. I'm not sure if I restored the old logging behavior correctly or if I'm attached to the right log.