### PR TITLE
Fixing Metal rendering when the vertex color contains an alpha

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
@@ -473,7 +473,7 @@ fragment half4 pipelineFragmentShader(ColorInOut in [[stage_in]],
             }
         }
         
-        currentColor = lightingContributionColor * currentColor;
+        currentColor = half4(lightingContributionColor.rgb, 1.h) * currentColor;
     }
     
     currentColor.rgb = mix(in.fogColor.rgb, currentColor.rgb, (float)clamp(in.fogColor.a, 0.0h, 1.0h));


### PR DESCRIPTION
This is a regression from the per pixel lighting changes. Re-multiplying lightingContributionColor is not supposed to include the alpha.