### PR TITLE
Improve `hsRef` and simplify ref management in a few places

### DIFF
--- a/Sources/MaxPlugin/MaxComponent/plAnimEventComponent.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plAnimEventComponent.cpp
@@ -167,7 +167,7 @@ plEventCallbackMsg* CreateCallbackMsg(plAnimCmdMsg* animMsg, plKey modKey)
     eventMsg->fRepeats = -1;
 
     animMsg->AddCallback(eventMsg);
-    hsRefCnt_SafeUnRef(eventMsg);   // AddCallback adds it's own ref, so remove ours (the default of 1)
+    eventMsg->UnRef(); // AddCallback adds it's own ref, so remove ours (the default of 1)
 
     return eventMsg;
 }

--- a/Sources/MaxPlugin/MaxComponent/plClickDragComponent.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plClickDragComponent.cpp
@@ -491,8 +491,8 @@ bool plClickDragComponent::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
         pMsg->AddCallback(pCall1);
         pMsg->AddCallback(pCall2);
 
-        hsRefCnt_SafeUnRef( pCall1 );
-        hsRefCnt_SafeUnRef( pCall2 );
+        pCall1->UnRef();
+        pCall2->UnRef();
 
         pMsg->AddReceiver( pAnim->GetModKey(node) );
         plgDispatch::MsgSend(pMsg);

--- a/Sources/MaxPlugin/MaxComponent/plGUIComponents.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plGUIComponents.cpp
@@ -688,7 +688,7 @@ public:
         kRefFontShadowed
     };
 
-    static void     ConvertScheme( IParamBlock2 *pb, pfGUIColorScheme *destScheme, plErrorMsg *pErrMsg );
+    static void ConvertScheme(IParamBlock2* pb, hsWeakRef<pfGUIColorScheme> destScheme, plErrorMsg* pErrMsg);
 };
 
 //Max desc stuff necessary below.
@@ -977,9 +977,9 @@ bool plGUIColorSchemeComp::Convert(plMaxNode *node, plErrorMsg *pErrMsg)
     pfGUIControlMod *ctrl = plGUIControlBase::GrabControlFromObject( node );
     if (ctrl != nullptr)
     {
-        pfGUIColorScheme *cs = new pfGUIColorScheme;
+        hsRef cs(new pfGUIColorScheme(), hsStealRef);
         ConvertScheme( fCompPB, cs, pErrMsg );
-        ctrl->SetColorScheme( cs );
+        ctrl->SetColorScheme(std::move(cs));
     }
     else
     {
@@ -996,7 +996,7 @@ void    SMaxRGBAToPlasmaRGBA( Color maxRGB, hsColorRGBA &plasmaRGBA )
     plasmaRGBA.Set( maxRGB.r, maxRGB.g, maxRGB.b, 1.f );
 }
 
-void    plGUIColorSchemeComp::ConvertScheme( IParamBlock2 *pb, pfGUIColorScheme *destScheme, plErrorMsg *pErrMsg )
+void plGUIColorSchemeComp::ConvertScheme(IParamBlock2* pb, hsWeakRef<pfGUIColorScheme> destScheme, plErrorMsg* pErrMsg)
 {
     SMaxRGBAToPlasmaRGBA( pb->GetColor( kRefForeColor ), destScheme->fForeColor );
     SMaxRGBAToPlasmaRGBA( pb->GetColor( kRefBackColor ), destScheme->fBackColor );

--- a/Sources/MaxPlugin/MaxComponent/plResponderAnim.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plResponderAnim.cpp
@@ -533,7 +533,7 @@ void plResponderCmdAnim::CreateWait(plMaxNode* node, plErrorMsg* pErrMsg, IParam
     plMessageWithCallbacks *callbackMsg = plMessageWithCallbacks::ConvertNoRef(waitInfo.msg);
     callbackMsg->AddCallback(eventMsg);
     // AddCallback adds it's own ref, so remove ours (the default of 1)
-    hsRefCnt_SafeUnRef(eventMsg);
+    eventMsg->UnRef();
 }
 
 class plResponderAnimProc : public plAnimCompProc

--- a/Sources/MaxPlugin/MaxComponent/plResponderMtl.cpp
+++ b/Sources/MaxPlugin/MaxComponent/plResponderMtl.cpp
@@ -480,7 +480,7 @@ void plResponderCmdMtl::CreateWait(plMaxNode* node, plErrorMsg* pErrMsg, IParamB
 
     plMessageWithCallbacks *callbackMsg = plMessageWithCallbacks::ConvertNoRef(waitInfo.msg);
     callbackMsg->AddCallback(eventMsg);
-    hsRefCnt_SafeUnRef( eventMsg );
+    eventMsg->UnRef();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Sources/MaxPlugin/MaxConvert/hsControlConverter.cpp
+++ b/Sources/MaxPlugin/MaxConvert/hsControlConverter.cpp
@@ -2141,7 +2141,7 @@ void hsControlConverter::IExportAnimatedCameraFOV(plMaxNode* node, std::vector<h
         pMsg->SetAnimName(ENTIRE_ANIMATION_NAME);
         pMsg->fTime = (*kfArray)[i].fFrame / MAX_FRAMES_PER_SEC;
         pMsg->AddCallback(pCall);
-        hsRefCnt_SafeUnRef(pCall);
+        pCall->UnRef();
         plConvert::Instance().AddMessageToQueue(pFOVMsg);
         plConvert::Instance().AddMessageToQueue(pMsg);
     }

--- a/Sources/Plasma/Apps/plClient/plClient.cpp
+++ b/Sources/Plasma/Apps/plClient/plClient.cpp
@@ -846,7 +846,7 @@ bool plClient::MsgReceive(plMessage* msg)
                 cmd->SetCmd(plAnimCmdMsg::kRemoveCallbacks);
                 cmd->AddCallback(callback);
                 plgDispatch::MsgSend(cmd);
-                hsRefCnt_SafeUnRef(callback);
+                callback->UnRef();
             }
             else if( aud )
             {
@@ -855,7 +855,7 @@ bool plClient::MsgReceive(plMessage* msg)
                 cmd->SetCmd(plSoundMsg::kRemoveCallbacks);
                 cmd->AddCallback(callback);
                 plgDispatch::MsgSend(cmd);
-                hsRefCnt_SafeUnRef(callback);
+                callback->UnRef();
             }
             hsStatusMessage("Removed");
             gotten = 0;
@@ -1266,7 +1266,7 @@ void plClient::IRoomLoaded(plSceneNode* node, bool hold)
         }
     }
 
-    hsRefCnt_SafeUnRef(fCurrentNode);
+    fCurrentNode->UnRef();
     plKey pRmKey = fCurrentNode->GetKey();
     plAgeLoader::GetInstance()->FinishedPagingInRoom(&pRmKey, 1);
     // *** this used to call "ActivateNode" (in physics) which wasn't implemented.
@@ -1306,7 +1306,7 @@ void plClient::IRoomUnloaded(plSceneNode* node)
     #endif
 
     fCurrentNode = node; 
-    hsRefCnt_SafeUnRef(fCurrentNode);
+    fCurrentNode->UnRef();
     plKey pRmKey = fCurrentNode->GetKey();
     if (plAgeLoader::GetInstance())
         plAgeLoader::GetInstance()->FinishedPagingOutRoom(&pRmKey, 1);
@@ -1941,7 +1941,7 @@ void plClient::IProcessRenderRequests(std::vector<plRenderRequest*>& reqs)
     for (plRenderRequest* rr : reqs)
     {
         rr->Render(fPipeline, fPageMgr);
-        hsRefCnt_SafeUnRef(rr);
+        rr->UnRef();
     }
     reqs.clear();
 }
@@ -1967,7 +1967,7 @@ void plClient::IAddRenderRequest(plRenderRequest* req)
                 break;
         }
         fPreRenderRequests.insert(it, req);
-        hsRefCnt_SafeRef(req);
+        req->Ref();
     }
     else
     {
@@ -1978,7 +1978,7 @@ void plClient::IAddRenderRequest(plRenderRequest* req)
                 break;
         }
         fPostRenderRequests.insert(it, req);
-        hsRefCnt_SafeRef(req);
+        req->Ref();
     }
 }
 

--- a/Sources/Plasma/CoreLib/hsRefCnt.h
+++ b/Sources/Plasma/CoreLib/hsRefCnt.h
@@ -90,19 +90,42 @@ class hsRef
 public:
     hsRef() : fObj() { }
     hsRef(std::nullptr_t) : fObj() { }
-    hsRef(_Ref *obj, hsStealRef_Type) : fObj(obj) { }
-    hsRef(const hsRef<_Ref> &copy) : fObj(copy.fObj) { if (fObj) fObj->Ref(); }
-    hsRef(hsRef<_Ref> &&move) : fObj(move.fObj) { move.fObj = nullptr; }
+
+    hsRef(_Ref* obj, hsStealRef_Type) : fObj(obj) {}
+
+    // Needed to allow passing an S* into an hsRef<T> parameter (where S is a subclass of T).
+    hsRef(_Ref* copy) : fObj(copy) { if (fObj) fObj->Ref(); }
+    // This is redundant with the next overload, but allows template argument deduction for hsRef(otherRef).
+    hsRef(const hsRef<_Ref>& copy) : fObj(copy.Get()) { if (fObj) fObj->Ref(); }
+    // Needed to allow passing an hsRef<S> into an hsRef<T> parameter (where S is a subclass of T).
+    template<class _OtherRef>
+    hsRef(const hsRef<_OtherRef>& copy) : fObj(copy.Get()) { if (fObj) fObj->Ref(); }
+    // Most of the other constructor and operator= overloads are duplicated for the same reasons.
+
+    hsRef(hsRef<_Ref>&& move) : fObj(move.Release()) {}
+    template<class _OtherRef>
+    hsRef(hsRef<_OtherRef>&& move) : fObj(move.Release()) {}
 
     ~hsRef() { if (fObj) fObj->UnRef(); }
 
     hsRef<_Ref> &operator=(const hsRef<_Ref> &copy)
     {
-        if (copy.fObj)
-            copy.fObj->Ref();
+        if (copy)
+            copy.Get()->Ref();
         if (fObj)
             fObj->UnRef();
-        fObj = copy.fObj;
+        fObj = copy.Get();
+        return *this;
+    }
+
+    template<class _OtherRef>
+    hsRef<_Ref>& operator=(const hsRef<_OtherRef>& copy)
+    {
+        if (copy)
+            copy.Get()->Ref();
+        if (fObj)
+            fObj->UnRef();
+        fObj = copy.Get();
         return *this;
     }
 
@@ -110,8 +133,16 @@ public:
     {
         if (fObj)
             fObj->UnRef();
-        fObj = move.fObj;
-        move.fObj = nullptr;
+        fObj = move.Release();
+        return *this;
+    }
+
+    template<class _OtherRef>
+    hsRef<_Ref>& operator=(hsRef<_OtherRef>&& move)
+    {
+        if (fObj)
+            fObj->UnRef();
+        fObj = move.Release();
         return *this;
     }
 
@@ -123,8 +154,12 @@ public:
         return *this;
     }
 
-    inline hsRef(const hsWeakRef<_Ref> &weak);
-    inline hsRef<_Ref> &operator=(const hsWeakRef<_Ref> &weak);
+    inline hsRef(const hsWeakRef<_Ref>& weak);
+    template<class _OtherRef>
+    inline hsRef(const hsWeakRef<_OtherRef>& weak);
+    inline hsRef<_Ref>& operator=(const hsWeakRef<_Ref>& weak);
+    template<class _OtherRef>
+    inline hsRef<_Ref>& operator=(const hsWeakRef<_OtherRef>& weak);
 
     bool operator==(const hsRef<_Ref> &other) const { return fObj == other.fObj; }
     bool operator!=(const hsRef<_Ref> &other) const { return fObj != other.fObj; }
@@ -149,6 +184,13 @@ public:
         if (fObj)
             fObj->UnRef();
         fObj = obj;
+    }
+
+    _Ref* Release()
+    {
+        _Ref* obj = fObj;
+        fObj = nullptr;
+        return obj;
     }
 
 private:
@@ -214,10 +256,31 @@ hsRef<_Ref>::hsRef(const hsWeakRef<_Ref> &weak) : fObj(weak.Get())
         fObj->Ref();
 }
 
+template<class _Ref>
+template<class _OtherRef>
+hsRef<_Ref>::hsRef(const hsWeakRef<_OtherRef>& weak) : fObj(weak.Get())
+{
+    if (fObj)
+        fObj->Ref();
+}
+
 template <class _Ref>
 hsRef<_Ref> &hsRef<_Ref>::operator=(const hsWeakRef<_Ref> &weak)
 {
     _Ref* weakObj = weak.Get();
+    if (weakObj)
+        weakObj->Ref();
+    if (fObj)
+        fObj->UnRef();
+    fObj = weakObj;
+    return *this;
+}
+
+template<class _Ref>
+template<class _OtherRef>
+hsRef<_Ref>& hsRef<_Ref>::operator=(const hsWeakRef<_OtherRef>& weak)
+{
+    _OtherRef* weakObj = weak.Get();
     if (weakObj)
         weakObj->Ref();
     if (fObj)

--- a/Sources/Plasma/FeatureLib/pfCamera/plCameraModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfCamera/plCameraModifier.cpp
@@ -170,7 +170,7 @@ bool plCameraModifier1::MsgReceive(plMessage* msg)
     {
         if (pCamMsg->Cmd(plCameraMsg::kAddFOVKeyframe))
         {
-            hsRefCnt_SafeRef(msg);
+            msg->Ref();
             fFOVInstructions.emplace_back(pCamMsg);
             return true;
         }
@@ -196,7 +196,7 @@ bool plCameraModifier1::MsgReceive(plMessage* msg)
     plAnimCmdMsg* pAnimMsg = plAnimCmdMsg::ConvertNoRef(msg);
     if (pAnimMsg)
     {
-        hsRefCnt_SafeRef(msg);
+        msg->Ref();
         msg->ClearReceivers();
         msg->AddReceiver(msg->GetSender());
         fMessageQueue.emplace_back(msg);

--- a/Sources/Plasma/FeatureLib/pfConditional/plAnimationEventConditionalObject.cpp
+++ b/Sources/Plasma/FeatureLib/pfConditional/plAnimationEventConditionalObject.cpp
@@ -74,7 +74,7 @@ void plAnimationEventConditionalObject::SetEvent(const plEventCallbackMsg::Callb
     plEventCallbackMsg* cb = new plEventCallbackMsg(GetKey(), b, 0, time);
 
     pMsg->AddCallback( cb );
-    hsRefCnt_SafeUnRef(cb);
+    cb->UnRef();
     pMsg->SetCmd( plAnimCmdMsg::kAddCallbacks );
     pMsg->Send();
 }

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -209,7 +209,7 @@ pfConsole::~pfConsole()
         msg->SetIFace( fInputInterface );
         plgDispatch::MsgSend( msg );
 
-        hsRefCnt_SafeUnRef( fInputInterface );
+        fInputInterface->UnRef();
         fInputInterface = nullptr;
     }
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -196,7 +196,7 @@ pfConsole::pfConsole()
     : fNumDisplayLines(32), fDisplayBuffer(), fFXEnabled(true), fEffectCounter(), fLastTime(),
       fHelpTimer(), fMode(), fInited(), fHelpMode(), fCursorTicks(), fMsgTimeoutTimer(),
       fPythonMode(), fPythonFirstTime(true), fPythonMultiLines(), fHistory(), fWorkingCursor(),
-      fInputInterface(), fEngine()
+      fEngine()
 {
     fTheConsole = this;
 }
@@ -209,7 +209,6 @@ pfConsole::~pfConsole()
         msg->SetIFace( fInputInterface );
         plgDispatch::MsgSend( msg );
 
-        fInputInterface->UnRef();
         fInputInterface = nullptr;
     }
 
@@ -283,7 +282,7 @@ void    pfConsole::Init( pfConsoleEngine *engine )
     fLastHelpMsg.clear();
     fEngine = engine;
 
-    fInputInterface = new pfConsoleInputInterface( this );
+    fInputInterface.Steal(new pfConsoleInputInterface(this));
     plInputIfaceMgrMsg *msg = new plInputIfaceMgrMsg( plInputIfaceMgrMsg::kAddInterface );
     msg->SetIFace( fInputInterface );
     plgDispatch::MsgSend( msg );

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.h
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.h
@@ -110,7 +110,7 @@ class pfConsole : public hsKeyedObject
         char    fWorkingLine[ kWorkingLineSize ];
         uint32_t  fWorkingCursor;
 
-        pfConsoleInputInterface *fInputInterface;
+        hsRef<pfConsoleInputInterface> fInputInterface;
 
         pfConsoleEngine     *fEngine;
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -2466,6 +2466,7 @@ PF_CONSOLE_CMD( Registry, ToggleDebugStats, "", "Toggles the debug statistics sc
         plStatusLogMgr::GetInstance().SetCurrStatusLog( "ResManager Status" );
         PrintString( "ResManager debug stats enabled" );
     }
+    on = !on;
 }
 
 PF_CONSOLE_CMD( Registry, SetLoggingLevel, "int level", "Sets the logging level for the registry. 0 is no logging, 3 is max detail." )

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsoleCommands.cpp
@@ -2061,7 +2061,7 @@ PF_CONSOLE_CMD( App,
 
     plEventCallbackMsg* callback = new plEventCallbackMsg(plClient::GetInstance()->GetKey(), event, 0, secs, reps);
     cmd->AddCallback(callback);
-    hsRefCnt_SafeUnRef(callback);
+    callback->UnRef();
     plgDispatch::MsgSend(cmd);
 }
 
