### PR TITLE
Move some wiki pages to Markdown files under Docs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,6 +7,9 @@ bcaade13ddc0c9728e87f625fe755d4a2d0cc10b
 c7724ed256aead5371ed5f47ec285cef8b6f8e68
 7b1debfabdebea3bf8bab395ed894c740900b36d
 
+# Line length rewrapping
+85692737847d1c6614215d22ee0c967f7a14aebe
+
 # Some 2to3 commits
 a3a146376ae7387f186c5d6b1b3f4134bd66068f
 9b1b499df67cf3eaef87d2b893ab27369d63fd3f

--- a/Docs/CMake flags.md
+++ b/Docs/CMake flags.md
@@ -1,80 +1,105 @@
 CMake Flags
 ===========
 
-These flags can be specified on the command-line when invoking CMake to generate the project files, alongside CMake generators and toolsets to control what type of build files are generated.
+These flags can be specified on the command-line when invoking CMake to generate
+the project files, alongside CMake generators and toolsets to control what type
+of build files are generated.
 
-For example, to generate Ninja build files, building with debug libraries, and enabling unit tests, you might run a command like this in the project root:  
+For example, to generate Ninja build files, building with debug libraries, and
+enabling unit tests, you might run a command like this in the project root:
+
 ```
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPLASMA_BUILD_TESTS=ON -S . -B build-ninja-debug
 ```
 
-The resulting Ninja build files will be generated in a `build-ninja-debug` subfolder and can be built either by running `ninja` directly or by running CMake in the project root and specifying a specific target:  
+The resulting Ninja build files will be generated in a `build-ninja-debug`
+subfolder and can be built either by running `ninja` directly or by running
+CMake in the project root and specifying a specific target:
+
 ```
 cmake --build build-ninja-debug --target plClient
 ```
 
-To generate Visual Studio 2019 project files building a 32-bit Windows client, invoke CMake with the following generator and arch options: `-G "Visual Studio 16 2019" -A Win32`
+To generate Visual Studio 2019 project files building a 32-bit Windows client,
+invoke CMake with the following generator and arch options:
+`-G "Visual Studio 16 2019" -A Win32`
 
 Build Configuration Flags
 -------------------------
 
 * `USE_VCPKG`
 
