### PR TITLE
Fix `PtPageInNode` crashing when called during Max plugin startup

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMisc.cpp
@@ -1323,24 +1323,21 @@ int cyMisc::GetNumRemotePlayers()
 
 static void IPageNodes(int action, const std::vector<plLocation>& nodeLocs, bool netForce)
 {
-    if (hsgResMgr::ResMgr())
-    {
-        plSynchEnabler ps(false); // disable dirty tracking while paging
-        plClientMsg* msg = new plClientMsg(action);
-        plKey clientKey = hsgResMgr::ResMgr()->FindKey(kClient_KEY);
-        msg->AddReceiver(clientKey);
+    plSynchEnabler ps(false); // disable dirty tracking while paging
+    plClientMsg* msg = new plClientMsg(action);
+    plKey clientKey = hsgResMgr::ResMgr()->FindKey(kClient_KEY);
+    msg->AddReceiver(clientKey);
 
-        if (netForce) {
-            msg->SetBCastFlag(plMessage::kNetPropagate);
-            msg->SetBCastFlag(plMessage::kNetForce);
-        }
-
-        for (const auto& nodeLoc : nodeLocs) {
-            msg->AddRoomLoc(nodeLoc);
-        }
-
-        msg->Send();
+    if (netForce) {
+        msg->SetBCastFlag(plMessage::kNetPropagate);
+        msg->SetBCastFlag(plMessage::kNetForce);
     }
+
+    for (const auto& nodeLoc : nodeLocs) {
+        msg->AddRoomLoc(nodeLoc);
+    }
+
+    msg->Send();
 }
 
 void cyMisc::PageInNodes(const std::vector<plLocation>& nodeLocs, bool netForce)

--- a/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyMiscGlue2.cpp
@@ -46,6 +46,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include <string_view>
 #include <vector>
 
+#include "hsResMgr.h"
+
 #include "plMessage/plConfirmationMsg.h"
 #include "plMessage/plLOSRequestMsg.h"
 #include "plNetClientComm/plNetClientComm.h"
@@ -323,6 +325,17 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtPageInNode, args, "Params: nodeName, netForce=
         PYTHON_RETURN_ERROR;
     }
 
+    // In the past, some age scripts called this function in their __init__,
+    // which gets called during Max plugin startup where there is no ResMgr yet.
+    // This "worked" in the past, but isn't supported anymore.
+    // We still guard against this case so that scripts that haven't been updated
+    // will only cause Python errors and not hard-crash the Max plugin on startup.
+    // See: https://github.com/H-uru/Plasma/issues/1874
+    if (hsgResMgr::ResMgr() == nullptr) {
+        PyErr_SetString(PyExc_RuntimeError, "No ResMgr present. PtPageInNode needs a ResMgr to find pages. If you are calling PtPageInNode from your Python modifier __init__, move the call into an OnInit callback to fix this error.");
+        PYTHON_RETURN_ERROR;
+    }
+
     std::vector<plLocation> nodeLocs;
     for (const auto& nodeName : nodeNames) {
         plLocation nodeLoc = plKeyFinder::Instance().FindLocation(ageName, nodeName);
@@ -344,6 +357,17 @@ PYTHON_GLOBAL_METHOD_DEFINITION(PtPageOutNode, args, "Params: nodeName, netForce
     if (!PyArg_ParseTuple(args, "O&|b", PyUnicode_STStringConverter, &nodeName, &netForce))
     {
         PyErr_SetString(PyExc_TypeError, "PtPageOutNode expects a string and bool");
+        PYTHON_RETURN_ERROR;
+    }
+
+    // In the past, some age scripts called this function in their __init__,
+    // which gets called during Max plugin startup where there is no ResMgr yet.
+    // This "worked" in the past, but isn't supported anymore.
+    // We still guard against this case so that scripts that haven't been updated
+    // will only cause Python errors and not hard-crash the Max plugin on startup.
+    // See: https://github.com/H-uru/Plasma/issues/1874
+    if (hsgResMgr::ResMgr() == nullptr) {
+        PyErr_SetString(PyExc_RuntimeError, "No ResMgr present. PtPageOutNode needs a ResMgr to find pages. If you are calling PtPageOutNode from your Python modifier __init__, move the call into an OnInit callback to fix this error.");
         PYTHON_RETURN_ERROR;
     }
 


### PR DESCRIPTION
Fixes #1874. I can't test this myself, but @Filtik told me that this fixes the crash.

As discussed in #1874, the proper solution is to not call `PtPageInNode` inside PythonFileMod `__init__` methods at all. #1881 by @dpogue changes the Python scripts accordingly. It's probably still good to have this workaround on the C++ side though - it's not very complex, and it prevents the plugin crashing for no clear reason if one of the old faulty scripts is present. (Which may well happen by accident, because Cyan's scripts have done the wrong thing for a long time with no negative effects, and some fan ages, such as TOC's City of Dimensions, have copied it not knowing any better.)