@@ -2108,7 +2108,7 @@ PF_CONSOLE_CMD( App,
 
     plEventCallbackMsg* callback = new plEventCallbackMsg(plClient::GetInstance()->GetKey(), event, 0, secs, reps);
     cmd->AddCallback(callback);
-    hsRefCnt_SafeUnRef(callback);
+    callback->UnRef();
     plgDispatch::MsgSend(cmd);
 }
 

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
@@ -1681,7 +1681,7 @@ void    plDXPipeline::IReleaseDeviceObjects()
     {
         if( fLayerRef[i] )
         {
-            hsRefCnt_SafeUnRef(fLayerRef[i]);
+            fLayerRef[i]->UnRef();
             fLayerRef[i] = nullptr;
         }
     }
@@ -1691,9 +1691,10 @@ void    plDXPipeline::IReleaseDeviceObjects()
     hackOffscreens.clear();
 #endif // MF_ENABLE_HACKOFF
 
-    if( fULutTextureRef )
+    if (fULutTextureRef) {
         delete [] fULutTextureRef->fData;
-    hsRefCnt_SafeUnRef(fULutTextureRef);
+        fULutTextureRef->UnRef();
+    }
     fULutTextureRef = nullptr;
 
     while( fVtxBuffRefList )
@@ -3153,7 +3154,7 @@ bool plDXPipeline::EndRender()
     {
         if( fLayerRef[i] )
         {
-            hsRefCnt_SafeUnRef(fLayerRef[i]);
+            fLayerRef[i]->UnRef();
             fLayerRef[i] = nullptr;
         }
     }
@@ -3584,7 +3585,7 @@ hsGDeviceRef    *plDXPipeline::MakeRenderTargetRef( plRenderTarget *owner )
                     face->SetDeviceRef( new plDXRenderTargetRef( surfFormat, 0, face, false ) );
                     ( (plDXRenderTargetRef *)face->GetDeviceRef())->Link( &fRenderTargetRefList );
                     // Unref now, since for now ONLY the RT owns the ref, not us (not until we use it, at least)
-                    hsRefCnt_SafeUnRef( face->GetDeviceRef() );
+                    face->GetDeviceRef()->UnRef();
                 }
             }
 
@@ -3595,7 +3596,7 @@ hsGDeviceRef    *plDXPipeline::MakeRenderTargetRef( plRenderTarget *owner )
         else
         {
             ReleaseObject(depthSurface);
-            hsRefCnt_SafeUnRef(ref);
+            ref->UnRef();
             ref = nullptr;
         }
     }
@@ -3619,7 +3620,7 @@ hsGDeviceRef    *plDXPipeline::MakeRenderTargetRef( plRenderTarget *owner )
         else
         {
             ReleaseObject(depthSurface);
-            hsRefCnt_SafeUnRef(ref);
+            ref->UnRef();
             ref = nullptr;
         }
     }
@@ -3654,7 +3655,7 @@ hsGDeviceRef    *plDXPipeline::MakeRenderTargetRef( plRenderTarget *owner )
         else
         {
             ReleaseObject(depthSurface);
-            hsRefCnt_SafeUnRef(ref);
+            ref->UnRef();
             ref = nullptr;
         }
 
@@ -3781,7 +3782,7 @@ hsGDeviceRef* plDXPipeline::SharedRenderTargetRef(plRenderTarget* share, plRende
                     face->SetDeviceRef( new plDXRenderTargetRef( surfFormat, 0, face, false ) );
                     ( (plDXRenderTargetRef *)face->GetDeviceRef())->Link( &fRenderTargetRefList );
                     // Unref now, since for now ONLY the RT owns the ref, not us (not until we use it, at least)
-                    hsRefCnt_SafeUnRef( face->GetDeviceRef() );
+                    face->GetDeviceRef()->UnRef();
                 }
             }
         
@@ -3792,7 +3793,7 @@ hsGDeviceRef* plDXPipeline::SharedRenderTargetRef(plRenderTarget* share, plRende
         else
         {
             ReleaseObject(depthSurface);
-            hsRefCnt_SafeUnRef(ref);
+            ref->UnRef();
             ref = nullptr;
         }
     }
@@ -3816,7 +3817,7 @@ hsGDeviceRef* plDXPipeline::SharedRenderTargetRef(plRenderTarget* share, plRende
         else
         {
             ReleaseObject(depthSurface);
-            hsRefCnt_SafeUnRef(ref);
+            ref->UnRef();
             ref = nullptr;
         }
     }
@@ -3843,7 +3844,7 @@ hsGDeviceRef* plDXPipeline::SharedRenderTargetRef(plRenderTarget* share, plRende
         else
         {
             ReleaseObject(depthSurface);
-            hsRefCnt_SafeUnRef(ref);
+            ref->UnRef();
             ref = nullptr;
         }
 
@@ -4081,7 +4082,7 @@ void plDXPipeline::PushRenderRequest(plRenderRequest* req)
     fView.fRenderState = req->GetRenderState();
 
     fView.fRenderRequest = req;
-    hsRefCnt_SafeRef(fView.fRenderRequest);
+    fView.fRenderRequest->Ref();
 
     SetDrawableTypeMask(req->GetDrawableMask());
     SetSubDrawableTypeMask(req->GetSubDrawableMask());
@@ -4687,7 +4688,7 @@ hsGDeviceRef    *plDXPipeline::IMakeLightRef( plLightInfo *owner )
     lRef->fOwner = owner;
     owner->SetDeviceRef( lRef );
     // Unref now, since for now ONLY the BG owns the ref, not us (not until we use it, at least)
-    hsRefCnt_SafeUnRef( lRef );
+    lRef->UnRef();
 
     lRef->Link( &fLights.fRefList );
 
@@ -7422,7 +7423,7 @@ hsGDeviceRef    *plDXPipeline::MakeTextureRef( plLayerInterface* layer, plMipmap
         original->SetDeviceRef( ref );
         // Note: this is because SetDeviceRef() will ref it, and at this point,
         // only the bitmap should own the ref, not us. We ref/unref it on Use()
-        hsRefCnt_SafeUnRef( ref );  
+        ref->UnRef();  
     }
     else
         ref->Set( formatType, mmlvs, b->GetWidth(), b->GetHeight(), 
@@ -7549,7 +7550,7 @@ hsGDeviceRef    *plDXPipeline::IMakeCubicTextureRef( plLayerInterface* layer, pl
         cubic->SetDeviceRef( ref );
         // Note: this is because SetDeviceRef() will ref it, and at this point,
         // only the bitmap should own the ref, not us. We ref/unref it on Use()
-        hsRefCnt_SafeUnRef( ref );
+        ref->UnRef();
     }
     else
     {
@@ -8095,7 +8096,7 @@ void plDXPipeline::ISetupVertexBufferRef(plGBufferGroup* owner, uint32_t idx, pl
     vRef->fIndex = idx;
 
     owner->SetVertexBufferRef(idx, vRef);
-    hsRefCnt_SafeUnRef(vRef);
+    vRef->UnRef();
 }
 
 // ICheckStaticVertexBuffer ///////////////////////////////////////////////////////////////////////
@@ -8501,7 +8502,7 @@ void plDXPipeline::ISetupIndexBufferRef(plGBufferGroup* owner, uint32_t idx, plD
     iRef->SetRebuiltSinceUsed(true);
 
     owner->SetIndexBufferRef(idx, iRef);
-    hsRefCnt_SafeUnRef(iRef);
+    iRef->UnRef();
 
     iRef->SetVolatile(owner->AreIdxVolatile());
 }
@@ -9128,7 +9129,7 @@ HRESULT plDXPipeline::ISetShaders(plShader* vShader, plShader* pShader)
         if( !vRef )
         {
             vRef = new plDXVertexShader(vShader);
-            hsRefCnt_SafeUnRef(vRef);
+            vRef->UnRef();
         }
         if( !vRef->IsLinked() )
             vRef->Link(&fVShaderRefList);
@@ -9156,7 +9157,7 @@ HRESULT plDXPipeline::ISetShaders(plShader* vShader, plShader* pShader)
         if( !pRef )
         {
             pRef = new plDXPixelShader(pShader);
-            hsRefCnt_SafeUnRef(pRef);
+            pRef->UnRef();
         }
         if( !pRef->IsLinked() )
             pRef->Link(&fPShaderRefList);

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
@@ -692,13 +692,13 @@ void    pfGUIControlMod::SetColorScheme( pfGUIColorScheme *newScheme )
 {
     if (fColorScheme != nullptr)
     {
-        hsRefCnt_SafeUnRef( fColorScheme );
+        fColorScheme->UnRef();
         fColorScheme = nullptr;
     }
 
     fColorScheme = newScheme;
     if (fColorScheme != nullptr)
-        hsRefCnt_SafeRef( fColorScheme );
+        fColorScheme->Ref();
 }
 
 //// SetDynTextMap ///////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.cpp
@@ -680,7 +680,7 @@ bool    pfGUIControlMod::ISetUpDynTextMap( plPipeline *pipe )
 
 //// Get/SetColorScheme //////////////////////////////////////////////////////
 
-pfGUIColorScheme    *pfGUIControlMod::GetColorScheme() const
+hsWeakRef<pfGUIColorScheme> pfGUIControlMod::GetColorScheme() const
 {
     if (fColorScheme == nullptr)
         return fDialog->GetColorScheme();
@@ -688,17 +688,9 @@ pfGUIColorScheme    *pfGUIControlMod::GetColorScheme() const
     return fColorScheme;
 }
 
-void    pfGUIControlMod::SetColorScheme( pfGUIColorScheme *newScheme )
+void pfGUIControlMod::SetColorScheme(hsRef<pfGUIColorScheme> newScheme)
 {
-    if (fColorScheme != nullptr)
-    {
-        fColorScheme->UnRef();
-        fColorScheme = nullptr;
-    }
-
-    fColorScheme = newScheme;
-    if (fColorScheme != nullptr)
-        fColorScheme->Ref();
+    fColorScheme = std::move(newScheme);
 }
 
 //// SetDynTextMap ///////////////////////////////////////////////////////////
@@ -799,7 +791,7 @@ void    pfGUIControlMod::Read( hsStream *s, hsResMgr *mgr )
     if( s->ReadBool() )
     {
         SetColorScheme(nullptr);
-        fColorScheme = new pfGUIColorScheme();
+        fColorScheme.Steal(new pfGUIColorScheme());
         fColorScheme->Read( s );
     }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIControlMod.h
@@ -137,7 +137,7 @@ class pfGUIControlMod : public plSingleModifier
         plDynamicTextMap    *fDynTextMap;   // Some controls use this; for others, it'll be nil
         plLayerInterface    *fDynTextLayer; // Juse so we can reset the transform. Sheesh!
 
-        pfGUIColorScheme    *fColorScheme;
+        hsRef<pfGUIColorScheme> fColorScheme;
         plSceneObject       *fProxy;
 
         std::vector<hsPoint3> fBoundsPoints;      // For more accurate bounds tests
@@ -170,7 +170,7 @@ class pfGUIControlMod : public plSingleModifier
             : fEnabled(true), fDialog(), fBoundsValid(), fCenterValid(),
               fFocused(), fInteresting(), fVisible(true), fHandler(),
               fTagID(), fDropTargetHdlr(), fDynTextMap(), fProxy(),
-              fColorScheme(), fSkin(), fNotifyOnInteresting(),
+              fSkin(), fNotifyOnInteresting(),
               fScreenMinZ(), fDynTextLayer() { }
         virtual ~pfGUIControlMod();
 
@@ -260,8 +260,8 @@ class pfGUIControlMod : public plSingleModifier
             kDerivedFlagsStart = 32
         };
 
-        virtual void        SetColorScheme( pfGUIColorScheme *newScheme );
-        pfGUIColorScheme    *GetColorScheme() const;
+        virtual void SetColorScheme(hsRef<pfGUIColorScheme> newScheme);
+        hsWeakRef<pfGUIColorScheme> GetColorScheme() const;
 
         virtual void    UpdateColorScheme() { IPostSetUpDynTextMap(); IUpdate(); }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
@@ -99,7 +99,7 @@ pfGUIDialogMod::~pfGUIDialogMod()
 
     SetHandler(nullptr);
 
-    hsRefCnt_SafeUnRef( fColorScheme );
+    fColorScheme->UnRef();
     fColorScheme = nullptr;
 }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.cpp
@@ -78,7 +78,7 @@ pfGUIDialogMod::pfGUIDialogMod()
       fControlOfInterest(), fFocusCtrl(), fMousedCtrl(),
       fTagID(), fHandler(), fVersion(), fProcReceiver(),
       fDragMode(), fDragReceptive(), fDragTarget(),
-      fDragSource(), fColorScheme(new pfGUIColorScheme())
+      fDragSource(), fColorScheme(new pfGUIColorScheme(), hsStealRef)
 { }
 
 pfGUIDialogMod::~pfGUIDialogMod()
@@ -98,9 +98,6 @@ pfGUIDialogMod::~pfGUIDialogMod()
     }
 
     SetHandler(nullptr);
-
-    fColorScheme->UnRef();
-    fColorScheme = nullptr;
 }
 
 //// ScreenToWorldPoint //////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIDialogMod.h
@@ -80,7 +80,7 @@ class pfGUIDialogMod : public plSingleModifier
         pfGUIControlMod             *fControlOfInterest;
         pfGUIControlMod             *fFocusCtrl;
         pfGUIControlMod             *fMousedCtrl;   // Which one is the mouse over?
-        pfGUIColorScheme            *fColorScheme;
+        hsRef<pfGUIColorScheme>     fColorScheme;
 
         pfGUIDialogProc             *fHandler;
         plKey                       fProcReceiver;      // Non-nil means we handle everything by creating notify messages and sending them to this key
@@ -152,7 +152,7 @@ class pfGUIDialogMod : public plSingleModifier
         size_t          GetNumControls() const { return fControls.size(); }
         pfGUIControlMod *GetControl(size_t idx) const { return fControls[idx]; }
 
