### PR TITLE
Python: Move work from __init__ to OnInit

### DIFF
--- a/Scripts/Python/Cleft.py
+++ b/Scripts/Python/Cleft.py
@@ -72,6 +72,7 @@ class Cleft(ptResponder):
         self.id = 5209
         self.version = 22
 
+    def OnInit(self):
         #var used to load in Cleft/Tomahna specific stuff based on chronicle vals
         global loadTomahna
         global loadZandi

--- a/Scripts/Python/LiveBahroCaves.py
+++ b/Scripts/Python/LiveBahroCaves.py
@@ -61,11 +61,12 @@ class LiveBahroCaves(ptResponder):
         self.id = 8810
         self.version = 1
 
+    def OnInit(self):
         ageFrom = PtGetPrevAgeName()
 
         pages = []
 
-        PtDebugPrint("LiveBahroCaves.__init__(): came from: %s" % (ageFrom))
+        PtDebugPrint("LiveBahroCaves.OnInit(): came from: %s" % (ageFrom))
         if ageFrom in BlueSpiral:
             pages += ["BlueSpiralCave"]
         elif ageFrom in Pods:
@@ -75,10 +76,10 @@ class LiveBahroCaves(ptResponder):
         elif ageFrom in Live6:
         	pages += ["POTScave"]
         else:
-            PtDebugPrint("LiveBahroCaves.__init__(): age not recognized, will page in BlueSpiralCave as default")
+            PtDebugPrint("LiveBahroCaves.OnInit(): age not recognized, will page in BlueSpiralCave as default")
             pages += ["BlueSpiralCave"]
 
-        PtDebugPrint("LiveBahroCaves.__init__(): paging in: %s" % (pages))
+        PtDebugPrint("LiveBahroCaves.OnInit(): paging in: %s" % (pages))
         PtPageInNode(pages)
 
 

--- a/Scripts/Python/city.py
+++ b/Scripts/Python/city.py
@@ -68,6 +68,7 @@ class city(ptResponder):
         self.id = 5026
         self.version = 1
 
+    def OnInit(self):
         global IsPublic
         global IsKadishGallery
 
@@ -102,8 +103,8 @@ class city(ptResponder):
             spTitle = "title unknown"
             spName = "spawn point unknown"
 
-        PtDebugPrint("city.__init__(): spTitle = ",spTitle)
-        PtDebugPrint("city.__init__(): spName = ",spName)
+        PtDebugPrint("city.OnInit(): spTitle = ",spTitle)
+        PtDebugPrint("city.OnInit(): spName = ",spName)
 
         ## NOT USING THIS FOR NOW - MAY NEED TO LOAD IN SPECIFIC PAGE(S) FOR FUTURE CITY AREAS...
 #        if spTitle == "KadishGallery":

--- a/Scripts/Python/grsnPageMaster.py
+++ b/Scripts/Python/grsnPageMaster.py
@@ -60,6 +60,7 @@ class grsnPageMaster(ptResponder):
         self.id = 50100
         self.version = 1
 
+    def OnInit(self):
         global IsPublic
 
         parentname = None
@@ -75,9 +76,9 @@ class grsnPageMaster(ptResponder):
     
         if parentname == "Neighborhood":
             IsPublic = 1
-            PtDebugPrint("grsnPageMaster.__init__(): Garrison version = public")
+            PtDebugPrint("grsnPageMaster.OnInit(): Garrison version = public")
         else:
-            PtDebugPrint("grsnPageMaster.__init__(): Garrison version = Yeesha")
+            PtDebugPrint("grsnPageMaster.OnInit(): Garrison version = Yeesha")
 
         pages = []
 


### PR DESCRIPTION
Refs #1874.

The `__init__` method is called by the PlasmaMax plugin because it needs the script ID and version values to be set. If we try to do other work there (such as loading pages) it might cause issues because the full client and all of its machinery are not necessarily available. To be safe, we move that work to `OnInit` which is called when the PythonFileMod is initialized by the client.

Some of this might be unnecessary, and I'm not sure if it's better to do all the variable assignments with default values in `__init__` or if it's fine to wait until `OnInit`, but this is a starting point at least.