### PR TITLE
Fix endianness and alignment assumptions in `pnNpCommon` IO code

### DIFF
--- a/Sources/Plasma/CoreLib/CMakeLists.txt
+++ b/Sources/Plasma/CoreLib/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CoreLib_SOURCES
     hsBounds.cpp
     hsCpuID.cpp
     hsDebug.cpp
+    hsEndian.cpp
     hsExceptions.cpp
     hsExceptionStack.cpp
     hsFastMath.cpp

--- a/Sources/Plasma/CoreLib/hsEndian.cpp
+++ b/Sources/Plasma/CoreLib/hsEndian.cpp
@@ -58,21 +58,21 @@ ST::string hsSTStringFromUTF16LE(const void* buffer, size_t char16Count)
 ST::string hsSTStringFromTerminatedUTF16LE(const void* buffer, size_t bufferSize, size_t& consumedSize)
 {
     auto byteBuffer = static_cast<const uint8_t*>(buffer);
-    // consumedChar16Count may be equal to or one higher than utf16Buffer.size(),
-    // depending on whether a terminator was found before the end of the buffer.
+    // Count how many char16_ts there are in the string.
+    // char16Count only counts the actual string contents,
+    // consumedChar16Count also counts the terminator, if present
+    // (there is no terminator if the end of the buffer was reached unexpectedly).
     size_t consumedChar16Count = 0;
-    // Can't pre-allocate anything, because we don't know the string length yet...
-    std::vector<char16_t> utf16Buffer;
+    size_t char16Count = 0;
     for (size_t i = 0; i < bufferSize / sizeof(char16_t); i++) {
-        char16_t c = byteBuffer[2*i] | byteBuffer[2*i + 1] << 8;
         consumedChar16Count++;
-        if (c == 0) {
+        if (byteBuffer[2*i] == 0 && byteBuffer[2*i + 1] == 0) {
             break;
         }
-        utf16Buffer.emplace_back(c);
+        char16Count++;
     }
     consumedSize = consumedChar16Count * sizeof(char16_t);
-    return ST::string::from_utf16(utf16Buffer.data(), utf16Buffer.size());
+    return hsSTStringFromUTF16LE(buffer, char16Count);
 }
 
 std::vector<uint8_t> hsSTStringToUTF16LE(const ST::string& string)

--- a/Sources/Plasma/CoreLib/hsEndian.cpp
+++ b/Sources/Plasma/CoreLib/hsEndian.cpp
@@ -67,7 +67,8 @@ ST::string hsSTStringFromTerminatedUTF16LE(const void* buffer, size_t bufferSize
         }
         utf16Buffer.emplace_back(c);
     }
-    consumedSize = utf16Buffer.size() * sizeof(char16_t);
+    // consumedSize includes the terminator, which is not stored in utf16Buffer
+    consumedSize = (utf16Buffer.size() + 1) * sizeof(char16_t);
     return ST::string::from_utf16(utf16Buffer.data(), utf16Buffer.size());
 }
 

--- a/Sources/Plasma/CoreLib/hsEndian.cpp
+++ b/Sources/Plasma/CoreLib/hsEndian.cpp
@@ -1,0 +1,85 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "hsEndian.h"
+
+#include <string_theory/string>
+
+ST::string hsSTStringFromUTF16LE(const void* buffer, size_t char16Count)
+{
+    auto byteBuffer = static_cast<const uint8_t*>(buffer);
+    ST::utf16_buffer utf16Buffer;
+    utf16Buffer.allocate(char16Count);
+    for (size_t i = 0; i < char16Count; i++) {
+        utf16Buffer[i] = byteBuffer[2*i] | byteBuffer[2*i + 1] << 8;
+    }
+    return ST::string::from_utf16(utf16Buffer);
+}
+
+ST::string hsSTStringFromTerminatedUTF16LE(const void* buffer, size_t bufferSize, size_t& consumedSize)
+{
+    auto byteBuffer = static_cast<const uint8_t*>(buffer);
+    // Can't pre-allocate anything, because we don't know the string length yet...
+    std::vector<char16_t> utf16Buffer;
+    for (size_t i = 0; i < bufferSize / sizeof(char16_t); i++) {
+        char16_t c = byteBuffer[2*i] | byteBuffer[2*i + 1] << 8;
+        if (c == 0) {
+            break;
+        }
+        utf16Buffer.emplace_back(c);
+    }
+    consumedSize = utf16Buffer.size() * sizeof(char16_t);
+    return ST::string::from_utf16(utf16Buffer.data(), utf16Buffer.size());
+}
+
+std::vector<uint8_t> hsSTStringToUTF16LE(const ST::string& string)
+{
+    ST::utf16_buffer utf16Buffer = string.to_utf16();
+    std::vector<uint8_t> buffer;
+    buffer.resize(utf16Buffer.size() * 2);
+    for (size_t i = 0; i < utf16Buffer.size(); i++) {
+        char16_t c = utf16Buffer[i];
+        buffer[2*i] = c & 0xff;
+        buffer[2*i + 1] = c >> 8 & 0xff;
+    }
+    return buffer;
+}

