### PR TITLE
Be honest about depending on `plPythonSDLModifier`

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -5126,8 +5126,6 @@ PF_CONSOLE_CMD( Mouse, ForceHide, "bool force", "Forces the mouse to be hidden (
 
 PF_CONSOLE_GROUP( Age )
 
-plPythonSDLModifier* ExternFindAgePySDL();
-
 template<typename _PrintStringT>
 void IShowSDL(const plStateDataRecord* rec, _PrintStringT&& PrintString)
 {
@@ -5150,7 +5148,7 @@ void IShowSDL(const plStateDataRecord* rec, _PrintStringT&& PrintString)
 
 PF_CONSOLE_CMD(Age, ShowPythonSDL, "", "Prints the Python AgeSDL values")
 {
-    plPythonSDLModifier* sdlMod = ExternFindAgePySDL();
+    plPythonSDLModifier* sdlMod = plPythonSDLModifier::FindAgeSDL();
     if (sdlMod && sdlMod->GetStateCache() != nullptr) {
         IShowSDL(sdlMod->GetStateCache(), PrintString);
     } else {
@@ -5169,7 +5167,7 @@ PF_CONSOLE_CMD(Age, ShowVaultSDL, "", "Prints the age vault SDL values")
 
 PF_CONSOLE_CMD(Age, ResetPythonSDL, "", "Resets the Python Age SDL")
 {
-    plPythonSDLModifier* sdlMod = ExternFindAgePySDL();
+    plPythonSDLModifier* sdlMod = plPythonSDLModifier::FindAgeSDL();
     if (sdlMod == nullptr) {
         PrintString("Python Age SDL not found");
         return;
@@ -5233,21 +5231,21 @@ PF_CONSOLE_CMD( Age, GetTimeOfDay, "string agedefnfile", "Gets the elapsed days 
 
 PF_CONSOLE_CMD( Age, SetSDLFloat, "string varName, float value, int index", "Set the value of an age global variable" )
 {
-    plPythonSDLModifier* sdlMod = ExternFindAgePySDL();
+    plPythonSDLModifier* sdlMod = plPythonSDLModifier::FindAgeSDL();
     if (sdlMod)
         sdlMod->SetItem(params[0], (int)params[2], (float)params[1]);
 }
 
 PF_CONSOLE_CMD( Age, SetSDLInt, "string varName, int value, int index", "Set the value of an age global variable" )
 {
-    plPythonSDLModifier* sdlMod = ExternFindAgePySDL();
+    plPythonSDLModifier* sdlMod = plPythonSDLModifier::FindAgeSDL();
     if (sdlMod)
         sdlMod->SetItem(params[0], (int)params[2], (int)params[1]);
 }
 
 PF_CONSOLE_CMD( Age, SetSDLBool, "string varName, bool value, int index", "Set the value of an age global variable" )
 {
-    plPythonSDLModifier* sdlMod = ExternFindAgePySDL();
+    plPythonSDLModifier* sdlMod = plPythonSDLModifier::FindAgeSDL();
     if (sdlMod)
         sdlMod->SetItem(params[0], (int)params[2], (bool)params[1]);
 }

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -532,16 +532,6 @@ bool plPythonSDLModifier::HasSDL(const ST::string& pythonFile)
     return (plSDLMgr::GetInstance()->FindDescriptor(pythonFile, plSDL::kLatestVersion) != nullptr);
 }
 
-const plSDLModifier* ExternFindAgeSDL()
-{
-    return plPythonSDLModifier::FindAgeSDL();
-}
-
-plPythonSDLModifier* ExternFindAgePySDL()
-{
-    return plPythonSDLModifier::FindAgeSDL();
-}
-
 plPythonSDLModifier* plPythonSDLModifier::FindAgeSDL()
 {
     ST::string ageName = cyMisc::GetAgeName();
@@ -583,11 +573,6 @@ plPythonSDLModifier* plPythonSDLModifier::FindAgeSDL()
 
     // couldn't find one (maybe because we didn't look)
     return nullptr;
-}
-
-plKey ExternFindAgeSDLTarget()
-{
-    return plPythonSDLModifier::FindAgeSDLTarget();
 }
 
 plKey plPythonSDLModifier::FindAgeSDLTarget()

--- a/Sources/Plasma/PubUtilLib/plAnimation/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAnimation/CMakeLists.txt
@@ -49,7 +49,10 @@ target_link_libraries(
         plMessage
         plModifier
         plSDL
+        pfPython # for plPythonSDLModifier::FindAgeSDL :(
 )
+
+target_include_directories(plAnimation PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
 
 source_group("Source Files" FILES ${plAnimation_SOURCES})
 source_group("Header Files" FILES ${plAnimation_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -68,6 +68,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plModifier/plSDLModifier.h"
 #include "plSDL/plSDL.h"
 
+#include "pfPython/plPythonSDLModifier.h" // for plPythonSDLModifier::FindAgeSDL :(
+
 /////////////////////////////////////////////////////////////////////////////////////////
 //
 // FLAGS
@@ -262,8 +264,7 @@ void plAGAnimInstance::SearchForGlobals()
     const plAgeGlobalAnim *ageAnim = plAgeGlobalAnim::ConvertNoRef(fAnimation);
     if (ageAnim != nullptr && fSDLChannels.size() > 0)
     {
-        extern const plSDLModifier *ExternFindAgeSDL();
-        const plSDLModifier *sdlMod = ExternFindAgeSDL();
+        const plSDLModifier *sdlMod = plPythonSDLModifier::FindAgeSDL();
         if (!sdlMod)
             return;
 

--- a/Sources/Plasma/PubUtilLib/plSurface/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plSurface/CMakeLists.txt
@@ -90,9 +90,12 @@ target_link_libraries(plSurface
         plModifier
         plNetClient
         plSDL
+        pfPython # for plPythonSDLModifier::FindAgeSDL :(
     INTERFACE
         pnFactory
 )
+
+target_include_directories(plSurface PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
 
 source_group("Source Files" FILES ${plSurface_SOURCES})
 source_group("Header Files" FILES ${plSurface_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plSurface/plLayerAnimation.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plLayerAnimation.cpp
@@ -64,6 +64,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plNetClient/plLinkEffectsMgr.h"
 #include "plSDL/plSDL.h"
 
+#include "pfPython/plPythonSDLModifier.h" // for plPythonSDLModifier::FindAgeSDL :(
 
 plLayerAnimationBase::~plLayerAnimationBase()
 {
@@ -678,8 +679,7 @@ uint32_t plLayerSDLAnimation::Eval(double wSecs, uint32_t frame, uint32_t ignore
         {
             if (!fVarName.empty())
             {
-                extern const plSDLModifier *ExternFindAgeSDL();
-                const plSDLModifier *sdlMod = ExternFindAgeSDL();
+                const plSDLModifier *sdlMod = plPythonSDLModifier::FindAgeSDL();
                 if (sdlMod)
                 {
                     fVar = sdlMod->GetStateCache()->FindVar(fVarName);


### PR DESCRIPTION
Fixes unresolved symbol errors when linking to `plAnimation` or `plSurface` without also linking to `pfPython`. As far as I can tell, the `extern` wrapper functions aren't any better than properly including the header.