### PR TITLE
Improve xAgeSDL logic gate scripts.

### DIFF
--- a/Scripts/Python/xAgeSDLBoolAndSet.py
+++ b/Scripts/Python/xAgeSDLBoolAndSet.py
@@ -50,7 +50,7 @@ detects changes in two age sdl bools and sets a third...A and B => C
 from Plasma import *
 from PlasmaTypes import *
 
-from xAgeSDLBoolAndSetV2 import xAgeSDLBoolAndSetBase
+from xAgeSDLBoolGateSet import xAgeSDLBoolGateSetBase
 
 # ---------
 # max wiring
@@ -60,7 +60,7 @@ stringOpA = ptAttribString(1,"AgeSDL Operand 1")
 stringOpB = ptAttribString(2,"AgeSDL Operand 2")
 stringResult = ptAttribString(3,"AgeSDL Result")
 
-class xAgeSDLBoolAndSet(xAgeSDLBoolAndSetBase, ptResponder):
+class xAgeSDLBoolAndSet(xAgeSDLBoolGateSetBase, ptResponder):
     def __init__(self):
         super().__init__()
         self.id = 5041
@@ -73,3 +73,7 @@ class xAgeSDLBoolAndSet(xAgeSDLBoolAndSetBase, ptResponder):
     @property
     def outputVariable(self):
         return stringResult.value
+
+    @property
+    def logicOp(self):
+        return "AND"

--- a/Scripts/Python/xAgeSDLBoolAndSet.py
+++ b/Scripts/Python/xAgeSDLBoolAndSet.py
@@ -50,6 +50,8 @@ detects changes in two age sdl bools and sets a third...A and B => C
 from Plasma import *
 from PlasmaTypes import *
 
+from xAgeSDLBoolAndSetV2 import xAgeSDLBoolAndSetBase
+
 # ---------
 # max wiring
 # ---------
@@ -58,47 +60,16 @@ stringOpA = ptAttribString(1,"AgeSDL Operand 1")
 stringOpB = ptAttribString(2,"AgeSDL Operand 2")
 stringResult = ptAttribString(3,"AgeSDL Result")
 
-class xAgeSDLBoolAndSet(ptResponder):
-
+class xAgeSDLBoolAndSet(xAgeSDLBoolAndSetBase, ptResponder):
     def __init__(self):
-        ptResponder.__init__(self)
+        super().__init__()
         self.id = 5041
         self.version = 1
 
-    def OnFirstUpdate(self):
-        if not stringOpA.value:
-            PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnFirstUpdate():\tERROR: missing SDLOpA var name in max file")
-        if not stringOpB.value:
-            PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnFirstUpdate():\tERROR: missing SDLOpB var name in max file")
-        if not stringResult.value:
-            PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnFirstUpdate():\tERROR: missing SDLResult var name in max file")
-            
-    def OnServerInitComplete(self):
-        ageSDL = PtGetAgeSDL()
-        ageSDL.setFlags(stringResult.value,1,1)
-        ageSDL.sendToClients(stringResult.value)
-        ageSDL.setNotify(self.key,stringOpA.value,0.0)
-        ageSDL.setNotify(self.key,stringOpB.value,0.0)
-        # correct state (doesn't hurt if it's already correct)
-        try:
-            result = (ageSDL[stringOpA.value][0] and ageSDL[stringOpB.value][0])
-            ageSDL[stringResult.value] = ( result, )
-            PtDebugPrint("DEBUG: xAgeSDLBoolAndSet.OnServerInitComplete:\tset %s=%d" % (stringResult.value,result))
-        except:
-            PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnServerInitComplete:\tcan't access age sdl")
-        
-    def OnSDLNotify(self,VARname,SDLname,playerID,tag):
-        # is it a var we care about?
-        if VARname != stringOpA.value and VARname != stringOpB.value:
-            return
-        ageSDL = PtGetAgeSDL()
-        PtDebugPrint("DEBUG: xAgeSDLBoolAndSet.OnSDLNotify():\t VARname:%s, SDLname:%s, tag:%s, value:%d" % (VARname,SDLname,tag,ageSDL[VARname][0]))
+    @property
+    def inputVariables(self):
+        return [stringOpA.value, stringOpB.value]
 