--- a/Sources/Plasma/CoreLib/hsEndian.cpp
+++ b/Sources/Plasma/CoreLib/hsEndian.cpp
@@ -58,17 +58,20 @@ ST::string hsSTStringFromUTF16LE(const void* buffer, size_t char16Count)
 ST::string hsSTStringFromTerminatedUTF16LE(const void* buffer, size_t bufferSize, size_t& consumedSize)
 {
     auto byteBuffer = static_cast<const uint8_t*>(buffer);
+    // consumedChar16Count may be equal to or one higher than utf16Buffer.size(),
+    // depending on whether a terminator was found before the end of the buffer.
+    size_t consumedChar16Count = 0;
     // Can't pre-allocate anything, because we don't know the string length yet...
     std::vector<char16_t> utf16Buffer;
     for (size_t i = 0; i < bufferSize / sizeof(char16_t); i++) {
         char16_t c = byteBuffer[2*i] | byteBuffer[2*i + 1] << 8;
+        consumedChar16Count++;
         if (c == 0) {
             break;
         }
         utf16Buffer.emplace_back(c);
     }
-    // consumedSize includes the terminator, which is not stored in utf16Buffer
-    consumedSize = (utf16Buffer.size() + 1) * sizeof(char16_t);
+    consumedSize = consumedChar16Count * sizeof(char16_t);
     return ST::string::from_utf16(utf16Buffer.data(), utf16Buffer.size());
 }
 

--- a/Sources/Plasma/CoreLib/hsEndian.h
+++ b/Sources/Plasma/CoreLib/hsEndian.h
@@ -45,6 +45,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
+#include <vector>
+
 #ifdef _MSC_VER
     #define hsSwapEndian16(val) _byteswap_ushort(val)
     #define hsSwapEndian32(val) _byteswap_ulong(val)
