### PR TITLE
Fix error in grtzMarkerScopeGUI.py

### DIFF
--- a/Scripts/Python/grtzMarkerScopeGUI.py
+++ b/Scripts/Python/grtzMarkerScopeGUI.py
@@ -148,6 +148,7 @@ class grtzMarkerScopeGUI(ptModifier):
             legacyScore = xMarkerGameUtils.GetLegacyCGZMScore(mission)
             try:
                 scores = msg.getScores()
+                score = scores[0]
             except:
                 self._scores[mission] = 0
                 # If we have a score in the legacy chronicle, then force the ScoreSrv value
@@ -157,7 +158,6 @@ class grtzMarkerScopeGUI(ptModifier):
             else:
                 # Pick the lowest score in the list to use.
                 scores = sorted(scores, key=lambda x: x.getPoints())
-                score = scores[0]
                 self._scores[mission] = score
 
                 # All the other scores are garbage.


### PR DESCRIPTION
Noticed that the client reported a bunch of errors when linking to GreatZero on Destiny. This should be a simple fix.

Original Error:
```
(08/07 19:23:32) cPythGUIHandler - Traceback (most recent call last):
(08/07 19:23:32)   File ".\python\grtzMarkerScopeGUI.py", line 160, in OnGameScoreMsg
(08/07 19:23:32)     score = scores[0]
(08/07 19:23:32)             ~~~~~~^^^
(08/07 19:23:32) IndexError: list index out of range
```