### PR TITLE
Fix broken cleft imager due to calling `PtGetAgeSDL` too early

### DIFF
--- a/Scripts/Python/GardenBugs.py
+++ b/Scripts/Python/GardenBugs.py
@@ -97,9 +97,9 @@ class GardenBugs(ptResponder):
         return 0 # no chronicle var
 
     def OnServerInitComplete(self):
-        self.ageSDL = PtGetAgeSDL()
-        self.ageSDL[raining.value]=(0,)
-            
+        ageSDL = PtGetAgeSDL()
+        ageSDL[raining.value]=(0,)
+
         avatar = 0
         try:
             avatar = PtGetLocalAvatar()
@@ -160,8 +160,8 @@ class GardenBugs(ptResponder):
             return
 
         if (id == kRainStarting):
-            self.ageSDL = PtGetAgeSDL()
-            self.ageSDL[raining.value] = (1,)
+            ageSDL = PtGetAgeSDL()
+            ageSDL[raining.value] = (1,)
             PtSetParticleOffset(0,0,100,bugEmitter.value.getKey())
             PtDebugPrint("GardenBugs.OnTimer():\tIt's rain, bug cloud gone")
             if (localInTunnel or self.bugCount == 0):
@@ -212,8 +212,8 @@ class GardenBugs(ptResponder):
 
             if (self.bugCount > 19):
                 return
-            self.ageSDL = PtGetAgeSDL()
-            rain = self.ageSDL[raining.value][0]
+            ageSDL = PtGetAgeSDL()
+            rain = ageSDL[raining.value][0]
             if (rain):
                 PtDebugPrint("gardenBugs.OnNotify()-->\tnope, it's raining")
                 return
@@ -241,8 +241,8 @@ class GardenBugs(ptResponder):
 
         if (id == rainEnd.id):
             PtDebugPrint("gardenBugs.OnNotify()-->\train stopping")
-            self.ageSDL = PtGetAgeSDL()
-            self.ageSDL[raining.value] = (0,)
+            ageSDL = PtGetAgeSDL()
+            ageSDL[raining.value] = (0,)
             PtSetParticleOffset(0,0,4,bugEmitter.value.getKey())
         
         if (id == bharoCave.id and self.bugCount > 0):
@@ -265,8 +265,8 @@ class GardenBugs(ptResponder):
                 elif event[0]==1 and event[1]==0:
                     localInTunnel = False
                     PtDebugPrint("gardenBugs.OnNotify()-->\tlocal exit tunnel")
-                    self.ageSDL = PtGetAgeSDL()
-                    rain = self.ageSDL[raining.value][0]
+                    ageSDL = PtGetAgeSDL()
+                    rain = ageSDL[raining.value][0]
                     if (rain):
                         PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                         PtKillParticles(3.0,1,avatar.getKey())
@@ -294,8 +294,8 @@ class GardenBugs(ptResponder):
             PtKillParticles(0,1,local.getKey())
             
             local.avatar.unRegisterForBehaviorNotify(self.key)       
-            self.ageSDL = PtGetAgeSDL()
-            self.ageSDL[raining.value] = (0,)
+            ageSDL = PtGetAgeSDL()
+            ageSDL[raining.value] = (0,)
 
     def OnBehaviorNotify(self,behavior,id,state):
         global currentBehavior

--- a/Scripts/Python/GiraCave1.py
+++ b/Scripts/Python/GiraCave1.py
@@ -65,9 +65,9 @@ class GiraCave1(ptResponder):
 
     def OnServerInitComplete(self):
         if sdlSolved.value:
-            self.ageSDL = PtGetAgeSDL()
-            self.ageSDL.setFlags(sdlSolved.value,1,1)
-            self.ageSDL.sendToClients(sdlSolved.value)
+            ageSDL = PtGetAgeSDL()
+            ageSDL.setFlags(sdlSolved.value,1,1)
+            ageSDL.sendToClients(sdlSolved.value)
         else:
             PtDebugPrint("GiraCave.OnFirstUpdate():\tERROR: missing SDL var in max file")
         
