### PR TITLE
Don't try to run macOS bundle fixups if cross-compiling

### DIFF
--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -265,7 +265,7 @@ if(PLASMA_EXTERNAL_RELEASE)
     set_target_properties(plClient PROPERTIES OUTPUT_NAME "UruExplorer")
 endif(PLASMA_EXTERNAL_RELEASE)
 
-if(APPLE)
+if(APPLE AND NOT CMAKE_CROSSCOMPILING)
     # CMake will attempt to strip rpaths, thus preventing fixup_bundle from finding libraries.
     # Not sure why - turning that off.
     set_target_properties(plClient PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)


### PR DESCRIPTION
This step fails when cross-compiling because it tries to invoke a bunch of tools that are either targeting the host (and expecting a different executable format) or are missing entirely.

When I'm cross-compiling (at least for macOS) I don't expect to get a fully working app bundle, I mostly care to check that it compiles successfully for easier validation of changes in cross-platform code. So if we detect that we're cross-compiling, skip the bundle fixup step.

---

The alternative (which might be better because it wouldn't silently skip steps) is to expose a boolean option of whether to perform bundle fixes, defaulting to yes, but able to be overridden manually for special circumstances.