### PR TITLE
CI builds for arm64 Windows/Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       matrix:
         platform:
           - { generator: Visual Studio 17 2022, max-version: 7, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2, runner: "windows-2022", str: windows-x86 }
-          - { generator: Visual Studio 18 2026, max-version: 2022, arch: x64, qt-arch: win64_msvc2022_64, qt-version: 6.9.1, runner: "windows-2025-vs2026", str: windows-x64 }
-          - { generator: Visual Studio 18 2026, max-version: 2022, arch: arm64, qt-arch: win64_msvc2022_arm64, qt-version: 6.9.1, runner: "windows-11-vs2026-arm", str: windows-arm64 }
+          - { generator: Visual Studio 18 2026, max-version: 2022, arch: x64, qt-arch: win64_msvc2022_64, qt-version: 6.11.1, runner: "windows-2025-vs2026", str: windows-x64 }
+          - { generator: Visual Studio 18 2026, max-version: 2022, arch: arm64, qt-arch: win64_msvc2022_arm64, qt-version: 6.11.1, runner: "windows-11-vs2026-arm", str: windows-arm64 }
         cfg:
           - { external: OFF, type: RelWithPDB, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -281,8 +281,8 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { str: macos-arm64, arch: arm64, runner: "macos-26", qt-version: 6, min-deploy-target: 11.0 }
-          - { str: macos-x64, arch: x86_64, runner: "macos-15-intel", qt-version: 5, min-deploy-target: 10.14 }
+          - { str: macos-arm64, arch: arm64, runner: "macos-26", qt-version: 6.11.1, min-deploy-target: 11.0 }
+          - { str: macos-x64, arch: x86_64, runner: "macos-15-intel", qt-version: 5.15.2, min-deploy-target: 10.14 }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -295,7 +295,6 @@ jobs:
       - name: Install dependencies
         run: |
           brew install -q \
-              qt@${{ matrix.platform.qt-version }} \
               autoconf \
               autoconf-archive \
               automake \
@@ -303,6 +302,15 @@ jobs:
               nasm \
               nuget \
               python-setuptools
+
+      - name: Install Qt
+        continue-on-error: true
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ matrix.platform.qt-version }}
+          arch: clang_64
+          host: mac
+          dir: ${{ github.workspace }}/qt
 
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
@@ -333,7 +341,6 @@ jobs:
             -DPLASMA_BUILD_TESTS=ON \
             -DPLASMA_BUILD_TOOLS=ON \
             -DPLASMA_EXTERNAL_RELEASE=${{ matrix.cfg.external }} \
-            -DQt${{ matrix.platform.qt-version }}_ROOT=$(brew --prefix qt@${{ matrix.platform.qt-version }}) \
             -DVCPKG_INSTALL_OPTIONS=--clean-after-build \
             -S . -B build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         platform:
           - { generator: Visual Studio 17 2022, max-version: 7, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2, runner: "windows-2022", str: windows-x86 }
           - { generator: Visual Studio 18 2026, max-version: 2022, arch: x64, qt-arch: win64_msvc2022_64, qt-version: 6.9.1, runner: "windows-2025-vs2026", str: windows-x64 }
