### PR TITLE
Metal render destinations

### DIFF
--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -103,6 +103,7 @@ elseif(APPLE)
     list(APPEND plClient_SOURCES
         Mac-Cocoa/main.mm
         Mac-Cocoa/NSString+StringTheory.mm
+        Mac-Cocoa/plDirectMetalRenderDestination.mm
         Mac-Cocoa/PLSKeyboardEventMonitor.mm
         Mac-Cocoa/PLSView.mm
         Mac-Cocoa/PLSLoginController.mm
@@ -113,6 +114,7 @@ elseif(APPLE)
     )
     list(APPEND plClient_HEADERS
         Mac-Cocoa/NSString+StringTheory.h
+        Mac-Cocoa/plDirectMetalRenderDestination.h
         Mac-Cocoa/PLSKeyboardEventMonitor.h
         Mac-Cocoa/PLSView.h
         Mac-Cocoa/PLSLoginController.h

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -221,6 +221,9 @@ static uint32_t ParseRendererArgument(const ST::string& requested)
 @property NSWindow* gameWindow;
 @property plMetalRenderDestinationType*    renderDestination;
 
+@property plMetalPipeline* metalPipeline;
+@property plGLPipeline*    glPipeline;
+
 @end
 
 void plClient::IResizeNativeDisplayDevice(int width, int height, bool windowed)
@@ -262,7 +265,17 @@ void plClient::IResizeNativeDisplayDevice(int width, int height, bool windowed)
 
 void plClient::IChangeResolution(int width, int height) {}
 void plClient::IUpdateProgressIndicator(plOperationProgress* progress) {}
-void plClient::ShowClientWindow() {}
+void plClient::ShowClientWindow()
+{
+    AppDelegate* appDelegate = (AppDelegate*)[NSApp delegate];
+    plPipeline* pipeline = appDelegate->gClient->GetPipeline();
+    appDelegate.metalPipeline = dynamic_cast<plMetalPipeline*>(pipeline);
+    appDelegate.glPipeline = dynamic_cast<plGLPipeline*>(pipeline);
+
+    if (appDelegate.metalPipeline) {
+        appDelegate.metalPipeline->SetRenderDestination(appDelegate.renderDestination);
+    }
+}
 void plClient::FlashWindow()
 {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -329,15 +342,14 @@ static void* const DeviceDidChangeContext = (void*)&DeviceDidChangeContext;
     _displayHelper = new plMacDisplayHelper();
     plDisplayHelper::SetInstance(_displayHelper);
 
-    gClient.SetClientWindow((__bridge void*)view.layer);
-    gClient.SetClientDisplay([window.screen.deviceDescription[@"NSScreenNumber"] unsignedIntValue]);
-
     // Start the game with a direct render destination
     // Components like the intro movie may want to draw
     // before we're ready to start a vsync managed render
     // destination.
     self.renderDestination = new plMetalRenderDestination<plDirectMetalRenderDestination*>((CAMetalLayer*)self.plsView.layer);
-    self.renderDestination->MakeCurrentRenderDestination();
+
+    gClient.SetClientWindow(&_renderDestination);
+    gClient.SetClientDisplay([window.screen.deviceDescription[@"NSScreenNumber"] unsignedIntValue]);
 
     self = [super initWithWindow:window];
     self.window.acceptsMouseMovedEvents = YES;

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -271,10 +271,6 @@ void plClient::ShowClientWindow()
     plPipeline* pipeline = appDelegate->gClient->GetPipeline();
     appDelegate.metalPipeline = plMetalPipeline::ConvertNoRef(pipeline);
     appDelegate.glPipeline = plGLPipeline::ConvertNoRef(pipeline);
-
-    if (appDelegate.metalPipeline) {
-        appDelegate.metalPipeline->SetRenderDestination(appDelegate.renderDestination);
-    }
 }
 
 void plClient::FlashWindow()

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -276,6 +276,7 @@ void plClient::ShowClientWindow()
         appDelegate.metalPipeline->SetRenderDestination(appDelegate.renderDestination);
     }
 }
+
 void plClient::FlashWindow()
 {
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -59,6 +59,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #import "PLSKeyboardEventMonitor.h"
 #import "PLSLoginWindowController.h"
 #import "PLSPatcherWindowController.h"
+#import "plDirectMetalRenderDestination.h"
 #import "PLSServerStatus.h"
 #import "PLSView.h"
 
@@ -218,6 +219,7 @@ static uint32_t ParseRendererArgument(const ST::string& requested)
 @property PLSPatcher* patcher;
 @property PLSLoginWindowController* loginWindow;
 @property NSWindow* gameWindow;
+@property plMetalRenderDestinationType*    renderDestination;
 
 @end
 
@@ -329,6 +331,13 @@ static void* const DeviceDidChangeContext = (void*)&DeviceDidChangeContext;
 
     gClient.SetClientWindow((__bridge void*)view.layer);
     gClient.SetClientDisplay([window.screen.deviceDescription[@"NSScreenNumber"] unsignedIntValue]);
+
+    // Start the game with a direct render destination
+    // Components like the intro movie may want to draw
+    // before we're ready to start a vsync managed render
+    // destination.
+    self.renderDestination = new plMetalRenderDestination<plDirectMetalRenderDestination*>((CAMetalLayer*)self.plsView.layer);
+    self.renderDestination->MakeCurrentRenderDestination();
 
     self = [super initWithWindow:window];
     self.window.acceptsMouseMovedEvents = YES;

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -196,6 +196,24 @@ static uint32_t ParseRendererArgument(const ST::string& requested)
     return hsG3DDeviceSelector::kDevTypeUnknown;
 }
 
+@class AppDelegate;
+
+// Stub placeholder for actual plClientWindow implementation
+class plClientWindow {
+
+};
+
+class plMacClientWindow: public plClientWindow, public plMetalWindow
+{
+public:
+    plMetalRenderDestinationType& metalRenderDestination() override {
+        return *fMetalRenderDestination;
+    }
+
+    std::unique_ptr<plMetalRenderDestinationType> fMetalRenderDestination;
+    ~plMacClientWindow() = default;
+};
+
 @interface AppDelegate : NSWindowController <NSApplicationDelegate,
                                              NSWindowDelegate,
                                              PLSViewDelegate,
@@ -207,6 +225,7 @@ static uint32_t ParseRendererArgument(const ST::string& requested)
     dispatch_source_t   _displaySource;
     plMacDisplayHelper* _displayHelper;
     PLSWakeLockHolder   _wakeLockHolder;
+    plMacClientWindow   _plasmaWindow;
 }
 
 @property(retain) PLSKeyboardEventMonitor* eventMonitor;
@@ -219,7 +238,6 @@ static uint32_t ParseRendererArgument(const ST::string& requested)
 @property PLSPatcher* patcher;
 @property PLSLoginWindowController* loginWindow;
 @property NSWindow* gameWindow;
-@property plMetalRenderDestinationType*    renderDestination;
 
 @property plMetalPipeline* metalPipeline;
 @property plGLPipeline*    glPipeline;
