### PR TITLE
CMake/Metal support fixes

### DIFF
--- a/Sources/Plasma/Apps/plClient/CMakeLists.txt
+++ b/Sources/Plasma/Apps/plClient/CMakeLists.txt
@@ -193,8 +193,14 @@ if(PLASMA_PIPELINE_METAL)
     target_embed_metal_shader_libraries(plClient
         pfMetalPipelineShadersMSL21
         pfMetalPipelineShadersMSL23
-        pfMetalPipelineShadersMSL30
     )
+
+    if(NOT DEFINED CMAKE_XCODE_VERSION_MAJOR OR
+        CMAKE_XCODE_VERSION_MAJOR VERSION_GREATER_EQUAL 13)
+        target_embed_metal_shader_libraries(plClient
+            pfMetalPipelineShadersMSL30
+        )
+    endif()
 endif()
 
 if(PLASMA_BUILD_RESOURCE_DAT)

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/CMakeLists.txt
@@ -123,7 +123,7 @@ if(NOT DEFINED CMAKE_XCODE_VERSION_MAJOR OR
     CMAKE_XCODE_VERSION_MAJOR VERSION_GREATER_EQUAL 13)
 
     add_metal_shader_library(pfMetalPipelineShadersMSL30
-        STANDARD macos-metal3.0
+        STANDARD metal3.0
         ${pfMetalPipeline_SHADERS}
     )
     target_include_directories(pfMetalPipelineShadersMSL30
@@ -136,5 +136,10 @@ if(NOT DEFINED CMAKE_XCODE_VERSION_MAJOR OR
     target_compile_definitions(pfMetalPipeline
         PRIVATE
         METAL_3_SDK
+    )
+
+    add_dependencies(
+        pfMetalPipeline
+        pfMetalPipelineShadersMSL30
     )
 endif()

--- a/cmake/CMakeDetermineMetalCompiler.cmake
+++ b/cmake/CMakeDetermineMetalCompiler.cmake
@@ -12,15 +12,20 @@ endif()
 if("${CMAKE_GENERATOR}" STREQUAL "Xcode" OR (APPLE AND CMAKE_VERSION VERSION_GREATER_EQUAL "4.0"))
     set(CMAKE_Metal_COMPILER_XCODE_TYPE sourcecode.metal)
 
-    execute_process(COMMAND xcrun --find metal
-        OUTPUT_VARIABLE _xcrun_out OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_VARIABLE _xcrun_err RESULT_VARIABLE _xcrun_result
-    )
-
-    if(_xcrun_result EQUAL 0 AND EXISTS "${_xcrun_out}")
-        set(CMAKE_Metal_COMPILER "${_xcrun_out}")
-    else()
+    if(CMAKE_Metal_COMPILER)
+        # Specified via -D or a pre-made cache, resolve it like the branch below.
         _cmake_find_compiler_path(Metal)
+    else()
+        execute_process(COMMAND xcrun --find metal
+            OUTPUT_VARIABLE _xcrun_out OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_VARIABLE _xcrun_err RESULT_VARIABLE _xcrun_result
+        )
+
+        if(_xcrun_result EQUAL 0 AND EXISTS "${_xcrun_out}")
+            set(CMAKE_Metal_COMPILER "${_xcrun_out}")
+        else()
+            _cmake_find_compiler_path(Metal)
+        endif()
     endif()
 else()
     if(CMAKE_Metal_COMPILER)
@@ -60,6 +65,22 @@ if(CMAKE_Metal_COMPILER AND NOT CMAKE_Metal_COMPILER_VERSION)
         "Running the Metal compiler: \"${CMAKE_Metal_COMPILER}\" --version\n"
         "${output}\n"
     )
+
+    # Xcode ships a metal stub that xcrun happily reports even when the Metal
+    # Toolchain itself is missing, or when its on-demand cryptex mount is not
+    # available yet. Running the stub only prints
+    #   error: cannot execute tool 'metal' due to missing Metal Toolchain
+    # and exits non-zero, so reject it here. With the Xcode generator this is the
+    # only place that catches it, since CMakeTestMetalCompiler assumes a working
+    # compiler there and skips its try_compile; elsewhere it replaces a "compiler
+    # is broken" report, whose actual reason is buried in the try_compile output.
+    # CMAKE_Metal_COMPILER_FORCED opts out, as it does for the compiler test.
+    if(NOT result EQUAL 0 AND NOT CMAKE_Metal_COMPILER_FORCED)
+        string(STRIP "${output}" output)
+        string(REPLACE "\n" "\n  " output "${output}")
+        message(FATAL_ERROR "The Metal compiler\n  \"${CMAKE_Metal_COMPILER}\"\n"
+            "cannot be run:\n  ${output}\n")
+    endif()
 
     if(output MATCHES [[metal version ([0-9]+\.[0-9]+(\.[0-9]+)?)]])
         set(CMAKE_Metal_COMPILER_VERSION "${CMAKE_MATCH_1}")

--- a/cmake/CMakeMetalCompiler.cmake.in
+++ b/cmake/CMakeMetalCompiler.cmake.in
@@ -10,6 +10,29 @@ set(CMAKE_Metal_COMPILER "@CMAKE_Metal_COMPILER@")
 set(CMAKE_Metal_COMPILER_ID "@CMAKE_Metal_COMPILER_ID@")
 set(CMAKE_Metal_COMPILER_VERSION "@CMAKE_Metal_COMPILER_VERSION@")
 
+if(NOT EXISTS "${CMAKE_Metal_COMPILER}" AND CMAKE_Metal_COMPILER_ID STREQUAL "Apple")
+    if("${CMAKE_GENERATOR}" STREQUAL "Xcode" OR (APPLE AND CMAKE_VERSION VERSION_GREATER_EQUAL "4.0"))
+        set(CMAKE_Metal_COMPILER_XCODE_TYPE sourcecode.metal)
+        execute_process(COMMAND xcrun --find metal
+            OUTPUT_VARIABLE _xcrun_out OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_VARIABLE _xcrun_err RESULT_VARIABLE _xcrun_result
+        )
+        if(_xcrun_result EQUAL 0 AND EXISTS "${_xcrun_out}")
+            execute_process(
+                COMMAND "${_xcrun_out}" --version
+                OUTPUT_VARIABLE output ERROR_VARIABLE output
+                RESULT_VARIABLE result
+                TIMEOUT 10
+            )
+            if(output MATCHES [[metal version ([0-9]+\.[0-9]+(\.[0-9]+)?)]])
+                if(CMAKE_Metal_COMPILER_VERSION VERSION_EQUAL "${CMAKE_MATCH_1}")
+                    set(CMAKE_Metal_COMPILER "${_xcrun_out}")
+                endif()
+            endif()
+        endif()
+    endif()
+endif()
+
 set(CMAKE_Metal_COMPILER_LOADED 1)
 set(CMAKE_Metal_COMPILER_WORKS "@CMAKE_Metal_COMPILER_WORKS@")
 

--- a/cmake/CheckLanguage.cmake
+++ b/cmake/CheckLanguage.cmake
@@ -167,4 +167,3 @@ else()
 
     endblock()
 endif()
-

--- a/cmake/MetalShaderSupport.cmake
+++ b/cmake/MetalShaderSupport.cmake
@@ -39,13 +39,19 @@ function(target_embed_metal_shader_libraries TARGET)
         ""
     )
 