+          - { generator: Visual Studio 18 2026, max-version: 2022, arch: arm64, qt-arch: win64_msvc2022_arm64, qt-version: 6.9.1, runner: "windows-11-vs2026-arm", str: windows-arm64 }
         cfg:
           - { external: OFF, type: RelWithPDB, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -188,6 +189,7 @@ jobs:
       matrix:
         platform:
           - { str: linux-x64, runner: "ubuntu-26.04" }
+          - { str: linux-arm64, runner: "ubuntu-26.04-arm" }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -366,7 +368,9 @@ jobs:
         platform:
           - { str: macos-arm64, runner: "macos-26" }
           - { str: macos-x64, runner: "macos-15-intel" }
+          - { str: linux-arm64, runner: "ubuntu-26.04-arm" }
           - { str: linux-x64, runner: "ubuntu-26.04" }
+          - { str: windows-arm64, runner: "windows-11-vs2026-arm" }
           - { str: windows-x64, runner: "windows-2025" }
           - { str: windows-x86, runner: "windows-2022" }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,14 @@ jobs:
           MACHINE_USER_TOKEN: ${{ secrets.MACHINE_USER_REPO_READ }}
 
   windows:
-    runs-on: windows-2022
+    runs-on: ${{ matrix.platform.runner }}
     name: ${{ matrix.platform.str }}-${{ matrix.cfg.str }}
     needs: ["max-secrets"]
     strategy:
       matrix:
         platform:
-          - { generator: Visual Studio 17 2022, max-version: 7, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2,  str: windows-x86 }
-          - { generator: Visual Studio 17 2022, max-version: 2022, arch: x64, qt-arch: win64_msvc2022_64, qt-version: 6.9.1,  str: windows-x64 }
+          - { generator: Visual Studio 17 2022, max-version: 7, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2, runner: "windows-2022", str: windows-x86 }
+          - { generator: Visual Studio 18 2026, max-version: 2022, arch: x64, qt-arch: win64_msvc2022_64, qt-version: 6.9.1, runner: "windows-2025-vs2026", str: windows-x64 }
         cfg:
           - { external: OFF, type: RelWithPDB, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -55,12 +55,12 @@ jobs:
           arch: ${{ matrix.platform.qt-arch }}
           dir: ${{ github.workspace }}/qt
 
-      - name: Setup cmake
+      - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.29.2'
+          cmake-version: '4.2.7'
 
-      - name: Setup NuGet
+      - name: Configure NuGet
         run: |
           nuget sources add `
               -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
@@ -138,12 +138,12 @@ jobs:
           token: ${{ secrets.MACHINE_USER_REPO_READ }}
           path: maxsdk
 
-      - name: Setup cmake
+      - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.29.2'
+          cmake-version: '4.2.7'
 
-      - name: Setup NuGet
+      - name: Configure NuGet
         run: |
           nuget sources add `
               -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
@@ -182,12 +182,12 @@ jobs:
           path: build/install
 
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.platform.runner }}
     name: ${{ matrix.platform.str }}-${{ matrix.cfg.str }}
     strategy:
       matrix:
         platform:
-          - { str: linux-x64 }
+          - { str: linux-x64, runner: "ubuntu-26.04" }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -206,21 +206,26 @@ jobs:
               cmake \
               libcairo2 \
               libexpected-dev \
+              libltdl-dev \
               libsecret-1-dev \
               libtool \
               libx11-dev \
               libxfixes-dev \
               libxrandr-dev \
+              mono-complete \
               nasm \
               ninja-build \
               qtbase5-dev
 
-      - name: Setup cmake
+      - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.29.2'
+          cmake-version: '4.2.7'
 
       - name: Setup NuGet
+        uses: nuget/setup-nuget@v4
+
+      - name: Configure NuGet
         run: |
           nuget sources add \
               -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
@@ -274,7 +279,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { str: macos-arm64, arch: arm64, runner: "macos-15", qt-version: 6, min-deploy-target: 11.0 }
+          - { str: macos-arm64, arch: arm64, runner: "macos-26", qt-version: 6, min-deploy-target: 11.0 }
           - { str: macos-x64, arch: x86_64, runner: "macos-15-intel", qt-version: 5, min-deploy-target: 10.14 }
         cfg:
           - { external: OFF, type: RelWithDebInfo, str: internal-release }
@@ -297,12 +302,12 @@ jobs:
               nuget \
               python-setuptools
 
-      - name: Setup cmake
+      - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.29.2'
+          cmake-version: '4.2.7'
 
-      - name: Setup NuGet
+      - name: Configure NuGet
         run: |
           nuget sources add \
               -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
@@ -359,10 +364,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { str: macos-arm64, runner: "macos-15" }
+          - { str: macos-arm64, runner: "macos-26" }
           - { str: macos-x64, runner: "macos-15-intel" }
-          - { str: linux-x64, runner: "ubuntu-22.04" }
-          - { str: windows-x64, runner: "windows-2022" }
+          - { str: linux-x64, runner: "ubuntu-26.04" }
+          - { str: windows-x64, runner: "windows-2025" }
           - { str: windows-x86, runner: "windows-2022" }
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
         platform:
           - { generator: Visual Studio 17 2022, max-version: 7, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2, runner: "windows-2022", str: windows-x86 }
           - { generator: Visual Studio 18 2026, max-version: 2022, arch: x64, qt-arch: win64_msvc2022_64, qt-version: 6.11.1, runner: "windows-2025-vs2026", str: windows-x64 }
