### PR TITLE
Migrate FileSrv/AuthSrv manifest parsing to `ST::string`

### DIFF
--- a/Sources/Plasma/CoreLib/hsEndian.cpp
+++ b/Sources/Plasma/CoreLib/hsEndian.cpp
@@ -59,19 +59,15 @@ ST::string hsSTStringFromTerminatedUTF16LE(const void* buffer, size_t bufferSize
 {
     auto byteBuffer = static_cast<const uint8_t*>(buffer);
     // Count how many char16_ts there are in the string.
-    // char16Count only counts the actual string contents,
-    // consumedChar16Count also counts the terminator, if present
-    // (there is no terminator if the end of the buffer was reached unexpectedly).
-    size_t consumedChar16Count = 0;
+    // The terminator (if present) isn't included in this count.
     size_t char16Count = 0;
     for (size_t i = 0; i < bufferSize / sizeof(char16_t); i++) {
-        consumedChar16Count++;
         if (byteBuffer[2*i] == 0 && byteBuffer[2*i + 1] == 0) {
             break;
         }
         char16Count++;
     }
-    consumedSize = consumedChar16Count * sizeof(char16_t);
+    consumedSize = char16Count * sizeof(char16_t);
     return hsSTStringFromUTF16LE(buffer, char16Count);
 }
 

--- a/Sources/Plasma/CoreLib/hsEndian.cpp
+++ b/Sources/Plasma/CoreLib/hsEndian.cpp
@@ -75,15 +75,55 @@ ST::string hsSTStringFromTerminatedUTF16LE(const void* buffer, size_t bufferSize
     return hsSTStringFromUTF16LE(buffer, char16Count);
 }
 
+static void ICopyUTF16BufferToLE(const char16_t* utf16Buffer, size_t char16Count, uint8_t* utf16LEBuffer)
+{
+    for (size_t i = 0; i < char16Count; i++) {
+        char16_t c = utf16Buffer[i];
+        utf16LEBuffer[2*i] = c & 0xff;
+        utf16LEBuffer[2*i + 1] = c >> 8 & 0xff;
+    }
+}
+
 std::vector<uint8_t> hsSTStringToUTF16LE(const ST::string& string)
 {
     ST::utf16_buffer utf16Buffer = string.to_utf16();
     std::vector<uint8_t> buffer;
     buffer.resize(utf16Buffer.size() * 2);
-    for (size_t i = 0; i < utf16Buffer.size(); i++) {
-        char16_t c = utf16Buffer[i];
-        buffer[2*i] = c & 0xff;
-        buffer[2*i + 1] = c >> 8 & 0xff;
-    }
+    ICopyUTF16BufferToLE(utf16Buffer.data(), utf16Buffer.size(), buffer.data());
     return buffer;
+}
+
+bool hsSTStringToFixedSizeUTF16LE(const ST::string& string, void* buffer, size_t bufferSize)
+{
+    ST::utf16_buffer utf16Buffer = string.to_utf16();
+
+    // Calculate how many char16_ts fit into the provided buffer
+    // while still leaving room for a terminating zero char16_t
+    // (except if the buffer is shorter than 2 bytes, obviously).
+    size_t char16CountToCopy;
+    bool bufferIsBigEnough;
+    if (bufferSize < (utf16Buffer.size() + 1) * 2) {
+        char16CountToCopy = bufferSize / 2;
+        if (char16CountToCopy > 0) {
+            char16CountToCopy--;
+        }
+        bufferIsBigEnough = false;
+    } else {
+        char16CountToCopy = utf16Buffer.size();
+        bufferIsBigEnough = true;
+    }
+
+    auto byteBuffer = static_cast<uint8_t*>(buffer);
+
+    // Copy and convert the characters.
+    ICopyUTF16BufferToLE(utf16Buffer.data(), char16CountToCopy, byteBuffer);
+
+    // Fill the rest of the buffer with zeroes.
+    // This terminates the string and ensures that no uninitialized data
+    // is sent over the network, written to disk, or similar.
+    for (size_t i = char16CountToCopy * 2; i < bufferSize; i++) {
+        byteBuffer[i] = 0;
+    }
+
+    return bufferIsBigEnough;
 }

--- a/Sources/Plasma/CoreLib/hsEndian.h
+++ b/Sources/Plasma/CoreLib/hsEndian.h
@@ -144,5 +144,6 @@ template <> inline double hsToLE(double value) { return hsToLEDouble(value); }
 ST::string hsSTStringFromUTF16LE(const void* buffer, size_t char16Count);
 ST::string hsSTStringFromTerminatedUTF16LE(const void* buffer, size_t bufferSize, size_t& consumedSize);
 std::vector<uint8_t> hsSTStringToUTF16LE(const ST::string& string);
+bool hsSTStringToFixedSizeUTF16LE(const ST::string& string, void* buffer, size_t bufferSize);
 
 #endif // hsEndian_inc

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -334,7 +334,7 @@ void pfPatcherWorker::IGotAuthFileList(ENetError result, const std::vector<NetCl
             for (const auto& info : infos) {
                 PatcherLogYellow("\tEnqueuing Legacy File '{}'", info.filename);
 
-                plFileName fn = ST::string::from_utf16(info.filename);
+                plFileName fn = info.filename;
                 plFileSystem::CreateDir(fn.StripFileName());
 
                 // We purposefully do NOT Open this stream! This uses a special auth-file constructor that

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -125,12 +125,11 @@ struct pfPatcherQueuedFile
     uint32_t fFlags;
 
     pfPatcherQueuedFile(Type t, const NetCliFileManifestEntry& file)
-    : fType(t), fClientPath(plFileName(ST::string::from_utf16(file.clientName)).Normalize()),
-          fServerPath(ST::string::from_utf16(file.downloadName)), fChecksum(),
+        : fType(t), fClientPath(plFileName(file.clientName).Normalize()),
+          fServerPath(file.downloadName), fChecksum(),
           fFileSize(file.fileSize), fZipSize(file.zipSize), fFlags(file.flags)
     {
-        ST::string temp(file.md5, std::size(file.md5));
-        fChecksum.SetFromHexString(temp.c_str());
+        fChecksum.SetFromHexString(file.md5.c_str());
     }
 
     pfPatcherQueuedFile(Type t, plFileName path, uint32_t flags=0)

--- a/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
+++ b/Sources/Plasma/FeatureLib/pfPatcher/pfPatcher.cpp
@@ -485,14 +485,14 @@ bool pfPatcherWorker::IssueRequest()
             });
             break;
         case Request::kManifest:
-            NetCliFileManifestRequest(req.fName.to_utf16().data(), 0, [this, group = req.fName](auto result, const auto& manifest) {
+            NetCliFileManifestRequest(req.fName, 0, [this, group = req.fName](auto result, const auto& manifest) {
                 IFileManifestDownloadCB(result, group, manifest);
             });
             break;
         case Request::kSecurePreloader:
             // so, yeah, this is usually the "SecurePreloader" manifest on the file server...
             // except on legacy servers, this may not exist, so we need to fall back without nuking everything!
-            NetCliFileManifestRequest(req.fName.to_utf16().data(), 0, [this, group = req.fName](auto result, const auto& manifest) {
+            NetCliFileManifestRequest(req.fName, 0, [this, group = req.fName](auto result, const auto& manifest) {
                 IPreloaderManifestDownloadCB(result, group, manifest);
             });
             break;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Intern.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Intern.h
@@ -412,11 +412,14 @@ unsigned ConnGetId (ENetProtocol protocol);
 
 // For tests only
 
+struct Auth2Cli_FileListReply;
 struct File2Cli_ManifestReply;
+struct NetCliAuthFileInfo;
 struct NetCliFileManifestEntry;
 
-namespace Ngl { namespace File {
-    bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFileManifestEntry>& manifest, unsigned& numEntriesReceived);
-}}
+namespace Ngl {
+    namespace Auth { bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAuthFileInfo>& fileInfoArray); }
+    namespace File { bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFileManifestEntry>& manifest, unsigned& numEntriesReceived); }
+}
 
 #endif // PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETGAMELIB_INTERN_H

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/Intern.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/Intern.h
@@ -410,4 +410,13 @@ unsigned ConnGetId (ENetProtocol protocol);
 
 } using namespace Ngl;
 
+// For tests only
+
+struct File2Cli_ManifestReply;
+struct NetCliFileManifestEntry;
+
+namespace Ngl { namespace File {
+    bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFileManifestEntry>& manifest, unsigned& numEntriesReceived);
+}}
+
 #endif // PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETGAMELIB_INTERN_H

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
@@ -2877,12 +2877,12 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
 
             // read in the filename
             size_t filenameConsumed;
-            ST::string filename = hsSTStringFromTerminatedUTF16LE(curChar, kNetDefaultStringSize - 1, filenameConsumed);
+            ST::string filename = hsSTStringFromTerminatedUTF16LE(curChar, wcharCount * sizeof(char16_t), filenameConsumed);
 
             unsigned filenameLen = filenameConsumed / sizeof(char16_t);
             curChar += filenameLen; // advance the pointer
             wcharCount -= filenameLen; // keep track of the amount remaining
-            if ((*curChar != L'\0') || (wcharCount <= 0))
+            if (wcharCount == 0 || *curChar != L'\0')
                 return false; // something is screwy, abort and disconnect
 
             curChar++; // point it at the first part of the size value (format: 0xHHHHLLLL)
@@ -2892,7 +2892,7 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
             unsigned size = (hsToLE16(*curChar) << 16) + hsToLE16(*(curChar + 1));
             curChar += 2;
             wcharCount -= 2;
-            if ((*curChar != L'\0') || (wcharCount <= 0))
+            if (wcharCount == 0 || *curChar != L'\0')
                 return false; // screwy data
 
             // save the data in our array
@@ -2910,8 +2910,6 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
                     return false; // invalid data, we shouldn't have any more
                 done = true; // we're done
             }
-            else if (wcharCount < 6) // we must have at least a 1 char string, '\0', size, and "\0\0" terminator left
-                return false; // screwy data
         }
     }
 

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
@@ -2856,19 +2856,14 @@ void FileListRequestTrans::Post () {
     m_callback(m_result, m_fileInfoArray);
 }
 