@@ -343,9 +361,9 @@ static void* const DeviceDidChangeContext = (void*)&DeviceDidChangeContext;
     // Components like the intro movie may want to draw
     // before we're ready to start a vsync managed render
     // destination.
-    self.renderDestination = new plMetalRenderDestination<plDirectMetalRenderDestination*>((CAMetalLayer*)self.plsView.layer);
+    _plasmaWindow.fMetalRenderDestination = std::make_unique<plMetalRenderDestination<plDirectMetalRenderDestination*>>((CAMetalLayer*)self.plsView.layer);
 
-    gClient.SetClientWindow(&_renderDestination);
+    gClient.SetClientWindow(&_plasmaWindow);
     gClient.SetClientDisplay([window.screen.deviceDescription[@"NSScreenNumber"] unsignedIntValue]);
 
     self = [super initWithWindow:window];

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -239,9 +239,6 @@ public:
 @property PLSLoginWindowController* loginWindow;
 @property NSWindow* gameWindow;
 
-@property plMetalPipeline* metalPipeline;
-@property plGLPipeline*    glPipeline;
-
 @end
 
 void plClient::IResizeNativeDisplayDevice(int width, int height, bool windowed)
@@ -283,13 +280,7 @@ void plClient::IResizeNativeDisplayDevice(int width, int height, bool windowed)
 
 void plClient::IChangeResolution(int width, int height) {}
 void plClient::IUpdateProgressIndicator(plOperationProgress* progress) {}
-void plClient::ShowClientWindow()
-{
-    AppDelegate* appDelegate = (AppDelegate*)[NSApp delegate];
-    plPipeline* pipeline = appDelegate->gClient->GetPipeline();
-    appDelegate.metalPipeline = plMetalPipeline::ConvertNoRef(pipeline);
-    appDelegate.glPipeline = plGLPipeline::ConvertNoRef(pipeline);
-}
+void plClient::ShowClientWindow() {}
 
 void plClient::FlashWindow()
 {

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/main.mm
@@ -269,8 +269,8 @@ void plClient::ShowClientWindow()
 {
     AppDelegate* appDelegate = (AppDelegate*)[NSApp delegate];
     plPipeline* pipeline = appDelegate->gClient->GetPipeline();
-    appDelegate.metalPipeline = dynamic_cast<plMetalPipeline*>(pipeline);
-    appDelegate.glPipeline = dynamic_cast<plGLPipeline*>(pipeline);
+    appDelegate.metalPipeline = plMetalPipeline::ConvertNoRef(pipeline);
+    appDelegate.glPipeline = plGLPipeline::ConvertNoRef(pipeline);
 
     if (appDelegate.metalPipeline) {
         appDelegate.metalPipeline->SetRenderDestination(appDelegate.renderDestination);

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/plDirectMetalRenderDestination.h
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/plDirectMetalRenderDestination.h
@@ -50,10 +50,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 class plDirectMetalRenderDestination
 {
 public:
-    plDirectMetalRenderDestination(CAMetalLayer *layer);
+    plDirectMetalRenderDestination(CAMetalLayer* layer);
     std::optional<plMetalRenderSurface> GetNextRenderSurface(MTL::CommandBuffer* buffer);
     void SetOutputSize(CGSize size);
 
 private:
-    CAMetalLayer *fLayer;
+    CAMetalLayer* fLayer;
 };

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/plDirectMetalRenderDestination.h
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/plDirectMetalRenderDestination.h
@@ -1,0 +1,59 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#import <QuartzCore/QuartzCore.h>
+#import <Metal/Metal.hpp>
+
+#import <optional>
+
+#import "pfMetalPipeline/plMetalRenderDestination.h"
+
+class plDirectMetalRenderDestination
+{
+public:
+    plDirectMetalRenderDestination(CAMetalLayer *layer);
+    std::optional<plMetalRenderSurface> GetNextRenderSurface(MTL::CommandBuffer* buffer);
+    void SetOutputSize(CGSize size);
+
+private:
+    CAMetalLayer *fLayer;
+};

--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/plDirectMetalRenderDestination.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/plDirectMetalRenderDestination.mm
@@ -1,0 +1,68 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#import <Metal/Metal.h>
+
+#import "plDirectMetalRenderDestination.h"
+
+plDirectMetalRenderDestination::plDirectMetalRenderDestination(CAMetalLayer *layer) : fLayer(layer)
+{
+}
+
+plOptionalMetalRenderSurface plDirectMetalRenderDestination::GetNextRenderSurface(MTL::CommandBuffer *buffer)
+{
+    id<MTLCommandBuffer> bufferObjc = (__bridge id<MTLCommandBuffer>)(buffer);
+    if (fLayer.device != bufferObjc.device)
+        fLayer.device = bufferObjc.device;
+
+    id<CAMetalDrawable> drawable = fLayer.nextDrawable;
+    if (drawable == nil)
+        return std::nullopt;
+    return plMetalRenderSurface(
+        (__bridge MTL::Texture *)drawable.texture,
+        (__bridge CA::MetalDrawable *)drawable);
+}
+
+void plDirectMetalRenderDestination::SetOutputSize(CGSize size)
+{
+    fLayer.drawableSize = size;
+}

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
@@ -36,6 +36,7 @@ set(pfMetalPipeline_HEADERS
     plMetalPipeline.h
     plMetalPipelineState.h
     plMetalPlateManager.h
+    plMetalRenderDestination.h
     plMetalShader.h
     plMetalTextFont.h
     plMetalFragmentShader.h

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
@@ -61,6 +61,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfMetalPipeline/plMetalPipelineState.h"
 #include "pfMetalPipeline/ShaderSrc/ShaderTypes.h"
 
+plMetalRenderDestinationType* plMetalRenderDestinationType::fCurrentRenderDestination;
+
 /// Macros for getting/setting data in a vertex buffer
 template<typename T>
 static inline void inlCopy(uint8_t*& src, uint8_t*& dst)
@@ -458,7 +460,7 @@ void plMetalDevice::SetRenderTarget(plRenderTarget* target)
             fCurrentDepthFormat = MTL::PixelFormatInvalid;
         }
     } else {
-        fCurrentFragmentOutputTexture = fCurrentDrawable->texture();
+        fCurrentFragmentOutputTexture = fCurrentRenderSurface ? fCurrentRenderSurface->colorTexture : nullptr;
         fCurrentDepthFormat = MTL::PixelFormatDepth32Float_Stencil8;
     }
 }
@@ -466,7 +468,7 @@ void plMetalDevice::SetRenderTarget(plRenderTarget* target)
 plMetalDevice::plMetalDevice()
     : fErrorMsg(),
       fActiveThread(hsThread::ThisThreadHash()),
-      fCurrentDrawable(),
+      fCurrentRenderSurface(),
       fCommandQueue(),
       fCurrentRenderTargetCommandEncoder(),
       fCurrentDrawableDepthTexture(),
@@ -1002,15 +1004,24 @@ void plMetalDevice::SetLocalToWorldMatrix(const hsMatrix44& src)
     fMatrixW2L = hsMatrix2SIMD(inv);
 }
 
