### PR TITLE
Add xLinkEventTrigger.py.

### DIFF
--- a/Scripts/Python/xLinkEventTrigger.py
+++ b/Scripts/Python/xLinkEventTrigger.py
@@ -68,7 +68,6 @@ from Plasma import *
 from PlasmaTypes import *
 
 import enum
-import itertools
 
 # Fire this "responder" on link in. In 3ds Max or Korman logic nodes, this can be a responder
 # with some messages that you fire on link in. You need to be careful about doing that, though,


### PR DESCRIPTION
This new general purpose global script enables triggering either responders or an arbitrary logic modifier when a player spawns or links, depending on rules set on the script attributes. This is useful because, presently, the only way to achieve anything remotely like this effect is to auto-start an animation or sound on age load. Age load and link in don't exactly correspond, so that can result in things starting before the player is even in the Age to observe the action. There is no general mechanism for firing on link out or spawn out.

The downside to this is that it makes it trivial for someone to wire up things that have gotchas. For example, having a Python file mod that triggers when the local player spawns out is not actually useful for regular Ages. The Python file mod would likely be unloaded before such a thing ever fired.