### PR TITLE
Allow certain safe console commands through net message screener again

### DIFF
--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgScreener.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgScreener.cpp
@@ -41,6 +41,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include "plNetClientMsgScreener.h"
+
+#include <string_theory/string>
+#include <unordered_set>
+
 #include "plCreatableIndex.h"
 #include "plNetLinkingMgr.h"
 
@@ -57,11 +61,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plAvatar/plCoopCoordinator.h"
 #include "plMessage/plAvCoopMsg.h"
 #include "plMessage/plAvatarMsg.h"
+#include "plMessage/plInputEventMsg.h"
 #include "plMessage/plLoadAvatarMsg.h"
 #include "plMessage/plLoadCloneMsg.h"
 #include "plStatusLog/plStatusLog.h"
 
 #include "pfMessage/pfKIMsg.h"
+
+using namespace ST::literals;
 
 ///////////////////////////////////////////////////////////////
 // CLIENT Version
@@ -133,6 +140,80 @@ bool plNetClientMsgScreener::AllowOutgoingMessage(const plMessage* msg) const
         WarningMsg("Rejected: (Outgoing) {} [Validation Failed]", msg->ClassName());
         return false;
     }
+    return true;
+}
+
+// The longest safe command name is 34 characters,
+// so this maximum leaves at least 93 characters for the arguments,
+// which is hopefully enough.
+static constexpr size_t kMaxSafeCommandLength = 128;
+
+/**
+ * Console command names that are always safe to execute.
+ * Currently includes all commands used by the TOC-MOUL shard and by Mir-o-Bot,
+ * mostly for changing visual settings like fog color and distance.
+ * We do not want to just allow all commands under Graphics.Renderer,
+ * because some of them write files to disk (such as Graphics.Renderer.GrabCubeMap).
+ */
+static const std::unordered_set<ST::string, ST::hash_i, ST::equal_i> kSafeConsoleCommandNames = {
+    "Avatar.Spawn.DontPanic"_st,
+    "Graphics.Renderer.Fog.SetDefColor"_st,
+    "Graphics.Renderer.Fog.SetDefExp"_st,
+    "Graphics.Renderer.Fog.SetDefExp2"_st,
+    "Graphics.Renderer.Fog.SetDefLinear"_st,
+    "Graphics.Renderer.SetClearColor"_st,
+    "Graphics.Renderer.SetYon"_st,
+    "Graphics.SetDebugFlag"_st,
+    "Nav.PageInNode"_st,
+    "Nav.PageOutNode"_st,
+};
+
+/**
+ * Checks whether the given command is definitely safe to execute
+ * and thus accepted when received over the network.
+ * Currently, a command is only considered safe
+ * if its command name is listed in \ref kSafeConsoleCommandNames
+ * and its arguments only consist of ASCII letters, digits, "-", ".", and "_".
+ *
+ * This check is very restrictive - it rejects many commands that are not actually dangerous
+ * and disallows alternative spellings of otherwise allowed commands
+ * (such as "_" instead of "." as the command group separator).
+ * This is intentional, to avoid overly complex parsing of untrusted inputs.
+ *
+ * @param command the complete command (name and arguments) to check
+ * @return whether the command is definitely safe
+ */
+bool plNetClientMsgScreener::IIsConsoleCommandSafe(const ST::string& command)
+{
+    // Overly long commands are considered unsafe.
+    if (command.size() > kMaxSafeCommandLength) {
+        return false;
+    }
+
+    // Split name and arguments.
+    auto parts = command.split(' ', 1);
+    if (parts.empty()) {
+        hsAssert(false, "ST::string::split returned an empty vector??");
+        return false;
+    }
+
+    // Is the command name safe?
+    const ST::string& name = parts[0];
+    if (kSafeConsoleCommandNames.find(name) == kSafeConsoleCommandNames.end()) {
+        return false;
+    }
+
+    // If there are arguments, are they all "simple" characters?
+    if (parts.size() > 1) {
+        const ST::string& args = parts[1];
+        for (char c : args) {
+            if (c < 0 || !(isalnum(c) || c == ' ' || c == '-' || c == '.' || c == '_')) {
+                return false;
+            }
+        }
+    }
+
+    // Everything seems to be in order.
     return true;
 }
 
@@ -234,6 +315,19 @@ bool plNetClientMsgScreener::IScreenIncoming(const plMessage* msg)
     case CLASS_INDEX_SCOPED(plConsoleMsg):
         // Python remote code execution vulnerability
         return false;
