### PR TITLE
Unify checksum code.

### DIFF
--- a/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSLoginController.mm
+++ b/Sources/Plasma/Apps/plClient/Mac-Cocoa/PLSLoginController.mm
@@ -157,7 +157,11 @@ static NSOperationQueue* _loginQueue = nil;
     std::cmatch match;
     std::regex_search(username.c_str(), match, re_domain);
     if (match.empty() || ST::string(match[2].str()).compare_i("gametap") == 0) {
-        plSHA1Checksum shasum(password.size(), reinterpret_cast<const uint8_t*>(password.c_str()));
+        plChecksum shasum(
+            plChecksum::Type::kSHA1,
+            password.size(),
+            reinterpret_cast<const uint8_t*>(password.c_str())
+        );
         uint32_t* dest = reinterpret_cast<uint32_t*>(namePassHash);
         const uint32_t* from = reinterpret_cast<const uint32_t*>(shasum.GetValue());
         dest[0] = hsToBE32(from[0]);

--- a/Sources/Plasma/Apps/plClient/win32/winmain.cpp
+++ b/Sources/Plasma/Apps/plClient/win32/winmain.cpp
@@ -631,7 +631,11 @@ static void StoreHash(const ST::string& username, const ST::string& password, Lo
     std::regex_search(username.c_str(), match, re_domain);
     if (match.empty() || ST::string(match[2].str()).compare_i("gametap") == 0) {
         //  Plain Usernames...
-        plSHA1Checksum shasum(password.size(), reinterpret_cast<const uint8_t*>(password.c_str()));
+        plChecksum shasum(
+            plChecksum::Type::kSHA1,
+            password.size(),
+            reinterpret_cast<const uint8_t*>(password.c_str())
+        );
         uint32_t* dest = reinterpret_cast<uint32_t*>(pLoginParam->namePassHash);
         const uint32_t* from = reinterpret_cast<const uint32_t*>(shasum.GetValue());
 

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -119,14 +119,14 @@ struct pfPatcherQueuedFile
     Type fType;
     plFileName fClientPath;
     plFileName fServerPath;
-    plMD5Checksum fChecksum;
+    plChecksum fChecksum;
     uint32_t fFileSize;
     uint32_t fZipSize;
     uint32_t fFlags;
 
     pfPatcherQueuedFile(Type t, const NetCliFileManifestEntry& file)
-    : fType(t), fClientPath(plFileName(ST::string::from_utf16(file.clientName)).Normalize()),
-          fServerPath(ST::string::from_utf16(file.downloadName)), fChecksum(),
+        : fType(t), fClientPath(plFileName(ST::string::from_utf16(file.clientName)).Normalize()),
+          fServerPath(ST::string::from_utf16(file.downloadName)), fChecksum(plChecksum::Type::kMD5),
           fFileSize(file.fileSize), fZipSize(file.zipSize), fFlags(file.flags)
     {
         ST::string temp(file.md5, std::size(file.md5));
@@ -134,7 +134,8 @@ struct pfPatcherQueuedFile
     }
 
     pfPatcherQueuedFile(Type t, plFileName path, uint32_t flags=0)
-        : fType(t), fClientPath(std::move(path)), fChecksum(), fFileSize(), fZipSize(), fFlags(flags)
+        : fType(t), fClientPath(std::move(path)), fChecksum(plChecksum::Type::kMD5),
+          fFileSize(), fZipSize(), fFlags(flags)
     { }
 
     pfPatcherQueuedFile(const pfPatcherQueuedFile& copy) = delete;
@@ -575,7 +576,7 @@ void pfPatcherWorker::IHashFile(pfPatcherQueuedFile& file)
     }
     plFileInfo mine(clientPathForComparison);
     if (mine.FileSize() == file.fFileSize) {
-        plMD5Checksum cliMD5(clientPathForComparison);
+        plChecksum cliMD5(plChecksum::Type::kMD5, clientPathForComparison);
         if (cliMD5 == file.fChecksum) {
             WhitelistFile(file.fClientPath, false);
             return;

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -119,22 +119,23 @@ struct pfPatcherQueuedFile
     Type fType;
     plFileName fClientPath;
     plFileName fServerPath;
-    plMD5Checksum fChecksum;
+    plChecksum fChecksum;
     uint32_t fFileSize;
     uint32_t fZipSize;
     uint32_t fFlags;
 
     pfPatcherQueuedFile(Type t, const NetCliFileManifestEntry& file)
     : fType(t), fClientPath(plFileName(ST::string::from_utf16(file.clientName)).Normalize()),
-          fServerPath(ST::string::from_utf16(file.downloadName)), fChecksum(),
-          fFileSize(file.fileSize), fZipSize(file.zipSize), fFlags(file.flags)
+      fServerPath(ST::string::from_utf16(file.downloadName)), fChecksum(plChecksum::Type::kMD5),
+      fFileSize(file.fileSize), fZipSize(file.zipSize), fFlags(file.flags)
     {
         ST::string temp(file.md5, std::size(file.md5));
         fChecksum.SetFromHexString(temp.c_str());
     }
 
     pfPatcherQueuedFile(Type t, plFileName path, uint32_t flags=0)
-        : fType(t), fClientPath(std::move(path)), fChecksum(), fFileSize(), fZipSize(), fFlags(flags)
+        : fType(t), fClientPath(std::move(path)), fChecksum(plChecksum::Type::kMD5),
+          fFileSize(), fZipSize(), fFlags(flags)
     { }
 
     pfPatcherQueuedFile(const pfPatcherQueuedFile& copy) = delete;
@@ -575,7 +576,7 @@ void pfPatcherWorker::IHashFile(pfPatcherQueuedFile& file)
     }
     plFileInfo mine(clientPathForComparison);
     if (mine.FileSize() == file.fFileSize) {
-        plMD5Checksum cliMD5(clientPathForComparison);
+        plChecksum cliMD5(plChecksum::Type::kMD5, clientPathForComparison);
         if (cliMD5 == file.fChecksum) {
             WhitelistFile(file.fClientPath, false);
             return;

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.h
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.h
@@ -51,7 +51,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 class plFileName;
 class plFilePath;
-class plMD5Checksum;
 class plStatusLog;
 class hsStream;
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyAgeInfoStruct.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyAgeInfoStruct.cpp
@@ -130,7 +130,7 @@ void pyAgeInfoStruct::SetAgeInstanceGuid(const ST::string& guid)
         ST::string curInst = fAgeInfo.GetAgeInstanceName();
         ST::string y = curInst + guid;
 
-        plMD5Checksum hash;
+        plChecksum hash(plChecksum::Type::kMD5);
         hash.Start();
         hash.AddTo(y.size(), (uint8_t*)y.c_str());
         hash.Finish();

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChallengeHash.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChallengeHash.cpp
@@ -69,7 +69,7 @@ void CryptCreateRandomSeed(size_t length, uint8_t* data)
     ((uint32_t*)fSeed)[4] ^= (uint32_t)((uintptr_t)data);
 
     // Hash seed
-    plSHAChecksum sum(sizeof(ShaDigest), (uint8_t*)fSeed);
+    plChecksum sum(plChecksum::Type::kSHA0, sizeof(ShaDigest), (uint8_t*)fSeed);
     ShaDigest digest;
     memcpy(digest, sum.GetValue(), sizeof(ShaDigest));
 
@@ -101,14 +101,18 @@ void CryptHashPassword(const ST::string& username, const ST::string& password, S
     if (!username.empty())
         buf << username.to_lower().left(username.size() - 1) << '\0';
     ST::utf16_buffer result = buf.to_string().to_utf16();
-    plSHAChecksum sum(result.size() * sizeof(char16_t), (uint8_t*)result.data());
+    plChecksum sum(
+        plChecksum::Type::kSHA0,
+        result.size() * sizeof(char16_t),
+        (uint8_t*)result.data()
+    );
 
     memcpy(dest, sum.GetValue(), sizeof(ShaDigest));
 }
 
 void CryptHashPasswordChallenge(uint32_t clientChallenge, uint32_t serverChallenge, ShaDigest namePassHash, ShaDigest challengeHash)
 {
-    plSHAChecksum sum;
+    plChecksum sum(plChecksum::Type::kSHA0);
 
     sum.Start();
     sum.AddTo(sizeof(uint32_t), (uint8_t*)&clientChallenge);

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -373,9 +373,9 @@ bool plChecksum::operator==(const plChecksum& rhs) const
 
     // In progress and invalid checksums can't be equal. They're in an
     // indeterminant state..
-    if (!IsValid())
+    if (!IsFinished())
         return false;
-    if (!rhs.IsValid())
+    if (!rhs.IsFinished())
         return false;
 
     if (fType != rhs.fType)

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -307,7 +307,9 @@ void plChecksum::CalcFromStream(hsStream* stream)
 void plChecksum::SetFromHexString(const char* string)
 {
     size_t stringLen = strlen(string);
-    if (fStatus != Status::kReady)
+    if (fStatus == Status::kInvalid)
+        throw plChecksumException("Checksum invalid");
+    if (fStatus == Status::kStarted)
         throw plChecksumException("Checksum in use");
     if (stringLen != 2 * GetSize())
         throw plChecksumException("Invalid string in ISetFromHexString");
@@ -361,8 +363,8 @@ void plChecksum::Finish()
 
 size_t plChecksum::GetSize() const
 {
-    if (fStatus != Status::kFinished)
-        throw plChecksumException("Checksum not finished");
+    if (fStatus == Status::kInvalid)
+        throw plChecksumException("Checksum is invalid");
     return fImpl->GetSize();
 }
 

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -302,7 +302,9 @@ void plChecksum::CalcFromStream(hsStream* stream)
 void plChecksum::SetFromHexString(const char* string)
 {
     size_t stringLen = strlen(string);
-    if (fStatus != Status::kReady)
+    if (fStatus == Status::kInvalid)
+        throw plChecksumException("Checksum invalid");
+    if (fStatus == Status::kStarted)
         throw plChecksumException("Checksum in use");
     if (stringLen != 2 * GetSize())
         throw plChecksumException("Invalid string in ISetFromHexString");
@@ -356,8 +358,8 @@ void plChecksum::Finish()
 
 size_t plChecksum::GetSize() const
 {
-    if (fStatus != Status::kFinished)
-        throw plChecksumException("Checksum not finished");
+    if (fStatus == Status::kInvalid)
+        throw plChecksumException("Checksum is invalid");
     return fImpl->GetSize();
 }
 

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -366,6 +366,13 @@ const uint8_t* plChecksum::GetValue() const
 
 bool plChecksum::operator==(const plChecksum& rhs) const
 {
+    // Early bail out: if we're the same object, it's obviously the same checksum,
+    // so who really cares if we're finished or not.
+    if (this == &rhs)
+        return true;
+
+    // In progress and invalid checksums can't be equal. They're in an
+    // indeterminant state..
     if (!IsValid())
         return false;
     if (!rhs.IsValid())

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -41,7 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 #include "plChecksum.h"
 
-#include "hsEndian.h"
+#include "plSha0.h"
 #include "hsStream.h"
 
 #include <cstring>
@@ -100,402 +100,303 @@ static uint8_t IHexCharToInt(char c)
 
 //============================================================================
 
-plMD5Checksum::plMD5Checksum(size_t size, const uint8_t* buffer)
-    : fValid(), fContext()
+class plChecksumImpl
 {
-    Start();
-    AddTo(size, buffer);
-    Finish();
-}
+protected:
+    plChecksumImpl() = default;
+    plChecksumImpl(const plChecksumImpl&) = delete;
+    plChecksumImpl(plChecksumImpl&&) = delete;
 
-plMD5Checksum::plMD5Checksum()
-    : fValid(), fContext()
-{
-    memset(fChecksum, 0, sizeof(fChecksum));
-}
+public:
+    virtual ~plChecksumImpl() = default;
 
-plMD5Checksum::plMD5Checksum(const plMD5Checksum& rhs)
-    : fValid(rhs.fValid), fContext()
-{
-    memcpy(fChecksum, rhs.fChecksum, sizeof(fChecksum));
-}
+    virtual void Start() = 0;
+    virtual void AddTo(size_t size, const uint8_t* buffer) = 0;
+    virtual void Finish() = 0;
 
-plMD5Checksum::plMD5Checksum(const plFileName& fileName)
-    : fValid(), fContext()
-{
-    CalcFromFile(fileName);
-}
-
-plMD5Checksum::plMD5Checksum(hsStream* stream)
-    : fValid(), fContext()
-{
-    CalcFromStream(stream);
-}
-
-void plMD5Checksum::Clear()
-{
-    if (fContext)
-        EVP_MD_CTX_destroy(fContext);
-    fContext = nullptr;
-    memset(fChecksum, 0, sizeof(fChecksum));
-    fValid = false;
-}
-
-void plMD5Checksum::CalcFromFile(const plFileName& fileName)
-{
-    hsUNIXStream s;
-    fValid = false;
-
-    if (s.Open(fileName))
-    {
-        CalcFromStream(&s);
-    }
-}
-
-void plMD5Checksum::CalcFromStream(hsStream* stream)
-{
-    uint32_t sPos = stream->GetPosition();
-    unsigned loadLen = 1024 * 1024;
-    Start();
-
-    uint8_t *buf = new uint8_t[loadLen];
-
-    while (int read = stream->Read(loadLen, buf))
-        AddTo(read, buf);
-    delete[] buf;
-
-    Finish();
-    stream->SetPosition(sPos);
-}
-
-void plMD5Checksum::Start()
-{
-    const EVP_MD* md = EVP_get_digestbyname("md5");
-    hsAssert(md, "This OpenSSL has no support for MD5");
-
-    size_t out_size = EVP_MD_size(md);
-    hsAssert(out_size == sizeof(fChecksum), "Incorrect output size for MD5");
-
-    fContext = EVP_MD_CTX_create();
-    EVP_DigestInit_ex(fContext, md, nullptr);
-    fValid = false;
-}
-
-void plMD5Checksum::AddTo(size_t size, const uint8_t* buffer)
-{
-    EVP_DigestUpdate(fContext, buffer, size);
-}
-
-void plMD5Checksum::Finish()
-{
-    unsigned int out_size;
-    EVP_DigestFinal_ex(fContext, fChecksum, &out_size);
-    fValid = true;
-    if (fContext)
-        EVP_MD_CTX_destroy(fContext);
-    fContext = nullptr;
-}
-
-ST::string plMD5Checksum::GetAsHexString() const
-{
-    hsAssert(fValid, "Trying to get string version of invalid checksum");
-
-    return ST::hex_encode(fChecksum, sizeof(fChecksum));
-}
-
-void plMD5Checksum::SetFromHexString(const char* string)
-{
-    const char  *ptr;
-    int         i;
-
-
-    hsAssert(strlen(string) == 2 * MD5_DIGEST_LENGTH, "Invalid string in MD5Checksum Set()");
-
-    for (i = 0, ptr = string; i < sizeof(fChecksum); i++, ptr += 2)
-        fChecksum[i] = (IHexCharToInt(ptr[0]) << 4) | IHexCharToInt(ptr[1]);
-
-    fValid = true;
-}
-
-void plMD5Checksum::SetValue(uint8_t* checksum)
-{
-    fValid = true;
-    memcpy(fChecksum, checksum, sizeof(fChecksum));
-}
-
-bool plMD5Checksum::operator==(const plMD5Checksum& rhs) const
-{
-    return (fValid && rhs.fValid && memcmp(fChecksum, rhs.fChecksum, sizeof(fChecksum)) == 0);
-}
+    virtual size_t GetSize() const = 0;
+    virtual uint8_t* GetValue() = 0;
+};
 
 //============================================================================
-plSHAChecksum::plSHAChecksum(size_t size, const uint8_t* buffer)
-    : fValid(), fOpenSSLContext()
+
+class plEVPChecksum : public plChecksumImpl
 {
+    EVP_MD_CTX* fCtx;
+    const EVP_MD* fMd;
+    std::unique_ptr<uint8_t[]> fValue;
+
+public:
+    plEVPChecksum() = delete;
+    plEVPChecksum(const plEVPChecksum&) = delete;
+    plEVPChecksum(plEVPChecksum&&) = delete;
+
+    plEVPChecksum(const EVP_MD* md)
+        : fCtx(), fMd(md)
+    {
+        // This could have been passed in as a template paraemter, which could
+        // be used to statically allocate the buffer. That would be more performant,
+        // but it would also mean generating a different class in the executable
+        // for almost every checksum type, which seems a little silly. This is
+        // not a performace-critical path, so we'll just allocate the buffer dynamically.
+        size_t size = EVP_MD_size(md);
+        fValue = std::make_unique<uint8_t[]>(size);
+        memset(fValue.get(), 0, size);
+    }
+
+    ~plEVPChecksum()
+    {
+        if (fCtx)
+            EVP_MD_CTX_destroy(fCtx);
+    }
+
+public:
+    void Start() override
+    {
+        if (fCtx == nullptr)
+            fCtx = EVP_MD_CTX_create();
+        EVP_DigestInit_ex(fCtx, fMd, nullptr);
+    }
+
+    void AddTo(size_t size, const uint8_t* buffer) override
+    {
+        EVP_DigestUpdate(fCtx, buffer, size);
+    }
+
+    void Finish() override
+    {
+        EVP_DigestFinal_ex(fCtx, fValue.get(), nullptr);
+        EVP_MD_CTX_reset(fCtx);
+    }
+
+    size_t GetSize() const override
+    {
+        return EVP_MD_size(fMd);
+    }
+
+    uint8_t* GetValue() override
+    {
+        return fValue.get();
+    }
+};
+
+//============================================================================
+
+class plSHA0Checksum : public plChecksumImpl
+{
+    plSha0 fCtx;
+    ShaDigest fValue;
+
+public:
+    plSHA0Checksum()
+    {
+        memset(fValue, 0, sizeof(fValue));
+    }
+
+    plSHA0Checksum(const plSHA0Checksum&) = delete;
+    plSHA0Checksum(plSHA0Checksum&&) = delete;
+
+public:
+    void Start() override { fCtx.Start(); }
+    void AddTo(size_t size, const uint8_t* buffer) override { fCtx.AddTo(size, buffer); }
+    void Finish() override { fCtx.Finish(fValue); }
+    size_t GetSize() const override { return sizeof(fValue); }
+    uint8_t* GetValue() override { return fValue; }
+};
+
+//============================================================================
+
+plChecksum::plChecksum(plChecksum&& move) noexcept
+    : fStatus(move.fStatus), fType(move.fType),
+      fImpl(std::move(move.fImpl))
+{
+    move.fStatus = Status::kInvalid;
+}
+
+plChecksum::plChecksum(plChecksum::Type type)
+    : fStatus(Status::kReady), fType(type)
+{
+    IInit(type);
+}
+
+plChecksum::plChecksum(plChecksum::Type type, const plFileName& fileName)
+    : fStatus(Status::kReady), fType(type)
+{
+    IInit(type);
+    CalcFromFile(fileName);
+}
+
+plChecksum::plChecksum(plChecksum::Type type, hsStream* stream)
+    : fStatus(Status::kReady), fType(type)
+{
+    IInit(type);
+    CalcFromStream(stream);
+}
+
+plChecksum::plChecksum(plChecksum::Type type, size_t size, const uint8_t* buffer)
+    : fStatus(Status::kReady), fType(type)
+{
+    IInit(type);
     Start();
     AddTo(size, buffer);
     Finish();
 }
 
-plSHAChecksum::plSHAChecksum()
-    : fValid(), fOpenSSLContext()
+void plChecksum::IInit(plChecksum::Type type)
 {
-    memset(fChecksum, 0, sizeof(fChecksum));
-}
-
-plSHAChecksum::plSHAChecksum(const plSHAChecksum& rhs)
-    : fValid(rhs.fValid), fOpenSSLContext()
-{
-    memcpy(fChecksum, rhs.fChecksum, sizeof(fChecksum));
-}
-
-plSHAChecksum::plSHAChecksum(const plFileName& fileName)
-    : fValid(), fOpenSSLContext()
-{
-    CalcFromFile(fileName);
-}
-
-plSHAChecksum::plSHAChecksum(hsStream* stream)
-    : fValid(), fOpenSSLContext()
-{
-    CalcFromStream(stream);
-}
-
-void plSHAChecksum::Clear()
-{
-    if (fOpenSSLContext)
-        EVP_MD_CTX_destroy(fOpenSSLContext);
-    fOpenSSLContext = nullptr;
-    memset(fChecksum, 0, sizeof(fChecksum));
-    fValid = false;
-}
-
-void plSHAChecksum::CalcFromFile(const plFileName& fileName)
-{
-    hsUNIXStream s;
-    fValid = false;
-
-    if (s.Open(fileName))
-    {
-        CalcFromStream(&s);
+    switch (type) {
+        case Type::kMD5:
+            fImpl = std::make_unique<plEVPChecksum>(EVP_md5());
+            break;
+        case Type::kSHA0: {
+            // SHA-0 is not supported by OpenSSL these days, so we may have to
+            // use our own implementation.
+            const EVP_MD* md = EVP_get_digestbyname("sha");
+            if (md)
+                fImpl = std::make_unique<plEVPChecksum>(md);
+            else
+                fImpl = std::make_unique<plSHA0Checksum>();
+            break;
+        }
+        case Type::kSHA1:
+            fImpl = std::make_unique<plEVPChecksum>(EVP_sha1());
+            break;
+        DEFAULT_FATAL("checksumType");
     }
 }
 
-void plSHAChecksum::CalcFromStream(hsStream* stream)
+plChecksum::~plChecksum()
 {
-    uint32_t sPos = stream->GetPosition();
-    unsigned loadLen = 1024 * 1024;
-    Start();
-
-    uint8_t* buf = new uint8_t[loadLen];
-
-    while (int read = stream->Read(loadLen, buf))
-    {
-        AddTo( read, buf );
-    }
-    delete[] buf;
-
-    Finish();
-    stream->SetPosition(sPos);
-}
-
-void plSHAChecksum::Start()
-{
-    const EVP_MD* md = EVP_get_digestbyname("sha");
-    if (md) {
-        size_t out_size = EVP_MD_size(md);
-        hsAssert(out_size == sizeof(fChecksum), "Incorrect output size for SHA0");
-
-        fOpenSSLContext = EVP_MD_CTX_create();
-        EVP_DigestInit_ex(fOpenSSLContext, md, nullptr);
-    } else {
-        fOpenSSLContext = nullptr;
-        fPlasmaContext.Start();
-    }
-    fValid = false;
-}
-
-void plSHAChecksum::AddTo(size_t size, const uint8_t* buffer)
-{
-    if (fOpenSSLContext)
-        EVP_DigestUpdate(fOpenSSLContext, buffer, size);
-    else
-        fPlasmaContext.AddTo(size, buffer);
-}
-
-void plSHAChecksum::Finish()
-{
-    if (fOpenSSLContext) {
-        unsigned int out_size;
-        EVP_DigestFinal_ex(fOpenSSLContext, fChecksum, &out_size);
-        if (fOpenSSLContext)
-            EVP_MD_CTX_destroy(fOpenSSLContext);
-        fOpenSSLContext = nullptr;
-    } else {
-        fPlasmaContext.Finish(fChecksum);
-    }
-    fValid = true;
-}
-
-ST::string plSHAChecksum::GetAsHexString() const
-{
-    hsAssert(fValid, "Trying to get string version of invalid checksum");
-
-    return ST::hex_encode(fChecksum, sizeof(fChecksum));
-}
-
-void plSHAChecksum::SetFromHexString(const char* string)
-{
-    const char* ptr;
-    int         i;
-
-    hsAssert(strlen(string) == (2 * SHA_DIGEST_LENGTH), "Invalid string in SHAChecksum Set()");
-
-    for (i = 0, ptr = string; i < sizeof(fChecksum); i++, ptr += 2)
-        fChecksum[i] = (IHexCharToInt(ptr[0]) << 4) | IHexCharToInt(ptr[1]);
-
-    fValid = true;
-}
-
-void plSHAChecksum::SetValue(uint8_t* checksum)
-{
-    fValid = true;
-    memcpy(fChecksum, checksum, sizeof(fChecksum));
-}
-
-bool plSHAChecksum::operator==(const plSHAChecksum& rhs) const
-{
-    return (fValid && rhs.fValid && memcmp(fChecksum, rhs.fChecksum, sizeof(fChecksum)) == 0);
+    // This is in the cpp file because plChecksumImpl is incomplete in the header file.
 }
 
 //============================================================================
 
-plSHA1Checksum::plSHA1Checksum(size_t size, const uint8_t* buffer)
-    : fValid(), fContext()
-{
-    Start();
-    AddTo(size, buffer);
-    Finish();
-}
-
-plSHA1Checksum::plSHA1Checksum()
-    : fValid(), fContext()
-{
-    memset(fChecksum, 0, sizeof(fChecksum));
-}
-
-plSHA1Checksum::plSHA1Checksum(const plSHA1Checksum& rhs)
-    : fValid(rhs.fValid), fContext()
-{
-    memcpy(fChecksum, rhs.fChecksum, sizeof(fChecksum));
-}
-
-plSHA1Checksum::plSHA1Checksum(const plFileName& fileName)
-    : fValid(), fContext()
-{
-    CalcFromFile(fileName);
-}
-
-plSHA1Checksum::plSHA1Checksum(hsStream* stream)
-    : fValid(), fContext()
-{
-    CalcFromStream(stream);
-}
-
-void plSHA1Checksum::Clear()
-{
-    if (fContext)
-        EVP_MD_CTX_destroy(fContext);
-    fContext = nullptr;
-    memset(fChecksum, 0, sizeof(fChecksum));
-    fValid = false;
-}
-
-void plSHA1Checksum::CalcFromFile(const plFileName& fileName)
+void plChecksum::CalcFromFile(const plFileName& fileName)
 {
     hsUNIXStream s;
-    fValid = false;
-
     if (s.Open(fileName))
-    {
         CalcFromStream(&s);
-    }
 }
 
-void plSHA1Checksum::CalcFromStream(hsStream* stream)
+void plChecksum::CalcFromStream(hsStream* stream)
 {
+    if (fStatus == Status::kStarted)
+        throw plChecksumException("Checksum already started");
+
     uint32_t sPos = stream->GetPosition();
-    unsigned loadLen = 1024 * 1024;
+    constexpr uint32_t loadLen = 1024 * 1024;
+    auto buf = std::make_unique<uint8_t[]>(loadLen);
+
     Start();
-
-    uint8_t* buf = new uint8_t[loadLen];
-
-    while (int read = stream->Read(loadLen, buf))
-    {
-        AddTo( read, buf );
-    }
-    delete[] buf;
-
+    while (int read = stream->Read(loadLen, buf.get()))
+        AddTo(read, buf.get());
     Finish();
+
     stream->SetPosition(sPos);
 }
 
-void plSHA1Checksum::Start()
+//============================================================================
+
+void plChecksum::SetFromHexString(const char* string)
 {
-    const EVP_MD* md = EVP_get_digestbyname("sha1");
-    hsAssert(md, "This OpenSSL has no support for SHA1");
+    size_t stringLen = strlen(string);
+    if (fStatus != Status::kReady)
+        throw plChecksumException("Checksum in use");
+    if (stringLen != 2 * GetSize())
+        throw plChecksumException("Invalid string in ISetFromHexString");
 
-    size_t out_size = EVP_MD_size(md);
-    hsAssert(out_size == sizeof(fChecksum), "Incorrect output size for SHA1");
+    size_t checksumSz = fImpl->GetSize();
+    uint8_t* value = fImpl->GetValue();
 
-    fContext = EVP_MD_CTX_create();
-    EVP_DigestInit_ex(fContext, md, nullptr);
-    fValid = false;
-}
-
-void plSHA1Checksum::AddTo(size_t size, const uint8_t* buffer)
-{
-    EVP_DigestUpdate(fContext, buffer, size);
-}
-
-void plSHA1Checksum::Finish()
-{
-    unsigned int out_size;
-    EVP_DigestFinal_ex(fContext, fChecksum, &out_size);
-    fValid = true;
-    if (fContext)
-        EVP_MD_CTX_destroy(fContext);
-    fContext = nullptr;
-}
-
-ST::string plSHA1Checksum::GetAsHexString() const
-{
-    hsAssert(fValid, "Trying to get string version of invalid checksum");
-
-    return ST::hex_encode(fChecksum, sizeof(fChecksum));
-}
-
-void plSHA1Checksum::SetFromHexString(const char* string)
-{
     const char* ptr;
-    int         i;
-
-    hsAssert(strlen(string) == (2 * SHA_DIGEST_LENGTH), "Invalid string in SHA1Checksum Set()");
-
-    for (i = 0, ptr = string; i < sizeof(fChecksum); i++, ptr += 2)
-        fChecksum[i] = (IHexCharToInt(ptr[0]) << 4) | IHexCharToInt(ptr[1]);
-
-    fValid = true;
+    size_t i;
+    for (i = 0, ptr = string; i < checksumSz; i++, ptr += 2)
+        value[i] = (IHexCharToInt(ptr[0]) << 4) | IHexCharToInt(ptr[1]);
+    fStatus = Status::kFinished;
 }
 
-void plSHA1Checksum::SetValue(uint8_t* checksum)
+ST::string plChecksum::GetAsHexString() const
 {
-    fValid = true;
-    memcpy(fChecksum, checksum, sizeof(fChecksum));
+    if (fStatus != Status::kFinished)
+        throw plChecksumException("Checksum not finished");
+    return ST::hex_encode(fImpl->GetValue(), GetSize());
 }
 
-bool plSHA1Checksum::operator==(const plSHA1Checksum& rhs) const
+//============================================================================
+
+void plChecksum::Start()
 {
-    return (fValid && rhs.fValid && memcmp(fChecksum, rhs.fChecksum, sizeof(fChecksum)) == 0);
+    if (fStatus == Status::kInvalid)
+        throw plChecksumException("Checksum invalid");
+    if (fStatus == Status::kStarted)
+        throw plChecksumException("Checksum in use");
+
+    fImpl->Start();
+    fStatus = Status::kStarted;
 }
 
+void plChecksum::AddTo(size_t size, const uint8_t* buffer)
+{
+    if (fStatus != Status::kStarted)
+        throw plChecksumException("Checksum not started");
+
+    fImpl->AddTo(size, buffer);
+}
+
+void plChecksum::Finish()
+{
+    if (fStatus != Status::kStarted)
+        throw plChecksumException("Checksum not started");
+
+    fImpl->Finish();
+    fStatus = Status::kFinished;
+}
+
+size_t plChecksum::GetSize() const
+{
+    if (fStatus != Status::kFinished)
+        throw plChecksumException("Checksum not finished");
+    return fImpl->GetSize();
+}
+
+const uint8_t* plChecksum::GetValue() const
+{
+    if (fStatus != Status::kFinished)
+        throw plChecksumException("Checksum not finished");
+    return fImpl->GetValue();
+}
+
+//============================================================================
+
+bool plChecksum::operator==(const plChecksum& rhs) const
+{
+    if (!IsValid())
+        return false;
+    if (!rhs.IsValid())
+        return false;
+
+    if (fType != rhs.fType)
+        return false;
+    if (fImpl->GetSize() != rhs.fImpl->GetSize())
+        return false;
+
+    return memcmp(
+        fImpl->GetValue(),
+        rhs.fImpl->GetValue(),
+        fImpl->GetSize()
+    ) == 0;
+}
+
+//============================================================================
+
+plChecksum& plChecksum::operator=(plChecksum&& move) noexcept
+{
+    if (this != &move) {
+        fStatus = move.fStatus;
+        fType = move.fType;
+        fImpl = std::move(move.fImpl);
+        move.fStatus = Status::kInvalid;
+    }
+    return *this;
+}

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -46,6 +46,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <cstring>
 #include <string_theory/codecs>
+#include <openssl/evp.h>
 
 struct _InitOpenSSL
 {

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -261,6 +261,12 @@ void plChecksum::IInit(plChecksum::Type type)
         case Type::kSHA1:
             fImpl = std::make_unique<plEVPChecksum>(EVP_sha1());
             break;
+        case Type::kSHA256:
+            fImpl = std::make_unique<plEVPChecksum>(EVP_sha256());
+            break;
+        case Type::kSHA512:
+            fImpl = std::make_unique<plEVPChecksum>(EVP_sha512());
+            break;
         DEFAULT_FATAL("checksumType");
     }
 }

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -256,6 +256,12 @@ void plChecksum::IInit(plChecksum::Type type)
         case Type::kSHA1:
             fImpl = std::make_unique<plEVPChecksum>(EVP_sha1());
             break;
+        case Type::kSHA256:
+            fImpl = std::make_unique<plEVPChecksum>(EVP_sha256());
+            break;
+        case Type::kSHA512:
+            fImpl = std::make_unique<plEVPChecksum>(EVP_sha512());
+            break;
         DEFAULT_FATAL("checksumType");
     }
 }

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -41,7 +41,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 #include "plChecksum.h"
 
-#include "hsEndian.h"
+#include "plSha0.h"
 #include "hsStream.h"
 
 #include <cstring>
@@ -100,402 +100,298 @@ static uint8_t IHexCharToInt(char c)
 
 //============================================================================
 
-plMD5Checksum::plMD5Checksum(size_t size, const uint8_t* buffer)
-    : fValid(), fContext()
+class plChecksumImpl
 {
-    Start();
-    AddTo(size, buffer);
-    Finish();
-}
+protected:
+    plChecksumImpl() = default;
+    plChecksumImpl(const plChecksumImpl&) = delete;
+    plChecksumImpl(plChecksumImpl&&) = delete;
 
-plMD5Checksum::plMD5Checksum()
-    : fValid(), fContext()
-{
-    memset(fChecksum, 0, sizeof(fChecksum));
-}
+public:
+    virtual ~plChecksumImpl() = default;
 
-plMD5Checksum::plMD5Checksum(const plMD5Checksum& rhs)
-    : fValid(rhs.fValid), fContext()
-{
-    memcpy(fChecksum, rhs.fChecksum, sizeof(fChecksum));
-}
+    virtual void Start() = 0;
+    virtual void AddTo(size_t size, const uint8_t* buffer) = 0;
+    virtual void Finish() = 0;
 
-plMD5Checksum::plMD5Checksum(const plFileName& fileName)
-    : fValid(), fContext()
-{
-    CalcFromFile(fileName);
-}
-
-plMD5Checksum::plMD5Checksum(hsStream* stream)
-    : fValid(), fContext()
-{
-    CalcFromStream(stream);
-}
-
-void plMD5Checksum::Clear()
-{
-    if (fContext)
-        EVP_MD_CTX_destroy(fContext);
-    fContext = nullptr;
-    memset(fChecksum, 0, sizeof(fChecksum));
-    fValid = false;
-}
-
-void plMD5Checksum::CalcFromFile(const plFileName& fileName)
-{
-    hsUNIXStream s;
-    fValid = false;
-
-    if (s.Open(fileName))
-    {
-        CalcFromStream(&s);
-    }
-}
-
-void plMD5Checksum::CalcFromStream(hsStream* stream)
-{
-    uint32_t sPos = stream->GetPosition();
-    unsigned loadLen = 1024 * 1024;
-    Start();
-
-    uint8_t *buf = new uint8_t[loadLen];
-
-    while (int read = stream->Read(loadLen, buf))
-        AddTo(read, buf);
-    delete[] buf;
-
-    Finish();
-    stream->SetPosition(sPos);
-}
-
-void plMD5Checksum::Start()
-{
-    const EVP_MD* md = EVP_get_digestbyname("md5");
-    hsAssert(md, "This OpenSSL has no support for MD5");
-
-    size_t out_size = EVP_MD_size(md);
-    hsAssert(out_size == sizeof(fChecksum), "Incorrect output size for MD5");
-
-    fContext = EVP_MD_CTX_create();
-    EVP_DigestInit_ex(fContext, md, nullptr);
-    fValid = false;
-}
-
-void plMD5Checksum::AddTo(size_t size, const uint8_t* buffer)
-{
-    EVP_DigestUpdate(fContext, buffer, size);
-}
-
-void plMD5Checksum::Finish()
-{
-    unsigned int out_size;
-    EVP_DigestFinal_ex(fContext, fChecksum, &out_size);
-    fValid = true;
-    if (fContext)
-        EVP_MD_CTX_destroy(fContext);
-    fContext = nullptr;
-}
-
-ST::string plMD5Checksum::GetAsHexString() const
-{
-    hsAssert(fValid, "Trying to get string version of invalid checksum");
-
-    return ST::hex_encode(fChecksum, sizeof(fChecksum));
-}
-
-void plMD5Checksum::SetFromHexString(const char* string)
-{
-    const char  *ptr;
-    int         i;
-
-
-    hsAssert(strlen(string) == 2 * MD5_DIGEST_LENGTH, "Invalid string in MD5Checksum Set()");
-
-    for (i = 0, ptr = string; i < sizeof(fChecksum); i++, ptr += 2)
-        fChecksum[i] = (IHexCharToInt(ptr[0]) << 4) | IHexCharToInt(ptr[1]);
-
-    fValid = true;
-}
-
-void plMD5Checksum::SetValue(uint8_t* checksum)
-{
-    fValid = true;
-    memcpy(fChecksum, checksum, sizeof(fChecksum));
-}
-
-bool plMD5Checksum::operator==(const plMD5Checksum& rhs) const
-{
-    return (fValid && rhs.fValid && memcmp(fChecksum, rhs.fChecksum, sizeof(fChecksum)) == 0);
-}
+    virtual size_t GetSize() const = 0;
+    virtual uint8_t* GetValue() = 0;
+};
 
 //============================================================================
-plSHAChecksum::plSHAChecksum(size_t size, const uint8_t* buffer)
-    : fValid(), fOpenSSLContext()
+
+class plEVPChecksum : public plChecksumImpl
 {
+    EVP_MD_CTX* fCtx;
+    const EVP_MD* fMd;
+    std::unique_ptr<uint8_t[]> fValue;
+
+public:
+    plEVPChecksum() = delete;
+    plEVPChecksum(const plEVPChecksum&) = delete;
+    plEVPChecksum(plEVPChecksum&&) = delete;
+
+    plEVPChecksum(const EVP_MD* md)
+        : fCtx(), fMd(md)
+    {
+        // This could have been passed in as a template paraemter, which could
+        // be used to statically allocate the buffer. That would be more performant,
+        // but it would also mean generating a different class in the executable
+        // for almost every checksum type, which seems a little silly. This is
+        // not a performace-critical path, so we'll just allocate the buffer dynamically.
+        size_t size = EVP_MD_size(md);
+        fValue = std::make_unique<uint8_t[]>(size);
+    }
+
+    ~plEVPChecksum()
+    {
+        if (fCtx)
+            EVP_MD_CTX_destroy(fCtx);
+    }
+
+public:
+    void Start() override
+    {
+        if (fCtx == nullptr)
+            fCtx = EVP_MD_CTX_create();
+        EVP_DigestInit_ex(fCtx, fMd, nullptr);
+    }
+
+    void AddTo(size_t size, const uint8_t* buffer) override
+    {
+        EVP_DigestUpdate(fCtx, buffer, size);
+    }
+
+    void Finish() override
+    {
+        EVP_DigestFinal_ex(fCtx, fValue.get(), nullptr);
+        EVP_MD_CTX_reset(fCtx);
+    }
+
+    size_t GetSize() const override
+    {
+        return EVP_MD_size(fMd);
+    }
+
+    uint8_t* GetValue() override
+    {
+        return fValue.get();
+    }
+};
+
+//============================================================================
+
+class plSHA0Checksum : public plChecksumImpl
+{
+    plSha0 fCtx;
+    ShaDigest fValue;
+
+public:
+    plSHA0Checksum() : fValue() {}
+    plSHA0Checksum(const plSHA0Checksum&) = delete;
+    plSHA0Checksum(plSHA0Checksum&&) = delete;
+
+public:
+    void Start() override { fCtx.Start(); }
+    void AddTo(size_t size, const uint8_t* buffer) override { fCtx.AddTo(size, buffer); }
+    void Finish() override { fCtx.Finish(fValue); }
+    size_t GetSize() const override { return sizeof(fValue); }
+    uint8_t* GetValue() override { return fValue; }
+};
+
+//============================================================================
+
+plChecksum::plChecksum(plChecksum&& move) noexcept
+    : fStatus(move.fStatus), fType(move.fType),
+      fImpl(std::move(move.fImpl))
+{
+    move.fStatus = Status::kInvalid;
+}
+
+plChecksum::plChecksum(plChecksum::Type type)
+    : fStatus(Status::kReady), fType(type)
+{
+    IInit(type);
+}
+
+plChecksum::plChecksum(plChecksum::Type type, const plFileName& fileName)
+    : fStatus(Status::kReady), fType(type)
+{
+    IInit(type);
+    CalcFromFile(fileName);
+}
+
+plChecksum::plChecksum(plChecksum::Type type, hsStream* stream)
+    : fStatus(Status::kReady), fType(type)
+{
+    IInit(type);
+    CalcFromStream(stream);
+}
+
+plChecksum::plChecksum(plChecksum::Type type, size_t size, const uint8_t* buffer)
+    : fStatus(Status::kReady), fType(type)
+{
+    IInit(type);
     Start();
     AddTo(size, buffer);
     Finish();
 }
 
-plSHAChecksum::plSHAChecksum()
-    : fValid(), fOpenSSLContext()
+void plChecksum::IInit(plChecksum::Type type)
 {
-    memset(fChecksum, 0, sizeof(fChecksum));
-}
-
-plSHAChecksum::plSHAChecksum(const plSHAChecksum& rhs)
-    : fValid(rhs.fValid), fOpenSSLContext()
-{
-    memcpy(fChecksum, rhs.fChecksum, sizeof(fChecksum));
-}
-
-plSHAChecksum::plSHAChecksum(const plFileName& fileName)
-    : fValid(), fOpenSSLContext()
-{
-    CalcFromFile(fileName);
-}
-
-plSHAChecksum::plSHAChecksum(hsStream* stream)
-    : fValid(), fOpenSSLContext()
-{
-    CalcFromStream(stream);
-}
-
-void plSHAChecksum::Clear()
-{
-    if (fOpenSSLContext)
-        EVP_MD_CTX_destroy(fOpenSSLContext);
-    fOpenSSLContext = nullptr;
-    memset(fChecksum, 0, sizeof(fChecksum));
-    fValid = false;
-}
-
-void plSHAChecksum::CalcFromFile(const plFileName& fileName)
-{
-    hsUNIXStream s;
-    fValid = false;
-
-    if (s.Open(fileName))
-    {
-        CalcFromStream(&s);
+    switch (type) {
+        case Type::kMD5:
+            fImpl = std::make_unique<plEVPChecksum>(EVP_md5());
+            break;
+        case Type::kSHA0: {
+            // SHA-0 is not supported by OpenSSL these days, so we may have to
+            // use our own implementation.
+            const EVP_MD* md = EVP_get_digestbyname("sha");
+            if (md)
+                fImpl = std::make_unique<plEVPChecksum>(md);
+            else
+                fImpl = std::make_unique<plSHA0Checksum>();
+            break;
+        }
+        case Type::kSHA1:
+            fImpl = std::make_unique<plEVPChecksum>(EVP_sha1());
+            break;
+        DEFAULT_FATAL("checksumType");
     }
 }
 
-void plSHAChecksum::CalcFromStream(hsStream* stream)
+plChecksum::~plChecksum()
 {
-    uint32_t sPos = stream->GetPosition();
-    unsigned loadLen = 1024 * 1024;
-    Start();
-
-    uint8_t* buf = new uint8_t[loadLen];
-
-    while (int read = stream->Read(loadLen, buf))
-    {
-        AddTo( read, buf );
-    }
-    delete[] buf;
-
-    Finish();
-    stream->SetPosition(sPos);
-}
-
-void plSHAChecksum::Start()
-{
-    const EVP_MD* md = EVP_get_digestbyname("sha");
-    if (md) {
-        size_t out_size = EVP_MD_size(md);
-        hsAssert(out_size == sizeof(fChecksum), "Incorrect output size for SHA0");
-
-        fOpenSSLContext = EVP_MD_CTX_create();
-        EVP_DigestInit_ex(fOpenSSLContext, md, nullptr);
-    } else {
-        fOpenSSLContext = nullptr;
-        fPlasmaContext.Start();
-    }
-    fValid = false;
-}
-
-void plSHAChecksum::AddTo(size_t size, const uint8_t* buffer)
-{
-    if (fOpenSSLContext)
-        EVP_DigestUpdate(fOpenSSLContext, buffer, size);
-    else
-        fPlasmaContext.AddTo(size, buffer);
-}
-
-void plSHAChecksum::Finish()
-{
-    if (fOpenSSLContext) {
-        unsigned int out_size;
-        EVP_DigestFinal_ex(fOpenSSLContext, fChecksum, &out_size);
-        if (fOpenSSLContext)
-            EVP_MD_CTX_destroy(fOpenSSLContext);
-        fOpenSSLContext = nullptr;
-    } else {
-        fPlasmaContext.Finish(fChecksum);
-    }
-    fValid = true;
-}
-
-ST::string plSHAChecksum::GetAsHexString() const
-{
-    hsAssert(fValid, "Trying to get string version of invalid checksum");
-
-    return ST::hex_encode(fChecksum, sizeof(fChecksum));
-}
-
-void plSHAChecksum::SetFromHexString(const char* string)
-{
-    const char* ptr;
-    int         i;
-
-    hsAssert(strlen(string) == (2 * SHA_DIGEST_LENGTH), "Invalid string in SHAChecksum Set()");
-
-    for (i = 0, ptr = string; i < sizeof(fChecksum); i++, ptr += 2)
-        fChecksum[i] = (IHexCharToInt(ptr[0]) << 4) | IHexCharToInt(ptr[1]);
-
-    fValid = true;
-}
-
-void plSHAChecksum::SetValue(uint8_t* checksum)
-{
-    fValid = true;
-    memcpy(fChecksum, checksum, sizeof(fChecksum));
-}
-
-bool plSHAChecksum::operator==(const plSHAChecksum& rhs) const
-{
-    return (fValid && rhs.fValid && memcmp(fChecksum, rhs.fChecksum, sizeof(fChecksum)) == 0);
+    // This is in the cpp file because plChecksumImpl is incomplete in the header file.
 }
 
 //============================================================================
 
-plSHA1Checksum::plSHA1Checksum(size_t size, const uint8_t* buffer)
-    : fValid(), fContext()
-{
-    Start();
-    AddTo(size, buffer);
-    Finish();
-}
-
-plSHA1Checksum::plSHA1Checksum()
-    : fValid(), fContext()
-{
-    memset(fChecksum, 0, sizeof(fChecksum));
-}
-
-plSHA1Checksum::plSHA1Checksum(const plSHA1Checksum& rhs)
-    : fValid(rhs.fValid), fContext()
-{
-    memcpy(fChecksum, rhs.fChecksum, sizeof(fChecksum));
-}
-
-plSHA1Checksum::plSHA1Checksum(const plFileName& fileName)
-    : fValid(), fContext()
-{
-    CalcFromFile(fileName);
-}
-
-plSHA1Checksum::plSHA1Checksum(hsStream* stream)
-    : fValid(), fContext()
-{
-    CalcFromStream(stream);
-}
-
-void plSHA1Checksum::Clear()
-{
-    if (fContext)
-        EVP_MD_CTX_destroy(fContext);
-    fContext = nullptr;
-    memset(fChecksum, 0, sizeof(fChecksum));
-    fValid = false;
-}
-
-void plSHA1Checksum::CalcFromFile(const plFileName& fileName)
+void plChecksum::CalcFromFile(const plFileName& fileName)
 {
     hsUNIXStream s;
-    fValid = false;
-
     if (s.Open(fileName))
-    {
         CalcFromStream(&s);
-    }
 }
 
-void plSHA1Checksum::CalcFromStream(hsStream* stream)
+void plChecksum::CalcFromStream(hsStream* stream)
 {
+    if (fStatus == Status::kStarted)
+        throw plChecksumException("Checksum already started");
+
     uint32_t sPos = stream->GetPosition();
-    unsigned loadLen = 1024 * 1024;
+    constexpr uint32_t loadLen = 1024 * 1024;
+    auto buf = std::make_unique<uint8_t[]>(loadLen);
+
     Start();
-
-    uint8_t* buf = new uint8_t[loadLen];
-
-    while (int read = stream->Read(loadLen, buf))
-    {
-        AddTo( read, buf );
-    }
-    delete[] buf;
-
+    while (int read = stream->Read(loadLen, buf.get()))
+        AddTo(read, buf.get());
     Finish();
+
     stream->SetPosition(sPos);
 }
 
-void plSHA1Checksum::Start()
+//============================================================================
+
+void plChecksum::SetFromHexString(const char* string)
 {
-    const EVP_MD* md = EVP_get_digestbyname("sha1");
-    hsAssert(md, "This OpenSSL has no support for SHA1");
+    size_t stringLen = strlen(string);
+    if (fStatus != Status::kReady)
+        throw plChecksumException("Checksum in use");
+    if (stringLen != 2 * GetSize())
+        throw plChecksumException("Invalid string in ISetFromHexString");
 
-    size_t out_size = EVP_MD_size(md);
-    hsAssert(out_size == sizeof(fChecksum), "Incorrect output size for SHA1");
+    size_t checksumSz = fImpl->GetSize();
+    uint8_t* value = fImpl->GetValue();
 
-    fContext = EVP_MD_CTX_create();
-    EVP_DigestInit_ex(fContext, md, nullptr);
-    fValid = false;
-}
-
-void plSHA1Checksum::AddTo(size_t size, const uint8_t* buffer)
-{
-    EVP_DigestUpdate(fContext, buffer, size);
-}
-
-void plSHA1Checksum::Finish()
-{
-    unsigned int out_size;
-    EVP_DigestFinal_ex(fContext, fChecksum, &out_size);
-    fValid = true;
-    if (fContext)
-        EVP_MD_CTX_destroy(fContext);
-    fContext = nullptr;
-}
-
-ST::string plSHA1Checksum::GetAsHexString() const
-{
-    hsAssert(fValid, "Trying to get string version of invalid checksum");
-
-    return ST::hex_encode(fChecksum, sizeof(fChecksum));
-}
-
-void plSHA1Checksum::SetFromHexString(const char* string)
-{
     const char* ptr;
-    int         i;
-
-    hsAssert(strlen(string) == (2 * SHA_DIGEST_LENGTH), "Invalid string in SHA1Checksum Set()");
-
-    for (i = 0, ptr = string; i < sizeof(fChecksum); i++, ptr += 2)
-        fChecksum[i] = (IHexCharToInt(ptr[0]) << 4) | IHexCharToInt(ptr[1]);
-
-    fValid = true;
+    size_t i;
+    for (i = 0, ptr = string; i < checksumSz; i++, ptr += 2)
+        value[i] = (IHexCharToInt(ptr[0]) << 4) | IHexCharToInt(ptr[1]);
+    fStatus = Status::kFinished;
 }
 
-void plSHA1Checksum::SetValue(uint8_t* checksum)
+ST::string plChecksum::GetAsHexString() const
 {
-    fValid = true;
-    memcpy(fChecksum, checksum, sizeof(fChecksum));
+    if (fStatus != Status::kFinished)
+        throw plChecksumException("Checksum not finished");
+    return ST::hex_encode(fImpl->GetValue(), GetSize());
 }
 
-bool plSHA1Checksum::operator==(const plSHA1Checksum& rhs) const
+//============================================================================
+
+void plChecksum::Start()
 {
-    return (fValid && rhs.fValid && memcmp(fChecksum, rhs.fChecksum, sizeof(fChecksum)) == 0);
+    if (fStatus == Status::kInvalid)
+        throw plChecksumException("Checksum invalid");
+    if (fStatus == Status::kStarted)
+        throw plChecksumException("Checksum in use");
+
+    fImpl->Start();
+    fStatus = Status::kStarted;
 }
 
+void plChecksum::AddTo(size_t size, const uint8_t* buffer)
+{
+    if (fStatus != Status::kStarted)
+        throw plChecksumException("Checksum not started");
+
+    fImpl->AddTo(size, buffer);
+}
+
+void plChecksum::Finish()
+{
+    if (fStatus != Status::kStarted)
+        throw plChecksumException("Checksum not started");
+
+    fImpl->Finish();
+    fStatus = Status::kFinished;
+}
+
+size_t plChecksum::GetSize() const
+{
+    if (fStatus != Status::kFinished)
+        throw plChecksumException("Checksum not finished");
+    return fImpl->GetSize();
+}
+
+const uint8_t* plChecksum::GetValue() const
+{
+    if (fStatus != Status::kFinished)
+        throw plChecksumException("Checksum not finished");
+    return fImpl->GetValue();
+}
+
+//============================================================================
+
+bool plChecksum::operator==(const plChecksum& rhs) const
+{
+    if (!IsValid())
+        return false;
+    if (!rhs.IsValid())
+        return false;
+
+    if (fType != rhs.fType)
+        return false;
+    if (fImpl->GetSize() != rhs.fImpl->GetSize())
+        return false;
+
+    return memcmp(
+        fImpl->GetValue(),
+        rhs.fImpl->GetValue(),
+        fImpl->GetSize()
+    ) == 0;
+}
+
+//============================================================================
+
+plChecksum& plChecksum::operator=(plChecksum&& move) noexcept
+{
+    if (this != &move) {
+        fStatus = move.fStatus;
+        fType = move.fType;
+        fImpl = std::move(move.fImpl);
+        move.fStatus = Status::kInvalid;
+    }
+    return *this;
+}

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -97,29 +97,6 @@ static uint8_t IHexCharToInt(char c)
     return 0xff;
 }
 
-plChecksum::plChecksum(unsigned int bufsize, const char* buffer)
-{
-    unsigned int wndsz = GetWindowSize(),i = 0;
-    fSum = 0;
-
-    const char* bufferAbsEnd = buffer + bufsize;
-    const char* bufferEnvenEnd = buffer + bufsize - (bufsize % wndsz);
-
-    while (buffer < bufferEnvenEnd)
-    {
-        fSum += hsToLE32(*((SumStorage*)buffer));
-        buffer += wndsz;
-    }
-
-    SumStorage last = 0;
-    while (buffer < bufferAbsEnd)
-    {
-        ((char*)&last)[i % wndsz] = *buffer;
-        buffer++;
-    }
-    fSum+= hsToLE32(last);
-}
-
 //============================================================================
 
 plMD5Checksum::plMD5Checksum(size_t size, const uint8_t* buffer)

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -211,34 +211,6 @@ plChecksum::plChecksum(plChecksum&& move) noexcept
 plChecksum::plChecksum(plChecksum::Type type)
     : fStatus(Status::kReady), fType(type)
 {
-    IInit(type);
-}
-
-plChecksum::plChecksum(plChecksum::Type type, const plFileName& fileName)
-    : fStatus(Status::kReady), fType(type)
-{
-    IInit(type);
-    CalcFromFile(fileName);
-}
-
-plChecksum::plChecksum(plChecksum::Type type, hsStream* stream)
-    : fStatus(Status::kReady), fType(type)
-{
-    IInit(type);
-    CalcFromStream(stream);
-}
-
-plChecksum::plChecksum(plChecksum::Type type, size_t size, const uint8_t* buffer)
-    : fStatus(Status::kReady), fType(type)
-{
-    IInit(type);
-    Start();
-    AddTo(size, buffer);
-    Finish();
-}
-
-void plChecksum::IInit(plChecksum::Type type)
-{
     switch (type) {
         case Type::kMD5:
             fImpl = std::make_unique<plEVPChecksum>(EVP_md5());
@@ -264,6 +236,26 @@ void plChecksum::IInit(plChecksum::Type type)
             break;
         DEFAULT_FATAL("checksumType");
     }
+}
+
+plChecksum::plChecksum(plChecksum::Type type, const plFileName& fileName)
+    : plChecksum(type)
+{
+    CalcFromFile(fileName);
+}
+
+plChecksum::plChecksum(plChecksum::Type type, hsStream* stream)
+    : plChecksum(type)
+{
+    CalcFromStream(stream);
+}
+
+plChecksum::plChecksum(plChecksum::Type type, size_t size, const uint8_t* buffer)
+    : plChecksum(type)
+{
+    Start();
+    AddTo(size, buffer);
+    Finish();
 }
 
 plChecksum::~plChecksum()

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp
@@ -216,13 +216,10 @@ plChecksum::plChecksum(plChecksum::Type type)
             fImpl = std::make_unique<plEVPChecksum>(EVP_md5());
             break;
         case Type::kSHA0: {
-            // SHA-0 is not supported by OpenSSL these days, so we may have to
-            // use our own implementation.
-            const EVP_MD* md = EVP_get_digestbyname("sha");
-            if (md)
-                fImpl = std::make_unique<plEVPChecksum>(md);
-            else
-                fImpl = std::make_unique<plSHA0Checksum>();
+            // SHA-0 is not supported by OpenSSL these days, so just use our
+            // hand rolled implementation. This way, we can be sure it's being
+            // tested in the tests (not OpenSSL's implementation) for consistency.
+            fImpl = std::make_unique<plSHA0Checksum>();
             break;
         }
         case Type::kSHA1:

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -49,19 +49,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define MD5_DIGEST_LENGTH 16
 #define SHA_DIGEST_LENGTH 20
 
-class plChecksum
-{
-public:
-    typedef uint32_t SumStorage;
-private:
-    SumStorage fSum;
-public:
-    plChecksum(unsigned int bufsize, const char* buffer);
-    static int GetChecksumSize() { return sizeof(SumStorage); }
-    static int GetWindowSize() { return sizeof(SumStorage); }
-    SumStorage GetChecksum() { return fSum; }
-};
-
 class hsStream;
 class plFileName;
 

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -94,7 +94,7 @@ public:
 
     size_t GetSize() const;
     const uint8_t* GetValue() const;
-    bool IsValid() const { return fStatus == Status::kFinished; }
+    bool IsFinished() const { return fStatus == Status::kFinished; }
 
     void Start();
     void AddTo(size_t size, const uint8_t* buffer);

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -44,7 +44,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 #include "plSha0.h"
-#include <openssl/evp.h>
+
+#include <openssl/ossl_typ.h>
 
 #define MD5_DIGEST_LENGTH 16
 #define SHA_DIGEST_LENGTH 20

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -44,8 +44,8 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "HeadSpin.h"
 
-#include <exception>
 #include <memory>
+#include <stdexcept>
 
 /* A bunch of things might store either a SHA or a SHA1 checksum, this provides
  * them a way to store the checksum itself, rather than a union of the classes.
@@ -117,11 +117,11 @@ public:
     plChecksum& operator=(plChecksum&& move) noexcept;
 };
 
-class plChecksumException : public std::exception
+class plChecksumException : public std::logic_error
 {
 public:
-    plChecksumException() = default;
-    plChecksumException(const char* message) : std::exception(message) {}
+    plChecksumException() = delete;
+    plChecksumException(const char* message) : std::logic_error(message) {}
     plChecksumException(const plChecksumException&) = default;
     plChecksumException(plChecksumException&&) = default;
 };

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -63,6 +63,8 @@ public:
         kMD5,
         kSHA0,
         kSHA1,
+        kSHA256,
+        kSHA512,
     };
 
 private:

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -43,134 +43,85 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define PL_CHECKSUM_H
 
 #include "HeadSpin.h"
-#include "plSha0.h"
 
-#include <openssl/ossl_typ.h>
-
-#define MD5_DIGEST_LENGTH 16
-#define SHA_DIGEST_LENGTH 20
-
-class hsStream;
-class plFileName;
-
-class plMD5Checksum
-{
-    protected:
-        bool        fValid;
-        EVP_MD_CTX* fContext;
-        uint8_t     fChecksum[MD5_DIGEST_LENGTH];
-
-    public:
-        plMD5Checksum(size_t size, const uint8_t* buffer);
-        plMD5Checksum();
-        plMD5Checksum(const plMD5Checksum& rhs);
-        plMD5Checksum(const plFileName& fileName);
-        plMD5Checksum(hsStream* stream);
-        ~plMD5Checksum() { Clear(); }
-
-        bool IsValid() const { return fValid; }
-        void Clear();
-
-        void CalcFromFile(const plFileName& fileName);
-        void CalcFromStream(hsStream* stream);
-
-        void Start();
-        void AddTo(size_t size, const uint8_t* buffer);
-        void Finish();
-
-        const uint8_t* GetValue() const { return fChecksum; }
-        size_t GetSize() const { return sizeof(fChecksum); }
-
-        // Backdoor for cached checksums (ie, if you loaded it off disk)
-        void SetValue(uint8_t* checksum);
-
-        ST::string GetAsHexString() const;
-        void SetFromHexString(const char* string);
-
-        bool operator==(const plMD5Checksum& rhs) const;
-        bool operator!=(const plMD5Checksum& rhs) const { return !operator==(rhs); }
-};
+#include <exception>
+#include <memory>
 
 /* A bunch of things might store either a SHA or a SHA1 checksum, this provides
  * them a way to store the checksum itself, rather than a union of the classes.
  */
-typedef uint8_t ShaDigest[SHA_DIGEST_LENGTH];
+typedef uint8_t ShaDigest[20];
 
-class plSHAChecksum
+class hsStream;
+class plFileName;
+
+class plChecksum
 {
-    protected:
-        bool        fValid;
-        EVP_MD_CTX* fOpenSSLContext;
-        plSha0      fPlasmaContext;
-        ShaDigest   fChecksum;
+public:
+    enum class Type
+    {
+        kMD5,
+        kSHA0,
+        kSHA1,
+    };
 
-    public:
-        plSHAChecksum(size_t size, const uint8_t* buffer);
-        plSHAChecksum();
-        plSHAChecksum(const plSHAChecksum& rhs);
-        plSHAChecksum(const plFileName& fileName);
-        plSHAChecksum(hsStream* stream);
-        ~plSHAChecksum() { Clear(); }
+private:
+    enum class Status
+    {
+        kInvalid,
+        kReady,
+        kStarted,
+        kFinished,
+    };
 
-        bool IsValid() const { return fValid; }
-        void Clear();
+    Status fStatus;
+    Type fType;
+    std::unique_ptr<class plChecksumImpl> fImpl;
 
-        void CalcFromFile(const plFileName& fileName);
-        void CalcFromStream(hsStream* stream);
+private:
+    void IInit(Type type);
 
-        void Start();
-        void AddTo(size_t size, const uint8_t* buffer);
-        void Finish();
+public:
+    plChecksum() = delete;
+    plChecksum(plChecksum&& move) noexcept;
+    plChecksum(const plChecksum& copy) = delete;
 
-        const uint8_t* GetValue() const { return fChecksum; }
-        size_t GetSize() const { return sizeof(fChecksum); }
+    plChecksum(Type type);
+    plChecksum(Type type, const plFileName& fileName);
+    plChecksum(Type type, hsStream* stream);
+    plChecksum(Type type, size_t size, const uint8_t* buffer);
 
-        // Backdoor for cached checksums (ie, if you loaded it off disk)
-        void SetValue(uint8_t* checksum);
+    ~plChecksum();
 
-        ST::string GetAsHexString() const;
-        void SetFromHexString(const char* string);
+    size_t GetSize() const;
+    const uint8_t* GetValue() const;
+    bool IsValid() const { return fStatus == Status::kFinished; }
 
-        bool operator==(const plSHAChecksum& rhs) const;
-        bool operator!=(const plSHAChecksum& rhs) const { return !operator==(rhs); }
+    void Start();
+    void AddTo(size_t size, const uint8_t* buffer);
+    void Finish();
+
+    void CalcFromFile(const plFileName& fileName);
+    void CalcFromStream(hsStream* stream);
+
+    ST::string GetAsHexString() const;
+    void SetFromHexString(const char* string);
+
+public:
+    bool operator==(const plChecksum& rhs) const;
+    bool operator!=(const plChecksum& rhs) const { return !operator==(rhs); }
+
+    plChecksum& operator=(const plChecksum& copy) = delete;
+    plChecksum& operator=(plChecksum&& move) noexcept;
 };
 
-class plSHA1Checksum
+class plChecksumException : public std::exception
 {
-    protected:
-        bool        fValid;
-        EVP_MD_CTX* fContext;
-        ShaDigest   fChecksum;
-
-    public:
-        plSHA1Checksum(size_t size, const uint8_t* buffer);
-        plSHA1Checksum();
-        plSHA1Checksum(const plSHA1Checksum& rhs);
-        plSHA1Checksum(const plFileName& fileName);
-        plSHA1Checksum(hsStream* stream);
-        ~plSHA1Checksum() { Clear(); }
-
-        bool IsValid() const { return fValid; }
-        void Clear();
-
-        void CalcFromFile(const plFileName& fileName);
-        void CalcFromStream(hsStream* stream);
-
-        void Start();
-        void AddTo(size_t size, const uint8_t* buffer);
-        void Finish();
-
-        const uint8_t* GetValue() const { return fChecksum; }
-        size_t GetSize() const { return sizeof(fChecksum); }
-
-        // Backdoor for cached checksums (ie, if you loaded it off disk)
-        void SetValue(uint8_t* checksum);
-
-        ST::string GetAsHexString() const;
-        void SetFromHexString(const char* string);
-
-        bool operator==(const plSHA1Checksum& rhs) const;
-        bool operator!=(const plSHA1Checksum& rhs) const { return !operator==(rhs); }
+public:
+    plChecksumException() = default;
+    plChecksumException(const char* message) : std::exception(message) {}
+    plChecksumException(const plChecksumException&) = default;
+    plChecksumException(plChecksumException&&) = default;
 };
 
 #endif // PL_CHECKSUM_H

--- a/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
+++ b/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.h
@@ -80,9 +80,6 @@ private:
     Type fType;
     std::unique_ptr<class plChecksumImpl> fImpl;
 
-private:
-    void IInit(Type type);
-
 public:
     plChecksum() = delete;
     plChecksum(plChecksum&& move) noexcept;

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/CMakeLists.txt
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/CMakeLists.txt
@@ -2,6 +2,8 @@ set(pnEncryptionTest_SOURCES
     test_plMD5Checksum.cpp
     test_plSHAChecksum.cpp
     test_plSHA1Checksum.cpp
+    test_plSHA256Checksum.cpp
+    test_plSHA512Checksum.cpp
 )
 
 plasma_test(test_pnEncryption SOURCES ${pnEncryptionTest_SOURCES})

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plMD5Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plMD5Checksum.cpp
@@ -52,7 +52,7 @@ TEST(plMD5Checksum, ctor_with_buffer)
     const uint8_t value[16] = {0xb1, 0x0a, 0x8d, 0xb1, 0x64, 0xe0, 0x75, 0x41,
                                0x05, 0xb7, 0xa9, 0x9b, 0xe7, 0x2e, 0x3f, 0xe5};
 
-    plMD5Checksum sum(strlen(buffer), (const uint8_t*)buffer);
+    plChecksum sum(plChecksum::Type::kMD5, strlen(buffer), (const uint8_t*)buffer);
 
     EXPECT_EQ(sizeof(value), sum.GetSize());
     EXPECT_EQ(0, memcmp(sum.GetValue(), value, 16));
@@ -66,7 +66,7 @@ TEST(plMD5Checksum, update)
     const uint8_t value[16] = {0xb1, 0x0a, 0x8d, 0xb1, 0x64, 0xe0, 0x75, 0x41,
                                0x05, 0xb7, 0xa9, 0x9b, 0xe7, 0x2e, 0x3f, 0xe5};
 
-    plMD5Checksum sum;
+    plChecksum sum(plChecksum::Type::kMD5);
     sum.Start();
     sum.AddTo(strlen(buffer[0]), (const uint8_t*)buffer[0]);
     sum.AddTo(strlen(buffer[1]), (const uint8_t*)buffer[1]);
@@ -82,30 +82,44 @@ TEST(plMD5Checksum, well_known_hashes)
     // From NIST FIPS-180
     const char case0_text[] = "";
     const char case0_digest[] = "d41d8cd98f00b204e9800998ecf8427e";
-    plMD5Checksum case0(strlen(case0_text), (const uint8_t*)case0_text);
+    plChecksum case0(
+        plChecksum::Type::kMD5,
+        strlen(case0_text),
+        (const uint8_t*)case0_text
+    );
     EXPECT_STREQ(case0_digest, case0.GetAsHexString().c_str());
 
     const char case1_text[] = "abc";
     const char case1_digest[] = "900150983cd24fb0d6963f7d28e17f72";
-    plMD5Checksum case1(strlen(case1_text), (const uint8_t*)case1_text);
+    plChecksum case1(
+        plChecksum::Type::kMD5,
+        strlen(case1_text),
+        (const uint8_t*)case1_text);
     EXPECT_STREQ(case1_digest, case1.GetAsHexString().c_str());
 
     const char case2_text[] = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
     const char case2_digest[] = "8215ef0796a20bcaaae116d3876c664a";
-    plMD5Checksum case2(strlen(case2_text), (const uint8_t*)case2_text);
+    plChecksum case2(
+        plChecksum::Type::kMD5,
+        strlen(case2_text),
+        (const uint8_t*)case2_text);
     EXPECT_STREQ(case2_digest, case2.GetAsHexString().c_str());
 
     const char case3_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
                               "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
     const char case3_digest[] = "03dd8807a93175fb062dfb55dc7d359c";
-    plMD5Checksum case3(strlen(case3_text), (const uint8_t*)case3_text);
+    plChecksum case3(
+        plChecksum::Type::kMD5,
+        strlen(case3_text),
+        (const uint8_t*)case3_text
+    );
     EXPECT_STREQ(case3_digest, case3.GetAsHexString().c_str());
 
     // 1,000,000 copies of 'a'
     uint8_t onek_a[1000];
     memset(onek_a, 'a', sizeof(onek_a));
     const char case4_digest[] = "7707d6ae4e027c70eea2a935c2296f21";
-    plMD5Checksum case4;
+    plChecksum case4(plChecksum::Type::kMD5);
     case4.Start();
     for (size_t i = 0; i < 1000; ++i)
         case4.AddTo(sizeof(onek_a), onek_a);
@@ -116,7 +130,7 @@ TEST(plMD5Checksum, well_known_hashes)
     const char case5_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno";
     const size_t case5_text_len = strlen(case5_text);
     const char case5_digest[] = "d338139169d50f55526194c790ec0448";
-    plMD5Checksum case5;
+    plChecksum case5(plChecksum::Type::kMD5);
     case5.Start();
     for (size_t i = 0; i < 16777216; ++i)
         case5.AddTo(case5_text_len, (const uint8_t*)case5_text);

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plMD5Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plMD5Checksum.cpp
@@ -45,6 +45,45 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnEncryption/plChecksum.h"
 #include <string_theory/string>
 
+TEST(plMD5Checksum, lifecycle)
+{
+    plChecksum sum(plChecksum::Type::kMD5);
+
+    // Can't add to or finish until Start() is called.
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+    EXPECT_THROW(sum.Finish(), plChecksumException);
+
+    // Calling Start() twice doesn't make sense.
+    EXPECT_NO_THROW(sum.Start());
+    EXPECT_THROW(sum.Start(), plChecksumException);
+
+    // Can't get the value or size until Finish() is called.
+    EXPECT_THROW(sum.GetValue(), plChecksumException);
+    EXPECT_THROW(sum.GetSize(), plChecksumException);
+
+    // Can't add after Finish() is called.
+    EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
+    EXPECT_NO_THROW(sum.Finish());
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+
+    // Value and size should work now.
+    EXPECT_NO_THROW(sum.GetSize());
+    EXPECT_NO_THROW(sum.GetValue());
+
+    // Should be able to restart and reuse the checksum object.
+    EXPECT_NO_THROW(sum.Start());
+    EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
+    EXPECT_NO_THROW(sum.Finish());
+
+    // Moving invalidates the source.
+    plChecksum sum2 = std::move(sum);
+    EXPECT_THROW(sum.GetValue(), plChecksumException);
+    EXPECT_THROW(sum.GetSize(), plChecksumException);
+    EXPECT_THROW(sum.Start(), plChecksumException);
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+    EXPECT_THROW(sum.Finish(), plChecksumException);
+}
+
 TEST(plMD5Checksum, ctor_with_buffer)
 {
     const char buffer[] = "Hello World";

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plMD5Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plMD5Checksum.cpp
@@ -49,6 +49,10 @@ TEST(plMD5Checksum, lifecycle)
 {
     plChecksum sum(plChecksum::Type::kMD5);
 
+    // We can set the checksum value directly if no checksum is in progress.
+    EXPECT_NO_THROW(sum.SetFromHexString("d41d8cd98f00b204e9800998ecf8427e"));
+    EXPECT_THROW(sum.SetFromHexString("1"), plChecksumException);
+
     // Can't add to or finish until Start() is called.
     EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
     EXPECT_THROW(sum.Finish(), plChecksumException);
@@ -57,9 +61,11 @@ TEST(plMD5Checksum, lifecycle)
     EXPECT_NO_THROW(sum.Start());
     EXPECT_THROW(sum.Start(), plChecksumException);
 
-    // Can't get the value or size until Finish() is called.
+    // Now that we've started, we can't set the checksum value directly.
+    EXPECT_THROW(sum.SetFromHexString("d41d8cd98f00b204e9800998ecf8427e"), plChecksumException);
+
+    // Can't get the value until Finish() is called.
     EXPECT_THROW(sum.GetValue(), plChecksumException);
-    EXPECT_THROW(sum.GetSize(), plChecksumException);
 
     // Can't add after Finish() is called.
     EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
@@ -75,6 +81,9 @@ TEST(plMD5Checksum, lifecycle)
     EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
     EXPECT_NO_THROW(sum.Finish());
 
+    // We can set the checksum value directly if no checksum is in progress.
+    EXPECT_NO_THROW(sum.SetFromHexString("d41d8cd98f00b204e9800998ecf8427e"));
+
     // Moving invalidates the source.
     plChecksum sum2 = std::move(sum);
     EXPECT_THROW(sum.GetValue(), plChecksumException);
@@ -82,6 +91,7 @@ TEST(plMD5Checksum, lifecycle)
     EXPECT_THROW(sum.Start(), plChecksumException);
     EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
     EXPECT_THROW(sum.Finish(), plChecksumException);
+    EXPECT_THROW(sum.SetFromHexString("d41d8cd98f00b204e9800998ecf8427e"), plChecksumException);
 }
 
 TEST(plMD5Checksum, ctor_with_buffer)

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA1Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA1Checksum.cpp
@@ -49,6 +49,10 @@ TEST(plSHA1Checksum, lifecycle)
 {
     plChecksum sum(plChecksum::Type::kSHA1);
 
+    // We can set the checksum value directly if no checksum is in progress.
+    EXPECT_NO_THROW(sum.SetFromHexString("da39a3ee5e6b4b0d3255bfef95601890afd80709"));
+    EXPECT_THROW(sum.SetFromHexString("1"), plChecksumException);
+
     // Can't add to or finish until Start() is called.
     EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
     EXPECT_THROW(sum.Finish(), plChecksumException);
@@ -57,9 +61,11 @@ TEST(plSHA1Checksum, lifecycle)
     EXPECT_NO_THROW(sum.Start());
     EXPECT_THROW(sum.Start(), plChecksumException);
 
-    // Can't get the value or size until Finish() is called.
+    // Now that we've started, we can't set the checksum value directly.
+    EXPECT_THROW(sum.SetFromHexString("da39a3ee5e6b4b0d3255bfef95601890afd80709"), plChecksumException);
+
+    // Can't get the value until Finish() is called.
     EXPECT_THROW(sum.GetValue(), plChecksumException);
-    EXPECT_THROW(sum.GetSize(), plChecksumException);
 
     // Can't add after Finish() is called.
     EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
@@ -75,6 +81,9 @@ TEST(plSHA1Checksum, lifecycle)
     EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
     EXPECT_NO_THROW(sum.Finish());
 
+    // We can set the checksum value directly if no checksum is in progress.
+    EXPECT_NO_THROW(sum.SetFromHexString("da39a3ee5e6b4b0d3255bfef95601890afd80709"));
+
     // Moving invalidates the source.
     plChecksum sum2 = std::move(sum);
     EXPECT_THROW(sum.GetValue(), plChecksumException);
@@ -82,6 +91,7 @@ TEST(plSHA1Checksum, lifecycle)
     EXPECT_THROW(sum.Start(), plChecksumException);
     EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
     EXPECT_THROW(sum.Finish(), plChecksumException);
+    EXPECT_THROW(sum.SetFromHexString("da39a3ee5e6b4b0d3255bfef95601890afd80709"), plChecksumException);
 }
 
 TEST(plSHA1Checksum, ctor_with_buffer)

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA1Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA1Checksum.cpp
@@ -55,7 +55,7 @@ TEST(plSHA1Checksum, ctor_with_buffer)
                              0x77, 0xc5, 0xd8, 0x40,
                              0xbb, 0xc4, 0x86, 0xd0};
 
-    plSHA1Checksum sum(strlen(buffer), (const uint8_t*)buffer);
+    plChecksum sum(plChecksum::Type::kSHA1, strlen(buffer), (const uint8_t*)buffer);
 
     EXPECT_EQ(sizeof(value), sum.GetSize());
     EXPECT_EQ(0, memcmp(sum.GetValue(), value, 20));
@@ -72,7 +72,7 @@ TEST(plSHA1Checksum, update)
                              0x77, 0xc5, 0xd8, 0x40,
                              0xbb, 0xc4, 0x86, 0xd0};
 
-    plSHA1Checksum sum;
+    plChecksum sum(plChecksum::Type::kSHA1);
     sum.Start();
     sum.AddTo(strlen(buffer[0]), (const uint8_t*)buffer[0]);
     sum.AddTo(strlen(buffer[1]), (const uint8_t*)buffer[1]);
@@ -88,30 +88,30 @@ TEST(plSHA1Checksum, well_known_hashes)
     // From NIST FIPS-180
     const char case0_text[] = "";
     const char case0_digest[] = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
-    plSHA1Checksum case0(strlen(case0_text), (const uint8_t*)case0_text);
+    plChecksum case0(plChecksum::Type::kSHA1, strlen(case0_text), (const uint8_t*)case0_text);
     EXPECT_STREQ(case0_digest, case0.GetAsHexString().c_str());
 
     const char case1_text[] = "abc";
     const char case1_digest[] = "a9993e364706816aba3e25717850c26c9cd0d89d";
-    plSHA1Checksum case1(strlen(case1_text), (const uint8_t*)case1_text);
+    plChecksum case1(plChecksum::Type::kSHA1, strlen(case1_text), (const uint8_t*)case1_text);
     EXPECT_STREQ(case1_digest, case1.GetAsHexString().c_str());
 
     const char case2_text[] = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
     const char case2_digest[] = "84983e441c3bd26ebaae4aa1f95129e5e54670f1";
-    plSHA1Checksum case2(strlen(case2_text), (const uint8_t*)case2_text);
+    plChecksum case2(plChecksum::Type::kSHA1, strlen(case2_text), (const uint8_t*)case2_text);
     EXPECT_STREQ(case2_digest, case2.GetAsHexString().c_str());
 
     const char case3_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
                               "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
     const char case3_digest[] = "a49b2446a02c645bf419f995b67091253a04a259";
-    plSHA1Checksum case3(strlen(case3_text), (const uint8_t*)case3_text);
+    plChecksum case3(plChecksum::Type::kSHA1, strlen(case3_text), (const uint8_t*)case3_text);
     EXPECT_STREQ(case3_digest, case3.GetAsHexString().c_str());
 
     // 1,000,000 copies of 'a'
     uint8_t onek_a[1000];
     memset(onek_a, 'a', sizeof(onek_a));
     const char case4_digest[] = "34aa973cd4c4daa4f61eeb2bdbad27316534016f";
-    plSHA1Checksum case4;
+    plChecksum case4(plChecksum::Type::kSHA1);
     case4.Start();
     for (size_t i = 0; i < 1000; ++i)
         case4.AddTo(sizeof(onek_a), onek_a);
@@ -122,7 +122,7 @@ TEST(plSHA1Checksum, well_known_hashes)
     const char case5_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno";
     const size_t case5_text_len = strlen(case5_text);
     const char case5_digest[] = "7789f0c9ef7bfc40d93311143dfbe69e2017f592";
-    plSHA1Checksum case5;
+    plChecksum case5(plChecksum::Type::kSHA1);
     case5.Start();
     for (size_t i = 0; i < 16777216; ++i)
         case5.AddTo(case5_text_len, (const uint8_t*)case5_text);

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA1Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA1Checksum.cpp
@@ -45,6 +45,45 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnEncryption/plChecksum.h"
 #include <string_theory/string>
 
+TEST(plSHA1Checksum, lifecycle)
+{
+    plChecksum sum(plChecksum::Type::kSHA1);
+
+    // Can't add to or finish until Start() is called.
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+    EXPECT_THROW(sum.Finish(), plChecksumException);
+
+    // Calling Start() twice doesn't make sense.
+    EXPECT_NO_THROW(sum.Start());
+    EXPECT_THROW(sum.Start(), plChecksumException);
+
+    // Can't get the value or size until Finish() is called.
+    EXPECT_THROW(sum.GetValue(), plChecksumException);
+    EXPECT_THROW(sum.GetSize(), plChecksumException);
+
+    // Can't add after Finish() is called.
+    EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
+    EXPECT_NO_THROW(sum.Finish());
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+
+    // Value and size should work now.
+    EXPECT_NO_THROW(sum.GetSize());
+    EXPECT_NO_THROW(sum.GetValue());
+
+    // Should be able to restart and reuse the checksum object.
+    EXPECT_NO_THROW(sum.Start());
+    EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
+    EXPECT_NO_THROW(sum.Finish());
+
+    // Moving invalidates the source.
+    plChecksum sum2 = std::move(sum);
+    EXPECT_THROW(sum.GetValue(), plChecksumException);
+    EXPECT_THROW(sum.GetSize(), plChecksumException);
+    EXPECT_THROW(sum.Start(), plChecksumException);
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+    EXPECT_THROW(sum.Finish(), plChecksumException);
+}
+
 TEST(plSHA1Checksum, ctor_with_buffer)
 {
     const char buffer[] = "Hello World";

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA256Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA256Checksum.cpp
@@ -1,0 +1,179 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <cstring>
+#include <gtest/gtest.h>
+#include "pnEncryption/plChecksum.h"
+#include <string_theory/string>
+
+TEST(plSHA256Checksum, lifecycle)
+{
+    plChecksum sum(plChecksum::Type::kSHA256);
+
+    // Can't add to or finish until Start() is called.
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+    EXPECT_THROW(sum.Finish(), plChecksumException);
+
+    // Calling Start() twice doesn't make sense.
+    EXPECT_NO_THROW(sum.Start());
+    EXPECT_THROW(sum.Start(), plChecksumException);
+
+    // Can't get the value or size until Finish() is called.
+    EXPECT_THROW(sum.GetValue(), plChecksumException);
+    EXPECT_THROW(sum.GetSize(), plChecksumException);
+
+    // Can't add after Finish() is called.
+    EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
+    EXPECT_NO_THROW(sum.Finish());
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+
+    // Value and size should work now.
+    EXPECT_NO_THROW(sum.GetSize());
+    EXPECT_NO_THROW(sum.GetValue());
+
+    // Should be able to restart and reuse the checksum object.
+    EXPECT_NO_THROW(sum.Start());
+    EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
+    EXPECT_NO_THROW(sum.Finish());
+
+    // Moving invalidates the source.
+    plChecksum sum2 = std::move(sum);
+    EXPECT_THROW(sum.GetValue(), plChecksumException);
+    EXPECT_THROW(sum.GetSize(), plChecksumException);
+    EXPECT_THROW(sum.Start(), plChecksumException);
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+    EXPECT_THROW(sum.Finish(), plChecksumException);
+}
+
+TEST(plSHA256Checksum, ctor_with_buffer)
+{
+    const char buffer[] = "Hello World";
+    const char hexStr[] = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e";
+    const uint8_t value[] = {
+        0xa5, 0x91, 0xa6, 0xd4,
+        0x0b, 0xf4, 0x20, 0x40,
+        0x4a, 0x01, 0x17, 0x33,
+        0xcf, 0xb7, 0xb1, 0x90,
+        0xd6, 0x2c, 0x65, 0xbf,
+        0x0b, 0xcd, 0xa3, 0x2b,
+        0x57, 0xb2, 0x77, 0xd9,
+        0xad, 0x9f, 0x14, 0x6e,
+    };
+
+    plChecksum sum(plChecksum::Type::kSHA256, strlen(buffer), (const uint8_t*)buffer);
+
+    EXPECT_EQ(sizeof(value), sum.GetSize());
+    EXPECT_EQ(0, memcmp(sum.GetValue(), value, 32));
+    EXPECT_STREQ(hexStr, sum.GetAsHexString().c_str());
+}
+
+TEST(plSHA256Checksum, update)
+{
+    const char* buffer[] = {"Hello ", "World"};
+    const char hexStr[] = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e";
+    const uint8_t value[] = {
+        0xa5, 0x91, 0xa6, 0xd4,
+        0x0b, 0xf4, 0x20, 0x40,
+        0x4a, 0x01, 0x17, 0x33,
+        0xcf, 0xb7, 0xb1, 0x90,
+        0xd6, 0x2c, 0x65, 0xbf,
+        0x0b, 0xcd, 0xa3, 0x2b,
+        0x57, 0xb2, 0x77, 0xd9,
+        0xad, 0x9f, 0x14, 0x6e,
+    };
+
+    plChecksum sum(plChecksum::Type::kSHA256);
+    sum.Start();
+    sum.AddTo(strlen(buffer[0]), (const uint8_t*)buffer[0]);
+    sum.AddTo(strlen(buffer[1]), (const uint8_t*)buffer[1]);
+    sum.Finish();
+
+    EXPECT_EQ(sizeof(value), sum.GetSize());
+    EXPECT_EQ(0, memcmp(sum.GetValue(), value, 32));
+    EXPECT_STREQ(hexStr, sum.GetAsHexString().c_str());
+}
+
+TEST(plSHA256Checksum, well_known_hashes)
+{
+    const char case0_text[] = "";
+    const char case0_digest[] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    plChecksum case0(plChecksum::Type::kSHA256, strlen(case0_text), (const uint8_t*)case0_text);
+    EXPECT_STREQ(case0_digest, case0.GetAsHexString().c_str());
+
+    const char case1_text[] = "abc";
+    const char case1_digest[] = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    plChecksum case1(plChecksum::Type::kSHA256, strlen(case1_text), (const uint8_t*)case1_text);
+    EXPECT_STREQ(case1_digest, case1.GetAsHexString().c_str());
+
+    const char case2_text[] = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    const char case2_digest[] = "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1";
+    plChecksum case2(plChecksum::Type::kSHA256, strlen(case2_text), (const uint8_t*)case2_text);
+    EXPECT_STREQ(case2_digest, case2.GetAsHexString().c_str());
+
+    const char case3_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+                              "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
+    const char case3_digest[] = "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1";
+    plChecksum case3(plChecksum::Type::kSHA256, strlen(case3_text), (const uint8_t*)case3_text);
+    EXPECT_STREQ(case3_digest, case3.GetAsHexString().c_str());
+
+    // 1,000,000 copies of 'a'
+    uint8_t onek_a[1000];
+    memset(onek_a, 'a', sizeof(onek_a));
+    const char case4_digest[] = "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0";
+    plChecksum case4(plChecksum::Type::kSHA256);
+    case4.Start();
+    for (size_t i = 0; i < 1000; ++i)
+        case4.AddTo(sizeof(onek_a), onek_a);
+    case4.Finish();
+    EXPECT_STREQ(case4_digest, case4.GetAsHexString().c_str());
+
+    // case5_text repeated 16,777,216 times
+    const char case5_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno";
+    const size_t case5_text_len = strlen(case5_text);
+    const char case5_digest[] = "50e72a0e26442fe2552dc3938ac58658228c0cbfb1d2ca872ae435266fcd055e";
+    plChecksum case5(plChecksum::Type::kSHA256);
+    case5.Start();
+    for (size_t i = 0; i < 16777216; ++i)
+        case5.AddTo(case5_text_len, (const uint8_t*)case5_text);
+    case5.Finish();
+    EXPECT_STREQ(case5_digest, case5.GetAsHexString().c_str());
+}

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA256Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA256Checksum.cpp
@@ -49,6 +49,10 @@ TEST(plSHA256Checksum, lifecycle)
 {
     plChecksum sum(plChecksum::Type::kSHA256);
 
+    // We can set the checksum value directly if no checksum is in progress.
+    EXPECT_NO_THROW(sum.SetFromHexString("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+    EXPECT_THROW(sum.SetFromHexString("1"), plChecksumException);
+
     // Can't add to or finish until Start() is called.
     EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
     EXPECT_THROW(sum.Finish(), plChecksumException);
@@ -57,9 +61,11 @@ TEST(plSHA256Checksum, lifecycle)
     EXPECT_NO_THROW(sum.Start());
     EXPECT_THROW(sum.Start(), plChecksumException);
 
-    // Can't get the value or size until Finish() is called.
+    // Now that we've started, we can't set the checksum value directly.
+    EXPECT_THROW(sum.SetFromHexString("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"), plChecksumException);
+
+    // Can't get the value until Finish() is called.
     EXPECT_THROW(sum.GetValue(), plChecksumException);
-    EXPECT_THROW(sum.GetSize(), plChecksumException);
 
     // Can't add after Finish() is called.
     EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
@@ -75,6 +81,9 @@ TEST(plSHA256Checksum, lifecycle)
     EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
     EXPECT_NO_THROW(sum.Finish());
 
+    // We can set the checksum value directly if no checksum is in progress.
+    EXPECT_NO_THROW(sum.SetFromHexString("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+
     // Moving invalidates the source.
     plChecksum sum2 = std::move(sum);
     EXPECT_THROW(sum.GetValue(), plChecksumException);
@@ -82,6 +91,7 @@ TEST(plSHA256Checksum, lifecycle)
     EXPECT_THROW(sum.Start(), plChecksumException);
     EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
     EXPECT_THROW(sum.Finish(), plChecksumException);
+    EXPECT_THROW(sum.SetFromHexString("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"), plChecksumException);
 }
 
 TEST(plSHA256Checksum, ctor_with_buffer)

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA512Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA512Checksum.cpp
@@ -49,6 +49,10 @@ TEST(plSHA512Checksum, lifecycle)
 {
     plChecksum sum(plChecksum::Type::kSHA512);
 
+    // We can set the checksum value directly if no checksum is in progress.
+    EXPECT_NO_THROW(sum.SetFromHexString("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"));
+    EXPECT_THROW(sum.SetFromHexString("1"), plChecksumException);
+
     // Can't add to or finish until Start() is called.
     EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
     EXPECT_THROW(sum.Finish(), plChecksumException);
@@ -57,9 +61,14 @@ TEST(plSHA512Checksum, lifecycle)
     EXPECT_NO_THROW(sum.Start());
     EXPECT_THROW(sum.Start(), plChecksumException);
 
-    // Can't get the value or size until Finish() is called.
+    // Now that we've started, we can't set the checksum value directly.
+    EXPECT_THROW(
+        sum.SetFromHexString("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"),
+        plChecksumException
+    );
+
+    // Can't get the value until Finish() is called.
     EXPECT_THROW(sum.GetValue(), plChecksumException);
-    EXPECT_THROW(sum.GetSize(), plChecksumException);
 
     // Can't add after Finish() is called.
     EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
@@ -75,6 +84,9 @@ TEST(plSHA512Checksum, lifecycle)
     EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
     EXPECT_NO_THROW(sum.Finish());
 
+    // We can set the checksum value directly if no checksum is in progress.
+    EXPECT_NO_THROW(sum.SetFromHexString("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"));
+
     // Moving invalidates the source.
     plChecksum sum2 = std::move(sum);
     EXPECT_THROW(sum.GetValue(), plChecksumException);
@@ -82,6 +94,10 @@ TEST(plSHA512Checksum, lifecycle)
     EXPECT_THROW(sum.Start(), plChecksumException);
     EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
     EXPECT_THROW(sum.Finish(), plChecksumException);
+    EXPECT_THROW(
+        sum.SetFromHexString("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"),
+        plChecksumException
+    );
 }
 
 TEST(plSHA512Checksum, ctor_with_buffer)

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA512Checksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHA512Checksum.cpp
@@ -1,0 +1,195 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <cstring>
+#include <gtest/gtest.h>
+#include "pnEncryption/plChecksum.h"
+#include <string_theory/string>
+
+TEST(plSHA512Checksum, lifecycle)
+{
+    plChecksum sum(plChecksum::Type::kSHA512);
+
+    // Can't add to or finish until Start() is called.
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+    EXPECT_THROW(sum.Finish(), plChecksumException);
+
+    // Calling Start() twice doesn't make sense.
+    EXPECT_NO_THROW(sum.Start());
+    EXPECT_THROW(sum.Start(), plChecksumException);
+
+    // Can't get the value or size until Finish() is called.
+    EXPECT_THROW(sum.GetValue(), plChecksumException);
+    EXPECT_THROW(sum.GetSize(), plChecksumException);
+
+    // Can't add after Finish() is called.
+    EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
+    EXPECT_NO_THROW(sum.Finish());
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+
+    // Value and size should work now.
+    EXPECT_NO_THROW(sum.GetSize());
+    EXPECT_NO_THROW(sum.GetValue());
+
+    // Should be able to restart and reuse the checksum object.
+    EXPECT_NO_THROW(sum.Start());
+    EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
+    EXPECT_NO_THROW(sum.Finish());
+
+    // Moving invalidates the source.
+    plChecksum sum2 = std::move(sum);
+    EXPECT_THROW(sum.GetValue(), plChecksumException);
+    EXPECT_THROW(sum.GetSize(), plChecksumException);
+    EXPECT_THROW(sum.Start(), plChecksumException);
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+    EXPECT_THROW(sum.Finish(), plChecksumException);
+}
+
+TEST(plSHA512Checksum, ctor_with_buffer)
+{
+    const char buffer[] = "Hello World";
+    const char hexStr[] = "2c74fd17edafd80e8447b0d46741ee243b7eb74dd2149a0ab1b9246fb30382f27e853d8585719e0e67cbda0daa8f51671064615d645ae27acb15bfb1447f459b";
+    const uint8_t value[] = {
+        0x2c, 0x74, 0xfd, 0x17,
+        0xed, 0xaf, 0xd8, 0x0e,
+        0x84, 0x47, 0xb0, 0xd4,
+        0x67, 0x41, 0xee, 0x24,
+        0x3b, 0x7e, 0xb7, 0x4d,
+        0xd2, 0x14, 0x9a, 0x0a,
+        0xb1, 0xb9, 0x24, 0x6f,
+        0xb3, 0x03, 0x82, 0xf2,
+        0x7e, 0x85, 0x3d, 0x85,
+        0x85, 0x71, 0x9e, 0x0e,
+        0x67, 0xcb, 0xda, 0x0d,
+        0xaa, 0x8f, 0x51, 0x67,
+        0x10, 0x64, 0x61, 0x5d,
+        0x64, 0x5a, 0xe2, 0x7a,
+        0xcb, 0x15, 0xbf, 0xb1,
+        0x44, 0x7f, 0x45, 0x9b,
+    };
+
+    plChecksum sum(plChecksum::Type::kSHA512, strlen(buffer), (const uint8_t*)buffer);
+
+    EXPECT_EQ(sizeof(value), sum.GetSize());
+    EXPECT_EQ(0, memcmp(sum.GetValue(), value, 64));
+    EXPECT_STREQ(hexStr, sum.GetAsHexString().c_str());
+}
+
+TEST(plSHA512Checksum, update)
+{
+    const char* buffer[] = {"Hello ", "World"};
+    const char hexStr[] = "2c74fd17edafd80e8447b0d46741ee243b7eb74dd2149a0ab1b9246fb30382f27e853d8585719e0e67cbda0daa8f51671064615d645ae27acb15bfb1447f459b";
+    const uint8_t value[] = {
+        0x2c, 0x74, 0xfd, 0x17,
+        0xed, 0xaf, 0xd8, 0x0e,
+        0x84, 0x47, 0xb0, 0xd4,
+        0x67, 0x41, 0xee, 0x24,
+        0x3b, 0x7e, 0xb7, 0x4d,
+        0xd2, 0x14, 0x9a, 0x0a,
+        0xb1, 0xb9, 0x24, 0x6f,
+        0xb3, 0x03, 0x82, 0xf2,
+        0x7e, 0x85, 0x3d, 0x85,
+        0x85, 0x71, 0x9e, 0x0e,
+        0x67, 0xcb, 0xda, 0x0d,
+        0xaa, 0x8f, 0x51, 0x67,
+        0x10, 0x64, 0x61, 0x5d,
+        0x64, 0x5a, 0xe2, 0x7a,
+        0xcb, 0x15, 0xbf, 0xb1,
+        0x44, 0x7f, 0x45, 0x9b,
+    };
+
+    plChecksum sum(plChecksum::Type::kSHA512);
+    sum.Start();
+    sum.AddTo(strlen(buffer[0]), (const uint8_t*)buffer[0]);
+    sum.AddTo(strlen(buffer[1]), (const uint8_t*)buffer[1]);
+    sum.Finish();
+
+    EXPECT_EQ(sizeof(value), sum.GetSize());
+    EXPECT_EQ(0, memcmp(sum.GetValue(), value, 64));
+    EXPECT_STREQ(hexStr, sum.GetAsHexString().c_str());
+}
+
+TEST(plSHA512Checksum, well_known_hashes)
+{
+    const char case0_text[] = "";
+    const char case0_digest[] = "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+    plChecksum case0(plChecksum::Type::kSHA512, strlen(case0_text), (const uint8_t*)case0_text);
+    EXPECT_STREQ(case0_digest, case0.GetAsHexString().c_str());
+
+    const char case1_text[] = "abc";
+    const char case1_digest[] = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f";
+    plChecksum case1(plChecksum::Type::kSHA512, strlen(case1_text), (const uint8_t*)case1_text);
+    EXPECT_STREQ(case1_digest, case1.GetAsHexString().c_str());
+
+    const char case2_text[] = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    const char case2_digest[] = "204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c33596fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445";
+    plChecksum case2(plChecksum::Type::kSHA512, strlen(case2_text), (const uint8_t*)case2_text);
+    EXPECT_STREQ(case2_digest, case2.GetAsHexString().c_str());
+
+    const char case3_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+                              "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
+    const char case3_digest[] = "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909";
+    plChecksum case3(plChecksum::Type::kSHA512, strlen(case3_text), (const uint8_t*)case3_text);
+    EXPECT_STREQ(case3_digest, case3.GetAsHexString().c_str());
+
+    // 1,000,000 copies of 'a'
+    uint8_t onek_a[1000];
+    memset(onek_a, 'a', sizeof(onek_a));
+    const char case4_digest[] = "e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b";
+    plChecksum case4(plChecksum::Type::kSHA512);
+    case4.Start();
+    for (size_t i = 0; i < 1000; ++i)
+        case4.AddTo(sizeof(onek_a), onek_a);
+    case4.Finish();
+    EXPECT_STREQ(case4_digest, case4.GetAsHexString().c_str());
+
+    // case5_text repeated 16,777,216 times
+    const char case5_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno";
+    const size_t case5_text_len = strlen(case5_text);
+    const char case5_digest[] = "b47c933421ea2db149ad6e10fce6c7f93d0752380180ffd7f4629a712134831d77be6091b819ed352c2967a2e2d4fa5050723c9630691f1a05a7281dbe6c1086";
+    plChecksum case5(plChecksum::Type::kSHA512);
+    case5.Start();
+    for (size_t i = 0; i < 16777216; ++i)
+        case5.AddTo(case5_text_len, (const uint8_t*)case5_text);
+    case5.Finish();
+    EXPECT_STREQ(case5_digest, case5.GetAsHexString().c_str());
+}

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
@@ -45,6 +45,45 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnEncryption/plChecksum.h"
 #include <string_theory/string>
 
+TEST(plSHAChecksum, lifecycle)
+{
+    plChecksum sum(plChecksum::Type::kSHA0);
+
+    // Can't add to or finish until Start() is called.
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+    EXPECT_THROW(sum.Finish(), plChecksumException);
+
+    // Calling Start() twice doesn't make sense.
+    EXPECT_NO_THROW(sum.Start());
+    EXPECT_THROW(sum.Start(), plChecksumException);
+
+    // Can't get the value or size until Finish() is called.
+    EXPECT_THROW(sum.GetValue(), plChecksumException);
+    EXPECT_THROW(sum.GetSize(), plChecksumException);
+
+    // Can't add after Finish() is called.
+    EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
+    EXPECT_NO_THROW(sum.Finish());
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+
+    // Value and size should work now.
+    EXPECT_NO_THROW(sum.GetSize());
+    EXPECT_NO_THROW(sum.GetValue());
+
+    // Should be able to restart and reuse the checksum object.
+    EXPECT_NO_THROW(sum.Start());
+    EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
+    EXPECT_NO_THROW(sum.Finish());
+
+    // Moving invalidates the source.
+    plChecksum sum2 = std::move(sum);
+    EXPECT_THROW(sum.GetValue(), plChecksumException);
+    EXPECT_THROW(sum.GetSize(), plChecksumException);
+    EXPECT_THROW(sum.Start(), plChecksumException);
+    EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
+    EXPECT_THROW(sum.Finish(), plChecksumException);
+}
+
 TEST(plSHAChecksum, ctor_with_buffer)
 {
     const char buffer[] = "Hello World";

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
@@ -49,6 +49,10 @@ TEST(plSHAChecksum, lifecycle)
 {
     plChecksum sum(plChecksum::Type::kSHA0);
 
+    // We can set the checksum value directly if no checksum is in progress.
+    EXPECT_NO_THROW(sum.SetFromHexString("f96cea198ad1dd5617ac084a3d92c6107708c0ef"));
+    EXPECT_THROW(sum.SetFromHexString("1"), plChecksumException);
+
     // Can't add to or finish until Start() is called.
     EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
     EXPECT_THROW(sum.Finish(), plChecksumException);
@@ -57,9 +61,11 @@ TEST(plSHAChecksum, lifecycle)
     EXPECT_NO_THROW(sum.Start());
     EXPECT_THROW(sum.Start(), plChecksumException);
 
-    // Can't get the value or size until Finish() is called.
+    // Now that we've started, we can't set the checksum value directly.
+    EXPECT_THROW(sum.SetFromHexString("f96cea198ad1dd5617ac084a3d92c6107708c0ef"), plChecksumException);
+
+    // Can't get the value until Finish() is called.
     EXPECT_THROW(sum.GetValue(), plChecksumException);
-    EXPECT_THROW(sum.GetSize(), plChecksumException);
 
     // Can't add after Finish() is called.
     EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
@@ -75,6 +81,9 @@ TEST(plSHAChecksum, lifecycle)
     EXPECT_NO_THROW(sum.AddTo(1, (const uint8_t*)"a"));
     EXPECT_NO_THROW(sum.Finish());
 
+    // We can set the checksum value directly if no checksum is in progress.
+    EXPECT_NO_THROW(sum.SetFromHexString("f96cea198ad1dd5617ac084a3d92c6107708c0ef"));
+
     // Moving invalidates the source.
     plChecksum sum2 = std::move(sum);
     EXPECT_THROW(sum.GetValue(), plChecksumException);
@@ -82,6 +91,7 @@ TEST(plSHAChecksum, lifecycle)
     EXPECT_THROW(sum.Start(), plChecksumException);
     EXPECT_THROW(sum.AddTo(1, (const uint8_t*)"a"), plChecksumException);
     EXPECT_THROW(sum.Finish(), plChecksumException);
+    EXPECT_THROW(sum.SetFromHexString("f96cea198ad1dd5617ac084a3d92c6107708c0ef"), plChecksumException);
 }
 
 TEST(plSHAChecksum, ctor_with_buffer)

--- a/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
+++ b/Sources/Tests/NucleusTests/pnEncryptionTest/test_plSHAChecksum.cpp
@@ -55,7 +55,7 @@ TEST(plSHAChecksum, ctor_with_buffer)
                              0x7e, 0xbd, 0x58, 0x68,
                              0x38, 0xb0, 0xf7, 0xfb};
 
-    plSHAChecksum sum(strlen(buffer), (const uint8_t*)buffer);
+    plChecksum sum(plChecksum::Type::kSHA0, strlen(buffer), (const uint8_t*)buffer);
 
     EXPECT_EQ(sizeof(value), sum.GetSize());
     EXPECT_EQ(0, memcmp(sum.GetValue(), value, 20));
@@ -72,7 +72,7 @@ TEST(plSHAChecksum, update)
                              0x7e, 0xbd, 0x58, 0x68,
                              0x38, 0xb0, 0xf7, 0xfb};
 
-    plSHAChecksum sum;
+    plChecksum sum(plChecksum::Type::kSHA0);
     sum.Start();
     sum.AddTo(strlen(buffer[0]), (const uint8_t*)buffer[0]);
     sum.AddTo(strlen(buffer[1]), (const uint8_t*)buffer[1]);
@@ -88,30 +88,30 @@ TEST(plSHAChecksum, well_known_hashes)
     // From NIST FIPS-180
     const char case0_text[] = "";
     const char case0_digest[] = "f96cea198ad1dd5617ac084a3d92c6107708c0ef";
-    plSHAChecksum case0(strlen(case0_text), (const uint8_t*)case0_text);
+    plChecksum case0(plChecksum::Type::kSHA0, strlen(case0_text), (const uint8_t*)case0_text);
     EXPECT_STREQ(case0_digest, case0.GetAsHexString().c_str());
 
     const char case1_text[] = "abc";
     const char case1_digest[] = "0164b8a914cd2a5e74c4f7ff082c4d97f1edf880";
-    plSHAChecksum case1(strlen(case1_text), (const uint8_t*)case1_text);
+    plChecksum case1(plChecksum::Type::kSHA0, strlen(case1_text), (const uint8_t*)case1_text);
     EXPECT_STREQ(case1_digest, case1.GetAsHexString().c_str());
 
     const char case2_text[] = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
     const char case2_digest[] = "d2516ee1acfa5baf33dfc1c471e438449ef134c8";
-    plSHAChecksum case2(strlen(case2_text), (const uint8_t*)case2_text);
+    plChecksum case2(plChecksum::Type::kSHA0, strlen(case2_text), (const uint8_t*)case2_text);
     EXPECT_STREQ(case2_digest, case2.GetAsHexString().c_str());
 
     const char case3_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
                               "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
     const char case3_digest[] = "459f83b95db2dc87bb0f5b513a28f900ede83237";
-    plSHAChecksum case3(strlen(case3_text), (const uint8_t*)case3_text);
+    plChecksum case3(plChecksum::Type::kSHA0, strlen(case3_text), (const uint8_t*)case3_text);
     EXPECT_STREQ(case3_digest, case3.GetAsHexString().c_str());
 
     // 1,000,000 copies of 'a'
     uint8_t onek_a[1000];
     memset(onek_a, 'a', sizeof(onek_a));
     const char case4_digest[] = "3232affa48628a26653b5aaa44541fd90d690603";
-    plSHAChecksum case4;
+    plChecksum case4(plChecksum::Type::kSHA0);
     case4.Start();
     for (size_t i = 0; i < 1000; ++i)
         case4.AddTo(sizeof(onek_a), onek_a);
@@ -125,7 +125,7 @@ TEST(plSHAChecksum, well_known_hashes)
     const char case5_text[] = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno";
     const size_t case5_text_len = strlen(case5_text);
     const char case5_digest[] = "bd18f2e7736c8e6de8b5abdfdeab948f5171210c";
-    plSHAChecksum case5;
+    plChecksum case5(plChecksum::Type::kSHA0);
     case5.Start();
     for (size_t i = 0; i < 16777216; ++i)
         case5.AddTo(case5_text_len, (const uint8_t*)case5_text);


### PR DESCRIPTION
In the asset download work I'm proposing in #737, we will want to be able to use SHA-512. Currently, the checksum code is a bit of a mess in that every checksum is reimplemented as a separate class, and most of them are just thin wrappers over OpenSSL EVP. This PR removes the old, unused `plChecksum` and unifies all hashes using a PIMPL pattern. This allows us to de-duplicate code and more trivially add new algorithms. I went ahead and added SHA-256 and SHA-512, for an example. This will help with the asset download overhaul because I can just use `plChecksum` instead of having to do something like `std::variant<plMD5Checksum, plSHA512Checksum>` to support both MD5 and SHA-512.

It may be best to review [plChecksum.cpp itself](https://github.com/Hoikas/Plasma/blob/c1c2254bbcb425d180f61a3d347413f2610a2a0e/Sources/Plasma/NucleusLib/pnEncryption/plChecksum.cpp), rather than trying to read the diff.