-        pfGUIColorScheme    *GetColorScheme() const { return fColorScheme; }
+        hsWeakRef<pfGUIColorScheme> GetColorScheme() const { return fColorScheme; }
 
         void    LinkToList( pfGUIDialogMod **prevPtr )
         {

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -98,7 +98,7 @@ bool    pfGUIEditBoxMod::MsgReceive( plMessage *msg )
 
 void    pfGUIEditBoxMod::IPostSetUpDynTextMap()
 {
-    pfGUIColorScheme *scheme = GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> scheme = GetColorScheme();
     fDynTextMap->SetFont( scheme->fFontFace, scheme->fFontSize, scheme->fFontFlags, 
                             HasFlag( kXparentBgnd ) ? false : true );
 }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.cpp
@@ -174,7 +174,7 @@ bool    pfGUIListBoxMod::MsgReceive( plMessage *msg )
 
 void    pfGUIListBoxMod::IPostSetUpDynTextMap()
 {
-    pfGUIColorScheme *scheme = GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> scheme = GetColorScheme();
     fDynTextMap->SetFont( scheme->fFontFace, scheme->fFontSize, scheme->fFontFlags, 
                             !HasFlag( kXparentBgnd ));
 
@@ -1032,15 +1032,15 @@ void    pfGUIListBoxMod::ScrollToBegin()
     IUpdate();
 }
 
-void        pfGUIListBoxMod::SetColorScheme( pfGUIColorScheme *newScheme )
+void pfGUIListBoxMod::SetColorScheme(hsRef<pfGUIColorScheme> newScheme)
 {
-    pfGUIControlMod::SetColorScheme( newScheme );
-
     for (pfGUIListElement* element : fElements)
     {
         element->SetColorScheme(newScheme);
         element->SetSkin(fSkin);
     }
+
+    pfGUIControlMod::SetColorScheme(std::move(newScheme));
 }
 
 void pfGUIListBoxMod::SetScrollPos( int32_t pos )

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListBoxMod.h
@@ -173,7 +173,7 @@ class pfGUIListBoxMod : public pfGUIControlMod
 
         void    Refresh() override { IUpdate(); }
 
-        void        SetColorScheme(pfGUIColorScheme *newScheme) override;
+        void    SetColorScheme(hsRef<pfGUIColorScheme> newScheme) override;
 
         // Element manipulation
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListElement.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIListElement.h
@@ -67,7 +67,7 @@ class pfGUIListElement
         bool        fCollapsed;     // For tree view support
         uint8_t       fIndentLevel;   // Ditto
 
-        pfGUIColorScheme    *fColors;
+        hsWeakRef<pfGUIColorScheme> fColors; // owned by the pfGUIListBoxMod
         pfGUISkin           *fSkin;
 
     public:
@@ -81,7 +81,7 @@ class pfGUIListElement
 
         pfGUIListElement( uint8_t type )
             : fType(type), fSelected(), fCollapsed(), fIndentLevel(),
-              fColors(), fSkin() { }
+              fSkin() { }
         virtual ~pfGUIListElement() { }
         
         virtual void    Read( hsStream *s, hsResMgr *mgr );
@@ -101,7 +101,7 @@ class pfGUIListElement
 
         uint8_t   GetType() { return fType; }
 
-        void    SetColorScheme( pfGUIColorScheme *scheme ) { fColors = scheme; }
+        void    SetColorScheme(hsWeakRef<pfGUIColorScheme> scheme) { fColors = scheme; }
         void    SetSkin( pfGUISkin *skin ) { fSkin = skin; }
 
         bool            IsCollapsed() const { return fCollapsed; }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -303,7 +303,7 @@ void pfGUIMultiLineEditCtrl::SetScrollEnable( bool state )
 
 void    pfGUIMultiLineEditCtrl::IPostSetUpDynTextMap()
 {
-    pfGUIColorScheme *scheme = GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> scheme = GetColorScheme();
 
     // fill in any blanks
     if (!(fFontFlagsSet & kFontFaceSet))

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIPopUpMenu.cpp
@@ -418,7 +418,7 @@ bool    pfGUIPopUpMenu::IBuildMenu()
     if (fWaitingForSkin && fSkin == nullptr)
         return false;       // Still waiting to get our skin before building
 
-    pfGUIColorScheme *scheme = new pfGUIColorScheme();
+    hsRef scheme(new pfGUIColorScheme(), hsStealRef);
     scheme->fForeColor.Set( 0, 0, 0, 1 );
     scheme->fBackColor.Set( 1, 1, 1, 1 );
 
@@ -547,7 +547,7 @@ bool    pfGUIPopUpMenu::IBuildMenu()
         pfGUIMenuItem *button = pfGUICtrlGenerator::Instance().CreateRectButton(this, x, y + thisOffset, width, height + thisMargin, mat);
         if (button != nullptr)
         {
-            button->SetColorScheme( scheme );
+            button->SetColorScheme(std::move(scheme));
             button->SetName(fMenuItems[i].fName);
             button->SetHandler( new pfGUIMenuItemProc( this, i ) );
             // make the tag ID the position in the menu list

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUITextBoxMod.cpp
@@ -86,7 +86,7 @@ bool    pfGUITextBoxMod::MsgReceive( plMessage *msg )
 
 void    pfGUITextBoxMod::IPostSetUpDynTextMap()
 {
-    pfGUIColorScheme *scheme = GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> scheme = GetColorScheme();
 
     fDynTextMap->SetFont( scheme->fFontFace, scheme->fFontSize, scheme->fFontFlags, 
                             HasFlag( kXparentBgnd ) ? false : true );

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.cpp
@@ -129,7 +129,7 @@ pfGameGUIMgr    *pfGameGUIMgr::fInstance = nullptr;
 //// Constructor & Destructor ////////////////////////////////////////////////
 
 pfGameGUIMgr::pfGameGUIMgr()
-    : fActivated(), fInputCtlIndex(), fActiveDialogs(), fInputConfig(),
+    : fActivated(), fInputCtlIndex(), fActiveDialogs(),
       fDefaultCursor(plInputInterface::kCursorUp), fCursorOpacity(1.f), fAspectRatio(),
       fActiveDlgCount()
 {
@@ -149,8 +149,6 @@ pfGameGUIMgr::~pfGameGUIMgr()
 
     if( fActivated )
         IActivateGUI( false );
-
-    delete fInputConfig;
 }
 
 
@@ -479,7 +477,7 @@ void    pfGameGUIMgr::IActivateGUI( bool activate )
 
     if( activate )
     {
-        fInputConfig = new pfGameUIInputInterface( this );
+        fInputConfig.Steal(new pfGameUIInputInterface(this));
         plInputIfaceMgrMsg *msg = new plInputIfaceMgrMsg( plInputIfaceMgrMsg::kAddInterface );
         msg->SetIFace( fInputConfig );
         msg->Send();
@@ -490,7 +488,6 @@ void    pfGameGUIMgr::IActivateGUI( bool activate )
         msg->SetIFace( fInputConfig );
         msg->Send();
 
-        hsRefCnt_SafeUnRef( fInputConfig );
         fInputConfig = nullptr;
     }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGameGUIMgr.h
@@ -146,7 +146,7 @@ class pfGameGUIMgr : public hsKeyedObject
         bool    fActivated;
         uint32_t  fActiveDlgCount;
 
-        pfGameUIInputInterface      *fInputConfig;
+        hsRef<pfGameUIInputInterface> fInputConfig;
         uint32_t                      fInputCtlIndex;
 
         uint32_t                      fDefaultCursor;

--- a/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
+++ b/Sources/Plasma/FeatureLib/pfJournalBook/pfJournalBook.cpp
@@ -917,7 +917,7 @@ void pfBookData::ITriggerPageFlip(bool flipBackwards, bool immediate)
     }
     msg->SetCmd(plAnimCmdMsg::kAddCallbacks);
     msg->AddCallback(eventMsg);
-    hsRefCnt_SafeUnRef(eventMsg);
+    eventMsg->UnRef();
     if (!immediate)
     {
         // We want a second callback to tell us when, indeed, the page has started turning
@@ -929,7 +929,7 @@ void pfBookData::ITriggerPageFlip(bool flipBackwards, bool immediate)
         eventMsg->fUser = !flipBackwards ? (0x04 | 0x01) : 0x04;
         eventMsg->fEvent = plEventCallbackMsg::kBegin;  // Should cause it to be triggered once it seeks at the start of the command
         msg->AddCallback(eventMsg);
-        hsRefCnt_SafeUnRef(eventMsg);
+        eventMsg->UnRef();
     }
     fCurrentlyTurning = true;
 
@@ -1481,7 +1481,7 @@ void    pfJournalBook::ITriggerCloseWithNotify( bool closeNotOpen, bool immediat
     eventMsg->fEvent = immediate ? ( plEventCallbackMsg::kSingleFrameEval ) : plEventCallbackMsg::kStop;
     msg->SetCmd( plAnimCmdMsg::kAddCallbacks );
     msg->AddCallback( eventMsg );
-    hsRefCnt_SafeUnRef( eventMsg );
+    eventMsg->UnRef();
 
     msg->Send();
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalDevice.cpp
@@ -559,7 +559,7 @@ void plMetalDevice::SetupVertexBufferRef(plGBufferGroup* owner, uint32_t idx, pl
 
     owner->SetVertexBufferRef(idx, vRef);
 
-    hsRefCnt_SafeUnRef(vRef);
+    vRef->UnRef();
 }
 
 void plMetalDevice::CheckStaticVertexBuffer(plMetalDevice::VertexBufferRef* vRef, plGBufferGroup* owner, uint32_t idx)
@@ -688,7 +688,7 @@ void plMetalDevice::SetupIndexBufferRef(plGBufferGroup* owner, uint32_t idx, plM
     iRef->SetRebuiltSinceUsed(true);
 
     owner->SetIndexBufferRef(idx, iRef);
-    hsRefCnt_SafeUnRef(iRef);
+    iRef->UnRef();
 
     iRef->SetVolatile(owner->AreIdxVolatile());
 }
@@ -779,7 +779,7 @@ void plMetalDevice::SetupTextureRef(plBitmap* img, plMetalDevice::TextureRef* tR
     tRef->SetDirty(true);
 
     img->SetDeviceRef(tRef);
-    hsRefCnt_SafeUnRef(tRef);
+    tRef->UnRef();
 }
 
 void plMetalDevice::ReleaseFramebufferObjects()

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -354,7 +354,7 @@ void plMetalPipeline::PushRenderRequest(plRenderRequest* req)
     fView.fRenderState = req->GetRenderState();
 
     fView.fRenderRequest = req;
-    hsRefCnt_SafeRef(fView.fRenderRequest);
+    fView.fRenderRequest->Ref();
 
     SetDrawableTypeMask(req->GetDrawableMask());
     SetSubDrawableTypeMask(req->GetSubDrawableMask());
@@ -501,7 +501,7 @@ hsGDeviceRef* plMetalPipeline::MakeRenderTargetRef(plRenderTarget* owner)
                 face->SetDeviceRef(fRef);
                 ((plMetalRenderTargetRef*)face->GetDeviceRef())->Link(&fRenderTargetRefList);
                 // Unref now, since for now ONLY the RT owns the ref, not us (not until we use it, at least)
-                hsRefCnt_SafeUnRef(face->GetDeviceRef());
+                face->GetDeviceRef()->UnRef();
             }
 
             // in since the root texture has changed reload all the face textures
@@ -720,7 +720,7 @@ bool plMetalPipeline::EndRender()
 
     for (int i = 0; i < 8; i++) {
         if (fLayerRef[i]) {
-            hsRefCnt_SafeUnRef(fLayerRef[i]);
+            fLayerRef[i]->UnRef();
             fLayerRef[i] = nullptr;
         }
     }
@@ -1775,7 +1775,7 @@ hsGDeviceRef* plMetalPipeline::IMakeLightRef(plLightInfo* owner)
     lRef->fOwner = owner;
     owner->SetDeviceRef(lRef);
     // Unref now, since for now ONLY the BG owns the ref, not us (not until we use it, at least)
-    hsRefCnt_SafeUnRef(lRef);
+    lRef->UnRef();
 
     lRef->Link(&fLightRefList);
 
@@ -2014,7 +2014,7 @@ bool plMetalPipeline::ISetShaders(const plMetalVertexBufferRef* vRef, const hsGM
         plMetalVertexShader* vRef = (plMetalVertexShader*)vShader->GetDeviceRef();
         if (!vRef) {
             vRef = new plMetalVertexShader(vShader);
-            hsRefCnt_SafeUnRef(vRef);
+            vRef->UnRef();
         }
         if (!vRef->IsLinked())
             vRef->Link(&fVShaderRefList);
@@ -2030,7 +2030,7 @@ bool plMetalPipeline::ISetShaders(const plMetalVertexBufferRef* vRef, const hsGM
         plMetalFragmentShader* pRef = (plMetalFragmentShader*)pShader->GetDeviceRef();
         if (!pRef) {
             pRef = new plMetalFragmentShader(pShader);
-            hsRefCnt_SafeUnRef(pRef);
+            pRef->UnRef();
         }
         if (!pRef->IsLinked())
             pRef->Link(&fPShaderRefList);
@@ -3574,13 +3574,13 @@ hsGDeviceRef* plMetalPipeline::SharedRenderTargetRef(plRenderTarget* share, plRe
                     face->SetDeviceRef(targetRef);
                     ((plMetalRenderTargetRef*)face->GetDeviceRef())->Link(&fRenderTargetRefList);
                     // Unref now, since for now ONLY the RT owns the ref, not us (not until we use it, at least)
-                    hsRefCnt_SafeUnRef(face->GetDeviceRef());
+                    face->GetDeviceRef()->UnRef();
                 }
             }
 
             ref->fTexture = cubeTexture;
         } else {
-            hsRefCnt_SafeUnRef(ref);
+            ref->UnRef();
             ref = nullptr;
         }
     }
@@ -3602,7 +3602,7 @@ hsGDeviceRef* plMetalPipeline::SharedRenderTargetRef(plRenderTarget* share, plRe
         if (texture) {
             ref->fTexture = texture;
         } else {
-            hsRefCnt_SafeUnRef(ref);
+            ref->UnRef();
             ref = nullptr;
         }
 

--- a/Sources/Plasma/FeatureLib/pfPython/cyInputInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyInputInterface.cpp
@@ -51,9 +51,7 @@ fTelescopeInterface()
 }
 
 cyInputInterface::~cyInputInterface() 
-{
-    hsRefCnt_SafeUnRef(fTelescopeInterface);
-}
+{}
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -69,7 +67,7 @@ void cyInputInterface::PushTelescopeInterface()
 {
     if (!fTelescopeInterface)
     {
-        fTelescopeInterface = new plTelescopeInputInterface;
+        fTelescopeInterface.Steal(new plTelescopeInputInterface());
         plInputIfaceMgrMsg* pMsg = new plInputIfaceMgrMsg(plInputIfaceMgrMsg::kAddInterface);
         pMsg->SetIFace(fTelescopeInterface);
         pMsg->Send();
@@ -90,7 +88,6 @@ void cyInputInterface::PopTelescope()
         plInputIfaceMgrMsg* pMsg = new plInputIfaceMgrMsg(plInputIfaceMgrMsg::kRemoveInterface);
         pMsg->SetIFace(fTelescopeInterface);
         pMsg->Send();
-        fTelescopeInterface->UnRef();
         fTelescopeInterface = nullptr;
     }
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyInputInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyInputInterface.cpp
@@ -52,8 +52,7 @@ fTelescopeInterface()
 
 cyInputInterface::~cyInputInterface() 
 {
-    if (fTelescopeInterface)
-        hsRefCnt_SafeUnRef( fTelescopeInterface );
+    hsRefCnt_SafeUnRef(fTelescopeInterface);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -91,7 +90,7 @@ void cyInputInterface::PopTelescope()
         plInputIfaceMgrMsg* pMsg = new plInputIfaceMgrMsg(plInputIfaceMgrMsg::kRemoveInterface);
         pMsg->SetIFace(fTelescopeInterface);
         pMsg->Send();
-        hsRefCnt_SafeUnRef( fTelescopeInterface );
+        fTelescopeInterface->UnRef();
         fTelescopeInterface = nullptr;
     }
 }

--- a/Sources/Plasma/FeatureLib/pfPython/cyInputInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyInputInterface.h
@@ -49,6 +49,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // PURPOSE: Class wrapper to map InputInterface functions to plasma2 message
 //
 
+#include "hsRefCnt.h"
+
 #include "pyGlueDefinitions.h"
 
 class plInputInterface;
@@ -56,7 +58,7 @@ class plInputInterface;
 class cyInputInterface
 {
 protected:
-    plInputInterface* fTelescopeInterface;
+    hsRef<plInputInterface> fTelescopeInterface;
 
     cyInputInterface();
 public:

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControl.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControl.cpp
@@ -287,7 +287,7 @@ PyObject* pyGUIControl::GetForeColor() const
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             return pyColor::New(color->fForeColor.r,color->fForeColor.g,color->fForeColor.b,color->fForeColor.a);
         }
     }
@@ -301,7 +301,7 @@ PyObject* pyGUIControl::GetSelColor() const
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             return pyColor::New(color->fSelForeColor.r,color->fSelForeColor.g,color->fSelForeColor.b,color->fSelForeColor.a);
         }
     }
@@ -315,7 +315,7 @@ PyObject* pyGUIControl::GetBackColor() const
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             return pyColor::New(color->fBackColor.r,color->fBackColor.g,color->fBackColor.b,color->fBackColor.a);
         }
     }
@@ -329,7 +329,7 @@ PyObject* pyGUIControl::GetBackSelColor() const
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             return pyColor::New(color->fSelBackColor.r,color->fSelBackColor.g,color->fSelBackColor.b,color->fSelBackColor.a);
         }
     }
@@ -343,7 +343,7 @@ uint32_t pyGUIControl::GetFontSize() const
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             return color->fFontSize;
         }
     }
@@ -360,7 +360,7 @@ void pyGUIControl::SetForeColor( float r, float g, float b, float a )
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             if ( r >= 0.0 && r <= 1.0 )
                 color->fForeColor.r = r;
             if ( g >= 0.0 && g <= 1.0 )
@@ -380,7 +380,7 @@ void pyGUIControl::SetSelColor( float r, float g, float b, float a )
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             if ( r >= 0.0 && r <= 1.0 )
                 color->fSelForeColor.r = r;
             if ( g >= 0.0 && g <= 1.0 )
@@ -400,7 +400,7 @@ void pyGUIControl::SetBackColor( float r, float g, float b, float a )
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             if ( r >= 0.0 && r <= 1.0 )
                 color->fBackColor.r = r;
             if ( g >= 0.0 && g <= 1.0 )
@@ -420,7 +420,7 @@ void pyGUIControl::SetBackSelColor( float r, float g, float b, float a )
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             if ( r >= 0.0 && r <= 1.0 )
                 color->fSelBackColor.r = r;
             if ( g >= 0.0 && g <= 1.0 )
@@ -441,7 +441,7 @@ void pyGUIControl::SetFontSize(uint32_t fontsize)
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             color->fFontSize = (uint8_t)fontsize;
         }
     }
@@ -455,7 +455,7 @@ void pyGUIControl::SetFontFlags(uint8_t fontFlags)
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if (pdmod)
         {
-            pfGUIColorScheme* colorscheme = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> colorscheme = pdmod->GetColorScheme();
             colorscheme->fFontFlags = fontFlags;
             pdmod->UpdateColorScheme();
         }