@@ -138,5 +140,9 @@ template <> inline int64_t hsToLE(int64_t value) { return (int64_t)hsToLE64((uin
 template <> inline uint64_t hsToLE(uint64_t value) { return hsToLE64(value); }
 template <> inline float hsToLE(float value) { return hsToLEFloat(value); }
 template <> inline double hsToLE(double value) { return hsToLEDouble(value); }
+
+ST::string hsSTStringFromUTF16LE(const void* buffer, size_t char16Count);
+ST::string hsSTStringFromTerminatedUTF16LE(const void* buffer, size_t bufferSize, size_t& consumedSize);
+std::vector<uint8_t> hsSTStringToUTF16LE(const ST::string& string);
 
 #endif // hsEndian_inc

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/CMakeLists.txt
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/CMakeLists.txt
@@ -25,8 +25,6 @@ target_link_libraries(
         pnNetBase
         pnNetCli
         pnUUID
-    PRIVATE
-        pnUtils
 )
 
 source_group("Header Files" FILES ${pnNetProtocol_HEADERS})

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.cpp
@@ -42,9 +42,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnNpCommon.h"
 
-#include "pnUUID/pnUUID.h"
+#include "hsEndian.h"
 
-#include <string>
+#include "pnUUID/pnUUID.h"
 
 namespace pnNpCommon {
 
@@ -69,34 +69,32 @@ const unsigned kNumBlobFields   = 4;
 template <typename T>
 inline void IReadValue (T * value, uint8_t ** buffer, unsigned * bufsz) {
     ASSERT(*bufsz >= sizeof(T));
-    *value = *(T *)*buffer;
+    T leValue;
+    memcpy(&leValue, *buffer, sizeof(T));
+    *value = hsToLE(leValue);
     *buffer += sizeof(T);
     *bufsz -= sizeof(T);
 }
 
 //============================================================================
-template <typename T>
-inline void IReadArray (T ** buf, unsigned * elems, uint8_t ** buffer, unsigned * bufsz) {
+inline void IReadUTF16String(ST::string* string, uint8_t** buffer, unsigned* bufsz)
+{
     uint32_t bytes;
     IReadValue(&bytes, buffer, bufsz);
-    ASSERT(bytes % sizeof(T) == 0);
-    *elems = bytes / sizeof(T);
-    T * src = (T *)*buffer;
-    free(*buf);
-    *buf = (T *)malloc(bytes);
-    memcpy(*buf, src, bytes);
+    ASSERT(bytes % sizeof(char16_t) == 0);
+
+    // Check for and ignore the explicit string terminator in the data.
+    if (bytes >= sizeof(char16_t)) {
+        ASSERT((*buffer)[bytes-2] == 0 && (*buffer)[bytes-1] == 0);
+        size_t char16Count = bytes / sizeof(char16_t) - 1;
+        *string = hsSTStringFromUTF16LE(*buffer, char16Count);
+    } else {
+        ASSERT(false);
+        string->clear();
+    }
+
     *buffer += bytes;
     *bufsz -= bytes;
-}
-
-//============================================================================
-template <typename T>
-inline void IReadString (T ** buf, uint8_t ** buffer, unsigned * bufsz) {
-    unsigned elems;
-    IReadArray(buf, &elems, buffer, bufsz);
-    // ensure the string is null-terminated
-    if (elems)
-        (*buf)[elems-1] = 0;
 }
 
 //============================================================================
@@ -106,25 +104,23 @@ inline void IWriteValue (const T & value, std::vector<uint8_t> * buffer) {
                   "IWriteValue can only be used on trivially copyable types");
     const size_t endPos = buffer->size();
     buffer->resize(endPos + sizeof(T));
-    memcpy(buffer->data() + endPos, &value, sizeof(T));
+    T leValue = hsToLE(value);
+    memcpy(buffer->data() + endPos, &leValue, sizeof(T));
 }
 
 //============================================================================
-template <typename T>
-inline void IWriteArray (const T buf[], unsigned elems, std::vector<uint8_t> * buffer) {
-    static_assert(std::is_trivially_copyable_v<T>,
-                  "IWriteArray can only be used on trivially copyable types");
-    unsigned bytes = elems * sizeof(T);
+inline void IWriteUTF16String(const ST::string& str, std::vector<uint8_t>* buffer)
+{
+    std::vector<uint8_t> strBuf = hsSTStringToUTF16LE(str);
+    // Add string terminator
+    strBuf.emplace_back(0);
+    strBuf.emplace_back(0);
+    uint32_t bytes = strBuf.size();
     IWriteValue(bytes, buffer);
-    const size_t endPos = buffer->size();
-    buffer->resize(endPos + bytes);
-    memcpy(buffer->data() + endPos, buf, bytes);
-}
 
-//============================================================================
-template <typename T>
-inline void IWriteString (const T str[], std::vector<uint8_t> * buffer) {
-    IWriteArray(str, std::char_traits<T>::length(str) + 1, buffer);
+    size_t endPos = buffer->size();
+    buffer->resize(endPos + bytes);
+    memcpy(buffer->data() + endPos, strBuf.data(), bytes);
 }
 
 
@@ -143,17 +139,12 @@ unsigned NetGameScore::Read(const uint8_t inbuffer[], unsigned bufsz, uint8_t** 
     uint8_t * buffer = const_cast<uint8_t *>(inbuffer);
     uint8_t * start = buffer;
 
-    char16_t* tempstr = nullptr;
-
     IReadValue(&scoreId, &buffer, &bufsz);
     IReadValue(&ownerId, &buffer, &bufsz);
     IReadValue(&createdTime, &buffer, &bufsz);
     IReadValue(&gameType, &buffer, &bufsz);
     IReadValue(&value, &buffer, &bufsz);
-    IReadString(&tempstr, &buffer, &bufsz);
-
-    gameName = ST::string::from_utf16(tempstr);
-    free(tempstr);
+    IReadUTF16String(&gameName, &buffer, &bufsz);
 
     if (end)
         *end = buffer;
@@ -171,7 +162,7 @@ unsigned NetGameScore::Write(std::vector<uint8_t> * buffer) const {
     IWriteValue(createdTime, buffer);
     IWriteValue(gameType, buffer);
     IWriteValue(value, buffer);
-    IWriteString(gameName.to_wchar().data(), buffer);
+    IWriteUTF16String(gameName, buffer);
 
     return buffer->size() - pos;
 }
@@ -188,14 +179,9 @@ unsigned NetGameRank::Read(const uint8_t inbuffer[], unsigned bufsz, uint8_t** e
     uint8_t * buffer = const_cast<uint8_t *>(inbuffer);
     uint8_t * start = buffer;
 
-    char16_t* tempstr = nullptr;
-
     IReadValue(&rank, &buffer, &bufsz);
     IReadValue(&score, &buffer, &bufsz);
-    IReadString(&tempstr, &buffer, &bufsz);
-
-    name = ST::string::from_utf16(tempstr);
-    free(tempstr);
+    IReadUTF16String(&name, &buffer, &bufsz);
 
     if (end)
         *end = buffer;
@@ -210,7 +196,7 @@ unsigned NetGameRank::Write(std::vector<uint8_t> * buffer) const {
 
     IWriteValue(rank, buffer);
     IWriteValue(score, buffer);
-    IWriteString(name.to_wchar().data(), buffer);
+    IWriteUTF16String(name, buffer);
 
     return buffer->size() - pos;
 }
@@ -369,8 +355,9 @@ inline bool IRead(const uint8_t*& buf, size_t& bufsz, T& dest)
     if (bufsz < sizeof(T)) {
         return false;
     }
-    const T* ptr = reinterpret_cast<const T*>(buf);
-    dest = *ptr;
+    T leValue;
+    memcpy(&leValue, buf, sizeof(T));
+    dest = hsToLE(leValue);
     buf += sizeof(T);
     bufsz -= sizeof(T);
     return true;
@@ -391,12 +378,21 @@ inline bool IRead<ST::string>(const uint8_t*& buf, size_t& bufsz, ST::string& de
     }
     uint32_t nChars = (size / sizeof(char16_t)) - 1;
 
-    ST::utf16_buffer str;
-    str.allocate(nChars);
-    memcpy(str.data(), buf, nChars * sizeof(char16_t));
-    dest = ST::string::from_utf16(str);
+    dest = hsSTStringFromUTF16LE(buf, nChars);
     buf += size;
     bufsz -= size;
+    return true;
+}
+
+template<>
+inline bool IRead<plUUID>(const uint8_t*& buf, size_t& bufsz, plUUID& dest)
+{
+    if (bufsz < sizeof(dest.fData)) {
+        return false;
+    }
+    memcpy(dest.fData, buf, sizeof(dest.fData));
+    buf += sizeof(dest.fData);
+    bufsz -= sizeof(dest.fData);
     return true;
 }
 
@@ -468,19 +464,31 @@ inline void IWrite(std::vector<uint8_t>* buffer, const T& value)
                   "IWrite can only be used on trivially copyable types");
     const size_t oldSize = buffer->size();
     buffer->resize(oldSize + sizeof(T));
-    memcpy(buffer->data() + oldSize, &value, sizeof(T));
+    T leValue = hsToLE(value);
+    memcpy(buffer->data() + oldSize, &leValue, sizeof(T));
 }
 
 template<>
 inline void IWrite<ST::string>(std::vector<uint8_t>* buffer, const ST::string& value)
 {
-    ST::utf16_buffer utf16 = value.to_utf16();
-    uint32_t strsz = (utf16.size() + 1) * sizeof(char16_t);
+    std::vector<uint8_t> utf16 = hsSTStringToUTF16LE(value);
+    // Add string terminator
+    utf16.emplace_back(0);
+    utf16.emplace_back(0);
+    uint32_t strsz = utf16.size();
     IWrite(buffer, strsz);
 
     const size_t oldSize = buffer->size();
     buffer->resize(oldSize + strsz);
     memcpy(buffer->data() + oldSize, utf16.data(), strsz);
+}
+
+template<>
+inline void IWrite<plUUID>(std::vector<uint8_t>* buffer, const plUUID& value)
+{
+    const size_t oldSize = buffer->size();
+    buffer->resize(oldSize + sizeof(value.fData));
+    memcpy(buffer->data() + oldSize, &value.fData, sizeof(value.fData));
 }
 
 template<>

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.cpp
@@ -176,16 +176,6 @@ unsigned NetGameScore::Write(std::vector<uint8_t> * buffer) const {
     return buffer->size() - pos;
 }
 
-//============================================================================
-void NetGameScore::CopyFrom(const NetGameScore & score) {
-    scoreId     = score.scoreId;
-    ownerId     = score.ownerId;
-    createdTime = score.createdTime;
-    gameType    = score.gameType;
-    value       = score.value;
-    gameName    = score.gameName;
-}
-
 /*****************************************************************************
 *
 *   NetGameRank
@@ -223,13 +213,6 @@ unsigned NetGameRank::Write(std::vector<uint8_t> * buffer) const {
     IWriteString(name.to_wchar().data(), buffer);
 
     return buffer->size() - pos;
-}
-
-//============================================================================
-void NetGameRank::CopyFrom(const NetGameRank & fromRank) {
-    rank        = fromRank.rank;
-    score       = fromRank.score;
-    name        = fromRank.name;
 }
 
 /*****************************************************************************

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.cpp
@@ -42,7 +42,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "pnNpCommon.h"
 
-#include "pnUtils/pnUtStr.h"
 #include "pnUUID/pnUUID.h"
 
 #include <string>
@@ -205,7 +204,7 @@ unsigned NetGameRank::Read(const uint8_t inbuffer[], unsigned bufsz, uint8_t** e
     IReadValue(&score, &buffer, &bufsz);
     IReadString(&tempstr, &buffer, &bufsz);
 
-    StrCopy(name, tempstr, std::size(name));
+    name = ST::string::from_utf16(tempstr);
     free(tempstr);
 
     if (end)
@@ -221,7 +220,7 @@ unsigned NetGameRank::Write(std::vector<uint8_t> * buffer) const {
 
     IWriteValue(rank, buffer);
     IWriteValue(score, buffer);
-    IWriteString(name, buffer);
+    IWriteString(name.to_wchar().data(), buffer);
 
     return buffer->size() - pos;
 }
@@ -230,7 +229,7 @@ unsigned NetGameRank::Write(std::vector<uint8_t> * buffer) const {
 void NetGameRank::CopyFrom(const NetGameRank & fromRank) {
     rank        = fromRank.rank;
     score       = fromRank.score;
-    StrCopy(name, fromRank.name, std::size(name));
+    name        = fromRank.name;
 }
 
 /*****************************************************************************

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.cpp
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.cpp
@@ -373,6 +373,8 @@ inline bool IRead<ST::string>(const uint8_t*& buf, size_t& bufsz, ST::string& de
         || size % sizeof(char16_t) != 0
         // String must contain at least one character (the terminator)
         || size < sizeof(char16_t)
+        // Last 2 bytes (the terminator) must be 0
+        || buf[size-2] != 0 || buf[size-1] != 0
     ) {
         return false;
     }

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.h
@@ -177,8 +177,6 @@ struct NetGameScore {
 
     unsigned Read (const uint8_t inbuffer[], unsigned bufsz, uint8_t** end = nullptr); // returns number of bytes read
     unsigned Write (std::vector<uint8_t> * buffer) const;                             // returns number of bytes written
-
-    void CopyFrom (const NetGameScore & score);
 };
 
 /*****************************************************************************
@@ -194,8 +192,6 @@ struct NetGameRank {
 
     unsigned Read (const uint8_t inbuffer[], unsigned bufsz, uint8_t** end = nullptr); // returns number of bytes read
     unsigned Write (std::vector<uint8_t> * buffer) const;                             // returns number of bytes written
-
-    void CopyFrom (const NetGameRank & fromRank);
 };
 
 /*****************************************************************************

--- a/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.h
+++ b/Sources/Plasma/NucleusLib/pnNetProtocol/pnNpCommon.h
@@ -190,7 +190,7 @@ struct NetGameScore {
 struct NetGameRank {
     unsigned    rank;
     int         score;
-    char16_t    name[kMaxPlayerNameLength];
+    ST::string  name;
 
     unsigned Read (const uint8_t inbuffer[], unsigned bufsz, uint8_t** end = nullptr); // returns number of bytes read
     unsigned Write (std::vector<uint8_t> * buffer) const;                             // returns number of bytes written

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
@@ -1130,8 +1130,7 @@ struct ScoreGetRanksTrans : NetAuthTrans {
     unsigned                        m_sortDesc;
 
     // recv
-    NetGameRank *                   m_ranks;
-    unsigned                        m_rankCount;
+    std::vector<NetGameRank>        m_ranks;
 
     ScoreGetRanksTrans (
         unsigned                    ownerId,
@@ -4129,7 +4128,7 @@ ScoreGetRanksTrans::ScoreGetRanksTrans(
     : NetAuthTrans(kScoreGetRanksTrans), m_callback(std::move(callback)),
       m_ownerId(ownerId),  m_scoreGroup(scoreGroup), m_parentFolderId(parentFolderId),
       m_gameName(gameName), m_timePeriod(timePeriod), m_numResults(numResults),
-      m_pageNumber(pageNumber), m_sortDesc(sortDesc), m_ranks(), m_rankCount()
+      m_pageNumber(pageNumber), m_sortDesc(sortDesc)
 { }
 
 //============================================================================
@@ -4159,7 +4158,7 @@ bool ScoreGetRanksTrans::Send () {
 
 //============================================================================
 void ScoreGetRanksTrans::Post () {
-    m_callback(m_result, m_ranks, m_rankCount);
+    m_callback(m_result, m_ranks);
 }
 
 //============================================================================
@@ -4169,20 +4168,14 @@ bool ScoreGetRanksTrans::Recv (
 ) {
     const Auth2Cli_ScoreGetRanksReply & reply = *(const Auth2Cli_ScoreGetRanksReply *) msg;
 
+    m_ranks.resize(reply.rankCount);
     if (reply.rankCount > 0) {
-        m_rankCount = reply.rankCount;
-        m_ranks     = new NetGameRank[m_rankCount];
-
         uint8_t*       bufferPos = const_cast<uint8_t*>(reply.buffer);
         unsigned    bufferLength = reply.byteCount;
 
-        for (unsigned i = 0; i < m_rankCount; ++i) {
-            bufferLength -= m_ranks[i].Read(bufferPos, bufferLength, &bufferPos);
+        for (NetGameRank& rank : m_ranks) {
+            bufferLength -= rank.Read(bufferPos, bufferLength, &bufferPos);
         }
-    }
-    else {
-        m_rankCount = 0;
-        m_ranks     = nullptr;
     }
 
     m_result        = reply.result;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.h
@@ -606,8 +606,7 @@ void NetCliAuthScoreSetPoints(
 struct NetGameRank;
 using FNetCliAuthGetRanksCallback = std::function<void(
     ENetError           result,
-    const NetGameRank   ranks[],
-    unsigned            rankCount
+    const std::vector<NetGameRank>& ranks
 )>;
 
 void NetCliAuthScoreGetRankList(

--- a/Sources/Tests/CoreTests/CMakeLists.txt
+++ b/Sources/Tests/CoreTests/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CoreLibTest_SOURCES
-    test_endianSwap.cpp
+    test_hsEndian.cpp
     test_plCmdParser.cpp
     test_RAMStream.cpp
     $<$<PLATFORM_ID:Darwin>:test_hsDarwin_CF.cpp>

--- a/Sources/Tests/CoreTests/test_endianSwap.cpp
+++ b/Sources/Tests/CoreTests/test_endianSwap.cpp
@@ -194,11 +194,30 @@ TEST(endianSwap, hsSTStringFromTerminatedUTF16LE)
     buffer[sizeof(kTestStringUtf16) + 4] = '\236';
 
     size_t consumedSize;
-    ST::string string = hsSTStringFromTerminatedUTF16LE(buffer, bufferSize, consumedSize);
 
-    // consumedSize includes the terminator
+    ST::string string = hsSTStringFromTerminatedUTF16LE(buffer, bufferSize, consumedSize);
+    // consumedSize includes the terminator.
     EXPECT_EQ(consumedSize, sizeof(kTestStringUtf16) + 2);
     EXPECT_EQ(string, kTestString);
+
+    ST::string string2 = hsSTStringFromTerminatedUTF16LE(buffer, sizeof(kTestStringUtf16) + 1, consumedSize);
+    // consumedSize does *not* count a terminator if there was none in the source buffer.
+    EXPECT_EQ(consumedSize, sizeof(kTestStringUtf16));
+    EXPECT_EQ(string2, kTestString);
+
+    ST::string string3 = hsSTStringFromTerminatedUTF16LE(buffer, sizeof(kTestStringUtf16), consumedSize);
+    EXPECT_EQ(consumedSize, sizeof(kTestStringUtf16));
+    EXPECT_EQ(string3, kTestString);
+
+    // Test that buffers shorter than one char16_t are handled correctly.
+
+    ST::string string4 = hsSTStringFromTerminatedUTF16LE(buffer, 1, consumedSize);
+    EXPECT_EQ(consumedSize, 0);
+    EXPECT_TRUE(string4.empty());
+
+    ST::string string5 = hsSTStringFromTerminatedUTF16LE(buffer, 0, consumedSize);
+    EXPECT_EQ(consumedSize, 0);
+    EXPECT_TRUE(string5.empty());
 }
 
 TEST(endianSwap, hsSTStringToUTF16LE)

--- a/Sources/Tests/CoreTests/test_endianSwap.cpp
+++ b/Sources/Tests/CoreTests/test_endianSwap.cpp
@@ -41,6 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include <gtest/gtest.h>
+#include <string_theory/string>
 
 #include "HeadSpin.h"
 
@@ -152,4 +153,57 @@ TEST(endianSwap, toBEDouble)
     memcpy(c, &d, sizeof(d));
 
     EXPECT_EQ(c[0], 0x40);
+}
+
+const ST::string kTestString = ST_LITERAL("hḗllo");
+constexpr char kTestStringUtf16[] = {
+    'h', 0x00,
+    0x17, 0x1e, // U+1E17 LATIN SMALL LETTER E WITH MACRON AND ACUTE
+    'l', 0x00,
+    'l', 0x00,
+    'o', 0x00,
+};
+
+TEST(endianSwap, hsSTStringFromUTF16LE)
+{
+    constexpr size_t bufferSize = sizeof(kTestStringUtf16);
+    // Force non-even alignment
+    alignas(char16_t) char allocation[bufferSize + 1];
+    char* buffer = allocation + 1;
+
+    memcpy(buffer, kTestStringUtf16, bufferSize);
+
+    ST::string string = hsSTStringFromUTF16LE(buffer, bufferSize / sizeof(char16_t));
+
+    EXPECT_EQ(string, kTestString);
+}
+
+TEST(endianSwap, hsSTStringFromTerminatedUTF16LE)
+{
+    constexpr size_t bufferSize = sizeof(kTestStringUtf16) + 5;
+    // Force non-even alignment
+    alignas(char16_t) char allocation[bufferSize + 1];
+    char* buffer = allocation + 1;
+
+    memcpy(buffer, kTestStringUtf16, sizeof(kTestStringUtf16));
+    // Add string terminator and some junk data that should be ignored
+    buffer[sizeof(kTestStringUtf16)] = 0;
+    buffer[sizeof(kTestStringUtf16) + 1] = 0;
+    buffer[sizeof(kTestStringUtf16) + 2] = '\234';
+    buffer[sizeof(kTestStringUtf16) + 3] = '\235';
+    buffer[sizeof(kTestStringUtf16) + 4] = '\236';
+
+    size_t consumedSize;
+    ST::string string = hsSTStringFromTerminatedUTF16LE(buffer, bufferSize, consumedSize);
+
+    // consumedSize includes the terminator
+    EXPECT_EQ(consumedSize, sizeof(kTestStringUtf16) + 2);
+    EXPECT_EQ(string, kTestString);
+}
+
+TEST(endianSwap, hsSTStringToUTF16LE)
+{
+    std::vector<uint8_t> buffer = hsSTStringToUTF16LE(kTestString);
+    EXPECT_EQ(buffer.size(), sizeof(kTestStringUtf16));
+    EXPECT_EQ(memcmp(buffer.data(), kTestStringUtf16, sizeof(kTestStringUtf16)), 0);
 }

--- a/Sources/Tests/CoreTests/test_hsEndian.cpp
+++ b/Sources/Tests/CoreTests/test_hsEndian.cpp
@@ -48,7 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsEndian.h"
 #include "hsMath.h"
 
-TEST(endianSwap, detection_accuracy)
+TEST(hsEndian, detection_accuracy)
 {
     uint32_t i = 0x01020304;
     uint8_t c[sizeof(i)] {};
@@ -61,7 +61,7 @@ TEST(endianSwap, detection_accuracy)
 #endif
 }
 
-TEST(endianSwap, toLE16)
+TEST(hsEndian, toLE16)
 {
     uint16_t s = hsToLE16(0x0102);
     uint8_t c[sizeof(s)] {};
@@ -70,7 +70,7 @@ TEST(endianSwap, toLE16)
     EXPECT_EQ(c[0], 0x02);
 }
 
-TEST(endianSwap, toBE16)
+TEST(hsEndian, toBE16)
 {
     uint16_t s = hsToBE16(0x0102);
     uint8_t c[sizeof(s)] {};
@@ -79,7 +79,7 @@ TEST(endianSwap, toBE16)
     EXPECT_EQ(c[0], 0x01);
 }
 
-TEST(endianSwap, toLE32)
+TEST(hsEndian, toLE32)
 {
     uint32_t i = hsToLE32(0x01020304);
     uint8_t c[sizeof(i)] {};
@@ -88,7 +88,7 @@ TEST(endianSwap, toLE32)
     EXPECT_EQ(c[0], 0x04);
 }
 
-TEST(endianSwap, toBE32)
+TEST(hsEndian, toBE32)
 {
     uint32_t i = hsToBE32(0x01020304);
     uint8_t c[sizeof(i)] {};
@@ -97,7 +97,7 @@ TEST(endianSwap, toBE32)
     EXPECT_EQ(c[0], 0x01);
 }
 
-TEST(endianSwap, toLE64)
+TEST(hsEndian, toLE64)
 {
     uint64_t l = hsToLE64(0x0102030405060708);
     uint8_t c[sizeof(l)] {};
@@ -106,7 +106,7 @@ TEST(endianSwap, toLE64)
     EXPECT_EQ(c[0], 0x08);
 }
 
-TEST(endianSwap, toBE64)
+TEST(hsEndian, toBE64)
 {
     uint64_t l = hsToBE64(0x0102030405060708);
     uint8_t c[sizeof(l)] {};
@@ -115,7 +115,7 @@ TEST(endianSwap, toBE64)
     EXPECT_EQ(c[0], 0x01);
 }
 
-TEST(endianSwap, toLEFloat)
+TEST(hsEndian, toLEFloat)
 {
     // Float value of PI is 0x40490fdb
     float f = hsToLEFloat(hsConstants::pi<float>);
@@ -125,7 +125,7 @@ TEST(endianSwap, toLEFloat)
     EXPECT_EQ(c[0], 0xdb);
 }
 
-TEST(endianSwap, toBEFloat)
+TEST(hsEndian, toBEFloat)
 {
     // Float value of PI is 0x40490fdb
     float f = hsToBEFloat(hsConstants::pi<float>);
@@ -135,7 +135,7 @@ TEST(endianSwap, toBEFloat)
     EXPECT_EQ(c[0], 0x40);
 }
 
-TEST(endianSwap, toLEDouble)
+TEST(hsEndian, toLEDouble)
 {
     // Double value of PI is 0x400921fb54442d18
     double d = hsToLEDouble(hsConstants::pi<double>);
@@ -145,7 +145,7 @@ TEST(endianSwap, toLEDouble)
     EXPECT_EQ(c[0], 0x18);
 }
 
-TEST(endianSwap, toBEDouble)
+TEST(hsEndian, toBEDouble)
 {
     // Double value of PI is 0x400921fb54442d18
     double d = hsToBEDouble(hsConstants::pi<double>);
@@ -164,7 +164,7 @@ constexpr char kTestStringUtf16[] = {
     'o', 0x00,
 };
 
-TEST(endianSwap, hsSTStringFromUTF16LE)
+TEST(hsEndian, hsSTStringFromUTF16LE)
 {
     constexpr size_t bufferSize = sizeof(kTestStringUtf16);
     // Force non-even alignment
@@ -178,7 +178,7 @@ TEST(endianSwap, hsSTStringFromUTF16LE)
     EXPECT_EQ(string, kTestString);
 }
 
-TEST(endianSwap, hsSTStringFromTerminatedUTF16LE)
+TEST(hsEndian, hsSTStringFromTerminatedUTF16LE)
 {
     constexpr size_t bufferSize = sizeof(kTestStringUtf16) + 5;
     // Force non-even alignment
@@ -220,7 +220,7 @@ TEST(endianSwap, hsSTStringFromTerminatedUTF16LE)
     EXPECT_TRUE(string5.empty());
 }
 
-TEST(endianSwap, hsSTStringToUTF16LE)
+TEST(hsEndian, hsSTStringToUTF16LE)
 {
     std::vector<uint8_t> buffer = hsSTStringToUTF16LE(kTestString);
     EXPECT_EQ(buffer.size(), sizeof(kTestStringUtf16));


### PR DESCRIPTION
My goal was just to remove the `StrCopy` calls, but while I was here, I also fixed the endianness and alignment issues in this code. Perhaps it will help @dpogue on PowerPC :)

This adds some helper functions for converting little-endian UTF-16 directly from/to `ST::string`, which could also be useful for other code that reads/writes UTF-16 strings manually, like file server manifests and the GameMgr.