@@ -79,7 +79,8 @@ class GiraCave1(ptResponder):
                 avatar = PtFindAvatar(events)
                 bugs = PtGetNumParticles(avatar.getKey())
                 if (bugs > 0):
-                    self.ageSDL[sdlSolved.value] = (1,)
+                    ageSDL = PtGetAgeSDL()
+                    ageSDL[sdlSolved.value] = (1,)
                     return
             
     

--- a/Scripts/Python/GiraDoor.py
+++ b/Scripts/Python/GiraDoor.py
@@ -65,18 +65,18 @@ class GiraDoor(ptResponder):
     
 
     def OnServerInitComplete(self):
-        self.ageSDL = PtGetAgeSDL()
-            
-        self.ageSDL.setFlags("giraDoorOpen",1,1)
-        self.ageSDL.sendToClients("giraDoorOpen")
+        ageSDL = PtGetAgeSDL()
+
+        ageSDL.setFlags("giraDoorOpen",1,1)
+        ageSDL.sendToClients("giraDoorOpen")
 
         # register for notification of locked SDL var changes
-        self.ageSDL.setNotify(self.key,"giraDoorOpen",0.0)
+        ageSDL.setNotify(self.key,"giraDoorOpen",0.0)
         
         # get initial SDL state
         doorClosed = True
         try:
-            doorOpen = self.ageSDL["giraDoorOpen"][0]
+            doorOpen = ageSDL["giraDoorOpen"][0]
         except:
             doorOpen = True
         
@@ -88,15 +88,15 @@ class GiraDoor(ptResponder):
             
     #def OnSDLNotify(self,VARname,SDLname,playerID,tag):
     def OnNotify(self, state, id, events):
-        self.ageSDL = PtGetAgeSDL()
         if id == doorAct.id and state:
-            doorOpen = self.ageSDL["giraDoorOpen"][0]
+            ageSDL = PtGetAgeSDL()
+            doorOpen = ageSDL["giraDoorOpen"][0]
             if (doorOpen):
-                self.ageSDL["giraDoorOpen"] = (0,)
+                ageSDL["giraDoorOpen"] = (0,)
                 doorAct.disable()
                 doorResp.run(self.key,state = 'Close',avatar = PtFindAvatar(events))
             else:
-                self.ageSDL["giraDoorOpen"] = (1,)
+                ageSDL["giraDoorOpen"] = (1,)
                 doorAct.disable()
                 doorResp.run(self.key,state = 'Open',avatar = PtFindAvatar(events))
         elif id == doorResp.id:

--- a/Scripts/Python/clftImager.py
+++ b/Scripts/Python/clftImager.py
@@ -148,14 +148,6 @@ class clftImager(ptResponder):
         self.version = 29
         random.seed()
 
-
-    def OnFirstUpdate(self):
-        #self.ageSDL = PtGetAgeSDL()
-        #self.ageSDL.setFlags(stringSDLVarPanelE.value,1,1)
-        #self.ageSDL.sendToClients(stringSDLVarPanelE.value)
-        pass
-        
-    
     def OnServerInitComplete(self):
         global statesN
         global statesS
@@ -169,49 +161,49 @@ class clftImager(ptResponder):
         # makes sure Tomahna book is disabled and invisible when linking in to age
         respBookAnim.run(self.key)
         #TomahnaBookDisable.run(self.key,avatar=PtGetLocalAvatar())
-        
-        self.ageSDL = PtGetAgeSDL()
+
+        ageSDL = PtGetAgeSDL()
         # register for notification of locked SDL var changes
-        self.ageSDL.setNotify(self.key,stringSDLVarLocked.value,0.0)
+        ageSDL.setNotify(self.key,stringSDLVarLocked.value,0.0)
         # register for notification of 4 Imager Panels SDL var changes