@@ -470,7 +470,7 @@ uint8_t pyGUIControl::GetFontFlags() const
         pfGUIControlMod* pdmod = pfGUIControlMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if (pdmod)
         {
-            pfGUIColorScheme* colorscheme = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> colorscheme = pdmod->GetColorScheme();
             return colorscheme->fFontFlags;
         }
     }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.cpp
@@ -51,15 +51,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyKey.h"
 
 pyGUIControlTextBox::pyGUIControlTextBox(pyKey& gckey) : pyGUIControl(gckey)
-{
-    fOriginalColorScheme = nullptr;
-}
+{}
 
 pyGUIControlTextBox::pyGUIControlTextBox(plKey objkey) : pyGUIControl(std::move(objkey))
-{
-    fOriginalColorScheme = nullptr;
-}
-
+{}
 
 bool pyGUIControlTextBox::IsGUIControlTextBox(const plKey& key)
 {

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.cpp
@@ -99,7 +99,7 @@ void pyGUIControlTextBox::SetFontSize( uint8_t size )
         pfGUITextBoxMod* ptbmod = pfGUITextBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( ptbmod )
         {
-            pfGUIColorScheme* colorscheme = ptbmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> colorscheme = ptbmod->GetColorScheme();
             colorscheme->fFontSize = size;
             ptbmod->UpdateColorScheme();
         }
@@ -115,7 +115,7 @@ void pyGUIControlTextBox::SetForeColor( pyColor& color )
         pfGUITextBoxMod* ptbmod = pfGUITextBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( ptbmod )
         {
-            pfGUIColorScheme* colorscheme = ptbmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> colorscheme = ptbmod->GetColorScheme();
             colorscheme->fForeColor = color.getColor();
             ptbmod->UpdateColorScheme();
         }
@@ -131,7 +131,7 @@ void pyGUIControlTextBox::SetBackColor( pyColor& color )
         pfGUITextBoxMod* ptbmod = pfGUITextBoxMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( ptbmod )
         {
-            pfGUIColorScheme* colorscheme = ptbmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> colorscheme = ptbmod->GetColorScheme();
             colorscheme->fBackColor = color.getColor();
         }
     }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIControlTextBox.h
@@ -52,18 +52,14 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pyGlueDefinitions.h"
 #include "pyGUIControl.h"
 
-class pfGUIColorScheme;
 class plKey;
 class pyColor;
 class pyKey;
 
 class pyGUIControlTextBox : public pyGUIControl
 {
-private:
-    pfGUIColorScheme*       fOriginalColorScheme;
-
 protected:
-    pyGUIControlTextBox() : pyGUIControl(), fOriginalColorScheme() { } // for python glue only, do NOT call
+    pyGUIControlTextBox() : pyGUIControl() {} // for python glue only, do NOT call
     pyGUIControlTextBox(pyKey& gckey);
     pyGUIControlTextBox(plKey objkey);
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIDialog.cpp
@@ -399,7 +399,7 @@ PyObject* pyGUIDialog::GetForeColor()
         pfGUIDialogMod* pdmod = pfGUIDialogMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             return pyColor::New(color->fForeColor.r,color->fForeColor.g,color->fForeColor.b,color->fForeColor.a);
         }
     }
@@ -413,7 +413,7 @@ PyObject* pyGUIDialog::GetSelColor()
         pfGUIDialogMod* pdmod = pfGUIDialogMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             return pyColor::New(color->fSelForeColor.r,color->fSelForeColor.g,color->fSelForeColor.b,color->fSelForeColor.a);
         }
     }
@@ -427,7 +427,7 @@ PyObject* pyGUIDialog::GetBackColor()
         pfGUIDialogMod* pdmod = pfGUIDialogMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             return pyColor::New(color->fBackColor.r,color->fBackColor.g,color->fBackColor.b,color->fBackColor.a);
         }
     }
@@ -441,7 +441,7 @@ PyObject* pyGUIDialog::GetBackSelColor()
         pfGUIDialogMod* pdmod = pfGUIDialogMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             return pyColor::New(color->fSelBackColor.r,color->fSelBackColor.g,color->fSelBackColor.b,color->fSelBackColor.a);
         }
     }
@@ -455,7 +455,7 @@ uint32_t pyGUIDialog::GetFontSize()
         pfGUIDialogMod* pdmod = pfGUIDialogMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             return color->fFontSize;
         }
     }
@@ -472,7 +472,7 @@ void pyGUIDialog::SetForeColor( float r, float g, float b, float a )
         pfGUIDialogMod* pdmod = pfGUIDialogMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             if ( r >= 0.0 && r <= 1.0 )
                 color->fForeColor.r = r;
             if ( g >= 0.0 && g <= 1.0 )
@@ -492,7 +492,7 @@ void pyGUIDialog::SetSelColor( float r, float g, float b, float a )
         pfGUIDialogMod* pdmod = pfGUIDialogMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             if ( r >= 0.0 && r <= 1.0 )
                 color->fSelForeColor.r = r;
             if ( g >= 0.0 && g <= 1.0 )
@@ -512,7 +512,7 @@ void pyGUIDialog::SetBackColor( float r, float g, float b, float a )
         pfGUIDialogMod* pdmod = pfGUIDialogMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             if ( r >= 0.0 && r <= 1.0 )
                 color->fBackColor.r = r;
             if ( g >= 0.0 && g <= 1.0 )
@@ -532,7 +532,7 @@ void pyGUIDialog::SetBackSelColor( float r, float g, float b, float a )
         pfGUIDialogMod* pdmod = pfGUIDialogMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             if ( r >= 0.0 && r <= 1.0 )
                 color->fSelBackColor.r = r;
             if ( g >= 0.0 && g <= 1.0 )
@@ -553,7 +553,7 @@ void pyGUIDialog::SetFontSize(uint32_t fontsize)
         pfGUIDialogMod* pdmod = pfGUIDialogMod::ConvertNoRef(fGCkey->ObjectIsLoaded());
         if ( pdmod )
         {
-            pfGUIColorScheme* color = pdmod->GetColorScheme();
+            hsWeakRef<pfGUIColorScheme> color = pdmod->GetColorScheme();
             color->fFontSize = (uint8_t)fontsize;
         }
     }

--- a/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyGUIPopUpMenu.cpp
@@ -258,7 +258,7 @@ PyObject* pyGUIPopUpMenu::GetForeColor()
 {
     kGetMenuPtr(nullptr);
 
-    pfGUIColorScheme* color = menu->GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> color = menu->GetColorScheme();
     return pyColor::New(color->fForeColor.r,color->fForeColor.g,color->fForeColor.b,color->fForeColor.a);
 }
 
@@ -266,7 +266,7 @@ PyObject* pyGUIPopUpMenu::GetSelColor()
 {
     kGetMenuPtr(nullptr);
 
-    pfGUIColorScheme* color = menu->GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> color = menu->GetColorScheme();
     return pyColor::New(color->fSelForeColor.r,color->fSelForeColor.g,color->fSelForeColor.b,color->fSelForeColor.a);
 }
 
@@ -274,7 +274,7 @@ PyObject* pyGUIPopUpMenu::GetBackColor()
 {
     kGetMenuPtr(nullptr);
 
-    pfGUIColorScheme* color = menu->GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> color = menu->GetColorScheme();
     return pyColor::New(color->fBackColor.r,color->fBackColor.g,color->fBackColor.b,color->fBackColor.a);
 }
 
@@ -282,7 +282,7 @@ PyObject* pyGUIPopUpMenu::GetBackSelColor()
 {
     kGetMenuPtr(nullptr);
 
-    pfGUIColorScheme* color = menu->GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> color = menu->GetColorScheme();
     return pyColor::New(color->fSelBackColor.r,color->fSelBackColor.g,color->fSelBackColor.b,color->fSelBackColor.a);
 }
 
@@ -291,7 +291,7 @@ void pyGUIPopUpMenu::SetForeColor( float r, float g, float b, float a )
 {
     kGetMenuPtr( ; );
 
-    pfGUIColorScheme* color = menu->GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> color = menu->GetColorScheme();
     if ( r >= 0.0 && r <= 1.0 )
         color->fForeColor.r = r;
     if ( g >= 0.0 && g <= 1.0 )
@@ -306,7 +306,7 @@ void pyGUIPopUpMenu::SetSelColor( float r, float g, float b, float a )
 {
     kGetMenuPtr( ; );
 
-    pfGUIColorScheme* color = menu->GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> color = menu->GetColorScheme();
     if ( r >= 0.0 && r <= 1.0 )
         color->fSelForeColor.r = r;
     if ( g >= 0.0 && g <= 1.0 )
@@ -321,7 +321,7 @@ void pyGUIPopUpMenu::SetBackColor( float r, float g, float b, float a )
 {
     kGetMenuPtr( ; );
 
-    pfGUIColorScheme* color = menu->GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> color = menu->GetColorScheme();
     if ( r >= 0.0 && r <= 1.0 )
         color->fBackColor.r = r;
     if ( g >= 0.0 && g <= 1.0 )
@@ -336,7 +336,7 @@ void pyGUIPopUpMenu::SetBackSelColor( float r, float g, float b, float a )
 {
     kGetMenuPtr( ; );
 
-    pfGUIColorScheme* color = menu->GetColorScheme();
+    hsWeakRef<pfGUIColorScheme> color = menu->GetColorScheme();
     if ( r >= 0.0 && r <= 1.0 )
         color->fSelBackColor.r = r;
     if ( g >= 0.0 && g <= 1.0 )

--- a/Sources/Plasma/FeatureLib/pfPython/pyMoviePlayer.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyMoviePlayer.cpp
@@ -67,7 +67,7 @@ pyMoviePlayer::pyMoviePlayer(const ST::string& movieName, pyKey& selfKey)
         movCallback->AddReceiver(fSelfKey);
         mov->AddCallback(movCallback);
         mov->Send();
-        hsRefCnt_SafeUnRef(movCallback);
+        movCallback->UnRef();
     }
 }
 
@@ -90,7 +90,7 @@ void pyMoviePlayer::MakeMovie(const ST::string& movieName, pyKey& selfKey)
         movCallback->AddReceiver(fSelfKey);
         mov->AddCallback(movCallback);
         mov->Send();
-        hsRefCnt_SafeUnRef(movCallback);
+        movCallback->UnRef();
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfSurface/plGrabCubeMap.cpp
+++ b/Sources/Plasma/FeatureLib/pfSurface/plGrabCubeMap.cpp
@@ -151,6 +151,6 @@ void plGrabCubeMap::ISetupRenderRequests(plPipeline* pipe, const hsPoint3& cente
 
         plRenderRequestMsg* reqMsg = new plRenderRequestMsg(nullptr, req);
         reqMsg->Send();
-        hsRefCnt_SafeUnRef(req);
+        req->UnRef();
     }
 }

--- a/Sources/Plasma/NucleusLib/inc/pnSingletons.cpp
+++ b/Sources/Plasma/NucleusLib/inc/pnSingletons.cpp
@@ -54,7 +54,7 @@ plDispatchBase* plgDispatch::Dispatch()
 bool hsgResMgr::Init(hsResMgr* m)
 {
     hsRefCnt_SafeAssign(fResMgr, m); 
-    hsRefCnt_SafeUnRef(m);
+    m->UnRef();
     if (!m->IInit())
         return false;
     return true; 
@@ -67,12 +67,12 @@ void hsgResMgr::Shutdown()
         if (fResMgr->RefCnt() <= 1)
         {
             fResMgr->IShutdown();
-            hsRefCnt_SafeUnRef(fResMgr); 
+            fResMgr->UnRef(); 
             fResMgr = nullptr;
         }
         else
         {
-            hsRefCnt_SafeUnRef(fResMgr);
+            fResMgr->UnRef();
         }
     }
 }

--- a/Sources/Plasma/NucleusLib/pnDispatch/plDispatch.cpp
+++ b/Sources/Plasma/NucleusLib/pnDispatch/plDispatch.cpp
@@ -449,7 +449,7 @@ bool plDispatch::IMsgNetPropagate(plMessage* msg)
     // Decide if msg should get sent locally
     if (!msg->HasBCastFlag(plMessage::kLocalPropagate))
     {   
-        hsRefCnt_SafeUnRef(msg);
+        msg->UnRef();
         return true;
     }
 
@@ -472,7 +472,7 @@ bool plDispatch::MsgSend(plMessage* msg, bool async)
         ICheckDeferred(timeMsg->DSeconds());
 
     plMsgWrap* msgWrap = new plMsgWrap(msg);
-    hsRefCnt_SafeUnRef(msg);
+    msg->UnRef();
 
     // broadcast
     if( msg->HasBCastFlag(plMessage::kBCastByExactType) | msg->HasBCastFlag(plMessage::kBCastByType) )

--- a/Sources/Plasma/NucleusLib/pnFactory/plFactory.cpp
+++ b/Sources/Plasma/NucleusLib/pnFactory/plFactory.cpp
@@ -139,7 +139,7 @@ void plFactory::UnRegister(uint16_t hClass, plCreator* worker)
     if( theFactory )
     {
         theFactory->IUnRegister(hClass);
-        hsRefCnt_SafeUnRef(theFactory);
+        theFactory->UnRef();
         if( theFactory->RefCnt() < 2 )
             IShutdown();
     }
@@ -155,7 +155,7 @@ uint16_t plFactory::Register(uint16_t hClass, plCreator* worker)
     if( !theFactory && !ICreateTheFactory() )
         return 0;
 
-    hsRefCnt_SafeRef(theFactory);
+    theFactory->Ref();
     return theFactory->IRegister(hClass, worker);
 }
 
@@ -239,16 +239,19 @@ void plFactory::SetTheFactory(plFactory* fac)
     //      Shouldn't happen, but if it does, just ignore it.
     if( !theFactory && fac )
     {
-        hsRefCnt_SafeAssign(theFactory, fac);
+        fac->Ref();
+        theFactory = fac;
     }
     else if( theFactory && fac )
     {
         theFactory->IForceShutdown();
-        hsRefCnt_SafeAssign(theFactory, fac);
+        fac->Ref();
+        theFactory->UnRef();
+        theFactory = fac;
     }
     else if( theFactory && !fac )
     {
-        hsRefCnt_SafeUnRef(theFactory);
+        theFactory->UnRef();
         if( theFactory->RefCnt() < 2 )
             delete theFactory;
         theFactory = nullptr;

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/hsKeyedObject.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/hsKeyedObject.cpp
@@ -84,7 +84,7 @@ hsKeyedObject::~hsKeyedObject()
         // decrement our RefCnt. Unfortunately, we are here because of a call
         // to our destructor, in which case we don't want to go back into our
         // destructor again. So we'll just up the RefCnt, plKey::UnRegister will dec it back to 1.
-        hsRefCnt_SafeRef(fpKey->ObjectIsLoaded());
+        fpKey->ObjectIsLoaded()->Ref();
     }
     UnRegister(); 
 }

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
@@ -223,7 +223,7 @@ void plKeyImp::UnRegister()     // called from plRegistry
         fObjectPtr = nullptr;
         fNumActiveRefs = 0;
 
-        hsRefCnt_SafeUnRef(ko);
+        ko->UnRef();
     }
     IClearRefs();
     ClearNotifyCreated();
@@ -440,12 +440,12 @@ void plKeyImp::SetupNotify(plRefMsg* msg, plRefFlags::Type flags)
     // the KeyedObject is already Loaded, so we better go ahead and send the notify message just added.
     if (ko)
     {
-        hsRefCnt_SafeRef(ko);
+        ko->Ref();
         msg->SetRef(ko);
         msg->SetTimeStamp(hsTimer::GetSysSeconds());
 
         // Add ref, since Dispatch will unref this msg but we want to keep using it.
-        hsRefCnt_SafeRef(msg);
+        msg->Ref();
 
         SetNotified(GetNumNotifyCreated()-1);
         SatisfyPending(msg);
@@ -456,9 +456,9 @@ void plKeyImp::SetupNotify(plRefMsg* msg, plRefFlags::Type flags)
         plgDispatch::Dispatch()->MsgSend(msg);
 #endif
 
-        hsRefCnt_SafeUnRef(ko);
+        ko->UnRef();
     }
-    hsRefCnt_SafeUnRef(msg);
+    msg->UnRef();
 }
 
 // We could just call NotifyCreated() on all our fRefs, and then fix
@@ -489,7 +489,7 @@ void plKeyImp::INotifySelf(hsKeyedObject* ko)
                             ref->SetNotified(j);
                             ref->SatisfyPending(refMsg);
 
-                            hsRefCnt_SafeRef(refMsg);
+                            refMsg->Ref();
                             plgDispatch::MsgSend(refMsg);
                             break;
                         }
@@ -516,7 +516,7 @@ void plKeyImp::NotifyCreated()
             msg->SetRef(ko);
             msg->SetTimeStamp(hsTimer::GetSysSeconds());
             msg->SetContext(plRefMsg::kOnCreate);
