### PR TITLE
Clean up plShader a bit, decouple from plShaderTable

### DIFF
--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPixelShader.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPixelShader.cpp
@@ -49,6 +49,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plDXPipeline.h"
 
 #include "plSurface/plShader.h"
+#include "plSurface/plShaderTable.h"
 
 
 plDXPixelShader::plDXPixelShader(plShader* owner)
@@ -67,11 +68,6 @@ void plDXPixelShader::Release()
     fHandle = nullptr;
     fPipe = nullptr;
     fErrorString.clear();
-}
-
-bool plDXPixelShader::VerifyFormat(uint8_t format) const
-{
-    return (fOwner->GetInputFormat() & format) == fOwner->GetInputFormat();
 }
 
 IDirect3DPixelShader9 *plDXPixelShader::GetShader(plDXPipeline* pipe)
@@ -95,7 +91,7 @@ HRESULT plDXPixelShader::ICreate(plDXPipeline* pipe)
     fPipe = nullptr;
     fErrorString.clear();
 
-    DWORD* shaderCodes = (DWORD*)(fOwner->GetDecl()->GetCodes());
+    DWORD* shaderCodes = (DWORD*)(plShaderTable::Decl(fOwner->GetShaderID())->GetCodes());
 
     if( !shaderCodes )
         return IOnError(-1, ST_LITERAL("Shaders must be compiled into the engine."));

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXVertexShader.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXVertexShader.cpp
@@ -50,6 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include "plDrawable/plGBufferGroup.h"
 #include "plSurface/plShader.h"
+#include "plSurface/plShaderTable.h"
 
 plDXVertexShader::plDXVertexShader(plShader* owner)
 :   plDXShader(owner), fHandle()
@@ -67,11 +68,6 @@ void plDXVertexShader::Release()
     fHandle = nullptr;
     fPipe = nullptr;
     fErrorString.clear();
-}
-
-bool plDXVertexShader::VerifyFormat(uint8_t format) const
-{
-    return (fOwner->GetInputFormat() & format) == fOwner->GetInputFormat();
 }
 
 IDirect3DVertexShader9 *plDXVertexShader::GetShader(plDXPipeline* pipe)
@@ -98,7 +94,7 @@ HRESULT plDXVertexShader::ICreate(plDXPipeline* pipe)
     // We could store the compiled buffer and skip the assembly step
     // if we need to recreate the shader (e.g. on device lost).
     // But whatever.
-    DWORD* shaderCodes = (DWORD*)(fOwner->GetDecl()->GetCodes());
+    DWORD* shaderCodes = (DWORD*)(plShaderTable::Decl(fOwner->GetShaderID())->GetCodes());
 
     if( !shaderCodes )
         return IOnError(-1, ST_LITERAL("Shaders must be compiled into the engine."));

--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXVertexShader.h
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXVertexShader.h
@@ -65,7 +65,6 @@ public:
     void            Release() override;
     void            Link(plDXVertexShader** back) { plDXDeviceRef::Link((plDXDeviceRef**)back); }
 