-//============================================================================
-bool FileListRequestTrans::Recv (
-    const uint8_t  msg[],
-    unsigned    bytes
-) {
-    const Auth2Cli_FileListReply & reply = *(const Auth2Cli_FileListReply *) msg;
-
+bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAuthFileInfo>& fileInfoArray)
+{
     uint32_t wcharCount = reply.wcharCount;
     const char16_t* curChar = reply.fileData;
     // if wcharCount is 2, the data only contains the terminator "\0\0" and we
     // don't need to convert anything
     if (wcharCount == 2)
-        m_fileInfoArray.clear();
+        fileInfoArray.clear();
     else
     {
         // fileData format: "filename\0size\0filename\0size\0...\0\0"
@@ -2902,7 +2897,7 @@ bool FileListRequestTrans::Recv (
                 return false; // screwy data
 
             // save the data in our array
-            NetCliAuthFileInfo& info = m_fileInfoArray.emplace_back();
+            NetCliAuthFileInfo& info = fileInfoArray.emplace_back();
             StrCopy(info.filename, filename, std::size(info.filename));
             info.filesize = size;
 
@@ -2919,6 +2914,20 @@ bool FileListRequestTrans::Recv (
             else if (wcharCount < 6) // we must have at least a 1 char string, '\0', size, and "\0\0" terminator left
                 return false; // screwy data
         }
+    }
+
+    return true;
+}
+
+//============================================================================
+bool FileListRequestTrans::Recv (
+    const uint8_t  msg[],
+    unsigned    bytes
+) {
+    const Auth2Cli_FileListReply & reply = *(const Auth2Cli_FileListReply *) msg;
+
+    if (!IReceiveFileList(reply, m_fileInfoArray)) {
+        return false;
     }
 
     m_result    = reply.result;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
@@ -2876,11 +2876,10 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
             }
 
             // read in the filename
-            char16_t filename[kNetDefaultStringSize];
-            StrCopy(filename, curChar, std::size(filename));
-            filename[std::size(filename) - 1] = L'\0'; // make sure it's terminated
+            size_t filenameConsumed;
+            ST::string filename = hsSTStringFromTerminatedUTF16LE(curChar, kNetDefaultStringSize - 1, filenameConsumed);
 
-            unsigned filenameLen = std::char_traits<char16_t>::length(filename);
+            unsigned filenameLen = filenameConsumed / sizeof(char16_t);
             curChar += filenameLen; // advance the pointer
             wcharCount -= filenameLen; // keep track of the amount remaining
             if ((*curChar != L'\0') || (wcharCount <= 0))
@@ -2890,7 +2889,7 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
             wcharCount--;
             if (wcharCount < 4) // we have to have 2 chars for the size, and 2 for terminator at least
                 return false; // screwy data
-            unsigned size = ((*curChar) << 16) + (*(curChar + 1));
+            unsigned size = (hsToLE16(*curChar) << 16) + hsToLE16(*(curChar + 1));
             curChar += 2;
             wcharCount -= 2;
             if ((*curChar != L'\0') || (wcharCount <= 0))
@@ -2898,7 +2897,7 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
 
             // save the data in our array
             NetCliAuthFileInfo& info = fileInfoArray.emplace_back();
-            info.filename = ST::string::from_utf16(filename, filenameLen);
+            info.filename = filename;
             info.filesize = size;
 
             // point it at either the second part of the terminator, or the next filename

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
@@ -2862,17 +2862,18 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
     const char16_t* curChar = reply.fileData;
     // if wcharCount is 2, the data only contains the terminator "\0\0" and we
     // don't need to convert anything
-    if (wcharCount == 2)
+    if (wcharCount == 0 || wcharCount == 2) {
         fileInfoArray.clear();
-    else
-    {
+        return true;
+    } else {
         // fileData format: "filename\0size\0filename\0size\0...\0\0"
-        bool done = false;
-        while (!done) {
-            if (wcharCount == 0)
-            {
-                done = true;
-                break;
+        while (wcharCount > 0) {
+            if (*curChar == L'\0') {
+                // we hit the terminator
+                curChar++;
+                wcharCount--;
+                // Check that there's no data after the terminator.
+                return wcharCount == 0;
             }
 
             // read in the filename
@@ -2900,20 +2901,15 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
             info.filename = filename;
             info.filesize = size;
 
-            // point it at either the second part of the terminator, or the next filename
+            // point it at either the next file or the terminator for the file list
             curChar++;
             wcharCount--;
-            if (*curChar == L'\0')
-            {
-                // we hit the terminator
-                if (wcharCount != 1)
-                    return false; // invalid data, we shouldn't have any more
-                done = true; // we're done
-            }
         }
+    
+        // Ran out of data without hitting the file list terminator,
+        // meaning that the file list is truncated.
+        return false;
     }
-
-    return true;
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
@@ -2860,9 +2860,9 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
 {
     uint32_t wcharCount = reply.wcharCount;
     const char16_t* curChar = reply.fileData;
-    // if wcharCount is 2, the data only contains the terminator "\0\0" and we
-    // don't need to convert anything
-    if (wcharCount == 0 || wcharCount == 2) {
+    // Special case: 0 or 2 terminator chars are also accepted as a file list with 0 files,
+    // even though following the pattern, it should be a single terminator.
+    if (wcharCount == 0 || (wcharCount == 2 && curChar[0] == L'\0' && curChar[1] == L'\0')) {
         fileInfoArray.clear();
         return true;
     } else {

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
@@ -2898,7 +2898,7 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
 
             // save the data in our array
             NetCliAuthFileInfo& info = fileInfoArray.emplace_back();
-            StrCopy(info.filename, filename, std::size(info.filename));
+            info.filename = ST::string::from_utf16(filename, filenameLen);
             info.filesize = size;
 
             // point it at either the second part of the terminator, or the next filename

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
@@ -2862,13 +2862,13 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
     const char16_t* curChar = reply.fileData;
     // Special case: 0 or 2 terminator chars are also accepted as a file list with 0 files,
     // even though following the pattern, it should be a single terminator.
-    if (wcharCount == 0 || (wcharCount == 2 && curChar[0] == L'\0' && curChar[1] == L'\0')) {
+    if (wcharCount == 0 || (wcharCount == 2 && curChar[0] == 0 && curChar[1] == 0)) {
         fileInfoArray.clear();
         return true;
     } else {
         // fileData format: "filename\0size\0filename\0size\0...\0\0"
         while (wcharCount > 0) {
-            if (*curChar == L'\0') {
+            if (*curChar == 0) {
                 // we hit the terminator
                 curChar++;
                 wcharCount--;
@@ -2883,7 +2883,7 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
             unsigned filenameLen = filenameConsumed / sizeof(char16_t);
             curChar += filenameLen; // advance the pointer
             wcharCount -= filenameLen; // keep track of the amount remaining
-            if (wcharCount == 0 || *curChar != L'\0')
+            if (wcharCount == 0 || *curChar != 0)
                 return false; // something is screwy, abort and disconnect
 
             curChar++; // point it at the first part of the size value (format: 0xHHHHLLLL)
@@ -2893,7 +2893,7 @@ bool IReceiveFileList(const Auth2Cli_FileListReply& reply, std::vector<NetCliAut
             unsigned size = (hsToLE16(*curChar) << 16) + hsToLE16(*(curChar + 1));
             curChar += 2;
             wcharCount -= 2;
-            if (wcharCount == 0 || *curChar != L'\0')
+            if (wcharCount == 0 || *curChar != 0)
                 return false; // screwy data
 
             // save the data in our array

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.cpp
@@ -2953,14 +2953,12 @@ bool FileDownloadRequestTrans::Send () {
     if (!AcquireConn())
         return false;
 
-    char16_t filename[kNetDefaultStringSize] {};
     const ST::utf16_buffer buffer = m_filename.AsString().to_utf16();
-    memcpy(filename, buffer.data(), std::min(sizeof(filename), buffer.size() * sizeof(char16_t)));
 
     const uintptr_t msg[] = {
         kCli2Auth_FileDownloadRequest,
         m_transId,
-        reinterpret_cast<uintptr_t>(filename),
+        reinterpret_cast<uintptr_t>(buffer.data()),
     };
 
     m_conn->Send(msg, std::size(msg));

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglAuth.h
@@ -315,7 +315,7 @@ void NetCliAuthGetEncryptionKey (
 // File List
 //============================================================================
 struct NetCliAuthFileInfo {
-    char16_t    filename[kNetDefaultStringSize];
+    ST::string  filename;
     unsigned    filesize;
 };
 using FNetCliAuthFileListRequestCallback = std::function<void(

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -891,7 +891,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
     if (numFiles > manifest.size())
         manifest.resize(numFiles); // reserve the space ahead of time
 
-    // manifestData format: "clientFile\0downloadFile\0md5\0filesize\0zipsize\0flags\0...\0\0"
+    // manifestData format: "clientName\0downloadName\0md5\0md5compressed\0fileSize\0zipSize\0flags\0...\0\0"
     while (wcharCount > 0) {
         if (*curChar == L'\0') {
             // we hit the terminator

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -880,7 +880,8 @@ inline size_t FIXME_u16snlen(const char16_t* str, size_t maxlen)
 }
 
 //============================================================================
-void ReadStringFromMsg(const char16_t* curMsgPtr, char16_t* destPtr, unsigned* length) {
+void ReadStringFromMsg(const char16_t* curMsgPtr, char16_t* destPtr, size_t* length)
+{
     size_t maxlen = FIXME_u16snlen(curMsgPtr, kNetDefaultStringSize - 1); // Hacky sack
     *length = maxlen;
     destPtr[maxlen] = 0;
@@ -915,7 +916,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
 
         // --------------------------------------------------------------------
         // read in the clientFilename
-        unsigned filenameLen = 0;
+        size_t filenameLen = 0;
         ReadStringFromMsg(curChar, entry.clientName, &filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -61,7 +61,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "pnNetBase/pnNbSrvs.h"
 #include "pnNetCommon/plNetAddress.h"
 #include "pnNetProtocol/pnNpCli2File.h"
-#include "pnUtils/pnUtStr.h"
 
 #include "Intern.h"
 
@@ -171,7 +170,7 @@ struct BuildIdRequestTrans : NetFileTrans {
 //============================================================================
 struct ManifestRequestTrans : NetFileTrans {
     FNetCliFileManifestRequestCallback  m_callback;
-    char16_t                            m_group[kNetDefaultStringSize];
+    ST::string                          m_group;
     unsigned                            m_buildId;
 
     std::vector<NetCliFileManifestEntry>  m_manifest;
@@ -179,7 +178,7 @@ struct ManifestRequestTrans : NetFileTrans {
 
     ManifestRequestTrans (
         FNetCliFileManifestRequestCallback  callback,
-        const char16_t                      group[],
+        ST::string                          group,
         unsigned                            buildId
     );
 
@@ -758,7 +757,6 @@ bool CliFileConn::Recv_ManifestReply (
     msg->numFiles = hsToLE32(msg->numFiles);
     msg->wcharCount = hsToLE32(msg->wcharCount);
 
-    // The manifest format includes \0 characters, so we can't just StrCopy
     for (size_t i = 0; i < msg->wcharCount; i++) {
         msg->manifestData[i] = hsToLE16(msg->manifestData[i]);
     }
@@ -851,18 +849,14 @@ bool BuildIdRequestTrans::Recv (
 //============================================================================
 ManifestRequestTrans::ManifestRequestTrans (
     FNetCliFileManifestRequestCallback  callback,
-    const char16_t                      group[],
+    ST::string                          group,
     unsigned                            buildId
 ) : NetFileTrans(kManifestRequestTrans)
 ,   m_callback(std::move(callback))
+,   m_group(std::move(group))
 ,   m_numEntriesReceived(0)
 ,   m_buildId(buildId)
-{
-    if (group)
-        StrCopy(m_group, group, std::size(m_group));
-    else
-        m_group[0] = L'\0';
-}
+{}
 
 //============================================================================
 bool ManifestRequestTrans::Send () {
@@ -870,7 +864,7 @@ bool ManifestRequestTrans::Send () {
         return false;
 
     Cli2File_ManifestRequest manifestReq;
-    StrCopyLE16(manifestReq.group, m_group, std::size(manifestReq.group));
+    StrCopyLE16(manifestReq.group, m_group.to_utf16().data(), std::size(manifestReq.group));
     manifestReq.messageId = hsToLE32(kCli2File_ManifestRequest);
     manifestReq.transId = hsToLE32(m_transId);
     manifestReq.messageBytes = hsToLE32(sizeof(manifestReq));
@@ -1341,13 +1335,13 @@ void NetCliFileRegisterBuildIdUpdate (FNetCliFileBuildIdUpdateCallback callback)
 
 //============================================================================
 void NetCliFileManifestRequest (
-    const char16_t                      group[],
+    ST::string                          group,
     unsigned                            buildId,
     FNetCliFileManifestRequestCallback  callback
 ) {
     ManifestRequestTrans * trans = new ManifestRequestTrans(
         std::move(callback),
-        group,
+        std::move(group),
         buildId
     );
     NetTransSend(trans);

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -869,10 +869,10 @@ void ManifestRequestTrans::Post () {
 }
 
 //============================================================================
-ST::string ReadStringFromMsg(const char16_t* curMsgPtr, size_t* length)
+ST::string ReadStringFromMsg(const char16_t* curMsgPtr, size_t msgChar16Count, size_t* length)
 {
     size_t consumedSize;
-    ST::string res = hsSTStringFromTerminatedUTF16LE(curMsgPtr, (kNetDefaultStringSize - 1) * sizeof(char16_t), consumedSize);
+    ST::string res = hsSTStringFromTerminatedUTF16LE(curMsgPtr, msgChar16Count * sizeof(char16_t), consumedSize);
     *length = consumedSize / sizeof(char16_t);
     return res;
 }
@@ -906,10 +906,10 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         // --------------------------------------------------------------------
         // read in the clientFilename
         size_t filenameLen = 0;
-        entry.clientName = ReadStringFromMsg(curChar, &filenameLen);
+        entry.clientName = ReadStringFromMsg(curChar, wcharCount, &filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
-        if ((*curChar != L'\0') || (wcharCount <= 0))
+        if (wcharCount == 0 || *curChar != L'\0')
             return false; // something is screwy, abort and disconnect
 
         // point it at the downloadFile
@@ -919,10 +919,10 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         // --------------------------------------------------------------------
         // read in the downloadFilename
         filenameLen = 0;
-        entry.downloadName = ReadStringFromMsg(curChar, &filenameLen);
+        entry.downloadName = ReadStringFromMsg(curChar, wcharCount, &filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
-        if ((*curChar != L'\0') || (wcharCount <= 0))
+        if (wcharCount == 0 || *curChar != L'\0')
             return false; // something is screwy, abort and disconnect
 
         // point it at the md5
@@ -932,10 +932,13 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         // --------------------------------------------------------------------
         // read in the md5
         filenameLen = 32;
+        if (wcharCount < filenameLen) {
+            return false; // something is screwy, abort and disconnect
+        }
         entry.md5 = hsSTStringFromUTF16LE(curChar, filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
-        if ((*curChar != L'\0') || (wcharCount <= 0))
+        if (wcharCount == 0 || *curChar != L'\0')
             return false; // something is screwy, abort and disconnect
 
         // point it at the md5 for compressed files
@@ -945,10 +948,13 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         // --------------------------------------------------------------------
         // read in the md5 for compressed files
         filenameLen = 32;
+        if (wcharCount < filenameLen) {
+            return false; // something is screwy, abort and disconnect
+        }
         entry.md5compressed = hsSTStringFromUTF16LE(curChar, filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
-        if ((*curChar != L'\0') || (wcharCount <= 0))
+        if (wcharCount == 0 || *curChar != L'\0')
             return false; // something is screwy, abort and disconnect
 
         // point it at the first part of the filesize value (format: 0xHHHHLLLL)
@@ -961,7 +967,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         ReadUnsignedFromMsg(curChar, &entry.fileSize);
         curChar += 2;
         wcharCount -= 2;
-        if ((*curChar != L'\0') || (wcharCount <= 0))
+        if (wcharCount == 0 || *curChar != L'\0')
             return false; // screwy data
 
         // point it at the first part of the zipsize value (format: 0xHHHHLLLL)
@@ -974,7 +980,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         ReadUnsignedFromMsg(curChar, &entry.zipSize);
         curChar += 2;
         wcharCount -= 2;
-        if ((*curChar != L'\0') || (wcharCount <= 0))
+        if (wcharCount == 0 || *curChar != L'\0')
             return false; // screwy data
 
         // point it at the first part of the flags value (format: 0xHHHHLLLL)
@@ -987,7 +993,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         ReadUnsignedFromMsg(curChar, &entry.flags);
         curChar += 2;
         wcharCount -= 2;
-        if ((*curChar != L'\0') || (wcharCount <= 0))
+        if (wcharCount == 0 || *curChar != L'\0')
             return false; // screwy data
 
         // --------------------------------------------------------------------
@@ -996,15 +1002,12 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         wcharCount--;
 
         // do sanity checking
-        if (*curChar == L'\0') {
+        if (wcharCount != 0 && *curChar == L'\0') {
             // we hit the terminator
             if (wcharCount != 1)
                 return false; // invalid data, we shouldn't have any more
             done = true; // we're done
         }
-        else if (wcharCount < 14)
-            // we must have at least three 1-char strings, three nulls, three 32-bit ints, and 2-char terminator left (3+3+6+2)
-            return false; // screwy data
 
         // increment entries received
         numEntriesReceived++;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -891,6 +891,12 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
     if (numFiles > manifest.size())
         manifest.resize(numFiles); // reserve the space ahead of time
 
+    // Special case: 0 or 2 terminator chars are also accepted as a manifest with 0 files,
+    // even though following the pattern, it should be a single terminator.
+    if (wcharCount == 0 || (wcharCount == 2 && curChar[0] == L'\0' && curChar[1] == L'\0')) {
+        return true;
+    }
+
     // manifestData format: "clientName\0downloadName\0md5\0md5compressed\0fileSize\0zipSize\0flags\0...\0\0"
     while (wcharCount > 0) {
         if (*curChar == L'\0') {
@@ -1032,10 +1038,8 @@ bool ManifestRequestTrans::Recv (
 
     m_conn->Send(&manifestAck, sizeof(manifestAck));
 
-    // if wcharCount is 2 or less, the data only contains the terminator "\0\0" and we
-    // don't need to convert anything (and we are done)
-    if (IS_NET_ERROR(reply.result) || reply.wcharCount <= 2) {
-        // we have a problem... or we have nothing to so, so we're done
+    if (IS_NET_ERROR(reply.result)) {
+        // we have a problem...
         m_result    = reply.result;
         m_state     = kTransStateComplete;
         return true;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -68,16 +68,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // It changes the logic by which the decision to attempt a reconnect is made.
 #define LOAD_BALANCER_HARDWARE
 
-static void StrCopyLE16(char16_t* dest, const char16_t source[], size_t chars) {
-    while ((chars > 1) && ((*dest = hsToLE16(*source++)) != 0)) {
-        --chars;
-        ++dest;
-    }
-    if (chars)
-        *dest = 0;
-}
-
-
 namespace Ngl { namespace File {
 /*****************************************************************************
 *
@@ -864,10 +854,11 @@ bool ManifestRequestTrans::Send () {
         return false;
 
     Cli2File_ManifestRequest manifestReq;
-    StrCopyLE16(manifestReq.group, m_group.to_utf16().data(), std::size(manifestReq.group));
     manifestReq.messageId = hsToLE32(kCli2File_ManifestRequest);
     manifestReq.transId = hsToLE32(m_transId);
     manifestReq.messageBytes = hsToLE32(sizeof(manifestReq));
+    bool ok = hsSTStringToFixedSizeUTF16LE(m_group, manifestReq.group, sizeof(manifestReq.group));
+    hsAssert(ok, "Requested a manifest name longer than the protocol allows - truncating...");
     manifestReq.buildId = hsToLE32(m_buildId);
 
     m_conn->Send(&manifestReq, sizeof(manifestReq));
@@ -1101,10 +1092,11 @@ bool DownloadRequestTrans::Send () {
 
     Cli2File_FileDownloadRequest filedownloadReq;
     const ST::utf16_buffer buffer = m_filename.AsString().to_utf16();
-    StrCopyLE16(filedownloadReq.filename, buffer.data(), std::size(filedownloadReq.filename));
     filedownloadReq.messageId = hsToLE32(kCli2File_FileDownloadRequest);
     filedownloadReq.transId = hsToLE32(m_transId);
     filedownloadReq.messageBytes = hsToLE32(sizeof(filedownloadReq));
+    bool ok = hsSTStringToFixedSizeUTF16LE(m_filename.AsString(), filedownloadReq.filename, sizeof(filedownloadReq.filename));
+    hsAssert(ok, "Requested a file name longer than the protocol allows - truncating...");
     filedownloadReq.buildId = hsToLE32(m_buildId);
 
     m_conn->Send(&filedownloadReq, sizeof(filedownloadReq));

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -881,11 +881,9 @@ inline size_t FIXME_u16snlen(const char16_t* str, size_t maxlen)
 
 //============================================================================
 void ReadStringFromMsg(const char16_t* curMsgPtr, char16_t* destPtr, unsigned* length) {
-    if (!(*length)) {
-        size_t maxlen = FIXME_u16snlen(curMsgPtr, kNetDefaultStringSize - 1);   // Hacky sack
-        (*length) = maxlen;
-        destPtr[maxlen] = 0;    // Don't do this on fixed length, because there's no room for it
-    }
+    size_t maxlen = FIXME_u16snlen(curMsgPtr, kNetDefaultStringSize - 1); // Hacky sack
+    *length = maxlen;
+    destPtr[maxlen] = 0;
     memcpy(destPtr, curMsgPtr, *length * sizeof(char16_t));
 }
 
@@ -944,7 +942,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         // --------------------------------------------------------------------
         // read in the md5
         filenameLen = 32;
-        ReadStringFromMsg(curChar, entry.md5, &filenameLen);
+        memcpy(entry.md5, curChar, filenameLen * sizeof(char16_t));
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
         if ((*curChar != L'\0') || (wcharCount <= 0))
@@ -957,7 +955,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         // --------------------------------------------------------------------
         // read in the md5 for compressed files
         filenameLen = 32;
-        ReadStringFromMsg(curChar, entry.md5compressed, &filenameLen);
+        memcpy(entry.md5compressed, curChar, filenameLen * sizeof(char16_t));
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
         if ((*curChar != L'\0') || (wcharCount <= 0))

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -44,7 +44,6 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <algorithm>
 #include <mutex>
-#include <string>
 #include <string_theory/string>
 #include <utility>
 
@@ -746,10 +745,8 @@ bool CliFileConn::Recv_ManifestReply (
     msg->readerId = hsToLE32(msg->readerId);
     msg->numFiles = hsToLE32(msg->numFiles);
     msg->wcharCount = hsToLE32(msg->wcharCount);
-
-    for (size_t i = 0; i < msg->wcharCount; i++) {
-        msg->manifestData[i] = hsToLE16(msg->manifestData[i]);
-    }
+    // Intentionally don't convert manifestData to native byte order yet.
+    // IReceiveManifest later converts the byte order of each field in the manifest individually.
 
     NetTransRecv(msg->transId, (const uint8_t *)msg, msg->messageBytes);
 
@@ -871,26 +868,18 @@ void ManifestRequestTrans::Post () {
     m_callback(m_result, m_manifest);
 }
 
-// Neither char_traits nor C's string library have a "strnlen" equivalent for
-// char16_t strings...
-inline size_t FIXME_u16snlen(const char16_t* str, size_t maxlen)
-{
-    const char16_t* end = std::char_traits<char16_t>::find(str, maxlen, 0);
-    return end ? size_t(end - str) : maxlen;
-}
-
 //============================================================================
-void ReadStringFromMsg(const char16_t* curMsgPtr, char16_t* destPtr, size_t* length)
+ST::string ReadStringFromMsg(const char16_t* curMsgPtr, size_t* length)
 {
-    size_t maxlen = FIXME_u16snlen(curMsgPtr, kNetDefaultStringSize - 1); // Hacky sack
-    *length = maxlen;
-    destPtr[maxlen] = 0;
-    memcpy(destPtr, curMsgPtr, *length * sizeof(char16_t));
+    size_t consumedSize;
+    ST::string res = hsSTStringFromTerminatedUTF16LE(curMsgPtr, (kNetDefaultStringSize - 1) * sizeof(char16_t), consumedSize);
+    *length = consumedSize / sizeof(char16_t);
+    return res;
 }
 
 //============================================================================
 void ReadUnsignedFromMsg(const char16_t* curMsgPtr, unsigned* val) {
-    (*val) = ((*curMsgPtr) << 16) + (*(curMsgPtr + 1));
+    *val = (hsToLE16(*curMsgPtr) << 16) + hsToLE16(*(curMsgPtr + 1));
 }
 
 bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFileManifestEntry>& manifest, unsigned& numEntriesReceived)
@@ -917,7 +906,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         // --------------------------------------------------------------------
         // read in the clientFilename
         size_t filenameLen = 0;
-        ReadStringFromMsg(curChar, entry.clientName, &filenameLen);
+        entry.clientName = ReadStringFromMsg(curChar, &filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
         if ((*curChar != L'\0') || (wcharCount <= 0))
@@ -930,7 +919,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         // --------------------------------------------------------------------
         // read in the downloadFilename
         filenameLen = 0;
-        ReadStringFromMsg(curChar, entry.downloadName, &filenameLen);
+        entry.downloadName = ReadStringFromMsg(curChar, &filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
         if ((*curChar != L'\0') || (wcharCount <= 0))
@@ -943,7 +932,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         // --------------------------------------------------------------------
         // read in the md5
         filenameLen = 32;
-        memcpy(entry.md5, curChar, filenameLen * sizeof(char16_t));
+        entry.md5 = hsSTStringFromUTF16LE(curChar, filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
         if ((*curChar != L'\0') || (wcharCount <= 0))
@@ -956,7 +945,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         // --------------------------------------------------------------------
         // read in the md5 for compressed files
         filenameLen = 32;
-        memcpy(entry.md5compressed, curChar, filenameLen * sizeof(char16_t));
+        entry.md5compressed = hsSTStringFromUTF16LE(curChar, filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
         if ((*curChar != L'\0') || (wcharCount <= 0))

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -892,12 +892,16 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         manifest.resize(numFiles); // reserve the space ahead of time
 
     // manifestData format: "clientFile\0downloadFile\0md5\0filesize\0zipsize\0flags\0...\0\0"
-    bool done = false;
-    while (!done) {
-        if (wcharCount == 0)
-        {
-            done = true;
-            break;
+    while (wcharCount > 0) {
+        if (*curChar == L'\0') {
+            // we hit the terminator
+            curChar++;
+            wcharCount--;
+            // Check that there's no data after the terminator.
+            return wcharCount == 0;
+        } else if (numEntriesReceived >= numFiles) {
+            // too much data, abort
+            return false;
         }
 
         // copy the data over to our array (m_numEntriesReceived is the current index)
@@ -997,27 +1001,17 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
             return false; // screwy data
 
         // --------------------------------------------------------------------
-        // point it at either the second part of the terminator, or the next filename
+        // point it at either the next file or the terminator for the manifest
         curChar++;
         wcharCount--;
 
-        // do sanity checking
-        if (wcharCount != 0 && *curChar == L'\0') {
-            // we hit the terminator
-            if (wcharCount != 1)
-                return false; // invalid data, we shouldn't have any more
-            done = true; // we're done
-        }
-
         // increment entries received
         numEntriesReceived++;
-        if (numEntriesReceived >= numFiles && !done) {
-            // too much data, abort
-            return false;
-        }
     }
 
-    return true;
+    // Ran out of data without hitting the manifest terminator,
+    // meaning that the manifest is truncated.
+    return false;
 }
 
 //============================================================================

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -893,13 +893,13 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
 
     // Special case: 0 or 2 terminator chars are also accepted as a manifest with 0 files,
     // even though following the pattern, it should be a single terminator.
-    if (wcharCount == 0 || (wcharCount == 2 && curChar[0] == L'\0' && curChar[1] == L'\0')) {
+    if (wcharCount == 0 || (wcharCount == 2 && curChar[0] == 0 && curChar[1] == 0)) {
         return true;
     }
 
     // manifestData format: "clientName\0downloadName\0md5\0md5compressed\0fileSize\0zipSize\0flags\0...\0\0"
     while (wcharCount > 0) {
-        if (*curChar == L'\0') {
+        if (*curChar == 0) {
             // we hit the terminator
             curChar++;
             wcharCount--;
@@ -919,7 +919,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         entry.clientName = ReadStringFromMsg(curChar, wcharCount, &filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
-        if (wcharCount == 0 || *curChar != L'\0')
+        if (wcharCount == 0 || *curChar != 0)
             return false; // something is screwy, abort and disconnect
 
         // point it at the downloadFile
@@ -932,7 +932,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         entry.downloadName = ReadStringFromMsg(curChar, wcharCount, &filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
-        if (wcharCount == 0 || *curChar != L'\0')
+        if (wcharCount == 0 || *curChar != 0)
             return false; // something is screwy, abort and disconnect
 
         // point it at the md5
@@ -948,7 +948,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         entry.md5 = hsSTStringFromUTF16LE(curChar, filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
-        if (wcharCount == 0 || *curChar != L'\0')
+        if (wcharCount == 0 || *curChar != 0)
             return false; // something is screwy, abort and disconnect
 
         // point it at the md5 for compressed files
@@ -964,7 +964,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         entry.md5compressed = hsSTStringFromUTF16LE(curChar, filenameLen);
         curChar += filenameLen; // advance the pointer
         wcharCount -= filenameLen; // keep track of the amount remaining
-        if (wcharCount == 0 || *curChar != L'\0')
+        if (wcharCount == 0 || *curChar != 0)
             return false; // something is screwy, abort and disconnect
 
         // point it at the first part of the filesize value (format: 0xHHHHLLLL)
@@ -977,7 +977,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         ReadUnsignedFromMsg(curChar, &entry.fileSize);
         curChar += 2;
         wcharCount -= 2;
-        if (wcharCount == 0 || *curChar != L'\0')
+        if (wcharCount == 0 || *curChar != 0)
             return false; // screwy data
 
         // point it at the first part of the zipsize value (format: 0xHHHHLLLL)
@@ -990,7 +990,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         ReadUnsignedFromMsg(curChar, &entry.zipSize);
         curChar += 2;
         wcharCount -= 2;
-        if (wcharCount == 0 || *curChar != L'\0')
+        if (wcharCount == 0 || *curChar != 0)
             return false; // screwy data
 
         // point it at the first part of the flags value (format: 0xHHHHLLLL)
@@ -1003,7 +1003,7 @@ bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFil
         ReadUnsignedFromMsg(curChar, &entry.flags);
         curChar += 2;
         wcharCount -= 2;
-        if (wcharCount == 0 || *curChar != L'\0')
+        if (wcharCount == 0 || *curChar != 0)
             return false; // screwy data
 
         // --------------------------------------------------------------------

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.cpp
@@ -894,39 +894,14 @@ void ReadUnsignedFromMsg(const char16_t* curMsgPtr, unsigned* val) {
     (*val) = ((*curMsgPtr) << 16) + (*(curMsgPtr + 1));
 }
 
-//============================================================================
-bool ManifestRequestTrans::Recv (
-    const uint8_t  msg[],
-    unsigned    bytes
-) {
-    m_timeoutAtMs = hsTimer::GetMilliSeconds<uint32_t>() + NetTransGetTimeoutMs(); // Reset the timeout counter
-
-    const File2Cli_ManifestReply & reply = *(const File2Cli_ManifestReply *) msg;
-
+bool IReceiveManifest(const File2Cli_ManifestReply& reply, std::vector<NetCliFileManifestEntry>& manifest, unsigned& numEntriesReceived)
+{
     uint32_t numFiles = reply.numFiles;
     uint32_t wcharCount = reply.wcharCount;
     const char16_t* curChar = reply.manifestData; // the pointer is not yet dereferenced here!
 
-    // tell the server we got the data
-    Cli2File_ManifestEntryAck manifestAck;
-    manifestAck.messageId = hsToLE32(kCli2File_ManifestEntryAck);
-    manifestAck.transId = hsToLE32(reply.transId);
-    manifestAck.messageBytes = hsToLE32(sizeof(manifestAck));
-    manifestAck.readerId = hsToLE32(reply.readerId);
-
-    m_conn->Send(&manifestAck, sizeof(manifestAck));
-
-    // if wcharCount is 2 or less, the data only contains the terminator "\0\0" and we
-    // don't need to convert anything (and we are done)
-    if ((IS_NET_ERROR(reply.result)) || (wcharCount <= 2)) {
-        // we have a problem... or we have nothing to so, so we're done
-        m_result    = reply.result;
-        m_state     = kTransStateComplete;
-        return true;
-    }
-
-    if (numFiles > m_manifest.size())
-        m_manifest.resize(numFiles); // reserve the space ahead of time
+    if (numFiles > manifest.size())
+        manifest.resize(numFiles); // reserve the space ahead of time
 
     // manifestData format: "clientFile\0downloadFile\0md5\0filesize\0zipsize\0flags\0...\0\0"
     bool done = false;
@@ -938,7 +913,7 @@ bool ManifestRequestTrans::Recv (
         }
 
         // copy the data over to our array (m_numEntriesReceived is the current index)
-        NetCliFileManifestEntry& entry = m_manifest[m_numEntriesReceived];
+        NetCliFileManifestEntry& entry = manifest[numEntriesReceived];
 
         // --------------------------------------------------------------------
         // read in the clientFilename
@@ -1044,16 +1019,49 @@ bool ManifestRequestTrans::Recv (
             return false; // screwy data
 
         // increment entries received
-        m_numEntriesReceived++;
-        if ((m_numEntriesReceived >= numFiles) && !done) {
+        numEntriesReceived++;
+        if (numEntriesReceived >= numFiles && !done) {
             // too much data, abort
             return false;
         }
     }
-    
+
+    return true;
+}
+
+//============================================================================
+bool ManifestRequestTrans::Recv (
+    const uint8_t  msg[],
+    unsigned    bytes
+) {
+    m_timeoutAtMs = hsTimer::GetMilliSeconds<uint32_t>() + NetTransGetTimeoutMs(); // Reset the timeout counter
+
+    const File2Cli_ManifestReply & reply = *(const File2Cli_ManifestReply *) msg;
+
+    // tell the server we got the data
+    Cli2File_ManifestEntryAck manifestAck;
+    manifestAck.messageId = hsToLE32(kCli2File_ManifestEntryAck);
+    manifestAck.transId = hsToLE32(reply.transId);
+    manifestAck.messageBytes = hsToLE32(sizeof(manifestAck));
+    manifestAck.readerId = hsToLE32(reply.readerId);
+
+    m_conn->Send(&manifestAck, sizeof(manifestAck));
+
+    // if wcharCount is 2 or less, the data only contains the terminator "\0\0" and we
+    // don't need to convert anything (and we are done)
+    if (IS_NET_ERROR(reply.result) || reply.wcharCount <= 2) {
+        // we have a problem... or we have nothing to so, so we're done
+        m_result    = reply.result;
+        m_state     = kTransStateComplete;
+        return true;
+    }
+
+    if (!IReceiveManifest(reply, m_manifest, m_numEntriesReceived)) {
+        return false;
+    }
+
     // check for completion
-    if (m_numEntriesReceived >= numFiles)
-    {
+    if (m_numEntriesReceived >= reply.numFiles) {
         // all entires received, mark as complete
         m_result    = reply.result;
         m_state     = kTransStateComplete;

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.h
@@ -103,7 +103,7 @@ using FNetCliFileManifestRequestCallback = std::function<void(
     const std::vector<NetCliFileManifestEntry>& manifest
 )>;
 void NetCliFileManifestRequest (
-    const char16_t                      group[], // the group of files you want (empty or nil = all)
+    ST::string                          group, // the group of files you want (empty or nil = all)
     unsigned                            buildId, // 0 = get latest, other = get particular build (servers only)
     FNetCliFileManifestRequestCallback  callback
 );

--- a/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.h
+++ b/Sources/Plasma/PubUtilLib/plNetGameLib/plNglFile.h
@@ -44,6 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define PLASMA20_SOURCES_PLASMA_PUBUTILLIB_PLNETGAMELIB_PLNGLFILE_H
 
 #include <functional>
+#include <string_theory/string>
 #include <vector>
 
 #include "pnNetBase/pnNbConst.h"
@@ -90,10 +91,10 @@ void NetCliFileRegisterBuildIdUpdate (FNetCliFileBuildIdUpdateCallback callback)
 // Manifest
 //============================================================================
 struct NetCliFileManifestEntry {
-    char16_t    clientName[kNetDefaultStringSize]; // path and file on client side (for comparison)
-    char16_t    downloadName[kNetDefaultStringSize]; // path and file on server side (for download)
-    char16_t    md5[32];
-    char16_t    md5compressed[32]; // md5 for the compressed file
+    ST::string  clientName; // path and file on client side (for comparison)
+    ST::string  downloadName; // path and file on server side (for download)
+    ST::string  md5;
+    ST::string  md5compressed; // md5 for the compressed file
     unsigned    fileSize;
     unsigned    zipSize;
     unsigned    flags;

--- a/Sources/Tests/CoreTests/test_hsEndian.cpp
+++ b/Sources/Tests/CoreTests/test_hsEndian.cpp
@@ -195,16 +195,17 @@ TEST(hsEndian, hsSTStringFromTerminatedUTF16LE)
 
     size_t consumedSize;
 
+    // With a complete terminator:
     ST::string string = hsSTStringFromTerminatedUTF16LE(buffer, bufferSize, consumedSize);
-    // consumedSize includes the terminator.
-    EXPECT_EQ(consumedSize, sizeof(kTestStringUtf16) + 2);
+    EXPECT_EQ(consumedSize, sizeof(kTestStringUtf16));
     EXPECT_EQ(string, kTestString);
 
+    // With half a terminator:
     ST::string string2 = hsSTStringFromTerminatedUTF16LE(buffer, sizeof(kTestStringUtf16) + 1, consumedSize);
-    // consumedSize does *not* count a terminator if there was none in the source buffer.
     EXPECT_EQ(consumedSize, sizeof(kTestStringUtf16));
     EXPECT_EQ(string2, kTestString);
 
+    // With no terminator:
     ST::string string3 = hsSTStringFromTerminatedUTF16LE(buffer, sizeof(kTestStringUtf16), consumedSize);
     EXPECT_EQ(consumedSize, sizeof(kTestStringUtf16));
     EXPECT_EQ(string3, kTestString);

--- a/Sources/Tests/CoreTests/test_hsEndian.cpp
+++ b/Sources/Tests/CoreTests/test_hsEndian.cpp
@@ -226,3 +226,65 @@ TEST(hsEndian, hsSTStringToUTF16LE)
     EXPECT_EQ(buffer.size(), sizeof(kTestStringUtf16));
     EXPECT_EQ(memcmp(buffer.data(), kTestStringUtf16, sizeof(kTestStringUtf16)), 0);
 }
+
+TEST(hsEndian, hsSTStringToFixedSizeUTF16LE)
+{
+    constexpr size_t bufferSize = sizeof(kTestStringUtf16) + 5;
+    // Force non-even alignment
+    alignas(char16_t) char allocation[bufferSize + 1];
+    char* buffer = allocation + 1;
+
+    // Enough space to output the full string:
+
+    memset(buffer, 0xaa, bufferSize);
+    EXPECT_TRUE(hsSTStringToFixedSizeUTF16LE(kTestString, buffer, bufferSize));
+    EXPECT_EQ(memcmp(buffer, kTestStringUtf16, sizeof(kTestStringUtf16)), 0);
+    EXPECT_EQ(memcmp(buffer + sizeof(kTestStringUtf16), "\0\0\0\0\0", 5), 0);
+
+    memset(buffer, 0xaa, bufferSize);
+    EXPECT_TRUE(hsSTStringToFixedSizeUTF16LE(kTestString, buffer, sizeof(kTestStringUtf16) + 2));
+    EXPECT_EQ(memcmp(buffer, kTestStringUtf16, sizeof(kTestStringUtf16)), 0);
+    EXPECT_EQ(memcmp(buffer + sizeof(kTestStringUtf16), "\0\0\xaa\xaa\xaa", 5), 0);
+
+    // Space for all characters except the last:
+
+    memset(buffer, 0xaa, bufferSize);
+    EXPECT_FALSE(hsSTStringToFixedSizeUTF16LE(kTestString, buffer, sizeof(kTestStringUtf16) + 1));
+    EXPECT_EQ(memcmp(buffer, kTestStringUtf16, sizeof(kTestStringUtf16) - 2), 0);
+    EXPECT_EQ(memcmp(buffer + sizeof(kTestStringUtf16) - 2, "\0\0\0\xaa\xaa\xaa\xaa", 7), 0);
+
+    memset(buffer, 0xaa, bufferSize);
+    EXPECT_FALSE(hsSTStringToFixedSizeUTF16LE(kTestString, buffer, sizeof(kTestStringUtf16)));
+    EXPECT_EQ(memcmp(buffer, kTestStringUtf16, sizeof(kTestStringUtf16) - 2), 0);
+    EXPECT_EQ(memcmp(buffer + sizeof(kTestStringUtf16) - 2, "\0\0\xaa\xaa\xaa\xaa\xaa", 7), 0);
+
+    // Space for only the first character:
+
+    memset(buffer, 0xaa, bufferSize);
+    EXPECT_FALSE(hsSTStringToFixedSizeUTF16LE(kTestString, buffer, 5));
+    EXPECT_EQ(memcmp(buffer, kTestStringUtf16, 2), 0);
+    EXPECT_EQ(memcmp(buffer + 2, "\0\0\0\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa", bufferSize - 2), 0);
+
+    memset(buffer, 0xaa, bufferSize);
+    EXPECT_FALSE(hsSTStringToFixedSizeUTF16LE(kTestString, buffer, 4));
+    EXPECT_EQ(memcmp(buffer, kTestStringUtf16, 2), 0);
+    EXPECT_EQ(memcmp(buffer + 2, "\0\0\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa", bufferSize - 2), 0);
+
+    // No space for any characters, only the terminator, at best:
+
+    memset(buffer, 0xaa, bufferSize);
+    EXPECT_FALSE(hsSTStringToFixedSizeUTF16LE(kTestString, buffer, 3));
+    EXPECT_EQ(memcmp(buffer, "\0\0\0\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa", bufferSize), 0);
+
+    memset(buffer, 0xaa, bufferSize);
+    EXPECT_FALSE(hsSTStringToFixedSizeUTF16LE(kTestString, buffer, 2));
+    EXPECT_EQ(memcmp(buffer, "\0\0\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa", bufferSize), 0);
+
+    memset(buffer, 0xaa, bufferSize);
+    EXPECT_FALSE(hsSTStringToFixedSizeUTF16LE(kTestString, buffer, 1));
+    EXPECT_EQ(memcmp(buffer, "\0\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa", bufferSize), 0);
+
+    memset(buffer, 0xaa, bufferSize);
+    EXPECT_FALSE(hsSTStringToFixedSizeUTF16LE(kTestString, buffer, 0));
+    EXPECT_EQ(memcmp(buffer, "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa", bufferSize), 0);
+}

--- a/Sources/Tests/PubUtilTests/CMakeLists.txt
+++ b/Sources/Tests/PubUtilTests/CMakeLists.txt
@@ -4,4 +4,5 @@ include_directories("${PLASMA_SOURCE_ROOT}/PubUtilLib")
 
 add_subdirectory(plLocalizationTest)
 add_subdirectory(plNetClientTest)
+add_subdirectory(plNetGameLibTest)
 add_subdirectory(plUnifiedTimeTest)

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/CMakeLists.txt
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(plNetGameLibTest_SOURCES
+    test_plNglFile.cpp
+)
+
+plasma_test(test_plNetGameLib SOURCES ${plNetGameLibTest_SOURCES})
+target_link_libraries(
+    test_plNetGameLib
+    PRIVATE
+        CoreLib
+        pnNetProtocol
+        plNetGameLib
+        gtest_main
+)

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/CMakeLists.txt
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(plNetGameLibTest_SOURCES
+    test_plNglAuth.cpp
     test_plNglFile.cpp
 )
 

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglAuth.cpp
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglAuth.cpp
@@ -121,3 +121,21 @@ TEST(plNglAuth, IReceiveFileList_ThreeFiles)
     EXPECT_EQ(fileInfoArray[2].filename, "filename2"_st);
     EXPECT_EQ(fileInfoArray[2].filesize, 0x120022);
 }
+
+TEST(plNglAuth, IReceiveFileList_Truncated)
+{
+    std::vector<NetCliAuthFileInfo> fileInfoArray;
+
+    auto reply = IMakeFileListReply(
+        u"filename\0\u0012\u3456\0"sv
+        u"\0"sv
+    );
+
+    // wcharCount == 2 is special-cased as valid regardless of contents, so stop there.
+    while (reply->wcharCount > 3) {
+        reply->wcharCount--;
+        fileInfoArray.clear();
+        EXPECT_FALSE(Ngl::Auth::IReceiveFileList(*reply, fileInfoArray));
+        EXPECT_TRUE(fileInfoArray.empty());
+    }
+}

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglAuth.cpp
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglAuth.cpp
@@ -84,6 +84,23 @@ static std::unique_ptr<Auth2Cli_FileListReply, FileListReplyDeleter> IMakeFileLi
     return std::unique_ptr<Auth2Cli_FileListReply, FileListReplyDeleter>(reply, s_fileListReplyDeleter);
 }
 
+TEST(plNglAuth, IReceiveFileList_Empty)
+{
+    std::vector<NetCliAuthFileInfo> fileInfoArray;
+
+    auto reply_0 = IMakeFileListReply(u""sv);
+    EXPECT_TRUE(Ngl::Auth::IReceiveFileList(*reply_0, fileInfoArray));
+    EXPECT_TRUE(fileInfoArray.empty());
+
+    auto reply_1 = IMakeFileListReply(u"\0"sv);
+    EXPECT_TRUE(Ngl::Auth::IReceiveFileList(*reply_1, fileInfoArray));
+    EXPECT_TRUE(fileInfoArray.empty());
+
+    auto reply_2 = IMakeFileListReply(u"\0\0"sv);
+    EXPECT_TRUE(Ngl::Auth::IReceiveFileList(*reply_2, fileInfoArray));
+    EXPECT_TRUE(fileInfoArray.empty());
+}
+
 TEST(plNglAuth, IReceiveFileList_OneFile)
 {
     std::vector<NetCliAuthFileInfo> fileInfoArray;

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglAuth.cpp
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglAuth.cpp
@@ -42,6 +42,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <functional>
 #include <gtest/gtest.h>
+#include <string_theory/string>
 #include <string_view>
 #include <vector>
 
@@ -53,6 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plNetGameLib/plNglAuth.h"
 
 using namespace std::literals::string_view_literals;
+using namespace ST::literals;
 
 // Can't put Auth2Cli_FileListReply normally into a std::unique_ptr
 // because of the variable-size array field,
@@ -93,7 +95,7 @@ TEST(plNglAuth, IReceiveFileList_OneFile)
     EXPECT_TRUE(Ngl::Auth::IReceiveFileList(*reply, fileInfoArray));
     EXPECT_EQ(fileInfoArray.size(), 1);
 
-    EXPECT_EQ(std::u16string_view(fileInfoArray[0].filename), u"filename"sv);
+    EXPECT_EQ(fileInfoArray[0].filename, "filename"_st);
     EXPECT_EQ(fileInfoArray[0].filesize, 0x123456);
 }
 
@@ -110,12 +112,12 @@ TEST(plNglAuth, IReceiveFileList_ThreeFiles)
     EXPECT_TRUE(Ngl::Auth::IReceiveFileList(*reply, fileInfoArray));
     EXPECT_EQ(fileInfoArray.size(), 3);
 
-    EXPECT_EQ(std::u16string_view(fileInfoArray[0].filename), u"filename0"sv);
+    EXPECT_EQ(fileInfoArray[0].filename, "filename0"_st);
     EXPECT_EQ(fileInfoArray[0].filesize, 0x100020);
 
-    EXPECT_EQ(std::u16string_view(fileInfoArray[1].filename), u"filename1"sv);
+    EXPECT_EQ(fileInfoArray[1].filename, "filename1"_st);
     EXPECT_EQ(fileInfoArray[1].filesize, 0x110021);
 
-    EXPECT_EQ(std::u16string_view(fileInfoArray[2].filename), u"filename2"sv);
+    EXPECT_EQ(fileInfoArray[2].filename, "filename2"_st);
     EXPECT_EQ(fileInfoArray[2].filesize, 0x120022);
 }

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglAuth.cpp
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglAuth.cpp
@@ -148,7 +148,7 @@ TEST(plNglAuth, IReceiveFileList_Truncated)
         u"\0"sv
     );
 
-    // wcharCount == 2 is special-cased as valid regardless of contents, so stop there.
+    // Stop before wcharCount == 0, which is a valid empty manifest.
     while (reply->wcharCount > 3) {
         reply->wcharCount--;
         fileInfoArray.clear();

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglAuth.cpp
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglAuth.cpp
@@ -1,0 +1,121 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011 Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <functional>
+#include <gtest/gtest.h>
+#include <string_view>
+#include <vector>
+
+#include "hsEndian.h"
+
+#include "pnNetProtocol/pnNpCli2Auth.h"
+
+#include "plNetGameLib/Intern.h"
+#include "plNetGameLib/plNglAuth.h"
+
+using namespace std::literals::string_view_literals;
+
+// Can't put Auth2Cli_FileListReply normally into a std::unique_ptr
+// because of the variable-size array field,
+// so we have to allocate it as a uint8_t[] and provide a custom deleter.
+using FileListReplyDeleter = std::function<void(Auth2Cli_FileListReply*)>;
+static FileListReplyDeleter s_fileListReplyDeleter = [](auto ptr) {
+    delete[] reinterpret_cast<uint8_t*>(ptr);
+};
+
+static std::unique_ptr<Auth2Cli_FileListReply, FileListReplyDeleter> IMakeFileListReply(std::u16string_view fileData)
+{
+    size_t fileDataOffset = offsetof(Auth2Cli_FileListReply, fileData);
+    size_t fileDataSize = fileData.size() * sizeof(fileData.front());
+    size_t replySize = fileDataOffset + fileDataSize;
+    uint8_t* replyData = new uint8_t[replySize];
+
+    auto reply = reinterpret_cast<Auth2Cli_FileListReply*>(replyData);
+    reply->messageId = kAuth2Cli_FileListReply;
+    reply->transId = 42;
+    reply->result = kNetSuccess;
+    reply->wcharCount = fileData.size();
+
+    for (size_t i = 0; i < fileData.size(); i++) {
+        reply->fileData[i] = hsToLE16(fileData[i]);
+    }
+
+    return std::unique_ptr<Auth2Cli_FileListReply, FileListReplyDeleter>(reply, s_fileListReplyDeleter);
+}
+
+TEST(plNglAuth, IReceiveFileList_OneFile)
+{
+    std::vector<NetCliAuthFileInfo> fileInfoArray;
+
+    auto reply = IMakeFileListReply(
+        u"filename\0\u0012\u3456\0"sv
+        u"\0"sv
+    );
+    EXPECT_TRUE(Ngl::Auth::IReceiveFileList(*reply, fileInfoArray));
+    EXPECT_EQ(fileInfoArray.size(), 1);
+
+    EXPECT_EQ(std::u16string_view(fileInfoArray[0].filename), u"filename"sv);
+    EXPECT_EQ(fileInfoArray[0].filesize, 0x123456);
+}
+
+TEST(plNglAuth, IReceiveFileList_ThreeFiles)
+{
+    std::vector<NetCliAuthFileInfo> fileInfoArray;
+
+    auto reply = IMakeFileListReply(
+        u"filename0\0\u0010\u0020\0"sv
+        u"filename1\0\u0011\u0021\0"sv
+        u"filename2\0\u0012\u0022\0"sv
+        u"\0"sv
+    );
+    EXPECT_TRUE(Ngl::Auth::IReceiveFileList(*reply, fileInfoArray));
+    EXPECT_EQ(fileInfoArray.size(), 3);
+
+    EXPECT_EQ(std::u16string_view(fileInfoArray[0].filename), u"filename0"sv);
+    EXPECT_EQ(fileInfoArray[0].filesize, 0x100020);
+
+    EXPECT_EQ(std::u16string_view(fileInfoArray[1].filename), u"filename1"sv);
+    EXPECT_EQ(fileInfoArray[1].filesize, 0x110021);
+
+    EXPECT_EQ(std::u16string_view(fileInfoArray[2].filename), u"filename2"sv);
+    EXPECT_EQ(fileInfoArray[2].filesize, 0x120022);
+}

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglFile.cpp
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglFile.cpp
@@ -42,8 +42,11 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <functional>
 #include <gtest/gtest.h>
+#include <string_theory/string>
 #include <string_view>
 #include <vector>
+
+#include "hsEndian.h"
 
 #include "pnNetProtocol/pnNpCli2File.h"
 
@@ -51,6 +54,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plNetGameLib/plNglFile.h"
 
 using namespace std::literals::string_view_literals;
+using namespace ST::literals;
 
 // Can't put File2Cli_ManifestReply normally into a std::unique_ptr
 // because of the variable-size array field,
@@ -68,6 +72,9 @@ static std::unique_ptr<File2Cli_ManifestReply, ManifestReplyDeleter> IMakeManife
     uint8_t* replyData = new uint8_t[replySize];
 
     auto reply = reinterpret_cast<File2Cli_ManifestReply*>(replyData);
+    // In the real code, all of these fields are converted to native byte order
+    // before the message is passed to IReceiveManifest,
+    // so we also store them in native byte order here.
     reply->messageBytes = replySize;
     reply->messageId = kFile2Cli_ManifestReply;
     reply->transId = 42;
@@ -75,7 +82,12 @@ static std::unique_ptr<File2Cli_ManifestReply, ManifestReplyDeleter> IMakeManife
     reply->readerId = 42;
     reply->numFiles = numFiles;
     reply->wcharCount = manifestData.size();
-    memcpy(reply->manifestData, manifestData.data(), manifestSize);
+
+    // The real code leaves manifestData as little-endian, unlike the other fields,
+    // so we have to convert the test data to little-endian as well.
+    for (size_t i = 0; i < manifestData.size(); i++) {
+        reply->manifestData[i] = hsToLE16(manifestData[i]);
+    }
 
     return std::unique_ptr<File2Cli_ManifestReply, ManifestReplyDeleter>(reply, s_manifestReplyDeleter);
 }
@@ -94,10 +106,10 @@ TEST(plNglFile, IReceiveManifest_OneFile)
     EXPECT_EQ(numEntriesReceived, 1);
     EXPECT_EQ(manifest.size(), 1);
 
-    EXPECT_EQ(std::u16string_view(manifest[0].clientName), u"clientName"sv);
-    EXPECT_EQ(std::u16string_view(manifest[0].downloadName), u"downloadName"sv);
-    EXPECT_EQ(std::u16string_view(manifest[0].md5, std::size(manifest[0].md5)), u"d41d8cd98f00b204e9800998ecf8427e"sv);
-    EXPECT_EQ(std::u16string_view(manifest[0].md5compressed, std::size(manifest[0].md5compressed)), u"d1457b72c3fb323a2671125aef3eab5d"sv);
+    EXPECT_EQ(manifest[0].clientName, "clientName"_st);
+    EXPECT_EQ(manifest[0].downloadName, "downloadName"_st);
+    EXPECT_EQ(manifest[0].md5, "d41d8cd98f00b204e9800998ecf8427e"_st);
+    EXPECT_EQ(manifest[0].md5compressed, "d1457b72c3fb323a2671125aef3eab5d"_st);
     EXPECT_EQ(manifest[0].fileSize, 0x123456);
     EXPECT_EQ(manifest[0].zipSize, 0x789a);
     EXPECT_EQ(manifest[0].flags, 0xffeeccdd);
@@ -119,26 +131,26 @@ TEST(plNglFile, IReceiveManifest_ThreeFiles)
     EXPECT_EQ(numEntriesReceived, 3);
     EXPECT_EQ(manifest.size(), 3);
 
-    EXPECT_EQ(std::u16string_view(manifest[0].clientName), u"client0"sv);
-    EXPECT_EQ(std::u16string_view(manifest[0].downloadName), u"download0"sv);
-    EXPECT_EQ(std::u16string_view(manifest[0].md5, std::size(manifest[0].md5)), u"ddddddddddddddddddddddddddddddd0"sv);
-    EXPECT_EQ(std::u16string_view(manifest[0].md5compressed, std::size(manifest[0].md5compressed)), u"ccccccccccccccccccccccccccccccc0"sv);
+    EXPECT_EQ(manifest[0].clientName, "client0"_st);
+    EXPECT_EQ(manifest[0].downloadName, "download0"_st);
+    EXPECT_EQ(manifest[0].md5, "ddddddddddddddddddddddddddddddd0"_st);
+    EXPECT_EQ(manifest[0].md5compressed, "ccccccccccccccccccccccccccccccc0"_st);
     EXPECT_EQ(manifest[0].fileSize, 0x100020);
     EXPECT_EQ(manifest[0].zipSize, 0x300040);
     EXPECT_EQ(manifest[0].flags, 0x500060);
 
-    EXPECT_EQ(std::u16string_view(manifest[1].clientName), u"client1"sv);
-    EXPECT_EQ(std::u16string_view(manifest[1].downloadName), u"download1"sv);
-    EXPECT_EQ(std::u16string_view(manifest[1].md5, std::size(manifest[1].md5)), u"ddddddddddddddddddddddddddddddd1"sv);
-    EXPECT_EQ(std::u16string_view(manifest[1].md5compressed, std::size(manifest[1].md5compressed)), u"ccccccccccccccccccccccccccccccc1"sv);
+    EXPECT_EQ(manifest[1].clientName, "client1"_st);
+    EXPECT_EQ(manifest[1].downloadName, "download1"_st);
+    EXPECT_EQ(manifest[1].md5, "ddddddddddddddddddddddddddddddd1"_st);
+    EXPECT_EQ(manifest[1].md5compressed, "ccccccccccccccccccccccccccccccc1"_st);
     EXPECT_EQ(manifest[1].fileSize, 0x110021);
     EXPECT_EQ(manifest[1].zipSize, 0x310041);
     EXPECT_EQ(manifest[1].flags, 0x510061);
 
-    EXPECT_EQ(std::u16string_view(manifest[2].clientName), u"client2"sv);
-    EXPECT_EQ(std::u16string_view(manifest[2].downloadName), u"download2"sv);
-    EXPECT_EQ(std::u16string_view(manifest[2].md5, std::size(manifest[2].md5)), u"ddddddddddddddddddddddddddddddd2"sv);
-    EXPECT_EQ(std::u16string_view(manifest[2].md5compressed, std::size(manifest[2].md5compressed)), u"ccccccccccccccccccccccccccccccc2"sv);
+    EXPECT_EQ(manifest[2].clientName, "client2"_st);
+    EXPECT_EQ(manifest[2].downloadName, "download2"_st);
+    EXPECT_EQ(manifest[2].md5, "ddddddddddddddddddddddddddddddd2"_st);
+    EXPECT_EQ(manifest[2].md5compressed, "ccccccccccccccccccccccccccccccc2"_st);
     EXPECT_EQ(manifest[2].fileSize, 0x120022);
     EXPECT_EQ(manifest[2].zipSize, 0x320042);
     EXPECT_EQ(manifest[2].flags, 0x520062);
@@ -159,18 +171,18 @@ TEST(plNglFile, IReceiveManifest_ThreeFilesChunked)
     EXPECT_EQ(numEntriesReceived, 2);
     EXPECT_EQ(manifest.size(), 3); // IReceiveManifest resizes the manifest vector ahead of time
 
-    EXPECT_EQ(std::u16string_view(manifest[0].clientName), u"client0"sv);
-    EXPECT_EQ(std::u16string_view(manifest[0].downloadName), u"download0"sv);
-    EXPECT_EQ(std::u16string_view(manifest[0].md5, std::size(manifest[0].md5)), u"ddddddddddddddddddddddddddddddd0"sv);
-    EXPECT_EQ(std::u16string_view(manifest[0].md5compressed, std::size(manifest[0].md5compressed)), u"ccccccccccccccccccccccccccccccc0"sv);
+    EXPECT_EQ(manifest[0].clientName, "client0"_st);
+    EXPECT_EQ(manifest[0].downloadName, "download0"_st);
+    EXPECT_EQ(manifest[0].md5, "ddddddddddddddddddddddddddddddd0"_st);
+    EXPECT_EQ(manifest[0].md5compressed, "ccccccccccccccccccccccccccccccc0"_st);
     EXPECT_EQ(manifest[0].fileSize, 0x100020);
     EXPECT_EQ(manifest[0].zipSize, 0x300040);
     EXPECT_EQ(manifest[0].flags, 0x500060);
 
-    EXPECT_EQ(std::u16string_view(manifest[1].clientName), u"client1"sv);
-    EXPECT_EQ(std::u16string_view(manifest[1].downloadName), u"download1"sv);
-    EXPECT_EQ(std::u16string_view(manifest[1].md5, std::size(manifest[1].md5)), u"ddddddddddddddddddddddddddddddd1"sv);
-    EXPECT_EQ(std::u16string_view(manifest[1].md5compressed, std::size(manifest[1].md5compressed)), u"ccccccccccccccccccccccccccccccc1"sv);
+    EXPECT_EQ(manifest[1].clientName, "client1"_st);
+    EXPECT_EQ(manifest[1].downloadName, "download1"_st);
+    EXPECT_EQ(manifest[1].md5, "ddddddddddddddddddddddddddddddd1"_st);
+    EXPECT_EQ(manifest[1].md5compressed, "ccccccccccccccccccccccccccccccc1"_st);
     EXPECT_EQ(manifest[1].fileSize, 0x110021);
     EXPECT_EQ(manifest[1].zipSize, 0x310041);
     EXPECT_EQ(manifest[1].flags, 0x510061);
@@ -184,10 +196,10 @@ TEST(plNglFile, IReceiveManifest_ThreeFilesChunked)
     EXPECT_EQ(numEntriesReceived, 3);
     EXPECT_EQ(manifest.size(), 3);
 
-    EXPECT_EQ(std::u16string_view(manifest[2].clientName), u"client2"sv);
-    EXPECT_EQ(std::u16string_view(manifest[2].downloadName), u"download2"sv);
-    EXPECT_EQ(std::u16string_view(manifest[2].md5, std::size(manifest[2].md5)), u"ddddddddddddddddddddddddddddddd2"sv);
-    EXPECT_EQ(std::u16string_view(manifest[2].md5compressed, std::size(manifest[2].md5compressed)), u"ccccccccccccccccccccccccccccccc2"sv);
+    EXPECT_EQ(manifest[2].clientName, "client2"_st);
+    EXPECT_EQ(manifest[2].downloadName, "download2"_st);
+    EXPECT_EQ(manifest[2].md5, "ddddddddddddddddddddddddddddddd2"_st);
+    EXPECT_EQ(manifest[2].md5compressed, "ccccccccccccccccccccccccccccccc2"_st);
     EXPECT_EQ(manifest[2].fileSize, 0x120022);
     EXPECT_EQ(manifest[2].zipSize, 0x320042);
     EXPECT_EQ(manifest[2].flags, 0x520062);

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglFile.cpp
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglFile.cpp
@@ -92,6 +92,29 @@ static std::unique_ptr<File2Cli_ManifestReply, ManifestReplyDeleter> IMakeManife
     return std::unique_ptr<File2Cli_ManifestReply, ManifestReplyDeleter>(reply, s_manifestReplyDeleter);
 }
 
+TEST(plNglFile, IReceiveManifest_Empty)
+{
+    std::vector<NetCliFileManifestEntry> manifest;
+    unsigned numEntriesReceived = 0;
+
+    // wcharCount == 0 currently special-cased outside of IReceiveManifest
+    //auto reply_0 = IMakeManifestReply(0, u""sv);
+    //EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply_0, manifest, numEntriesReceived));
+    //EXPECT_EQ(numEntriesReceived, 0);
+    //EXPECT_TRUE(manifest.empty());
+
+    auto reply_1 = IMakeManifestReply(0, u"\0"sv);
+    EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply_1, manifest, numEntriesReceived));
+    EXPECT_EQ(numEntriesReceived, 0);
+    EXPECT_TRUE(manifest.empty());
+
+    // wcharCount == 2 currently special-cased outside of IReceiveManifest
+    //auto reply_2 = IMakeManifestReply(0, u"\0\0"sv);
+    //EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply_2, manifest, numEntriesReceived));
+    //EXPECT_EQ(numEntriesReceived, 0);
+    //EXPECT_TRUE(manifest.empty());
+}
+
 TEST(plNglFile, IReceiveManifest_OneFile)
 {
     std::vector<NetCliFileManifestEntry> manifest;

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglFile.cpp
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglFile.cpp
@@ -1,0 +1,194 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011 Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include <functional>
+#include <gtest/gtest.h>
+#include <string_view>
+#include <vector>
+
+#include "pnNetProtocol/pnNpCli2File.h"
+
+#include "plNetGameLib/Intern.h"
+#include "plNetGameLib/plNglFile.h"
+
+using namespace std::literals::string_view_literals;
+
+// Can't put File2Cli_ManifestReply normally into a std::unique_ptr
+// because of the variable-size array field,
+// so we have to allocate it as a uint8_t[] and provide a custom deleter.
+using ManifestReplyDeleter = std::function<void(File2Cli_ManifestReply*)>;
+static ManifestReplyDeleter s_manifestReplyDeleter = [](auto ptr) {
+    delete[] reinterpret_cast<uint8_t*>(ptr);
+};
+
+static std::unique_ptr<File2Cli_ManifestReply, ManifestReplyDeleter> IMakeManifestReply(uint32_t numFiles, std::u16string_view manifestData)
+{
+    size_t manifestOffset = offsetof(File2Cli_ManifestReply, manifestData);
+    size_t manifestSize = manifestData.size() * sizeof(manifestData.front());
+    size_t replySize = manifestOffset + manifestSize;
+    uint8_t* replyData = new uint8_t[replySize];
+
+    auto reply = reinterpret_cast<File2Cli_ManifestReply*>(replyData);
+    reply->messageBytes = replySize;
+    reply->messageId = kFile2Cli_ManifestReply;
+    reply->transId = 42;
+    reply->result = kNetSuccess;
+    reply->readerId = 42;
+    reply->numFiles = numFiles;
+    reply->wcharCount = manifestData.size();
+    memcpy(reply->manifestData, manifestData.data(), manifestSize);
+
+    return std::unique_ptr<File2Cli_ManifestReply, ManifestReplyDeleter>(reply, s_manifestReplyDeleter);
+}
+
+TEST(plNglFile, IReceiveManifest_OneFile)
+{
+    std::vector<NetCliFileManifestEntry> manifest;
+    unsigned numEntriesReceived = 0;
+
+    auto reply = IMakeManifestReply(
+        1,
+        u"clientName\0downloadName\0d41d8cd98f00b204e9800998ecf8427e\0d1457b72c3fb323a2671125aef3eab5d\0\u0012\u3456\0\u0000\u789a\0\uffee\uccdd\0"sv
+        u"\0"sv
+    );
+    EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply, manifest, numEntriesReceived));
+    EXPECT_EQ(numEntriesReceived, 1);
+    EXPECT_EQ(manifest.size(), 1);
+
+    EXPECT_EQ(std::u16string_view(manifest[0].clientName), u"clientName"sv);
+    EXPECT_EQ(std::u16string_view(manifest[0].downloadName), u"downloadName"sv);
+    EXPECT_EQ(std::u16string_view(manifest[0].md5, std::size(manifest[0].md5)), u"d41d8cd98f00b204e9800998ecf8427e"sv);
+    EXPECT_EQ(std::u16string_view(manifest[0].md5compressed, std::size(manifest[0].md5compressed)), u"d1457b72c3fb323a2671125aef3eab5d"sv);
+    EXPECT_EQ(manifest[0].fileSize, 0x123456);
+    EXPECT_EQ(manifest[0].zipSize, 0x789a);
+    EXPECT_EQ(manifest[0].flags, 0xffeeccdd);
+}
+
+TEST(plNglFile, IReceiveManifest_ThreeFiles)
+{
+    std::vector<NetCliFileManifestEntry> manifest;
+    unsigned numEntriesReceived = 0;
+
+    auto reply = IMakeManifestReply(
+        3,
+        u"client0\0download0\0ddddddddddddddddddddddddddddddd0\0ccccccccccccccccccccccccccccccc0\0\u0010\u0020\0\u0030\u0040\0\u0050\u0060\0"sv
+        u"client1\0download1\0ddddddddddddddddddddddddddddddd1\0ccccccccccccccccccccccccccccccc1\0\u0011\u0021\0\u0031\u0041\0\u0051\u0061\0"sv
+        u"client2\0download2\0ddddddddddddddddddddddddddddddd2\0ccccccccccccccccccccccccccccccc2\0\u0012\u0022\0\u0032\u0042\0\u0052\u0062\0"sv
+        u"\0"sv
+    );
+    EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply, manifest, numEntriesReceived));
+    EXPECT_EQ(numEntriesReceived, 3);
+    EXPECT_EQ(manifest.size(), 3);
+
+    EXPECT_EQ(std::u16string_view(manifest[0].clientName), u"client0"sv);
+    EXPECT_EQ(std::u16string_view(manifest[0].downloadName), u"download0"sv);
+    EXPECT_EQ(std::u16string_view(manifest[0].md5, std::size(manifest[0].md5)), u"ddddddddddddddddddddddddddddddd0"sv);
+    EXPECT_EQ(std::u16string_view(manifest[0].md5compressed, std::size(manifest[0].md5compressed)), u"ccccccccccccccccccccccccccccccc0"sv);
+    EXPECT_EQ(manifest[0].fileSize, 0x100020);
+    EXPECT_EQ(manifest[0].zipSize, 0x300040);
+    EXPECT_EQ(manifest[0].flags, 0x500060);
+
+    EXPECT_EQ(std::u16string_view(manifest[1].clientName), u"client1"sv);
+    EXPECT_EQ(std::u16string_view(manifest[1].downloadName), u"download1"sv);
+    EXPECT_EQ(std::u16string_view(manifest[1].md5, std::size(manifest[1].md5)), u"ddddddddddddddddddddddddddddddd1"sv);
+    EXPECT_EQ(std::u16string_view(manifest[1].md5compressed, std::size(manifest[1].md5compressed)), u"ccccccccccccccccccccccccccccccc1"sv);
+    EXPECT_EQ(manifest[1].fileSize, 0x110021);
+    EXPECT_EQ(manifest[1].zipSize, 0x310041);
+    EXPECT_EQ(manifest[1].flags, 0x510061);
+
+    EXPECT_EQ(std::u16string_view(manifest[2].clientName), u"client2"sv);
+    EXPECT_EQ(std::u16string_view(manifest[2].downloadName), u"download2"sv);
+    EXPECT_EQ(std::u16string_view(manifest[2].md5, std::size(manifest[2].md5)), u"ddddddddddddddddddddddddddddddd2"sv);
+    EXPECT_EQ(std::u16string_view(manifest[2].md5compressed, std::size(manifest[2].md5compressed)), u"ccccccccccccccccccccccccccccccc2"sv);
+    EXPECT_EQ(manifest[2].fileSize, 0x120022);
+    EXPECT_EQ(manifest[2].zipSize, 0x320042);
+    EXPECT_EQ(manifest[2].flags, 0x520062);
+}
+
+TEST(plNglFile, IReceiveManifest_ThreeFilesChunked)
+{
+    std::vector<NetCliFileManifestEntry> manifest;
+    unsigned numEntriesReceived = 0;
+
+    auto reply_1 = IMakeManifestReply(
+        3,
+        u"client0\0download0\0ddddddddddddddddddddddddddddddd0\0ccccccccccccccccccccccccccccccc0\0\u0010\u0020\0\u0030\u0040\0\u0050\u0060\0"sv
+        u"client1\0download1\0ddddddddddddddddddddddddddddddd1\0ccccccccccccccccccccccccccccccc1\0\u0011\u0021\0\u0031\u0041\0\u0051\u0061\0"sv
+        u"\0"sv
+    );
+    EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply_1, manifest, numEntriesReceived));
+    EXPECT_EQ(numEntriesReceived, 2);
+    EXPECT_EQ(manifest.size(), 3); // IReceiveManifest resizes the manifest vector ahead of time
+
+    EXPECT_EQ(std::u16string_view(manifest[0].clientName), u"client0"sv);
+    EXPECT_EQ(std::u16string_view(manifest[0].downloadName), u"download0"sv);
+    EXPECT_EQ(std::u16string_view(manifest[0].md5, std::size(manifest[0].md5)), u"ddddddddddddddddddddddddddddddd0"sv);
+    EXPECT_EQ(std::u16string_view(manifest[0].md5compressed, std::size(manifest[0].md5compressed)), u"ccccccccccccccccccccccccccccccc0"sv);
+    EXPECT_EQ(manifest[0].fileSize, 0x100020);
+    EXPECT_EQ(manifest[0].zipSize, 0x300040);
+    EXPECT_EQ(manifest[0].flags, 0x500060);
+
+    EXPECT_EQ(std::u16string_view(manifest[1].clientName), u"client1"sv);
+    EXPECT_EQ(std::u16string_view(manifest[1].downloadName), u"download1"sv);
+    EXPECT_EQ(std::u16string_view(manifest[1].md5, std::size(manifest[1].md5)), u"ddddddddddddddddddddddddddddddd1"sv);
+    EXPECT_EQ(std::u16string_view(manifest[1].md5compressed, std::size(manifest[1].md5compressed)), u"ccccccccccccccccccccccccccccccc1"sv);
+    EXPECT_EQ(manifest[1].fileSize, 0x110021);
+    EXPECT_EQ(manifest[1].zipSize, 0x310041);
+    EXPECT_EQ(manifest[1].flags, 0x510061);
+
+    auto reply_2 = IMakeManifestReply(
+        3,
+        u"client2\0download2\0ddddddddddddddddddddddddddddddd2\0ccccccccccccccccccccccccccccccc2\0\u0012\u0022\0\u0032\u0042\0\u0052\u0062\0"sv
+        u"\0"sv
+    );
+    EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply_2, manifest, numEntriesReceived));
+    EXPECT_EQ(numEntriesReceived, 3);
+    EXPECT_EQ(manifest.size(), 3);
+
+    EXPECT_EQ(std::u16string_view(manifest[2].clientName), u"client2"sv);
+    EXPECT_EQ(std::u16string_view(manifest[2].downloadName), u"download2"sv);
+    EXPECT_EQ(std::u16string_view(manifest[2].md5, std::size(manifest[2].md5)), u"ddddddddddddddddddddddddddddddd2"sv);
+    EXPECT_EQ(std::u16string_view(manifest[2].md5compressed, std::size(manifest[2].md5compressed)), u"ccccccccccccccccccccccccccccccc2"sv);
+    EXPECT_EQ(manifest[2].fileSize, 0x120022);
+    EXPECT_EQ(manifest[2].zipSize, 0x320042);
+    EXPECT_EQ(manifest[2].flags, 0x520062);
+}

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglFile.cpp
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglFile.cpp
@@ -204,3 +204,29 @@ TEST(plNglFile, IReceiveManifest_ThreeFilesChunked)
     EXPECT_EQ(manifest[2].zipSize, 0x320042);
     EXPECT_EQ(manifest[2].flags, 0x520062);
 }
+
+TEST(plNglFile, IReceiveManifest_Truncated)
+{
+    std::vector<NetCliFileManifestEntry> manifest;
+    unsigned numEntriesReceived = 0;
+
+    auto reply = IMakeManifestReply(
+        1,
+        u"clientName\0downloadName\0d41d8cd98f00b204e9800998ecf8427e\0d1457b72c3fb323a2671125aef3eab5d\0\u0012\u3456\0\u0000\u789a\0\uffee\uccdd\0"sv
+        u"\0"sv
+    );
+
+    reply->wcharCount--;
+    EXPECT_FALSE(Ngl::File::IReceiveManifest(*reply, manifest, numEntriesReceived));
+    // If only the manifest terminator is missing, the entry itself is read fully.
+    EXPECT_EQ(numEntriesReceived, 1);
+
+    // wcharCount <= 2 is currently special-cased outside of IReceiveManifest, so ignore those cases for now.
+    while (reply->wcharCount > 3) {
+        reply->wcharCount--;
+        manifest.clear();
+        numEntriesReceived = 0;
+        EXPECT_FALSE(Ngl::File::IReceiveManifest(*reply, manifest, numEntriesReceived));
+        EXPECT_EQ(numEntriesReceived, 0);
+    }
+}

--- a/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglFile.cpp
+++ b/Sources/Tests/PubUtilTests/plNetGameLibTest/test_plNglFile.cpp
@@ -98,10 +98,10 @@ TEST(plNglFile, IReceiveManifest_Empty)
     unsigned numEntriesReceived = 0;
 
     // wcharCount == 0 currently special-cased outside of IReceiveManifest
-    //auto reply_0 = IMakeManifestReply(0, u""sv);
-    //EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply_0, manifest, numEntriesReceived));
-    //EXPECT_EQ(numEntriesReceived, 0);
-    //EXPECT_TRUE(manifest.empty());
+    auto reply_0 = IMakeManifestReply(0, u""sv);
+    EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply_0, manifest, numEntriesReceived));
+    EXPECT_EQ(numEntriesReceived, 0);
+    EXPECT_TRUE(manifest.empty());
 
     auto reply_1 = IMakeManifestReply(0, u"\0"sv);
     EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply_1, manifest, numEntriesReceived));
@@ -109,10 +109,10 @@ TEST(plNglFile, IReceiveManifest_Empty)
     EXPECT_TRUE(manifest.empty());
 
     // wcharCount == 2 currently special-cased outside of IReceiveManifest
-    //auto reply_2 = IMakeManifestReply(0, u"\0\0"sv);
-    //EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply_2, manifest, numEntriesReceived));
-    //EXPECT_EQ(numEntriesReceived, 0);
-    //EXPECT_TRUE(manifest.empty());
+    auto reply_2 = IMakeManifestReply(0, u"\0\0"sv);
+    EXPECT_TRUE(Ngl::File::IReceiveManifest(*reply_2, manifest, numEntriesReceived));
+    EXPECT_EQ(numEntriesReceived, 0);
+    EXPECT_TRUE(manifest.empty());
 }
 
 TEST(plNglFile, IReceiveManifest_OneFile)
@@ -244,8 +244,8 @@ TEST(plNglFile, IReceiveManifest_Truncated)
     // If only the manifest terminator is missing, the entry itself is read fully.
     EXPECT_EQ(numEntriesReceived, 1);
 
-    // wcharCount <= 2 is currently special-cased outside of IReceiveManifest, so ignore those cases for now.
-    while (reply->wcharCount > 3) {
+    // Stop before wcharCount == 0, which is a valid empty manifest.
+    while (reply->wcharCount > 1) {
         reply->wcharCount--;
         manifest.clear();
         numEntriesReceived = 0;


### PR DESCRIPTION
More of the usual, working on getting rid of all the manual C string manipulation.

I cleaned up the manifest parsing logic a little bit, but didn't want to change too much, to keep the diff readable. I also added proper bounds checking everywhere.

Because I want to use my new hsEndian.h functions for converting UTF-16-LE to `ST::string`, I changed where the byte order conversion happens for the FileSrv manifests. Instead of converting the entire manifest char by char to native byte order before parsing, like before, each field of the manifest is now converted individually as it's read. (The AuthSrv manifest parsing had no byte order handling at all - that's fixed now too.)

I wrote unit tests for parsing both kinds of manifests, based on the original code, to try to ensure that the parsing behavior doesn't change. (These should also be useful when working towards a new manifest format as discussed in #737.) I did some quick local testing of the AuthSrv manifests, but not the FileSrv ones, because my local test server doesn't have that set up. So I'm marking this as draft until I (or someone else) confirms that the patcher still works.

(One commit here has a trivial conflict with #1910 - I'll resolve that once that PR is merged.)