### PR TITLE
Fix #1858.

### DIFF
--- a/Sources/MaxPlugin/MaxConvert/plLayerConverter.cpp
+++ b/Sources/MaxPlugin/MaxConvert/plLayerConverter.cpp
@@ -388,8 +388,12 @@ plLayerInterface    *plLayerConverter::IConvertLayerTex( plPlasmaMAXLayer *layer
     int expHt = bitmapPB->GetInt( kBmpExportHeight );
     if( bd.maxDimension < expHt )
         bd.maxDimension = expHt;
-    int clipID = 0, w;
-    for( clipID = 0, w = bi->Width(); w > bd.maxDimension; w >>= 1, clipID++ );
+
+    int clipID = 0;
+    if (bi != nullptr) {
+        for (int w = bi->Width(); w > bd.maxDimension; w >>= 1)
+            ++clipID;
+    }
 
     // Do the UV gen (before we do texture, since it could modify the bitmapData struct)
     IProcessUVGen( layer, plasmaLayer, &bd, preserveUVOffset );


### PR DESCRIPTION
This fixes a potential access violation in the 3ds Max plugin when a layer is exported with "Use Texture" unchecked. While I was here, I cleaned up the loop to not be so cursed looking. Fixes #1858.