-            hsRefCnt_SafeRef(msg);
+            msg->Ref();
 
             SetNotified(i);
             SatisfyPending(msg);
@@ -538,7 +538,7 @@ void plKeyImp::INotifyDestroyed()
         msg->SetRef(ko);
         msg->SetTimeStamp(hsTimer::GetSysSeconds());
         msg->SetContext(plRefMsg::kOnDestroy);
-        hsRefCnt_SafeRef(msg);
+        msg->Ref();
         msg->Send();
     }
     fNotified.Clear();
@@ -628,7 +628,7 @@ void plKeyImp::IRelease(plKeyImp* iTargetKey)
             refMsg->SetRef(iTargetKey->ObjectIsLoaded());
             refMsg->SetTimeStamp(hsTimer::GetSysSeconds());
             refMsg->SetContext(plRefMsg::kOnRemove);
-            hsRefCnt_SafeRef(refMsg);
+            refMsg->Ref();
             plgDispatch::MsgSend(refMsg);
         }
         hsRefCnt_SafeUnRef(refMsg);

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plKeyImp.cpp
@@ -489,8 +489,7 @@ void plKeyImp::INotifySelf(hsKeyedObject* ko)
                             ref->SetNotified(j);
                             ref->SatisfyPending(refMsg);
 
-                            refMsg->Ref();
-                            plgDispatch::MsgSend(refMsg);
+                            refMsg->SendAndKeep();
                             break;
                         }
                     }
@@ -538,8 +537,7 @@ void plKeyImp::INotifyDestroyed()
         msg->SetRef(ko);
         msg->SetTimeStamp(hsTimer::GetSysSeconds());
         msg->SetContext(plRefMsg::kOnDestroy);
-        msg->Ref();
-        msg->Send();
+        msg->SendAndKeep();
     }
     fNotified.Clear();
 }
@@ -628,8 +626,7 @@ void plKeyImp::IRelease(plKeyImp* iTargetKey)
             refMsg->SetRef(iTargetKey->ObjectIsLoaded());
             refMsg->SetTimeStamp(hsTimer::GetSysSeconds());
             refMsg->SetContext(plRefMsg::kOnRemove);
-            refMsg->Ref();
-            plgDispatch::MsgSend(refMsg);
+            refMsg->SendAndKeep();
         }
         hsRefCnt_SafeUnRef(refMsg);
     }

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
@@ -178,8 +178,7 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
                 eventMsg->ClearReceivers();
                 eventMsg->AddReceivers(fc->fOrigReceivers);
                 eventMsg->SetSender(GetKey());
-                eventMsg->Ref();
-                eventMsg->Send();
+                eventMsg->SendAndKeep();
 
                 delete fc;
             }
@@ -205,10 +204,9 @@ void plMsgForwarder::IForwardMsg(plMessage *msg)
         oldKeys.emplace_back(msg->GetReceiver(i));
 
     // Set to our receivers and send
-    msg->Ref();
     msg->ClearReceivers();
     msg->AddReceivers(fForwardKeys);
-    msg->Send();
+    msg->SendAndKeep();
 
     // Reset back to the original receivers.  This is so we don't screw up objects
     // who reuse their messages

--- a/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
+++ b/Sources/Plasma/NucleusLib/pnKeyedObject/plMsgForwarder.cpp
@@ -178,7 +178,7 @@ bool plMsgForwarder::IForwardCallbackMsg(plMessage *msg)
                 eventMsg->ClearReceivers();
                 eventMsg->AddReceivers(fc->fOrigReceivers);
                 eventMsg->SetSender(GetKey());
-                hsRefCnt_SafeRef(eventMsg);
+                eventMsg->Ref();
                 eventMsg->Send();
 
                 delete fc;
@@ -205,7 +205,7 @@ void plMsgForwarder::IForwardMsg(plMessage *msg)
         oldKeys.emplace_back(msg->GetReceiver(i));
 
     // Set to our receivers and send
-    hsRefCnt_SafeRef(msg);
+    msg->Ref();
     msg->ClearReceivers();
     msg->AddReceivers(fForwardKeys);
     msg->Send();

--- a/Sources/Plasma/NucleusLib/pnMessage/plMessageWithCallbacks.cpp
+++ b/Sources/Plasma/NucleusLib/pnMessage/plMessageWithCallbacks.cpp
@@ -55,7 +55,7 @@ plMessageWithCallbacks::~plMessageWithCallbacks()
 
 void plMessageWithCallbacks::AddCallback(plMessage* e) 
 { 
-    hsRefCnt_SafeRef(e); 
+    e->Ref(); 
 
     // make sure callback msgs have the same net propagate properties as the container msg
     e->SetBCastFlag(plMessage::kNetPropagate, HasBCastFlag(plMessage::kNetPropagate));

--- a/Sources/Plasma/NucleusLib/pnTimer/plTimerCallbackManager.cpp
+++ b/Sources/Plasma/NucleusLib/pnTimer/plTimerCallbackManager.cpp
@@ -151,8 +151,7 @@ fMsg(pMsg)
 
 plTimerCallback::~plTimerCallback()
 {
-    if (fMsg)
-        hsRefCnt_SafeUnRef(fMsg);
+    hsRefCnt_SafeUnRef(fMsg);
     fMsg = nullptr;
 }
 

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -475,7 +475,7 @@ double plAGAnimInstance::WorldToAnimTime(double foo)
 
 // AttachCallbacks --------------------------------------------------
 // ----------------
-void plAGAnimInstance::AttachCallbacks(plOneShotCallbacks *callbacks)
+void plAGAnimInstance::AttachCallbacks(hsWeakRef<plOneShotCallbacks> callbacks)
 {
     const plATCAnim *anim = plATCAnim::ConvertNoRef(fAnimation);
     if (callbacks && anim)

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.cpp
@@ -198,17 +198,17 @@ void plAGAnimInstance::IInitAnimTimeConvert(plAnimTimeConvert* atc, plATCAnim* a
     instMsg = new plAGInstanceCallbackMsg(master->GetKey(), plEventCallbackMsg::kStart);
     instMsg->fInstance = this;
     atc->AddCallback(instMsg);
-    hsRefCnt_SafeUnRef(instMsg);
+    instMsg->UnRef();
 
     instMsg = new plAGInstanceCallbackMsg(master->GetKey(), plEventCallbackMsg::kStop);
     instMsg->fInstance = this;
     atc->AddCallback(instMsg);
-    hsRefCnt_SafeUnRef(instMsg);
+    instMsg->UnRef();
 
     instMsg = new plAGInstanceCallbackMsg(master->GetKey(), plEventCallbackMsg::kSingleFrameAdjust);
     instMsg->fInstance = this;
     atc->AddCallback(instMsg);
-    hsRefCnt_SafeUnRef(instMsg);
+    instMsg->UnRef();
 
     atc->SetOwner(master);
     atc->ClearFlags();
@@ -505,7 +505,7 @@ void plAGAnimInstance::AttachCallbacks(plOneShotCallbacks *callbacks)
             }
             
             animMsg.AddCallback(eventMsg);
-            hsRefCnt_SafeUnRef(eventMsg);
+            eventMsg->UnRef();
         }
         
         fTimeConvert->HandleCmd(&animMsg);

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.h
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGAnimInstance.h
@@ -211,7 +211,7 @@ public:
     /** Attach a sequence of callback messages to the animation instance.
         Messages are each associated with a specific (local) time
         in the animation and will be sent when playback passes that time. */
-    void AttachCallbacks(plOneShotCallbacks *callbacks);
+    void AttachCallbacks(hsWeakRef<plOneShotCallbacks> callbacks);
     
     void ProcessFade(float elapsed);             // process any outstanding fades    
     void SearchForGlobals(); // Util function to setup SDL channels

--- a/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAnimation/plAGMasterMod.cpp
@@ -456,7 +456,7 @@ void plAGMasterMod::PlaySimpleAnim(const ST::string &name)
         plAGDetachCallbackMsg *msg = new plAGDetachCallbackMsg(GetKey(), plEventCallbackMsg::kStop); 
         msg->SetAnimName(name);
         instance->GetTimeConvert()->AddCallback(msg);
-        hsRefCnt_SafeUnRef(msg);
+        msg->UnRef();
     }
 }
 

--- a/Sources/Plasma/PubUtilLib/plAudio/plSoundEvent.cpp
+++ b/Sources/Plasma/PubUtilLib/plAudio/plSoundEvent.cpp
@@ -98,7 +98,7 @@ void    plSoundEvent::SendCallbacks()
             plSoundMsg* sMsg = nullptr;
 
             // Ref to make sure the dispatcher doesn't delete it on us
-            hsRefCnt_SafeRef( msg );
+            msg->Ref();
             if( msg->fRepeats == 0 && fCallbackEndingFlags[ j ] == 0 )
             {
                 // Note: we get fancy here. We never want to remove the callback directly,

--- a/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plArmatureMod.cpp
@@ -2419,8 +2419,8 @@ void plArmatureMod::ISetupMarkerCallbacks(plATCAnim *anim, plAnimTimeConvert *at
             iMsg->fEvent = plEventCallbackMsg::kTime;
             iMsg->SetMessageRef(msg);
             atc->AddCallback(iMsg);
-            hsRefCnt_SafeUnRef(msg);
-            hsRefCnt_SafeUnRef(iMsg);
+            msg->UnRef();
+            iMsg->UnRef();
 
             plAvatarFootMsg* foot = new plAvatarFootMsg(GetKey(), this, isLeft);
             foot->fEventTime = time;
@@ -2431,8 +2431,8 @@ void plArmatureMod::ISetupMarkerCallbacks(plATCAnim *anim, plAnimTimeConvert *at
             iMsg->fEvent = plEventCallbackMsg::kTime;
             iMsg->SetMessageRef(foot);
             atc->AddCallback(iMsg);
-            hsRefCnt_SafeUnRef(foot);
-            hsRefCnt_SafeUnRef(iMsg);
+            foot->UnRef();
+            iMsg->UnRef();
         }
     }
 }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
@@ -499,61 +499,42 @@ void plAvAnimTask::Write(hsStream *stream, hsResMgr *mgr)
 //
 ////////////////
 
-void plAvOneShotTask::InitDefaults()
-{
-    fBackwards = false;
-    fDisableLooping = false;
-    fDisablePhysics = true;
-    fMoveHandle = false;
-    fAnimInstance = nullptr;
-    fDrivable = false;
-    fReversible = false;
-    fEnablePhysicsAtEnd = false;
-    fDetachAnimation = false;
-    fIgnore = false;
-    fCallbacks = nullptr;
-    fWaitFrames = 0;
-}
-
 // CTOR default
 plAvOneShotTask::plAvOneShotTask()
-{
-    InitDefaults();
-}
+    : plAvOneShotTask({}, false, false, nullptr)
+{}
 
 // CTOR (animName, drivable, reversible)
 // this construct is typically used when you want to create a one-shot task as part of a sequence
 // of tasks
 // it's different than the message-based constructor in that fDetachAnimation and fMoveHandle default to false
-plAvOneShotTask::plAvOneShotTask(const ST::string &animName, bool drivable, bool reversible, plOneShotCallbacks *callbacks)
+plAvOneShotTask::plAvOneShotTask(ST::string animName, bool drivable, bool reversible, plOneShotCallbacks *callbacks)
+    : fBackwards(),
+      fDisableLooping(),
+      fDisablePhysics(true),
+      fAnimName(std::move(animName)),
+      fMoveHandle(),
+      fAnimInstance(),
+      fDrivable(drivable),
+      fReversible(reversible),
+      fEnablePhysicsAtEnd(),
+      fDetachAnimation(),
+      fIgnore(),
+      fCallbacks(callbacks),
+      fWaitFrames()
 {
-    InitDefaults();
-
-    fDrivable = drivable;
-    fReversible = reversible;
-    fCallbacks = callbacks;
-    
     // we're going to use this sometime in the future, better ref it so someone else doesn't release it
     hsRefCnt_SafeRef(fCallbacks);
-    fAnimName = animName;
 }
 
 // CTOR (plAvOneShotMsg, plArmatureMod)
 // this constructor is typically used when we're doing a classic, isolated one-shot
 // fDetachAnimation and fMoveHandle both default to *true*
 plAvOneShotTask::plAvOneShotTask (plAvOneShotMsg *msg, plArmatureMod *avatar, plArmatureBrain *brain)
+    : plAvOneShotTask(msg->fAnimName, msg->fDrivable, msg->fReversible, msg->fCallbacks)
 {
-    InitDefaults();
-
-    fDrivable = msg->fDrivable;
-    fReversible = msg->fReversible;
-    fCallbacks = msg->fCallbacks;
     fDetachAnimation = true;
     fMoveHandle = true;
-
-    // we're going to use this sometime in the future, better ref it so someone else doesn't release it
-    hsRefCnt_SafeRef(fCallbacks);
-    fAnimName = msg->fAnimName;
 }
 
 // DTOR

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
@@ -508,7 +508,7 @@ plAvOneShotTask::plAvOneShotTask()
 // this construct is typically used when you want to create a one-shot task as part of a sequence
 // of tasks
 // it's different than the message-based constructor in that fDetachAnimation and fMoveHandle default to false
-plAvOneShotTask::plAvOneShotTask(ST::string animName, bool drivable, bool reversible, plOneShotCallbacks *callbacks)
+plAvOneShotTask::plAvOneShotTask(ST::string animName, bool drivable, bool reversible, hsRef<plOneShotCallbacks> callbacks)
     : fBackwards(),
       fDisableLooping(),
       fDisablePhysics(true),
