### PR TITLE
Eliminating manual reflection calculation in Metal

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveDecEnv.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveDecEnv.metal
@@ -424,8 +424,8 @@ fragment float4 ps_WaveDecEnv(vs_WaveDecEnv7InOut in            [[ stage_in ]],
     float3 N = float3(u, v, w);
     float3 E = float3(in.texCoord1.w, in.texCoord2.w, in.texCoord3.w);
 
-    //float3 coord = reflect(E, N);
-    float3 coord = 2*(dot(N, E) / dot(N, N))*N - E;
+    // Invert the normal to an incident ray, then reflect
+    float3 coord = reflect(-E, N);
 
     // t3 now has our reflected environment map value
     // We've (presumably) attenuated the effect on a vertex basis

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveSet7.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveSet7.metal
@@ -471,8 +471,8 @@ fragment float4 ps_WaveFixed(vs_WaveFixedFin7InOut in           [[stage_in]],
     float3 N = float3(u, v, w);
     float3 E = float3(in.texCoord1.w, in.texCoord2.w, in.texCoord3.w);
 
-    //float3 coord = reflect(E, N);
-    float3 coord = 2*(dot(N, E) / dot(N, N))*N - E;
+    // Invert the normal to an incident ray, then reflect
+    float3 coord = reflect(-E, N);
 
     float4 out = float4(environmentMap.sample(colorSampler, coord));
     out = (out * in.c1) + in.c2;


### PR DESCRIPTION
The way D3D defined the reflection algorithm in the original texm3x3vspec instruction was slightly different. This was because the output of the matrix mul was a normal, and we need to invert it into an incident ray. Because that is now understood, using the built in reflect.