### PR TITLE
Cleaning up Metal Matrix Multiplies

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveDec1Lay_7.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveDec1Lay_7.metal
@@ -40,6 +40,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+// Used in Ahnonay on the edge of the sphere
+
 #include <metal_stdlib>
 using namespace metal;
 
@@ -58,13 +60,10 @@ typedef struct
     float4 CosConsts;
     float4 PiConsts;
     float4 NumericConsts;
-    float4 Tex0_Row0;
-    float4 Tex0_Row1;
+    float2x4 Tex0;
     float4 Tex1_Row0;
     float4 Tex1_Row1;
-    float4 L2WRow0;
-    float4 L2WRow1;
-    float4 L2WRow2;
+    float3x4 L2W;
     float4 Lengths;
     float4 WaterLevel;
     float4 DepthFalloff;
@@ -98,14 +97,7 @@ vertex vs_WaveDev1Lay_7InOut vs_WaveDec1Lay_7(Vertex in                         
 {
     vs_WaveDev1Lay_7InOut out;
     // Store our input position in world space in r6
-    float4 worldPosition = float4(0);
-    worldPosition.x = dot(float4(in.position, 1.0), uniforms.L2WRow0);
-    worldPosition.y = dot(float4(in.position, 1.0), uniforms.L2WRow1);
-    worldPosition.z = dot(float4(in.position, 1.0), uniforms.L2WRow2);
-    // Fill out our w (m4x3 doesn't touch w).
-    worldPosition.w = 1.0;
-
-    //
+    float4 worldPosition = float4(float4(in.position, 1.f) * uniforms.L2W, 1.f);
 
     // Input diffuse v5 color is:
     // v5.r = overall transparency
@@ -264,10 +256,7 @@ vertex vs_WaveDev1Lay_7InOut vs_WaveDec1Lay_7(Vertex in                         
     out.c0 = half4(in.color.yyyz) * half4(uniforms.MatColor);
 
     // Usual texture transform
-    out.texCoord0.x = dot(float4(in.texCoord1, 1.0), uniforms.Tex0_Row0);
-    out.texCoord0.y = dot(float4(in.texCoord1, 1.0), uniforms.Tex0_Row1);
-    out.texCoord0.z = 0.0f;
-    out.texCoord0.w = 0.0f;
+    out.texCoord0 = float4(float4(in.texCoord1, 1.0) * uniforms.Tex0, 0.f, 0.f);
 
     return out;
 }

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveDecEnv.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveDecEnv.metal
@@ -40,6 +40,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+// Used in Ahnonay around the edges of the island
+
 #include <metal_stdlib>
 using namespace metal;
 
@@ -58,13 +60,10 @@ typedef struct
     float4 CosConsts;
     float4 PiConsts;
     float4 NumericConsts;
-    float4 Tex0_Row0;
-    float4 Tex0_Row1;
+    float2x4 Tex0;
     float4 Tex1_Row0;
     float4 Tex1_Row1;
-    float4 L2WRow0;
-    float4 L2WRow1;
-    float4 L2WRow2;
+    float3x4 L2W;
     float4 Lengths;
     float4 WaterLevel;
     float4 DepthFalloff;
@@ -102,14 +101,7 @@ vertex vs_WaveDecEnv7InOut vs_WaveDecEnv_7(Vertex in                        [[ s
     vs_WaveDecEnv7InOut out;
 
     // Store our input position in world space in r6
-    float4 worldPosition = float4(0);
-    worldPosition.x = dot(float4(in.position, 1.0), uniforms.L2WRow0);
-    worldPosition.y = dot(float4(in.position, 1.0), uniforms.L2WRow1);
-    worldPosition.z = dot(float4(in.position, 1.0), uniforms.L2WRow2);
-    // Fill out our w (m4x3 doesn't touch w).
-    worldPosition.w = 1.0;
-
-    //
+    float4 worldPosition = float4(float4(in.position, 1.f) * uniforms.L2W, 1.f);
 
     // Input diffuse v5 color is:
     // v5.r = overall transparency
@@ -262,11 +254,7 @@ vertex vs_WaveDecEnv7InOut vs_WaveDecEnv_7(Vertex in                        [[ s
     // Now onto texture coordinate generation.
     //
     // First is the usual texture transform
-    out.texCoord0 = float4(
-                           dot(float4(in.texCoord1, 1.0), uniforms.Tex0_Row0),
-                           dot(float4(in.texCoord1, 1.0), uniforms.Tex0_Row1),
-                           uniforms.NumericConsts.zz
-                           );
+    out.texCoord0 = float4(float4(in.texCoord1, 1.0) * uniforms.Tex0, 0.f, 0.f);
 
     // Calculate our basis vectors as input into our tex3x3vspec
     // First we get our basis set off our surface. This is

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveRip.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveRip.metal
@@ -40,6 +40,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
+// Used in Kemo to render ripples when the player swims
+
 #include <metal_stdlib>
 using namespace metal;
 
@@ -69,10 +71,12 @@ typedef struct
     float4 Tex1_Row0;
     float4 Tex1_Row1;
     float4 Tex1_Row2;
-    float4 L2WRow0;
-    float4 L2WRow1;
-    float4 L2WRow2;
-    float4 L2WRow3;
+    float3x4 L2W;
+    // This is defined in plWaveSetShaderConsts - but L2W is only a 3x4 matrix?
+    // Never used by the HLSL shader.
+    // Ripple is the only one where kLocalToWorld and kL2WRow0 have different indexes,
+    // Likely a mistake when the uniform indexes were written.
+    float4 L2WUnused;
     float4 Lengths;
     float4 WaterLevel;
     float4 DepthFalloff;
@@ -96,14 +100,7 @@ vertex waveRipInOut vs_WaveRip7(Vertex in                               [[stage_
     waveRipInOut out;
 
     // Store our input position in world space in r6
-    float4 worldPosition = float4(0);
-    worldPosition.x = dot(float4(in.position, 1.0), uniforms.L2WRow0);
-    worldPosition.y = dot(float4(in.position, 1.0), uniforms.L2WRow1);
-    worldPosition.z = dot(float4(in.position, 1.0), uniforms.L2WRow2);
-    // Fill out our w (m4x3 doesn't touch w).
-    worldPosition.w = 1.0;
-
-    //
+    float4 worldPosition = float4(float4(in.position, 1.f) * uniforms.L2W, 1.f);
 
     // Input diffuse v5 color is:
     // v5.r = overall transparency

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveSet7.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveSet7.metal
@@ -65,9 +65,7 @@ typedef struct
     float4 WindRot;
     float4 EnvAdjust;
     float4 EnvTint;
-    float4 LocalToWorldRow1;
-    float4 LocalToWorldRow2;
-    float4 LocalToWorldRow3;
+    float3x4 LocalToWorld;
     float4 Lengths;
     float4 WaterLevel;
     float4 DepthFalloff;
@@ -101,20 +99,7 @@ vertex vs_WaveFixedFin7InOut vs_WaveFixedFin7(Vertex in                     [[st
     vs_WaveFixedFin7InOut out;
 
     // Store our input position in world space in r6
-    float3 column1 = float3(uniforms.LocalToWorldRow1[0], uniforms.LocalToWorldRow2[0], uniforms.LocalToWorldRow3[0]);
-    float3 column2 = float3(uniforms.LocalToWorldRow1[1], uniforms.LocalToWorldRow2[1], uniforms.LocalToWorldRow3[1]);
-    float3 column3 = float3(uniforms.LocalToWorldRow1[2], uniforms.LocalToWorldRow2[2], uniforms.LocalToWorldRow3[2]);
-    float3 column4 = float3(uniforms.LocalToWorldRow1[3], uniforms.LocalToWorldRow2[3], uniforms.LocalToWorldRow3[3]);
-
-    matrix_float4x3 localToWorld;
-    localToWorld[0] = column1;
-    localToWorld[1] = column2;
-    localToWorld[2] = column3;
-    localToWorld[3] = column4;
-
-    float4 worldPosition = float4(localToWorld * float4(in.position, 1.0), 1.0);
-
-    //
+    float4 worldPosition = float4(float4(in.position, 1.f) * uniforms.LocalToWorld, 1.f);
 
     // Input diffuse v5 color is:
     // v5.r = overall transparency


### PR DESCRIPTION
Some of the HLSL translated code is manually performing matrix muls with dot products. The Metal code also carried that in by declaring parts of the buffers as individual float4 rows instead of matrices. Moving code over to normal matrix muls for clarity.