+    # Build-order dependency is required regardless of how the embedding is
+    # done: XCODE_EMBED_RESOURCES is a packaging hint and does not, by itself,
+    # cause CMake to build the shader library before the embed phase runs.
+    foreach(SHADERLIB IN LISTS _temsl_UNPARSED_ARGUMENTS)
+        add_dependencies(${TARGET} ${SHADERLIB})
+    endforeach()
+
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.28 AND ${CMAKE_GENERATOR} STREQUAL "Xcode")
         set_target_properties(${TARGET} PROPERTIES
             XCODE_EMBED_RESOURCES "${_temsl_UNPARSED_ARGUMENTS}"
         )
     else()
         foreach(SHADERLIB IN LISTS _temsl_UNPARSED_ARGUMENTS)
-            add_dependencies(${TARGET} ${SHADERLIB})
             add_custom_command(TARGET ${TARGET} POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${SHADERLIB}>" "$<TARGET_BUNDLE_CONTENT_DIR:${TARGET}>/Resources/$<TARGET_FILE_NAME:${SHADERLIB}>"
                 VERBATIM


### PR DESCRIPTION
Bring in some fixes from https://github.com/dpogue/CMake-MetalShaderSupport/ for detecting the Metal compiler (because Apple insists on making this unreasonably difficult)

Also make sure the pfMetalPipelineShadersMTL30 library is set up properly so it builds as a dependency when it should, and doesn't try to get bundled when it shouldn't.

Is there some better option for detecting Metal 3 support? Maybe based on the Metal compiler version?