-        self.ageSDL.setNotify(self.key,stringSDLVarPanelN.value,0.0)
-        self.ageSDL.setNotify(self.key,stringSDLVarPanelS.value,0.0)
-        self.ageSDL.setNotify(self.key,stringSDLVarPanelE.value,0.0)
-        self.ageSDL.setNotify(self.key,stringSDLVarPanelW.value,0.0)
-                
+        ageSDL.setNotify(self.key,stringSDLVarPanelN.value,0.0)
+        ageSDL.setNotify(self.key,stringSDLVarPanelS.value,0.0)
+        ageSDL.setNotify(self.key,stringSDLVarPanelE.value,0.0)
+        ageSDL.setNotify(self.key,stringSDLVarPanelW.value,0.0)
+
         # gets SDL values of 4 Imager panels, uses this value to retrieve correct state from 4 state lists,
         # and runs the corresponding responder to set initial default state for each state panel
         try:
-            intPanelN = self.ageSDL[stringSDLVarPanelN.value][0]            
+            intPanelN = ageSDL[stringSDLVarPanelN.value][0]            
         except:
             intPanelN = 3
             PtDebugPrint("ERROR:  clftImager.OnServerInitComplete():\tERROR: age sdl read failed, defaulting intPanelN = 3")                                
         panelN = statesN[intPanelN]
         imagerRespN.run(self.key,state="%s" % (panelN))
         try:
-            intPanelS = self.ageSDL[stringSDLVarPanelS.value][0]            
+            intPanelS = ageSDL[stringSDLVarPanelS.value][0]            
         except:
             intPanelS = 5
             PtDebugPrint("ERROR:  clftImager.OnServerInitComplete():\tERROR: age sdl read failed, defaulting intPanelS = 5")                                
         panelS = statesS[intPanelS]
         imagerRespS.run(self.key,state="%s" % (panelS))
         try:
-            intPanelE = self.ageSDL[stringSDLVarPanelE.value][0]            
+            intPanelE = ageSDL[stringSDLVarPanelE.value][0]            
         except:
             intPanelE = 3
             PtDebugPrint("ERROR:  clftImager.OnServerInitComplete():\tERROR: age sdl read failed, defaulting intPanelE = 3")                                
         panelE = statesE[intPanelE]
         imagerRespE.run(self.key,state="%s" % (panelE))
         try:
-            intPanelW = self.ageSDL[stringSDLVarPanelW.value][0]            
+            intPanelW = ageSDL[stringSDLVarPanelW.value][0]            
         except:
             intPanelW = 0
             PtDebugPrint("ERROR:  clftImager.OnServerInitComplete():\tERROR: age sdl read failed, defaulting intPanelW = 0")                                
         panelW = statesW[intPanelW]
         imagerRespW.run(self.key,state="%s" % (panelW))
 
-        boolSceneYeesha = self.ageSDL[SDLVarSceneYeesha][0]
-        boolTomahnaActive = self.ageSDL[SDLVarTomahnaActive][0]
+        boolSceneYeesha = ageSDL[SDLVarSceneYeesha][0]
+        boolTomahnaActive = ageSDL[SDLVarTomahnaActive][0]
 
         if boolTomahnaActive:
             PtDebugPrint("clftImager.OnServerInitComplete: SDL says Tomahna is active, will set Imager to break...")
@@ -261,11 +253,11 @@ class clftImager(ptResponder):
         global statesE
         global statesW
         global speechKilled
-        
-        self.ageSDL = PtGetAgeSDL()
-            
+
+        ageSDL = PtGetAgeSDL()
+
         if VARname == stringSDLVarLocked.value:
-            windmillLocked = self.ageSDL[stringSDLVarLocked.value][0]
+            windmillLocked = ageSDL[stringSDLVarLocked.value][0]
             if windmillLocked and visionplaying:
                 PtAtTimeCallback(self.key,3,kLostPowerID)
                 #~ speechKilled = 1