@@ -520,12 +520,9 @@ plAvOneShotTask::plAvOneShotTask(ST::string animName, bool drivable, bool revers
       fEnablePhysicsAtEnd(),
       fDetachAnimation(),
       fIgnore(),
-      fCallbacks(callbacks),
+      fCallbacks(std::move(callbacks)),
       fWaitFrames()
-{
-    // we're going to use this sometime in the future, better ref it so someone else doesn't release it
-    hsRefCnt_SafeRef(fCallbacks);
-}
+{}
 
 // CTOR (plAvOneShotMsg, plArmatureMod)
 // this constructor is typically used when we're doing a classic, isolated one-shot
@@ -539,10 +536,7 @@ plAvOneShotTask::plAvOneShotTask (plAvOneShotMsg *msg, plArmatureMod *avatar, pl
 
 // DTOR
 plAvOneShotTask::~plAvOneShotTask()
-{
-    hsRefCnt_SafeUnRef(fCallbacks);
-}
-
+{}
 
 // START
 bool plAvOneShotTask::Start(plArmatureMod *avatar, plArmatureBrain *brain, double time, float elapsed)
@@ -572,8 +566,6 @@ bool plAvOneShotTask::Start(plArmatureMod *avatar, plArmatureBrain *brain, doubl
         if (fCallbacks)
         {
             fAnimInstance->AttachCallbacks(fCallbacks);
-            // ok, we're done with it, release it back to the river
-            fCallbacks->UnRef();
             fCallbacks = nullptr;
         }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.cpp
@@ -585,14 +585,14 @@ bool plAvOneShotTask::Start(plArmatureMod *avatar, plArmatureBrain *brain, doubl
             // step over some script's attempt to disable physics again.
             plAvatarPhysicsEnableCallbackMsg *epMsg = new plAvatarPhysicsEnableCallbackMsg(avatar->GetKey(), plEventCallbackMsg::kStop, 0, 0, 0, 0);
             fAnimInstance->GetTimeConvert()->AddCallback(epMsg);
-            hsRefCnt_SafeUnRef(epMsg);
+            epMsg->UnRef();
         }   
 
         if (fCallbacks)
         {
             fAnimInstance->AttachCallbacks(fCallbacks);
             // ok, we're done with it, release it back to the river
-            hsRefCnt_SafeUnRef(fCallbacks);
+            fCallbacks->UnRef();
             fCallbacks = nullptr;
         }
 

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.h
@@ -176,7 +176,7 @@ public:
     /** Canonical constructor
         \param animName The name of the animation we're going to play
         \param drivable Unused. Allows the oneshot to be controlled by keyboard input
-        \param reversable Unused. Allows the oneshot to be backed up by keyboard input
+        \param reversible Unused. Allows the oneshot to be backed up by keyboard input
         \param callbacks A vector of callback messages to be sent at specific times during the animation
         */
     plAvOneShotTask(ST::string animName, bool drivable, bool reversible, plOneShotCallbacks *callbacks);

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.h
@@ -170,9 +170,6 @@ protected:
 */
 class plAvOneShotTask : public plAvTask {
 public:
-    /** Put default values for all member variables. */
-    void InitDefaults();
-    
     /** Default constructor for the class factor and descendants. */
     plAvOneShotTask();
 
@@ -182,7 +179,7 @@ public:
         \param reversable Unused. Allows the oneshot to be backed up by keyboard input
         \param callbacks A vector of callback messages to be sent at specific times during the animation
         */
-    plAvOneShotTask(const ST::string &animName, bool drivable, bool reversible, plOneShotCallbacks *callbacks);
+    plAvOneShotTask(ST::string animName, bool drivable, bool reversible, plOneShotCallbacks *callbacks);
     /** Construct from a oneshot message.
         \param msg The message to copy our parameters from
         \param brain The brain to attach the task to.

--- a/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.h
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plAvatarTasks.h
@@ -179,7 +179,7 @@ public:
         \param reversible Unused. Allows the oneshot to be backed up by keyboard input
         \param callbacks A vector of callback messages to be sent at specific times during the animation
         */
-    plAvOneShotTask(ST::string animName, bool drivable, bool reversible, plOneShotCallbacks *callbacks);
+    plAvOneShotTask(ST::string animName, bool drivable, bool reversible, hsRef<plOneShotCallbacks> callbacks);
     /** Construct from a oneshot message.
         \param msg The message to copy our parameters from
         \param brain The brain to attach the task to.
@@ -215,7 +215,7 @@ protected:
     bool fDetachAnimation;            // should we detach the animation when we're done?
     bool fIgnore;                     // if this gets set before we start, we just finish without doing anything.
     
-    plOneShotCallbacks *fCallbacks;     // a set of callbacks to set up on our animation
+    hsRef<plOneShotCallbacks> fCallbacks; // a set of callbacks to set up on our animation
     
     hsMatrix44 fPlayer2Anim;            // matrix from player root space to animation root space
     hsMatrix44 fAnim2Player;            // matrix from animation root space to player root space

--- a/Sources/Plasma/PubUtilLib/plAvatar/plOneShotMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plOneShotMod.cpp
@@ -130,7 +130,7 @@ bool plOneShotMod::MsgReceive(plMessage* msg)
 
                     avOSmsg->fNoSeek = fNoSeek;
                     avOSmsg->SetBCastFlag(plMessage::kPropagateToModifiers);
-                    hsRefCnt_SafeRef(oneShotMsg->fCallbacks);
+                    oneShotMsg->fCallbacks->Ref();
                     avOSmsg->fCallbacks = oneShotMsg->fCallbacks;
                     plgDispatch::MsgSend(avOSmsg);
                 }

--- a/Sources/Plasma/PubUtilLib/plAvatar/plOneShotMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plAvatar/plOneShotMod.cpp
@@ -130,7 +130,6 @@ bool plOneShotMod::MsgReceive(plMessage* msg)
 
                     avOSmsg->fNoSeek = fNoSeek;
                     avOSmsg->SetBCastFlag(plMessage::kPropagateToModifiers);
-                    oneShotMsg->fCallbacks->Ref();
                     avOSmsg->fCallbacks = oneShotMsg->fCallbacks;
                     plgDispatch::MsgSend(avOSmsg);
                 }

--- a/Sources/Plasma/PubUtilLib/plDrawable/plAccessGeometry.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plAccessGeometry.cpp
@@ -111,9 +111,10 @@ void plAccessGeometry::Init(plPipeline* pipe)
 
 void plAccessGeometry::DeInit()
 {
-    if( fInstance )
+    if (fInstance) {
         fInstance->Nilify();
-    hsRefCnt_SafeUnRef(fInstance);
+        fInstance->UnRef();
+    }
 }
 
 void plAccessGeometry::SetTheIntance(plAccessGeometry* i)

--- a/Sources/Plasma/PubUtilLib/plDrawable/plAccessGeometry.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plAccessGeometry.cpp
@@ -98,31 +98,17 @@ plAccessGeometry::plAccessGeometry(plPipeline* pipe)
 //////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////
 // Global access stuff.
-plAccessGeometry*   plAccessGeometry::fInstance = nullptr;
+std::unique_ptr<plAccessGeometry> plAccessGeometry::fInstance;
 
 void plAccessGeometry::Init(plPipeline* pipe)
 {
-    plAccessGeometry* oldAcc = fInstance;
-
-    fInstance = new plAccessGeometry(pipe);
-
-    hsRefCnt_SafeUnRef(oldAcc);
+    fInstance = std::make_unique<plAccessGeometry>(pipe);
 }
 
 void plAccessGeometry::DeInit()
 {
-    if (fInstance) {
-        fInstance->Nilify();
-        fInstance->UnRef();
-    }
+    fInstance.reset();
 }
-
-void plAccessGeometry::SetTheIntance(plAccessGeometry* i)
-{
-    hsRefCnt_SafeAssign(fInstance, i);
-}
-
-
 
 
 //////////////////////////////////////////////////////////////////////////////////

--- a/Sources/Plasma/PubUtilLib/plDrawable/plAccessGeometry.h
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plAccessGeometry.h
@@ -43,8 +43,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #ifndef plAccessGeometry_inc
 #define plAccessGeometry_inc
 
-#include "hsRefCnt.h"
-
+#include <memory>
 #include <vector>
 
 class plAccessSpan;
@@ -58,35 +57,24 @@ class plPipeline;
 class plSpan;
 class plVertexSpan;
 
-class plAccessGeometry : public hsRefCnt
+class plAccessGeometry
 {
 protected:
-    void                    Nilify() { fPipe = nullptr; }
-
     plPipeline*                     fPipe;
 
-    static plAccessGeometry*        fInstance;
+    static std::unique_ptr<plAccessGeometry> fInstance;
 public:
     // You're welcome to make your own,
     // but this is normally just called by the global plAccessGeometry's Init() function.
     // You should normally just use the instance supplied by Instance();
     plAccessGeometry(plPipeline* pipe=nullptr);
 
-    static plAccessGeometry*        Instance() { return fInstance; }
+    static plAccessGeometry* Instance() { return fInstance.get(); }
 
     // App will initialize, which will create the global instance.
     // DeInit will nil the global instance.
     static void Init(plPipeline* pipe);
     static void DeInit();
-
-    // External DLL's will share the same plAccessGeometry. After the main App has
-    // DeInited the AccessGeometry,
-    // all calls to Instance()->Function() will return nil in one form or another (e.g.
-    // empty triangle lists). The external DLL needs to either not try to use these
-    // accessor functions after PythonInterface::WeAreInShutdown() (it won't do any good
-    // anyway as any work done will be thrown away), or else be prepared for receiving
-    // empty data where there was data before.
-    static void SetTheIntance(plAccessGeometry* i);
 
     // You have 2 options in opening the data.
     // RO - Read Only. 

--- a/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plGBufferGroup.cpp
@@ -571,7 +571,7 @@ void    plGBufferGroup::DeleteVertsFromStorage( uint32_t which, uint32_t start, 
 
     if (fVertexBufferRefs.size() > which && fVertexBufferRefs[which])
     {
-        hsRefCnt_SafeUnRef(fVertexBufferRefs[which]);
+        fVertexBufferRefs[which]->UnRef();
         fVertexBufferRefs[which] = nullptr;
     }
 
@@ -624,7 +624,7 @@ void    plGBufferGroup::DeleteIndicesFromStorage( uint32_t which, uint32_t start
 
     if (fIndexBufferRefs.size() > which && fIndexBufferRefs[which])
     {
-        hsRefCnt_SafeUnRef(fIndexBufferRefs[which]);
+        fIndexBufferRefs[which]->UnRef();
         fIndexBufferRefs[which] = nullptr;
     }
 
@@ -793,7 +793,7 @@ bool    plGBufferGroup::ReserveVertStorage( uint32_t numVerts, uint32_t *vbIndex
 
     if (fVertexBufferRefs.size() > i && fVertexBufferRefs[i])
     {
-        hsRefCnt_SafeUnRef(fVertexBufferRefs[i]);
+        fVertexBufferRefs[i]->UnRef();
         fVertexBufferRefs[i] = nullptr;
     }
 
@@ -1062,7 +1062,7 @@ bool    plGBufferGroup::ReserveIndexStorage( uint32_t numIndices, uint32_t *ibIn
     /// All done!
     if ( fIndexBufferRefs.size() > i && fIndexBufferRefs[i])
     {
-        hsRefCnt_SafeUnRef(fIndexBufferRefs[i]);
+        fIndexBufferRefs[i]->UnRef();
         fIndexBufferRefs[i] = nullptr;
     }
 

--- a/Sources/Plasma/PubUtilLib/plGImage/plBitmap.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plBitmap.cpp
@@ -81,8 +81,7 @@ plBitmap::plBitmap()
 
 plBitmap::~plBitmap()
 {
-    if (fDeviceRef != nullptr)
-        hsRefCnt_SafeUnRef( fDeviceRef );
+    hsRefCnt_SafeUnRef(fDeviceRef);
 }
 
 bool plBitmap::IsSameModifiedTime(uint32_t lowTime, uint32_t highTime)

--- a/Sources/Plasma/PubUtilLib/plGImage/plBitmap.h
+++ b/Sources/Plasma/PubUtilLib/plGImage/plBitmap.h
@@ -190,7 +190,7 @@ class plBitmap : public hsKeyedObject
         uint8_t           fSpace;     // no, direct, gray, index
         uint16_t          fFlags;     // alphachannel | alphabit
 
-        mutable hsGDeviceRef    *fDeviceRef;
+        hsGDeviceRef* fDeviceRef;
 
         static uint8_t            fGlobalNumLevelsToChop;
 

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -518,7 +518,7 @@ bool    plInputInterfaceMgr::MsgReceive( plMessage *msg )
     {
         if( mgrMsg->GetCommand() == plInputIfaceMgrMsg::kAddInterface )
         {
-            IAddInterface(hsWeakRef(mgrMsg->GetIFace()));
+            IAddInterface(mgrMsg->GetIFace());
             return true;
         }
         else if( mgrMsg->GetCommand() == plInputIfaceMgrMsg::kRemoveInterface )

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -161,16 +161,15 @@ void    plInputInterfaceMgr::Init()
     /// Hacks (?) for now
     plAvatarInputInterface *avatar = new plAvatarInputInterface();
     IAddInterface( avatar );
-    hsRefCnt_SafeUnRef( avatar );
+    avatar->UnRef();
 
     plSceneInputInterface *scene = new plSceneInputInterface();
     IAddInterface( scene );
-    hsRefCnt_SafeUnRef( scene );
+    scene->UnRef();
 
     plDebugInputInterface *camDrive = new plDebugInputInterface();
     IAddInterface( camDrive );
-    hsRefCnt_SafeUnRef( camDrive );
-    
+    camDrive->UnRef();
 }
 
 //// Shutdown ////////////////////////////////////////////////////////////////
@@ -183,7 +182,7 @@ void    plInputInterfaceMgr::Shutdown()
     for (plInputInterface* iface : fInterfaces)
     {
         iface->Shutdown();
-        hsRefCnt_SafeUnRef(iface);
+        iface->UnRef();
     }
     fInterfaces.clear();
 
@@ -217,7 +216,7 @@ void    plInputInterfaceMgr::IAddInterface( plInputInterface *iface )
     }
 
     fInterfaces.insert(iter, iface);
-    hsRefCnt_SafeRef( iface );
+    iface->Ref();
     iface->Init( this );
     iface->ISetMessageQueue( &fMessageQueue );
 }
@@ -245,7 +244,7 @@ void    plInputInterfaceMgr::IRemoveInterface( plInputInterface *iface )
             }
         }
 
-        hsRefCnt_SafeUnRef(*iter);
+        (*iter)->UnRef();
         fInterfaces.erase(iter);
     }
 }

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.cpp
@@ -159,17 +159,9 @@ void    plInputInterfaceMgr::Init()
     plgDispatch::Dispatch()->RegisterForExactType( plClientMsg::Index(), GetKey() );
     
     /// Hacks (?) for now
-    plAvatarInputInterface *avatar = new plAvatarInputInterface();
-    IAddInterface( avatar );
-    avatar->UnRef();
-
-    plSceneInputInterface *scene = new plSceneInputInterface();
-    IAddInterface( scene );
-    scene->UnRef();
-
-    plDebugInputInterface *camDrive = new plDebugInputInterface();
-    IAddInterface( camDrive );
-    camDrive->UnRef();
+    IAddInterface(hsRef<plInputInterface>(new plAvatarInputInterface(), hsStealRef));
+    IAddInterface(hsRef<plInputInterface>(new plSceneInputInterface(), hsStealRef));
+    IAddInterface(hsRef<plInputInterface>(new plDebugInputInterface(), hsStealRef));
 }
 
 //// Shutdown ////////////////////////////////////////////////////////////////
@@ -179,10 +171,8 @@ void    plInputInterfaceMgr::Shutdown()
 
 //  WriteKeyMap();
 
-    for (plInputInterface* iface : fInterfaces)
-    {
+    for (const auto& iface : fInterfaces) {
         iface->Shutdown();
-        iface->UnRef();
     }
     fInterfaces.clear();
 
@@ -206,7 +196,7 @@ void    plInputInterfaceMgr::Shutdown()
 //  Doing it this way allows us to keep the manager unaware of the number or 
 //  types of interfaces.
 
-void    plInputInterfaceMgr::IAddInterface( plInputInterface *iface )
+void plInputInterfaceMgr::IAddInterface(hsRef<plInputInterface> iface)
 {
     auto iter = fInterfaces.cbegin();
     for (; iter != fInterfaces.cend(); ++iter)
@@ -215,13 +205,12 @@ void    plInputInterfaceMgr::IAddInterface( plInputInterface *iface )
             break;
     }
 
-    fInterfaces.insert(iter, iface);
-    iface->Ref();
-    iface->Init( this );
-    iface->ISetMessageQueue( &fMessageQueue );
+    auto inserted = fInterfaces.insert(iter, std::move(iface));
+    (*inserted)->Init(this);
+    (*inserted)->ISetMessageQueue(&fMessageQueue);
 }
 
-void    plInputInterfaceMgr::IRemoveInterface( plInputInterface *iface )
+void plInputInterfaceMgr::IRemoveInterface(hsWeakRef<plInputInterface> iface)
 {
     auto iter = std::find(fInterfaces.begin(), fInterfaces.end(), iface);
     if (iter != fInterfaces.end())
@@ -244,7 +233,6 @@ void    plInputInterfaceMgr::IRemoveInterface( plInputInterface *iface )
             }
         }
 
-        (*iter)->UnRef();
         fInterfaces.erase(iter);
     }
 }
@@ -254,7 +242,7 @@ void    plInputInterfaceMgr::IRemoveInterface( plInputInterface *iface )
 void plInputInterfaceMgr::ResetClickableState()
 {
     // look for the scene input interface
-    for (plInputInterface* iface : fInterfaces)
+    for (const auto& iface : fInterfaces)
         iface->ResetClickableState();
 }
 
@@ -311,7 +299,7 @@ bool plInputInterfaceMgr::IEval( double secs, float del, uint32_t dirty )
 
 
     // Let all our layers eval
-    for (plInputInterface* iface : fInterfaces)
+    for (const auto& iface : fInterfaces)
         iface->IEval(secs, del, dirty);
 
     // Handle our message queue now
@@ -406,7 +394,7 @@ void plInputInterfaceMgr::ForceCursorHidden( bool requestedState )
 
 }
 
-bool plInputInterfaceMgr::ICheckCursor(plInputInterface *iFace)
+bool plInputInterfaceMgr::ICheckCursor(hsWeakRef<plInputInterface> iFace)
 {
     if( iFace->IsEnabled() && iFace->HasInterestingCursorID() )
     {
@@ -440,7 +428,7 @@ bool    plInputInterfaceMgr::MsgReceive( plMessage *msg )
         plProfile_BeginLap(Input, inputIEM);
         bool handled = false;
         size_t missedInputStartIdx = 0;
-        plInputInterface *oldCurrentFocus = fCurrentFocus;
+        hsWeakRef<plInputInterface> oldCurrentFocus = fCurrentFocus;
 
         // Current focus (if there is one) gets first crack
         if( fCurrentFocus )
@@ -495,7 +483,7 @@ bool    plInputInterfaceMgr::MsgReceive( plMessage *msg )
 
             if (!cursorHandled)
             {
-                for (plInputInterface* iface : fInterfaces)
+                for (const auto& iface : fInterfaces)
                 {
                     if (ICheckCursor(iface))
                     {
@@ -530,7 +518,7 @@ bool    plInputInterfaceMgr::MsgReceive( plMessage *msg )
     {
         if( mgrMsg->GetCommand() == plInputIfaceMgrMsg::kAddInterface )
         {
-            IAddInterface( mgrMsg->GetIFace() );
+            IAddInterface(hsWeakRef(mgrMsg->GetIFace()));
             return true;
         }
         else if( mgrMsg->GetCommand() == plInputIfaceMgrMsg::kRemoveInterface )
@@ -601,8 +589,7 @@ bool    plInputInterfaceMgr::MsgReceive( plMessage *msg )
         return true;
     }
     // Wasn't one we want. Was it one that one of our interfaces wanted?
-    for (plInputInterface* iface : fInterfaces)
-    {
+    for (const auto& iface : fInterfaces) {
         if (iface->MsgReceive(msg))
             return true;
     }
@@ -632,8 +619,7 @@ void    plInputInterfaceMgr::Write( hsStream* s, hsResMgr* mgr )
         
 plKeyMap    *plInputInterfaceMgr::IGetRoutedKeyMap( ControlEventCode code )
 {
-    for (plInputInterface* iface : fInterfaces)
-    {
+    for (const auto& iface : fInterfaces) {
         if (iface->IOwnsControlCode(code))
             return iface->fControlMap;
     }
@@ -651,14 +637,14 @@ plKeyMap    *plInputInterfaceMgr::IGetRoutedKeyMap( ControlEventCode code )
 void    plInputInterfaceMgr::IUnbind( const plKeyCombo &key )
 {
 #if !(ALLOW_MULTIPLE_CMDS_PER_KEY)
-    for (plInputInterface* iface : fInterfaces)
+    for (const auto& iface : fInterfaces)
         iface->fControlMap->UnmapKey(key);
 #endif
 }
 
 void plInputInterfaceMgr::ClearAllKeyMaps()
 {
-    for (plInputInterface* iface : fInterfaces)
+    for (const auto& iface : fInterfaces)
         iface->ClearKeyMap();
 }
 
@@ -738,7 +724,7 @@ const plKeyBinding* plInputInterfaceMgr::FindBindingByConsoleCmd(const ST::strin
 
 void    plInputInterfaceMgr::InitDefaultKeyMap()
 {
-    for (plInputInterface* iface : fInterfaces)
+    for (const auto& iface : fInterfaces)
         iface->RestoreDefaultKeyMappings();
 
     RefreshInterfaceKeyMaps();
@@ -748,7 +734,7 @@ void    plInputInterfaceMgr::InitDefaultKeyMap()
 
 void    plInputInterfaceMgr::RefreshInterfaceKeyMaps()
 {
-    for (plInputInterface* iface : fInterfaces)
+    for (const auto& iface : fInterfaces)
         iface->RefreshKeyMap();
 }
 
@@ -788,7 +774,7 @@ void    plInputInterfaceMgr::WriteKeyMap()
         fprintf(gKeyFile, "#\n");
 //      fprintf(gKeyFile, "Keyboard.ClearBindings\n");
         
-        for (plInputInterface* iface : fInterfaces)
+        for (const auto& iface : fInterfaces)
             IWriteNonConsoleCmdKeys(iface->fControlMap, gKeyFile);
 
         fprintf(gKeyFile, "#\n");
@@ -797,7 +783,7 @@ void    plInputInterfaceMgr::WriteKeyMap()
         fprintf(gKeyFile, "# Keyboard.BindConsoleCmd \tKey\t\t\tCommand\n");
         fprintf(gKeyFile, "#\n");
         
-        for (plInputInterface* iface : fInterfaces)
+        for (const auto& iface : fInterfaces)
             IWriteConsoleCmdKeys(iface->fControlMap, gKeyFile);
 
         fprintf(gKeyFile, "#\n");
@@ -822,12 +808,12 @@ void    plInputInterfaceMgr::WriteKeyMap()
     }
 }
 
-void plInputInterfaceMgr::SetCurrentFocus(plInputInterface *focus)
+void plInputInterfaceMgr::SetCurrentFocus(hsWeakRef<plInputInterface> focus)
 {
     fCurrentFocus = focus;
 }
 
-void plInputInterfaceMgr::ReleaseCurrentFocus(plInputInterface *focus)
+void plInputInterfaceMgr::ReleaseCurrentFocus(hsWeakRef<plInputInterface> focus)
 {
     if (fCurrentFocus == focus)
         fCurrentFocus = nullptr;

--- a/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
+++ b/Sources/Plasma/PubUtilLib/plInputCore/plInputInterfaceMgr.h
@@ -81,7 +81,7 @@ class plInputInterfaceMgr : public plSingleModifier
 
         static plInputInterfaceMgr  *fInstance;
 
-        std::vector<plInputInterface *> fInterfaces;
+        std::vector<hsRef<plInputInterface>> fInterfaces;
         std::vector<plCtrlCmd *>        fMessageQueue;
         std::vector<plKey>              fReceivers;
 
@@ -90,17 +90,17 @@ class plInputInterfaceMgr : public plSingleModifier
         float    fCursorOpacity;
         bool        fForceCursorHidden;
         int32_t       fForceCursorHiddenCount;
-        plInputInterface        *fCurrentFocus;
+        hsWeakRef<plInputInterface> fCurrentFocus;
         plDefaultKeyCatcher     *fDefaultCatcher;
 
         
         bool IEval(double secs, float del, uint32_t dirty) override;
 
-        void    IAddInterface( plInputInterface *iface );
-        void    IRemoveInterface( plInputInterface *iface );
+        void    IAddInterface(hsRef<plInputInterface> iface);
+        void    IRemoveInterface(hsWeakRef<plInputInterface> iface);
 
         void    IUpdateCursor( int32_t newCursor );
-        bool    ICheckCursor(plInputInterface *iFace); // returns true if the iface changed cursor settings
+        bool    ICheckCursor(hsWeakRef<plInputInterface> iFace); // returns true if the iface changed cursor settings
             
         void    IWriteConsoleCmdKeys( plKeyMap *keyMap, FILE *keyFile );
         void    IWriteNonConsoleCmdKeys( plKeyMap *keyMap, FILE *keyFile );
@@ -127,8 +127,8 @@ class plInputInterfaceMgr : public plSingleModifier
         void        WriteKeyMap();
         void        RefreshInterfaceKeyMaps();
 
-        void    SetCurrentFocus(plInputInterface *focus);
-        void    ReleaseCurrentFocus(plInputInterface *focus);
+        void    SetCurrentFocus(hsWeakRef<plInputInterface> focus);
+        void    ReleaseCurrentFocus(hsWeakRef<plInputInterface> focus);
         void    SetDefaultKeyCatcher( plDefaultKeyCatcher *c ) { fDefaultCatcher = c; }
 
         bool    IsClickEnabled() { return fClickEnabled; }
@@ -155,10 +155,10 @@ class plCtrlCmd
 {
     private:
         ST::string          fCmd;
-        plInputInterface    *fSource;
+        hsWeakRef<plInputInterface> fSource;
 
     public:
-        plCtrlCmd(plInputInterface* source)
+        plCtrlCmd(hsWeakRef<plInputInterface> source)
             : fCmd(), fPct(1.f), fSource(source),
               fControlCode(), fControlActivated(), fNetPropagateToPlayers()
         { }
@@ -176,7 +176,7 @@ class plCtrlCmd
         void Read( hsStream* s, hsResMgr* mgr );
         void Write( hsStream* s, hsResMgr* mgr );
 
-        plInputInterface    *GetSource() const { return fSource; }
+        hsWeakRef<plInputInterface> GetSource() const { return fSource; }
 };
 
 //// Tiny Virtual Class For The Default Key Processor ////////////////////////

--- a/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
+++ b/Sources/Plasma/PubUtilLib/plInterp/plAnimTimeConvert.cpp
@@ -238,13 +238,13 @@ void plAnimTimeConvert::ISendCallback(hsSsize_t i)
     {
         fCallbackMsgs[i]->SetSender(fOwner ? fOwner->GetKey() : nullptr);
 
-        hsRefCnt_SafeRef(fCallbackMsgs[i]);
+        fCallbackMsgs[i]->Ref();
         plgDispatch::MsgSend(fCallbackMsgs[i]);
 
         // No more repeats, remove this callback from our list
         if (fCallbackMsgs[i]->fRepeats == 0)
         {
-            hsRefCnt_SafeUnRef(fCallbackMsgs[i]);
+            fCallbackMsgs[i]->UnRef();
             fCallbackMsgs.erase(fCallbackMsgs.begin() + i);
         }
         // If this isn't infinite, decrement the number of repeats

--- a/Sources/Plasma/PubUtilLib/plMessage/plAvatarMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAvatarMsg.cpp
@@ -286,7 +286,7 @@ void plAvTaskSeekDoneMsg::Write(hsStream *stream, hsResMgr *mgr)
 
 // CTOR()
 plAvOneShotMsg::plAvOneShotMsg()
-: plAvSeekMsg(), fDrivable(false), fReversible(false), fCallbacks()
+: plAvSeekMsg(), fDrivable(false), fReversible(false)
 {
 }
 
@@ -295,16 +295,13 @@ plAvOneShotMsg::plAvOneShotMsg(const plKey &sender, const plKey& receiver,
                          const plKey& seekKey, float duration, bool smartSeek,
                          const ST::string &animName, bool drivable, bool reversible)
 : plAvSeekMsg(sender, receiver, seekKey, duration, smartSeek, kAlignHandle, animName),
-  fDrivable(drivable), fReversible(reversible), fCallbacks()
+  fDrivable(drivable), fReversible(reversible)
 {
 }
 
 // DTOR
 plAvOneShotMsg::~plAvOneShotMsg()
-{
-    hsRefCnt_SafeUnRef(fCallbacks);
-    fCallbacks = nullptr;
-}
+{}
 
 // READ
 void plAvOneShotMsg::Read(hsStream *stream, hsResMgr *mgr)

--- a/Sources/Plasma/PubUtilLib/plMessage/plAvatarMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plAvatarMsg.h
@@ -262,8 +262,7 @@ public:
     // public members
     bool fDrivable;               // are we animated by time or by mouse movement?
     bool fReversible;             // can we play backwards?
-    plOneShotCallbacks *fCallbacks; // Callbacks given to us by a one-shot modifier
-                                    // we share it, so release with UnRef
+    hsRef<plOneShotCallbacks> fCallbacks; // Callbacks given to us by a one-shot modifier
 };
 
 ////////////////

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.cpp
@@ -47,15 +47,20 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plInputCore/plInputInterface.h"
 
-plInputIfaceMgrMsg::~plInputIfaceMgrMsg()
+plInputIfaceMgrMsg::plInputIfaceMgrMsg(uint8_t command, uint32_t pageID)
+    : plMessage(nullptr, nullptr, nullptr),
+      fCommand(command),
+      fPageID(pageID)
 {
-    hsRefCnt_SafeUnRef(fInterface);
+    SetBCastFlag(kBCastByExactType);
 }
 
-void    plInputIfaceMgrMsg::SetIFace(plInputInterface* iface)
+plInputIfaceMgrMsg::~plInputIfaceMgrMsg()
+{}
+
+void plInputIfaceMgrMsg::SetIFace(hsRef<plInputInterface> iface)
 {
-    fInterface = iface;
-    hsRefCnt_SafeRef(fInterface);
+    fInterface = std::move(iface);
 }
 
 void plInputIfaceMgrMsg::Read(hsStream* s, hsResMgr* mgr)

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.h
@@ -87,7 +87,6 @@ class plInputIfaceMgrMsg : public plMessage
         };
 
         plInputIfaceMgrMsg() : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fInterface = nullptr; fAvKey = nullptr; }
-        plInputIfaceMgrMsg(const plKey& receiver, uint8_t command) : plMessage(nullptr, receiver, nullptr) { fCommand = command; fInterface = nullptr; fAvKey = nullptr; }
         plInputIfaceMgrMsg(uint8_t command) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fCommand = command; fInterface = nullptr; fAvKey = nullptr; }
         plInputIfaceMgrMsg(uint8_t command, uint32_t pageID) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fCommand = command; fPageID = pageID; fInterface = nullptr; fAvKey = nullptr; }
         ~plInputIfaceMgrMsg();

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.h
@@ -58,7 +58,7 @@ class plInputIfaceMgrMsg : public plMessage
     protected:
 
         uint8_t   fCommand;
-        plInputInterface    *fInterface;
+        hsRef<plInputInterface> fInterface;
         uint32_t  fPageID;
         ST::string  ageName;
         ST::string  ageFileName;
@@ -86,14 +86,7 @@ class plInputIfaceMgrMsg : public plMessage
             kSetShareAgeInstanceGuid,
         };
 
-        plInputIfaceMgrMsg(uint8_t command = 0, uint32_t pageID = 0)
-            : plMessage(nullptr, nullptr, nullptr),
-              fCommand(command),
-              fInterface(),
-              fPageID(pageID)
-        {
-            SetBCastFlag(kBCastByExactType);
-        }
+        plInputIfaceMgrMsg(uint8_t command = 0, uint32_t pageID = 0);
         ~plInputIfaceMgrMsg();
 
         CLASSNAME_REGISTER( plInputIfaceMgrMsg );
@@ -112,8 +105,8 @@ class plInputIfaceMgrMsg : public plMessage
         const plUUID&     GetAgeInstanceGuid() const { return ageInstanceGuid; }
         uint8_t           GetCommand() const { return fCommand; }
         uint32_t          GetPageID() const { return fPageID; }
-        void              SetIFace(plInputInterface *iface);
-        plInputInterface* GetIFace() const { return fInterface; }
+        void              SetIFace(hsRef<plInputInterface> iface);
+        hsWeakRef<plInputInterface> GetIFace() const { return fInterface; }
         plKey             GetAvKey() const { return fAvKey; }
         void              SetAvKey(const plKey& k ) { fAvKey = k; }
 };

--- a/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plInputIfaceMgrMsg.h
@@ -86,9 +86,14 @@ class plInputIfaceMgrMsg : public plMessage
             kSetShareAgeInstanceGuid,
         };
 
-        plInputIfaceMgrMsg() : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fInterface = nullptr; fAvKey = nullptr; }
-        plInputIfaceMgrMsg(uint8_t command) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fCommand = command; fInterface = nullptr; fAvKey = nullptr; }
-        plInputIfaceMgrMsg(uint8_t command, uint32_t pageID) : plMessage(nullptr, nullptr, nullptr) { SetBCastFlag(kBCastByExactType); fCommand = command; fPageID = pageID; fInterface = nullptr; fAvKey = nullptr; }
+        plInputIfaceMgrMsg(uint8_t command = 0, uint32_t pageID = 0)
+            : plMessage(nullptr, nullptr, nullptr),
+              fCommand(command),
+              fInterface(),
+              fPageID(pageID)
+        {
+            SetBCastFlag(kBCastByExactType);
+        }
         ~plInputIfaceMgrMsg();
 
         CLASSNAME_REGISTER( plInputIfaceMgrMsg );

--- a/Sources/Plasma/PubUtilLib/plMessage/plLinkToAgeMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plLinkToAgeMsg.cpp
@@ -288,14 +288,12 @@ void plLinkEffectsTriggerMsg::SetLinkInAnimKey(plKey &key)
 
 plLinkEffectsTriggerPrepMsg::~plLinkEffectsTriggerPrepMsg()
 {
-    if (fTrigger)
-        hsRefCnt_SafeUnRef(fTrigger);
+    hsRefCnt_SafeUnRef(fTrigger);
 }
 
 void plLinkEffectsTriggerPrepMsg::SetTrigger(plLinkEffectsTriggerMsg *msg)
 {
-    if (fTrigger)
-        hsRefCnt_SafeUnRef(fTrigger);
+    hsRefCnt_SafeUnRef(fTrigger);
     
     hsRefCnt_SafeRef(msg);
     fTrigger = msg;

--- a/Sources/Plasma/PubUtilLib/plMessage/plLoadCloneMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plLoadCloneMsg.cpp
@@ -249,8 +249,7 @@ bool plLoadCloneMsg::GetIsLoading() const
 
 void plLoadCloneMsg::SetTriggerMsg(plMessage *msg)
 {
-    if (fTriggerMsg != nullptr)
-        hsRefCnt_SafeUnRef(fTriggerMsg);
+    hsRefCnt_SafeUnRef(fTriggerMsg);
 
     hsRefCnt_SafeRef(msg);
     fTriggerMsg = msg;

--- a/Sources/Plasma/PubUtilLib/plMessage/plOneShotCallbacks.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plOneShotCallbacks.cpp
@@ -45,15 +45,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "hsResMgr.h"
 #include "hsStream.h"
 
-plOneShotCallbacks::plOneShotCallbacks()
-{
-}
-
-plOneShotCallbacks::~plOneShotCallbacks()
-{
-    fCallbacks.clear();
-}
-
 void plOneShotCallbacks::AddCallback(const ST::string &marker, plKey &receiver, int16_t user)
 {
     fCallbacks.push_back(plOneShotCallback(marker, receiver, user));

--- a/Sources/Plasma/PubUtilLib/plMessage/plOneShotCallbacks.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plOneShotCallbacks.h
@@ -77,9 +77,6 @@ protected:
     std::vector<plOneShotCallback> fCallbacks;
 
 public:
-    plOneShotCallbacks();
-    ~plOneShotCallbacks();
-
     void AddCallback(const ST::string &marker, plKey &receiver, int16_t user=0);
     int GetNumCallbacks();
     plOneShotCallback& GetCallback(int i);

--- a/Sources/Plasma/PubUtilLib/plMessage/plOneShotMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plOneShotMsg.cpp
@@ -51,7 +51,7 @@ plOneShotMsg::plOneShotMsg()
 
 plOneShotMsg::~plOneShotMsg()
 {
-    hsRefCnt_SafeUnRef(fCallbacks);
+    fCallbacks->UnRef();
     fCallbacks = nullptr;
 }
 

--- a/Sources/Plasma/PubUtilLib/plMessage/plOneShotMsg.cpp
+++ b/Sources/Plasma/PubUtilLib/plMessage/plOneShotMsg.cpp
@@ -45,15 +45,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plOneShotCallbacks.h"
 
 plOneShotMsg::plOneShotMsg()
-{
-    fCallbacks = new plOneShotCallbacks;
-}
-
-plOneShotMsg::~plOneShotMsg()
-{
-    fCallbacks->UnRef();
-    fCallbacks = nullptr;
-}
+    : fCallbacks(new plOneShotCallbacks(), hsStealRef)
+{}
 
 void plOneShotMsg::Read(hsStream* stream, hsResMgr* mgr)
 {

--- a/Sources/Plasma/PubUtilLib/plMessage/plOneShotMsg.h
+++ b/Sources/Plasma/PubUtilLib/plMessage/plOneShotMsg.h
@@ -52,10 +52,9 @@ public:
     // We can't use a plEventCallbackMsg since we don't know the actual times we
     // want to be called back at.  We need to use a string, then the plAGAnim
     // will figure out the time internally and create a plEventCallbackMsg.
-    plOneShotCallbacks *fCallbacks;
+    hsRef<plOneShotCallbacks> fCallbacks;
 
     plOneShotMsg();
-    ~plOneShotMsg();
 
     CLASSNAME_REGISTER(plOneShotMsg);
     GETINTERFACE_ANY(plOneShotMsg, plResponderMsg);

--- a/Sources/Plasma/PubUtilLib/plModifier/plAnimEventModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plAnimEventModifier.cpp
@@ -99,8 +99,7 @@ bool plAnimEventModifier::MsgReceive(plMessage* msg)
     plGenRefMsg* genRefMsg = plGenRefMsg::ConvertNoRef(msg);
     if (genRefMsg && (genRefMsg->GetContext() & plRefMsg::kOnCreate) && fCallback)
     {
-        fCallback->Ref();
-        fCallback->Send();
+        fCallback->SendAndKeep();
     }
 
     plEventCallbackMsg* callbackMsg = plEventCallbackMsg::ConvertNoRef(msg);

--- a/Sources/Plasma/PubUtilLib/plModifier/plAnimEventModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plAnimEventModifier.cpp
@@ -99,7 +99,7 @@ bool plAnimEventModifier::MsgReceive(plMessage* msg)
     plGenRefMsg* genRefMsg = plGenRefMsg::ConvertNoRef(msg);
     if (genRefMsg && (genRefMsg->GetContext() & plRefMsg::kOnCreate) && fCallback)
     {
-        hsRefCnt_SafeRef(fCallback);
+        fCallback->Ref();
         fCallback->Send();
     }
 

--- a/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
@@ -110,12 +110,11 @@ fIface(),
 fAllOrNothing()
 {
     fNotify = new plNotifyMsg;
-    fInputIface = new plAxisInputInterface( this );
+    fInputIface.Steal(new plAxisInputInterface(this));
 }
 plAxisAnimModifier::~plAxisAnimModifier()
 {
     hsRefCnt_SafeUnRef(fNotify);
-    fInputIface->UnRef();
 }
 
 

--- a/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
@@ -115,7 +115,7 @@ fAllOrNothing()
 plAxisAnimModifier::~plAxisAnimModifier()
 {
     hsRefCnt_SafeUnRef(fNotify);
-    hsRefCnt_SafeUnRef( fInputIface );
+    fInputIface->UnRef();
 }
 
 
@@ -150,7 +150,7 @@ bool plAxisAnimModifier::MsgReceive(plMessage* msg)
         fNotify->SetState(1.0f);
         fNotify->AddActivateEvent(true);
         fNotify->AddClickDragEvent(GetTarget()->GetKey(), plNetClientApp::GetInstance()->GetLocalPlayerKey(), time);
-        hsRefCnt_SafeRef(fNotify);
+        fNotify->Ref();
         plgDispatch::MsgSend( fNotify );
         return true;
     }
@@ -301,8 +301,8 @@ bool plAxisAnimModifier::MsgReceive(plMessage* msg)
                 pMsg->SetAnimName(fAnimLabel);
                 pMsg->AddReceiver( fXAnim );
 
-                hsRefCnt_SafeUnRef( pCall1 );
-                hsRefCnt_SafeUnRef( pCall2 );
+                pCall1->UnRef();
+                pCall2->UnRef();
 
                 plgDispatch::MsgSend(pMsg);
             }
@@ -329,8 +329,8 @@ bool plAxisAnimModifier::MsgReceive(plMessage* msg)
                 pMsg->AddReceiver( fYAnim );
                 pMsg->SetAnimName(fAnimLabel);
 
-                hsRefCnt_SafeUnRef( pCall1 );
-                hsRefCnt_SafeUnRef( pCall2 );
+                pCall1->UnRef();
+                pCall2->UnRef();
 
                 plgDispatch::MsgSend(pMsg);
             }

--- a/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.cpp
@@ -150,8 +150,7 @@ bool plAxisAnimModifier::MsgReceive(plMessage* msg)
         fNotify->SetState(1.0f);
         fNotify->AddActivateEvent(true);
         fNotify->AddClickDragEvent(GetTarget()->GetKey(), plNetClientApp::GetInstance()->GetLocalPlayerKey(), time);
-        fNotify->Ref();
-        plgDispatch::MsgSend( fNotify );
+        fNotify->SendAndKeep();
         return true;
     }
         

--- a/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.h
+++ b/Sources/Plasma/PubUtilLib/plModifier/plAxisAnimModifier.h
@@ -75,7 +75,7 @@ protected:
 
     ST::string      fAnimLabel;
 
-    plAxisInputInterface    *fInputIface;
+    hsRef<plAxisInputInterface> fInputIface;
 
     bool IEval(double secs, float del, uint32_t dirty) override;
 

--- a/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
@@ -375,8 +375,7 @@ bool plResponderModifier::IContinueSending()
                 }
                 else
                 {
-                    msg->Ref();
-                    plgDispatch::MsgSend(msg);
+                    msg->SendAndKeep();
                 }
             }
         }

--- a/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
+++ b/Sources/Plasma/PubUtilLib/plModifier/plResponderModifier.cpp
@@ -370,12 +370,12 @@ bool plResponderModifier::IContinueSending()
 
                 if (plTimerCallbackMsg *timerMsg = plTimerCallbackMsg::ConvertNoRef(msg))
                 {
-                    hsRefCnt_SafeRef(timerMsg);
+                    timerMsg->Ref();
                     plgTimerCallbackMgr::NewTimer(timerMsg->fTime, timerMsg);
                 }
                 else
                 {
-                    hsRefCnt_SafeRef(msg);
+                    msg->Ref();
                     plgDispatch::MsgSend(msg);
                 }
             }
@@ -470,7 +470,7 @@ void plResponderModifier::Restore()
                 for (size_t iCallback = 0; iCallback < numCallbacks; iCallback++)
                 {
                     plMessage* callback = callbackMsg->GetCallback(iCallback);
-//                  hsRefCnt_SafeRef(callback); AddCallback will ref this for us.
+                    //callback->Ref(); // AddCallback will ref this for us.
                     newCallbackMsg->AddCallback(callback);
                 }
 
@@ -519,7 +519,7 @@ plMessage* plResponderModifier::IGetFastForwardMsg(plMessage* msg, bool python)
         }
 
         ResponderLog(ILog(plStatusLog::kWhite, "FF Animation Non-Play Msg"));
-        hsRefCnt_SafeRef(msg);
+        msg->Ref();
         return msg;
     }
     else if(plSoundMsg *soundMsg = plSoundMsg::ConvertNoRef(msg))
@@ -566,31 +566,31 @@ plMessage* plResponderModifier::IGetFastForwardMsg(plMessage* msg, bool python)
             return newSoundMsg;
         }
         ResponderLog(ILog(plStatusLog::kWhite, "FF Sound Non-Play/Toggle Msg"));
-        hsRefCnt_SafeRef(msg);
+        msg->Ref();
         return msg;
     }
     else if (msg->ClassIndex() == CLASS_INDEX_SCOPED(plExcludeRegionMsg))
     {
         ResponderLog(ILog(plStatusLog::kWhite, "FF Exclude Region Msg"));
-        hsRefCnt_SafeRef(msg);
+        msg->Ref();
         return msg;
     }
     else if (msg->ClassIndex() == CLASS_INDEX_SCOPED(plEnableMsg))
     {
         ResponderLog(ILog(plStatusLog::kWhite, "FF Visibility/Detector Enable Msg"));
-        hsRefCnt_SafeRef(msg);
+        msg->Ref();
         return msg;
     }
     else if (msg->ClassIndex() == CLASS_INDEX_SCOPED(plResponderEnableMsg))
     {
         ResponderLog(ILog(plStatusLog::kWhite, "FF Responder Enable Msg"));
-        hsRefCnt_SafeRef(msg);
+        msg->Ref();
         return msg;
     }
     else if (msg->ClassIndex() == CLASS_INDEX_SCOPED(plSimSuppressMsg))
     {
         ResponderLog(ILog(plStatusLog::kWhite, "FF Physical Enable Msg"));
-        hsRefCnt_SafeRef(msg);
+        msg->Ref();
         return msg;
     }
 
@@ -730,7 +730,7 @@ void plResponderModifier::IDebugPlayMsg(plAnimCmdMsg* msg)
     eventMsg->fEvent = plEventCallbackMsg::kStop;
     msg->SetCmd(plAnimCmdMsg::kAddCallbacks);
     msg->AddCallback(eventMsg);
-    hsRefCnt_SafeUnRef(eventMsg);
+    eventMsg->UnRef();
 
     IDebugAnimBox(true);
 }

--- a/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.cpp
@@ -214,7 +214,7 @@ void plLinkEffectsMgr::ISendAllReadyCallbacks()
                 }
             }
 
-            hsRefCnt_SafeUnRef(fLinks[i]);
+            fLinks[i]->UnRef();
             fLinks.erase(fLinks.begin() + i);
 
             hsStatusMessage("Done - removing link FX msg");

--- a/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plLinkEffectsMgr.cpp
@@ -64,6 +64,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plMessage/plAvatarMsg.h"
 #include "plMessage/plLinkToAgeMsg.h"
 #include "plMessage/plLoadAgeMsg.h"
+#include "plMessage/plOneShotCallbacks.h"
 #include "plMessage/plTransitionMsg.h"
 #include "plNetTransport/plNetTransportMember.h"
 

--- a/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientRecorder.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientRecorder.cpp
@@ -141,7 +141,7 @@ bool plNetClientLoggingRecorder::IProcessRecordMsg(plNetMessage* msg, double sec
                     hasPick = true;
             }
 
-            hsRefCnt_SafeUnRef(notifyMsg);
+            notifyMsg->UnRef();
 
             if (!hasPick)
                 return false;

--- a/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientStatsRecorder.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientStatsRecorder.cpp
@@ -120,7 +120,7 @@ void plNetClientStatsRecorder::ILogMsg(plNetMessage* msg, const char* preText)
                 fLog->AddLineF("\t{}", eventName);
             }
 
-            hsRefCnt_SafeUnRef(notifyMsg);
+            notifyMsg->UnRef();
         }
     }
     else if (plNetMsgSDLState* sdlMsg = plNetMsgSDLState::ConvertNoRef(msg))

--- a/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientStreamRecorder.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClientRecorder/plNetClientStreamRecorder.cpp
@@ -188,7 +188,7 @@ plNetMessage* plNetClientStreamRecorder::GetNextMessage()
         if (IIsValidMsg(msg))
             return msg;
         else
-            hsRefCnt_SafeUnRef(msg);
+            msg->UnRef();
     }
 
     return nullptr;
@@ -252,7 +252,7 @@ bool plNetClientStreamRecorder::IIsValidMsg(plNetMessage* msg)
             if (plNetClientApp::GetInstance())
             {
                 bool isLocal = (linkMsg->GetLinkKey() == plNetClientApp::GetInstance()->GetLocalPlayerKey());
-                hsRefCnt_SafeUnRef(linkMsg);
+                linkMsg->UnRef();
 
                 if (isLocal)
                 {
@@ -267,7 +267,7 @@ bool plNetClientStreamRecorder::IIsValidMsg(plNetMessage* msg)
             if (plNetClientApp::GetInstance())
             {
                 bool isLocal = (loadAvMsg->GetCloneKey() == plNetClientApp::GetInstance()->GetLocalPlayerKey());
-                hsRefCnt_SafeUnRef(loadAvMsg);
+                loadAvMsg->UnRef();
 
                 if (isLocal)
                 {
@@ -317,7 +317,7 @@ void plNetClientStreamRecorder::ILogMsg(plNetMessage* msg, const char* preText)
                 fLog->AddLineF("\t{}", eventName);
             }
 
-            hsRefCnt_SafeUnRef(notifyMsg);
+            notifyMsg->UnRef();
         }
     }
     else if (plNetMsgSDLState* sdlMsg = plNetMsgSDLState::ConvertNoRef(msg))

--- a/Sources/Plasma/PubUtilLib/plPipeline/plCaptureRender.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plCaptureRender.cpp
@@ -169,7 +169,7 @@ bool plCaptureRender::Capture(const plKey& ack, uint16_t width, uint16_t height)
 
     // Submit
     plRenderRequestMsg* msg = new plRenderRequestMsg(ack, req);
-    hsRefCnt_SafeUnRef(req);
+    req->UnRef();
     msg->Send();
 
     return true;

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.cpp
@@ -432,8 +432,8 @@ class plDebugPrintIterator : public plRegistryPageIterator, plRegistryKeyIterato
                         char line[ 128 ];
                         memset( line, ' ', sizeof( line ) - 1 );
                         line[ 127 ] = 0;
-                        if(page->GetPageInfo().GetPage().GetSize() < startPos - 2 )
-                            memcpy( line + 2, page->GetPageInfo().GetPage().c_str(), page->GetPageInfo().GetPage().GetSize() );
+                        if(page->GetPageInfo().GetPage().size() < startPos - 2 )
+                            memcpy( line + 2, page->GetPageInfo().GetPage().c_str(), page->GetPageInfo().GetPage().size() );
                         else
                             memcpy( line + 2, page->GetPageInfo().GetPage().c_str(), startPos - 2 );
 
@@ -479,10 +479,10 @@ class plDebugPrintIterator : public plRegistryPageIterator, plRegistryKeyIterato
             if( key->ObjectIsLoaded() )
             {
                 fLoadedKeys++;
-                fLoadedSize += ((plKeyImp *)key)->GetDataLen();
+                fLoadedSize += plKeyImp::GetFromKey(key)->GetDataLen();
             }
             fTotalKeys++;
-            fTotalSize += ((plKeyImp *)key)->GetDataLen();
+            fTotalSize += plKeyImp::GetFromKey(key)->GetDataLen();
             return true;
         }
 };

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.cpp
@@ -295,7 +295,7 @@ void    plResManagerHelper::EnableDebugScreen( bool enable )
 //          msg->SetTimeStamp( hsTimer::GetSysSeconds() + kUpdateDelay );
             msg->Send( GetKey() );
 
-            fDebugInput = new plResMgrDebugInterface( this );
+            fDebugInput.Steal(new plResMgrDebugInterface(this));
             plInputIfaceMgrMsg *imsg = new plInputIfaceMgrMsg( plInputIfaceMgrMsg::kAddInterface );
             imsg->SetIFace( fDebugInput );
             imsg->Send();
@@ -313,7 +313,6 @@ void    plResManagerHelper::EnableDebugScreen( bool enable )
             imsg->SetIFace( fDebugInput );
             imsg->Send();
 
-            hsRefCnt_SafeUnRef( fDebugInput );
             fDebugInput = nullptr;
         }
     }

--- a/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plResManagerHelper.h
@@ -96,7 +96,7 @@ class plResManagerHelper : public hsKeyedObject
             kBars,
             kMaxDisplayType
         };
-        plResMgrDebugInterface  *fDebugInput;
+        hsRef<plResMgrDebugInterface> fDebugInput;
 #endif
 
         void    IUpdateDebugScreen( bool force = false );

--- a/Sources/Plasma/PubUtilLib/plSurface/plLayerAnimation.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plLayerAnimation.cpp
@@ -424,7 +424,7 @@ plLayerLinkAnimation::plLayerLinkAnimation() :
 
 plLayerLinkAnimation::~plLayerLinkAnimation() 
 { 
-    hsRefCnt_SafeUnRef(fIFaceCallback);
+    fIFaceCallback->UnRef();
 }
 
 


### PR DESCRIPTION
Replaces `hsRefCnt_Safe[Un]Ref` calls by direct calls to `Ref`/`UnRef` if it's clear from context that the pointer cannot be null - because it was already checked, or because it comes directly from `new`, or because the code path already assumes that the pointer is not null.

This fixes some false positive warnings in CLion about missing null checks - CLion takes the null check inside the "safe" macros as an indication that the pointer can indeed be null, and then warns about any other uses of the same pointer variable without an explicit null check.