-    Whether to use the [vcpkg](https://vcpkg.io/) package manager to automatically build all dependencies.
-    Default `ON` for Windows, `OFF` for other platforms.
+  Whether to use the [vcpkg](https://vcpkg.io/) package manager to automatically
+  build all dependencies. Default `ON` for Windows, `OFF` for other platforms.
 
 * `CMAKE_BUILD_TYPE`
 
-    Whether to make a `Debug` or `Release` build (or `RelWithDebInfo` to make a release build with debugging info). Default is probably `Debug`, but this is usually overridden by the build type as configured in the Visual Studio or Xcode IDEs.
+  Whether to make a `Debug` or `Release` build (or `RelWithDebInfo` to make a
+  release build with debugging info). Default is probably `Debug`, but this is
+  usually overridden by the build type as configured in the Visual Studio or
+  Xcode IDEs.
 
 * `PLASMA_EXTERNAL_RELEASE`
 
-    Whether this is an External release build (with internal developer tools such as the console disabled). Default is `OFF` (i.e., by default it will build an Internal client).
+  Whether this is an External release build (with internal developer tools such
+  as the console disabled). Default is `OFF` (i.e., by default it will build an
+  Internal client).
 
 * `PLASMA_BUILD_CLIENT`
 
-    Whether to build the plClient project. Default is `ON`.
+  Whether to build the plClient project. Default is `ON`.
 
 * `PLASMA_BUILD_LAUNCHER`
 
-    Whether to build the plUruLauncher project. Default is `ON`.
+  Whether to build the plUruLauncher project. Default is `ON`.
 
 * `PLASMA_BUILD_TESTS`
 
-    Whether to build the unit tests for the Plasma project. Default is `OFF`.
+  Whether to build the unit tests for the Plasma project. Default is `OFF`.
 
 * `PLASMA_BUILD_TOOLS`
 
-    Whether to build the non-client Plasma developer tools. Default is `ON`.
+  Whether to build the non-client Plasma developer tools. Default is `ON`.
 
 * `PLASMA_BUILD_MAX_PLUGIN`
 
-    Whether to build the 3D Studio Max plugin. Default is `OFF` and cannot be turned `ON` if the 3DSMax SDK is not found.
-    Can be set to `REQUIRED` to fail the build if the 3DSMax SDK is not found.
+  Whether to build the 3D Studio Max plugin. Default is `OFF` and cannot be
+  turned `ON` if the 3DSMax SDK is not found. Can be set to `REQUIRED` to fail
+  the build if the 3DSMax SDK is not found.
 
 * `PLASMA_STACK_WALKER`
 
-    Whether to build the Plasma crash handler program with stacktrace support. Default is `ON`.
+  Whether to build the Plasma crash handler program with stacktrace support.
+  Default is `ON`.
 
 * `PLASMA_BUILD_RESOURCE_DAT`
 
-    Whether to build the resource.dat file resources at compile time. Default depends on whether Python, Pillow, and CairoSVG can be found (needed for generating PNG assets from the SVG source files before bundling into resource.dat).
+  Whether to build the resource.dat file resources at compile time. Default
+  depends on whether Python, Pillow, and CairoSVG can be found (needed for
+  generating PNG assets from the SVG source files before bundling into
+  resource.dat).
 
 * `PLASMA_UNITY_BUILD`
 
-    Whether to allow multiple source files to be combined at build time into "Unified Sources" to speed up compilation times. Default depends on CMake version and whether optimizations are enabled.
+  Whether to allow multiple source files to be combined at build time into
+  "Unified Sources" to speed up compilation times. Default depends on CMake
+  version and whether optimizations are enabled.
 
 * `PLASMA_USE_PCH`
 
-    Whether to allow precompiled header files to be generated and used to speed up compilation times. Default depends on CMake version and whether optimizations are enabled.
+  Whether to allow precompiled header files to be generated and used to speed up
+  compilation times. Default depends on CMake version and whether optimizations
+  are enabled.
 
 * `PRODUCT_EMBED_BUILD_INFO`
 
-    Whether to embed information about the git commit and branch in the product version. Default is `ON`.
+  Whether to embed information about the git commit and branch in the product
+  version. Default is `ON`.
 
 * `PRODUCT_EMBED_BUILD_TIME`
 
-    Whether to embed information about the build time in the product version. Default is based on the value of `PRODUCT_EMBED_BUILD_INFO`.
+  Whether to embed information about the build time in the product version.
+  Default is based on the value of `PRODUCT_EMBED_BUILD_INFO`.
 
 
 Build Feature Flags
@@ -82,77 +107,87 @@ Build Feature Flags
 
 * `PLASMA_PIPELINE_DX`
 
-    Whether to build Plasma with the DirectX rendering pipeline. Default is `ON` if the DirectX 9 SDK is found.
+  Whether to build Plasma with the DirectX rendering pipeline. Default is `ON`
+  if the DirectX 9 SDK is found.
 
 * `PLASMA_PIPELINE_GL`
 
-    Whether to build Plasma with the (incomplete) OpenGL rendering pipeline. Default is `ON` if the libepoxy library is found.
+  Whether to build Plasma with the (incomplete) OpenGL rendering pipeline.
+  Default is `ON` if the libepoxy library is found.
 
 * `PLASMA_PIPELINE_METAL`
 
-    Whether to build Plasma with the Apple Metal rendering pipeline. Default is `ON` if compiling on an Apple system (i.e., macOS).
+  Whether to build Plasma with the Apple Metal rendering pipeline. Default is
+  `ON` if compiling on an Apple system (i.e., macOS).
 
 * `PLASMA_RESMGR_DEBUGGING`
 
-    Whether to enable verbose plResManager debugging logs. Default is `OFF`.
+  Whether to enable verbose plResManager debugging logs. Default is `OFF`.
 
 * `USE_EFX`
 
-    Whether to use EFX for environmental audio effects. Default is `ON` if the efx.h header file is found.
+  Whether to use EFX for environmental audio effects. Default is `ON` if the
+  efx.h header file is found.
 
 * `USE_EGL`
 
-    Whether to use EGL as a backend option for the OpenGL rendering pipeline. Default is `ON` if libEGL is found.
+  Whether to use EGL as a backend option for the OpenGL rendering pipeline.
+  Default is `ON` if libEGL is found.
 
 * `USE_OPUS`
 
-    Whether to use Opus as a higher quality voice chat codec. Default is `ON` if the Opus library is found.
+  Whether to use Opus as a higher quality voice chat codec. Default is `ON` if
+  the Opus library is found.
 
 * `USE_SPEEX`
 
-    Whether to use Speex as a voice chat codec. Default is `ON` if the Speex library is found.
+  Whether to use Speex as a voice chat codec. Default is `ON` if the Speex
+  library is found.
 
 * `USE_VPX`
 
-    Whether to use the VPX library for supporting WebM-encoded video files. Default is `ON` if libvpx is found.
+  Whether to use the VPX library for supporting WebM-encoded video files.
+  Default is `ON` if libvpx is found.
 
 * `USE_WEBM`
 
-    Whether to use the libWebM library for supporting WebM-encoded video files. Default is `ON` if libwebm is found.
+  Whether to use the libWebM library for supporting WebM-encoded video files.
+  Default is `ON` if libwebm is found.
 
 * `USE_CLANG_TIDY`
 
-    Whether to enable using the clang-tidy sanitizer. Default is `OFF`.
+  Whether to enable using the clang-tidy sanitizer. Default is `OFF`.
 
 
 Product Flags
 -------------
-You can't really change these without breaking compatibility with the MOULa server.
+You can't really change these without breaking compatibility with the MOULa
+server.
 
 * `PRODUCT_BRANCH_ID`
 
-    The branch ID of the product. Default is `1`.
+  The branch ID of the product. Default is `1`.
 
 * `PRODUCT_BUILD_ID`
 
-    The build ID of the product. Default is `918`.
+  The build ID of the product. Default is `918`.
 
 * `PRODUCT_BUILD_TYPE`
 
-    The build type of the product. Default is `50`.
+  The build type of the product. Default is `50`.
 
 * `PRODUCT_CORE_NAME`
 
-    The product core name. Default is `UruLive`.
+  The product core name. Default is `UruLive`.
 
 * `PRODUCT_SHORT_NAME`
 
-    The product short name. Default is `UruLive`.
+  The product short name. Default is `UruLive`.
 
 * `PRODUCT_LONG_NAME`
 
-    The product's long name. Default is `Uru Live`.
+  The product's long name. Default is `Uru Live`.
 
 * `PRODUCT_UUID`
 
-    The product's UUID. Default is `ea489821-6c35-4bd0-9dae-bb17c585e680`.
+  The product's UUID. Default is `ea489821-6c35-4bd0-9dae-bb17c585e680`.

--- a/Docs/CMake flags.md
+++ b/Docs/CMake flags.md
@@ -1,0 +1,158 @@
+CMake Flags
+===========
+
+These flags can be specified on the command-line when invoking CMake to generate the project files, alongside CMake generators and toolsets to control what type of build files are generated.
+
+For example, to generate Ninja build files, building with debug libraries, and enabling unit tests, you might run a command like this in the project root:  
+```
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPLASMA_BUILD_TESTS=ON -S . -B build-ninja-debug
+```
+
+The resulting Ninja build files will be generated in a `build-ninja-debug` subfolder and can be built either by running `ninja` directly or by running CMake in the project root and specifying a specific target:  
+```
+cmake --build build-ninja-debug --target plClient
+```
+
+To generate Visual Studio 2019 project files building a 32-bit Windows client, invoke CMake with the following generator and arch options: `-G "Visual Studio 16 2019" -A Win32`
+
+Build Configuration Flags
+-------------------------
+
+* `USE_VCPKG`
+
+    Whether to use the [vcpkg](https://vcpkg.io/) package manager to automatically build all dependencies.
+    Default `ON` for Windows, `OFF` for other platforms.
+
+* `CMAKE_BUILD_TYPE`
+
+    Whether to make a `Debug` or `Release` build (or `RelWithDebInfo` to make a release build with debugging info). Default is probably `Debug`, but this is usually overridden by the build type as configured in the Visual Studio or Xcode IDEs.
+
+* `PLASMA_EXTERNAL_RELEASE`
+
+    Whether this is an External release build (with internal developer tools such as the console disabled). Default is `OFF` (i.e., by default it will build an Internal client).
+
+* `PLASMA_BUILD_CLIENT`
+
+    Whether to build the plClient project. Default is `ON`.
+
+* `PLASMA_BUILD_LAUNCHER`
+
+    Whether to build the plUruLauncher project. Default is `ON`.
+
+* `PLASMA_BUILD_TESTS`
+
+    Whether to build the unit tests for the Plasma project. Default is `OFF`.
+
+* `PLASMA_BUILD_TOOLS`
+
+    Whether to build the non-client Plasma developer tools. Default is `ON`.
+
+* `PLASMA_BUILD_MAX_PLUGIN`
+
+    Whether to build the 3D Studio Max plugin. Default is `OFF` and cannot be turned `ON` if the 3DSMax SDK is not found.
+    Can be set to `REQUIRED` to fail the build if the 3DSMax SDK is not found.
+
+* `PLASMA_STACK_WALKER`
+
+    Whether to build the Plasma crash handler program with stacktrace support. Default is `ON`.
+
+* `PLASMA_BUILD_RESOURCE_DAT`
+
+    Whether to build the resource.dat file resources at compile time. Default depends on whether Python, Pillow, and CairoSVG can be found (needed for generating PNG assets from the SVG source files before bundling into resource.dat).
+
+* `PLASMA_UNITY_BUILD`
+
+    Whether to allow multiple source files to be combined at build time into "Unified Sources" to speed up compilation times. Default depends on CMake version and whether optimizations are enabled.
+
+* `PLASMA_USE_PCH`
+
+    Whether to allow precompiled header files to be generated and used to speed up compilation times. Default depends on CMake version and whether optimizations are enabled.
+
+* `PRODUCT_EMBED_BUILD_INFO`
+
+    Whether to embed information about the git commit and branch in the product version. Default is `ON`.
+
+* `PRODUCT_EMBED_BUILD_TIME`
+
+    Whether to embed information about the build time in the product version. Default is based on the value of `PRODUCT_EMBED_BUILD_INFO`.
+
+
+Build Feature Flags
+-------------------
+
+* `PLASMA_PIPELINE_DX`
+
+    Whether to build Plasma with the DirectX rendering pipeline. Default is `ON` if the DirectX 9 SDK is found.
+
+* `PLASMA_PIPELINE_GL`
+
+    Whether to build Plasma with the (incomplete) OpenGL rendering pipeline. Default is `ON` if the libepoxy library is found.
+
+* `PLASMA_PIPELINE_METAL`
+
+    Whether to build Plasma with the Apple Metal rendering pipeline. Default is `ON` if compiling on an Apple system (i.e., macOS).
+
+* `PLASMA_RESMGR_DEBUGGING`
+
+    Whether to enable verbose plResManager debugging logs. Default is `OFF`.
+
+* `USE_EFX`
+
+    Whether to use EFX for environmental audio effects. Default is `ON` if the efx.h header file is found.
+
+* `USE_EGL`
+
+    Whether to use EGL as a backend option for the OpenGL rendering pipeline. Default is `ON` if libEGL is found.
+
+* `USE_OPUS`
+
+    Whether to use Opus as a higher quality voice chat codec. Default is `ON` if the Opus library is found.
+
+* `USE_SPEEX`
+
+    Whether to use Speex as a voice chat codec. Default is `ON` if the Speex library is found.
+
+* `USE_VPX`
+
+    Whether to use the VPX library for supporting WebM-encoded video files. Default is `ON` if libvpx is found.
+
+* `USE_WEBM`
+
+    Whether to use the libWebM library for supporting WebM-encoded video files. Default is `ON` if libwebm is found.
+
+* `USE_CLANG_TIDY`
+
+    Whether to enable using the clang-tidy sanitizer. Default is `OFF`.
+
+
+Product Flags
+-------------
+You can't really change these without breaking compatibility with the MOULa server.
+
+* `PRODUCT_BRANCH_ID`
+
+    The branch ID of the product. Default is `1`.
+
+* `PRODUCT_BUILD_ID`
+
+    The build ID of the product. Default is `918`.
+
+* `PRODUCT_BUILD_TYPE`
+
+    The build type of the product. Default is `50`.
+
+* `PRODUCT_CORE_NAME`
+
+    The product core name. Default is `UruLive`.
+
+* `PRODUCT_SHORT_NAME`
+
+    The product short name. Default is `UruLive`.
+
+* `PRODUCT_LONG_NAME`
+
+    The product's long name. Default is `Uru Live`.
+
+* `PRODUCT_UUID`
+
+    The product's UUID. Default is `ea489821-6c35-4bd0-9dae-bb17c585e680`.

--- a/Docs/Preferred code style.md
+++ b/Docs/Preferred code style.md
@@ -1,6 +1,7 @@
 ## Indentation
 
-Always use spaces, not tabs.  4 spaces indent a block.  Continuation can be aligned to the previous line, or with double-indent:
+Always use spaces, not tabs.  4 spaces indent a block.  Continuation can be
+aligned to the previous line, or with double-indent:
 
 ```c++
 DoSomething(arg1, arg2, arg3,
@@ -16,7 +17,8 @@ DoSomethingElseWithLongFunctionName(
 
 ### Functions/Namespaces/Classes
 
-New line for opening brace.  Visibility specifiers are aligned with the container's braces.
+New line for opening brace.  Visibility specifiers are aligned with the
+container's braces.
 
 ```c++
 namespace plFoo
@@ -58,7 +60,8 @@ if (SomeLongCondition(x, y)
 
 ### Single-line blocks
 
-Braces are optional.  It is **never** acceptable to put a one-line block on the same line as the if statement.
+Braces are optional.  It is **never** acceptable to put a one-line block on the
+same line as the if statement.
 
 ```c++
 if (x < y)
@@ -80,7 +83,8 @@ void plFoo::Bar(int x)
 
 ## Switch statements
 
-Cases align with switch statement.  Braces are indented (excluding the ```break```) and used only when necessary.  Always include default, even if it is empty.
+Cases align with switch statement.  Braces are indented (excluding the `break`)
+and used only when necessary.  Always include default, even if it is empty.
 
 ```c++
 switch (condition) {
@@ -118,7 +122,9 @@ plMyOtherKlass::plMyOtherKlass(int x)
 
 ## Type Declarations
 
-Pointers and references bind to the type.  Do not put more than one pointer or reference declaration in the same line.  The first const is on the left of the type.
+Pointers and references bind to the type.  Do not put more than one pointer or
+reference declaration in the same line.  The first const is on the left of the
+type.
 
 ```c++
 unsigned int x;
@@ -197,9 +203,14 @@ void Foo(const _T& x)
 
 ## Naming Convention
 
-Public function names should start with an upper case letter, and then be camelCase.  Classes should have a prefix (usually 'pl') and then be followed by camelCase.
+Public function names should start with an upper case letter, and then be
+camelCase.  Classes should have a prefix (usually 'pl') and then be followed by
+camelCase.
 
-Member variables should start with an 'f' ("field") and then be camelCase.  Global variables should be avoided, but may use 'g' followed by camelCase.  Static variables should start with an 's'.  Local variables and parameters have no prefix.
+Member variables should start with an 'f' ("field") and then be camelCase.
+Global variables should be avoided, but may use 'g' followed by camelCase.
+Static variables should start with an 's'.  Local variables and parameters have
+no prefix.
 
 ```c++
 class plKlass
@@ -223,7 +234,9 @@ void Bar(int x, int y)
 
 ## Spacing
 
-Function calls and declarations should have no space before parens.  Control flow statements should have a space between the keyword and the parens.  Do not use parens around a ```return``` statement's parameter.
+Function calls and declarations should have no space before parens.  Control
+flow statements should have a space between the keyword and the parens.  Do not
+use parens around a `return` statement's parameter.
 
 ```c++
 int Foo(int x)
@@ -261,7 +274,8 @@ for (const auto& x : myList)
 
 ## Labels and goto
 
-Just Say No (tm).  It is acceptable to use other control flow tricks if absolutely positively necessary.
+Just Say No (tm).  It is acceptable to use other control flow tricks if
+absolutely positively necessary.
 
 ```c++
 do {

--- a/Docs/Preferred code style.md
+++ b/Docs/Preferred code style.md
@@ -1,0 +1,303 @@
+## Indentation
+
+Always use spaces, not tabs.  4 spaces indent a block.  Continuation can be aligned to the previous line, or with double-indent:
+
+```c++
+DoSomething(arg1, arg2, arg3,
+            arg4, arg5, arg6);
+
+DoSomethingElseWithLongFunctionName(
+        arg1, arg2, arg3,
+        arg4, arg5, arg6);
+```
+
+
+## Blocks
+
+### Functions/Namespaces/Classes
+
+New line for opening brace.  Visibility specifiers are aligned with the container's braces.
+
+```c++
+namespace plFoo
+{
+    class plBar
+    {
+    public:
+        int Baz()
+        {
+            return 42;
+        }
+    };
+}
+
+static int foo()
+{
+    return 42;
+}
+```
+
+### Code blocks
+
+Keep on the same line.  Else is attached to the closing brace
+
+```c++
+if (x < y) {
+    // stuff
+} else {
+    // Other stuff
+}
+
+if (SomeLongCondition(x, y)
+    && SomeOtherLongCondition(z, w)) {
+    // Stuff
+} else {
+    // Other stuff
+}
+```
+
+### Single-line blocks
+
+Braces are optional.  It is **never** acceptable to put a one-line block on the same line as the if statement.
+
+```c++
+if (x < y)
+    return 5;
+else
+    return 10;
+```
+
+### Empty blocks
+
+Don't put closing braces on their own line.
+
+```c++
+void Foo() { }
+
+void plFoo::Bar(int x)
+{ }
+```
+
+## Switch statements
+
+Cases align with switch statement.  Braces are indented (excluding the ```break```) and used only when necessary.  Always include default, even if it is empty.
+
+```c++
+switch (condition) {
+case 1:
+    // Code for case 1
+    break;
+case 2:
+    {
+        int x;
+        // Code for case 2
+    }
+    break;
+default:
+    // Nothing to do
+    break;
+}
+```
+
+## Constructors
+
+Initializer lists are indented on the next line
+
+```c++
+plMyKlass::plMyKlass()
+    : plParent(foo), fZeroInitialized(), fNonZeroInitialized(42)
+{
+    // Stuff
+}
+
+plMyOtherKlass::plMyOtherKlass(int x)
+    : MyKlass(), fFirst(), fSecond(42),
+      fThird(8.1), fFourth("Hello")
+{ }
+```
+
+## Type Declarations
+
+Pointers and references bind to the type.  Do not put more than one pointer or reference declaration in the same line.  The first const is on the left of the type.
+
+```c++
+unsigned int x;
+const unsigned int x;
+const unsigned int* x;
+const unsigned int& x;
+const unsigned int** x;
+const unsigned int* const* x;
+
+char* str1;
+char* str2;
+char  fixedStr3[64];
+```
+
+C++11 allows nested templates to be used without an extra space:
+
+```c++
+std::vector<std::map<int, char>> x;
+```
+
+## Classes
+
+Specify parent(s) on same line
+
+```c++
+class plFoo : public plBar, public plBaz
+{
+public:
+    // Contents
+};
+```
+
+Explicitly call out overridden virtual functions
+
+```c++
+class plFoo : public plBar
+{
+public:
+    // New virtual function for plFoo
+    virtual void DoFooStuff();
+    
+    // Overloaded virtual function from plBar
+    void DoBarStuff() override;
+    
+    // Pure virtual function
+    virtual void NotImplemented() = 0;
+};
+```
+
+Use deleted functions rather than declaring disabled functions private:
+
+```c++
+class plFoo
+{
+public:
+    plFoo();
+    ~plFoo();
+
+    // Disable copying
+    plFoo(const plFoo&) = delete;
+    void operator=(const plFoo&) = delete;
+};
+```
+
+## Templates
+
+Template declaration should be on its own line.
+
+```c++
+template <typename _T>
+void Foo(const _T& x)
+{
+    // Stuff
+}
+```
+
+## Naming Convention
+
+Public function names should start with an upper case letter, and then be camelCase.  Classes should have a prefix (usually 'pl') and then be followed by camelCase.
+
+Member variables should start with an 'f' ("field") and then be camelCase.  Global variables should be avoided, but may use 'g' followed by camelCase.  Static variables should start with an 's'.  Local variables and parameters have no prefix.
+
+```c++
+class plKlass
+{
+public:
+    void plKlass(int x, const char* y)
+        : fX(x), fY(y)
+    { }
+
+private:
+    int fX;
+    const char* fY;
+};
+
+void Bar(int x, int y)
+{
+    int z = x + y;
+    return z - 5;
+}
+```
+
+## Spacing
+
+Function calls and declarations should have no space before parens.  Control flow statements should have a space between the keyword and the parens.  Do not use parens around a ```return``` statement's parameter.
+
+```c++
+int Foo(int x)
+{
+    if (x < 10)
+        return 5;
+
+    while (x > 0)
+        x += DoMath(x);
+    return x;
+}
+```
+
+Initializer lists should have spaces on both sides.
+
+```c++
+std::pair<int> x { 5, 10 };
+```
+
+Unary operators should have no space between themselves and their operand.
+
+```c++
+if (!fPointer)
+    return false;
+```
+
+Binary (and ternary) operators should have spaces on both sides.
+
+```c++
+return (x < 5 && y > 5) ? -1 : 1;
+
+for (const auto& x : myList)
+    Display(x);
+```
+
+## Labels and goto
+
+Just Say No (tm).  It is acceptable to use other control flow tricks if absolutely positively necessary.
+
+```c++
+do {
+    // Stuff
+
+    if (x < y)
+        break;
+
+    // Other stuff
+} while (false);
+```
+
+## Casting
+
+Use C++ casts whenever possible.
+
+```c++
+return static_cast<int>(5.0f);
+return reinterpret_cast<const void*>("Foo");
+```
+
+## Lambdas
+
+Treat lambdas as blocks for brace placement.  Captures should be explicit.
+
+```c++
+RegisterCallback(object,
+    [this, x](const char *message) {
+        ShowMessage(message, x);
+    });
+
+RegisterDataProvider(
+    [this](plGenerator* gen) -> plData* {
+        if (this)
+            return gen->GenerateFor(this);
+        else
+            return nullptr;
+    });
+```


### PR DESCRIPTION
As proposed in #1916, this converts the "[CMake Flags](https://github.com/H-uru/Plasma/wiki/CMake-Flags)" and "[Preferred Code Style](https://github.com/H-uru/Plasma/wiki/Preferred-Code-Style)" wiki pages to Markdown files in the Docs folder, because the information in these pages is useful to have in the repo itself.

To preserve attribution, I set the commit author to the person who wrote each wiki page, with myself only as the committer. Is that okay? Or should I use `Co-authored-by` instead to avoid confusion?