@@ -279,26 +271,26 @@ class clftImager(ptResponder):
         # checks if one of the Imager panel/symbol SDL vars has changed, 
         # sets new state of any changed panels and runs corresponding responder
         if VARname == stringSDLVarPanelN.value:
-            intPanelN = self.ageSDL[stringSDLVarPanelN.value][0]
+            intPanelN = ageSDL[stringSDLVarPanelN.value][0]
             panelN = statesN[intPanelN]
             imagerRespN.run(self.key,state="%s" % (panelN))
         if VARname == stringSDLVarPanelS.value:
-            intPanelS = self.ageSDL[stringSDLVarPanelS.value][0]
+            intPanelS = ageSDL[stringSDLVarPanelS.value][0]
             panelS = statesS[intPanelS]
             imagerRespS.run(self.key,state="%s" % (panelS))
         if VARname == stringSDLVarPanelE.value:
-            intPanelE = self.ageSDL[stringSDLVarPanelE.value][0]
+            intPanelE = ageSDL[stringSDLVarPanelE.value][0]
             panelE = statesE[intPanelE]
             imagerRespE.run(self.key,state="%s" % (panelE))
         if VARname == stringSDLVarPanelW.value:
-            intPanelW = self.ageSDL[stringSDLVarPanelW.value][0]
+            intPanelW = ageSDL[stringSDLVarPanelW.value][0]
             panelW = statesW[intPanelW]
             imagerRespW.run(self.key,state="%s" % (panelW))
 
-        intPanelN = self.ageSDL[stringSDLVarPanelN.value][0]
-        intPanelS = self.ageSDL[stringSDLVarPanelS.value][0]
-        intPanelE = self.ageSDL[stringSDLVarPanelE.value][0]
-        intPanelW = self.ageSDL[stringSDLVarPanelW.value][0]
+        intPanelN = ageSDL[stringSDLVarPanelN.value][0]
+        intPanelS = ageSDL[stringSDLVarPanelS.value][0]
+        intPanelE = ageSDL[stringSDLVarPanelE.value][0]
+        intPanelW = ageSDL[stringSDLVarPanelW.value][0]
         if intPanelN == 0 and intPanelS == 0 and intPanelW == 0 and intPanelE == 0:
             import xSndLogTracks
             if xSndLogTracks.LogTrack("421","15"):
@@ -461,7 +453,8 @@ class clftImager(ptResponder):
             PtEnableForwardMovement()
             if StartInRelto():
                 PtSendKIMessage(kEnableEntireYeeshaBook,0)
-            windmillRunning = self.ageSDL[stringSDLVarRunning.value][0]
+            ageSDL = PtGetAgeSDL()
+            windmillRunning = ageSDL[stringSDLVarRunning.value][0]
             if windmillRunning == 1 and imagerBusted == 0:
                 PtDebugPrint("clftImager.OnNotify: SDL says windmill is running, so button will do SOMETHING after oneshot...")
                 for event in events:
@@ -520,23 +513,23 @@ class clftImager(ptResponder):
 
         if (id == YeeshaSceneTimerDoorClose.id and state and PlayScene == 1):
             PtDebugPrint("clftImager.OnNotify(): Yeesha's leaving, now shutting Office Door")
-            self.ageSDL = PtGetAgeSDL()
+            ageSDL = PtGetAgeSDL()
             SDLVarOfficeDoor = "clftOfficeDoorClosed"
             xtraInfo = "fromOutside"
-            boolOfficeDoor = self.ageSDL[SDLVarOfficeDoor][0]
+            boolOfficeDoor = ageSDL[SDLVarOfficeDoor][0]
             if boolOfficeDoor == 0:
-                self.ageSDL.setTagString(SDLVarOfficeDoor,xtraInfo)
-                self.ageSDL[SDLVarOfficeDoor] = (1,)
+                ageSDL.setTagString(SDLVarOfficeDoor,xtraInfo)
+                ageSDL[SDLVarOfficeDoor] = (1,)
             else:
                 PtDebugPrint("what's wrong with the door?")
 
         if (id == YeeshaSceneTimerDone.id and state and PlayScene == 1):
             PtDebugPrint("clftImager.OnNotify(): Yeesha timer is done.  Getting rid of Yeesha and setting SDL.")