+    case CLASS_INDEX_SCOPED(plControlEventMsg):
+        // Other clients have no business sending us inputs,
+        // but plControlEventMsg is also used by PtConsoleNet
+        // to send console commands to other players.
+        // This is another remote code execution risk, like plConsoleMsg.
+        // Unfortunately, PtConsoleNet has some safe, legitimate uses (see kSafeConsoleCommandNames),
+        // so allow plControlEventMsgs containing such known-safe console commands.
+        {
+            const plControlEventMsg* controlEventMsg = plControlEventMsg::ConvertNoRef(msg);
+            return controlEventMsg->GetControlCode() == B_CONTROL_CONSOLE_COMMAND
+                && controlEventMsg->ControlActivated()
+                && IIsConsoleCommandSafe(controlEventMsg->GetCmdString());
+        }
     case CLASS_INDEX_SCOPED(pfKIMsg):
         {
             // Only accept Chat Messages!
@@ -248,8 +342,8 @@ bool plNetClientMsgScreener::IScreenIncoming(const plMessage* msg)
             return false;
 
         // Other clients have no business sending us inputs.
-        // Also mitigates another remote code execution risk:
-        // plControlEventMsg can run console commands.
+        // The only exception is plControlEventMsg,
+        // which is handled separately above.
         if (plFactory::DerivesFrom(CLASS_INDEX_SCOPED(plInputEventMsg), msg->ClassIndex())) {
             return false;
         }

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgScreener.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMsgScreener.h
@@ -61,11 +61,12 @@ protected:
     bool IIsSenderCCR(const plNetGameMember* gm=nullptr) const override;
     bool IAmClient() const override { return true; }
 
+    static bool IIsConsoleCommandSafe(const ST::string& command);
     static bool IScreenIncomingBrain(const plArmatureBrain* brain);
     static bool IScreenIncomingTask(const plAvTask* task);
-    static bool IScreenIncoming(const plMessage* msg);
-
 public:
+    static bool IScreenIncoming(const plMessage* msg); // public for tests only
+
     plNetClientMsgScreener();
     
     bool AllowOutgoingMessage(const plMessage* msg) const;

--- a/Sources/Plasma/PubUtilLib/plNetCommon/plNetMsgScreener.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetCommon/plNetMsgScreener.cpp
@@ -48,6 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnKeyedObject/plKey.h"
 
 #include "plMessage/plAnimCmdMsg.h"
+#include "plMessage/plInputEventMsg.h"
 #include "plMessage/plInputIfaceMgrMsg.h"
 #include "plMessage/plLinkToAgeMsg.h"
 
@@ -116,6 +117,7 @@ plNetMsgScreener::Answer plNetMsgScreener::IAllowMessageType(int16_t classIndex,
     case CLASS_INDEX_SCOPED(plAvTaskMsg):
     case CLASS_INDEX_SCOPED(plLinkEffectsTriggerMsg):
     case CLASS_INDEX_SCOPED(plInputIfaceMgrMsg):
+    case CLASS_INDEX_SCOPED(plControlEventMsg):
     case CLASS_INDEX_SCOPED(plParticleKillMsg):
     case CLASS_INDEX_SCOPED(plParticleTransferMsg):
     case CLASS_INDEX_SCOPED(plAvatarInputStateMsg):
@@ -202,6 +204,14 @@ bool plNetMsgScreener::IValidateMessage(const plMessage* msg, const plNetGameMem
             return ret;
         }
         break;
+
+    case CLASS_INDEX_SCOPED(plControlEventMsg):
+        {
+            const plControlEventMsg* controlEventMsg = plControlEventMsg::ConvertNoRef(msg);
+            // Console command messages only, as used by PtConsoleNet.
+            return controlEventMsg->GetControlCode() == B_CONTROL_CONSOLE_COMMAND
+                && controlEventMsg->ControlActivated();
+        }
     
     case CLASS_INDEX_SCOPED(plParticleKillMsg):
     case CLASS_INDEX_SCOPED(plParticleTransferMsg):

--- a/Sources/Tests/PubUtilTests/CMakeLists.txt
+++ b/Sources/Tests/PubUtilTests/CMakeLists.txt
@@ -3,4 +3,5 @@ include_directories("${PLASMA_SOURCE_ROOT}/NucleusLib")
 include_directories("${PLASMA_SOURCE_ROOT}/PubUtilLib")
 
 add_subdirectory(plLocalizationTest)
+add_subdirectory(plNetClientTest)
 add_subdirectory(plUnifiedTimeTest)

--- a/Sources/Tests/PubUtilTests/plNetClientTest/CMakeLists.txt
+++ b/Sources/Tests/PubUtilTests/plNetClientTest/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(plNetClientTest_SOURCES
+    test_plNetClientMsgScreener.cpp
+)
+
+plasma_test(test_plNetClient SOURCES ${plNetClientTest_SOURCES})
+target_include_directories(test_plNetClient PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
+target_link_libraries(
+    test_plNetClient
+    PRIVATE
+        CoreLib
+        pnNucleusInc
+        plNetClient
+        plPubUtilInc
+        pfAnimation
+        pfAudio
+        pfCamera
+        pfConditional
+        pfMessage
+        gtest_main
+)

--- a/Sources/Tests/PubUtilTests/plNetClientTest/test_plNetClientMsgScreener.cpp
+++ b/Sources/Tests/PubUtilTests/plNetClientTest/test_plNetClientMsgScreener.cpp
@@ -1,0 +1,105 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011 Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <gtest/gtest.h>
+#include <string_theory/string>
+
+#include "plNetClient/plNetClientMsgScreener.h"
+
+// Assorted creatables needed to make it link...
+#include "pnNucleusCreatables.h"
+#include "plAllCreatables.h"
+#include "pfAnimation/pfAnimationCreatable.h"
+#include "pfAudio/pfAudioCreatable.h"
+#include "pfCamera/pfCameraCreatable.h"
+#include "pfConditional/plConditionalObjectCreatable.h"
+#include "pfMessage/pfMessageCreatable.h"
+
+using namespace ST::literals;
+
+static hsRef<plControlEventMsg> IMakeControlEventMsgWithCommand(ST::string command)
+{
+    hsRef msg(new plControlEventMsg(), hsStealRef);
+    msg->SetControlCode(B_CONTROL_CONSOLE_COMMAND);
+    msg->SetControlActivated(true);
+    msg->SetCmdString(std::move(command));
+    return msg;
+}
+
+static bool IScreenIncomingCommand(ST::string command)
+{
+    return plNetClientMsgScreener::IScreenIncoming(IMakeControlEventMsgWithCommand(std::move(command)).Get());
+}
+
+TEST(plNetClientMsgScreener, IScreenIncomingControlEventMsg)
+{
+    EXPECT_TRUE(IScreenIncomingCommand("Avatar.Spawn.DontPanic"_st));
+    EXPECT_TRUE(IScreenIncomingCommand("Graphics.Renderer.Fog.SetDefColor 0.39999999960000004 0.26666666666399996 0.09999999990000001"_st));
+    EXPECT_TRUE(IScreenIncomingCommand("Graphics.Renderer.Fog.SetDefExp 100000 20"_st));
+    EXPECT_TRUE(IScreenIncomingCommand("Graphics.Renderer.Fog.SetDefExp2 100000 20"_st));
+    EXPECT_TRUE(IScreenIncomingCommand("Graphics.Renderer.Fog.SetDefLinear 1000 10000 1.0"_st));
+    EXPECT_TRUE(IScreenIncomingCommand("Graphics.Renderer.Fog.SetDefLinear -300 3000 1"_st));
+    EXPECT_TRUE(IScreenIncomingCommand("Graphics.Renderer.SetClearColor 0.6 0.6 0.6"_st));
+    EXPECT_TRUE(IScreenIncomingCommand("Graphics.Renderer.SetYon 100000"_st));
+    EXPECT_TRUE(IScreenIncomingCommand("Graphics.Renderer.Setyon 100000"_st)); // non-standard capitalization
+    EXPECT_TRUE(IScreenIncomingCommand("Graphics.SetDebugFlag noFog"_st));
+    EXPECT_TRUE(IScreenIncomingCommand("Nav.PageInNode grsnExterior"_st));
+    EXPECT_TRUE(IScreenIncomingCommand("Nav.PageOutNode grsnExterior"_st));
+
+    EXPECT_FALSE(IScreenIncomingCommand("Python.Cheat 123"_st)); // unsafe command name
+    EXPECT_FALSE(IScreenIncomingCommand("Graphics.Renderer.Fog 789"_st)); // incomplete command name
+    EXPECT_FALSE(IScreenIncomingCommand("Graphics.Renderer.GrabCubeMap 456"_st)); // unsafe command name inside mostly safe group
+    EXPECT_FALSE(IScreenIncomingCommand("Graphics.Renderer.SetClearColor $var"_st)); // safe command name with console variable in argument
+    EXPECT_FALSE(IScreenIncomingCommand("Graphics.Renderer.SetClearColor func()"_st)); // safe command name with other suspicious characters in argument
+    EXPECT_FALSE(IScreenIncomingCommand("Graphics.Renderer.SetYon 12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"_st)); // safe command name and argument, but longer than kMaxSafeCommandLength
+    EXPECT_FALSE(IScreenIncomingCommand("I realized the moment I fell into the fissure that the book would not be destroyed as I had planned."_st)); // not a command
+
+    // Safe command, but in a plControlEventMsg that's not a console command message:
+
+    hsRef nonActivatedMsg = IMakeControlEventMsgWithCommand("Graphics.Renderer.SetYon 100000"_st);
+    nonActivatedMsg->SetControlActivated(false);
+    EXPECT_FALSE(plNetClientMsgScreener::IScreenIncoming(nonActivatedMsg.Get()));
+
+    hsRef nonCommandMsg = IMakeControlEventMsgWithCommand("Graphics.Renderer.SetYon 100000"_st);
+    nonCommandMsg->SetControlCode(B_CONTROL_JUMP);
+    EXPECT_FALSE(plNetClientMsgScreener::IScreenIncoming(nonActivatedMsg.Get()));
+}


### PR DESCRIPTION
This un-breaks `PtConsoleNet` for visual effects in multiplayer, as used by TOC-MOUL and bots. Fixes #1831.

@Filtik (and perhaps @Mirphak): Could you test this to confirm that it fixes what you need?