### PR TITLE
Fix `PtGetAgeSDL` when called during age-global Python initialization

### DIFF
--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
@@ -254,7 +254,7 @@ tl::expected<tl::monostate, ST::string> plAgeLoader::LoadAge(const ST::string& a
     //
     // Load the Age's SDL Hook object (and it's python modifier)
     //  
-    plUoid oid=nc->GetAgeSDLObjectUoid(fAgeName);
+    plUoid oid = plNetClientMgr::GetAgeSDLObjectUoidForAge(ad);
     plKey ageSDLObjectKey = hsgResMgr::ResMgr()->FindKey(oid);
     // Loading the AgeSDLHook also loads the VeryVerySpecialPythonFileMod,
     // so the create notification only gets sent after the age Python has finished initializing.

--- a/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
+++ b/Sources/Plasma/PubUtilLib/plAgeLoader/plAgeLoader.cpp
@@ -188,7 +188,7 @@ void plAgeLoader::NotifyAgeLoaded( bool loaded )
 
 tl::expected<tl::monostate, ST::string> plAgeLoader::LoadAge(const ST::string& ageName)
 {
-    plNetClientApp* nc = plNetClientApp::GetInstance();
+    plNetClientMgr* nc = plNetClientMgr::GetInstance();
     ASSERT(!nc->GetFlagsBit(plNetClientApp::kPlayingGame));
 
     fAgeName = ageName;
@@ -256,6 +256,11 @@ tl::expected<tl::monostate, ST::string> plAgeLoader::LoadAge(const ST::string& a
     //  
     plUoid oid=nc->GetAgeSDLObjectUoid(fAgeName);
     plKey ageSDLObjectKey = hsgResMgr::ResMgr()->FindKey(oid);
+    // Loading the AgeSDLHook also loads the VeryVerySpecialPythonFileMod,
+    // so the create notification only gets sent after the age Python has finished initializing.
+    // Some existing age scripts call PtGetAgeSDL *during* their initialization though, even though they shouldn't.
+    // To make those early calls work, tell plNetClientMgr the AgeSDLHook key now, before the create notification.
+    nc->SetAgeSDLObjectKey(ageSDLObjectKey);
     if (ageSDLObjectKey)
         hsgResMgr::ResMgr()->AddViaNotify(ageSDLObjectKey, new plGenRefMsg(nc->GetKey(), plRefMsg::kOnCreate, -1, 
         plNetClientMgr::kAgeSDLHook), plRefFlags::kActiveRef);

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -58,6 +58,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnNetCommon/pnNetCommon.h"
 #include "pnSceneObject/plCoordinateInterface.h"
 
+#include "plAgeDescription/plAgeDescription.h"
 #include "plAgeLoader/plAgeLoader.h"
 #include "plAvatar/plAvatarClothing.h"
 #include "plAvatar/plAvatarMgr.h"
@@ -1280,6 +1281,18 @@ bool plNetClientMgr::IFindModifier(plSynchedObject* obj, int16_t classIdx)
     return cnt==0 ? false : true;
 }
 
+plUoid plNetClientMgr::GetAgeSDLObjectUoidForAge(const plAgeDescription& ageDesc)
+{
+    // if age is loaded
+    plLocation loc = plKeyFinder::Instance().FindLocation(ageDesc.GetAgeName(), plAgeDescription::GetCommonPage(plAgeDescription::kGlobal));
+    if (!loc.IsValid()) {
+        // check age desc
+        loc = ageDesc.CalcPageLocation("BuiltIn");
+    }
+
+    return plUoid(loc, plSceneObject::Index(), plSDL::kAgeSDLObjectName);
+}
+
 plUoid plNetClientMgr::GetAgeSDLObjectUoid(const ST::string& ageName) const
 {
     hsAssert(!ageName.empty(), "nil ageName");
@@ -1288,28 +1301,14 @@ plUoid plNetClientMgr::GetAgeSDLObjectUoid(const ST::string& ageName) const
     if (fAgeSDLObjectKey)
         return fAgeSDLObjectKey->GetUoid();
 
-    // if age is loaded
-    plLocation loc = plKeyFinder::Instance().FindLocation(ageName,plAgeDescription::GetCommonPage(plAgeDescription::kGlobal));
-    if (!loc.IsValid())
-    {
-        // check current age des
-        if (plAgeLoader::GetInstance()->GetCurrAgeDesc().GetAgeName() == ageName)
-            loc=plAgeLoader::GetInstance()->GetCurrAgeDesc().CalcPageLocation("BuiltIn");
-
-        if (!loc.IsValid())
-        {
-            // try to load age desc
-            std::unique_ptr<hsStream> stream = plAgeLoader::GetAgeDescFileStream(ageName);
-            if (stream)
-            {
-                plAgeDescription ad;
-                ad.Read(stream.get());
-                loc=ad.CalcPageLocation("BuiltIn");
-            }
-        }
+    std::unique_ptr<hsStream> stream = plAgeLoader::GetAgeDescFileStream(ageName);
+    if (stream) {
+        plAgeDescription ad;
+        ad.Read(stream.get());
+        return GetAgeSDLObjectUoidForAge(ad);
     }
 
-    return plUoid(loc, plSceneObject::Index(), plSDL::kAgeSDLObjectName);
+    return plUoid(plLocation(), plSceneObject::Index(), plSDL::kAgeSDLObjectName);
 }
 
 plSDLModifier* plNetClientMgr::GetAgeSDLModifier() const

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.cpp
@@ -798,7 +798,11 @@ bool plNetClientMgr::MsgReceive( plMessage* msg )
         hsAssert(ref->fType==kAgeSDLHook, "unknown ref msg context");
         if (ref->GetContext()==plRefMsg::kOnCreate)
         {
-            hsAssert(fAgeSDLObjectKey == nullptr, "already have a ref to age sdl hook");
+            hsAssert(fAgeSDLObjectKey == nullptr || fAgeSDLObjectKey == ref->GetRef()->GetKey(), ST::format(
+                "Newly loaded age SDL hook object {} doesn't match the key {} we were told earlier",
+                ref->GetRef()->GetKey()->GetUoid().StringIze(),
+                fAgeSDLObjectKey->GetUoid().StringIze()
+            ).c_str());
             fAgeSDLObjectKey = ref->GetRef()->GetKey();
             DebugMsg("Age SDL hook object created, uoid={}", fAgeSDLObjectKey->GetUoid().StringIze());
         }

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
@@ -339,6 +339,7 @@ public:
 
     void AddPendingLoad(PendingLoad *pl);
     const plKey& GetAgeSDLObjectKey() const { return fAgeSDLObjectKey; }
+    void SetAgeSDLObjectKey(plKey ageSDLObjectKey) { fAgeSDLObjectKey = std::move(ageSDLObjectKey); }
     plUoid GetAgeSDLObjectUoid(const ST::string& ageName) const override;
     plSDLModifier* GetAgeSDLModifier() const;
     plNetClientComm& GetNetClientComm()  { return fNetClientComm; }

--- a/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
+++ b/Sources/Plasma/PubUtilLib/plNetClient/plNetClientMgr.h
@@ -61,6 +61,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 ////////////////////////////////////////////////////////////////////
 
+class plAgeDescription;
 class plUoid;
 class hsStream;
 class plKey;
@@ -340,7 +341,8 @@ public:
     void AddPendingLoad(PendingLoad *pl);
     const plKey& GetAgeSDLObjectKey() const { return fAgeSDLObjectKey; }
     void SetAgeSDLObjectKey(plKey ageSDLObjectKey) { fAgeSDLObjectKey = std::move(ageSDLObjectKey); }
-    plUoid GetAgeSDLObjectUoid(const ST::string& ageName) const override;
+    static plUoid GetAgeSDLObjectUoidForAge(const plAgeDescription& ageDesc);
+    plUoid GetAgeSDLObjectUoid(const ST::string& ageName) const override; // for compatibility only - prefer GetAgeSDLObjectUoidForAge instead
     plSDLModifier* GetAgeSDLModifier() const;
     plNetClientComm& GetNetClientComm()  { return fNetClientComm; }
     ST::string GetNextAgeFilename() const;


### PR DESCRIPTION
Fixes #1896 in a more robust way than the workaround in #1897, in case other age scripts also accidentally need this corner case to work.

This is intentionally branched off the last commit before #1897 was merged, to allow confirming that this fix works even without that workaround.

While here, I also removed some unneeded special cases from the logic for calculating the AgeSDLHook's UOID.