-void plMetalDevice::CreateNewCommandBuffer(CA::MetalDrawable* drawable)
+bool plMetalDevice::CreateNewCommandBuffer()
 {
     fCurrentCommandBuffer = fCommandQueue->commandBuffer();
+
+    auto surface = plMetalRenderDestinationType::CurrentRenderDestination()->GetNextRenderSurface(fCurrentCommandBuffer);
+    if (!surface) {
+        fCurrentCommandBuffer = nullptr;
+        return false;
+    }
+
     fCurrentCommandBuffer->retain();
 
-    SetFramebufferFormat(drawable->texture()->pixelFormat());
+    auto colorAttachment = surface->colorTexture;
+
+    SetFramebufferFormat(colorAttachment->pixelFormat());
 
     bool depthNeedsRebuild = fCurrentDrawableDepthTexture == nullptr;
-    depthNeedsRebuild |= drawable->texture()->width() != fCurrentDrawableDepthTexture->width() || drawable->texture()->height() != fCurrentDrawableDepthTexture->height();
+    depthNeedsRebuild |= colorAttachment->width() != fCurrentDrawableDepthTexture->width() || colorAttachment->height() != fCurrentDrawableDepthTexture->height();
 
     // cache the depth buffer, we'll just clear it every time.
     if (depthNeedsRebuild) {
@@ -1020,8 +1031,8 @@ void plMetalDevice::CreateNewCommandBuffer(CA::MetalDrawable* drawable)
         }
 
         MTL::TextureDescriptor* depthTextureDescriptor = MTL::TextureDescriptor::texture2DDescriptor(MTL::PixelFormatDepth32Float_Stencil8,
-                                                                                                     drawable->texture()->width(),
-                                                                                                     drawable->texture()->height(),
+                                                                                                     colorAttachment->width(),
+                                                                                                     colorAttachment->height(),
                                                                                                      false);
         if (fMetalDevice->supportsFamily(MTL::GPUFamilyApple1) && fSampleCount == 1) {
             depthTextureDescriptor->setStorageMode(MTL::StorageModeMemoryless);
@@ -1042,9 +1053,9 @@ void plMetalDevice::CreateNewCommandBuffer(CA::MetalDrawable* drawable)
             }
             fCurrentDrawableDepthTexture = fMetalDevice->newTexture(depthTextureDescriptor);
 
-            MTL::TextureDescriptor* msaaColorTextureDescriptor = MTL::TextureDescriptor::texture2DDescriptor(drawable->texture()->pixelFormat(),
-                                                                                                             drawable->texture()->width(),
-                                                                                                             drawable->texture()->height(),
+            MTL::TextureDescriptor* msaaColorTextureDescriptor = MTL::TextureDescriptor::texture2DDescriptor(colorAttachment->pixelFormat(),
+                                                                                                             colorAttachment->width(),
+                                                                                                             colorAttachment->height(),
                                                                                                              false);
             msaaColorTextureDescriptor->setUsage(MTL::TextureUsageRenderTarget);
             if (fMetalDevice->supportsFamily(MTL::GPUFamilyApple1) && fSampleCount == 1) {
@@ -1065,7 +1076,7 @@ void plMetalDevice::CreateNewCommandBuffer(CA::MetalDrawable* drawable)
         // Do we need to create a unprocessed output texture?
         // If the depth needs to be rebuilt - we probably need to rebuild this one too
         if ((fCurrentUnprocessedOutputTexture && depthNeedsRebuild) || (fCurrentUnprocessedOutputTexture == nullptr && NeedsPostprocessing())) {
-            MTL::TextureDescriptor* mainPassDescriptor = MTL::TextureDescriptor::texture2DDescriptor(drawable->texture()->pixelFormat(), drawable->texture()->width(), drawable->texture()->height(), false);
+            MTL::TextureDescriptor* mainPassDescriptor = MTL::TextureDescriptor::texture2DDescriptor(colorAttachment->pixelFormat(), colorAttachment->width(), colorAttachment->height(), false);
             mainPassDescriptor->setStorageMode(MTL::StorageModePrivate);
             mainPassDescriptor->setUsage(MTL::TextureUsageShaderRead | MTL::TextureUsageRenderTarget);
             fCurrentUnprocessedOutputTexture->release();
@@ -1073,7 +1084,8 @@ void plMetalDevice::CreateNewCommandBuffer(CA::MetalDrawable* drawable)
         }
     }
 
-    fCurrentDrawable = drawable->retain();
+    fCurrentRenderSurface = surface;
+    return true;
 }
 
 void plMetalDevice::StartPipelineBuild(plMetalPipelineRecord& record, std::condition_variable** condOut)
@@ -1235,13 +1247,14 @@ void plMetalDevice::SubmitCommandBuffer()
     PostprocessIntoDrawable();
     FinalizePostProcessing();
 
-    fCurrentCommandBuffer->presentDrawable(fCurrentDrawable);
+    if (fCurrentRenderSurface.has_value() && fCurrentRenderSurface->drawable) {
+        fCurrentCommandBuffer->presentDrawable(fCurrentRenderSurface->drawable);
+    }
     fCurrentCommandBuffer->commit();
     fCurrentCommandBuffer->release();
     fCurrentCommandBuffer = nullptr;
 
-    fCurrentDrawable->release();
-    fCurrentDrawable = nullptr;
+    fCurrentRenderSurface.reset();
 
     // Reset the clear colors for the next pass
     // Metal clears on framebuffer load - so don't cause a clear
@@ -1301,7 +1314,7 @@ void plMetalDevice::PostprocessIntoDrawable()
         // source and the output drawable as the target to do post-processing.
         MTL::RenderPassDescriptor* gammaPassDescriptor = MTL::RenderPassDescriptor::renderPassDescriptor();
         gammaPassDescriptor->colorAttachments()->object(0)->setLoadAction(MTL::LoadActionDontCare);
-        gammaPassDescriptor->colorAttachments()->object(0)->setTexture(fCurrentDrawable->texture());
+        gammaPassDescriptor->colorAttachments()->object(0)->setTexture(fCurrentRenderSurface->colorTexture);
         gammaPassDescriptor->colorAttachments()->object(0)->setStoreAction(MTL::StoreActionStore);
         
         gammaAdjustEncoder = fCurrentCommandBuffer->renderCommandEncoder(gammaPassDescriptor);
@@ -1382,11 +1395,6 @@ MTL::RenderCommandEncoder* plMetalDevice::CurrentRenderCommandEncoder()
     }
 
     return fCurrentRenderTargetCommandEncoder;
