### PR TITLE
Fixing Metal water shader bug

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveSet7.metal
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/WaveSet7.metal
@@ -375,7 +375,7 @@ vertex vs_WaveFixedFin7InOut vs_WaveFixedFin7(Vertex in                     [[st
     // Questionble attenuation follows
     // vector from this point to camera and normalize stashed in r5
     // Dot that with the computed normal
-    r1.x = dot(-r5, r11);
+    r1.x = dot(-r5.xyz, r11.xyz);
     r1.x = r1.x * in.color.z;
     r1.xyzw = uniforms.NumericConsts.z - r1.x;
     r1.w += uniforms.NumericConsts.z;


### PR DESCRIPTION
Fixing an error from the port to Metal. The original HLSL here used dp3.

The original code from the HLSL assembly was:
```
// Questionble attenuation follows
// vector from this point to camera and normalize stashed in r5
// Dot that with the computed normal
dp3         r1.x, -r5, r11;
```

But the Metal is dotting the entire vector, not just the first three elements.

This bug would have changed the color attenuation used for the water effects. It wasn't previously noticed during testing, so I'm not sure how big of a change this is. It did get noticed during my efforts to simplify the shaders though (one of the terms should be a float3 - but I'll get to that later.)