### PR TITLE
Decouple age SDL accessing from pfPython where possible

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfConsole/CMakeLists.txt
@@ -58,7 +58,6 @@ target_link_libraries(
         plPhysical
         plPhysX
         plPipeline
-        pfPython
         plResMgr
         plScene
         plSDL

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -5162,7 +5162,7 @@ void IShowSDL(const plStateDataRecord* rec, _PrintStringT&& PrintString)
 
 PF_CONSOLE_CMD(Age, ShowPythonSDL, "", "Prints the Python AgeSDL values")
 {
-    plPythonSDLModifier* sdlMod = plPythonSDLModifier::FindAgeSDL();
+    plSDLModifier* sdlMod = plNetClientMgr::GetInstance()->GetAgeSDLModifier();
     if (sdlMod && sdlMod->GetStateCache() != nullptr) {
         IShowSDL(sdlMod->GetStateCache(), PrintString);
     } else {
@@ -5181,7 +5181,7 @@ PF_CONSOLE_CMD(Age, ShowVaultSDL, "", "Prints the age vault SDL values")
 
 PF_CONSOLE_CMD(Age, ResetPythonSDL, "", "Resets the Python Age SDL")
 {
-    plPythonSDLModifier* sdlMod = plPythonSDLModifier::FindAgeSDL();
+    plSDLModifier* sdlMod = plNetClientMgr::GetInstance()->GetAgeSDLModifier();
     if (sdlMod == nullptr) {
         PrintString("Python Age SDL not found");
         return;

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommandsNet.cpp
@@ -71,6 +71,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plMessage/plAvatarMsg.h"
 #include "plMessage/plConsoleMsg.h"
 #include "plMessage/plOneShotMsg.h"
+#include "plModifier/plSDLModifier.h"
 #include "plNetClient/plNetClientMgr.h"
 #include "plNetClient/plNetLinkingMgr.h"
 #include "plNetCommon/plNetObjectDebugger.h"
@@ -84,7 +85,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plVault/plVault.h"
 
 #include "pfConsoleCore/pfConsoleCmd.h"
-#include "pfPython/plPythonSDLModifier.h"
 
 // FIXME FIXME
 #include "../../Apps/plClient/plClient.h"
@@ -575,7 +575,7 @@ PF_CONSOLE_CMD( Net_DebugObject,        // groupName
                "bool dirtyOnly", // paramList
                "Dump the age SDL hook to the object debugger" ) // helpString
 {
-    const plPythonSDLModifier * mod = plPythonSDLModifier::FindAgeSDL();
+    const plSDLModifier* mod = plNetClientMgr::GetInstance()->GetAgeSDLModifier();
     mod->GetStateCache()->DumpToObjectDebugger("AgeSDLHook", params[0] );
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -58,15 +58,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyKey.h"
 #include "pyObjectRef.h"
 
-plStateDataRecord * GetAgeSDL()
-{
-    const plPythonSDLModifier * mod = plPythonSDLModifier::FindAgeSDL();
-    if ( mod )
-        return mod->GetStateCache();
-    return nullptr;
-}
-
-
 #define PyLoggedAssert(cond, text)                              \
     if (!cond) PythonInterface::WriteToLog(ST_LITERAL(text));   \
     hsAssert(cond, text);

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -575,28 +575,6 @@ plPythonSDLModifier* plPythonSDLModifier::FindAgeSDL()
     return nullptr;
 }
 
-plKey plPythonSDLModifier::FindAgeSDLTarget()
-{
-    // find the Age Global object
-    plLocation loc = plKeyFinder::Instance().FindLocation(cyMisc::GetAgeName(),plAgeDescription::GetCommonPage(plAgeDescription::kGlobal));
-    if (loc.IsValid()) {
-        plUoid oid(loc,plPythonFileMod::Index(), plPythonFileMod::kGlobalNameKonstant);
-        if (oid.IsValid()) {
-            plKey key = hsgResMgr::ResMgr()->FindKey(oid);
-
-            plPythonFileMod* pfmod = plPythonFileMod::ConvertNoRef(key ? key->GetObjectPtr() : nullptr);
-            if (pfmod) {
-                if (pfmod->GetTarget(0))
-                    return pfmod->GetTarget(0)->GetKey();
-            }
-        }
-    }
-
-    // couldn't find one (maybe because we didn't look)
-    return nullptr;
-}
-
-
 /////////////////////////////////////////////
 
 pySDLModifier::pySDLModifier(plPythonSDLModifier* sdlMod)

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -525,25 +525,7 @@ bool plPythonSDLModifier::HasSDL(const ST::string& pythonFile)
 
 plPythonSDLModifier* plPythonSDLModifier::FindAgeSDL()
 {
-    plNetClientMgr* netClientMgr = plNetClientMgr::GetInstance();
-    const plKey& ageSDLHookKey = netClientMgr->GetAgeSDLObjectKey();
-    if (ageSDLHookKey && ageSDLHookKey->ObjectIsLoaded()) {
-        if (const plSceneObject* ageSDLHook = plSceneObject::ConvertNoRef(ageSDLHookKey->GetObjectPtr())) {
-            plPythonSDLModifier* pythonSDLMod = plPythonSDLModifier::ConvertNoRef(const_cast<plModifier*>(ageSDLHook->GetModifierByType(plPythonSDLModifier::Index())));
-            if (pythonSDLMod != nullptr) {
-                return pythonSDLMod;
-            } else {
-                plNetClientApp::StaticErrorMsg("Cannot get plPythonSDLModifier, because the AgeSDLHook doesn't have one");
-            }
-        } else {
-            plNetClientApp::StaticErrorMsg("Cannot get plPythonSDLModifier, because the AgeSDLHook isn't a scene object???");
-        }
-    } else {
-        plNetClientApp::StaticErrorMsg("Cannot get plPythonSDLModifier, because the AgeSDLHook isn't loaded yet");
-    }
-
-    // couldn't find one
-    return nullptr;
+    return plPythonSDLModifier::ConvertNoRef(plNetClientMgr::GetInstance()->GetAgeSDLModifier());
 }
 
 /////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -48,7 +48,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnSceneObject/plSceneObject.h"
 
 #include "plAgeDescription/plAgeDescription.h"
-#include "plResMgr/plKeyFinder.h"
+#include "plNetClient/plNetClientMgr.h"
 #include "plSDL/plSDL.h"
 
 #include "cyMisc.h"
@@ -525,44 +525,24 @@ bool plPythonSDLModifier::HasSDL(const ST::string& pythonFile)
 
 plPythonSDLModifier* plPythonSDLModifier::FindAgeSDL()
 {
-    ST::string ageName = cyMisc::GetAgeName();
-
-    if (ageName.empty())
-        return nullptr; // don't have an age, probably because we're running in max?
-
-    // find the Age Global object
-    plLocation loc = plKeyFinder::Instance().FindLocation(ageName, plAgeDescription::GetCommonPage(plAgeDescription::kGlobal));
-    if (loc.IsValid()) {
-        plUoid oid(loc,plPythonFileMod::Index(), plPythonFileMod::kGlobalNameKonstant);
-        if (oid.IsValid()) {
-            plKey key = hsgResMgr::ResMgr()->FindKey(oid);
-
-            plPythonFileMod *pfmod = plPythonFileMod::ConvertNoRef(key ? key->ObjectIsLoaded() : nullptr);
-            if (pfmod) {
-                plPythonSDLModifier * sdlMod = pfmod->GetSDLMod();
-                if (sdlMod)
-                    return sdlMod;
-
-                plNetClientApp::StaticErrorMsg("pfmod {} has a nil python SDL modifier for age sdl {}",
-                    pfmod->GetKeyName().c_str("?"), ageName);
+    plNetClientMgr* netClientMgr = plNetClientMgr::GetInstance();
+    const plKey& ageSDLHookKey = netClientMgr->GetAgeSDLObjectKey();
+    if (ageSDLHookKey && ageSDLHookKey->ObjectIsLoaded()) {
+        if (const plSceneObject* ageSDLHook = plSceneObject::ConvertNoRef(ageSDLHookKey->GetObjectPtr())) {
+            plPythonSDLModifier* pythonSDLMod = plPythonSDLModifier::ConvertNoRef(const_cast<plModifier*>(ageSDLHook->GetModifierByType(plPythonSDLModifier::Index())));
+            if (pythonSDLMod != nullptr) {
+                return pythonSDLMod;
             } else {
-                if (!key)
-                    plNetClientApp::StaticErrorMsg("nil key {} for age sdl {}", ageName, oid.StringIze());
-                else if (!key->ObjectIsLoaded())
-                    plNetClientApp::StaticErrorMsg("key {} not loaded for age sdl {}",
-                                                   key->GetName().c_str("?"), ageName);
-                else if (!plPythonFileMod::ConvertNoRef(key->ObjectIsLoaded()))
-                    plNetClientApp::StaticErrorMsg("key {} is not a python file mod for age sdl {}",
-                                                   key->GetName().c_str("?"), ageName);
+                plNetClientApp::StaticErrorMsg("Cannot get plPythonSDLModifier, because the AgeSDLHook doesn't have one");
             }
         } else {
-            plNetClientApp::StaticErrorMsg("Invalid plUoid for age sdl {}", ageName);
+            plNetClientApp::StaticErrorMsg("Cannot get plPythonSDLModifier, because the AgeSDLHook isn't a scene object???");
         }
     } else {
-        plNetClientApp::StaticErrorMsg("Invalid plLocation for age sdl {}", ageName);
+        plNetClientApp::StaticErrorMsg("Cannot get plPythonSDLModifier, because the AgeSDLHook isn't loaded yet");
     }
 
-    // couldn't find one (maybe because we didn't look)
+    // couldn't find one
     return nullptr;
 }
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -542,9 +542,9 @@ PyObject* pySDLModifier::GetAgeSDL()
     if (ageName.empty())
         PYTHON_RETURN_NONE; // just return none if the age is blank (running in max?)
 
-    const plPythonSDLModifier* ageSDL = plPythonSDLModifier::FindAgeSDL();
+    plPythonSDLModifier* ageSDL = plPythonSDLModifier::FindAgeSDL();
     if (ageSDL)
-        return pySDLModifier::New((plPythonSDLModifier*)ageSDL);
+        return pySDLModifier::New(ageSDL);
 
     // didn't find one, throw an exception for the python programmer to chew on
     ST::string err = ST::format("Age Global SDL for {} does not exist!", ageName);

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.h
@@ -53,9 +53,6 @@ class plSimpleStateVariable;
 class plStateDataRecord;
 class pyKey;
 
-// hack for plNetClientVNodeMgr single-player mode SDLHook stuff.
-plStateDataRecord * GetAgeSDL();
-
 //
 // The fields of a SDL record in Python format.
 // If the Python code changes a value an update is sent automatically

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.h
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.h
@@ -104,7 +104,6 @@ public:
     static bool HasSDL(const ST::string& pythonFile);
     // find the Age global SDL guy... if there is one
     static plPythonSDLModifier* FindAgeSDL();
-    static plKey FindAgeSDLTarget();
 
     void SetDefault(const ST::string& key, PyObject* value);
     void SendToClients(const ST::string& key);

--- a/Sources/Plasma/PubUtilLib/plAnimation/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plAnimation/CMakeLists.txt
@@ -48,11 +48,9 @@ target_link_libraries(
         plInterp
         plMessage
         plModifier
+        plNetClient
         plSDL
-        pfPython # for plPythonSDLModifier::FindAgeSDL :(
 )
-
-target_include_directories(plAnimation PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
 
 source_group("Source Files" FILES ${plAnimation_SOURCES})
 source_group("Header Files" FILES ${plAnimation_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -66,9 +66,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plMessage/plAnimCmdMsg.h"
 #include "plMessage/plOneShotCallbacks.h"
 #include "plModifier/plSDLModifier.h"
+#include "plNetClient/plNetClientMgr.h"
 #include "plSDL/plSDL.h"
-
-#include "pfPython/plPythonSDLModifier.h" // for plPythonSDLModifier::FindAgeSDL :(
 
 /////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -264,7 +263,7 @@ void plAGAnimInstance::SearchForGlobals()
     const plAgeGlobalAnim *ageAnim = plAgeGlobalAnim::ConvertNoRef(fAnimation);
     if (ageAnim != nullptr && fSDLChannels.size() > 0)
     {
-        const plSDLModifier *sdlMod = plPythonSDLModifier::FindAgeSDL();
+        const plSDLModifier* sdlMod = plNetClientMgr::GetInstance()->GetAgeSDLModifier();
         if (!sdlMod)
             return;
 

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -73,6 +73,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plMessage/plVaultNotifyMsg.h"
 #include "plMessageBox/hsMessageBox.h"
 #include "plModifier/plResponderModifier.h"
+#include "plModifier/plSDLModifier.h"
 #include "plNetClientRecorder/plNetClientRecorder.h"
 #include "plNetCommon/plNetObjectDebugger.h"
 #include "plNetMessage/plNetMessage.h"
@@ -1305,6 +1306,27 @@ plUoid plNetClientMgr::GetAgeSDLObjectUoid(const ST::string& ageName) const
     }
 
     return plUoid(loc, plSceneObject::Index(), plSDL::kAgeSDLObjectName);
+}
+
+plSDLModifier* plNetClientMgr::GetAgeSDLModifier() const
+{
+    if (fAgeSDLObjectKey && fAgeSDLObjectKey->ObjectIsLoaded()) {
+        if (const plSceneObject* ageSDLHook = plSceneObject::ConvertNoRef(fAgeSDLObjectKey->GetObjectPtr())) {
+            plSDLModifier* sdlMod = plSDLModifier::ConvertNoRef(const_cast<plModifier*>(ageSDLHook->GetModifierByType(plSDLModifier::Index())));
+            if (sdlMod != nullptr) {
+                return sdlMod;
+            } else {
+                ErrorMsg("Cannot get age SDL, because the AgeSDLHook doesn't have a plSDLModifier");
+            }
+        } else {
+            ErrorMsg("Cannot get age SDL, because the AgeSDLHook isn't a scene object???");
+        }
+    } else {
+        ErrorMsg("Cannot get age SDL, because the AgeSDLHook isn't loaded yet");
+    }
+
+    // couldn't find one
+    return nullptr;
 }
 
 //

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
@@ -76,6 +76,7 @@ class plNetClientRecorder;
 class plVaultPlayerNode;
 class plVaultAgeNode;
 class plNetVoiceListMsg;
+class plSDLModifier;
 class plStateDataRecord;
 class plCCRPetitionMsg;
 class plNetMsgPagingRoom;
@@ -340,6 +341,7 @@ public:
     void AddPendingLoad(PendingLoad *pl);
     const plKey& GetAgeSDLObjectKey() const { return fAgeSDLObjectKey; }
     plUoid GetAgeSDLObjectUoid(const ST::string& ageName) const override;
+    plSDLModifier* GetAgeSDLModifier() const;
     plNetClientComm& GetNetClientComm()  { return fNetClientComm; }
     ST::string GetNextAgeFilename() const;
     void SetOverrideAgeTimeOfDayPercent(float f) { fOverrideAgeTimeOfDayPercent=f;  }

--- a/Sources/Plasma/PubUtilLib/plSurface/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plSurface/CMakeLists.txt
@@ -90,12 +90,9 @@ target_link_libraries(plSurface
         plModifier
         plNetClient
         plSDL
-        pfPython # for plPythonSDLModifier::FindAgeSDL :(
     INTERFACE
         pnFactory
 )
-
-target_include_directories(plSurface PRIVATE "${PLASMA_SOURCE_ROOT}/FeatureLib")
 
 source_group("Source Files" FILES ${plSurface_SOURCES})
 source_group("Header Files" FILES ${plSurface_HEADERS})

--- a/Sources/Plasma/PubUtilLib/plSurface/plLayerAnimation.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plLayerAnimation.cpp
@@ -62,9 +62,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plModifier/plLayerSDLModifier.h"
 #include "plModifier/plSDLModifier.h"
 #include "plNetClient/plLinkEffectsMgr.h"
+#include "plNetClient/plNetClientMgr.h"
 #include "plSDL/plSDL.h"
-
-#include "pfPython/plPythonSDLModifier.h" // for plPythonSDLModifier::FindAgeSDL :(
 
 plLayerAnimationBase::~plLayerAnimationBase()
 {
@@ -679,7 +678,7 @@ uint32_t plLayerSDLAnimation::Eval(double wSecs, uint32_t frame, uint32_t ignore
         {
             if (!fVarName.empty())
             {
-                const plSDLModifier *sdlMod = plPythonSDLModifier::FindAgeSDL();
+                const plSDLModifier* sdlMod = plNetClientMgr::GetInstance()->GetAgeSDLModifier();
                 if (sdlMod)
                 {
                     fVar = sdlMod->GetStateCache()->FindVar(fVarName);


### PR DESCRIPTION
The only way to access age SDL from C++ has been `plPythonSDLModifier::FindAgeSDL` in pfPython. This isn't great - as seen in #1822, some libraries in PubUtilLib need to access age SDL and thus depend on pfPython despite not having anything to do with Python.

This PR adds a new `plNetClientMgr::GetAgeSDLModifier` method, which has no direct dependency on pfPython. Externally, the only difference is that it returns a `plSDLModifier*` instead of a `plPythonSDLModifier*` specifically, but that's enough for most callers.

The internal implementation is a bit different. Previously, `FindAgeSDL` looked up the `VeryVerySpecialPythonFileMod` by name and returned its pointer to the `plPythonSDLModifier`. The new method instead takes the `AgeSDLHook` scene object (for which `plNetClientMgr` already knows the key) and looks through its modifiers to find a `plSDLModifier`. I *think* this works equally well as the previous implementation, and I haven't noticed any issues in my local testing.