-            self.ageSDL = PtGetAgeSDL()
+            ageSDL = PtGetAgeSDL()
             YeeshaName.draw.disable()
             YeeshaName.physics.warpObj(YeeshaWarpHid.value.getKey())
             YeeshaMultiStage.gotoStage(YeeshaName, 0,dirFlag=1,isForward=1)
-            self.ageSDL[SDLVarSceneYeesha] = (0,)
+            ageSDL[SDLVarSceneYeesha] = (0,)
             PlayScene == 0
             cam = ptCamera()
             cam.enableFirstPersonOverride()

--- a/Scripts/Python/clftImager.py
+++ b/Scripts/Python/clftImager.py
@@ -358,8 +358,6 @@ class clftImager(ptResponder):
         global PlayScene
         global PlayTPOT
 
-        self.ageSDL = PtGetAgeSDL()
-
         if (id == MakeMeVisible.id and state):
             if (PtFirstPerson()):
                 return

--- a/Scripts/Python/clftWindmill.py
+++ b/Scripts/Python/clftWindmill.py
@@ -97,18 +97,18 @@ class clftWindmill(ptResponder):
         global windmillRunning
         global windmillUnstuck
         global boolTomahnaActive
-        
+
+        ageSDL = PtGetAgeSDL()
+
         if stringSDLVarLocked.value:
-            self.ageSDL = PtGetAgeSDL()
-            self.ageSDL.setFlags(stringSDLVarLocked.value,1,1)
-            self.ageSDL.sendToClients(stringSDLVarLocked.value)
+            ageSDL.setFlags(stringSDLVarLocked.value,1,1)
+            ageSDL.sendToClients(stringSDLVarLocked.value)
         else:
             PtDebugPrint("clftWindmill.OnFirstUpdate():\tERROR: missing SDL var locked in max file")
 
         if stringSDLVarRunning.value:
-            self.ageSDL = PtGetAgeSDL()
-            self.ageSDL.setFlags(stringSDLVarRunning.value,1,1)
-            self.ageSDL.sendToClients(stringSDLVarRunning.value)
+            ageSDL.setFlags(stringSDLVarRunning.value,1,1)
+            ageSDL.sendToClients(stringSDLVarRunning.value)
         else:
             PtDebugPrint("clftWindmill.OnFirstUpdate():\tERROR: missing SDL var running in max file")
 
@@ -116,25 +116,23 @@ class clftWindmill(ptResponder):
         respImagerButtonLight.run(self.key,state='Off')
 
         if stringSDLVarUnstuck.value:
-            self.ageSDL = PtGetAgeSDL()
-            self.ageSDL.setFlags(stringSDLVarUnstuck.value,1,1)
-            self.ageSDL.sendToClients(stringSDLVarUnstuck.value)
+            ageSDL.setFlags(stringSDLVarUnstuck.value,1,1)
+            ageSDL.sendToClients(stringSDLVarUnstuck.value)
         else:
             PtDebugPrint("clftWindmill.OnFirstUpdate():\tERROR: missing SDL var unstuck in max file")
         
         #self.ResetImager()
-        self.ageSDL = PtGetAgeSDL()
-        
+
         # register for notification of locked SDL var changes
-        self.ageSDL.setNotify(self.key,stringSDLVarLocked.value,0.0)
-        
+        ageSDL.setNotify(self.key,stringSDLVarLocked.value,0.0)
+
         SDLVarTomahnaActive = "clftTomahnaActive"
-        boolTomahnaActive = self.ageSDL[SDLVarTomahnaActive][0]
+        boolTomahnaActive = ageSDL[SDLVarTomahnaActive][0]
 
         # get initial SDL state
         windmillLocked = 1
         try:
