### PR TITLE
Fix Metal alpha blends

### DIFF
--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipelineState.cpp
@@ -165,12 +165,13 @@ void plMetalRenderSpanPipelineState::ConfigureVertexDescriptor(MTL::VertexDescri
 
 void plMetalRenderSpanPipelineState::ConfigureBlendMode(const uint32_t blendMode, MTL::RenderPipelineColorAttachmentDescriptor* descriptor)
 {
+    descriptor->setAlphaBlendOperation(MTL::BlendOperationAdd);
+    descriptor->setSourceAlphaBlendFactor(MTL::BlendFactorZero);
+    descriptor->setDestinationAlphaBlendFactor(MTL::BlendFactorOne);
     if (blendMode & hsGMatState::kBlendNoColor) {
         // printf("glBlendFunc(GL_ZERO, GL_ONE);\n");
         descriptor->setSourceRGBBlendFactor(MTL::BlendFactorZero);
-        descriptor->setSourceAlphaBlendFactor(MTL::BlendFactorZero);
         descriptor->setDestinationRGBBlendFactor(MTL::BlendFactorOne);
-        descriptor->setDestinationAlphaBlendFactor(MTL::BlendFactorOne);
         return;
     }
     switch (blendMode & hsGMatState::kBlendMask) {
@@ -199,14 +200,10 @@ void plMetalRenderSpanPipelineState::ConfigureBlendMode(const uint32_t blendMode
         case hsGMatState::kBlendMult:
             if (blendMode & hsGMatState::kBlendInvertFinalColor) {
                 descriptor->setSourceRGBBlendFactor(MTL::BlendFactorZero);
-                descriptor->setSourceAlphaBlendFactor(MTL::BlendFactorZero);
                 descriptor->setDestinationRGBBlendFactor(MTL::BlendFactorOneMinusSourceColor);
-                descriptor->setDestinationAlphaBlendFactor(MTL::BlendFactorOneMinusSourceColor);
             } else {
                 descriptor->setSourceRGBBlendFactor(MTL::BlendFactorZero);
-                descriptor->setSourceAlphaBlendFactor(MTL::BlendFactorZero);
                 descriptor->setDestinationRGBBlendFactor(MTL::BlendFactorSourceColor);
-                descriptor->setDestinationAlphaBlendFactor(MTL::BlendFactorSourceColor);
             }
             break;
 
@@ -227,25 +224,18 @@ void plMetalRenderSpanPipelineState::ConfigureBlendMode(const uint32_t blendMode
         case hsGMatState::kBlendAddColorTimesAlpha:
             if (blendMode & hsGMatState::kBlendInvertFinalAlpha) {
                 descriptor->setSourceRGBBlendFactor(MTL::BlendFactorOneMinusSourceAlpha);
-                descriptor->setSourceAlphaBlendFactor(MTL::BlendFactorOneMinusSourceAlpha);
                 descriptor->setDestinationRGBBlendFactor(MTL::BlendFactorOne);
-                descriptor->setDestinationAlphaBlendFactor(MTL::BlendFactorOne);
             } else {
                 descriptor->setSourceRGBBlendFactor(MTL::BlendFactorSourceAlpha);
-                descriptor->setSourceAlphaBlendFactor(MTL::BlendFactorSourceAlpha);
                 descriptor->setDestinationRGBBlendFactor(MTL::BlendFactorOne);
-                descriptor->setDestinationAlphaBlendFactor(MTL::BlendFactorOne);
             }
             break;
 
         // Overwrite final color onto FB
         case 0:
             descriptor->setRgbBlendOperation(MTL::BlendOperationAdd);
-            descriptor->setAlphaBlendOperation(MTL::BlendOperationAdd);
             descriptor->setSourceRGBBlendFactor(MTL::BlendFactorOne);
             descriptor->setDestinationRGBBlendFactor(MTL::BlendFactorZero);
-            descriptor->setSourceAlphaBlendFactor(MTL::BlendFactorOne);
-            descriptor->setDestinationAlphaBlendFactor(MTL::BlendFactorZero);
             break;
 
         default: {
@@ -353,7 +343,7 @@ void plMetalRenderShadowPipelineState::ConfigureBlend(MTL::RenderPipelineColorAt
     descriptor->setSourceRGBBlendFactor(MTL::BlendFactorZero);
     descriptor->setSourceAlphaBlendFactor(MTL::BlendFactorOne);
     descriptor->setDestinationRGBBlendFactor(MTL::BlendFactorOneMinusSourceColor);
-    descriptor->setDestinationAlphaBlendFactor(MTL::BlendFactorZero);
+    descriptor->setDestinationAlphaBlendFactor(MTL::BlendFactorOne);
 }
 
 const MTL::Function* plMetalRenderShadowCasterPipelineState::GetVertexFunction(MTL::Library* library)


### PR DESCRIPTION
This bug was exposed by the Descent preview. It was causing the reflection frame buffer to store incorrect alpha values. The blending operation code is some of the earliest code in the Metal renderer - I don't think I understood the D3D modes when I wrote it. Fixing with the benefit of knowing more.

D3D doesn’t blend the alpha channel at all - it only does RGB blend. Set the alpha blend to preserve the state of the alpha channel.