### PR TITLE
GitHub Actions workflow updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: Checkout Plasma
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Checkout MaxSDK
         continue-on-error: true
         if: needs.max-secrets.outputs.HAS_MACHINE_USER_TOKEN == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: H-uruMachineUser/3dsMaxSDK
           token: ${{ secrets.MACHINE_USER_REPO_READ }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install Qt
         continue-on-error: true
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.platform.qt-version }}
           arch: ${{ matrix.platform.qt-arch }}
@@ -96,7 +96,7 @@ jobs:
           cmake --build build --target INSTALL --config "${{ matrix.cfg.type }}" -j 4
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plasma-${{ matrix.platform.str }}-${{ matrix.cfg.str }}
           path: build/install
@@ -129,10 +129,10 @@ jobs:
 
     steps:
       - name: Checkout Plasma
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Checkout MaxSDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: H-uruMachineUser/3dsMaxSDK
           token: ${{ secrets.MACHINE_USER_REPO_READ }}
@@ -176,7 +176,7 @@ jobs:
           cmake --build build --target INSTALL --config Release -j 4
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plasma-${{ matrix.cfg.str }}-max-${{ matrix.cfg.sdk-version }}
           path: build/install
@@ -195,7 +195,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |
@@ -262,7 +262,7 @@ jobs:
           cmake --build build --target install -j 4
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plasma-${{ matrix.platform.str }}-${{ matrix.cfg.str }}
           path: build/install
@@ -283,7 +283,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |
@@ -347,7 +347,7 @@ jobs:
           cmake --build build --target install --config "${{ matrix.cfg.type }}" -j 2
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plasma-${{ matrix.platform.str }}-${{ matrix.cfg.str }}
           path: build/install
@@ -367,10 +367,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: plasma-${{ matrix.platform.str }}-internal-release
           path: build/install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   # HACK to enable/disable the max CI based on presence/absence of secret. See also:
   # https://github.com/actions/runner/issues/1138
   max-secrets:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Check for Max SDK
     outputs:
       HAS_MACHINE_USER_TOKEN: ${{ steps.check.outputs.MACHINE_USER_TOKEN }}

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-publishing-enabled:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       SHOULD_PUBLISH: ${{ steps.check.outputs.SHOULD_PUBLISH }}
@@ -20,7 +20,7 @@ jobs:
           PUBLISH_ENABLED: ${{ vars.ENABLE_PRERELEASE_ARTIFACT_PUBLISHING }}
 
   publish-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [check-publishing-enabled]
     if: needs.check-publishing-enabled.outputs.SHOULD_PUBLISH == 'true'
 

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - run: |
           mkdir artifacts

--- a/.github/workflows/scripts_review.yml
+++ b/.github/workflows/scripts_review.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       PLASMA_PATH: ${{ github.workspace }}
     steps:

--- a/.github/workflows/scripts_review.yml
+++ b/.github/workflows/scripts_review.yml
@@ -14,10 +14,10 @@ jobs:
       PLASMA_PATH: ${{ github.workspace }}
     steps:
       - name: Checkout Plasma
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.8'
 


### PR DESCRIPTION
Several of the steps in our GitHub Actions workflow were using older versions and printing deprecation warnings to the CI logs. This updates to the latest version of action steps, and moves short build phases onto the `ubuntu-slim` runner (which uses a lightweight Docker image rather than a full VM).