-            windmillLocked = self.ageSDL[stringSDLVarLocked.value][0]
+            windmillLocked = ageSDL[stringSDLVarLocked.value][0]
         except:
             windmillLocked = 1
             PtDebugPrint("ERROR: clftWindmill.OnServerInitComplete():\tERROR: age sdl read failed, defaulting windmill locked")
@@ -144,12 +142,12 @@ class clftWindmill(ptResponder):
             respBrakeOnAtStart.run(self.key)
 
         # register for notification of running SDL var changes
-        self.ageSDL.setNotify(self.key,stringSDLVarRunning.value,0.0)
+        ageSDL.setNotify(self.key,stringSDLVarRunning.value,0.0)
 
         # get initial SDL state
         windmillRunning = 0
         try:
-            windmillRunning = self.ageSDL[stringSDLVarRunning.value][0]
+            windmillRunning = ageSDL[stringSDLVarRunning.value][0]
         except:
             windmillRunning = 0
             PtDebugPrint("ERROR: clftWindmill.OnServerInitComplete():\tERROR: age sdl read failed, defaulting windmill stopped")
@@ -163,12 +161,12 @@ class clftWindmill(ptResponder):
 
 
         # register for notification of running SDL var changes
-        self.ageSDL.setNotify(self.key,stringSDLVarUnstuck.value,0.0)
+        ageSDL.setNotify(self.key,stringSDLVarUnstuck.value,0.0)
         
         # get initial SDL state
         windmillUnstuck = 0
         try:
-            windmillUnstuck = self.ageSDL[stringSDLVarUnstuck.value][0]
+            windmillUnstuck = ageSDL[stringSDLVarUnstuck.value][0]
         except:
             windmillUnstuck = 0
             PtDebugPrint("ERROR: clftWindmill.OnServerInitComplete():\tERROR: age sdl read failed, defaulting windmill stuck")
@@ -181,8 +179,8 @@ class clftWindmill(ptResponder):
         global boolTomahnaActive
         global stopGrinder
 
-        self.ageSDL = PtGetAgeSDL()
-        
+        ageSDL = PtGetAgeSDL()
+
         #Avatar bugfix
         if playerID == 0:
             player = None
@@ -191,7 +189,7 @@ class clftWindmill(ptResponder):
             player = key.getSceneObject()
         
         if VARname == stringSDLVarLocked.value:
-            windmillLocked = self.ageSDL[stringSDLVarLocked.value][0]
+            windmillLocked = ageSDL[stringSDLVarLocked.value][0]
             PtDebugPrint("clftWindmill.OnSDLNotify():\t windmill locked ", windmillLocked)
             if windmillLocked ==1 and windmillRunning == 0:
                 respBrakeOn.run(self.key,avatar=player)
@@ -203,14 +201,14 @@ class clftWindmill(ptResponder):
                 #respLightsOnOff.run(self.key,state='Off',avatar=PtGetLocalAvatar())
                 #respImagerButtonLight.run(self.key,state='Off',avatar=PtGetLocalAvatar())
                 #windmillRunning = 0
-                #self.ageSDL[stringSDLVarRunning.value] = (windmillRunning,)
+                #ageSDL[stringSDLVarRunning.value] = (windmillRunning,)
             elif windmillLocked == 0 and windmillUnstuck == 1:
                 respBrakeOff.run(self.key,avatar=player)
                 PtDebugPrint("clftWindmill.OnSDLNotify: Locked is 0 and windmillUnstuck is 1, run StartAtLoad.")
                 #respStartAtLoad.run(self.key,avatar=PtGetLocalAvatar())
                 #respLightsOnOff.run(self.key,state='On',avatar=PtGetLocalAvatar())
                 windmillRunning = 1
-                #self.ageSDL[stringSDLVarRunning.value] = (windmillRunning,)
+                #ageSDL[stringSDLVarRunning.value] = (windmillRunning,)
                 #if boolTomahnaActive == 0:
                     #respImagerButtonLight.run(self.key,state='On',avatar=PtGetLocalAvatar())
             elif windmillLocked == 0 and windmillUnstuck == 0:
