### PR TITLE
Removing unused Metal code

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.cpp
@@ -64,11 +64,9 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 plMetalMaterialShaderRef::plMetalMaterialShaderRef(hsGMaterial* mat, plMetalPipeline* pipe) : fPipeline(pipe),
                                                                                               fMaterial(mat),
-                                                                                              fFragFunction(),
                                                                                               fNumPasses()
 {
     fDevice = pipe->fDevice.fMetalDevice;
-    fFragFunction = pipe->fFragFunction;
     CheckMateralRef();
 }
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalMaterialShaderRef.h
@@ -59,8 +59,6 @@ class plMetalMaterialShaderRef : public plMetalDeviceRef
 protected:
     plMetalPipeline*    fPipeline;
     hsGMaterial*        fMaterial;
-    // temporary holder for the fragment shader to use, we don't own this reference
-    MTL::Function*      fFragFunction;
 
 private:
     std::vector<uint32_t>      fPassIndices;

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -176,7 +176,6 @@ plMetalPipeline::plMetalPipeline(hsDisplayHndl display, hsWindowHndl window, con
                                                                                                                     fRenderTargetRefList(),
                                                                                                                     fMatRefList(),
                                                                                                                     fCurrentRenderPassUniforms(),
-                                                                                                                    fFragFunction(),
                                                                                                                     fVShaderRefList(),
                                                                                                                     fPShaderRefList(),
                                                                                                                     fULutTextureRef(),
@@ -834,10 +833,6 @@ void plMetalPipeline::LoadResources()
         plMetalLightRef* ref = fLightRefList;
         ref->Release();
         ref->Unlink();
-    }
-
-    if (fFragFunction == nil) {
-        FindFragFunction();
     }
 
     if (plMetalPlateManager* pm = static_cast<plMetalPlateManager*>(fPlateMgr))
@@ -2963,27 +2958,6 @@ void plMetalPipeline::IDrawClothingQuad(float x, float y, float w, float h,
 
     fDevice.CurrentRenderCommandEncoder()->setVertexBytes(ptr, sizeof(ptr), 0);
     fDevice.CurrentRenderCommandEncoder()->drawPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangleStrip, NS::UInteger(0), NS::UInteger(4));
-}
-
-void plMetalPipeline::FindFragFunction()
-{
-    MTL::Library* library = fDevice.fMetalDevice->newDefaultLibrary();
-
-    NS::Error* error = nullptr;
-
-    MTL::FunctionConstantValues* functionContents = MTL::FunctionConstantValues::alloc()->init();
-    short                        numUVs = 1;
-    functionContents->setConstantValue(&numUVs, MTL::DataTypeUShort, FunctionConstantNumUVs);
-    functionContents->setConstantValue(&numUVs, MTL::DataTypeUShort, FunctionConstantNumLayers);
-
-    MTL::Function* fragFunction = library->newFunction(
-        NS::String::string("pipelineFragmentShader", NS::ASCIIStringEncoding),
-        functionContents,
-        &error);
-    fFragFunction = fragFunction;
-
-    functionContents->release();
-    library->release();
 }
 
 /*plPipeline* plPipelineCreate::ICreateMetalPipeline(hsWindowHndl disp, hsWindowHndl hWnd, const hsG3DDeviceModeRecord* devMode)

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.h
@@ -89,10 +89,6 @@ public:
 
 class plMetalPipeline : public pl3DPipeline<plMetalDevice>
 {
-public:
-    // caching the frag function here so that the shader compiler can quickly access it
-    MTL::Function*                                         fFragFunction;
-
 protected:
     friend class plMetalDevice;
     friend class plMetalPlateManager;
@@ -177,8 +173,6 @@ private:
     plMaterialLightingDescriptor fCurrentRenderPassMaterialLighting;
     
     bool fIsFullscreen;
-
-    void FindFragFunction();
 
     void ISelectLights(const plSpan* span, plMetalMaterialShaderRef* mRef, bool proj = false);
     void ILoadLight(plLightInfo* light);


### PR DESCRIPTION
fFragFunction originates in a much older version of the engine - blame puts it all the way back to before the 2023 rebase. This isn’t used, remove. I think the plate shader code used to rely on this.