### PR TITLE
Small improvements to CMake folders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,10 @@ include_directories(${PROJECT_BINARY_DIR})
 if(PLASMA_BUILD_TOOLS)
     # Custom dummy target for compiling all tools
     add_custom_target(tools)
-    set_target_properties(tools PROPERTIES XCODE_GENERATE_SCHEME TRUE)
+    set_target_properties(tools PROPERTIES
+        FOLDER Tools
+        XCODE_GENERATE_SCHEME TRUE
+    )
 endif()
 
 include(TestBigEndian)
@@ -247,6 +250,7 @@ endif()
 if(PLASMA_BUILD_TESTS)
     enable_testing()
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION>)
+    set_target_properties(check PROPERTIES FOLDER Tests)
     add_subdirectory(Sources/Tests EXCLUDE_FROM_ALL)
 endif(PLASMA_BUILD_TESTS)
 

--- a/Scripts/CMakeLists.txt
+++ b/Scripts/CMakeLists.txt
@@ -9,7 +9,8 @@ source_group("Ages" FILES ${GameData})
 add_custom_target(Scripts
                   SOURCES ${GameScripts} ${GameSDL} ${GameData}
 )
-set_target_properties(Scripts PROPERTIES FOLDER "")
+# Move to top level, out of the default "CMakePredefinedTargets" folder.
+set_property(TARGET Scripts PROPERTY FOLDER)
 
 install(
     DIRECTORY "Python/"

--- a/Sources/Tests/CMakeLists.txt
+++ b/Sources/Tests/CMakeLists.txt
@@ -16,9 +16,17 @@ set(gtest_build_tests OFF CACHE INTERNAL "Override gtest default")
 set(gtest_disable_pthreads OFF CACHE INTERNAL "Override gtest default")
 set(gtest_hide_internal_symbols ON CACHE INTERNAL "Override gtest default")
 
+# Put gtest's targets in the Tests folder,
+# not our default "CMakePredefinedTargets" folder.
+set(_PREV_CMAKE_FOLDER ${CMAKE_FOLDER})
+set(CMAKE_FOLDER "Tests")
+
 set(GOOGLETEST_VERSION 1.12.1)
 set(INSTALL_GTEST OFF CACHE INTERNAL "Override gtest default" FORCE)
 add_subdirectory(gtest EXCLUDE_FROM_ALL)
+
+set(CMAKE_FOLDER ${_PREV_CMAKE_FOLDER})
+unset(_PREV_CMAKE_FOLDER)
 
 include_directories(${GTEST_INCLUDE_DIR})
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -52,7 +52,9 @@ if(USE_CLANG_TIDY)
             COMMAND ${CMAKE_COMMAND} -E remove_directory "${_TIDY_REPLACEMENTS_DIR}"
             COMMAND ${CMAKE_COMMAND} -E make_directory "${_TIDY_REPLACEMENTS_DIR}"
         )
+        set_target_properties(tidy_init PROPERTIES FOLDER tidy)
         add_custom_target(tidy DEPENDS tidy_init)
+        set_target_properties(tidy PROPERTIES FOLDER tidy)
         if(CLANG_APPLY_EXE)
             add_custom_target(fix
                 DEPENDS tidy
@@ -60,6 +62,7 @@ if(USE_CLANG_TIDY)
                 COMMAND ${CLANG_APPLY_EXE} "${_TIDY_REPLACEMENTS_DIR}"
                 WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
             )
+            set_target_properties(fix PROPERTIES FOLDER tidy)
         endif()
 
         # If we were on CMake 3.20, we could do this per-target...
@@ -105,6 +108,7 @@ function(plasma_sanitize_target TARGET)
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                     BYPRODUCTS "${_TARGET_FIXES_FILE}"
                 )
+                set_target_properties(tidy_${TARGET} PROPERTIES FOLDER tidy)
                 add_dependencies(tidy tidy_${TARGET})
             endif()
         endif()


### PR DESCRIPTION
Fixes the folder for the Scripts target to avoid this suboptimal display in CLion:

<img width="312" height="93" alt="CLion's Run Configurations menu, showing a folder with an empty name containing a target named Scripts" src="https://github.com/user-attachments/assets/1ee286a6-e584-4b04-afcd-6aaed248d06b"/>

and moves the many, many targets related to clang-tidy into a folder named `tidy` so that they don't fill up the `CMakePredefinedTargets` default folder.

With my build configuration, the folder `CMakePredefinedTargets` now still contains the targets `check`, `gmock`, `gmock_main`, `gtest`, `gtest_main`, and `tools`. Should I move any of those into different folders too (`Tests` and `Tools` presumably)? None of these targets come from CMake, so it's a bit surprising that they're in `CMakePredefinedTargets`.

(For context: the CMake folder structure was originally added in #1612.)