-          - { generator: Visual Studio 18 2026, max-version: 2022, arch: arm64, qt-arch: win64_msvc2022_arm64, qt-version: 6.11.1, runner: "windows-11-vs2026-arm", str: windows-arm64 }
         cfg:
           - { external: OFF, type: RelWithPDB, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -181,6 +180,81 @@ jobs:
         with:
           name: plasma-${{ matrix.cfg.str }}-max-${{ matrix.cfg.sdk-version }}
           path: build/install
+
+  # This has to be separate because we don't use a 3DS Max SDK with arm64 support
+  windows_arm:
+    runs-on: ${{ matrix.platform.runner }}
+    name: ${{ matrix.platform.str }}-${{ matrix.cfg.str }}
+    strategy:
+      matrix:
+        platform:
+          - { generator: Visual Studio 18 2026, max-version: 2022, arch: arm64, qt-arch: win64_msvc2022_arm64, qt-version: 6.9.1, runner: "windows-11-vs2026-arm", str: windows-arm64 }
+        cfg:
+          - { external: OFF, type: RelWithPDB, str: internal-release }
+          - { external: OFF, type: Debug, str: internal-debug }
+          - { external: ON, type: RelWithPDB, str: external-release }
+
+    steps:
+      - name: Checkout Plasma
+        uses: actions/checkout@v7
+
+      - name: Install Qt
+        continue-on-error: true
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ matrix.platform.qt-version }}
+          arch: ${{ matrix.platform.qt-arch }}
+          dir: ${{ github.workspace }}/qt
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '4.2.7'
+
+      - name: Configure NuGet
+        run: |
+          nuget sources add `
+              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
+              -storepasswordincleartext `
+              -name "GitHub" `
+              -username "${{ github.repository_owner }}" `
+              -password "${{ secrets.GITHUB_TOKEN }}"
+
+          nuget setapikey `
+              "${{ secrets.GITHUB_TOKEN }}" `
+              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
+      - name: Configure
+        run: |
+          cmake `
+            -G "${{ matrix.platform.generator }}" -A "${{ matrix.platform.arch }}" `
+            -DPLASMA_BUILD_TESTS=ON `
+            -DPLASMA_BUILD_TOOLS=ON `
+            -DPLASMA_EXTERNAL_RELEASE=${{ matrix.cfg.external }} `
+            -DVCPKG_INSTALL_OPTIONS=--clean-after-build `
+            -S . -B build
+        env:
+          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
+
+      - name: Build
+        run: |
+          cmake --build build --config "${{ matrix.cfg.type }}" -j 4
+
+      - name: Install
+        run: |
+          cmake --build build --target INSTALL --config "${{ matrix.cfg.type }}" -j 4
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: plasma-${{ matrix.platform.str }}-${{ matrix.cfg.str }}
+          path: build/install
+
+      - name: Test
+        run: |
+          cmake --build build --target check --config "${{ matrix.cfg.type }}" -j 4
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1
 
   linux:
     runs-on: ${{ matrix.platform.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         platform:
           - { generator: Visual Studio 17 2022, max-version: 7, arch: Win32, qt-arch: win32_msvc2019, qt-version: 5.15.2, runner: "windows-2022", str: windows-x86 }
           - { generator: Visual Studio 18 2026, max-version: 2022, arch: x64, qt-arch: win64_msvc2022_64, qt-version: 6.11.1, runner: "windows-2025-vs2026", str: windows-x64 }
+          - { generator: Visual Studio 18 2026, arch: arm64, qt-arch: win64_msvc2022_arm64, qt-version: 6.9.1, runner: "windows-11-vs2026-arm", str: windows-arm64 }
         cfg:
           - { external: OFF, type: RelWithPDB, str: internal-release }
           - { external: OFF, type: Debug, str: internal-debug }
@@ -77,7 +78,7 @@ jobs:
         run: |
           cmake `
             -G "${{ matrix.platform.generator }}" -A "${{ matrix.platform.arch }}" `
-            -DPLASMA_BUILD_MAX_PLUGIN=ON `
+            -DPLASMA_BUILD_MAX_PLUGIN=${{ case(matrix.platform.max-version != '', 'ON', 'OFF') }} `
             -DPLASMA_BUILD_TESTS=ON `
             -DPLASMA_BUILD_TOOLS=ON `
             -DPLASMA_EXTERNAL_RELEASE=${{ matrix.cfg.external }} `
@@ -181,80 +182,6 @@ jobs:
           name: plasma-${{ matrix.cfg.str }}-max-${{ matrix.cfg.sdk-version }}
           path: build/install
 
-  # This has to be separate because we don't use a 3DS Max SDK with arm64 support
-  windows_arm:
-    runs-on: ${{ matrix.platform.runner }}
-    name: ${{ matrix.platform.str }}-${{ matrix.cfg.str }}
-    strategy:
-      matrix:
-        platform:
-          - { generator: Visual Studio 18 2026, max-version: 2022, arch: arm64, qt-arch: win64_msvc2022_arm64, qt-version: 6.9.1, runner: "windows-11-vs2026-arm", str: windows-arm64 }
-        cfg:
-          - { external: OFF, type: RelWithPDB, str: internal-release }
-          - { external: OFF, type: Debug, str: internal-debug }
-          - { external: ON, type: RelWithPDB, str: external-release }
-
-    steps:
-      - name: Checkout Plasma
-        uses: actions/checkout@v7
-
-      - name: Install Qt
-        continue-on-error: true
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: ${{ matrix.platform.qt-version }}
-          arch: ${{ matrix.platform.qt-arch }}
-          dir: ${{ github.workspace }}/qt
-
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '4.2.7'
-
-      - name: Configure NuGet
-        run: |
-          nuget sources add `
-              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
-              -storepasswordincleartext `
-              -name "GitHub" `
-              -username "${{ github.repository_owner }}" `
-              -password "${{ secrets.GITHUB_TOKEN }}"
-
-          nuget setapikey `
-              "${{ secrets.GITHUB_TOKEN }}" `
-              -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-
-      - name: Configure
-        run: |
-          cmake `
-            -G "${{ matrix.platform.generator }}" -A "${{ matrix.platform.arch }}" `
-            -DPLASMA_BUILD_TESTS=ON `
-            -DPLASMA_BUILD_TOOLS=ON `
-            -DPLASMA_EXTERNAL_RELEASE=${{ matrix.cfg.external }} `
-            -DVCPKG_INSTALL_OPTIONS=--clean-after-build `
-            -S . -B build
-        env:
-          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
-
-      - name: Build
-        run: |
-          cmake --build build --config "${{ matrix.cfg.type }}" -j 4
-
-      - name: Install
-        run: |
-          cmake --build build --target INSTALL --config "${{ matrix.cfg.type }}" -j 4
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: plasma-${{ matrix.platform.str }}-${{ matrix.cfg.str }}
-          path: build/install
-
-      - name: Test
-        run: |
-          cmake --build build --target check --config "${{ matrix.cfg.type }}" -j 4
-        env:
-          CTEST_OUTPUT_ON_FAILURE: 1
 
   linux:
     runs-on: ${{ matrix.platform.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  CMAKE_VERSION: "4.2.7"
+
 jobs:
   # HACK to enable/disable the max CI based on presence/absence of secret. See also:
   # https://github.com/actions/runner/issues/1138
@@ -59,7 +62,7 @@ jobs:
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '4.2.7'
+          cmake-version: ${{ env.CMAKE_VERSION }}
 
       - name: Configure NuGet
         run: |
@@ -142,7 +145,7 @@ jobs:
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '4.2.7'
+          cmake-version: ${{ env.CMAKE_VERSION }}
 
       - name: Configure NuGet
         run: |
@@ -223,7 +226,7 @@ jobs:
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '4.2.7'
+          cmake-version: ${{ env.CMAKE_VERSION }}
 
       - name: Setup NuGet
         uses: nuget/setup-nuget@v4
@@ -316,7 +319,7 @@ jobs:
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '4.2.7'
+          cmake-version: ${{ env.CMAKE_VERSION }}
 
       - name: Configure NuGet
         run: |


### PR DESCRIPTION
I don't know if we _want_ this because it makes our build matrix even bigger (and slower), but as a proof of concept it's nice to see these builds working.

If we don't merge this as-is, I'll probably make a separate PR to address some of the other updates in here like bumping to Ubuntu 26.04 and using the Qt Install action for macOS.