-    bool            VerifyFormat(uint8_t format) const;
     IDirect3DVertexShader9* GetShader(plDXPipeline* pipe);
 };
 

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -1995,8 +1995,8 @@ bool plMetalPipeline::ISetShaders(const plMetalVertexBufferRef* vRef, const hsGM
 {
     hsAssert(vShader, "Can't handle programmable passes without vShader");
     hsAssert(pShader, "Can't handle programmable passes without pShader");
-    plShaderID::ID vertexShaderID = vShader->GetDecl()->GetID();
-    plShaderID::ID fragmentShaderID = pShader->GetDecl()->GetID();
+    plShaderID::ID vertexShaderID = vShader->GetShaderID();
+    plShaderID::ID fragmentShaderID = pShader->GetShaderID();
 
     plMetalDevice::plMetalLinkedPipeline* pipeline = plMetalDynamicMaterialPipelineState(&fDevice, vRef, blendMode.fBlendFlags, vertexShaderID, fragmentShaderID).GetRenderPipelineState();
     if (fState.fCurrentPipelineState != pipeline->pipelineState) {

--- a/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
+++ b/Sources/Plasma/PubUtilLib/plDrawable/plWaveSet7.cpp
@@ -1804,7 +1804,7 @@ void plWaveSet7::IAddBumpBiasShaders(plLayer* layer)
 {
     if( !fBiasVShader )
     {
-        plShader* vShader = new plShader;
+        plShader* vShader = new plShader(vs_BiasNormals);
 
         ST::string buff = ST::format("{}_BiasVS", GetKey()->GetName());
         hsgResMgr::ResMgr()->NewKey(buff, vShader, GetKey()->GetUoid().GetLocation());
@@ -1848,13 +1848,6 @@ void plWaveSet7::IAddBumpBiasShaders(plLayer* layer)
             0.f,
             1.f);
 
-        vShader->SetInputFormat(1);
-        vShader->SetOutputFormat(0);
-
-//      static const plShaderDecl vDecl("sha/vs_BiasNormals.inl");
-//      vShader->SetDecl(&vDecl);
-        vShader->SetDecl(plShaderTable::Decl(vs_BiasNormals));
-
         hsgResMgr::ResMgr()->SendRef(vShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, 0, kRefBiasVShader), plRefFlags::kActiveRef);
 
 
@@ -1867,20 +1860,13 @@ void plWaveSet7::IAddBumpBiasShaders(plLayer* layer)
 
     if( !fBiasPShader )
     {
-        plShader* pShader = new plShader;
+        plShader* pShader = new plShader(ps_BiasNormals);
 
         ST::string buff = ST::format("{}_BiasPS", GetKey()->GetName());
         hsgResMgr::ResMgr()->NewKey(buff, pShader, GetKey()->GetUoid().GetLocation());
         pShader->SetIsPixelShader(true);
         
         pShader->SetNumConsts(plBiasPS::kNumConsts);
-
-        pShader->SetInputFormat(0);
-        pShader->SetOutputFormat(0);
-
-//      static const plShaderDecl pDecl("sha/ps_BiasNormals.inl");
-//      pShader->SetDecl(&pDecl);
-        pShader->SetDecl(plShaderTable::Decl(ps_BiasNormals));
 
         hsgResMgr::ResMgr()->SendRef(pShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, 0, kRefBiasPShader), plRefFlags::kActiveRef);
 
@@ -1901,7 +1887,7 @@ void plWaveSet7::IAddBumpVertexShader(hsGMaterial* mat, int iShader, int iFirst,
         {
             int iShader = iBase / kBumpPerPass;
 
-            plShader* vShader = new plShader;
+            plShader* vShader = new plShader(vs_CompCosines);
             ST::string buff = ST::format("{}_BumpVS_{}", GetKey()->GetName(), iShader);
             hsgResMgr::ResMgr()->NewKey(buff, vShader, GetKey()->GetUoid().GetLocation());
             vShader->SetIsPixelShader(false);
@@ -1914,17 +1900,12 @@ void plWaveSet7::IAddBumpVertexShader(hsGMaterial* mat, int iShader, int iFirst,
                 1.f,
                 2.f);
 
-            vShader->SetInputFormat(1);
-            vShader->SetOutputFormat(0);
-
             vShader->SetNumPipeConsts(kBumpPerPass);
             int i;
             for( i = 0; i < kBumpPerPass; i++ )
             {
                 vShader->SetPipeConst(i, static_cast<plPipeConst::Type>(plPipeConst::kTex1x4_0 + i), plBumpVS::kUXform0 + i);
             }
-
-            vShader->SetDecl(plShaderTable::Decl(vs_CompCosines));
 
             hsgResMgr::ResMgr()->SendRef(vShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, iShader, kRefBumpVShader), plRefFlags::kActiveRef);
 
@@ -1946,7 +1927,7 @@ void plWaveSet7::IAddBumpPixelShader(hsGMaterial* mat, int iShader, int iFirst, 
         {
             int iShader = iBase / kBumpPerPass;
 
-            plShader* pShader = new plShader;
+            plShader* pShader = new plShader(ps_MoreCosines);
             ST::string buff = ST::format("{}_BumpPS_{}", GetKey()->GetName(), iShader);
             hsgResMgr::ResMgr()->NewKey(buff, pShader, GetKey()->GetUoid().GetLocation());
             pShader->SetIsPixelShader(true);
@@ -1962,16 +1943,6 @@ void plWaveSet7::IAddBumpPixelShader(hsGMaterial* mat, int iShader, int iFirst, 
                     1.f,
                     1.f);
             }
-
-            pShader->SetInputFormat(0);
-            pShader->SetOutputFormat(0);
-
-        //  pShader->SetShaderFileName("sha/ps_CompCosines.inl");
-        //  pShader->SetShaderFileName("sha/ps_TestPos.inl");
-//          static const plShaderDecl moreDecl("sha/ps_MoreCosines.inl");
-//          pShader->SetDecl(&moreDecl);
-
-            pShader->SetDecl(plShaderTable::Decl(ps_MoreCosines));
 
             pShader->SetVector(plBumpPS::kHalfOne, 0.25f, 0.25f, 0.25f, 1.f);
 
@@ -2247,16 +2218,13 @@ void plWaveSet7::IAddShoreVertexShader(hsGMaterial* mat)
     if( !fShoreVShader )
     {
 
-        plShader* vShader = new plShader;
+        plShader* vShader = new plShader(vs_ShoreLeave7);
 
         ST::string buff = ST::format("{}_ShoreVS", GetKey()->GetName());
         hsgResMgr::ResMgr()->NewKey(buff, vShader, GetKey()->GetUoid().GetLocation());
         vShader->SetIsPixelShader(false);
         
         vShader->SetNumConsts(plShoreVS::kNumConsts);
-
-        vShader->SetInputFormat(1); // This should really be one!!!
-        vShader->SetOutputFormat(0);
 
         vShader->SetVector(plShoreVS::kSinConsts, 1.f, -1.f/6.f, 1.f/120.f, -1.f/5040.f);
         vShader->SetVector(plShoreVS::kCosConsts, 1.f, -1.f/2.f, 1.f/24.f, -1.f/720.f);
@@ -2278,17 +2246,6 @@ void plWaveSet7::IAddShoreVertexShader(hsGMaterial* mat)
         vShader->SetPipeConst(3, plPipeConst::kLayRuntime, plShoreVS::kShoreTint);
         vShader->SetPipeConst(4, plPipeConst::kFogSet, plShoreVS::kFogSet);
 
-//      vShader->SetShaderFileName("sha/vs_Shore.inl");
-//      vShader->SetShaderFileName("sha/vs_ShoreSteep.inl");
-//      vShader->SetShaderFileName("sha/vs_ShoreSucks.inl");
-//      vShader->SetShaderFileName("sha/vs_ShoreLeave.inl");
-//      vShader->SetShaderFileName("sha/vs_ShoreLeave6.inl");
-//      vShader->SetDecl(plShaderTable::Decl(vs_ShoreLeave6));
-
-//      static const plShaderDecl decl("sha/vs_ShoreLeave7.inl");
-//      vShader->SetDecl(&decl);
-        vShader->SetDecl(plShaderTable::Decl(vs_ShoreLeave7));
-
         hsgResMgr::ResMgr()->SendRef(vShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, 0, kRefShoreVShader), plRefFlags::kActiveRef);
 
         fShoreVShader = vShader;
@@ -2303,15 +2260,11 @@ void plWaveSet7::IAddShorePixelShader(hsGMaterial* mat)
 {
     if( !fShorePShader )
     {
-        plShader* pShader = new plShader;
+        plShader* pShader = new plShader(ps_ShoreLeave6);
 
         ST::string buff = ST::format("{}_ShorePS", GetKey()->GetName());
         hsgResMgr::ResMgr()->NewKey(buff, pShader, GetKey()->GetUoid().GetLocation());
         pShader->SetIsPixelShader(true);
-
-//      pShader->SetShaderFileName("sha/ps_ShoreSucks.inl");
-//      pShader->SetShaderFileName("sha/ps_ShoreLeave6.inl");
-        pShader->SetDecl(plShaderTable::Decl(ps_ShoreLeave6));
 
         hsgResMgr::ResMgr()->SendRef(pShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, 0, kRefShorePShader), plRefFlags::kActiveRef);
 
@@ -2326,16 +2279,13 @@ void plWaveSet7::IAddFixedVertexShader(hsGMaterial* mat, const int numUVWs)
     if( !fFixedVShader )
     {
 
-        plShader* vShader = new plShader;
+        plShader* vShader = new plShader(vs_WaveFixedFin7);
 
         ST::string buff = ST::format("{}_FixedVS", GetKey()->GetName());
         hsgResMgr::ResMgr()->NewKey(buff, vShader, GetKey()->GetUoid().GetLocation());
         vShader->SetIsPixelShader(false);
         
         vShader->SetNumConsts(plFixedVS7::kNumConsts);
-
-        vShader->SetInputFormat(numUVWs);
-        vShader->SetOutputFormat(0);
 
         vShader->SetVector(plFixedVS7::kSinConsts, 1.f, -1.f/6.f, 1.f/120.f, -1.f/5040.f);
         vShader->SetVector(plFixedVS7::kCosConsts, 1.f, -1.f/2.f, 1.f/24.f, -1.f/720.f);
@@ -2351,16 +2301,6 @@ void plWaveSet7::IAddFixedVertexShader(hsGMaterial* mat, const int numUVWs)
         vShader->SetPipeConst(2, plPipeConst::kLocalToWorld, plFixedVS7::kLocalToWorld);
         vShader->SetPipeConst(3, plPipeConst::kLayRuntime, plFixedVS7::kWaterTint);
         vShader->SetPipeConst(4, plPipeConst::kFogSet, plFixedVS7::kFogSet);
-
-
-//      static const plShaderDecl decl("sha/vs_WaveFixedFin7.inl");
-//      vShader->SetDecl(&decl);
-        vShader->SetDecl(plShaderTable::Decl(vs_WaveFixedFin7));
-
-
-//      vShader->SetShaderFileName("sha/vs_WaveFixedFin6.inl");
-//      vShader->SetShaderFileName("sha/vs_WaveFixedFin.inl");
-//      vShader->SetShaderFileName("sha/vs_TestPos.inl");
 
         hsgResMgr::ResMgr()->SendRef(vShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, 0, kRefFixedVShader), plRefFlags::kActiveRef);
 
@@ -2399,21 +2339,14 @@ void plWaveSet7::IAddFixedPixelShader(hsGMaterial* mat)
 {
     if( !fFixedPShader )
     {
-        plShader* pShader = new plShader;
+        plShader* pShader = new plShader(ps_WaveFixed);
         ST::string buff = ST::format("{}_FixedPS", GetKey()->GetName());
         hsgResMgr::ResMgr()->NewKey(buff, pShader, GetKey()->GetUoid().GetLocation());
         pShader->SetIsPixelShader(true);
         
 //      pShader->SetNumConsts(plFixedPS::kNumConsts);
         pShader->SetNumConsts(0);
-        
-        pShader->SetInputFormat(0);
-        pShader->SetOutputFormat(0);
-        
-//      pShader->SetShaderFileName("sha/ps_WaveFixed.inl");
-//      pShader->SetShaderFileName("sha/ps_TestPos.inl");
-        pShader->SetDecl(plShaderTable::Decl(ps_WaveFixed));
-        
+
         hsgResMgr::ResMgr()->SendRef(pShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, 0, kRefFixedPShader), plRefFlags::kActiveRef);
         
         fFixedPShader = pShader;
@@ -2427,14 +2360,11 @@ void plWaveSet7::IAddRipVertexShader(hsGMaterial* mat, const plRipVSConsts& ripC
 {
     if( !fRipVShader )
     {
-        plShader* vShader = new plShader;
+        plShader* vShader = new plShader(vs_WaveRip7);
         ST::string buff = ST::format("{}_RipVS", GetKey()->GetName());
         hsgResMgr::ResMgr()->NewKey(buff, vShader, GetKey()->GetUoid().GetLocation());
         vShader->SetIsPixelShader(false);
         
-        vShader->SetInputFormat(1); // This should really be one!!!
-        vShader->SetOutputFormat(0);
-
         vShader->SetNumConsts(plRipVS::kNumConsts);
 
         vShader->SetVector(plRipVS::kSinConsts, 1.f, -1.f/6.f, 1.f/120.f, -1.f/5040.f);
@@ -2495,13 +2425,6 @@ void plWaveSet7::IAddRipVertexShader(hsGMaterial* mat, const plRipVSConsts& ripC
         vShader->SetPipeConst(2, plPipeConst::kLocalToWorld, plRipVS::kLocalToWorld);
         vShader->SetPipeConst(3, plPipeConst::kFogSet, plRipVS::kFogSet);
 
-//      vShader->SetShaderFileName("sha/vs_WaveRip.inl");
-//      vShader->SetDecl(plShaderTable::Decl(vs_WaveRip));
-
-//      static const plShaderDecl decl("sha/vs_WaveRip7.inl");
-//      vShader->SetDecl(&decl);
-        vShader->SetDecl(plShaderTable::Decl(vs_WaveRip7));
-
         hsgResMgr::ResMgr()->SendRef(vShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, 0, kRefRipVShader), plRefFlags::kActiveRef);
 
         hsAssert(vShader == fRipVShader, "Should have been set by SendRef");
@@ -2515,18 +2438,12 @@ void plWaveSet7::IAddRipPixelShader(hsGMaterial* mat, const plRipVSConsts& ripCo
 {
     if( !fRipPShader )
     {
-        plShader* pShader = new plShader;
+        plShader* pShader = new plShader(ps_WaveRip);
         ST::string buff = ST::format("{}_RipPS", GetKey()->GetName());
         hsgResMgr::ResMgr()->NewKey(buff, pShader, GetKey()->GetUoid().GetLocation());
         pShader->SetIsPixelShader(true);
         
         pShader->SetNumConsts(0);
-
-        pShader->SetInputFormat(0);
-        pShader->SetOutputFormat(0);
-
-//      pShader->SetShaderFileName("sha/ps_WaveRip.inl");
-        pShader->SetDecl(plShaderTable::Decl(ps_WaveRip));
 
         hsgResMgr::ResMgr()->SendRef(pShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, 0, kRefRipPShader), plRefFlags::kActiveRef);
 
@@ -2546,12 +2463,6 @@ plShader* plWaveSet7::ICreateDecalVShader(DecalVType t)
             "vs_WaveDec2Lay11_7",
             "vs_WaveDec2Lay12_7",
             "vs_WaveDecEnv_7"
-        };
-        static const plShaderDecl shaderDecls[kNumDecalVShaders] = {
-            plShaderDecl("sha/vs_WaveDec1Lay_7.inl"),
-            plShaderDecl("sha/vs_WaveDec2Lay11_7.inl"),
-            plShaderDecl("sha/vs_WaveDec2Lay12_7.inl"),
-            plShaderDecl("sha/vs_WaveDecEnv_7.inl")
         };
 
         static const plShaderID::ID shaderIDs[kNumDecalVShaders] = {
@@ -2574,14 +2485,11 @@ plShader* plWaveSet7::ICreateDecalVShader(DecalVType t)
         };
 
 
-        plShader* vShader = new plShader;
+        plShader* vShader = new plShader(shaderIDs[t]);
         ST::string buff = ST::format("{}_{}", GetKey()->GetName(), fname[t]);
         hsgResMgr::ResMgr()->NewKey(buff, vShader, GetKey()->GetUoid().GetLocation());
         vShader->SetIsPixelShader(false);
         
-        vShader->SetInputFormat(numUVWs[t]); // This should really be one!!!
-        vShader->SetOutputFormat(0);
-
         vShader->SetNumConsts(plWaveDecVS::kNumConsts);
 
         vShader->SetVector(plWaveDecVS::kSinConsts, 1.f, -1.f/6.f, 1.f/120.f, -1.f/5040.f);
@@ -2634,9 +2542,6 @@ plShader* plWaveSet7::ICreateDecalVShader(DecalVType t)
         {
             vShader->SetPipeConst(kNumPipe + i, plPipeConst::Type(plPipeConst::kTex2x4_0+i), plWaveDecVS::kTex0Transform + i);
         }
-
-//      vShader->SetDecl(&shaderDecls[t]);
-        vShader->SetDecl(plShaderTable::Decl(shaderIDs[t]));
 
         hsgResMgr::ResMgr()->SendRef(vShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, t, kRefDecVShader), plRefFlags::kActiveRef);
 
@@ -2704,15 +2609,11 @@ plShader* plWaveSet7::ICreateDecalPShader(DecalPType t)
             ps_WaveDecEnv
         };
 
-        plShader* pShader = new plShader;
+        plShader* pShader = new plShader(shaderIDs[t]);
 
         ST::string buff = ST::format("{}_{}", GetKey()->GetName(), fname[t]);
         hsgResMgr::ResMgr()->NewKey(buff, pShader, GetKey()->GetUoid().GetLocation());
         pShader->SetIsPixelShader(true);
-
-//      sprintf(buff, "sha/%s.inl", fname[t]);
-//      pShader->SetShaderFileName(buff);
-        pShader->SetDecl(plShaderTable::Decl(shaderIDs[t]));
 
         hsgResMgr::ResMgr()->SendRef(pShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, t, kRefDecPShader), plRefFlags::kActiveRef);
 
@@ -4066,7 +3967,7 @@ void plWaveSet7::ICreateGraphShoreMaterials()
 void plWaveSet7::IAddGraphVShader(hsGMaterial* mat, size_t iPass)
 {
     if (!fGraphVShader[iPass]) {
-        plShader* vShader = new plShader;
+        plShader* vShader = new plShader(vs_WaveGraph2);
         ST::string buff = ST::format("{}_GraphVS_{}", GetKey()->GetName(), iPass);
         hsgResMgr::ResMgr()->NewKey(buff, vShader, GetKey()->GetUoid().GetLocation());
         vShader->SetIsPixelShader(false);
@@ -4080,16 +3981,8 @@ void plWaveSet7::IAddGraphVShader(hsGMaterial* mat, size_t iPass)
                                                  hsConstants::two_pi<float>);
         vShader->SetVector(plGraphVS::kCosConsts, 1.f, -1.f/2.f, 1.f/24.f, -1.f/720.f);
 
-#ifndef TEST_UVWS
-        vShader->SetInputFormat(0);
-#else // TEST_UVWS
-        vShader->SetInputFormat(1);
-#endif // TEST_UVWS
-        vShader->SetOutputFormat(0);
-
 //      vShader->SetShaderFileName("sha/vs_WaveGraph.inl");
 //      vShader->SetShaderFileName("sha/vs_WaveGraph2.inl");
-        vShader->SetDecl(plShaderTable::Decl(vs_WaveGraph2));
 
         hsgResMgr::ResMgr()->SendRef(vShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, iPass, kRefGraphVShader), plRefFlags::kActiveRef);
 
@@ -4102,18 +3995,14 @@ void plWaveSet7::IAddGraphVShader(hsGMaterial* mat, size_t iPass)
 void plWaveSet7::IAddGraphPShader(hsGMaterial* mat, size_t iPass)
 {
     if (!fGraphPShader[iPass]) {
-        plShader* pShader = new plShader;
+        plShader* pShader = new plShader(ps_WaveGraph);
         ST::string buff = ST::format("{}_GraphPS_{}", GetKey()->GetName(), iPass);
         hsgResMgr::ResMgr()->NewKey(buff, pShader, GetKey()->GetUoid().GetLocation());
         pShader->SetIsPixelShader(true);
         
         pShader->SetNumConsts(plGraphPS::kNumConsts);
 
-        pShader->SetInputFormat(0);
-        pShader->SetOutputFormat(0);
-
 //      pShader->SetShaderFileName("sha/ps_WaveGraph.inl");
-        pShader->SetDecl(plShaderTable::Decl(ps_WaveGraph));
 
         hsgResMgr::ResMgr()->SendRef(pShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, iPass, kRefGraphPShader), plRefFlags::kActiveRef);
 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plVersion.cpp
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plVersion.cpp
@@ -61,6 +61,7 @@ static void GetChangedCreatables(int minorVersion, std::vector<uint16_t>& creata
     ChangedCreatable(1, plLoadAvatarMsg); 
     ChangedCreatable(1, plArmatureMod);
     ChangedCreatable(2, plAvBrainHuman);
+    ChangedCreatable(3, plShader);
 }
 
 

--- a/Sources/Plasma/PubUtilLib/plResMgr/plVersion.h
+++ b/Sources/Plasma/PubUtilLib/plResMgr/plVersion.h
@@ -50,7 +50,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 // If you change the minor, see GetChangedCreateables in plVersion.cpp
 
 #define PLASMA2_MAJOR_VERSION   70  // Major Version...every file will need to be reexported
-#define PLASMA2_MINOR_VERSION   2   // Minor Version...only files with the specified creatables
+#define PLASMA2_MINOR_VERSION   3   // Minor Version...only files with the specified creatables
                                     // will need to be reexported
 
 // Don't modify this, it's automatically updated when branches are made
@@ -288,6 +288,7 @@ public:
     0   02/12/07 bob    Reset for major version change
     1   03/29/07 jeff   Changed plLoadAvatarMsg and plArmatureMod to be more flexible
     2   06/28/07 jeff   Changed plAvBrainHuman format to store whether it's an actor or not
+    3   08/13/26 dpogue Changed plShader format (which I'm pretty sure was never used anywhere)
 */
 
 #endif // plVersion_h_inc

--- a/Sources/Plasma/PubUtilLib/plSurface/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plSurface/CMakeLists.txt
@@ -21,6 +21,7 @@ set(plSurface_HEADERS
     plLayerOr.h
     plLayerShadowBase.h
     plShader.h
+    plShaderID.h
     plShaderTable.h
     plSurfaceCreatable.h
 )

--- a/Sources/Plasma/PubUtilLib/plSurface/plGrassShaderMod.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plGrassShaderMod.cpp
@@ -222,12 +222,10 @@ void plGrassShaderMod::ISetupShaders()
 {
     if (!fVShader)
     {
-        plShader* vShader = new plShader;
+        plShader* vShader = new plShader(plShaderID::vs_GrassShader);
         ST::string buff = ST::format("{}_GrassVS", GetKey()->GetName());
         hsgResMgr::ResMgr()->NewKey(buff, vShader, GetKey()->GetUoid().GetLocation());
         vShader->SetIsPixelShader(false);
-        vShader->SetInputFormat(1);
-        vShader->SetOutputFormat(0);
 
         vShader->SetNumConsts(plGrassVS::kNumConsts);
         vShader->SetVector(plGrassVS::kNumericConsts, 0.f, 0.5f, 1.f, 2.f);
@@ -242,20 +240,16 @@ void plGrassShaderMod::ISetupShaders()
         vShader->SetNumPipeConsts(1);
         vShader->SetPipeConst(0, plPipeConst::kLocalToNDC, plGrassVS::kLocalToNDC);
 
-        vShader->SetDecl(plShaderTable::Decl(plShaderID::vs_GrassShader));
         hsgResMgr::ResMgr()->SendRef(vShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, 0, kRefGrassVS), plRefFlags::kActiveRef);
     }
 
     if (!fPShader)
     {
-        plShader* pShader = new plShader;
+        plShader* pShader = new plShader(plShaderID::ps_GrassShader);
         ST::string buff = ST::format("{}_GrassPS", GetKey()->GetName());
         hsgResMgr::ResMgr()->NewKey(buff, pShader, GetKey()->GetUoid().GetLocation());
         pShader->SetIsPixelShader(true);
         pShader->SetNumConsts(0);
-        pShader->SetInputFormat(0);
-        pShader->SetOutputFormat(0);
-        pShader->SetDecl(plShaderTable::Decl(plShaderID::ps_GrassShader));
         hsgResMgr::ResMgr()->SendRef(pShader->GetKey(), new plGenRefMsg(GetKey(), plRefMsg::kOnRequest, 0, kRefGrassPS), plRefFlags::kActiveRef);
     }
 

--- a/Sources/Plasma/PubUtilLib/plSurface/plShader.cpp
+++ b/Sources/Plasma/PubUtilLib/plSurface/plShader.cpp
@@ -41,12 +41,10 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 *==LICENSE==*/
 
 #include "plShader.h"
-#include "plShaderTable.h"
 
 #include "HeadSpin.h"
 #include "hsColorRGBA.h"
 #include "hsGDeviceRef.h"
-#include "hsMatrix44.h"
 #include "hsStream.h"
 
 // Little shader const helper
@@ -72,10 +70,15 @@ void plShaderConst::Write(hsStream* s) const
 
 plShader::plShader()
 :   fFlags(),
-    fDeviceRef(),
-    fInput(),
-    fOutput(),
-    fDecl()
+    fID(plShaderID::Unregistered),
+    fDeviceRef()
+{
+}
+
+plShader::plShader(plShaderID::ID id)
+:   fFlags(),
+    fID(id),
+    fDeviceRef()
 {
 }
 
@@ -84,9 +87,9 @@ plShader::~plShader()
     delete fDeviceRef;
 }
 
-void plShader::SetDeviceRef(hsGDeviceRef* ref) const 
-{ 
-    hsRefCnt_SafeAssign(fDeviceRef, ref); 
+void plShader::SetDeviceRef(hsGDeviceRef* ref)
+{
+    hsRefCnt_SafeAssign(fDeviceRef, ref);
 }
 
 
@@ -280,44 +283,29 @@ const float* plShader::GetFloat4(size_t i) const
 
 void plShader::Read(hsStream* s, hsResMgr* mgr)
 {
-    fFlags = 0;
-
     hsKeyedObject::Read(s, mgr);
+
+    fFlags = s->ReadLE32();
 
     uint32_t n = s->ReadLE32();
     fConsts.resize(n);
     for (uint32_t i = 0; i < n; i++)
         fConsts[i].Read(s);
 
-    plShaderID::ID id = plShaderID::ID(s->ReadLE32());
-    SetDecl(plShaderTable::Decl(id));
-
-    fInput = s->ReadByte();
-    fOutput = s->ReadByte();
+    fID = plShaderID::ID(s->ReadLE32());
 }
 
 void plShader::Write(hsStream* s, hsResMgr* mgr)
 {
     hsKeyedObject::Write(s, mgr);
 
+    s->WriteLE32(fFlags);
+
     s->WriteLE32((uint32_t)fConsts.size());
     for (const plShaderConst& konst : fConsts)
         konst.Write(s);
 
-    s->WriteLE32((uint32_t)fDecl->GetID());
-
-    s->WriteByte(fInput);
-    s->WriteByte(fOutput);
-}
-
-void plShader::SetDecl(const plShaderDecl* decl)
-{
-    fDecl = decl;
-}
-
-void plShader::SetDecl(plShaderID::ID id)
-{
-    SetDecl(plShaderTable::Decl(id));
+    s->WriteLE32((uint32_t)fID);
 }
 
 void plShader::SetNumPipeConsts(size_t n)

--- a/Sources/Plasma/PubUtilLib/plSurface/plShader.h
+++ b/Sources/Plasma/PubUtilLib/plSurface/plShader.h
@@ -45,7 +45,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 #include <vector>
 
-#include "plShaderTable.h"
+#include "plShaderID.h"
 
 #include "hsGeometry3.h"
 #include "hsMatrix44.h"
@@ -174,7 +174,7 @@ public:
     plPipeConst(Type t, uint16_t r) : fType(t), fReg(r) { }
 
     Type        fType;
-    uint16_t              fReg;
+    uint16_t    fReg;
 };
 
 typedef plPipeConst::Type plPipeConstType;
@@ -190,22 +190,19 @@ public:
         kShaderError        = 0x10,
         kShaderUnsupported  = 0x20
     };
+
 protected:
-    mutable uint32_t              fFlags;
+    uint32_t                    fFlags;
+    plShaderID::ID              fID;
 
     std::vector<plShaderConst>  fConsts;
-
-    mutable hsGDeviceRef*       fDeviceRef;
-
-    const plShaderDecl*         fDecl;
-
-    uint8_t                       fInput;
-    uint8_t                       fOutput;
-
     std::vector<plPipeConst>    fPipeConsts;
+
+    hsGDeviceRef*               fDeviceRef;
 
 public:
     plShader();
+    plShader(plShaderID::ID id);
     virtual ~plShader();
 
     CLASSNAME_REGISTER( plShader );
@@ -245,31 +242,23 @@ public:
     void                    SetFloat(size_t i, int chan, float v);
     void                    SetFloat4(size_t i, const float* const f);
 
-    const plShaderDecl*     GetDecl() const { return fDecl; }
-
-    void                    SetDecl(const plShaderDecl* p); // will reference (pointer copy)
-    void                    SetDecl(plShaderID::ID id);
-
     bool                    IsValid() const { return !(fFlags & kInvalid); }
-    void                    Invalidate() const { fFlags |= kInvalid; }
+    void                    Invalidate() { fFlags |= kInvalid; }
 
     bool                    IsPixelShader() const { return 0 != (fFlags & kIsPixel); }
     bool                    IsVertexShader() const { return !IsPixelShader(); }
     void                    SetIsPixelShader(bool on) { if(on)fFlags |= kIsPixel; else fFlags &= ~kIsPixel; }
 
+    plShaderID::ID          GetShaderID() const { return fID; }
+    void                    SetShaderID(plShaderID::ID id) { fID = id; }
+
     // These are only for use by the pipeline.
     hsGDeviceRef*           GetDeviceRef() const { return fDeviceRef; }
-    void                    SetDeviceRef(hsGDeviceRef* ref) const;
+    void                    SetDeviceRef(hsGDeviceRef* ref);
 
     const void*             GetConstBasePtr() const { return !fConsts.empty() ? &fConsts[0] : nullptr; }
 
     void                    CopyConsts(const plShader* src) { fConsts = src->fConsts; }
-
-    void                    SetInputFormat(uint8_t format) { fInput = format; }
-    void                    SetOutputFormat(uint8_t format) { fOutput = format; }
-
-    uint8_t                   GetInputFormat() const { return fInput; }
-    uint8_t                   GetOutputFormat() const { return fOutput; }
 
     size_t                  GetNumPipeConsts() const { return fPipeConsts.size(); }
     const plPipeConst&      GetPipeConst(size_t i) const { return fPipeConsts[i]; }

--- a/Sources/Plasma/PubUtilLib/plSurface/plShaderID.h
+++ b/Sources/Plasma/PubUtilLib/plSurface/plShaderID.h
@@ -40,32 +40,59 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 
 *==LICENSE==*/
 
-#ifndef plDXPixelShader_inc
-#define plDXPixelShader_inc
+#ifndef plShaderID_inc
+#define plShaderID_inc
 
-#include "plDXShader.h"
-
-class plShader;
-class plDXPipeline;
-
-struct IDirect3DPixelShader9;
-
-class plDXPixelShader : public plDXShader
+// When adding to the compiled table, make sure
+// you add the include in plShaderTable.cpp, or you'll
+// compile fine but have a nil shader (FFP) at runtime.
+namespace plShaderID
 {
-    HRESULT     ICreate(plDXPipeline* pipe) override; // On error, sets error string.
-    HRESULT     ISetConstants(plDXPipeline* pipe) override;
+    enum ID
+    {
+        Unregistered = 0,
+        vs_WaveFixedFin6,   //OBSOLETE
+        ps_WaveFixed,
+        vs_CompCosines,
+        ps_CompCosines,     //OBSOLETE
+        vs_ShoreLeave6,     //OBSOLETE
+        ps_ShoreLeave6,
+        vs_WaveRip,         //OBSOLETE
+        ps_WaveRip,
+        vs_WaveDec1Lay,     //OBSOLETE
+        vs_WaveDec2Lay11,   //OBSOLETE
+        vs_WaveDec2Lay12,   //OBSOLETE
+        vs_WaveDecEnv,      //OBSOLETE
+        ps_CbaseAbase,
+        ps_CalphaAbase,
+        ps_CalphaAMult,
+        ps_CalphaAadd,
+        ps_CaddAbase,
+        ps_CaddAMult,
+        ps_CaddAAdd,
+        ps_CmultAbase,
+        ps_CmultAMult,
+        ps_CmultAAdd,
+        ps_WaveDecEnv,
+        vs_WaveGraph2,
+        ps_WaveGraph,
+        vs_WaveGridFin,     //OBSOLETE
+        ps_WaveGrid,        //OBSOLETE
+        vs_BiasNormals,
+        ps_BiasNormals,
+        vs_ShoreLeave7,
+        vs_WaveRip7,
+        ps_MoreCosines,
+        vs_WaveDec1Lay_7,
+        vs_WaveDec2Lay11_7,
+        vs_WaveDec2Lay12_7,
+        vs_WaveDecEnv_7,
+        vs_WaveFixedFin7,
+        vs_GrassShader,
+        ps_GrassShader,
 
-    IDirect3DPixelShader9 *fHandle;
-
-public:
-    plDXPixelShader(plShader* owner);
-    virtual ~plDXPixelShader();
-
-    void            Release() override;
-    void            Link(plDXPixelShader** back) { plDXDeviceRef::Link((plDXDeviceRef**)back); }
-
-    IDirect3DPixelShader9 *GetShader(plDXPipeline* pipe);
+        kNumShaders
+    };
 };
 
-
-#endif // plDXPixelShader_inc
+#endif // plShaderID_inc

--- a/Sources/Plasma/PubUtilLib/plSurface/plShaderTable.h
+++ b/Sources/Plasma/PubUtilLib/plSurface/plShaderTable.h
@@ -44,59 +44,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #define plShaderTable_inc
 
 #include "HeadSpin.h"
-
-// When adding to the compiled table, make sure
-// you add the include in plShaderTable.cpp, or you'll
-// compile fine but have a nil shader (FFP) at runtime.
-namespace plShaderID
-{
-    enum ID
-    {
-        Unregistered = 0,
-            vs_WaveFixedFin6,   //OBSOLETE
-            ps_WaveFixed,
-            vs_CompCosines,
-            ps_CompCosines,     //OBSOLETE
-            vs_ShoreLeave6,     //OBSOLETE
-            ps_ShoreLeave6,
-            vs_WaveRip,         //OBSOLETE
-            ps_WaveRip,
-            vs_WaveDec1Lay,     //OBSOLETE
-            vs_WaveDec2Lay11,   //OBSOLETE
-            vs_WaveDec2Lay12,   //OBSOLETE
-            vs_WaveDecEnv,      //OBSOLETE
-            ps_CbaseAbase,
-            ps_CalphaAbase,
-            ps_CalphaAMult,
-            ps_CalphaAadd,
-            ps_CaddAbase,
-            ps_CaddAMult,
-            ps_CaddAAdd,
-            ps_CmultAbase,
-            ps_CmultAMult,
-            ps_CmultAAdd,
-            ps_WaveDecEnv,
-            vs_WaveGraph2,
-            ps_WaveGraph,
-            vs_WaveGridFin,     //OBSOLETE
-            ps_WaveGrid,        //OBSOLETE
-            vs_BiasNormals,
-            ps_BiasNormals,
-            vs_ShoreLeave7,
-            vs_WaveRip7,
-            ps_MoreCosines,
-            vs_WaveDec1Lay_7,
-            vs_WaveDec2Lay11_7,
-            vs_WaveDec2Lay12_7,
-            vs_WaveDecEnv_7,
-            vs_WaveFixedFin7,
-            vs_GrassShader,
-            ps_GrassShader,
-
-            kNumShaders
-    };
-};
-
+#include "plShaderID.h"
 
 class plShaderDecl
 {


### PR DESCRIPTION
Rather than the plShader grabbing its declaraction data from the table, it can instead just store its shader ID, and the pipeline (or whatever wants the declaration data) can worry about fetching it from the table.

This moves us towards it being possible for each pipeline to have its own shader table with different declarations for each of the shader IDs. I haven't figured out exactly what that will look like yet, so I'm opening this as the groundwork for that eventual next step.

**Note:** I changed the stream format of plShader because it didn't read or write the flags and had some other obsolete values. I am 99% sure plShaders have never been streamed and are all created locally on the client, so this _should_ have no effect, but to be safe I did bump the minor version for that class (which should also have no effect).