### PR TITLE
Fix Rainy Cleft page-ins

### DIFF
--- a/Scripts/Python/Cleft.py
+++ b/Scripts/Python/Cleft.py
@@ -104,7 +104,7 @@ class Cleft(ptResponder):
 
         # Add the age specific pages
         if loadTomahna:
-            pages += ["Cleft","tmnaDesert","MaleShortIdle","FemaleShortIdle","YeeshaFinalEncounter","FemaleTurnRight180","MaleTurnRight180","clftSndLogTracks","clftAtrusGoggles"]
+            pages += ["Cleft","tmnaDesert","YeeshaFinalEncounter","FemaleTurnRight180","MaleTurnRight180","clftSndLogTracks","clftAtrusGoggles"]
         else:
             pages += ["Desert","Cleft","FemaleCleftDropIn","MaleCleftDropIn","clftJCsDesert","clftJCsChasm"]
         if loadZandi:


### PR DESCRIPTION
These were forgotten to be removed from the page in list and are part of GlobalAnimations. Having two invalid pages in the list caused the entire page in process to fail so we would have a broken partially-loaded rainy Cleft version.

(Edited as a second look made me realize this was before some more animations were moved over. Idk for how long this was broken and why it's working on live. Maybe some page-in code regressed?)