### PR TITLE
Simplifying Metal handling of FVF colors

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/FixedPipelineShaders.metal
@@ -253,7 +253,8 @@ vertex ColorInOut pipelineVertexShader(Vertex in [[stage_in]],
                                        constant float4x4 & blendMatrix1     [[ buffer(VertexShaderArgumentBlendMatrix1), function_constant(temp_hasOnlyWeight1) ]])
 {
     ColorInOut out;
-    const half4 inColor = half4(in.color.b, in.color.g, in.color.r, in.color.a) / half4(255.f);
+    // FVF ARGB color is in little endian order, so we need to swizzle it into RGBA
+    const half4 inColor = half4(in.color.bgra);
 
     const float3 Ndirection = normalize(float4(in.normal, 0.f) * uniforms.localToWorldMatrix).xyz;
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/Grass.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/Grass.metal
@@ -103,7 +103,7 @@ vertex vs_GrassInOut vs_GrassShader(Vertex in                                   
     float4 position = float4(in.position.xyz + offset, 1);
     out.position = position * uniforms.Local2NDC;
 
-    out.color = float4(in.color.r, in.color.g, in.color.b, in.color.a) / 255.f;
+    out.color = float4(in.color.r, in.color.g, in.color.b, in.color.a);
     out.texCoord = float4(in.texCoord1, 0.f);
 
     return out;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderVertex.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderVertex.h
@@ -78,5 +78,5 @@ typedef struct
     float3 texCoord6 [[attribute(VertexAttributeTexcoord+5), function_constant(hasTexture6)]];
     float3 texCoord7 [[attribute(VertexAttributeTexcoord+6), function_constant(hasTexture7)]];
     float3 texCoord8 [[attribute(VertexAttributeTexcoord+7), function_constant(hasTexture8)]];
-    uchar4 color [[attribute(VertexAttributeColor)]];
+    float4 color [[attribute(VertexAttributeColor)]];
 } Vertex;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveDec1Lay_7.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveDec1Lay_7.metal
@@ -199,8 +199,7 @@ vertex vs_WaveDev1Lay_7InOut vs_WaveDec1Lay_7(Vertex in                         
     depth = clamp(depth, 0, 1);
 
     // Calc our filter (see above).
-    float4 inColor = float4(in.color) / 255.0f;
-    float4 filter = inColor.wwww * uniforms.Lengths;
+    float4 filter = in.color.wwww * uniforms.Lengths;
     filter = max(filter, uniforms.NumericConsts.xxxx);
     filter = min(filter, uniforms.NumericConsts.zzzz);
 
@@ -262,7 +261,7 @@ vertex vs_WaveDev1Lay_7InOut vs_WaveDec1Lay_7(Vertex in                         
     // Output alpha is vertex red (vtx alpha is used for wave filtering)
     // Whole thing modulated by material color/opacity.
 
-    out.c0 = half4(in.color.yyyz)/255.0 * half4(uniforms.MatColor);
+    out.c0 = half4(in.color.yyyz) * half4(uniforms.MatColor);
 
     // Usual texture transform
     out.texCoord0.x = dot(float4(in.texCoord1, 1.0), uniforms.Tex0_Row0);

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveDecEnv.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveDecEnv.metal
@@ -204,8 +204,7 @@ vertex vs_WaveDecEnv7InOut vs_WaveDecEnv_7(Vertex in                        [[ s
     depth = clamp(depth, 0, 1);
 
     // Calc our filter (see above).
-    float4 inColor = float4(in.color) / 255.0f;
-    float4 filter = inColor.wwww * uniforms.Lengths;
+    float4 filter = in.color.wwww * uniforms.Lengths;
     filter = max(filter, uniforms.NumericConsts.xxxx);
     filter = min(filter, uniforms.NumericConsts.zzzz);
 
@@ -401,7 +400,7 @@ vertex vs_WaveDecEnv7InOut vs_WaveDecEnv_7(Vertex in                        [[ s
     out.texCoord3 = r2 * r10.xxxw;
 
     float4 matColor = uniforms.MatColor;
-    out.c1 = clamp(float4(in.color).yyyz/255.0 * matColor, 0.0, 1.0);
+    out.c1 = clamp(in.color.yyyz * matColor, 0.0, 1.0);
 
     return out;
 }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveRip.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveRip.metal
@@ -198,8 +198,7 @@ vertex waveRipInOut vs_WaveRip7(Vertex in                               [[stage_
     depth = clamp(depth, 0, 1);
 
     // Calc our filter (see above).
-    float4 inColor = float4(in.color) / 255.0f;
-    float4 filter = inColor.wwww * uniforms.Lengths;
+    float4 filter = in.color.wwww * uniforms.Lengths;
     filter = clamp(filter, 0.0f, 1.0f);
 
     //mov    r2, r1;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveSet7.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveSet7.metal
@@ -214,8 +214,7 @@ vertex vs_WaveFixedFin7InOut vs_WaveFixedFin7(Vertex in                     [[st
     depth = clamp(depth, 0, 1);
 
     // Calc our filter (see above).
-    float4 inColor = float4(in.color) / 255.0f;
-    float4 filter = inColor.wwww * uniforms.Lengths;
+    float4 filter = in.color.wwww * uniforms.Lengths;
     filter = max(filter, uniforms.NumericConsts.xxxx);
     filter = min(filter, uniforms.NumericConsts.zzzz);
 
@@ -424,7 +423,7 @@ vertex vs_WaveFixedFin7InOut vs_WaveFixedFin7(Vertex in                     [[st
     // vector from this point to camera and normalize stashed in r5
     // Dot that with the computed normal
     r1.x = dot(-r5, r11);
-    r1.x = r1.x * inColor.z;
+    r1.x = r1.x * in.color.z;
     r1.xyzw = uniforms.NumericConsts.z - r1.x;
     r1.w += uniforms.NumericConsts.z;
     r1.w *= uniforms.NumericConsts.y;
@@ -432,7 +431,7 @@ vertex vs_WaveFixedFin7InOut vs_WaveFixedFin7(Vertex in                     [[st
     // will saturate [0..1] anyway.
     r1 *= depth.yyyx; // HACKTESTCOLOR
     //R in the in color is the alpha value, but remember it's encoded ARGB
-    r1.w *= inColor.g;
+    r1.w *= in.color.g;
     r1.w *= uniforms.WaterTint.w;
     out.c1 = clamp(r1 * uniforms.EnvTint, 0, 1);
     out.c2 = uniforms.WaterTint; // SEENORM

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.cpp
@@ -156,7 +156,7 @@ void plMetalRenderSpanPipelineState::ConfigureVertexDescriptor(MTL::VertexDescri
         vertexDescriptor->attributes()->object(VertexAttributeTexcoord + i)->setOffset(baseUvOffset + (i * sizeof(hsPoint3)));
     }
 
-    vertexDescriptor->attributes()->object(VertexAttributeColor)->setFormat(MTL::VertexFormatUChar4);
+    vertexDescriptor->attributes()->object(VertexAttributeColor)->setFormat(MTL::VertexFormatUChar4Normalized);
     vertexDescriptor->attributes()->object(VertexAttributeColor)->setBufferIndex(0);
     vertexDescriptor->attributes()->object(VertexAttributeColor)->setOffset(colorOffset);
 


### PR DESCRIPTION
FVF stores the color channels as uchars - so I’ve been normalizing them manually in the shader. Metal can convert the values to normalize floats automatically - which is cleaner.

Also fixing the swizzle in the “fixed” pipeline shader and adding note that we are dealing with little endian data.