### PR TITLE
Add word movement and deletion to several elements

### DIFF
--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -390,19 +390,6 @@ bool    pfConsole::MsgReceive( plMessage *msg )
 
 //// IHandleKey //////////////////////////////////////////////////////////////
 
-static inline bool IIsWordBoundary(const char c)
-{
-    if (c == ' ')
-        return true;
-    if (c == '_')
-        return true;
-    if (c == '.')
-        return true;
-    if (c == '\0')
-        return true;
-    return false;
-}
-
 void    pfConsole::IHandleKey( plKeyEventMsg *msg )
 {
     char            *c;
@@ -517,44 +504,27 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
     }
     else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_LEFT)
     {
-        // Move one word back
-        if (fWorkingCursor > 0) {
-            do {
-                fWorkingCursor--;
-            } while (fWorkingCursor > 0 && !IIsWordBoundary(fWorkingLine[fWorkingCursor - 1]));
-        }
+        IAdvanceWordFromPos(false, fWorkingCursor);
     }
-    else if( msg->GetKeyCode() == KEY_LEFT )
+    else if (msg->GetKeyCode() == KEY_LEFT)
     {
-        if( fWorkingCursor > 0 )
-            fWorkingCursor--;
+        if (fWorkingCursor > 0)
+            IAdvanceChar(false, fWorkingCursor);
     }
     else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_RIGHT)
     {
-        // Move one word forward
-        size_t end = strlen(fWorkingLine);
-        if (fWorkingCursor < end) {
-            do {
-                fWorkingCursor++;
-            } while (fWorkingCursor < end && !IIsWordBoundary(fWorkingLine[fWorkingCursor - 1]));
-        }
+        IAdvanceWordFromPos(true, fWorkingCursor);
     }
     else if( msg->GetKeyCode() == KEY_RIGHT )
     {
-        if( fWorkingCursor < strlen( fWorkingLine ) )
-            fWorkingCursor++;
+        if (fWorkingCursor < strlen(fWorkingLine))
+            IAdvanceChar(true, fWorkingCursor);
     }
     else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_BACKSPACE)
     {
         // Delete last word
         if (fWorkingCursor > 0) {
-            uint32_t removed = 0;
-            do {
-                fWorkingCursor--;
-                removed++;
-            } while (fWorkingCursor > 0 && !IIsWordBoundary(fWorkingLine[fWorkingCursor - 1]));
-            memmove(&fWorkingLine[fWorkingCursor], &fWorkingLine[fWorkingCursor + removed], (strlen(&fWorkingLine[fWorkingCursor + removed]) + 1) * sizeof(char));
-
+            IDeleteWord(false);
             findAgain = false;
             findCounter = 0;
         } else if (fHelpMode)
@@ -566,15 +536,7 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
     {
         if( fWorkingCursor > 0 )
         {
-            fWorkingCursor--;
-
-            c = &fWorkingLine[ fWorkingCursor ];
-            do
-            {
-                *c = *( c + 1 );
-                c++;
-            } while( *c != 0 );
-
+            IDeleteChar(false);
             findAgain = false;
             findCounter = 0;
         }
@@ -588,12 +550,7 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
         // Delete next word
         size_t end = strlen(fWorkingLine);
         if (fWorkingCursor < end) {
-            uint32_t removed = 0;
-            do {
-                removed++;
-            } while (fWorkingCursor + removed < end && !IIsWordBoundary(fWorkingLine[fWorkingCursor + removed - 1]));
-            memmove(&fWorkingLine[fWorkingCursor], &fWorkingLine[fWorkingCursor + removed], (strlen(&fWorkingLine[fWorkingCursor + removed]) + 1) * sizeof(char));
-
+            IDeleteWord(true);
             findAgain = false;
             findCounter = 0;
             IUpdateTooltip();
@@ -601,13 +558,7 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
     }
     else if( msg->GetKeyCode() == KEY_DELETE )
     {
-        c = &fWorkingLine[ fWorkingCursor ];
-        do
-        {
-            *c = *( c + 1 );
-            c++;
-        } while( *c != 0 );
-
+        IDeleteChar(true);
         findAgain = false;
         findCounter = 0;
         IUpdateTooltip();
@@ -740,6 +691,82 @@ void    pfConsole::IHandleCharacter(const char c)
     for (i += 1; i > fWorkingCursor; --i)
         fWorkingLine[i] = fWorkingLine[i - 1];
     fWorkingLine[fWorkingCursor++] = c;
+}
+
+static inline bool IIsWordBreaker(const char c)
+{
+    if (c == ' ')
+        return true;
+    if (c == '_')
+        return true;
+    if (c == '.')
+        return true;
+    if (c == '\0')
+        return true;
+    return false;
+}
+
+/**
+ * Check the next/previous character and adjust our position output variable accordingly.
+ */
+pfConsole::CharType pfConsole::IAdvanceChar(bool next, uint32_t& pos) const
+{
+    hsAssert(pos >= 0, "out of range");
+    hsAssert(pos <= strlen(fWorkingLine), "out of range");
+    hsAssert(next || pos > 0, "advanced left at start of string");
+
+    char c = next ? fWorkingLine[pos] : fWorkingLine[pos - 1];
+    if (next)
+        pos++;
+    else
+        pos--;
+    if (IIsWordBreaker(c))
+        return CharType::kWordBreaker;
+    return CharType::kNormal;
+}
+
+/**
+ * Advance the supplied position by one word left or right.
+ */
+void pfConsole::IAdvanceWordFromPos(bool next, uint32_t& pos) const
+{
+    // If we're moving left, we want to move into the previous word first.
+    while (!next && pos > 0) {
+        if (IAdvanceChar(next, pos) == CharType::kNormal)
+            break;
+    }
+    // Now, keep moving until we advanced past a word breaker
+    while (next && pos < strlen(fWorkingLine) || !next && pos > 0) {
+        if (IAdvanceChar(next, pos) == CharType::kWordBreaker) {
+            // If we're moving left, we now want to stop before a word breaker, so go one back when we moved past one.
+            if (!next)
+                IAdvanceChar(true, pos);
+            break;
+        }
+    }
+}
+
+void pfConsole::IDeleteChar(bool next)
+{
+    if (!next && fWorkingCursor > 0 || next && fWorkingCursor < strlen(fWorkingLine)) {
+        if (!next)
+            IAdvanceChar(false, fWorkingCursor);
+        memmove(&fWorkingLine[fWorkingCursor], &fWorkingLine[fWorkingCursor + 1], (strlen(&fWorkingLine[fWorkingCursor + 1]) + 1) * sizeof(char));
+    }
+}
+
+void pfConsole::IDeleteWord(bool next)
+{
+    uint32_t oldCursor, newCursor;
+    oldCursor = newCursor = fWorkingCursor;
+    IAdvanceWordFromPos(next, newCursor);
+
+    if (oldCursor != newCursor) {
+        if (!next)
+            fWorkingCursor = newCursor;
+        int32_t count = next ? newCursor - oldCursor : oldCursor - newCursor;
+        memmove(&fWorkingLine[fWorkingCursor], &fWorkingLine[fWorkingCursor + count], (strlen(&fWorkingLine[fWorkingCursor + count]) + 1) * sizeof(char));
+    }
 }
 
 //// IAddLineCallback ////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -390,7 +390,7 @@ bool    pfConsole::MsgReceive( plMessage *msg )
 
 //// IHandleKey //////////////////////////////////////////////////////////////
 
-inline bool IIsWordBoundary(const char& c)
+static inline bool IIsWordBoundary(const char c)
 {
     return strchr(" _.", c) != nullptr;
 }

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -730,8 +730,8 @@ pfConsole::CharType pfConsole::IAdvanceChar(bool next, uint32_t& pos) const
  */
 void pfConsole::IAdvanceWordFromPos(bool next, uint32_t& pos) const
 {
-    // If we're moving left, we want to move into the previous word first.
-    while (!next && pos > 0) {
+    // We want to move into the next/previous word first.
+    while (next && pos < strlen(fWorkingLine) || !next && pos > 0) {
         if (IAdvanceChar(next, pos) == CharType::kNormal)
             break;
     }
@@ -741,6 +741,13 @@ void pfConsole::IAdvanceWordFromPos(bool next, uint32_t& pos) const
             // If we're moving left, we now want to stop before a word breaker, so go one back when we moved past one.
             if (!next)
                 IAdvanceChar(true, pos);
+            break;
+        }
+    }
+    // Lastly, if moving right, we also wanna go to the end of the sequence if we have multiple word breakers in a row.
+    while (next && pos < strlen(fWorkingLine)) {
+        if (IAdvanceChar(next, pos) != CharType::kWordBreaker) {
+            IAdvanceChar(false, pos); // One back
             break;
         }
     }
@@ -757,14 +764,14 @@ void pfConsole::IDeleteChar(bool next)
 
 void pfConsole::IDeleteWord(bool next)
 {
-    uint32_t oldCursor, newCursor;
-    oldCursor = newCursor = fWorkingCursor;
-    IAdvanceWordFromPos(next, newCursor);
+    uint32_t cursor, deletePos;
+    cursor = deletePos = fWorkingCursor;
+    IAdvanceWordFromPos(next, deletePos);
 
-    if (oldCursor != newCursor) {
+    if (cursor != deletePos) {
         if (!next)
-            fWorkingCursor = newCursor;
-        int32_t count = next ? newCursor - oldCursor : oldCursor - newCursor;
+            fWorkingCursor = deletePos;
+        int32_t count = next ? deletePos - cursor : cursor - deletePos;
         memmove(&fWorkingLine[fWorkingCursor], &fWorkingLine[fWorkingCursor + count], (strlen(&fWorkingLine[fWorkingCursor + count]) + 1) * sizeof(char));
     }
 }

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -392,7 +392,15 @@ bool    pfConsole::MsgReceive( plMessage *msg )
 
 static inline bool IIsWordBoundary(const char c)
 {
-    return strchr(" _.", c) != nullptr;
+    if (c == ' ')
+        return true;
+    if (c == '_')
+        return true;
+    if (c == '.')
+        return true;
+    if (c == '\0')
+        return true;
+    return false;
 }
 
 void    pfConsole::IHandleKey( plKeyEventMsg *msg )
@@ -511,7 +519,6 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
     {
         // Move one word back
         if (fWorkingCursor > 0) {
-            fWorkingCursor--;
             do {
                 fWorkingCursor--;
             } while (fWorkingCursor > 0 && !IIsWordBoundary(fWorkingLine[fWorkingCursor - 1]));

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -711,7 +711,6 @@ static inline bool IIsWordBreaker(const char c)
  */
 pfConsole::CharType pfConsole::IAdvanceChar(bool next, uint32_t& pos) const
 {
-    hsAssert(pos >= 0, "out of range");
     hsAssert(pos <= strlen(fWorkingLine), "out of range");
     hsAssert(next || pos > 0, "advanced left at start of string");
 

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.cpp
@@ -390,6 +390,11 @@ bool    pfConsole::MsgReceive( plMessage *msg )
 
 //// IHandleKey //////////////////////////////////////////////////////////////
 
+inline bool IIsWordBoundary(const char& c)
+{
+    return strchr(" _.", c) != nullptr;
+}
+
 void    pfConsole::IHandleKey( plKeyEventMsg *msg )
 {
     char            *c;
@@ -502,15 +507,53 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
             IUpdateTooltip();
         }
     }
+    else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_LEFT)
+    {
+        // Move one word back
+        if (fWorkingCursor > 0) {
+            fWorkingCursor--;
+            do {
+                fWorkingCursor--;
+            } while (fWorkingCursor > 0 && !IIsWordBoundary(fWorkingLine[fWorkingCursor - 1]));
+        }
+    }
     else if( msg->GetKeyCode() == KEY_LEFT )
     {
         if( fWorkingCursor > 0 )
             fWorkingCursor--;
     }
+    else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_RIGHT)
+    {
+        // Move one word forward
+        size_t end = strlen(fWorkingLine);
+        if (fWorkingCursor < end) {
+            do {
+                fWorkingCursor++;
+            } while (fWorkingCursor < end && !IIsWordBoundary(fWorkingLine[fWorkingCursor - 1]));
+        }
+    }
     else if( msg->GetKeyCode() == KEY_RIGHT )
     {
         if( fWorkingCursor < strlen( fWorkingLine ) )
             fWorkingCursor++;
+    }
+    else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_BACKSPACE)
+    {
+        // Delete last word
+        if (fWorkingCursor > 0) {
+            uint32_t removed = 0;
+            do {
+                fWorkingCursor--;
+                removed++;
+            } while (fWorkingCursor > 0 && !IIsWordBoundary(fWorkingLine[fWorkingCursor - 1]));
+            memmove(&fWorkingLine[fWorkingCursor], &fWorkingLine[fWorkingCursor + removed], (strlen(&fWorkingLine[fWorkingCursor + removed]) + 1) * sizeof(char));
+
+            findAgain = false;
+            findCounter = 0;
+        } else if (fHelpMode)
+            fHelpMode = false;
+
+        IUpdateTooltip();
     }
     else if( msg->GetKeyCode() == KEY_BACKSPACE )
     {
@@ -532,6 +575,22 @@ void    pfConsole::IHandleKey( plKeyEventMsg *msg )
             fHelpMode = false;
 
         IUpdateTooltip();
+    }
+    else if (msg->GetCtrlKeyDown() && msg->GetKeyCode() == KEY_DELETE)
+    {
+        // Delete next word
+        size_t end = strlen(fWorkingLine);
+        if (fWorkingCursor < end) {
+            uint32_t removed = 0;
+            do {
+                removed++;
+            } while (fWorkingCursor + removed < end && !IIsWordBoundary(fWorkingLine[fWorkingCursor + removed - 1]));
+            memmove(&fWorkingLine[fWorkingCursor], &fWorkingLine[fWorkingCursor + removed], (strlen(&fWorkingLine[fWorkingCursor + removed]) + 1) * sizeof(char));
+
+            findAgain = false;
+            findCounter = 0;
+            IUpdateTooltip();
+        }
     }
     else if( msg->GetKeyCode() == KEY_DELETE )
     {

--- a/Sources/Plasma/FeatureLib/pfConsole/pfConsole.h
+++ b/Sources/Plasma/FeatureLib/pfConsole/pfConsole.h
@@ -121,6 +121,18 @@ class pfConsole : public hsKeyedObject
         void    IHandleKey( plKeyEventMsg *msg );
         void    IHandleCharacter(const char c);
 
+        enum class CharType
+        {
+            kNormal,
+            kWordBreaker,
+        };
+
+        CharType IAdvanceChar(bool next, uint32_t& pos) const;
+        void IAdvanceWordFromPos(bool next, uint32_t& pos) const;
+
+        void IDeleteChar(bool next);
+        void IDeleteWord(bool next);
+
         static uint32_t       fConsoleTextColor;
         static pfConsole    *fTheConsole;
         static void IAddLineCallback(const ST::string& string);

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -168,6 +168,78 @@ void    pfGUIEditBoxMod::IUpdate()
     fDynTextMap->FlushToHost();
 }
 
+static inline bool IIsWordBreaker(const wchar_t c)
+{
+    if (c == L' ')
+        return true;
+    if (c == L'\0')
+        return true;
+    return false;
+}
+
+/**
+ * Check the next/previous character and adjust our position output variable accordingly.
+ */
+pfGUIEditBoxMod::CharType pfGUIEditBoxMod::IAdvanceChar(bool next, uint32_t& pos) const
+{
+    hsAssert(pos >= 0, "out of range");
+    hsAssert(pos <= wcslen(fBuffer.c_str()), "out of range");
+    hsAssert(next || pos > 0, "advanced left at start of string");
+
+    wchar_t c = next ? fBuffer[pos] : fBuffer[pos - 1];
+    if (next)
+        pos++;
+    else
+        pos--;
+    if (IIsWordBreaker(c))
+        return CharType::kWordBreaker;
+    return CharType::kNormal;
+}
+
+/**
+ * Advance the supplied position by one word left or right.
+ */
+void pfGUIEditBoxMod::IAdvanceWordFromPos(bool next, uint32_t& pos) const
+{
+    // If we're moving left, we want to move into the previous word first.
+    while (!next && pos > 0) {
+        if (IAdvanceChar(next, pos) == CharType::kNormal)
+            break;
+    }
+    // Now, keep moving until we advanced past a word breaker
+    while (next && pos < wcslen(fBuffer.c_str()) || !next && pos > 0) {
+        if (IAdvanceChar(next, pos) == CharType::kWordBreaker) {
+            // If we're moving left, we now want to stop before a word breaker, so go one back when we moved past one.
+            if (!next)
+                IAdvanceChar(true, pos);
+            break;
+        }
+    }
+}
+
+void pfGUIEditBoxMod::IDeleteChar(bool next)
+{
+    if (!next && fCursorPos > 0 || next && fCursorPos < wcslen(fBuffer.c_str())) {
+        if (!next)
+            IAdvanceChar(false, fCursorPos);
+        memmove(&fBuffer[fCursorPos], &fBuffer[fCursorPos + 1], (wcslen(&fBuffer[fCursorPos + 1]) + 1) * sizeof(wchar_t));
+    }
+}
+
+void pfGUIEditBoxMod::IDeleteWord(bool next)
+{
+    uint32_t oldCursor, newCursor;
+    oldCursor = newCursor = fCursorPos;
+    IAdvanceWordFromPos(next, newCursor);
+
+    if (oldCursor != newCursor) {
+        if (!next)
+            fCursorPos = newCursor;
+        int32_t count = next ? newCursor - oldCursor : oldCursor - newCursor;
+        memmove(&fBuffer[fCursorPos], &fBuffer[fCursorPos + count], (wcslen(&fBuffer[fCursorPos + count]) + 1) * sizeof(wchar_t));
+    }
+}
+
 void pfGUIEditBoxMod::PurgeDynaTextMapImage()
 {
     if (fDynTextMap != nullptr)
@@ -293,66 +365,34 @@ bool    pfGUIEditBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
                 SetCursorToEnd();
             }
             else if (key == KEY_LEFT && modifiers & pfGameGUIMgr::kCtrlDown) {
-                // Go back a word
-                if (fCursorPos > 0) {
-                    do {
-                        fCursorPos--;
-                    } while (fCursorPos > 0 && fBuffer[fCursorPos - 1] != L' ');
-                }
+                IAdvanceWordFromPos(false, fCursorPos);
             }
             else if( key == KEY_LEFT )
             {
                 if( fCursorPos > 0 )
-                    fCursorPos--;
+                    IAdvanceChar(false, fCursorPos);
             }
             else if (key == KEY_RIGHT && modifiers & pfGameGUIMgr::kCtrlDown) {
-                // Go forward a word
-                size_t end = wcslen(fBuffer.c_str());
-                if (fCursorPos < end) {
-                    do {
-                        fCursorPos++;
-                    } while (fCursorPos < end && fBuffer[fCursorPos - 1] != L' ');
-                }
+                IAdvanceWordFromPos(true, fCursorPos);
             }
             else if (key == KEY_RIGHT)
             {
-                if( fCursorPos < wcslen( fBuffer.c_str() ) )
-                    fCursorPos++;
+                if (fCursorPos < wcslen(fBuffer.c_str()))
+                    IAdvanceChar(true, fCursorPos);
             }
             else if (key == KEY_BACKSPACE && modifiers & pfGameGUIMgr::kCtrlDown) {
-                // Delete last word
-                if (fCursorPos > 0) {
-                    uint32_t removed = 0;
-                    do {
-                        fCursorPos--;
-                        removed++;
-                    } while (fCursorPos > 0 && fBuffer[fCursorPos - 1] != L' ');
-                    memmove(&fBuffer[fCursorPos], &fBuffer[fCursorPos + removed], (wcslen(&fBuffer[fCursorPos + removed]) + 1) * sizeof(wchar_t));
-                }
+                IDeleteWord(false);
             }
             else if (key == KEY_BACKSPACE)
             {
-                if( fCursorPos > 0 )
-                {
-                    fCursorPos--;
-                    memmove( &fBuffer[fCursorPos], &fBuffer[fCursorPos + 1], (wcslen( &fBuffer[fCursorPos + 1] ) + 1) * sizeof(wchar_t) );
-                }
+                IDeleteChar(false);
             }
             else if (key == KEY_DELETE && modifiers & pfGameGUIMgr::kCtrlDown) {
-                // Delete next word
-                size_t end = wcslen(fBuffer.c_str());
-                if (fCursorPos < end) {
-                    uint32_t removed = 0;
-                    do {
-                        removed++;
-                    } while (fCursorPos + removed < end && fBuffer[fCursorPos + removed - 1] != L' ');
-                    memmove(&fBuffer[fCursorPos], &fBuffer[fCursorPos + removed], (wcslen(&fBuffer[fCursorPos + removed]) + 1) * sizeof(wchar_t));
-                }
+                IDeleteWord(true);
             }
             else if (key == KEY_DELETE)
             {
-                if( fCursorPos < wcslen( fBuffer.c_str() ) )
-                    memmove( &fBuffer[fCursorPos], &fBuffer[fCursorPos + 1], (wcslen( &fBuffer[fCursorPos + 1] ) + 1) * sizeof(wchar_t) );          
+                IDeleteChar(true);
             }
             else if( key == KEY_ENTER )
             {

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -201,8 +201,8 @@ pfGUIEditBoxMod::CharType pfGUIEditBoxMod::IAdvanceChar(bool next, uint32_t& pos
  */
 void pfGUIEditBoxMod::IAdvanceWordFromPos(bool next, uint32_t& pos) const
 {
-    // If we're moving left, we want to move into the previous word first.
-    while (!next && pos > 0) {
+    // We want to move into the next/previous word first.
+    while (next && pos < wcslen(fBuffer.c_str()) || !next && pos > 0) {
         if (IAdvanceChar(next, pos) == CharType::kNormal)
             break;
     }
@@ -212,6 +212,13 @@ void pfGUIEditBoxMod::IAdvanceWordFromPos(bool next, uint32_t& pos) const
             // If we're moving left, we now want to stop before a word breaker, so go one back when we moved past one.
             if (!next)
                 IAdvanceChar(true, pos);
+            break;
+        }
+    }
+    // Lastly, if moving right, we also wanna go to the end of the sequence if we have multiple word breakers in a row.
+    while (next && pos < wcslen(fBuffer.c_str())) {
+        if (IAdvanceChar(next, pos) != CharType::kWordBreaker) {
+            IAdvanceChar(false, pos); // One back
             break;
         }
     }
@@ -228,14 +235,14 @@ void pfGUIEditBoxMod::IDeleteChar(bool next)
 
 void pfGUIEditBoxMod::IDeleteWord(bool next)
 {
-    uint32_t oldCursor, newCursor;
-    oldCursor = newCursor = fCursorPos;
-    IAdvanceWordFromPos(next, newCursor);
+    uint32_t cursor, deletePos;
+    cursor = deletePos = fCursorPos;
+    IAdvanceWordFromPos(next, deletePos);
 
-    if (oldCursor != newCursor) {
+    if (cursor != deletePos) {
         if (!next)
-            fCursorPos = newCursor;
-        int32_t count = next ? newCursor - oldCursor : oldCursor - newCursor;
+            fCursorPos = deletePos;
+        int32_t count = next ? deletePos - cursor : cursor - deletePos;
         memmove(&fBuffer[fCursorPos], &fBuffer[fCursorPos + count], (wcslen(&fBuffer[fCursorPos + count]) + 1) * sizeof(wchar_t));
     }
 }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -292,15 +292,43 @@ bool    pfGUIEditBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
             {
                 SetCursorToEnd();
             }
+            else if (key == KEY_LEFT && modifiers & pfGameGUIMgr::kCtrlDown) {
+                // Go back a word
+                if (fCursorPos > 0) {
+                    do {
+                        fCursorPos--;
+                    } while (fCursorPos > 0 && fBuffer[fCursorPos - 1] != L' ');
+                }
+            }
             else if( key == KEY_LEFT )
             {
                 if( fCursorPos > 0 )
                     fCursorPos--;
             }
+            else if (key == KEY_RIGHT && modifiers & pfGameGUIMgr::kCtrlDown) {
+                // Go forward a word
+                size_t end = wcslen(fBuffer.c_str());
+                if (fCursorPos < end) {
+                    do {
+                        fCursorPos++;
+                    } while (fCursorPos < end && fBuffer[fCursorPos - 1] != L' ');
+                }
+            }
             else if (key == KEY_RIGHT)
             {
                 if( fCursorPos < wcslen( fBuffer.c_str() ) )
                     fCursorPos++;
+            }
+            else if (key == KEY_BACKSPACE && modifiers & pfGameGUIMgr::kCtrlDown) {
+                // Delete last word
+                if (fCursorPos > 0) {
+                    uint32_t removed = 0;
+                    do {
+                        fCursorPos--;
+                        removed++;
+                    } while (fCursorPos > 0 && fBuffer[fCursorPos - 1] != L' ');
+                    memmove(&fBuffer[fCursorPos], &fBuffer[fCursorPos + removed], (wcslen(&fBuffer[fCursorPos + removed]) + 1) * sizeof(wchar_t));
+                }
             }
             else if (key == KEY_BACKSPACE)
             {
@@ -308,6 +336,17 @@ bool    pfGUIEditBoxMod::HandleKeyEvent( pfGameGUIMgr::EventType event, plKeyDef
                 {
                     fCursorPos--;
                     memmove( &fBuffer[fCursorPos], &fBuffer[fCursorPos + 1], (wcslen( &fBuffer[fCursorPos + 1] ) + 1) * sizeof(wchar_t) );
+                }
+            }
+            else if (key == KEY_DELETE && modifiers & pfGameGUIMgr::kCtrlDown) {
+                // Delete next word
+                size_t end = wcslen(fBuffer.c_str());
+                if (fCursorPos < end) {
+                    uint32_t removed = 0;
+                    do {
+                        removed++;
+                    } while (fCursorPos + removed < end && fBuffer[fCursorPos + removed - 1] != L' ');
+                    memmove(&fBuffer[fCursorPos], &fBuffer[fCursorPos + removed], (wcslen(&fBuffer[fCursorPos + removed]) + 1) * sizeof(wchar_t));
                 }
             }
             else if (key == KEY_DELETE)

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.cpp
@@ -182,7 +182,6 @@ static inline bool IIsWordBreaker(const wchar_t c)
  */
 pfGUIEditBoxMod::CharType pfGUIEditBoxMod::IAdvanceChar(bool next, uint32_t& pos) const
 {
-    hsAssert(pos >= 0, "out of range");
     hsAssert(pos <= wcslen(fBuffer.c_str()), "out of range");
     hsAssert(next || pos > 0, "advanced left at start of string");
 
@@ -202,12 +201,13 @@ pfGUIEditBoxMod::CharType pfGUIEditBoxMod::IAdvanceChar(bool next, uint32_t& pos
 void pfGUIEditBoxMod::IAdvanceWordFromPos(bool next, uint32_t& pos) const
 {
     // We want to move into the next/previous word first.
-    while (next && pos < wcslen(fBuffer.c_str()) || !next && pos > 0) {
+    size_t len = wcslen(fBuffer.c_str());
+    while (next && pos < len || !next && pos > 0) {
         if (IAdvanceChar(next, pos) == CharType::kNormal)
             break;
     }
     // Now, keep moving until we advanced past a word breaker
-    while (next && pos < wcslen(fBuffer.c_str()) || !next && pos > 0) {
+    while (next && pos < len || !next && pos > 0) {
         if (IAdvanceChar(next, pos) == CharType::kWordBreaker) {
             // If we're moving left, we now want to stop before a word breaker, so go one back when we moved past one.
             if (!next)
@@ -216,7 +216,7 @@ void pfGUIEditBoxMod::IAdvanceWordFromPos(bool next, uint32_t& pos) const
         }
     }
     // Lastly, if moving right, we also wanna go to the end of the sequence if we have multiple word breakers in a row.
-    while (next && pos < wcslen(fBuffer.c_str())) {
+    while (next && pos < len) {
         if (IAdvanceChar(next, pos) != CharType::kWordBreaker) {
             IAdvanceChar(false, pos); // One back
             break;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIEditBoxMod.h
@@ -80,6 +80,18 @@ class pfGUIEditBoxMod : public pfGUIControlMod
         void    IPostSetUpDynTextMap() override;
         void    IUpdate() override;
 
+        enum class CharType
+        {
+            kNormal,
+            kWordBreaker,
+        };
+
+        CharType IAdvanceChar(bool next, uint32_t& pos) const;
+        void     IAdvanceWordFromPos(bool next, uint32_t& pos) const;
+
+        void IDeleteChar(bool next);
+        void IDeleteWord(bool next);
+
     public:
         enum
         {

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -694,9 +694,23 @@ int32_t   pfGUIMultiLineEditCtrl::IPointToPosition( int16_t ptX, int16_t ptY, bo
 //// IIsWordBreaker //////////////////////////////////////////////////////////
 //  Returns whether the given character is one that can break a line
 
-inline bool IIsWordBreaker( const wchar_t c )
+static inline bool IIsWordBreaker(const wchar_t c)
 {
-    return (wcschr(L" \t,.;\n", c) != nullptr);
+    if (c == L' ')
+        return true;
+    if (c == L'\t')
+        return true;
+    if (c == L'\n')
+        return true;
+    if (c == L',')
+        return true;
+    if (c == L'.')
+        return true;
+    if (c == L';')
+        return true;
+    if (c == L'\0')
+        return true;
+    return false;
 }
 
 //// IOffsetToNextChar ///////////////////////////////////////////////////////
@@ -1132,7 +1146,8 @@ bool    pfGUIMultiLineEditCtrl::HandleKeyEvent( pfGameGUIMgr::EventType event, p
         {
             if (IsLocked())
                 return true;
-            DeletePreviousWord();
+
+            DeleteWord(false);
         }
         else if( key == KEY_BACKSPACE )
         {
@@ -1149,7 +1164,8 @@ bool    pfGUIMultiLineEditCtrl::HandleKeyEvent( pfGameGUIMgr::EventType event, p
         {
             if (IsLocked())
                 return true;
-            DeleteNextWord();
+
+            DeleteWord(true);
         }
         else if( key == KEY_DELETE )
         {
@@ -1247,6 +1263,57 @@ void    pfGUIMultiLineEditCtrl::ISetCursor( int32_t newPosition )
     fLastCursorLine = newLine;
 }
 
+/**
+ * Check the next/previous character, accounting for control sequences, and adjust our position output variable accordingly.
+ */
+pfGUIMultiLineEditCtrl::CharType pfGUIMultiLineEditCtrl::IAdvanceChar(bool next, int32_t& pos) const
+{
+    hsAssert(pos >= 0, "out of range");
+    hsAssert(pos < (int32_t)fBuffer.size(), "out of range");
+    hsAssert(next || pos > 0, "advanced left at start of string");
+
+    wchar_t c = next ? fBuffer[pos] : fBuffer[pos - 1];
+    if (next)
+        pos += IOffsetToNextChar(c);
+    else
+        pos -= IOffsetToNextChar(c);
+    if (IIsCodeChar(c))
+        return CharType::kControlCode;
+    if (IIsWordBreaker(c))
+        return CharType::kWordBreaker;
+    // Assumption: we're never given anything in the middle of a control sequence.
+    return CharType::kNormal;
+}
+
+/**
+ * Advance the supplied position by one word left or right.
+ */
+bool pfGUIMultiLineEditCtrl::IAdvanceWordFromPos(bool next, int32_t& pos) const
+{
+    bool hitCtrlCode = false;
+
+    // If we're moving left, we want to move into the previous word first.
+    while (!next && pos > 0) {
+        CharType charType = IAdvanceChar(next, pos);
+        hitCtrlCode |= charType == CharType::kControlCode;
+        if (charType == CharType::kNormal)
+            break;
+    }
+    // Now, keep moving until we advanced past a word breaker
+    while (next && pos < (int32_t)fBuffer.size() - 1 || !next && pos > 0) {
+        CharType charType = IAdvanceChar(next, pos);
+        hitCtrlCode |= charType == CharType::kControlCode;
+        if (charType == CharType::kWordBreaker) {
+            // If we're moving left, we now want to stop before a word breaker, so go one back when we moved past one.
+            if (!next)
+              IAdvanceChar(true, pos);
+            break;
+        }
+    }
+
+    return hitCtrlCode;
+}
+
 //// IMoveCursor /////////////////////////////////////////////////////////////
 //  Moves the cursor in a relative direction.
 
@@ -1276,37 +1343,21 @@ void    pfGUIMultiLineEditCtrl::IMoveCursor( pfGUIMultiLineEditCtrl::Direction d
             break;
 
         case kOneBack:
-            if( cursor > 0 )
-            {
-                cursor--;
-                while (cursor > 0 && IIsCodeChar(fBuffer[cursor]))
-                    cursor -= IOffsetToNextChar( fBuffer[ cursor ] );
-            }
+            if (cursor > 0)
+                IAdvanceChar(false, cursor);
             break;
 
         case kOneForward:
             if (cursor < (int32_t)fBuffer.size() - 1)
-            {
-                cursor++;
-                while (cursor < (int32_t)fBuffer.size() - 1 && IIsCodeChar(fBuffer[cursor]))
-                    cursor += IOffsetToNextChar( fBuffer[ cursor ] );
-            }
+                IAdvanceChar(true, cursor);
             break;
 
         case kOneWordBack:
-            if( cursor > 0 )
-            {
-                for( ; cursor > 0 && IIsWordBreaker( fBuffer[ cursor - 1 ] ); cursor-- );
-                for( ; cursor > 0 && !IIsWordBreaker( fBuffer[ cursor - 1 ] ); cursor-- );
-            }
+            IAdvanceWordFromPos(false, cursor);
             break;
 
         case kOneWordForward:
-            if (cursor < (int32_t)fBuffer.size() - 1)
-            {
-                for (; cursor < (int32_t)fBuffer.size() - 1 && !IIsWordBreaker(fBuffer[cursor]); cursor++);
-                for (; cursor < (int32_t)fBuffer.size() - 1 && IIsWordBreaker(fBuffer[cursor]); cursor++);
-            }
+            IAdvanceWordFromPos(true, cursor);
             break;
 
         case kOneLineUp:
@@ -1494,9 +1545,6 @@ void     pfGUIMultiLineEditCtrl::IActuallyInsertLink(int32_t pos, int16_t linkId
 }
 
 //// DeleteChar //////////////////////////////////////////////////////////////
-//  If there is no selection, deletes the single character that the cursor
-//  is in front of. Otherwise, deletes the current selection and places the
-//  cursor where the selection used to be.
 
 void    pfGUIMultiLineEditCtrl::DeleteChar()
 {
@@ -1514,39 +1562,23 @@ void    pfGUIMultiLineEditCtrl::DeleteChar()
     }
 }
 
-void pfGUIMultiLineEditCtrl::DeleteNextWord()
+/**
+ * Deletes the next or previous word from the current cursor position.
+ */
+void pfGUIMultiLineEditCtrl::DeleteWord(bool next)
 {
-    if (fBuffer[fCursorPos] != L'\0') {
-        int32_t removed = 0;
-        bool forceUpdate = false;
-        do {
-            forceUpdate |= IIsCodeChar(fBuffer[fCursorPos + removed]);
-            removed++;
-        } while (fBuffer[fCursorPos + removed] != L'\0' && !IIsWordBreaker(fBuffer[fCursorPos + removed - 1]));
+    int32_t oldCursor, newCursor;
+    oldCursor = newCursor = fCursorPos;
+    bool forceUpdate = IAdvanceWordFromPos(next, newCursor);
 
+    if (oldCursor != newCursor) {
+        if (!next)
+            IMoveCursorTo(newCursor);
+        int32_t count = next ? newCursor - oldCursor : oldCursor - newCursor;
         const auto cursorIter = fBuffer.cbegin() + fCursorPos;
-        fBuffer.erase(cursorIter, cursorIter + removed);
+        fBuffer.erase(cursorIter, cursorIter + count);
         ISetGlobalBuffer(); // update the global buffer
-        IOffsetLineStarts(fCursorPos, -removed);
-        IRecalcFromCursor(forceUpdate);
-    }
-}
-
-void pfGUIMultiLineEditCtrl::DeletePreviousWord()
-{
-    if (fCursorPos > 0) {
-        int32_t removed = 0;
-        bool forceUpdate = false;
-        do {
-            fCursorPos--;
-            removed++;
-            forceUpdate |= IIsCodeChar(fBuffer[fCursorPos]);
-        } while (fCursorPos > 0 && !IIsWordBreaker(fBuffer[fCursorPos - 1]));
-
-        const auto cursorIter = fBuffer.cbegin() + fCursorPos;
-        fBuffer.erase(cursorIter, cursorIter + removed);
-        ISetGlobalBuffer(); // update the global buffer
-        IOffsetLineStarts(fCursorPos, -removed);
+        IOffsetLineStarts(fCursorPos, -count);
         IRecalcFromCursor(forceUpdate);
     }
 }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -134,12 +134,14 @@ class pfMLScrollProc : public pfGUICtrlProcObject
 
 //// Constants ///////////////////////////////////////////////////////////////
 
+// Do not try to use these manually when typing. These are meant for rendering via Python and won't save or go over the network.
+
 constexpr wchar_t kColorCodeChar = (wchar_t)1;
 constexpr wchar_t kStyleCodeChar = (wchar_t)2;
 constexpr wchar_t kLinkCodeChar = (wchar_t)3;
-constexpr size_t kColorCodeSize = 5;
-constexpr size_t kStyleCodeSize = 3;
-constexpr size_t kLinkCodeSize = 3;
+constexpr size_t kColorCodeSize = 5; // 0x01, r, g, b, 0x01 - via InsertColor
+constexpr size_t kStyleCodeSize = 3; // 0x02, style_flag, 0x02 - via InsertStyle
+constexpr size_t kLinkCodeSize = 3; // 0x03, idx, 0x03 - via InsertLink and ClearLink at the end
 
 //// Constructor/Destructor //////////////////////////////////////////////////
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -1518,7 +1518,7 @@ void pfGUIMultiLineEditCtrl::DeleteNextWord()
         int32_t removed = 0;
         bool forceUpdate = false;
         do {
-            forceUpdate = forceUpdate || IIsCodeChar(fBuffer[fCursorPos + removed]);
+            forceUpdate |= IIsCodeChar(fBuffer[fCursorPos + removed]);
             removed++;
         } while (fBuffer[fCursorPos + removed] != L'\0' && !IIsWordBreaker(fBuffer[fCursorPos + removed - 1]));
 
@@ -1538,7 +1538,7 @@ void pfGUIMultiLineEditCtrl::DeletePreviousWord()
         do {
             fCursorPos--;
             removed++;
-            forceUpdate = forceUpdate || IIsCodeChar(fBuffer[fCursorPos]);
+            forceUpdate |= IIsCodeChar(fBuffer[fCursorPos]);
         } while (fCursorPos > 0 && !IIsWordBreaker(fBuffer[fCursorPos - 1]));
 
         const auto cursorIter = fBuffer.cbegin() + fCursorPos;

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -1292,8 +1292,8 @@ bool pfGUIMultiLineEditCtrl::IAdvanceWordFromPos(bool next, int32_t& pos) const
 {
     bool hitCtrlCode = false;
 
-    // If we're moving left, we want to move into the previous word first.
-    while (!next && pos > 0) {
+    // We want to move into the next/previous word first.
+    while (next && pos < (int32_t)fBuffer.size() - 1  || !next && pos > 0) {
         CharType charType = IAdvanceChar(next, pos);
         hitCtrlCode |= charType == CharType::kControlCode;
         if (charType == CharType::kNormal)
@@ -1306,7 +1306,16 @@ bool pfGUIMultiLineEditCtrl::IAdvanceWordFromPos(bool next, int32_t& pos) const
         if (charType == CharType::kWordBreaker) {
             // If we're moving left, we now want to stop before a word breaker, so go one back when we moved past one.
             if (!next)
-              IAdvanceChar(true, pos);
+                IAdvanceChar(true, pos);
+            break;
+        }
+    }
+    // Lastly, if moving right, we also wanna go to the end of the sequence if we have multiple word breakers in a row.
+    while (next && pos < (int32_t)fBuffer.size() - 1) {
+        CharType charType = IAdvanceChar(next, pos);
+        hitCtrlCode |= charType == CharType::kControlCode;
+        if (charType != CharType::kWordBreaker) {
+            IAdvanceChar(false, pos); // One back
             break;
         }
     }
@@ -1567,14 +1576,14 @@ void    pfGUIMultiLineEditCtrl::DeleteChar()
  */
 void pfGUIMultiLineEditCtrl::DeleteWord(bool next)
 {
-    int32_t oldCursor, newCursor;
-    oldCursor = newCursor = fCursorPos;
-    bool forceUpdate = IAdvanceWordFromPos(next, newCursor);
+    int32_t cursor, deletePos;
+    cursor = deletePos = fCursorPos;
+    bool forceUpdate = IAdvanceWordFromPos(next, deletePos);
 
-    if (oldCursor != newCursor) {
+    if (cursor != deletePos) {
         if (!next)
-            IMoveCursorTo(newCursor);
-        int32_t count = next ? newCursor - oldCursor : oldCursor - newCursor;
+            IMoveCursorTo(deletePos);
+        int32_t count = next ? deletePos - cursor : cursor - deletePos;
         const auto cursorIter = fBuffer.cbegin() + fCursorPos;
         fBuffer.erase(cursorIter, cursorIter + count);
         ISetGlobalBuffer(); // update the global buffer

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -1290,37 +1290,43 @@ pfGUIMultiLineEditCtrl::CharType pfGUIMultiLineEditCtrl::IAdvanceChar(bool next,
  */
 bool pfGUIMultiLineEditCtrl::IAdvanceWordFromPos(bool next, int32_t& pos) const
 {
-    bool hitCtrlCode = false;
+    uint32_t hitCtrlCodeCount = 0;
 
     // We want to move into the next/previous word first.
     while (next && pos < (int32_t)fBuffer.size() - 1  || !next && pos > 0) {
         CharType charType = IAdvanceChar(next, pos);
-        hitCtrlCode |= charType == CharType::kControlCode;
+        if (charType == CharType::kControlCode)
+            hitCtrlCodeCount++;
         if (charType == CharType::kNormal)
             break;
     }
     // Now, keep moving until we advanced past a word breaker
     while (next && pos < (int32_t)fBuffer.size() - 1 || !next && pos > 0) {
         CharType charType = IAdvanceChar(next, pos);
-        hitCtrlCode |= charType == CharType::kControlCode;
+        if (charType == CharType::kControlCode)
+            hitCtrlCodeCount++;
         if (charType == CharType::kWordBreaker) {
             // If we're moving left, we now want to stop before a word breaker, so go one back when we moved past one.
-            if (!next)
-                IAdvanceChar(true, pos);
+            if (!next) {
+                if (IAdvanceChar(true, pos) == CharType::kControlCode)
+                    hitCtrlCodeCount--;
+            }
             break;
         }
     }
     // Lastly, if moving right, we also wanna go to the end of the sequence if we have multiple word breakers in a row.
     while (next && pos < (int32_t)fBuffer.size() - 1) {
         CharType charType = IAdvanceChar(next, pos);
-        hitCtrlCode |= charType == CharType::kControlCode;
+        if (charType == CharType::kControlCode)
+            hitCtrlCodeCount++;
         if (charType != CharType::kWordBreaker) {
-            IAdvanceChar(false, pos); // One back
+            if (IAdvanceChar(false, pos) == CharType::kControlCode) // Go one back
+                hitCtrlCodeCount--;
             break;
         }
     }
 
-    return hitCtrlCode;
+    return hitCtrlCodeCount > 0;
 }
 
 //// IMoveCursor /////////////////////////////////////////////////////////////

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -1126,6 +1126,12 @@ bool    pfGUIMultiLineEditCtrl::HandleKeyEvent( pfGameGUIMgr::EventType event, p
         else if( key == KEY_RIGHT )
             IMoveCursor( ( modifiers & pfGameGUIMgr::kCtrlDown ) ? kOneWordForward : kOneForward );
 
+        else if (modifiers & pfGameGUIMgr::kCtrlDown && key == KEY_BACKSPACE)
+        {
+            if (IsLocked())
+                return true;
+            DeletePreviousWord();
+        }
         else if( key == KEY_BACKSPACE )
         {
             if( IsLocked() )
@@ -1136,6 +1142,12 @@ bool    pfGUIMultiLineEditCtrl::HandleKeyEvent( pfGameGUIMgr::EventType event, p
                 IMoveCursor(kOneBack);
                 DeleteChar();
             }
+        }
+        else if (modifiers & pfGameGUIMgr::kCtrlDown && key == KEY_DELETE)
+        {
+            if (IsLocked())
+                return true;
+            DeleteNextWord();
         }
         else if( key == KEY_DELETE )
         {
@@ -1497,6 +1509,43 @@ void    pfGUIMultiLineEditCtrl::DeleteChar()
 
         IOffsetLineStarts( fCursorPos, -offset );
         IRecalcFromCursor( forceUpdate );
+    }
+}
+
+void pfGUIMultiLineEditCtrl::DeleteNextWord()
+{
+    if (fBuffer[fCursorPos] != L'\0') {
+        int32_t removed = 0;
+        bool forceUpdate = false;
+        do {
+            forceUpdate = forceUpdate || IIsCodeChar(fBuffer[fCursorPos + removed]);
+            removed++;
+        } while (fBuffer[fCursorPos + removed] != L'\0' && !IIsWordBreaker(fBuffer[fCursorPos + removed - 1]));
+
+        const auto cursorIter = fBuffer.cbegin() + fCursorPos;
+        fBuffer.erase(cursorIter, cursorIter + removed);
+        ISetGlobalBuffer(); // update the global buffer
+        IOffsetLineStarts(fCursorPos, -removed);
+        IRecalcFromCursor(forceUpdate);
+    }
+}
+
+void pfGUIMultiLineEditCtrl::DeletePreviousWord()
+{
+    if (fCursorPos > 0) {
+        int32_t removed = 0;
+        bool forceUpdate = false;
+        do {
+            fCursorPos--;
+            removed++;
+            forceUpdate = forceUpdate || IIsCodeChar(fBuffer[fCursorPos]);
+        } while (fCursorPos > 0 && !IIsWordBreaker(fBuffer[fCursorPos - 1]));
+
+        const auto cursorIter = fBuffer.cbegin() + fCursorPos;
+        fBuffer.erase(cursorIter, cursorIter + removed);
+        ISetGlobalBuffer(); // update the global buffer
+        IOffsetLineStarts(fCursorPos, -removed);
+        IRecalcFromCursor(forceUpdate);
     }
 }
 

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -1352,13 +1352,11 @@ void    pfGUIMultiLineEditCtrl::IMoveCursor( pfGUIMultiLineEditCtrl::Direction d
             break;
 
         case kOneBack:
-            if (cursor > 0)
-                IAdvanceChar(false, cursor);
+            while (cursor > 0 && IAdvanceChar(false, cursor) == CharType::kControlCode);
             break;
 
         case kOneForward:
-            if (cursor < (int32_t)fBuffer.size() - 1)
-                IAdvanceChar(true, cursor);
+            while (cursor < (int32_t)fBuffer.size() - 1 && IAdvanceChar(true, cursor) == CharType::kControlCode);
             break;
 
         case kOneWordBack:

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.cpp
@@ -1307,10 +1307,8 @@ bool pfGUIMultiLineEditCtrl::IAdvanceWordFromPos(bool next, int32_t& pos) const
             hitCtrlCodeCount++;
         if (charType == CharType::kWordBreaker) {
             // If we're moving left, we now want to stop before a word breaker, so go one back when we moved past one.
-            if (!next) {
-                if (IAdvanceChar(true, pos) == CharType::kControlCode)
-                    hitCtrlCodeCount--;
-            }
+            if (!next)
+                IAdvanceChar(true, pos);
             break;
         }
     }

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -147,13 +147,13 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
 
         enum class CharType
         {
-          kNormal,
-          kWordBreaker,
-          kControlCode,
+            kNormal,
+            kWordBreaker,
+            kControlCode,
         };
         
-        CharType IAdvanceChar(bool next, int32_t &pos) const;
-        bool IAdvanceWordFromPos(bool next, int32_t &pos) const;
+        CharType IAdvanceChar(bool next, int32_t& pos) const;
+        bool IAdvanceWordFromPos(bool next, int32_t& pos) const;
 
         void    IMoveCursor( Direction dir );
         void    IMoveCursorTo( int32_t position );    // Updates selection

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -249,6 +249,8 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         void    ClearLink() { InsertLink(-1); }
 
         void    DeleteChar();
+        void    DeleteNextWord();
+        void    DeletePreviousWord();
         void    ClearBuffer();
         void    SetBuffer(const ST::string& text);
         void    SetBuffer(const wchar_t *codedText, size_t length);

--- a/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
+++ b/Sources/Plasma/FeatureLib/pfGameGUIMgr/pfGUIMultiLineEditCtrl.h
@@ -145,6 +145,16 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
 
         int     fTopMargin,fLeftMargin,fBottomMargin,fRightMargin;
 
+        enum class CharType
+        {
+          kNormal,
+          kWordBreaker,
+          kControlCode,
+        };
+        
+        CharType IAdvanceChar(bool next, int32_t &pos) const;
+        bool IAdvanceWordFromPos(bool next, int32_t &pos) const;
+
         void    IMoveCursor( Direction dir );
         void    IMoveCursorTo( int32_t position );    // Updates selection
         void    ISetCursor( int32_t newPosition );    // Doesn't update selection
@@ -249,8 +259,7 @@ class pfGUIMultiLineEditCtrl : public pfGUIControlMod
         void    ClearLink() { InsertLink(-1); }
 
         void    DeleteChar();
-        void    DeleteNextWord();
-        void    DeletePreviousWord();
+        void    DeleteWord(bool next = true);
         void    ClearBuffer();
         void    SetBuffer(const ST::string& text);
         void    SetBuffer(const wchar_t *codedText, size_t length);

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -668,7 +668,7 @@ void    plFont::IRenderString( plMipmap *mip, uint16_t x, uint16_t y, const wcha
                 prevX = fRenderInfo.fX;
                 IRenderLoop( string, 1 );
             }
-            while( fRenderInfo.fX <= fRenderInfo.fClipRect.fX && *++string != 0 );
+            while( fRenderInfo.fX <= fRenderInfo.fClipRect.fX && *string != 0 && *++string != 0 );
             fRenderInfo.fMaxWidth += fRenderInfo.fX - prevX;
             fRenderInfo.fDestPtr -= (fRenderInfo.fX - prevX) * fRenderInfo.fDestBPP;
             fRenderInfo.fX = prevX;

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -662,13 +662,14 @@ void    plFont::IRenderString( plMipmap *mip, uint16_t x, uint16_t y, const wcha
             // Advance left past any clipping area
             CharRenderFunc oldFunc = fRenderInfo.fRenderFunc;
             fRenderInfo.fRenderFunc = &plFont::IRenderCharNull;
-            int16_t prevX;
-            do
-            {
+            int16_t prevX = fRenderInfo.fX;
+            while (*string != 0) {
+                IRenderLoop(string, 1);
+                if (fRenderInfo.fX > fRenderInfo.fClipRect.fX)
+                    break;
                 prevX = fRenderInfo.fX;
-                IRenderLoop( string, 1 );
+                ++string;
             }
-            while( fRenderInfo.fX <= fRenderInfo.fClipRect.fX && *string != 0 && *++string != 0 );
             fRenderInfo.fMaxWidth += fRenderInfo.fX - prevX;
             fRenderInfo.fDestPtr -= (fRenderInfo.fX - prevX) * fRenderInfo.fDestBPP;
             fRenderInfo.fX = prevX;

--- a/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
+++ b/Sources/Plasma/PubUtilLib/plGImage/plFont.cpp
@@ -664,10 +664,10 @@ void    plFont::IRenderString( plMipmap *mip, uint16_t x, uint16_t y, const wcha
             fRenderInfo.fRenderFunc = &plFont::IRenderCharNull;
             int16_t prevX = fRenderInfo.fX;
             while (*string != 0) {
+                prevX = fRenderInfo.fX;
                 IRenderLoop(string, 1);
                 if (fRenderInfo.fX > fRenderInfo.fClipRect.fX)
                     break;
-                prevX = fRenderInfo.fX;
                 ++string;
             }
             fRenderInfo.fMaxWidth += fRenderInfo.fX - prevX;

--- a/Sources/Tests/FeatureTests/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/CMakeLists.txt
@@ -7,5 +7,6 @@ include_directories("${PLASMA_SOURCE_ROOT}/FeatureLib")
 include_directories("${PLASMA_SOURCE_ROOT}/FeatureLib/inc")
 
 add_subdirectory(pfConsoleCoreTest)
+add_subdirectory(pfGameGUIMgrTest)
 add_subdirectory(pfPasswordStoreTest)
 add_subdirectory(pfPythonTest)

--- a/Sources/Tests/FeatureTests/pfGameGUIMgrTest/CMakeLists.txt
+++ b/Sources/Tests/FeatureTests/pfGameGUIMgrTest/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(pfGameGUIMgrTest_SOURCES
+    test_pfGUIMultiLineEditCtrl.cpp
+)
+
+plasma_test(test_pfGameGUIMgr SOURCES ${pfGameGUIMgrTest_SOURCES})
+target_link_libraries(
+    test_pfGameGUIMgr
+    PRIVATE
+        gtest
+        gtest_main
+        CoreLib
+        pnNucleusInc
+        pfFeatureInc
+        plPubUtilInc
+        pfGameGUIMgr
+)

--- a/Sources/Tests/FeatureTests/pfGameGUIMgrTest/test_pfGUIMultiLineEditCtrl.cpp
+++ b/Sources/Tests/FeatureTests/pfGameGUIMgrTest/test_pfGUIMultiLineEditCtrl.cpp
@@ -1,0 +1,263 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <gtest/gtest.h>
+#include <pfGameGUIMgr/pfGUIMultiLineEditCtrl.h>
+#include <string_theory/string>
+
+#include "pfAllCreatables.h"
+#include "plAllCreatables.h"
+#include "pnAllCreatables.h"
+
+// Macro helpers that will compile down to constants when used with hardcoded strings.
+#define STRLEN(x) std::char_traits<char>::length(x)
+#define WSTRLEN(x) std::char_traits<wchar_t>::length(x)
+
+TEST(pfGUIMultiLineEditCtrl, BasicWordNavigation)
+{
+    pfGUIMultiLineEditCtrl textBox;
+    ST::string testStr = "Hi, this is a test. Woop!";
+    textBox.InsertString(testStr);
+    ASSERT_EQ(textBox.GetCursor(), testStr.size());
+    // No change when moving right at end.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    ASSERT_EQ(textBox.GetCursor(), testStr.size());
+    // Expected left word movement in pure text.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    ASSERT_EQ(textBox.GetCursor(), STRLEN("Hi, this is a test. "));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    ASSERT_EQ(textBox.GetCursor(), STRLEN("Hi, this is a "));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    ASSERT_EQ(textBox.GetCursor(), STRLEN("Hi, this is "));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    ASSERT_EQ(textBox.GetCursor(), STRLEN("Hi, this "));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    ASSERT_EQ(textBox.GetCursor(), STRLEN("Hi, "));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    ASSERT_EQ(textBox.GetCursor(), 0);
+    // No weirdness when moving left at start.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    ASSERT_EQ(textBox.GetCursor(), 0);
+    // Expected right movement in pure text.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    ASSERT_EQ(textBox.GetCursor(), STRLEN("Hi, "));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    ASSERT_EQ(textBox.GetCursor(), STRLEN("Hi, this "));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    ASSERT_EQ(textBox.GetCursor(), STRLEN("Hi, this is "));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    ASSERT_EQ(textBox.GetCursor(), STRLEN("Hi, this is a "));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    ASSERT_EQ(textBox.GetCursor(), STRLEN("Hi, this is a test. "));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    ASSERT_EQ(textBox.GetCursor(), testStr.size());
+}
+
+TEST(pfGUIMultiLineEditCtrl, BasicWordBackwardDeletion)
+{
+    pfGUIMultiLineEditCtrl textBox;
+    ST::string testStr = "Hi, this is a test!";
+    textBox.InsertString(testStr);
+    ASSERT_EQ(textBox.GetCursor(), testStr.size());
+    textBox.DeleteWord(false);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL("Hi, this is a "));
+    textBox.DeleteWord(false);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL("Hi, this is "));
+    textBox.DeleteWord(false);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL("Hi, this "));
+    textBox.DeleteWord(false);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL("Hi, "));
+    textBox.DeleteWord(false);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL(""));
+    // No breakage when deleting at start.
+    textBox.DeleteWord(false);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL(""));
+}
+
+TEST(pfGUIMultiLineEditCtrl, BasicWordForwardDeletion)
+{
+    pfGUIMultiLineEditCtrl textBox;
+    textBox.InsertString(ST_LITERAL("Hi, this is a test!"));
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kBufferStart);
+    ASSERT_EQ(textBox.GetCursor(), 0);
+    textBox.DeleteWord(true);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL("this is a test!"));
+    textBox.DeleteWord(true);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL("is a test!"));
+    textBox.DeleteWord(true);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL("a test!"));
+    textBox.DeleteWord(true);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL("test!"));
+    textBox.DeleteWord(true);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL(""));
+    // No breakage when deleting at start.
+    textBox.DeleteWord(true);
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL(""));
+    ASSERT_EQ(textBox.GetCursor(), 0);
+}
+
+TEST(pfGUIMultiLineEditCtrl, WordBreakerBehavior) {
+    pfGUIMultiLineEditCtrl textBox;
+    // Test string that includes a word breaker block and an arbitrary code with a 0 param.
+    textBox.InsertString(ST_LITERAL("random, ; ,.   \x02\x00\x02words "));
+
+    // Moving a word back will move to the end of the word breaker block before the previous word.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    int32_t cursor = textBox.GetCursor();
+    auto buffer = textBox.GetCodedBuffer();
+    ASSERT_EQ(buffer[cursor - 1], L' ');
+    ASSERT_EQ(buffer[cursor], L'\x02');
+
+    // Moving a word forward will move past an entire word breaker block after the next word.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kBufferStart);
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    cursor = textBox.GetCursor();
+    buffer = textBox.GetCodedBuffer();
+    ASSERT_EQ(buffer[cursor - 1], L' ');
+    ASSERT_EQ(buffer[cursor], L'\x02');
+
+    textBox.DeleteWord(false);
+    textBox.DeleteChar();
+    ASSERT_EQ(textBox.GetCodedBuffer(), ST_WCHAR_LITERAL("words "));
+}
+
+TEST(pfGUIMultiLineEditCtrl, AdvancedMovementTest)
+{
+    // Welcome to me literally just slapping other random use cases that come to mind together into one.
+    pfGUIMultiLineEditCtrl textBox;
+    textBox.InsertString(ST_LITERAL("Lorem ipsum! "));
+    hsColorRGBA red;
+    red.Set(1.f, 0.f, 0.f, 1.f);
+    textBox.InsertColor(red);
+    textBox.InsertString(ST_LITERAL("Words of wisdom, for ages untold, outside the bounds of reality and reason, in very long lines that are sure to wrap into more lines, have been spoken.\n"));
+    // Insert a manual color code with space key code as color values.
+    textBox.InsertString(ST_LITERAL("\x01   \x01Until now!\n"));
+    textBox.InsertLink(0);
+    textBox.InsertString(ST_LITERAL("https://www.mystonline.com"));
+    textBox.InsertLink(-1);
+    textBox.InsertString(ST_LITERAL("\nTHE wordwith"));
+    textBox.InsertStyle(1);
+    textBox.InsertString(ST_LITERAL("stylecode"));
+    textBox.InsertStyle(0);
+    textBox.InsertString(ST_LITERAL("inside END"));
+
+    // Move two words back and delete the word with a style code inside.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    textBox.DeleteWord(true);
+    ASSERT_STREQ(&textBox.GetCodedBuffer()[textBox.GetCursor()], L"END");
+
+    // Moving another word back and deleting a char should move us right to the end of the link and in front of T.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordBack);
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneBack);
+    textBox.DeleteChar();
+    int32_t cursor = textBox.GetCursor();
+    auto buffer = textBox.GetCodedBuffer();
+    ASSERT_EQ(buffer[cursor - 1], L'\x03');
+    ASSERT_STREQ(&buffer[cursor], L"THE END");
+
+    textBox.DeleteWord(false); // Delete link up to com since dots are word breakers.
+    textBox.DeleteWord(false); // Delete link up to mystonline since dots are word breakers.
+    textBox.DeleteWord(false); // Delete again which should leave us at right after the "Until now!" newline.
+    cursor = textBox.GetCursor();
+    buffer = textBox.GetCodedBuffer();
+    ASSERT_EQ(buffer[cursor - 1], L'\n');
+    ASSERT_EQ(buffer[cursor], L'T');
+
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kBufferStart);
+    textBox.DeleteWord(true); // Delete Lorem
+    textBox.DeleteWord(true); // Delete ipsum!
+    // We should now be in front of the red color code.
+    cursor = textBox.GetCursor();
+    buffer = textBox.GetCodedBuffer();
+    ASSERT_EQ(buffer[cursor], L'\x01');
+    ASSERT_EQ(buffer[cursor + 1], L'\xFF');
+
+    // Moving a word right will now move past the color code and the word.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    cursor = textBox.GetCursor();
+    buffer = textBox.GetCodedBuffer();
+    ASSERT_EQ(buffer[cursor - 1], L' ');
+    ASSERT_EQ(buffer[cursor], L'o');
+    ASSERT_EQ(buffer[cursor + 1], L'f');
+
+    // Delete "for ages untold"
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    textBox.DeleteWord(true);
+    textBox.DeleteWord(true);
+    textBox.DeleteWord(true);
+    cursor = textBox.GetCursor();
+    buffer = textBox.GetCodedBuffer();
+    ASSERT_EQ(buffer[cursor - 3], L'm');
+    ASSERT_EQ(buffer[cursor - 2], L',');
+    ASSERT_EQ(buffer[cursor - 1], L' ');
+    ASSERT_EQ(buffer[cursor], L'o');
+    ASSERT_EQ(buffer[cursor + 1], L'u');
+    ASSERT_EQ(buffer[cursor + 2], L't');
+
+    // Moving 21 words right now should put us in front of "spoken."
+    for (size_t i = 0; i < 21; i++)
+        textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    cursor = textBox.GetCursor();
+    buffer = textBox.GetCodedBuffer();
+    ASSERT_EQ(buffer[cursor - 1], L' ');
+    ASSERT_EQ(buffer[cursor], L's');
+    ASSERT_EQ(buffer[cursor + 1], L'p');
+    ASSERT_EQ(buffer[cursor + 2], L'o');
+
+    // Now, another move right will go in front of the manual color code with "space characters" inside it.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    cursor = textBox.GetCursor();
+    buffer = textBox.GetCodedBuffer();
+    ASSERT_EQ(buffer[cursor - 1], L'\n');
+    ASSERT_EQ(buffer[cursor], L'\x01');
+    
+    // And the next will move past the entire code sequence and word.
+    textBox.MoveCursor(pfGUIMultiLineEditCtrl::kOneWordForward);
+    cursor = textBox.GetCursor();
+    buffer = textBox.GetCodedBuffer();
+    ASSERT_EQ(buffer[cursor - 1], L' ');
+    ASSERT_EQ(buffer[cursor], L'n');
+    ASSERT_EQ(buffer[cursor + 1], L'o');
+    ASSERT_EQ(buffer[cursor + 2], L'w');
+}


### PR DESCRIPTION
This adds support for using Ctrl+Left and Ctrl+Right to move the cursor by whole words, as well as Ctrl+Backspace to delete the last word and Ctrl+Delete to delete the next word to the following elements:
- EditBox (single line text boxes like the KI chat input line or Avatar naming)
- MultiLineEdit (most notably KI notes)
- The Developer Console (to make it easy to quickly delete parts of a command, in combination with using up/down to browse historical commands)

The changes to each elements were done for ease of review in a style that should match what is already there. This does mean using some old c-style strings in parts that would likely benefit from an update to use ST more widely, but changing that felt out of scope for this.

As an aside, I noticed and fixed an issue in plFont when rendering clipped strings. It would advance the string rendering pointer past the first value if an empty string is passed, thus rendering garbage that may be in the buffer behind the null terminator. In this particular case, the issue would surface when deleting the solely remaining last word on clipped edit boxes like the KI Chat input or the avatar naming field.

Demo:

https://github.com/user-attachments/assets/2ebbd2a1-6928-47a8-a6d6-75d0f2dffaca
