### PR TITLE
Fixing compilation under Xcode 13

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderTypes.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/ShaderSrc/ShaderTypes.h
@@ -165,10 +165,10 @@ struct plMetalShaderLightSource
 
 struct plMetalShaderActiveLight
 {
-    uint index;
+    unsigned int index;
     __fp16 scale;
     
-    plMetalShaderActiveLight(uint indexIn, float scaleIn)
+    plMetalShaderActiveLight(unsigned int indexIn, float scaleIn)
     {
         index = indexIn;
         scale = scaleIn;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalEnumerate.mm
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalEnumerate.mm
@@ -122,6 +122,11 @@ void plMetalEnumerate::Enumerate(std::vector<hsG3DDeviceRecord>& records, hsDisp
         }
         devRec.SetDefaultModeIndex(defaultMode - devRec.GetModes().data());
 
+        // ifdef check for Xcode 13 support
+        // Xcode 13 should not be used to generate an actual
+        // Mac client release if it does not compile the Metal 3
+        // path. But this is useful for development.
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
         if (@available(macOS 13.0, *)) {
             if ([device supportsFamily:MTLGPUFamilyMetal3]) {
                 devRec.SetG3DDeviceType(hsG3DDeviceSelector::kDevTypeMetal3);
@@ -129,6 +134,8 @@ void plMetalEnumerate::Enumerate(std::vector<hsG3DDeviceRecord>& records, hsDisp
                 records.emplace_back(devRec);
             }
         }
+#endif
+
         devRec.SetG3DDeviceType(hsG3DDeviceSelector::kDevTypeMetal2);
         devRec.SetDriverName("Metal 2");
         records.emplace_back(devRec);


### PR DESCRIPTION
Fixes #1879 

Compilation of an actual release should only be done under later versions of Xcode that can build the entire source. But this will keep Xcode 13 working for local development.

Note: I have not tested this on an Xcode 13 Mac - I'm just addressing the errors noticed in the bug. @Hoikas - would appreciate you testing this branch.