-}
-
-CA::MetalDrawable* plMetalDevice::GetCurrentDrawable() const
-{
-    return fCurrentDrawable;
 }
 
 void plMetalDevice::BlitTexture(MTL::Texture* src, MTL::Texture* dst)

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
@@ -1006,7 +1006,7 @@ bool plMetalDevice::CreateNewCommandBuffer()
 {
     fCurrentCommandBuffer = fCommandQueue->commandBuffer();
 
-    auto surface = (*fRenderDestination)->GetNextRenderSurface(fCurrentCommandBuffer);
+    auto surface = fWindow->metalRenderDestination().GetNextRenderSurface(fCurrentCommandBuffer);
     if (!surface) {
         fCurrentCommandBuffer = nullptr;
         return false;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
@@ -458,7 +458,7 @@ void plMetalDevice::SetRenderTarget(plRenderTarget* target)
             fCurrentDepthFormat = MTL::PixelFormatInvalid;
         }
     } else {
-        fCurrentFragmentOutputTexture = fCurrentRenderSurface ? fCurrentRenderSurface->colorTexture : nullptr;
+        fCurrentFragmentOutputTexture = fCurrentRenderSurface ? fCurrentRenderSurface->fColorTexture : nullptr;
         fCurrentDepthFormat = MTL::PixelFormatDepth32Float_Stencil8;
     }
 }
@@ -1014,7 +1014,7 @@ bool plMetalDevice::CreateNewCommandBuffer()
 
     fCurrentCommandBuffer->retain();
 
-    auto colorAttachment = surface->colorTexture;
+    auto colorAttachment = surface->fColorTexture;
 
     SetFramebufferFormat(colorAttachment->pixelFormat());
 
@@ -1245,8 +1245,8 @@ void plMetalDevice::SubmitCommandBuffer()
     PostprocessIntoDrawable();
     FinalizePostProcessing();
 