-        # Set the sdl value
-        try:
-            result = (ageSDL[stringOpA.value][0] and ageSDL[stringOpB.value][0])
-            ageSDL[stringResult.value] = ( result, )
-            PtDebugPrint("DEBUG: xAgeSDLBoolAndSet.OnSDLNotify:\tset %s=%d" % (stringResult.value,result))
-        except:
-            PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnServerInitComplete:\tcan't access age sdl")
-
+    @property
+    def outputVariable(self):
+        return stringResult.value

--- a/Scripts/Python/xAgeSDLBoolAndSetV2.py
+++ b/Scripts/Python/xAgeSDLBoolAndSetV2.py
@@ -49,75 +49,15 @@ that allows specifying the input and output variables and a ``ptResponder`` `xAg
 that accepts a comma separated list of input variables and a single output variable.
 """
 
-from __future__ import annotations
-import abc
-from typing import *
-
 from Plasma import *
 from PlasmaTypes import *
 
+from xAgeSDLBoolGateSet import xAgeSDLBoolGateSetBase
+
 stringSDLVariableInput = ptAttribString(1, "AgeSDL Input Variables (comma separated)")
 stringSDLVariableOutput = ptAttribString(2, "AgeSDL Output Variable")
-boolInvertOutput = ptAttribBoolean(3, "Invert Output (NAND)", default=False)
 
-class xAgeSDLBoolAndSetBase:
-    if TYPE_CHECKING:
-        key: ptKey = ...
-        sceneobject: ptSceneobject = ...
-
-    def OnServerInitComplete(self):
-        inputVariables, outputVariable = self.inputVariables, self.outputVariable
-        if not inputVariables:
-            PtDebugPrint(f"xAgeSDLBoolAndSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Input variable list empty, bailing!")
-            return
-        if not all(inputVariables):
-            PtDebugPrint(f"xAgeSDLBoolAndSet.OnServerInitComplete(): [{self.sceneobject.getName()}] One of the input variables is empty, bailing!")
-            return
-        if len(inputVariables) == 1:
-            PtDebugPrint(f"xAgeSDLBoolAndSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Hmm... Only one input variable?", level=kWarningLevel)
-        if not outputVariable:
-            PtDebugPrint(f"xAgeSDLBoolAndSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Output variable empty, bailing!")
-            return
-
-        ageSDL = PtGetAgeSDL()
-        ageSDL.setFlags(outputVariable, True, True)
-        ageSDL.sendToClients(outputVariable)
-        for i in inputVariables:
-            ageSDL.setNotify(self.key, i, 0.0)
-
-        self.updateSDL(ageSDL)
-
-    def OnSDLNotify(self, VARname, SDLname, playerID, tag):
-        if not VARname in self.inputVariables:
-            return
-
-        ageSDL = PtGetAgeSDL()
-        PtDebugPrint(f"xAgeSDLBoolAndSet.OnSDLNotify(): {VARname} = {ageSDL[VARname][0]}", level=kDebugDumpLevel)
-        self.updateSDL(ageSDL)
-
-    def updateSDL(self, ageSDL: ptSDL) -> None:
-        result = all((ageSDL[i][0] for i in self.inputVariables))
-        if self.invert:
-            result = not result
-        PtDebugPrint(f"xAgeSDLBoolAndSet.updateSDL(): {self.outputVariable} = {result} ({self.invert=})", level=kWarningLevel)
-        ageSDL[self.outputVariable] = (result,)
-
-    @property
-    @abc.abstractmethod
-    def inputVariables(self) -> List[str]:
-        ...
-
-    @property
-    @abc.abstractmethod
-    def outputVariable(self) -> str:
-        ...
-
-    @property
-    def invert(self) -> bool:
-        return False
-
-
-class xAgeSDLBoolAndSetV2(xAgeSDLBoolAndSetBase, ptResponder):
+class xAgeSDLBoolAndSetV2(xAgeSDLBoolGateSetBase, ptResponder):
     def __init__(self):
         super().__init__()
         self.id = 1384463667
@@ -132,5 +72,5 @@ class xAgeSDLBoolAndSetV2(xAgeSDLBoolAndSetBase, ptResponder):
         return stringSDLVariableOutput.value
 
     @property
-    def invert(self):
-        return boolInvertOutput.value
+    def logicOp(self):
+        return "AND"

--- a/Scripts/Python/xAgeSDLBoolAndSetV2.py
+++ b/Scripts/Python/xAgeSDLBoolAndSetV2.py
@@ -58,6 +58,7 @@ from PlasmaTypes import *
 
 stringSDLVariableInput = ptAttribString(1, "AgeSDL Input Variables (comma separated)")
 stringSDLVariableOutput = ptAttribString(2, "AgeSDL Output Variable")
+boolInvertOutput = ptAttribBoolean(3, "Invert Output (NAND)", default=False)
 
 class xAgeSDLBoolAndSetBase:
     if TYPE_CHECKING:
@@ -96,7 +97,9 @@ class xAgeSDLBoolAndSetBase:
 
     def updateSDL(self, ageSDL: ptSDL) -> None:
         result = all((ageSDL[i][0] for i in self.inputVariables))
-        PtDebugPrint(f"xAgeSDLBoolAndSet.updateSDL(): {self.outputVariable} = {result}", level=kWarningLevel)
+        if self.invert:
+            result = not result
+        PtDebugPrint(f"xAgeSDLBoolAndSet.updateSDL(): {self.outputVariable} = {result} ({self.invert=})", level=kWarningLevel)
         ageSDL[self.outputVariable] = (result,)
 
     @property
@@ -108,6 +111,10 @@ class xAgeSDLBoolAndSetBase:
     @abc.abstractmethod
     def outputVariable(self) -> str:
         ...
+
+    @property
+    def invert(self) -> bool:
+        return False
 
 
 class xAgeSDLBoolAndSetV2(xAgeSDLBoolAndSetBase, ptResponder):
@@ -123,3 +130,7 @@ class xAgeSDLBoolAndSetV2(xAgeSDLBoolAndSetBase, ptResponder):
     @property
     def outputVariable(self):
         return stringSDLVariableOutput.value
+
+    @property
+    def invert(self):
+        return boolInvertOutput.value

--- a/Scripts/Python/xAgeSDLBoolAndSetV2.py
+++ b/Scripts/Python/xAgeSDLBoolAndSetV2.py
@@ -1,0 +1,125 @@
+# /*==LICENSE==*
+#
+# CyanWorlds.com Engine - MMOG client, server and tools
+# Copyright (C) 2011  Cyan Worlds, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU GPL version 3 section 7
+#
+# If you modify this Program, or any covered work, by linking or
+# combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+# NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+# JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+# (or a modified version of those libraries),
+# containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+# PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+# JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+# licensors of this Program grant you additional
+# permission to convey the resulting work. Corresponding Source for a
+# non-source form of such a combination shall include the source code for
+# the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+# work.
+#
+# You can contact Cyan Worlds, Inc. by email legal@cyan.com
+#  or by snail mail at:
+#       Cyan Worlds, Inc.
+#       14617 N Newport Hwy
+#       Mead, WA   99021
+#
+# *==LICENSE==*/
+
+"""
+Age SDL Boolean AND Set Module
+
+This module provides functionality to perform a boolean AND on the value of a list of SDL variables
+and set the value of another SDL variable to the result of the AND operation. Provided are an ABC
+that allows specifying the input and output variables and a ``ptResponder`` `xAgeSDLBoolAndSetV2`
+that accepts a comma separated list of input variables and a single output variable.
+"""
+
+from __future__ import annotations
+import abc
+from typing import *
+
+from Plasma import *
+from PlasmaTypes import *
+
+stringSDLVariableInput = ptAttribString(1, "AgeSDL Input Variables (comma separated)")
+stringSDLVariableOutput = ptAttribString(2, "AgeSDL Output Variable")
+
+class xAgeSDLBoolAndSetBase:
+    if TYPE_CHECKING:
+        key: ptKey = ...
+        sceneobject: ptSceneobject = ...
+
+    def OnServerInitComplete(self):
+        inputVariables, outputVariable = self.inputVariables, self.outputVariable
+        if not inputVariables:
+            PtDebugPrint(f"xAgeSDLBoolAndSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Input variable list empty, bailing!")
+            return
+        if not all(inputVariables):
+            PtDebugPrint(f"xAgeSDLBoolAndSet.OnServerInitComplete(): [{self.sceneobject.getName()}] One of the input variables is empty, bailing!")
+            return
+        if len(inputVariables) == 1:
+            PtDebugPrint(f"xAgeSDLBoolAndSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Hmm... Only one input variable?", level=kWarningLevel)
+        if not outputVariable:
+            PtDebugPrint(f"xAgeSDLBoolAndSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Output variable empty, bailing!")
+            return
+
+        ageSDL = PtGetAgeSDL()
+        ageSDL.setFlags(outputVariable, True, True)
+        ageSDL.sendToClients(outputVariable)
+        for i in inputVariables:
+            ageSDL.setNotify(self.key, i, 0.0)
+
+        self.updateSDL(ageSDL)
+
+    def OnSDLNotify(self, VARname, SDLname, playerID, tag):
+        if not VARname in self.inputVariables:
+            return
+
+        ageSDL = PtGetAgeSDL()
+        PtDebugPrint(f"xAgeSDLBoolAndSet.OnSDLNotify(): {VARname} = {ageSDL[VARname][0]}", level=kDebugDumpLevel)
+        self.updateSDL(ageSDL)
+
+    def updateSDL(self, ageSDL: ptSDL) -> None:
+        result = all((ageSDL[i][0] for i in self.inputVariables))
+        PtDebugPrint(f"xAgeSDLBoolAndSet.updateSDL(): {self.outputVariable} = {result}", level=kWarningLevel)
+        ageSDL[self.outputVariable] = (result,)
+
+    @property
+    @abc.abstractmethod
+    def inputVariables(self) -> List[str]:
+        ...
+
+    @property
+    @abc.abstractmethod
+    def outputVariable(self) -> str:
+        ...
+
+
+class xAgeSDLBoolAndSetV2(xAgeSDLBoolAndSetBase, ptResponder):
+    def __init__(self):
+        super().__init__()
+        self.id = 1384463667
+        self.version = 1
+
+    @property
+    def inputVariables(self):
+        return [i.strip() for i in stringSDLVariableInput.value.split(",")]
+
+    @property
+    def outputVariable(self):
+        return stringSDLVariableOutput.value

--- a/Scripts/Python/xAgeSDLBoolGateSet.py
+++ b/Scripts/Python/xAgeSDLBoolGateSet.py
@@ -60,9 +60,8 @@ stringSDLVariableOutput = ptAttribString(2, "AgeSDL Output Variable")
 stringLogicOp = ptAttribDropDownList(3, "Logic operation", ["AND", "OR", "NAND", "XOR"])
 
 class xAgeSDLBoolGateSetBase:
-    if TYPE_CHECKING:
-        key: ptKey = ...
-        sceneobject: ptSceneobject = ...
+    key: ptKey
+    sceneobject: ptSceneobject
 
     def OnServerInitComplete(self):
         inputVariables, outputVariable, op = self.inputVariables, self.outputVariable, self.logicOp

--- a/Scripts/Python/xAgeSDLBoolGateSet.py
+++ b/Scripts/Python/xAgeSDLBoolGateSet.py
@@ -41,13 +41,15 @@
 # *==LICENSE==*/
 
 """
-Age SDL Boolean OR Set Module
+Age SDL Boolean Gate Set Module
 
-This module accepts a comma separated list of input SDL variables. When any of them change,
-a logical OR is performed on the values, and the result is stored in the output SDL variable.
+This module provides functionality to perform a boolean logic on SDL variables when one of the
+input variables changes. The result of the operation is stored in an output variable. The currently
+supported operations are AND, OR, NAND, and XOR.
 """
 
 from __future__ import annotations
+import abc
 from typing import *
 
 from Plasma import *
@@ -55,30 +57,28 @@ from PlasmaTypes import *
 
 stringSDLVariableInput = ptAttribString(1, "AgeSDL Input Variables (comma separated)")
 stringSDLVariableOutput = ptAttribString(2, "AgeSDL Output Variable")
-boolExclusive = ptAttribBoolean(3, "eXclusive OR", default=False)
+stringLogicOp = ptAttribDropDownList(3, "Logic operation", ["AND", "OR", "NAND", "XOR"])
 
-class xAgeSDLBoolOrSet(ptResponder):
+class xAgeSDLBoolGateSetBase:
     if TYPE_CHECKING:
         key: ptKey = ...
         sceneobject: ptSceneobject = ...
 
-    def __init__(self):
-        super().__init__()
-        self.id = 1827796758
-        self.version = 1
-
     def OnServerInitComplete(self):
-        inputVariables, outputVariable = self.inputVariables, self.outputVariable
+        inputVariables, outputVariable, op = self.inputVariables, self.outputVariable, self.logicOp
         if not inputVariables:
-            PtDebugPrint(f"xAgeSDLBoolOrSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Input variable list empty, bailing!")
+            PtDebugPrint(f"{self.__class__.__name__}.OnServerInitComplete(): [{self.sceneobject.getName()}] Input variable list empty, bailing!")
             return
         if not all(inputVariables):
-            PtDebugPrint(f"xAgeSDLBoolOrSet.OnServerInitComplete(): [{self.sceneobject.getName()}] One of the input variables is empty, bailing!")
+            PtDebugPrint(f"{self.__class__.__name__}.OnServerInitComplete(): [{self.sceneobject.getName()}] One of the input variables is empty, bailing!")
             return
         if len(inputVariables) == 1:
-            PtDebugPrint(f"xAgeSDLBoolOrSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Hmm... Only one input variable?", level=kWarningLevel)
+            PtDebugPrint(f"{self.__class__.__name__}.OnServerInitComplete(): [{self.sceneobject.getName()}] Hmm... Only one input variable?", level=kWarningLevel)
         if not outputVariable:
-            PtDebugPrint(f"xAgeSDLBoolOrSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Output variable empty, bailing!")
+            PtDebugPrint(f"{self.__class__.__name__}.OnServerInitComplete(): [{self.sceneobject.getName()}] Output variable empty, bailing!")
+            return
+        if self.logicOp not in {"AND", "OR", "NAND", "XOR"}:
+            PtDebugPrint(f"{self.__class__.__name__}.OnServerInitComplete(): [{self.sceneobject.getName()}] Invalid {op=}, bailing!")
             return
 
         ageSDL = PtGetAgeSDL()
@@ -94,16 +94,44 @@ class xAgeSDLBoolOrSet(ptResponder):
             return
 
         ageSDL = PtGetAgeSDL()
-        PtDebugPrint(f"xAgeSDLBoolOrSet.OnSDLNotify(): {VARname} = {ageSDL[VARname][0]}", level=kDebugDumpLevel)
+        PtDebugPrint(f"{self.__class__.__name__}.OnSDLNotify(): {VARname} = {ageSDL[VARname][0]}", level=kDebugDumpLevel)
         self.updateSDL(ageSDL)
 
     def updateSDL(self, ageSDL: ptSDL) -> None:
-        if self.xor:
+        if self.logicOp == "AND":
+            result = all((ageSDL[i][0] for i in self.inputVariables))
+        elif self.logicOp == "NAND":
+            result = not all((ageSDL[i][0] for i in self.inputVariables))
+        elif self.logicOp == "OR":
+            result = any((ageSDL[i][0] for i in self.inputVariables))
+        elif self.logicOp == "XOR":
             result = sum((1 for i in self.inputVariables if ageSDL[i][0])) % 2 == 1
         else:
-            result = any((ageSDL[i][0] for i in self.inputVariables))
-        PtDebugPrint(f"xAgeSDLBoolOrSet.updateSDL(): {self.outputVariable} = {result} ({self.xor=})", level=kWarningLevel)
+            raise ValueError(self.logicOp)
+        PtDebugPrint(f"{self.__class__.__name__}.updateSDL(): {self.outputVariable} = {result}", level=kWarningLevel)
         ageSDL[self.outputVariable] = (result,)
+
+    @property
+    @abc.abstractmethod
+    def inputVariables(self) -> List[str]:
+        ...
+
+    @property
+    @abc.abstractmethod
+    def outputVariable(self) -> str:
+        ...
+
+    @property
+    @abc.abstractmethod
+    def logicOp(self) -> str:
+        ...
+
+
+class xAgeSDLBoolGateSet(xAgeSDLBoolGateSetBase, ptResponder):
+    def __init__(self):
+        super().__init__()
+        self.id = 1827796758
+        self.version = 1
 
     @property
     def inputVariables(self):
@@ -114,5 +142,5 @@ class xAgeSDLBoolOrSet(ptResponder):
         return stringSDLVariableOutput.value
 
     @property
-    def xor(self):
-        return boolExclusive.value
+    def logicOp(self):
+        return stringLogicOp.value

--- a/Scripts/Python/xAgeSDLBoolOrSet.py
+++ b/Scripts/Python/xAgeSDLBoolOrSet.py
@@ -1,0 +1,110 @@
+# /*==LICENSE==*
+#
+# CyanWorlds.com Engine - MMOG client, server and tools
+# Copyright (C) 2011  Cyan Worlds, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU GPL version 3 section 7
+#
+# If you modify this Program, or any covered work, by linking or
+# combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+# NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+# JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+# (or a modified version of those libraries),
+# containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+# PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+# JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+# licensors of this Program grant you additional
+# permission to convey the resulting work. Corresponding Source for a
+# non-source form of such a combination shall include the source code for
+# the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+# work.
+#
+# You can contact Cyan Worlds, Inc. by email legal@cyan.com
+#  or by snail mail at:
+#       Cyan Worlds, Inc.
+#       14617 N Newport Hwy
+#       Mead, WA   99021
+#
+# *==LICENSE==*/
+
+"""
+Age SDL Boolean OR Set Module
+
+This module accepts a comma separated list of input SDL variables. When any of them change,
+a logical OR is performed on the values, and the result is stored in the output SDL variable.
+"""
+
+from __future__ import annotations
+from typing import *
+
+from Plasma import *
+from PlasmaTypes import *
+
+stringSDLVariableInput = ptAttribString(1, "AgeSDL Input Variables (comma separated)")
+stringSDLVariableOutput = ptAttribString(2, "AgeSDL Output Variable")
+
+class xAgeSDLBoolOrSet(ptResponder):
+    if TYPE_CHECKING:
+        key: ptKey = ...
+        sceneobject: ptSceneobject = ...
+
+    def __init__(self):
+        super().__init__()
+        self.id = 1827796758
+        self.version = 1
+
+    def OnServerInitComplete(self):
+        inputVariables, outputVariable = self.inputVariables, self.outputVariable
+        if not inputVariables:
+            PtDebugPrint(f"xAgeSDLBoolOrSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Input variable list empty, bailing!")
+            return
+        if not all(inputVariables):
+            PtDebugPrint(f"xAgeSDLBoolOrSet.OnServerInitComplete(): [{self.sceneobject.getName()}] One of the input variables is empty, bailing!")
+            return
+        if len(inputVariables) == 1:
+            PtDebugPrint(f"xAgeSDLBoolOrSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Hmm... Only one input variable?", level=kWarningLevel)
+        if not outputVariable:
+            PtDebugPrint(f"xAgeSDLBoolOrSet.OnServerInitComplete(): [{self.sceneobject.getName()}] Output variable empty, bailing!")
+            return
+
+        ageSDL = PtGetAgeSDL()
+        ageSDL.setFlags(outputVariable, True, True)
+        ageSDL.sendToClients(outputVariable)
+        for i in inputVariables:
+            ageSDL.setNotify(self.key, i, 0.0)
+
+        self.updateSDL(ageSDL)
+
+    def OnSDLNotify(self, VARname, SDLname, playerID, tag):
+        if not VARname in self.inputVariables:
+            return
+
+        ageSDL = PtGetAgeSDL()
+        PtDebugPrint(f"xAgeSDLBoolOrSet.OnSDLNotify(): {VARname} = {ageSDL[VARname][0]}", level=kDebugDumpLevel)
+        self.updateSDL(ageSDL)
+
+    def updateSDL(self, ageSDL: ptSDL) -> None:
+        result = any((ageSDL[i][0] for i in self.inputVariables))
+        PtDebugPrint(f"xAgeSDLBoolOrSet.updateSDL(): {self.outputVariable} = {result}", level=kWarningLevel)
+        ageSDL[self.outputVariable] = (result,)
+
+    @property
+    def inputVariables(self):
+        return [i.strip() for i in stringSDLVariableInput.value.split(",")]
+
+    @property
+    def outputVariable(self):
+        return stringSDLVariableOutput.value

--- a/Scripts/Python/xAgeSDLBoolOrSet.py
+++ b/Scripts/Python/xAgeSDLBoolOrSet.py
@@ -55,6 +55,7 @@ from PlasmaTypes import *
 
 stringSDLVariableInput = ptAttribString(1, "AgeSDL Input Variables (comma separated)")
 stringSDLVariableOutput = ptAttribString(2, "AgeSDL Output Variable")
+boolExclusive = ptAttribBoolean(3, "eXclusive OR", default=False)
 
 class xAgeSDLBoolOrSet(ptResponder):
     if TYPE_CHECKING:
@@ -97,8 +98,11 @@ class xAgeSDLBoolOrSet(ptResponder):
         self.updateSDL(ageSDL)
 
     def updateSDL(self, ageSDL: ptSDL) -> None:
-        result = any((ageSDL[i][0] for i in self.inputVariables))
-        PtDebugPrint(f"xAgeSDLBoolOrSet.updateSDL(): {self.outputVariable} = {result}", level=kWarningLevel)
+        if self.xor:
+            result = sum((1 for i in self.inputVariables if ageSDL[i][0])) % 2 == 1
+        else:
+            result = any((ageSDL[i][0] for i in self.inputVariables))
+        PtDebugPrint(f"xAgeSDLBoolOrSet.updateSDL(): {self.outputVariable} = {result} ({self.xor=})", level=kWarningLevel)
         ageSDL[self.outputVariable] = (result,)
 
     @property
@@ -108,3 +112,7 @@ class xAgeSDLBoolOrSet(ptResponder):
     @property
     def outputVariable(self):
         return stringSDLVariableOutput.value
+
+    @property
+    def xor(self):
+        return boolExclusive.value


### PR DESCRIPTION
An Age creator recently needed a way to perform a logical AND of multiple SDL variables. The built-in `xAgeSDLBoolAndSet` only supports logical ANDs of two variables, so I built an expanded script that accepts comma separated list of SDL variables. While I was here, I've also added another script that performs a logical OR to support an SDL logic gate node in Korman.

The two scripts could probably be merged to reduce the LOC, but I think having a clear separation of concerns might be a good idea, especially for backwards porting to versions of Python that should frankly be in the grave.