@@ -224,37 +222,38 @@ class clftWindmill(ptResponder):
         global boolTomahnaActive
         global stopGrinder
 
-        self.ageSDL = PtGetAgeSDL()
-
         if (id == clickLockStart.id and state):
             if windmillLocked == 0:
+                ageSDL = PtGetAgeSDL()
                 respStart.run(self.key,state='Start',avatar=PtFindAvatar(events))
                 respLightsOnOff.run(self.key,state='On',avatar=PtFindAvatar(events))
                 respGrinderOn.run(self.key)
                 if boolTomahnaActive == 0:
                     respImagerButtonLight.run(self.key,state='On',avatar=PtFindAvatar(events))
                 windmillRunning = 1
-                self.ageSDL[stringSDLVarRunning.value] = (windmillRunning,)
+                ageSDL[stringSDLVarRunning.value] = (windmillRunning,)
                 windmillUnstuck = 1
-                self.ageSDL[stringSDLVarUnstuck.value] = (windmillUnstuck,)
+                ageSDL[stringSDLVarUnstuck.value] = (windmillUnstuck,)
             elif windmillLocked == 1:
                 respLockedCCW.run(self.key,avatar=PtFindAvatar(events))
 
         if (id == respBrakeOn.id):
             if stopGrinder:
+                ageSDL = PtGetAgeSDL()
                 respGrinderOff.run(self.key)
                 stopGrinder = 0
                 respStop.run(self.key,state='Stop',avatar=PtFindAvatar(events))
                 respLightsOnOff.run(self.key,state='Off',avatar=PtFindAvatar(events))
                 respImagerButtonLight.run(self.key,state='Off',avatar=PtFindAvatar(events))
                 windmillRunning = 0
-                self.ageSDL[stringSDLVarRunning.value] = (windmillRunning,)
+                ageSDL[stringSDLVarRunning.value] = (windmillRunning,)
 
         if (id == respBrakeOff.id):
             if windmillRunning == 1:
+                ageSDL = PtGetAgeSDL()
                 respGrinderOn.run(self.key)
                 respStartAtLoad.run(self.key,avatar=PtFindAvatar(events))
                 respLightsOnOff.run(self.key,state='On',avatar=PtFindAvatar(events))
-                self.ageSDL[stringSDLVarRunning.value] = (windmillRunning,)
+                ageSDL[stringSDLVarRunning.value] = (windmillRunning,)
                 if boolTomahnaActive == 0:
                     respImagerButtonLight.run(self.key,state='On',avatar=PtFindAvatar(events))

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonSDLModifier.cpp
@@ -44,7 +44,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <optional>
 
-#include "pnNetCommon/plNetApp.h"
 #include "pnSceneObject/plSceneObject.h"
 
 #include "plAgeDescription/plAgeDescription.h"
@@ -547,9 +546,7 @@ PyObject* pySDLModifier::GetAgeSDL()
         return pySDLModifier::New(ageSDL);
 
     // didn't find one, throw an exception for the python programmer to chew on
-    ST::string err = ST::format("Age Global SDL for {} does not exist!", ageName);
-    plNetClientApp::StaticErrorMsg(err);
-    PyErr_SetString(PyExc_KeyError, err.c_str());
+    PyErr_SetString(PyExc_KeyError, ST::format("Age Global SDL for {} does not exist!", ageName).c_str());
     PYTHON_RETURN_ERROR;
 }
 


### PR DESCRIPTION
See #1896. This only fixes the specific issue for the cleft imager, not the general problem that may affect other scripts too.

The actual fix is the oneliner commit 9dcc4b2ed101b87caf01e8a9f51ee64c1a56b311 in the middle. The commit before it fixes a double log message, and the commits after it clean up clftImager.py's strange pattern of storing the age SDL object as an attribute (which was also repeated in some other scripts).