-    if (fCurrentRenderSurface.has_value() && fCurrentRenderSurface->drawable) {
-        fCurrentCommandBuffer->presentDrawable(fCurrentRenderSurface->drawable);
+    if (fCurrentRenderSurface.has_value() && fCurrentRenderSurface->fDrawable) {
+        fCurrentCommandBuffer->presentDrawable(fCurrentRenderSurface->fDrawable);
     }
     fCurrentCommandBuffer->commit();
     fCurrentCommandBuffer->release();
@@ -1312,7 +1312,7 @@ void plMetalDevice::PostprocessIntoDrawable()
         // source and the output drawable as the target to do post-processing.
         MTL::RenderPassDescriptor* gammaPassDescriptor = MTL::RenderPassDescriptor::renderPassDescriptor();
         gammaPassDescriptor->colorAttachments()->object(0)->setLoadAction(MTL::LoadActionDontCare);
-        gammaPassDescriptor->colorAttachments()->object(0)->setTexture(fCurrentRenderSurface->colorTexture);
+        gammaPassDescriptor->colorAttachments()->object(0)->setTexture(fCurrentRenderSurface->fColorTexture);
         gammaPassDescriptor->colorAttachments()->object(0)->setStoreAction(MTL::StoreActionStore);
         
         gammaAdjustEncoder = fCurrentCommandBuffer->renderCommandEncoder(gammaPassDescriptor);

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
@@ -61,8 +61,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pfMetalPipeline/plMetalPipelineState.h"
 #include "pfMetalPipeline/ShaderSrc/ShaderTypes.h"
 
-plMetalRenderDestinationType* plMetalRenderDestinationType::fCurrentRenderDestination;
-
 /// Macros for getting/setting data in a vertex buffer
 template<typename T>
 static inline void inlCopy(uint8_t*& src, uint8_t*& dst)
@@ -1008,7 +1006,7 @@ bool plMetalDevice::CreateNewCommandBuffer()
 {
     fCurrentCommandBuffer = fCommandQueue->commandBuffer();
 
-    auto surface = plMetalRenderDestinationType::CurrentRenderDestination()->GetNextRenderSurface(fCurrentCommandBuffer);
+    auto surface = (*fRenderDestination)->GetNextRenderSurface(fCurrentCommandBuffer);
     if (!surface) {
         fCurrentCommandBuffer = nullptr;
         return false;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -94,7 +94,7 @@ public:
     plMetalPipeline* fPipeline;
 
     hsWindowHndl fDevice;
-    hsWindowHndl fWindow;
+    plMetalWindow* fWindow;
 
     ST::string fErrorMsg;
 
@@ -103,8 +103,6 @@ public:
     uint32_t                   fDeviceType;
     MTL::CommandQueue*         fCommandQueue;
     MTL::Buffer*               fCurrentIndexBuffer;
-
-    plMetalRenderDestinationType** fRenderDestination;
 
     size_t          fActiveThread;
     matrix_float4x4 fMatrixProj;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -54,6 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsGMatState.h"
 #include "hsMatrix44.h"
 #include "plMetalDeviceRef.h"
+#include "plMetalRenderDestination.h"
 #include "plSurface/plShader.h"
 #include "plSurface/plShaderTable.h"
 
@@ -169,11 +170,9 @@ public:
     uint8_t                 fSampleCount;
 
     /// Create a new command buffer to encode all the operations needed to draw a frame
-    // Currently requires a CA drawable and not a Metal drawable. In since CA drawable is only abstract implementation I know about, not sure where we would find others?
-    void                CreateNewCommandBuffer(CA::MetalDrawable* drawable);
+    bool                CreateNewCommandBuffer();
     MTL::CommandBuffer* GetCurrentCommandBuffer() const;
     MTL::CommandBuffer* GetCurrentDrawableCommandBuffer() const { return fCurrentCommandBuffer; }
-    CA::MetalDrawable*  GetCurrentDrawable() const;
     /// Submit the command buffer to the GPU and draws all the render passes. Clears the current command buffer.
     void                SubmitCommandBuffer();
     void                Clear(bool shouldClearColor, simd_float4 clearColor, bool shouldClearDepth, float clearDepth);
@@ -231,9 +230,7 @@ private:
     std::mutex                                                                                             fPipelineCreationMtx;
     void                                                                                                   StartPipelineBuild(plMetalPipelineRecord& record, std::condition_variable** condOut);
     std::condition_variable*                                                                               PrewarmPipelineStateFor(plMetalPipelineState* pipelineState);
-    
-    void SetOutputLayer(CA::MetalLayer* layer) { fLayer = layer; }
-    CA::MetalLayer* GetOutputLayer() const { return fLayer; };
+
     hsDisplayHndl fDisplay;
 
 protected:
@@ -252,15 +249,14 @@ private:
     MTL::CommandBuffer*        fCurrentCommandBuffer;
     MTL::CommandBuffer*        fCurrentOffscreenCommandBuffer;
     MTL::RenderCommandEncoder* fCurrentRenderTargetCommandEncoder;
-    
-    CA::MetalLayer*            fLayer;
 
     MTL::Texture* fCurrentDrawableDepthTexture;
     MTL::Texture* fCurrentFragmentOutputTexture;
     MTL::Texture* fCurrentUnprocessedOutputTexture;
     MTL::Texture* fCurrentFragmentMSAAOutputTexture;
 
-    CA::MetalDrawable* fCurrentDrawable;
+    std::optional<plMetalRenderSurface> fCurrentRenderSurface;
+
     MTL::PixelFormat   fCurrentDepthFormat;
     simd_float4        fClearRenderTargetColor;
     simd_float4        fClearDrawableColor;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.h
@@ -65,6 +65,7 @@ class plMipmap;
 class plCubicEnvironmap;
 class plLayerInterface;
 class plMetalPipelineState;
+class plMetalRenderDestinationType;
 
 inline const matrix_float4x4 hsMatrix2SIMD(const hsMatrix44& src)
 {
@@ -102,6 +103,8 @@ public:
     uint32_t                   fDeviceType;
     MTL::CommandQueue*         fCommandQueue;
     MTL::Buffer*               fCurrentIndexBuffer;
+
+    plMetalRenderDestinationType** fRenderDestination;
 
     size_t          fActiveThread;
     matrix_float4x4 fMatrixProj;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -211,7 +211,9 @@ plMetalPipeline::plMetalPipeline(hsDisplayHndl display, hsWindowHndl window, con
 
     // For now - set this once at startup. If the underlying device is allow to change on
     // the fly (eGPU, display change, etc) - revisit.
-    plMetalRenderDestinationType::CurrentRenderDestination()->SetOutputSize(CGSizeMake(devMode->GetMode()->GetWidth(), devMode->GetMode()->GetHeight()));
+    plMetalRenderDestinationType** renderDestination = static_cast<plMetalRenderDestinationType**>(window);
+    (*renderDestination)->SetOutputSize(CGSizeMake(devMode->GetMode()->GetWidth(), devMode->GetMode()->GetHeight()));
+    fDevice.fRenderDestination = renderDestination;
     fDevice.fDisplay = display;
 
     // Default our output format to 8 bit BGRA. Client may immediately change this to
@@ -785,7 +787,7 @@ void plMetalPipeline::Resize(uint32_t width, uint32_t height)
         fOrigHeight = height;
         IGetViewTransform().SetScreenSize((uint16_t)(fOrigWidth), (uint16_t)(fOrigHeight));
         resetTransform.SetScreenSize((uint16_t)(fOrigWidth), (uint16_t)(fOrigHeight));
-        plMetalRenderDestinationType::CurrentRenderDestination()->SetOutputSize(CGSizeMake(width, height));
+        (*fDevice.fRenderDestination)->SetOutputSize(CGSizeMake(width, height));
     } else {
         // Just for debug
         hsStatusMessage("Recreating the pipeline...");

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -208,12 +208,10 @@ plMetalPipeline::plMetalPipeline(hsDisplayHndl display, hsWindowHndl window, con
     fIsFullscreen = !fInitialPipeParams.Windowed;
     
     fDesktopParams = plDisplayHelper::GetInstance()->DesktopDisplayMode();
-    
-    fDevice.SetOutputLayer(reinterpret_cast<CA::MetalLayer*>(window));
+
     // For now - set this once at startup. If the underlying device is allow to change on
     // the fly (eGPU, display change, etc) - revisit.
-    fDevice.GetOutputLayer()->setDevice(fDevice.fMetalDevice);
-    fDevice.GetOutputLayer()->setDrawableSize(CGSizeMake(devMode->GetMode()->GetWidth(), devMode->GetMode()->GetHeight()));
+    plMetalRenderDestinationType::CurrentRenderDestination()->SetOutputSize(CGSizeMake(devMode->GetMode()->GetWidth(), devMode->GetMode()->GetHeight()));
     fDevice.fDisplay = display;
 
     // Default our output format to 8 bit BGRA. Client may immediately change this to
@@ -678,16 +676,11 @@ bool plMetalPipeline::BeginRender()
         IPreprocessShadows();
         IPreprocessAvatarTextures();
 
-        CA::MetalLayer* outputLayer = fDevice.GetOutputLayer();
-        
-        CA::MetalDrawable* drawable = fDevice.GetOutputLayer()->nextDrawable()->retain();
-        if (!drawable) {
+        if (!fDevice.CreateNewCommandBuffer()) {
             // no framebuffer available - abort
             EndRender();
             return true;
         }
-        fDevice.CreateNewCommandBuffer(drawable);
-        drawable->release();
 
         /// If we have a renderTarget active, use its viewport
         // FIXME: New drawables should inherit existing viewport
@@ -792,7 +785,7 @@ void plMetalPipeline::Resize(uint32_t width, uint32_t height)
         fOrigHeight = height;
         IGetViewTransform().SetScreenSize((uint16_t)(fOrigWidth), (uint16_t)(fOrigHeight));
         resetTransform.SetScreenSize((uint16_t)(fOrigWidth), (uint16_t)(fOrigHeight));
-        fDevice.GetOutputLayer()->setDrawableSize(CGSizeMake(width, height));
+        plMetalRenderDestinationType::CurrentRenderDestination()->SetOutputSize(CGSizeMake(width, height));
     } else {
         // Just for debug
         hsStatusMessage("Recreating the pipeline...");

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -211,9 +211,11 @@ plMetalPipeline::plMetalPipeline(hsDisplayHndl display, hsWindowHndl window, con
 
     // For now - set this once at startup. If the underlying device is allow to change on
     // the fly (eGPU, display change, etc) - revisit.
-    plMetalRenderDestinationType** renderDestination = static_cast<plMetalRenderDestinationType**>(window);
-    (*renderDestination)->SetOutputSize(CGSizeMake(devMode->GetMode()->GetWidth(), devMode->GetMode()->GetHeight()));
-    fDevice.fRenderDestination = renderDestination;
+    // This is a static cast because plClientWindow has not been integrated into the engine yet
+    // The pointer to the window is going to be a void*. Assume it's a window that conforms to
+    // plMetalRenderDestinationProvider
+    fDevice.fWindow = static_cast<plMetalWindow*>(window);
+    fDevice.fWindow->metalRenderDestination().SetOutputSize(CGSizeMake(devMode->GetMode()->GetWidth(), devMode->GetMode()->GetHeight()));
     fDevice.fDisplay = display;
 
     // Default our output format to 8 bit BGRA. Client may immediately change this to
@@ -787,7 +789,7 @@ void plMetalPipeline::Resize(uint32_t width, uint32_t height)
         fOrigHeight = height;
         IGetViewTransform().SetScreenSize((uint16_t)(fOrigWidth), (uint16_t)(fOrigHeight));
         resetTransform.SetScreenSize((uint16_t)(fOrigWidth), (uint16_t)(fOrigHeight));
-        (*fDevice.fRenderDestination)->SetOutputSize(CGSizeMake(width, height));
+        fDevice.fWindow->metalRenderDestination().SetOutputSize(CGSizeMake(width, height));
     } else {
         // Just for debug
         hsStatusMessage("Recreating the pipeline...");

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
@@ -169,17 +169,12 @@ public:
     MTL::PixelFormat GetFramebufferFormat() { return fDevice.GetFramebufferFormat(); };
     void             SetFramebufferFormat(MTL::PixelFormat format) { fDevice.SetFramebufferFormat(format); };
 
-    void SetRenderDestination(plMetalRenderDestinationType* renderDestination) { fRenderDestination = renderDestination; }
-    const plMetalRenderDestinationType* GetRenderDestination() { return fRenderDestination; }
-
     void RegisterLight(plLightInfo* light) override;
     void UnRegisterLight(plLightInfo* light) override;
 
 private:
     VertexUniforms* fCurrentRenderPassUniforms;
     plMaterialLightingDescriptor fCurrentRenderPassMaterialLighting;
-
-    plMetalRenderDestinationType* fRenderDestination;
 
     bool fIsFullscreen;
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
@@ -169,13 +169,18 @@ public:
     MTL::PixelFormat GetFramebufferFormat() { return fDevice.GetFramebufferFormat(); };
     void             SetFramebufferFormat(MTL::PixelFormat format) { fDevice.SetFramebufferFormat(format); };
 
+    void                          SetRenderDestination(plMetalRenderDestinationType* renderDestination) { fRenderDestination = renderDestination; }
+    plMetalRenderDestinationType* GetRenderDestination() { return fRenderDestination; }
+
     void RegisterLight(plLightInfo* light) override;
     void UnRegisterLight(plLightInfo* light) override;
 
 private:
     VertexUniforms* fCurrentRenderPassUniforms;
     plMaterialLightingDescriptor fCurrentRenderPassMaterialLighting;
-    
+
+    plMetalRenderDestinationType* fRenderDestination;
+
     bool fIsFullscreen;
 
     void FindFragFunction();

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
@@ -169,8 +169,8 @@ public:
     MTL::PixelFormat GetFramebufferFormat() { return fDevice.GetFramebufferFormat(); };
     void             SetFramebufferFormat(MTL::PixelFormat format) { fDevice.SetFramebufferFormat(format); };
 
-    void                          SetRenderDestination(plMetalRenderDestinationType* renderDestination) { fRenderDestination = renderDestination; }
-    plMetalRenderDestinationType* GetRenderDestination() { return fRenderDestination; }
+    void SetRenderDestination(plMetalRenderDestinationType* renderDestination) { fRenderDestination = renderDestination; }
+    const plMetalRenderDestinationType* GetRenderDestination() { return fRenderDestination; }
 
     void RegisterLight(plLightInfo* light) override;
     void UnRegisterLight(plLightInfo* light) override;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
@@ -50,36 +50,36 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 struct plMetalRenderSurface
 {
     // Required - the color texture to draw to.
-    MTL::Texture*      colorTexture;
+    MTL::Texture*      fColorTexture;
     // Optional - only provided for a CA based windowing system
-    CA::MetalDrawable* drawable;
+    CA::MetalDrawable* fDrawable;
 
     // Initialize with new objects - retain them
     plMetalRenderSurface(MTL::Texture* colorTexture, CA::MetalDrawable* drawable)
-        : colorTexture(colorTexture->retain()), drawable(drawable->retain())
+        : fColorTexture(colorTexture->retain()), fDrawable(drawable->retain())
     { }
 
     // Move constructor - transfer ownership directly
     plMetalRenderSurface(plMetalRenderSurface&& other)
-        : colorTexture(other.colorTexture), drawable(other.drawable)
+        : fColorTexture(other.fColorTexture), fDrawable(other.fDrawable)
     {
-        other.colorTexture = nullptr;
-        other.drawable = nullptr;
+        other.fColorTexture = nullptr;
+        other.fDrawable = nullptr;
     }
 
     // Copy constructor - retain to create independent copy
     plMetalRenderSurface(const plMetalRenderSurface& other)
-        : colorTexture(other.colorTexture), drawable(other.drawable)
+        : fColorTexture(other.fColorTexture), fDrawable(other.fDrawable)
     { }
 
     // Copy assignment with self-assignment protection
     plMetalRenderSurface& operator=(const plMetalRenderSurface& other)
     {
         if (this != &other) {
-            colorTexture->release();
-            drawable->release();
-            colorTexture = other.colorTexture->retain();
-            drawable = other.drawable->retain();
+            fColorTexture->release();
+            fDrawable->release();
+            fColorTexture = other.fColorTexture->retain();
+            fDrawable = other.fDrawable->retain();
         }
         return *this;
     }
@@ -88,10 +88,10 @@ struct plMetalRenderSurface
     plMetalRenderSurface& operator=(plMetalRenderSurface&& other)
     {
         if (this != &other) {
-            colorTexture = other.colorTexture;
-            drawable = other.drawable;
-            other.colorTexture = nullptr;
-            other.drawable = nullptr;
+            fColorTexture = other.fColorTexture;
+            fDrawable = other.fDrawable;
+            other.fColorTexture = nullptr;
+            other.fDrawable = nullptr;
         }
         return *this;
     }
@@ -99,11 +99,11 @@ struct plMetalRenderSurface
     // Destructor - release retained resources
     ~plMetalRenderSurface()
     {
-        if (colorTexture) {
-            colorTexture->release();
+        if (fColorTexture) {
+            fColorTexture->release();
         }
-        if (drawable) {
-            drawable->release();
+        if (fDrawable) {
+            fDrawable->release();
         }
     }
 };

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
@@ -69,7 +69,7 @@ struct plMetalRenderSurface
 
     // Copy constructor - retain to create independent copy
     plMetalRenderSurface(const plMetalRenderSurface& other)
-        : fColorTexture(other.fColorTexture), fDrawable(other.fDrawable)
+        : fColorTexture(other.fColorTexture->retain()), fDrawable(other.fDrawable->retain())
     { }
 
     // Copy assignment with self-assignment protection

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
@@ -148,13 +148,7 @@ public:
     virtual plOptionalMetalRenderSurface GetNextRenderSurface(MTL::CommandBuffer* buffer) = 0;
     virtual void SetOutputSize(CGSize size) = 0;
 
-    void MakeCurrentRenderDestination() { fCurrentRenderDestination = this; }
-    static plMetalRenderDestinationType* CurrentRenderDestination() { return fCurrentRenderDestination; }
-
     virtual ~plMetalRenderDestinationType() = default;
-
-private:
-    static plMetalRenderDestinationType* fCurrentRenderDestination;
 };
 
 /*
@@ -192,6 +186,11 @@ public:
 
 private:
     std::unique_ptr<T> fProvider;
+};
+
+struct plMetalDestinationWindow
+{
+    plMetalRenderDestinationType* fMetalRenderDestination;
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
@@ -157,7 +157,7 @@ public:
  when this template specializes on a Swift type.
  */
 
-template <typename T>
+template<typename T>
 class plMetalRenderDestination : public plMetalRenderDestinationType
 {
 public:
@@ -169,11 +169,11 @@ private:
     T fProvider;
 };
 
-template <typename T>
+template<typename T>
 class plMetalRenderDestination<T*> : public plMetalRenderDestinationType
 {
 public:
-    template <typename... Args>
+    template<typename... Args>
     plMetalRenderDestination(Args&&... args)
         : fProvider(std::make_unique<T>(std::forward<Args>(args)...))
     { }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
@@ -148,12 +148,13 @@ public:
 
 /*
  One final twist - Swift exports it's types as value types,
- but these types behave as references - similar to std::shared_ptr.
+ but they behave like references - similar to std::shared_ptr.
  That means we need to have a version of plMetalRenderDestination
  for value types, and another for pointer types.
 
  The pointer types version is used when we have a real C++
- type that we need to specialize on.
+ type that we need to specialize on. The value type is used
+ when this template specializes on a Swift type.
  */
 
 template <typename T>
@@ -173,7 +174,7 @@ class plMetalRenderDestination<T*> : public plMetalRenderDestinationType
 {
 public:
     template <typename... Args>
-    plMetalRenderDestination(Args&&... args) : fProvider(new T(std::forward<Args>(args)...))
+    plMetalRenderDestination(Args&&... args) : fProvider(std::make_unique<T>(std::forward<Args>(args)...))
     {
     }
     plOptionalMetalRenderSurface GetNextRenderSurface(MTL::CommandBuffer* buffer) override { return fProvider->GetNextRenderSurface(buffer); }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
@@ -143,6 +143,10 @@ public:
     virtual plOptionalMetalRenderSurface GetNextRenderSurface(MTL::CommandBuffer* buffer) = 0;
     virtual void                         SetOutputSize(CGSize size) = 0;
 
+    plMetalRenderDestinationType() = default;
+    plMetalRenderDestinationType (const plMetalRenderDestinationType&) = delete;
+    plMetalRenderDestinationType& operator= (const plMetalRenderDestinationType&) = delete;
+
     virtual ~plMetalRenderDestinationType() = default;
 };
 
@@ -184,9 +188,12 @@ private:
     std::unique_ptr<T> fProvider;
 };
 
-struct plMetalDestinationWindow
+class plMetalWindow
 {
-    plMetalRenderDestinationType* fMetalRenderDestination;
+public:
+    // metalRenderDestination can change frame to frame (for now)
+    // Result provided as a reference to prevent holding on to a pointer
+    virtual plMetalRenderDestinationType& metalRenderDestination() = 0;
 };
 
 #endif

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
@@ -55,22 +55,22 @@ struct plMetalRenderSurface
     CA::MetalDrawable* drawable;
 
     // Initialize with new objects - retain them
-    plMetalRenderSurface(MTL::Texture* colorTexture, CA::MetalDrawable* drawable):
-        colorTexture(colorTexture->retain()), drawable(drawable->retain())
-    {}
+    plMetalRenderSurface(MTL::Texture* colorTexture, CA::MetalDrawable* drawable)
+        : colorTexture(colorTexture->retain()), drawable(drawable->retain())
+    { }
 
     // Move constructor - transfer ownership directly
-    plMetalRenderSurface(plMetalRenderSurface&& other):
-        colorTexture(other.colorTexture), drawable(other.drawable)
+    plMetalRenderSurface(plMetalRenderSurface&& other)
+        : colorTexture(other.colorTexture), drawable(other.drawable)
     {
         other.colorTexture = nullptr;
         other.drawable = nullptr;
     }
 
     // Copy constructor - retain to create independent copy
-    plMetalRenderSurface(const plMetalRenderSurface& other):
-        colorTexture(other.colorTexture), drawable(other.drawable)
-    {}
+    plMetalRenderSurface(const plMetalRenderSurface& other)
+        : colorTexture(other.colorTexture), drawable(other.drawable)
+    { }
 
     // Copy assignment with self-assignment protection
     plMetalRenderSurface& operator=(const plMetalRenderSurface& other)
@@ -141,7 +141,7 @@ class plMetalRenderDestinationType
 {
 public:
     virtual plOptionalMetalRenderSurface GetNextRenderSurface(MTL::CommandBuffer* buffer) = 0;
-    virtual void SetOutputSize(CGSize size) = 0;
+    virtual void                         SetOutputSize(CGSize size) = 0;
 
     virtual ~plMetalRenderDestinationType() = default;
 };
@@ -163,7 +163,7 @@ class plMetalRenderDestination : public plMetalRenderDestinationType
 public:
     plMetalRenderDestination(T provider) : fProvider(provider) {}
     plOptionalMetalRenderSurface GetNextRenderSurface(MTL::CommandBuffer* buffer) override { return fProvider.GetNextRenderSurface(buffer); }
-    void SetOutputSize(CGSize size) override { fProvider.SetOutputSize(size); }
+    void                         SetOutputSize(CGSize size) override { fProvider.SetOutputSize(size); }
 
 private:
     T fProvider;
@@ -174,11 +174,11 @@ class plMetalRenderDestination<T*> : public plMetalRenderDestinationType
 {
 public:
     template <typename... Args>
-    plMetalRenderDestination(Args&&... args) : fProvider(std::make_unique<T>(std::forward<Args>(args)...))
-    {
-    }
+    plMetalRenderDestination(Args&&... args)
+        : fProvider(std::make_unique<T>(std::forward<Args>(args)...))
+    { }
     plOptionalMetalRenderSurface GetNextRenderSurface(MTL::CommandBuffer* buffer) override { return fProvider->GetNextRenderSurface(buffer); }
-    void SetOutputSize(CGSize size) override { fProvider->SetOutputSize(size); }
+    void                         SetOutputSize(CGSize size) override { fProvider->SetOutputSize(size); }
 
 private:
     std::unique_ptr<T> fProvider;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
@@ -1,0 +1,197 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#ifndef plMetalRenderSurface_h
+#define plMetalRenderSurface_h
+
+#import <Metal/Metal.hpp>
+#import <QuartzCore/QuartzCore.hpp>
+#import <optional>
+
+struct plMetalRenderSurface
+{
+    // Required - the color texture to draw to.
+    MTL::Texture*      colorTexture;
+    // Optional - only provided for a CA based windowing system
+    CA::MetalDrawable* drawable;
+
+    // Initialize with new objects - retain them
+    plMetalRenderSurface(MTL::Texture* colorTexture, CA::MetalDrawable* drawable)
+    {
+        this->colorTexture = colorTexture->retain();
+        this->drawable = drawable->retain();
+    }
+
+    // Move constructor - transfer ownership directly
+    plMetalRenderSurface(plMetalRenderSurface&& other)
+    {
+        this->colorTexture = other.colorTexture;
+        this->drawable = other.drawable;
+        other.colorTexture = nullptr;
+        other.drawable = nullptr;
+    }
+
+    // Copy constructor - retain to create independent copy
+    plMetalRenderSurface(const plMetalRenderSurface& other)
+    {
+        this->colorTexture = other.colorTexture->retain();
+        this->drawable = other.drawable->retain();
+    }
+
+    // Copy assignment with self-assignment protection
+    plMetalRenderSurface& operator=(const plMetalRenderSurface& other)
+    {
+        if (this != &other) {
+            this->colorTexture = other.colorTexture->retain();
+            this->drawable = other.drawable->retain();
+        }
+        this->colorTexture->release();
+        this->drawable->release();
+        return *this;
+    }
+
+    // Move assignment - transfer ownership without releasing
+    plMetalRenderSurface& operator=(plMetalRenderSurface&& other)
+    {
+        if (this != &other) {
+            this->colorTexture = other.colorTexture;
+            this->drawable = other.drawable;
+            other.colorTexture = nullptr;
+            other.drawable = nullptr;
+        }
+        return *this;
+    }
+
+    // Destructor - release retained resources
+    ~plMetalRenderSurface()
+    {
+        if (colorTexture) {
+            colorTexture->release();
+        }
+        if (drawable) {
+            drawable->release();
+        }
+    }
+};
+
+// Swift cannot specialize optionals right now
+// Declare the specialization here
+typedef std::optional<plMetalRenderSurface> plOptionalMetalRenderSurface;
+
+/*
+ plMetalRenderDestination represents a destination we can render to
+ from the Metal renderer. On macOS and iOS this will usually
+ be a drawable - but on visionOS it might be something like
+ a RealityKit LowLevelTexture.
+
+ A client provides a platform specific plMetalRenderDestination to
+ the engine, and then the engine calls into the render destination
+ when it needs a frame. A render destination might be vsync'd,
+ and if the engine asks for a render destination before the next
+ frame is ready the render destination can return null.
+
+ One issue is that the client might have to provide a render destination
+ as a Swift type - but Swift does not support subclassing C++ types.
+ We can specialize a C++ template on a Swift type - but the engine
+ won't know what that specialization is at compile time.
+
+ This code does both. It declares a plMetalRenderDestinationType that
+ anonymizes render destinations, and then a plMetalRenderDestination
+ that can be specialized on something like a Swift type.
+
+ In the future - if Swift supports inheriting from C++ types with dynamic
+ dispatch this could be simplified.
+ */
+
+class plMetalRenderDestinationType
+{
+public:
+    virtual plOptionalMetalRenderSurface GetNextRenderSurface(MTL::CommandBuffer* buffer) = 0;
+    virtual void SetOutputSize(CGSize size) = 0;
+
+    void MakeCurrentRenderDestination() { fCurrentRenderDestination = this; }
+    static plMetalRenderDestinationType* CurrentRenderDestination() { return fCurrentRenderDestination; }
+
+    virtual ~plMetalRenderDestinationType() = default;
+
+private:
+    static plMetalRenderDestinationType* fCurrentRenderDestination;
+};
+
+/*
+ One final twist - Swift exports it's types as value types,
+ but these types behave as references - similar to std::shared_ptr.
+ That means we need to have a version of plMetalRenderDestination
+ for value types, and another for pointer types.
+
+ The pointer types version is used when we have a real C++
+ type that we need to specialize on.
+ */
+
+template <typename T>
+class plMetalRenderDestination : public plMetalRenderDestinationType
+{
+public:
+    plMetalRenderDestination(T provider) : fProvider(provider) {}
+    plOptionalMetalRenderSurface GetNextRenderSurface(MTL::CommandBuffer* buffer) override { return fProvider.GetNextRenderSurface(buffer); }
+    void SetOutputSize(CGSize size) override { fProvider.SetOutputSize(size); }
+
+private:
+    T fProvider;
+};
+
+template <typename T>
+class plMetalRenderDestination<T*> : public plMetalRenderDestinationType
+{
+public:
+    template <typename... Args>
+    plMetalRenderDestination(Args&&... args) : fProvider(new T(std::forward<Args>(args)...))
+    {
+    }
+    plOptionalMetalRenderSurface GetNextRenderSurface(MTL::CommandBuffer* buffer) override { return fProvider->GetNextRenderSurface(buffer); }
+    void SetOutputSize(CGSize size) override { fProvider->SetOutputSize(size); }
+
+private:
+    std::unique_ptr<T> fProvider;
+};
+
+#endif

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalRenderDestination.h
@@ -55,37 +55,32 @@ struct plMetalRenderSurface
     CA::MetalDrawable* drawable;
 
     // Initialize with new objects - retain them
-    plMetalRenderSurface(MTL::Texture* colorTexture, CA::MetalDrawable* drawable)
-    {
-        this->colorTexture = colorTexture->retain();
-        this->drawable = drawable->retain();
-    }
+    plMetalRenderSurface(MTL::Texture* colorTexture, CA::MetalDrawable* drawable):
+        colorTexture(colorTexture->retain()), drawable(drawable->retain())
+    {}
 
     // Move constructor - transfer ownership directly
-    plMetalRenderSurface(plMetalRenderSurface&& other)
+    plMetalRenderSurface(plMetalRenderSurface&& other):
+        colorTexture(other.colorTexture), drawable(other.drawable)
     {
-        this->colorTexture = other.colorTexture;
-        this->drawable = other.drawable;
         other.colorTexture = nullptr;
         other.drawable = nullptr;
     }
 
     // Copy constructor - retain to create independent copy
-    plMetalRenderSurface(const plMetalRenderSurface& other)
-    {
-        this->colorTexture = other.colorTexture->retain();
-        this->drawable = other.drawable->retain();
-    }
+    plMetalRenderSurface(const plMetalRenderSurface& other):
+        colorTexture(other.colorTexture), drawable(other.drawable)
+    {}
 
     // Copy assignment with self-assignment protection
     plMetalRenderSurface& operator=(const plMetalRenderSurface& other)
     {
         if (this != &other) {
-            this->colorTexture = other.colorTexture->retain();
-            this->drawable = other.drawable->retain();
+            colorTexture->release();
+            drawable->release();
+            colorTexture = other.colorTexture->retain();
+            drawable = other.drawable->retain();
         }
-        this->colorTexture->release();
-        this->drawable->release();
         return *this;
     }
 
@@ -93,8 +88,8 @@ struct plMetalRenderSurface
     plMetalRenderSurface& operator=(plMetalRenderSurface&& other)
     {
         if (this != &other) {
-            this->colorTexture = other.colorTexture;
-            this->drawable = other.drawable;
+            colorTexture = other.colorTexture;
+            drawable = other.drawable;
             other.colorTexture = nullptr;
             other.drawable = nullptr;
         }


### PR DESCRIPTION
When the Metal renderer was first written - details of the window server were allowed to leak into the renderer. This held up ok at first - Metal is only available on Apple platforms. But as Apple has added more variety to their operating systems it's no longer safe to allow window server details into the renderer. For example - stereoscopic rendering on Vision Pro requires integration with the RealityKit based window server. This is a very different window server than we use on macOS.

Another example of where this has fallen apart is CAMetalDisplayLink - which is the modern version of vsync for Metal. It monitors our frame rate and adjusts our frame rate in response to load. For these reasons CAMetalDisplayLink sits between us and the window server - and we're not allowed to talk directly to the window server.

This PR starts to pull that relationship apart by adding a new `plMetalRenderDestination` type that sits in between the client and the renderer - and allows the renderer to start to abstract these relationships.

The `plDirectMetalRenderDestination` provided with this PR is a very simple implementation that directly pulls framebuffers from Metal on a traditional window server - which is how Plasma has pulled framebuffers from the window server so far. This is part of a series of pull requests - and I do have a CAMetalDisplayLink frame provider in my back pocket. But I'm splitting up this work because CAMetalDisplayLink controls both vsync timing and the frame buffer destination, so it will require a few separate abstractions.

Another twist is that visionOS only provides a Swift API to RealityKit and the RealityKit window server. There are certain things - detailed in this PR - that I'm doing to prepare for that. For example - Swift can't subclass C++ types, but we can template Swift on C++ types. I'm not doing any Swift/C++ integration in this PR but assume I also have that back pocket and I'm getting ready for that in this PR.