### PR TITLE
Update pillow to fix macOS CI.

### DIFF
--- a/Scripts/Ports/python3-cairosvg/portfile.cmake
+++ b/Scripts/Ports/python3-cairosvg/portfile.cmake
@@ -5,14 +5,14 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Install cairo on Ubuntu with `sudo apt install libcairo2` and on macOS with `brew install cairo`.")
 endif()
 
-set(PILLOW_VERSION "9.5.0")
-set(CAIROSVG_VERSION "2.8.2")
+set(PILLOW_VERSION "12.2.0")
+set(CAIROSVG_VERSION "2.9.0")
 set(INSTALLED_PYTHON_PREFIX "${CURRENT_INSTALLED_DIR}/tools/python3")
 
 # We are running in script mode, so no toolchains are available. Sad.
 find_program(
     PYTHON_EXECUTABLE
-    NAMES python python3 python3.10
+    NAMES python python3 python3.12
     PATHS "${INSTALLED_PYTHON_PREFIX}"
     NO_DEFAULT_PATH
 )

--- a/Scripts/Ports/python3-cairosvg/vcpkg.json
+++ b/Scripts/Ports/python3-cairosvg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "python3-cairosvg",
-  "version-semver": "2.8.2",
+  "version-semver": "2.9.0",
   "description": "CairoSVG is an SVG converter based on Cairo. It can export SVG files to PDF, EPS, PS, and PNG files.",
   "homepage": "https://cairosvg.org/",
   "dependencies": [


### PR DESCRIPTION
Speculative fix. Verified that resource.dat is still generated correctly.