### PR TITLE
Argument buffers and Metal bump mapping support

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
@@ -14,6 +14,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(metalcpp)
 
 set(pfMetalPipeline_SOURCES
+    plMetalArgumentBuffer.cpp
     plMetalDevice.cpp
     plMetalDeviceRefs.cpp
     plMetalEnumerate.mm
@@ -30,6 +31,7 @@ set(pfMetalPipeline_SOURCES
 )
 
 set(pfMetalPipeline_HEADERS
+    plMetalArgumentBuffer.h
     plMetalDevice.h
     plMetalDeviceRef.h
     plMetalLightRef.h

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
@@ -212,7 +212,7 @@ struct plTier1Bumpmap
     char2 dTangentIndex         [[ id(dTangentIndexID) ]];
     texture2d<half> bumpTexture [[ id(textureID) ]];
     sampler bumpTextureSampler  [[ id(samplerID) ]];
-    float3 scale                [[ id(dScaleID) ]];
+    float scale                 [[ id(dScaleID) ]];
 };
     
 #if __METAL_VERSION__ >= 300

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
@@ -331,8 +331,10 @@ vertex ColorInOut pipelineVertexShader(Vertex in [[stage_in]],
 
     
     for (int bumpMap=0; bumpMap<numBumpMaps; bumpMap++) {
-        (&out.T)[bumpMap] = normalize(uniforms.localToWorldMatrix * float4((&in.texCoord1)[bumpInfo[bumpMap].dTangentIndex[0]], 0.f)). xyz;
-        (&out.B)[bumpMap] = normalize(uniforms.localToWorldMatrix * float4((&in.texCoord1)[bumpInfo[bumpMap].dTangentIndex[1]], 0.f)). xyz;
+        const float4 T = float4((&in.texCoord1)[bumpInfo[bumpMap].dTangentIndex[0]], 0.f);
+        const float4 B = float4((&in.texCoord1)[bumpInfo[bumpMap].dTangentIndex[1]], 0.f);
+        (&out.T)[bumpMap] = normalize(uniforms.localToWorldMatrix * T). xyz;
+        (&out.B)[bumpMap] = normalize(uniforms.localToWorldMatrix * B).xyz;
     }
     
     out.position = vCamPosition * uniforms.projectionMatrix;
@@ -519,12 +521,18 @@ fragment half4 pipelineFragmentShader(ColorInOut in [[stage_in]],
     constexpr bool performBaseLighting = bumpMapIsAdditive || !bumpMap;
     
     if (performBaseLighting) {
-        lightingContributionColor = perPixelLighting ? calcLitMaterialColor(lighting, in.vtxColor, materialLighting, in.worldPos, in.normal) : in.vtxColor;
+        lightingContributionColor = perPixelLighting ? calcLitMaterialColor(
+            lighting,
+            in.vtxColor,
+            materialLighting,
+            in.worldPos,
+            in.normal
+       ) : in.vtxColor;
     }
     
     if (bumpMap) {
         float3 normal = 0.f;
-        for (size_t bumpIndex=0; bumpIndex<numBumpMaps; bumpIndex++) {
+        for (int bumpIndex=0; bumpIndex<numBumpMaps; bumpIndex++) {
             device ShaderBumpMapType& bump = bumpInfo[bumpIndex];
             float3 sampleCoord = in.texCoord1;
             half3 bumpNormal = bump.bumpTexture.sample(bump.bumpTextureSampler, sampleCoord.xy).rgb;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
@@ -69,8 +69,10 @@ enum plUVWSrcModifiers: uint32_t
 
 using namespace metal;
 
-constant const bool perPixelLighting [[ function_constant(FunctionConstantPerPixelLighting)    ]];
-constant const bool perVertexLighting = !perPixelLighting;
+constant const bool     perPixelLighting [[ function_constant(FunctionConstantPerPixelLighting)    ]];
+constant const bool     perVertexLighting = !perPixelLighting;
+constant const uint8_t  numBumpMaps [[ function_constant(FunctionConstantNumBumpMaps)    ]];
+constant const bool     bumpMap = numBumpMaps > 0;
 
 constant const uint8_t sourceType1 [[ function_constant(FunctionConstantSources + 0)    ]];
 constant const uint8_t sourceType2 [[ function_constant(FunctionConstantSources + 1)    ]];
@@ -122,6 +124,15 @@ constant const bool hasCubicTexture5 = (sourceType5 == PassTypeCubicTexture && h
 constant const bool hasCubicTexture6 = (sourceType6 == PassTypeCubicTexture && hasLayer6);
 constant const bool hasCubicTexture7 = (sourceType7 == PassTypeCubicTexture && hasLayer7);
 constant const bool hasCubicTexture8 = (sourceType8 == PassTypeCubicTexture && hasLayer8);
+    
+constant const bool hasBumpMap1 = (numBumpMaps > 0);
+constant const bool hasBumpMap2 = (numBumpMaps > 1);
+constant const bool hasBumpMap3 = (numBumpMaps > 2);
+constant const bool hasBumpMap4 = (numBumpMaps > 3);
+constant const bool hasBumpMap5 = (numBumpMaps > 4);
+constant const bool hasBumpMap6 = (numBumpMaps > 5);
+constant const bool hasBumpMap7 = (numBumpMaps > 6);
+constant const bool hasBumpMap8 = (numBumpMaps > 7);
 
 struct FragmentShaderArguments
 {
@@ -167,6 +178,24 @@ typedef struct
     float3 texCoord6 [[ function_constant(hasLayer6) ]];
     float3 texCoord7 [[ function_constant(hasLayer7) ]];
     float3 texCoord8 [[ function_constant(hasLayer8) ]];
+    
+    float3 T    [[ function_constant(hasBumpMap1) ]];
+    float3 T1   [[ function_constant(hasBumpMap2) ]];
+    float3 T2   [[ function_constant(hasBumpMap3) ]];
+    float3 T3   [[ function_constant(hasBumpMap4) ]];
+    float3 T4   [[ function_constant(hasBumpMap5) ]];
+    float3 T5   [[ function_constant(hasBumpMap6) ]];
+    float3 T6   [[ function_constant(hasBumpMap7) ]];
+    float3 T7   [[ function_constant(hasBumpMap8) ]];
+    float3 B    [[ function_constant(hasBumpMap1) ]];
+    float3 B1   [[ function_constant(hasBumpMap2) ]];
+    float3 B2   [[ function_constant(hasBumpMap3) ]];
+    float3 B3   [[ function_constant(hasBumpMap4) ]];
+    float3 B4   [[ function_constant(hasBumpMap5) ]];
+    float3 B5   [[ function_constant(hasBumpMap6) ]];
+    float3 B6   [[ function_constant(hasBumpMap7) ]];
+    float3 B7   [[ function_constant(hasBumpMap8) ]];
+    
     half4 vtxColor   [[ centroid_perspective ]];
     half4 fogColor;
 } ColorInOut;
@@ -177,6 +206,19 @@ struct Lighting
     constant plMetalShaderActiveLight* activeLights      [[ buffer(ShaderActiveLights) ]];
     constant uint& lightCount [[ buffer(ShaderActiveLightCount)  ]];
 };
+    
+struct plTier1Bumpmap
+{
+    char2 dTangentIndex [[ id(dTangentIndexID) ]];
+    texture2d<half> bumpTexture [[ id(textureID) ]];
+    float3 scale [[ id(dScaleID) ]];
+};
+    
+#if __METAL_VERSION__ >= 300
+typedef plMetalBumpmap ShaderBumpMapType;
+#else
+typedef plTier1Bumpmap ShaderBumpMapType;
+#endif
 
 typedef struct
 {
@@ -250,7 +292,8 @@ vertex ColorInOut pipelineVertexShader(Vertex in [[stage_in]],
                                        constant VertexUniforms & uniforms   [[ buffer(VertexShaderArgumentFixedFunctionUniforms) ]],
                                        Lighting lighting [[ function_constant(perVertexLighting) ]],
                                        constant plMaterialLightingDescriptor & materialLighting   [[ buffer(VertexShaderArgumentMaterialLighting), function_constant(perVertexLighting) ]],
-                                       constant float4x4 & blendMatrix1     [[ buffer(VertexShaderArgumentBlendMatrix1), function_constant(temp_hasOnlyWeight1) ]])
+                                       constant float4x4 & blendMatrix1     [[ buffer(VertexShaderArgumentBlendMatrix1), function_constant(temp_hasOnlyWeight1) ]],
+                                       device ShaderBumpMapType *bumpInfo [[ buffer(BumpState), function_constant(bumpMap) ]])
 {
     ColorInOut out;
     // FVF ARGB color is in little endian order, so we need to swizzle it into RGBA
@@ -281,10 +324,16 @@ vertex ColorInOut pipelineVertexShader(Vertex in [[stage_in]],
 
     const float4 cameraSpaceNormal = normalize(((float4(in.normal, 0.f) * uniforms.localToWorldMatrix) * uniforms.worldToCameraMatrix));
 
-    for (size_t layer=0; layer<num_layers; layer++) {
+    for (int layer=0; layer<num_layers; layer++) {
         (&out.texCoord1)[layer] = uniforms.sampleLocation(layer, &in.texCoord1, cameraSpaceNormal, vCamPosition);
     }
 
+    
+    for (int bumpMap=0; bumpMap<numBumpMaps; bumpMap++) {
+        (&out.T)[bumpMap] = normalize(uniforms.localToWorldMatrix * float4((&in.texCoord1)[bumpInfo[bumpMap].dTangentIndex[0]], 0.f)). xyz;
+        (&out.B)[bumpMap] = normalize(uniforms.localToWorldMatrix * float4((&in.texCoord1)[bumpInfo[bumpMap].dTangentIndex[1]], 0.f)). xyz;
+    }
+    
     out.position = vCamPosition * uniforms.projectionMatrix;
 
     return out;
@@ -450,9 +499,47 @@ half4 FragmentShaderArguments::sampleLayer(const size_t index, const half4 verte
 fragment half4 pipelineFragmentShader(ColorInOut in [[stage_in]],
                                       const FragmentShaderArguments fragmentShaderArgs,
                                       Lighting lighting [[ function_constant(perPixelLighting) ]],
-                                      constant plMaterialLightingDescriptor & materialLighting   [[ buffer(FragmentShaderArgumentMaterialLighting), function_constant(perPixelLighting) ]])
+                                      constant plMaterialLightingDescriptor & materialLighting   [[ buffer(FragmentShaderArgumentMaterialLighting), function_constant(perPixelLighting) ]],
+                                      device ShaderBumpMapType *bumpInfo [[ buffer(BumpState), function_constant(bumpMap) ]])
 {
-    const half4 lightingContributionColor = perPixelLighting ? calcLitMaterialColor(lighting, in.vtxColor, materialLighting, in.worldPos, in.normal) : in.vtxColor;
+    half4 lightingContributionColor = half4(0.h);
+    
+    /*
+     This controls the bumpmap style:
+     - Additive bump maps do a secondary hilight pass on the material. This is
+     how Cyan shipped bump maps in Uru. These bump maps ignore the blue channel
+     of the normal map file.
+     - If bumpMapIsAdditive is false, full normal mapping is performed on a per
+     pixel basis. This is not how the engine shipped and will produce different
+     results than the original age artist may have expected. But it will be
+     proper normal mapping.
+     */
+    constexpr bool bumpMapIsAdditive = true;
+    constexpr bool performBaseLighting = bumpMapIsAdditive || !bumpMap;
+    
+    if (performBaseLighting) {
+        lightingContributionColor = perPixelLighting ? calcLitMaterialColor(lighting, in.vtxColor, materialLighting, in.worldPos, in.normal) : in.vtxColor;
+    }
+    
+    if (bumpMap) {
+        float3 normal = 0.f;
+        for (size_t bump=0; bump<numBumpMaps; bump++) {
+            float3 sampleCoord = in.texCoord1;
+            half3 bumpNormal = bumpInfo[bump].bumpTexture.sample(fragmentShaderArgs.samplers, sampleCoord.xy).rgb;
+            
+            bumpNormal -= 0.5f;
+            bumpNormal *= 2.f;
+            
+            float3x3 TBN = float3x3(in.T, in.B, in.normal);
+            normal += TBN * float3(bumpNormal) * bumpInfo[bump].scale;
+        }
+        
+        normal = normalize(normal);
+        if (performBaseLighting) {
+            normal.z = 0.f;
+        }
+        lightingContributionColor += perPixelLighting ? calcLitMaterialColor(lighting, in.vtxColor, materialLighting, in.worldPos, normal) : in.vtxColor;
+    }
     half4 currentColor = lightingContributionColor;
 
     /*

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
@@ -209,9 +209,10 @@ struct Lighting
     
 struct plTier1Bumpmap
 {
-    char2 dTangentIndex [[ id(dTangentIndexID) ]];
+    char2 dTangentIndex         [[ id(dTangentIndexID) ]];
     texture2d<half> bumpTexture [[ id(textureID) ]];
-    float3 scale [[ id(dScaleID) ]];
+    sampler bumpTextureSampler  [[ id(samplerID) ]];
+    float3 scale                [[ id(dScaleID) ]];
 };
     
 #if __METAL_VERSION__ >= 300
@@ -523,15 +524,16 @@ fragment half4 pipelineFragmentShader(ColorInOut in [[stage_in]],
     
     if (bumpMap) {
         float3 normal = 0.f;
-        for (size_t bump=0; bump<numBumpMaps; bump++) {
+        for (size_t bumpIndex=0; bumpIndex<numBumpMaps; bumpIndex++) {
+            device ShaderBumpMapType& bump = bumpInfo[bumpIndex];
             float3 sampleCoord = in.texCoord1;
-            half3 bumpNormal = bumpInfo[bump].bumpTexture.sample(fragmentShaderArgs.samplers, sampleCoord.xy).rgb;
+            half3 bumpNormal = bump.bumpTexture.sample(bump.bumpTextureSampler, sampleCoord.xy).rgb;
             
             bumpNormal -= 0.5f;
             bumpNormal *= 2.f;
             
             float3x3 TBN = float3x3(in.T, in.B, in.normal);
-            normal += TBN * float3(bumpNormal) * bumpInfo[bump].scale;
+            normal += TBN * float3(bumpNormal) * bump.scale;
         }
         
         normal = normalize(normal);

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderTypes.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderTypes.h
@@ -283,6 +283,7 @@ typedef enum plMetalBumpMappingBufferLayout
 {
     dTangentIndexID,
     textureID,
+    samplerID,
     dScaleID
 } plMetalBumpMappingBufferLayout;
 
@@ -290,6 +291,7 @@ struct plMetalBumpmap
 {
 #if __METAL_VERSION__ >= 300 || defined(METAL_3_SDK)
     texture2d<half> bumpTexture;
+    sampler         bumpTextureSampler;
 #endif
     float       scale;
     simd::char2 dTangentIndex;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
@@ -65,7 +65,8 @@ NS::Array* plMetalBumpArgumentBuffer::GetArgumentDescriptors()
     return array;
 }
 
-plMetalBumpArgumentBuffer::plMetalBumpArgumentBuffer(plMetalDevice* device, size_t numElements) : plMetalArgumentBuffer<plMetalBumpmap>(device, numElements)
+plMetalBumpArgumentBuffer::plMetalBumpArgumentBuffer(plMetalDevice* device, size_t numElements)
+    : plMetalArgumentBuffer<plMetalBumpmap>(device, numElements)
 {
     _bumps.resize(numElements);
 }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
@@ -72,10 +72,10 @@ void plMetalBumpArgumentBuffer::Set(const std::vector<plMetalBumpMapping>& bumps
         return;
     }
     ConfigureBuffer();
-    int i = 0;
     if (fTier == plMetalArgumentBufferTier::Tier1) {
         // Tier 1, because Tier 1 doesn't guarantee memory layout, go through the encoder
-        for (const auto& bump : bumps) {
+        for (int i = 0; i < bumps.size(); ++i) {
+            auto& bump = bumps[i];
             fEncoder->setArgumentBuffer(GetBuffer(), 0, i);
             fEncoder->setTexture(bump.texture, textureID);
             fEncoder->setSamplerState(bump.sampler, samplerID);
@@ -85,20 +85,19 @@ void plMetalBumpArgumentBuffer::Set(const std::vector<plMetalBumpMapping>& bumps
             memcpy(scaleBuffer, &bump.scale, sizeof(float));
 
             _bumps[i] = bump;
-            i++;
         }
     }
 #ifdef METAL_3_SDK
     else {
         // Tier 2, memory layout is guaranteed, we can scrible directly on buffer memory
-        for (const auto& bump : bumps) {
+        for (int i = 0; i < bumps.size(); ++i) {
+            auto& bump = bumps[i];
             fValue[i].bumpTexture = bump.texture->gpuResourceID();
             fValue[i].bumpTextureSampler = bump.sampler->gpuResourceID();
             fValue[i].dTangentIndex = simd::make_char2(bump.dTangentUIndex, bump.dTangentVIndex);
             fValue[i].scale = bump.scale;
 
             _bumps[i] = bump;
-            i++;
         }
     }
 #endif
@@ -124,7 +123,7 @@ bool plMetalBumpArgumentBuffer::CheckBuffer(const std::vector<plMetalBumpMapping
         return false;
     }
     int i = 0;
-    for (auto& bump : bumps) {
+    for (const auto& bump : bumps) {
         if (bump.texture != _bumps[i].texture)
             return false;
         if (bump.dTangentUIndex != _bumps[i].dTangentUIndex ||

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
@@ -44,7 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 NS::Array* plMetalBumpArgumentBuffer::GetArgumentDescriptors()
 {
-    MTL::ArgumentDescriptor* descriptors[3];
+    MTL::ArgumentDescriptor* descriptors[4];
     descriptors[0] = MTL::ArgumentDescriptor::argumentDescriptor();
     descriptors[0]->setIndex(dTangentIndexID);
     descriptors[0]->setDataType(MTL::DataTypeChar2);
@@ -54,10 +54,14 @@ NS::Array* plMetalBumpArgumentBuffer::GetArgumentDescriptors()
     descriptors[1]->setDataType(MTL::DataTypeTexture);
 
     descriptors[2] = MTL::ArgumentDescriptor::argumentDescriptor();
-    descriptors[2]->setIndex(dScaleID);
-    descriptors[2]->setDataType(MTL::DataTypeFloat);
+    descriptors[2]->setIndex(samplerID);
+    descriptors[2]->setDataType(MTL::DataTypeSampler);
 
-    NS::Array* array = NS::Array::array((const NS::Object* const*)descriptors, 3);
+    descriptors[3] = MTL::ArgumentDescriptor::argumentDescriptor();
+    descriptors[3]->setIndex(dScaleID);
+    descriptors[3]->setDataType(MTL::DataTypeFloat);
+
+    NS::Array* array = NS::Array::array((const NS::Object* const*)descriptors, 4);
     return array;
 }
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
@@ -77,12 +77,12 @@ void plMetalBumpArgumentBuffer::Set(const std::vector<plMetalBumpMapping>& bumps
         for (const auto& bump : bumps) {
             _encoder->setArgumentBuffer(GetBuffer(), 0, i);
             _encoder->setTexture(bump.texture, textureID);
+            _encoder->setSamplerState(bump.sampler, samplerID);
             uint8_t* cotangentUBuffer = static_cast<uint8_t*>(_encoder->constantData(dTangentIndexID));
             memcpy(cotangentUBuffer, &bump.dTangentUIndex, sizeof(uint8_t) * 2);
             float* scaleBuffer = static_cast<float*>(_encoder->constantData(dScaleID));
             memcpy(scaleBuffer, &bump.scale, sizeof(float));
 
-            // FIXME: We can't track this with a tier 1 buffer
             _bumps[i] = bump;
             i++;
         }
@@ -91,6 +91,7 @@ void plMetalBumpArgumentBuffer::Set(const std::vector<plMetalBumpMapping>& bumps
     else {
         for (const auto& bump : bumps) {
             _value[i].bumpTexture = bump.texture->gpuResourceID();
+            _value[i].bumpTextureSampler = bump.sampler->gpuResourceID();
             _value[i].dTangentIndex = simd::make_char2(bump.dTangentUIndex, bump.dTangentVIndex);
             _value[i].scale = bump.scale;
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
@@ -1,0 +1,137 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "plMetalArgumentBuffer.h"
+
+NS::Array* plMetalBumpArgumentBuffer::GetArgumentDescriptors()
+{
+    MTL::ArgumentDescriptor* descriptors[3];
+    descriptors[0] = MTL::ArgumentDescriptor::argumentDescriptor();
+    descriptors[0]->setIndex(dTangentIndexID);
+    descriptors[0]->setDataType(MTL::DataTypeChar2);
+
+    descriptors[1] = MTL::ArgumentDescriptor::argumentDescriptor();
+    descriptors[1]->setIndex(textureID);
+    descriptors[1]->setDataType(MTL::DataTypeTexture);
+
+    descriptors[2] = MTL::ArgumentDescriptor::argumentDescriptor();
+    descriptors[2]->setIndex(dScaleID);
+    descriptors[2]->setDataType(MTL::DataTypeFloat);
+
+    NS::Array* array = NS::Array::array((const NS::Object* const*)descriptors, 3);
+    return array;
+}
+
+plMetalBumpArgumentBuffer::plMetalBumpArgumentBuffer(MTL::Device* device, size_t numElements) : plMetalArgumentBuffer<plMetalBumpmap>(device, numElements)
+{
+    _bumps.resize(numElements);
+}
+
+void plMetalBumpArgumentBuffer::Set(const std::vector<plMetalBumpMapping>& bumps)
+{
+    if (CheckBuffer(bumps)) {
+        return;
+    }
+    ConfigureBuffer();
+    int i = 0;
+    if (_tier == plMetalArgumentBufferTier::Tier1) {
+        for (const auto& bump : bumps) {
+            _encoder->setArgumentBuffer(GetBuffer(), 0, i);
+            _encoder->setTexture(bump.texture, textureID);
+            uint8_t* cotangentUBuffer = static_cast<uint8_t*>(_encoder->constantData(dTangentIndexID));
+            memcpy(cotangentUBuffer, &bump.dTangentUIndex, sizeof(uint8_t) * 2);
+            float* scaleBuffer = static_cast<float*>(_encoder->constantData(dScaleID));
+            memcpy(scaleBuffer, &bump.scale, sizeof(float));
+
+            // FIXME: We can't track this with a tier 1 buffer
+            _bumps[i] = bump;
+            i++;
+        }
+    }
+#ifdef METAL_3_SDK
+    else {
+        for (const auto& bump : bumps) {
+            _value[i].bumpTexture = bump.texture->gpuResourceID();
+            _value[i].dTangentIndex = simd::make_char2(bump.dTangentUIndex, bump.dTangentVIndex);
+            _value[i].scale = bump.scale;
+
+            _bumps[i] = bump;
+            i++;
+        }
+    }
+#endif
+    if (GetBuffer()->storageMode() == MTL::StorageModeManaged) {
+        GetBuffer()->didModifyRange(NS::Range(0, GetBuffer()->length()));
+    }
+}
+
+void plMetalBumpArgumentBuffer::Bind(MTL::RenderCommandEncoder* encoder)
+{
+    for (const auto& bump : _bumps) {
+        // These textures can't go into a heap because they're shared by multiple
+        // materials, boo. Mark them as needing to be resident one at a time.
+        encoder->useResource(bump.texture, MTL::ResourceUsageRead, MTL::RenderStageFragment);
+    }
+    encoder->setVertexBuffer(GetBuffer(), 0, BumpState);
+    encoder->setFragmentBuffer(GetBuffer(), 0, BumpState);
+}
+
+bool plMetalBumpArgumentBuffer::CheckBuffer(const std::vector<plMetalBumpMapping>& bumps)
+{
+    if (bumps.size() != _numElements || GetBuffer() == nullptr) {
+        return false;
+    }
+    int i = 0;
+    for (auto& bump : bumps) {
+        if (bump.texture != _bumps[i].texture)
+            return false;
+        if (bump.dTangentUIndex != _bumps[i].dTangentUIndex ||
+            bump.dTangentVIndex != _bumps[i].dTangentVIndex) {
+            return false;
+        }
+        if (bump.scale != _bumps[i].scale) {
+            return false;
+        }
+        i++;
+    }
+    return true;
+}

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
@@ -65,7 +65,7 @@ NS::Array* plMetalBumpArgumentBuffer::GetArgumentDescriptors()
     return array;
 }
 
-plMetalBumpArgumentBuffer::plMetalBumpArgumentBuffer(MTL::Device* device, size_t numElements) : plMetalArgumentBuffer<plMetalBumpmap>(device, numElements)
+plMetalBumpArgumentBuffer::plMetalBumpArgumentBuffer(plMetalDevice* device, size_t numElements) : plMetalArgumentBuffer<plMetalBumpmap>(device, numElements)
 {
     _bumps.resize(numElements);
 }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
@@ -122,8 +122,8 @@ bool plMetalBumpArgumentBuffer::CheckBuffer(const std::vector<plMetalBumpMapping
     if (bumps.size() != fNumElements || GetBuffer() == nullptr) {
         return false;
     }
-    int i = 0;
-    for (const auto& bump : bumps) {
+    for (int i = 0; i < bumps.size(); ++i) {
+        auto& bump = bumps[i];
         if (bump.texture != _bumps[i].texture)
             return false;
         if (bump.dTangentUIndex != _bumps[i].dTangentUIndex ||
@@ -133,7 +133,6 @@ bool plMetalBumpArgumentBuffer::CheckBuffer(const std::vector<plMetalBumpMapping
         if (bump.scale != _bumps[i].scale) {
             return false;
         }
-        i++;
     }
     return true;
 }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.cpp
@@ -79,7 +79,7 @@ void plMetalBumpArgumentBuffer::Set(const std::vector<plMetalBumpMapping>& bumps
     ConfigureBuffer();
     if (fTier == plMetalArgumentBufferTier::Tier1) {
         // Tier 1, because Tier 1 doesn't guarantee memory layout, go through the encoder
-        for (int i = 0; i < bumps.size(); ++i) {
+        for (size_t i = 0; i < bumps.size(); ++i) {
             auto& bump = bumps[i];
             fEncoder->setArgumentBuffer(GetBuffer(), 0, i);
             fEncoder->setTexture(bump.fTexture, textureID);

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.h
@@ -67,7 +67,8 @@ template <class T>
 class plMetalArgumentBuffer
 {
 public:
-    plMetalArgumentBuffer(MTL::Device* device, size_t numElements) : fDevice(device), fNumElements(numElements), fEncoder(nullptr)
+    plMetalArgumentBuffer(MTL::Device* device, size_t numElements)
+        : fDevice(device), fNumElements(numElements), fEncoder(nullptr)
     {
         fCurrentBufferIndex = -1;
         auto tier = std::max(device->argumentBuffersSupport(), MTL::ArgumentBuffersTier2);
@@ -76,6 +77,7 @@ public:
         fBuffer[1] = nullptr;
         fBuffer[2] = nullptr;
     };
+    
     constexpr MTL::Buffer* GetBuffer()
     {
         if (fCurrentBufferIndex == -1) {
@@ -83,8 +85,11 @@ public:
         }
         return fBuffer[fCurrentBufferIndex];
     }
+    
     T*     ValueAt(size_t i) { return fValue[i]; }
-    size_t GetNumElements() { return fNumElements; }
+    
+    size_t GetNumElements() const { return fNumElements; }
+    
     ~plMetalArgumentBuffer()
     {
         fBuffer[0]->release();

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.h
@@ -1,0 +1,162 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef plMetalArgumentBuffer_hpp
+#define plMetalArgumentBuffer_hpp
+
+#include <stdio.h>
+#include <Metal/Metal.hpp>
+
+#include "ShaderTypes.h"
+
+// Define our own enum so our code doesn't do weird things
+// if tier 3 shows up.
+enum class plMetalArgumentBufferTier : NS::UInteger
+{
+    Tier1 = MTL::ArgumentBuffersTier1,
+#ifdef METAL_3_SDK
+    Tier2 = MTL::ArgumentBuffersTier2,
+#endif
+};
+
+template <class T>
+class plMetalArgumentBuffer
+{
+public:
+    plMetalArgumentBuffer(MTL::Device* device, size_t numElements) : _device(device), _numElements(numElements), _encoder(nullptr)
+    {
+        _currentBufferIndex = -1;
+        auto tier = std::max(device->argumentBuffersSupport(), MTL::ArgumentBuffersTier2);
+        _tier = plMetalArgumentBufferTier(tier);
+        _buffer[0] = nullptr;
+        _buffer[1] = nullptr;
+        _buffer[2] = nullptr;
+    };
+    constexpr MTL::Buffer* GetBuffer()
+    {
+        if (_currentBufferIndex == -1) {
+            return nullptr;
+        }
+        return _buffer[_currentBufferIndex];
+    }
+    T*     ValueAt(size_t i) { return _value[i]; }
+    size_t GetNumElements() { return _numElements; }
+    ~plMetalArgumentBuffer()
+    {
+        _buffer[0]->release();
+        _buffer[1]->release();
+        _buffer[2]->release();
+        _encoder->release();
+    }
+
+protected:
+    T*                        _value;
+    MTL::Buffer*              _buffer[3];
+    MTL::Device*              _device;
+    // Encoder for tier 1 buffers, don't use in tier 2
+    MTL::ArgumentEncoder*     _encoder;
+    size_t                    _numElements;
+    plMetalArgumentBufferTier _tier;
+    size_t                    _currentBufferIndex;
+    virtual NS::Array*        GetArgumentDescriptors() = 0;
+
+    void ConfigureBuffer()
+    {
+        _currentBufferIndex = (_currentBufferIndex + 1) % 3;
+        switch (_tier) {
+            case plMetalArgumentBufferTier::Tier1:
+                ConfigureTier1();
+                break;
+#ifdef METAL_3_SDK
+            case plMetalArgumentBufferTier::Tier2:
+                ConfigureTier2();
+                break;
+#endif
+        }
+    }
+
+private:
+    void ConfigureTier1()
+    {
+        if (!_encoder)
+            _encoder = _device->newArgumentEncoder(GetArgumentDescriptors());
+        if (!_buffer[_currentBufferIndex])
+            _buffer[_currentBufferIndex] = _device->newBuffer(_encoder->encodedLength() * _numElements, MTL::CPUCacheModeWriteCombined);
+        // raw access to buffer not available in tier 1 argument buffers
+        _value = nullptr;
+    }
+#ifdef METAL_3_SDK
+    void ConfigureTier2()
+    {
+        if (!_buffer[_currentBufferIndex])
+            _buffer[_currentBufferIndex] = _device->newBuffer(sizeof(T) * _numElements, MTL::CPUCacheModeWriteCombined);
+        _value = static_cast<T*>(_buffer[_currentBufferIndex]->contents());
+        // Encoders are not used in tier 2 argument buffers
+        _encoder = nullptr;
+    }
+#endif
+};
+
+struct plMetalBumpMapping
+{
+    uint8_t       dTangentUIndex;
+    uint8_t       dTangentVIndex;
+    float         scale;
+    MTL::Texture* texture;
+};
+
+class plMetalBumpArgumentBuffer final : public plMetalArgumentBuffer<plMetalBumpmap>
+{
+public:
+    void Set(const std::vector<plMetalBumpMapping>& bumps);
+    plMetalBumpArgumentBuffer(MTL::Device* device, size_t numElements);
+    void Bind(MTL::RenderCommandEncoder* encoder);
+    bool CheckBuffer(const std::vector<plMetalBumpMapping>& bumps);
+
+protected:
+    virtual NS::Array* GetArgumentDescriptors() override;
+
+private:
+    std::vector<plMetalBumpMapping> _bumps;
+};
+
+#endif /* plMetalArgumentBuffer_hpp */

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.h
@@ -138,10 +138,11 @@ private:
 
 struct plMetalBumpMapping
 {
-    uint8_t       dTangentUIndex;
-    uint8_t       dTangentVIndex;
-    float         scale;
-    MTL::Texture* texture;
+    uint8_t             dTangentUIndex;
+    uint8_t             dTangentVIndex;
+    float               scale;
+    MTL::Texture*       texture;
+    MTL::SamplerState*  sampler;
 };
 
 class plMetalBumpArgumentBuffer final : public plMetalArgumentBuffer<plMetalBumpmap>

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.h
@@ -71,6 +71,22 @@ enum class plMetalArgumentBufferTier : NS::UInteger
 template <class T>
 class plMetalArgumentBuffer
 {
+protected:
+    // Pointer to buffer memory - only available in tier 2
+    T*                          fValue;
+    // Triple buffered argument buffers
+    NS::SharedPtr<MTL::Buffer>  fBuffer[3];
+    // Host Plasma device for buffers
+    plMetalDevice*              fDevice;
+    // Encoder for tier 1 buffers, don't use in tier 2
+    NS::SharedPtr<MTL::ArgumentEncoder>   fEncoder;
+    // Number of array elements supported per buffer
+    size_t                      fNumElements;
+    // Tier of argument buffers targeted by this instance
+    plMetalArgumentBufferTier fTier;
+    // Current buffer in the triple buffer rotation
+    size_t                      fCurrentBufferIndex;
+
 public:
     plMetalArgumentBuffer(plMetalDevice* device, size_t numElements)
         : fDevice(device), fNumElements(numElements), fEncoder()
@@ -93,20 +109,6 @@ public:
     size_t GetNumElements() const { return fNumElements; }
 
 protected:
-    // Pointer to buffer memory - only available in tier 2
-    T*                          fValue;
-    // Triple buffered argument buffers
-    NS::SharedPtr<MTL::Buffer>  fBuffer[3];
-    // Host Plasma device for buffers
-    plMetalDevice*              fDevice;
-    // Encoder for tier 1 buffers, don't use in tier 2
-    NS::SharedPtr<MTL::ArgumentEncoder>   fEncoder;
-    // Number of array elements supported per buffer
-    size_t                      fNumElements;
-    // Tier of argument buffers targeted by this instance
-    plMetalArgumentBufferTier fTier;
-    // Current buffer in the triple buffer rotation
-    size_t                      fCurrentBufferIndex;
     // Subclasses must override this to create an encoder for
     // tier 1 buffers. Encoder creation needs to know the
     // buffer layout.

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalArgumentBuffer.h
@@ -78,9 +78,6 @@ public:
         fCurrentBufferIndex = -1;
         auto tier = std::min(device->ArgumentBuffersTier(), static_cast<MTL::ArgumentBuffersTier>(plMetalArgumentBufferTier::Tier2));
         fTier = plMetalArgumentBufferTier(tier);
-        fBuffer[0] = nullptr;
-        fBuffer[1] = nullptr;
-        fBuffer[2] = nullptr;
     };
     
     MTL::Buffer* GetBuffer() const
@@ -88,36 +85,28 @@ public:
         if (fCurrentBufferIndex == -1) {
             return nullptr;
         }
-        return fBuffer[fCurrentBufferIndex];
+        return fBuffer[fCurrentBufferIndex].get();
     }
     
     T*     ValueAt(size_t i) { return fValue[i]; }
     
     size_t GetNumElements() const { return fNumElements; }
-    
-    ~plMetalArgumentBuffer()
-    {
-        for (auto& buffer : fBuffer) {
-            buffer->release();
-        }
-        fEncoder->release();
-    }
 
 protected:
     // Pointer to buffer memory - only available in tier 2
-    T*                        fValue;
+    T*                          fValue;
     // Triple buffered argument buffers
-    MTL::Buffer*              fBuffer[3];
+    NS::SharedPtr<MTL::Buffer>  fBuffer[3];
     // Host Plasma device for buffers
-    plMetalDevice*            fDevice;
+    plMetalDevice*              fDevice;
     // Encoder for tier 1 buffers, don't use in tier 2
-    MTL::ArgumentEncoder*     fEncoder;
+    NS::SharedPtr<MTL::ArgumentEncoder>   fEncoder;
     // Number of array elements supported per buffer
-    size_t                    fNumElements;
+    size_t                      fNumElements;
     // Tier of argument buffers targeted by this instance
     plMetalArgumentBufferTier fTier;
     // Current buffer in the triple buffer rotation
-    size_t                    fCurrentBufferIndex;
+    size_t                      fCurrentBufferIndex;
     // Subclasses must override this to create an encoder for
     // tier 1 buffers. Encoder creation needs to know the
     // buffer layout.
@@ -140,9 +129,9 @@ private:
     void ConfigureTier1()
     {
         if (!fEncoder)
-            fEncoder = fDevice->fMetalDevice->newArgumentEncoder(GetArgumentDescriptors());
+            fEncoder = NS::TransferPtr(fDevice->fMetalDevice->newArgumentEncoder(GetArgumentDescriptors()));
         if (!fBuffer[fCurrentBufferIndex])
-            fBuffer[fCurrentBufferIndex] = fDevice->fMetalDevice->newBuffer(fEncoder->encodedLength() * fNumElements, MTL::CPUCacheModeWriteCombined);
+            fBuffer[fCurrentBufferIndex] = NS::TransferPtr(fDevice->fMetalDevice->newBuffer(fEncoder->encodedLength() * fNumElements, MTL::CPUCacheModeWriteCombined));
         // raw access to buffer not available in tier 1 argument buffers
         fValue = nullptr;
     }
@@ -150,10 +139,10 @@ private:
     void ConfigureTier2()
     {
         if (!fBuffer[fCurrentBufferIndex])
-            fBuffer[fCurrentBufferIndex] = fDevice->fMetalDevice->newBuffer(sizeof(T) * fNumElements, MTL::CPUCacheModeWriteCombined);
+            fBuffer[fCurrentBufferIndex] = NS::TransferPtr(fDevice->fMetalDevice->newBuffer(sizeof(T) * fNumElements, MTL::CPUCacheModeWriteCombined));
         fValue = static_cast<T*>(fBuffer[fCurrentBufferIndex]->contents());
         // Encoders are not used in tier 2 argument buffers
-        fEncoder = nullptr;
+        fEncoder.reset();
     }
 };
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
@@ -198,6 +198,7 @@ void plMetalDevice::SetMaxAnsiotropy(uint8_t maxAnsiotropy)
     samplerDescriptor->setMinFilter(MTL::SamplerMinMagFilterLinear);
     samplerDescriptor->setMagFilter(MTL::SamplerMinMagFilterLinear);
     samplerDescriptor->setMipFilter(MTL::SamplerMipFilterLinear);
+    samplerDescriptor->setSupportArgumentBuffers(true);
 
     samplerDescriptor->setSAddressMode(MTL::SamplerAddressModeRepeat);
     samplerDescriptor->setTAddressMode(MTL::SamplerAddressModeRepeat);

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
@@ -138,6 +138,9 @@ bool plMetalDevice::InitDevice()
     fSupportsTileMemory = fMetalDevice->supportsFamily(MTL::GPUFamilyApple1);
     fSupportsDXTTextures = fMetalDevice->supportsBCTextureCompression();
     
+    fArgumentBuffersTier = fDeviceType == hsG3DDeviceSelector::kDevTypeMetal2 ?
+                                MTL::ArgumentBuffersTier1 : fMetalDevice->argumentBuffersSupport();
+    
     if (!fSupportsDXTTextures) {
         hsStatusMessageF("Render device \"{}\" does not support DXT textures. Falling back on software decompression. Performance will be slower.", fMetalDevice->name()->cString(NS::StringEncoding::UTF8StringEncoding));
     }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -305,6 +305,10 @@ private:
     
     inline bool SupportsDXTTextures() const { return fSupportsDXTTextures; }
     bool fSupportsDXTTextures;
+
+    MTL::ArgumentBuffersTier fArgumentBuffersTier;
+public:
+    inline MTL::ArgumentBuffersTier ArgumentBuffersTier() const { return fArgumentBuffersTier; }
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
@@ -162,8 +162,8 @@ void plMetalMaterialShaderRef::FastEncodeArguments(MTL::RenderCommandEncoder* en
 
     encoder->setFragmentBuffer(fPassArgumentBuffers[pass], 0, FragmentShaderArgumentUniforms);
 
-    if (fBumps[pass].has_value()) {
-        auto& bump = fBumps[pass].value();
+    if (fBumps[pass]) {
+        auto& bump = fBumps[pass];
         bump->Bind(encoder);
     }
 }
@@ -202,8 +202,8 @@ void plMetalMaterialShaderRef::EncodeArguments(MTL::RenderCommandEncoder* encode
         }
     );
 
-    if (fBumps[pass].has_value()) {
-        auto& bump = fBumps[pass].value();
+    if (fBumps[pass]) {
+        auto& bump = fBumps[pass];
         bump->Bind(encoder);
     }
 
@@ -307,7 +307,7 @@ void plMetalMaterialShaderRef::ILoopOverLayers()
             // Shader only supports 8 bump maps, cap the number we build the shader for
             passDescription.fNumBumpMaps = std::min(bumps.size(), size_t(8));
         } else {
-            fBumps.emplace_back(std::nullopt);
+            fBumps.emplace_back(nullptr);
         }
 
         fFragmentShaderDescriptions.push_back(passDescription);
@@ -323,7 +323,7 @@ void plMetalMaterialShaderRef::ILoopOverLayers()
 void plMetalMaterialShaderRef::IEncodeBumpmapLayers(const std::vector<plMetalBumpMapping>& bumps, uint32_t pass)
 {
     if (fBumps.size() <= pass) {
-        fBumps.emplace_back(std::nullopt);
+        fBumps.emplace_back(nullptr);
     }
     auto& buffer = fBumps[pass];
     auto  bumpCount = bumps.size();
@@ -331,11 +331,11 @@ void plMetalMaterialShaderRef::IEncodeBumpmapLayers(const std::vector<plMetalBum
         buffer.reset();
         return;
     }
-    if (!buffer.has_value() || buffer.value()->GetNumElements() != bumpCount) {
-        buffer = std::make_shared<plMetalBumpArgumentBuffer>(fDevice, bumps.size());
+    if (!buffer|| buffer->GetNumElements() != bumpCount) {
+        buffer = std::make_unique<plMetalBumpArgumentBuffer>(fDevice, bumps.size());
     }
     size_t index = 0;
-    buffer.value()->Set(bumps);
+    buffer->Set(bumps);
 }
 
 void plMetalMaterialShaderRef::IEatBumpmapLayers(uint32_t& layerIdx, std::vector<plMetalBumpMapping>& bumpsOut)
@@ -361,7 +361,6 @@ void plMetalMaterialShaderRef::IEatBumpmapLayers(uint32_t& layerIdx, std::vector
             case hsGMatState::kMiscBumpDv:
                 bumpMapping.dTangentVIndex = layer->GetUVWSrc();
             case hsGMatState::kMiscBumpDw:
-            default:
                 break;
         }
     }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
@@ -332,7 +332,7 @@ void plMetalMaterialShaderRef::IEncodeBumpmapLayers(const std::vector<plMetalBum
         return;
     }
     if (!buffer|| buffer->GetNumElements() != bumpCount) {
-        buffer = std::make_unique<plMetalBumpArgumentBuffer>(fDevice, bumps.size());
+        buffer = std::make_unique<plMetalBumpArgumentBuffer>(&fPipeline->fDevice, bumps.size());
     }
     size_t index = 0;
     buffer->Set(bumps);

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
@@ -357,19 +357,19 @@ void plMetalMaterialShaderRef::IEatBumpmapLayers(uint32_t& layerIdx, std::vector
         uint32_t          miscFlags = layer->GetMiscFlags();
         switch (miscFlags & hsGMatState::kMiscBumpChans) {
             case hsGMatState::kMiscBumpDu:
-                bumpMapping.dTangentUIndex = layer->GetUVWSrc();
+                bumpMapping.fDTangentUIndex = layer->GetUVWSrc();
             case hsGMatState::kMiscBumpDv:
-                bumpMapping.dTangentVIndex = layer->GetUVWSrc();
+                bumpMapping.fDTangentVIndex = layer->GetUVWSrc();
             case hsGMatState::kMiscBumpDw:
                 break;
         }
     }
     plLayerInterface* bumpTextureLayer = fMaterial->GetLayer(layerIdx + 3);
-    bumpMapping.scale = bumpTextureLayer->GetRuntimeColor().r;
+    bumpMapping.fScale = bumpTextureLayer->GetRuntimeColor().r;
     fPipeline->CheckTextureRef(bumpTextureLayer);
-    bumpMapping.texture = static_cast<plMetalTextureRef*>(bumpTextureLayer->GetTexture()->GetDeviceRef())->fTexture;
+    bumpMapping.fTexture = static_cast<plMetalTextureRef*>(bumpTextureLayer->GetTexture()->GetDeviceRef())->fTexture;
     MTL::SamplerState* samplerState = fPipeline->fDevice.SampleStateForClampFlags(hsGMatState::hsGMatClampFlags(bumpTextureLayer->GetClampFlags()));
-    bumpMapping.sampler = samplerState;
+    bumpMapping.fSampler = samplerState;
 
     layerIdx += 4;
     // Keep going until they are all eaten

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
@@ -369,6 +369,8 @@ void plMetalMaterialShaderRef::IEatBumpmapLayers(uint32_t& layerIdx, std::vector
     bumpMapping.scale = bumpTextureLayer->GetRuntimeColor().r;
     fPipeline->CheckTextureRef(bumpTextureLayer);
     bumpMapping.texture = static_cast<plMetalTextureRef*>(bumpTextureLayer->GetTexture()->GetDeviceRef())->fTexture;
+    MTL::SamplerState* samplerState = fPipeline->fDevice.SampleStateForClampFlags(hsGMatState::hsGMatClampFlags(bumpTextureLayer->GetClampFlags()));
+    bumpMapping.sampler = samplerState;
     bumpsOut.emplace_back(bumpMapping);
 
     layerIdx += 4;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
@@ -350,7 +350,7 @@ void plMetalMaterialShaderRef::IEatBumpmapLayers(uint32_t& layerIdx, std::vector
         return;
     }
 
-    plMetalBumpMapping bumpMapping;
+    plMetalBumpMapping& bumpMapping = bumpsOut.emplace_back();
     // We have a bump map and it should occupy the next four layers
     for (size_t bumpLayer = 0; bumpLayer < 4; bumpLayer++) {
         plLayerInterface* layer = fMaterial->GetLayer(layerIdx + bumpLayer);
@@ -370,7 +370,6 @@ void plMetalMaterialShaderRef::IEatBumpmapLayers(uint32_t& layerIdx, std::vector
     bumpMapping.texture = static_cast<plMetalTextureRef*>(bumpTextureLayer->GetTexture()->GetDeviceRef())->fTexture;
     MTL::SamplerState* samplerState = fPipeline->fDevice.SampleStateForClampFlags(hsGMatState::hsGMatClampFlags(bumpTextureLayer->GetClampFlags()));
     bumpMapping.sampler = samplerState;
-    bumpsOut.emplace_back(bumpMapping);
 
     layerIdx += 4;
     // Keep going until they are all eaten

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
@@ -161,6 +161,11 @@ void plMetalMaterialShaderRef::FastEncodeArguments(MTL::RenderCommandEncoder* en
     }
 
     encoder->setFragmentBuffer(fPassArgumentBuffers[pass], 0, FragmentShaderArgumentUniforms);
+
+    if (fBumps[pass].has_value()) {
+        auto& bump = fBumps[pass].value();
+        bump->Bind(encoder);
+    }
 }
 
 void plMetalMaterialShaderRef::EncodeArguments(MTL::RenderCommandEncoder* encoder,
@@ -196,6 +201,11 @@ void plMetalMaterialShaderRef::EncodeArguments(MTL::RenderCommandEncoder* encode
             return postEncodeTransform(layer, index);
         }
     );
+
+    if (fBumps[pass].has_value()) {
+        auto& bump = fBumps[pass].value();
+        bump->Bind(encoder);
+    }
 
     encoder->setFragmentBytes(&uniforms, sizeof(plMetalFragmentShaderArgumentBuffer), FragmentShaderArgumentUniforms);
 }
@@ -237,8 +247,6 @@ void plMetalMaterialShaderRef::prepareTextures(MTL::RenderCommandEncoder* encode
 
 void plMetalMaterialShaderRef::ILoopOverLayers()
 {
-    uint32_t pass = 0;
-
     for (uint32_t j = 0; j < fMaterial->GetNumLayers();) {
         uint32_t currLayer = j;
 
@@ -268,11 +276,8 @@ void plMetalMaterialShaderRef::ILoopOverLayers()
             break;
 
         passDescription.CacheHash();
-        fFragmentShaderDescriptions.push_back(passDescription);
 
         std::vector<plLayerInterface*> layers(j);
-
-        pass++;
 
         // encode the colors for this pass into our buffer for fast rendering
         for (int layerOffset = 0; layerOffset < j - currLayer; layerOffset++) {
@@ -291,12 +296,84 @@ void plMetalMaterialShaderRef::ILoopOverLayers()
 
         fPassIndices.push_back(currLayer);
         fPassLengths.push_back(j - currLayer);
+
+        std::vector<plMetalBumpMapping> bumps;
+        IEatBumpmapLayers(j, bumps);
+
+        // Encode even empty ones to create the entry
+        IEncodeBumpmapLayers(bumps, fNumPasses);
+        if (!bumps.empty()) {
+            passDescription.fUsePerPixelLighting = true;
+            // Shader only supports 8 bump maps, cap the number we build the shader for
+            passDescription.fNumBumpMaps = std::min(bumps.size(), size_t(8));
+        } else {
+            fBumps.emplace_back(std::nullopt);
+        }
+
+        fFragmentShaderDescriptions.push_back(passDescription);
+
         fNumPasses++;
 
 #if 0
         ISetFogParameters(fMaterial->GetLayer(iCurrMat));
 #endif
     }
+}
+
+void plMetalMaterialShaderRef::IEncodeBumpmapLayers(const std::vector<plMetalBumpMapping>& bumps, uint32_t pass)
+{
+    if (fBumps.size() <= pass) {
+        fBumps.emplace_back(std::nullopt);
+    }
+    auto& buffer = fBumps[pass];
+    auto  bumpCount = bumps.size();
+    if (bumpCount == 0) {
+        buffer.reset();
+        return;
+    }
+    if (!buffer.has_value() || buffer.value()->GetNumElements() != bumpCount) {
+        buffer = std::make_shared<plMetalBumpArgumentBuffer>(fDevice, bumps.size());
+    }
+    size_t index = 0;
+    buffer.value()->Set(bumps);
+}
+
+void plMetalMaterialShaderRef::IEatBumpmapLayers(uint32_t& layerIdx, std::vector<plMetalBumpMapping>& bumpsOut)
+{
+    // If there aren't enough layers left to support a bump map, return
+    if (!(layerIdx + 3 < fMaterial->GetNumLayers())) {
+        return;
+    }
+
+    // Does the next layer imply a bump map?
+    if (!(fMaterial->GetLayer(layerIdx)->GetMiscFlags() & hsGMatState::kMiscBumpChans)) {
+        return;
+    }
+
+    plMetalBumpMapping bumpMapping;
+    // We have a bump map and it should occupy the next four layers
+    for (size_t bumpLayer = 0; bumpLayer < 4; bumpLayer++) {
+        plLayerInterface* layer = fMaterial->GetLayer(layerIdx + bumpLayer);
+        uint32_t          miscFlags = layer->GetMiscFlags();
+        switch (miscFlags & hsGMatState::kMiscBumpChans) {
+            case hsGMatState::kMiscBumpDu:
+                bumpMapping.dTangentUIndex = layer->GetUVWSrc();
+            case hsGMatState::kMiscBumpDv:
+                bumpMapping.dTangentVIndex = layer->GetUVWSrc();
+            case hsGMatState::kMiscBumpDw:
+            default:
+                break;
+        }
+    }
+    plLayerInterface* bumpTextureLayer = fMaterial->GetLayer(layerIdx + 3);
+    bumpMapping.scale = bumpTextureLayer->GetRuntimeColor().r;
+    fPipeline->CheckTextureRef(bumpTextureLayer);
+    bumpMapping.texture = static_cast<plMetalTextureRef*>(bumpTextureLayer->GetTexture()->GetDeviceRef())->fTexture;
+    bumpsOut.emplace_back(bumpMapping);
+
+    layerIdx += 4;
+    // Keep going until they are all eaten
+    IEatBumpmapLayers(layerIdx, bumpsOut);
 }
 
 const hsGMatState plMetalMaterialShaderRef::ICompositeLayerState(const plLayerInterface* layer) const

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.h
@@ -45,8 +45,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <map>
 #include <vector>
 
+#include <Metal/Metal.hpp>
+
 #include "ShaderTypes.h"
 #include "hsGMatState.h"
+#include "plMetalArgumentBuffer.h"
 #include "plMetalDeviceRef.h"
 #include "plMetalPipelineState.h"
 
@@ -117,10 +120,14 @@ private:
     bool     ICanEatLayer(plLayerInterface* lay);
     uint32_t ILayersAtOnce(uint32_t which);
 
-    void                                                 IBuildLayerTexture(MTL::RenderCommandEncoder* encoder, const uint32_t offsetFromRootLayer, plLayerInterface* layer);
-    void                                                 EncodeTransform(const plLayerInterface* layer, UVOutDescriptor *transform);
-    std::vector<std::vector<plLayerInterface*>>          fPasses;
-    std::vector<struct plMetalFragmentShaderDescription> fFragmentShaderDescriptions;
+    void IEatBumpmapLayers(uint32_t& layer, std::vector<plMetalBumpMapping>& bumpsOut);
+    void IEncodeBumpmapLayers(const std::vector<plMetalBumpMapping>& bumps, uint32_t pass);
+    void IBuildLayerTexture(MTL::RenderCommandEncoder* encoder, const uint32_t offsetFromRootLayer, plLayerInterface* layer);
+    void EncodeTransform(const plLayerInterface* layer, UVOutDescriptor* transform);
+
+    std::vector<std::vector<plLayerInterface*>>                            fPasses;
+    std::vector<std::optional<std::shared_ptr<plMetalBumpArgumentBuffer>>> fBumps;
+    std::vector<struct plMetalFragmentShaderDescription>                   fFragmentShaderDescriptions;
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.h
@@ -126,7 +126,7 @@ private:
     void EncodeTransform(const plLayerInterface* layer, UVOutDescriptor* transform);
 
     std::vector<std::vector<plLayerInterface*>>                            fPasses;
-    std::vector<std::optional<std::shared_ptr<plMetalBumpArgumentBuffer>>> fBumps;
+    std::vector<std::unique_ptr<plMetalBumpArgumentBuffer>>                fBumps;
     std::vector<struct plMetalFragmentShaderDescription>                   fFragmentShaderDescriptions;
 };
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -47,10 +47,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <string_theory/format>
 
 #include "HeadSpin.h"
+#include "ShaderTypes.h"
 #include "hsGMatState.inl"
 #include "hsMath.h"
 #include "hsTimer.h"
-
 #include "pfCamera/plVirtualCamNeu.h"
 #include "plAvatar/plAvatarClothing.h"
 #include "plDrawable/plAuxSpan.h"
@@ -82,7 +82,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plSurface/plLayerShadowBase.h"
 #include "plTweak.h"
 #include "plgDispatch.h"
-
 #include "pnMessage/plPipeResMakeMsg.h"
 #include "pnNetCommon/plNetApp.h" // for dbg logging
 
@@ -1694,8 +1693,11 @@ bool plMetalPipeline::IHandleMaterialPass(hsGMaterial* material, uint32_t pass, 
                                   preEncodeTransform,
                                   postEncodeTransform);
         }
-        
-        fragmentShaderDescription.fUsePerPixelLighting = PLASMA_FORCE_PER_PIXEL_LIGHTING;
+
+        if (!fragmentShaderDescription.fUsePerPixelLighting) {
+            fragmentShaderDescription.fUsePerPixelLighting = PLASMA_FORCE_PER_PIXEL_LIGHTING;
+        }
+
         ISetEnablePerPixelLighting( fragmentShaderDescription.fUsePerPixelLighting  );
 
         plMetalDevice::plMetalLinkedPipeline* linkedPipeline = plMetalMaterialPassPipelineState(&fDevice, vRef, fragmentShaderDescription).GetRenderPipelineState();
@@ -1722,7 +1724,7 @@ void plMetalPipeline::IBindLights()
 
     if (fLightsDirty) {
         if (fLightingPerPixel) {
-            fDevice.CurrentRenderCommandEncoder()->setFragmentBytes(fLights->data(), sizeof(plMetalShaderActiveLight) * fLights->size(), ShaderActiveLights);
+            fDevice.CurrentRenderCommandEncoder()->setFragmentBytes(fLights->data(), bindSize, ShaderActiveLights);
             fDevice.CurrentRenderCommandEncoder()->setFragmentBytes(&lightSize, sizeof(uint), ShaderActiveLightCount);
         } else {
             fDevice.CurrentRenderCommandEncoder()->setVertexBytes(fLights->data(), bindSize, ShaderActiveLights);
@@ -2508,6 +2510,7 @@ void plMetalPipeline::ISetEnablePerPixelLighting(const bool enable)
 {
     if (fLightingPerPixel != enable) {
         fLightingPerPixel = enable;
+        fLightsDirty = true;
 
         // These states need to be reset for a change in lighting technique
         fState.fBoundMaterialProperties.reset();

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.cpp
@@ -112,6 +112,7 @@ void plMetalMaterialPassPipelineState::GetFunctionConstants(MTL::FunctionConstan
     constants->setConstantValues(&fFragmentShaderDescription.fBlendModes, MTL::DataTypeUInt, NS::Range(FunctionConstantBlendModes, 8));
     constants->setConstantValues(&fFragmentShaderDescription.fMiscFlags, MTL::DataTypeUInt, NS::Range(FunctionConstantLayerFlags, 8));
     constants->setConstantValue(&fFragmentShaderDescription.fUsePerPixelLighting, MTL::DataTypeBool, FunctionConstantPerPixelLighting);
+    constants->setConstantValue(&fFragmentShaderDescription.fNumBumpMaps, MTL::DataTypeUChar, FunctionConstantNumBumpMaps);
 }
 
 size_t plMetalMaterialPassPipelineState::GetHash() const

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.h
@@ -148,12 +148,18 @@ struct plMetalFragmentShaderDescription
     uint32_t fMiscFlags[8];
     uint8_t  fNumLayers;
     bool     fUsePerPixelLighting;
+    uint8_t  fNumBumpMaps;
 
     size_t hash;
 
     bool operator==(const plMetalFragmentShaderDescription& p) const
     {
-        bool match = fNumLayers == p.fNumLayers && memcmp(fPassTypes, p.fPassTypes, sizeof(fPassTypes)) == 0 && memcmp(fBlendModes, p.fBlendModes, sizeof(fBlendModes)) == 0 && memcmp(fMiscFlags, p.fMiscFlags, sizeof(fMiscFlags)) == 0 && fUsePerPixelLighting == p.fUsePerPixelLighting;
+        bool match = fNumLayers == p.fNumLayers &&
+                                    memcmp(fPassTypes, p.fPassTypes, sizeof(fPassTypes)) == 0 &&
+                                    memcmp(fBlendModes, p.fBlendModes, sizeof(fBlendModes)) == 0 &&
+                                    memcmp(fMiscFlags, p.fMiscFlags, sizeof(fMiscFlags)) == 0 &&
+                                    fUsePerPixelLighting == p.fUsePerPixelLighting &&
+                                    fNumBumpMaps == p.fNumBumpMaps;
         return match;
     }
 
@@ -172,6 +178,7 @@ struct plMetalFragmentShaderDescription
         value ^= std::hash<uint8_t>()(fNumLayers);
         
         value ^= std::hash<bool>()(fUsePerPixelLighting);
+        value ^= std::hash<bool>()(fNumBumpMaps);
 
         for (int i = 0; i < 8; i++) {
             value ^= std::hash<uint32_t>()(fBlendModes[i]);

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.h
@@ -155,11 +155,11 @@ struct plMetalFragmentShaderDescription
     bool operator==(const plMetalFragmentShaderDescription& p) const
     {
         bool match = fNumLayers == p.fNumLayers &&
-                                    memcmp(fPassTypes, p.fPassTypes, sizeof(fPassTypes)) == 0 &&
-                                    memcmp(fBlendModes, p.fBlendModes, sizeof(fBlendModes)) == 0 &&
-                                    memcmp(fMiscFlags, p.fMiscFlags, sizeof(fMiscFlags)) == 0 &&
-                                    fUsePerPixelLighting == p.fUsePerPixelLighting &&
-                                    fNumBumpMaps == p.fNumBumpMaps;
+            memcmp(fPassTypes, p.fPassTypes, sizeof(fPassTypes)) == 0 &&
+            memcmp(fBlendModes, p.fBlendModes, sizeof(fBlendModes)) == 0 &&
+            memcmp(fMiscFlags, p.fMiscFlags, sizeof(fMiscFlags)) == 0 &&
+            fUsePerPixelLighting == p.fUsePerPixelLighting &&
+            fNumBumpMaps == p.fNumBumpMaps;
         return match;
     }
 


### PR DESCRIPTION
This PR implements argument buffers in the Metal renderer - and implements them first through bump mapping. Eventually I would like argument buffers to replace the entire layer system in the Metal shaders. I'm actively working on that - will be a future PR. If anyone is interested in rendering - please take your time on this one. Any improvements/feedback here will be very helpful for future work.

This came about because @dpogue asked about multiple bump maps in the original PR. There aren't an unlimited number of blind points in the shaders and the bind points have to be predefined - so supporting multiple bump maps would have been complicated.

Argument buffers replace bind points in shaders. I bind resources to the argument buffers instead, and then pass the buffers to the shader. The advantage is that now the bind points for textures, samplers, and other resources don't need to be predefined in the shader. And because they don't need to be predefined I can pass an array of argument buffers of any length and the shader can iterate over them. That means I can effectively bind an unlimited number of resources within shaders. This solves the problem of how we deliver an indeterminate amount of bump maps to the shader.

There is also a performance pickup. I can leave the argument buffers on the GPU, and instead of having to bind textures and samplers individually, I can just rebind the buffer I have cached. I have to be careful doing this around features like push over layers and piggyback layers. I'm doing some state tracking and comparisons right now to guard against changes and update the argument buffers when necessary. _This will get messier when layers themselves move over._

While this change lets us effectively support an unlimited number of bump maps - the structure passed between the vertex and fragment stages is still compile time defined. This has constrained the number of bump maps that can be supported by the shader to 8. (Which seems totally reasonable to me.)

Argument buffers work differently in Metal 3 and Metal 2. This code supports both approaches.

- Tier 2 argument buffers (Metal 3) give direct access to the underlying buffer. I can directly store texture/sampler/etc addresses into those buffers.
- Tier 1 argument buffers (Metal 2) have to support hardware with an inconsistent memory layout. An encoder object must be created that manages those differences - which adds some overhead.

Not all contributor Macs will support Metal 3, Apple lists the Metal 3 requirements here:
https://support.apple.com/en-us/102894

Tier 1 and Tier 2 buffers are also a little different in the shader. Tier 1 buffers still need ids for each binding so the encoder knows what is being bound where. Tier 2 argument buffers give me direct access - so there is no need to binding ids.

All previous conversations about the quality of the bump map still apply here. The code is present for full quality bump maps. But we're emulating the D3D Plasma behavior of ignoring the "height" component of the normal map.