### PR TITLE
Add simple /timestamps toggle for the chat

### DIFF
--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1670,7 +1670,6 @@ class xKI(ptModifier):
 
     ## Sets the KI Text Color from the Chronicle.
     def DetermineShowTimestamps(self):
-        self.chatMgr.timestamps = None
         if entry := ptVault().findChronicleEntry(kChron.ShowTimestamps):
             if value := entry.getValue():
                 self.chatMgr.timestamps = xKIChat.ChatTimestampSettings.from_string(value)

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1670,12 +1670,22 @@ class xKI(ptModifier):
 
     ## Sets the KI Text Color from the Chronicle.
     def DetermineShowTimestamps(self):
+        self.chatMgr.timestamps = None
         vault = ptVault()
         entry = vault.findChronicleEntry(kChron.ShowTimestamps)
-        if entry is not None and entry.getValue() == "yes":
-            self.chatMgr.timestamps = True
-            return
-        self.chatMgr.timestamps = False
+        if entry is not None:
+            if value := entry.getValue():
+                parts = value.strip().split(";", 1)
+                timeZone = "ki"
+                if parts[0]:
+                    timeZone = parts[0]
+                timeFormat = "%H:%M"
+                if len(parts) > 1 and parts[1]:
+                    timeFormat = parts[1]
+                self.chatMgr.timestamps = {
+                    "zone": timeZone,
+                    "format": timeFormat
+                }
 
 
     #~~~~~~~~~~#

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1337,6 +1337,7 @@ class xKI(ptModifier):
         self.DetermineKIFlags()
         self.DetermineGZ()
         self.DetermineTextColor()
+        self.DetermineShowTimestamps()
 
         # Hide all dialogs first.
         KIMicroBlackbar.dialog.hide()
@@ -1662,6 +1663,19 @@ class xKI(ptModifier):
         self.chatMgr.chatTextColor = None
         PtDebugPrint("xKI.DetermineTextColor(): KI Text Color is not overridden.", level=kWarningLevel)
 
+
+    #~~~~~~~~~~~~~~~~~~~~~~#
+    #  KI Chat Timestamps  #
+    #~~~~~~~~~~~~~~~~~~~~~~#
+
+    ## Sets the KI Text Color from the Chronicle.
+    def DetermineShowTimestamps(self):
+        vault = ptVault()
+        entry = vault.findChronicleEntry(kChron.ShowTimestamps)
+        if entry is not None and entry.getValue() == "yes":
+            self.chatMgr.timestamps = True
+            return
+        self.chatMgr.timestamps = False
 
 
     #~~~~~~~~~~#

--- a/Scripts/Python/ki/__init__.py
+++ b/Scripts/Python/ki/__init__.py
@@ -1671,21 +1671,9 @@ class xKI(ptModifier):
     ## Sets the KI Text Color from the Chronicle.
     def DetermineShowTimestamps(self):
         self.chatMgr.timestamps = None
-        vault = ptVault()
-        entry = vault.findChronicleEntry(kChron.ShowTimestamps)
-        if entry is not None:
+        if entry := ptVault().findChronicleEntry(kChron.ShowTimestamps):
             if value := entry.getValue():
-                parts = value.strip().split(";", 1)
-                timeZone = "ki"
-                if parts[0]:
-                    timeZone = parts[0]
-                timeFormat = "%H:%M"
-                if len(parts) > 1 and parts[1]:
-                    timeFormat = parts[1]
-                self.chatMgr.timestamps = {
-                    "zone": timeZone,
-                    "format": timeFormat
-                }
+                self.chatMgr.timestamps = xKIChat.ChatTimestampSettings.from_string(value)
 
 
     #~~~~~~~~~~#

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -44,6 +44,8 @@ import re
 import time
 import random
 import inspect
+from dataclasses import dataclass
+from typing import Literal
 
 # Plasma Engine.
 from Plasma import *
@@ -79,7 +81,7 @@ class xKIChat(object):
         self.privateChatChannel = 0
         self.toReplyToLastPrivatePlayerID = None
         self.chatTextColor = None
-        self.timestamps = None
+        self.timestamps = ChatTimestampSettings()
 
         # Fading & blinking globals.
         self.currentFadeTick = 0
@@ -624,16 +626,16 @@ class xKIChat(object):
             mentionColor = self.chatTextColor
 
         timestamp = ""
-        if self.timestamps is not None:
-            timeZone = self.timestamps.get("zone");
-            if timeZone == "local":
+        if self.timestamps.enabled:
+            if self.timestamps.zone == "local":
                 timeStruct = time.localtime(PtGetServerTime())
-            elif timeZone == "utc":
+            elif self.timestamps.zone == "utc":
                 timeStruct = time.gmtime(PtGetServerTime())
-            else:
+            elif self.timestamps.zone == "ki":
                 timeStruct = time.gmtime(PtGetDniTime())
-            timeFormat = self.timestamps.get("format") or "%H:%M"
-            timestamp = f"[{time.strftime(timeFormat, timeStruct)}] "
+            else:
+                raise ValueError(self.timestamps.zone)
+            timestamp = f"[{time.strftime(self.timestamps.format, timeStruct)}] "
 
         for chatArea in (self.miniChatArea, self.microChatArea):
             with PtBeginGUIUpdate(chatArea):
@@ -910,6 +912,24 @@ class ChatFlags:
         string += "flags = {}".format(self.flags)
         return string
 
+
+## Helper for the chat timestamp format
+@dataclass
+class ChatTimestampSettings:
+    enabled: bool = False
+    zone: Literal["ki", "local", "utc"] = "ki"
+    format: str = "%H:%M"
+
+    @classmethod
+    def from_string(cls, value: str):
+        if not value:
+            return cls()
+        return cls(True, *value.split(';', 1))
+
+    def __str__(self) -> str:
+        if not self.enabled:
+            return ""
+        return f"{self.zone};{self.format}"
 
 ## Processes KI Chat commands.
 class CommandsProcessor:
@@ -1347,26 +1367,21 @@ class CommandsProcessor:
                 self.chatMgr.AddChatLine(None, PtGetLocalizedString("KI.Errors.MalformedChatSetTextColorCmd"), kChat.SystemMessage)
                 return
 
-    def ToggleChatTimestamps(self, arg1 = "", arg2 = "%H:%M"):
+    def ToggleChatTimestamps(self, zone="", format="%H:%M"):
         # Docs on invalid params
-        if arg1 and arg1 not in ["ki", "utc", "local"]:
+        if zone and zone not in {"ki", "utc", "local"}:
             self.chatMgr.AddChatLine(None, "Usage: /timestamps <ki|utc|local> <format>. The first parameter defaults to 'ki' and the second to '%H:%M'. Use without parameters to toggle timestamps off again.", kChat.SystemMessage)
             return
 
-        # Toggle off if currently on and no params given
-        if self.chatMgr.timestamps is not None and not arg1:
-            self.chatMgr.timestamps = None
-            PtDebugPrint(f"xKIChat.ToggleChatTimestamps(): Setting KI Timestamps chronicle to empty", level=kWarningLevel)
-            ptVault().addChronicleEntry(kChron.ShowTimestamps, kChron.ShowTimestampsType, "")
-            self.chatMgr.AddChatLine(None, f"Chat timestamps disabled", 0)
-            return
+        # Toggle off if currently on and no params given, helper class will handle the chronicle conversion
+        self.chatMgr.timestamps.enabled = False if self.chatMgr.timestamps.enabled and not zone else True
+        self.chatMgr.timestamps.zone = zone or "ki"
+        self.chatMgr.timestamps.format = format
 
-        timeZone = arg1 if arg1 else "ki"
-        self.chatMgr.timestamps = { "zone": timeZone, "format": arg2 }
-        chronVal = f"{timeZone};{arg2}";
-        PtDebugPrint(f"xKIChat.ToggleChatTimestamps(): Setting KI Timestamps chronicle to: \"{chronVal}\".", level=kWarningLevel)
-        ptVault().addChronicleEntry(kChron.ShowTimestamps, kChron.ShowTimestampsType, chronVal)
-        self.chatMgr.AddChatLine(None, f"Chat timestamps enabled", 0)
+        # Helper class at ChatTimestampSettings will handle the chronicle conversion
+        PtDebugPrint(f"xKIChat.ToggleChatTimestamps(): Setting KI Timestamps chronicle to: \"{self.chatMgr.timestamps}\".", level=kWarningLevel)
+        ptVault().addChronicleEntry(kChron.ShowTimestamps, kChron.ShowTimestampsType, str(self.chatMgr.timestamps))
+        self.chatMgr.AddChatLine(None, f"Chat timestamps {'enabled' if self.chatMgr.timestamps.enabled else 'disabled'}", 0)
 
     #~~~~~~~~~~~~~~~~#
     # Jalak Commands #

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -79,6 +79,7 @@ class xKIChat(object):
         self.privateChatChannel = 0
         self.toReplyToLastPrivatePlayerID = None
         self.chatTextColor = None
+        self.timestamps = False
 
         # Fading & blinking globals.
         self.currentFadeTick = 0
@@ -622,13 +623,18 @@ class xKIChat(object):
             bodyColor = self.chatTextColor
             mentionColor = self.chatTextColor
 
+        timestamp = ""
+        if self.timestamps:
+            timeStruct = time.localtime(PtGetServerTime())
+            timestamp = f"[{timeStruct.tm_hour}:{timeStruct.tm_min}] "
+
         for chatArea in (self.miniChatArea, self.microChatArea):
             with PtBeginGUIUpdate(chatArea):
                 savedPosition = chatArea.getScrollPosition()
                 wasAtEnd = chatArea.isAtEnd()
                 chatArea.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
                 chatArea.insertColor(headerColor)
-                chatArea.insertString(f"\n{contextPrefix if self.chatTextColor else ''}{chatHeaderFormatted}")
+                chatArea.insertString(f"\n{timestamp}{contextPrefix if self.chatTextColor else ''}{chatHeaderFormatted}")
                 chatArea.insertColor(bodyColor)
 
                 lastInsert = 0
@@ -1333,6 +1339,13 @@ class CommandsProcessor:
                 # argument was not 3 or 6 characters long, so it cannot be a valid hexadecimal color
                 self.chatMgr.AddChatLine(None, PtGetLocalizedString("KI.Errors.MalformedChatSetTextColorCmd"), kChat.SystemMessage)
                 return
+
+    def ToggleChatTimestamps(self, args):
+        self.chatMgr.timestamps = not self.chatMgr.timestamps
+        chronVal = "yes" if self.chatMgr.timestamps else "no"
+        PtDebugPrint(f"xKIChat.ToggleChatTimestamps(): Setting KI Timestamps chronicle to: \"{chronVal}\".", level=kWarningLevel)
+        ptVault().addChronicleEntry(kChron.ShowTimestamps, kChron.ShowTimestampsType, chronVal)
+        self.chatMgr.DisplayStatusMessage(f"Chat timestamps {'enabled' if self.chatMgr.timestamps else 'disabled'}")
 
     #~~~~~~~~~~~~~~~~#
     # Jalak Commands #

--- a/Scripts/Python/ki/xKIChat.py
+++ b/Scripts/Python/ki/xKIChat.py
@@ -79,7 +79,7 @@ class xKIChat(object):
         self.privateChatChannel = 0
         self.toReplyToLastPrivatePlayerID = None
         self.chatTextColor = None
-        self.timestamps = False
+        self.timestamps = None
 
         # Fading & blinking globals.
         self.currentFadeTick = 0
@@ -624,9 +624,16 @@ class xKIChat(object):
             mentionColor = self.chatTextColor
 
         timestamp = ""
-        if self.timestamps:
-            timeStruct = time.localtime(PtGetServerTime())
-            timestamp = f"[{timeStruct.tm_hour}:{timeStruct.tm_min}] "
+        if self.timestamps is not None:
+            timeZone = self.timestamps.get("zone");
+            if timeZone == "local":
+                timeStruct = time.localtime(PtGetServerTime())
+            elif timeZone == "utc":
+                timeStruct = time.gmtime(PtGetServerTime())
+            else:
+                timeStruct = time.gmtime(PtGetDniTime())
+            timeFormat = self.timestamps.get("format") or "%H:%M"
+            timestamp = f"[{time.strftime(timeFormat, timeStruct)}] "
 
         for chatArea in (self.miniChatArea, self.microChatArea):
             with PtBeginGUIUpdate(chatArea):
@@ -1340,12 +1347,26 @@ class CommandsProcessor:
                 self.chatMgr.AddChatLine(None, PtGetLocalizedString("KI.Errors.MalformedChatSetTextColorCmd"), kChat.SystemMessage)
                 return
 
-    def ToggleChatTimestamps(self, args):
-        self.chatMgr.timestamps = not self.chatMgr.timestamps
-        chronVal = "yes" if self.chatMgr.timestamps else "no"
+    def ToggleChatTimestamps(self, arg1 = "", arg2 = "%H:%M"):
+        # Docs on invalid params
+        if arg1 and arg1 not in ["ki", "utc", "local"]:
+            self.chatMgr.AddChatLine(None, "Usage: /timestamps <ki|utc|local> <format>. The first parameter defaults to 'ki' and the second to '%H:%M'. Use without parameters to toggle timestamps off again.", kChat.SystemMessage)
+            return
+
+        # Toggle off if currently on and no params given
+        if self.chatMgr.timestamps is not None and not arg1:
+            self.chatMgr.timestamps = None
+            PtDebugPrint(f"xKIChat.ToggleChatTimestamps(): Setting KI Timestamps chronicle to empty", level=kWarningLevel)
+            ptVault().addChronicleEntry(kChron.ShowTimestamps, kChron.ShowTimestampsType, "")
+            self.chatMgr.AddChatLine(None, f"Chat timestamps disabled", 0)
+            return
+
+        timeZone = arg1 if arg1 else "ki"
+        self.chatMgr.timestamps = { "zone": timeZone, "format": arg2 }
+        chronVal = f"{timeZone};{arg2}";
         PtDebugPrint(f"xKIChat.ToggleChatTimestamps(): Setting KI Timestamps chronicle to: \"{chronVal}\".", level=kWarningLevel)
         ptVault().addChronicleEntry(kChron.ShowTimestamps, kChron.ShowTimestampsType, chronVal)
-        self.chatMgr.DisplayStatusMessage(f"Chat timestamps {'enabled' if self.chatMgr.timestamps else 'disabled'}")
+        self.chatMgr.AddChatLine(None, f"Chat timestamps enabled", 0)
 
     #~~~~~~~~~~~~~~~~#
     # Jalak Commands #

--- a/Scripts/Python/ki/xKIConstants.py
+++ b/Scripts/Python/ki/xKIConstants.py
@@ -263,6 +263,8 @@ class kChron:
     BuddiesOnRequestType = 2
     CGZPlaying = "CGZPlaying"
     Party = "PartyAge"
+    ShowTimestamps = "KIShowTimestamps"
+    ShowTimestampsType = 2
 
 ## Color definitions.
 class kColors:
@@ -348,7 +350,8 @@ class kCommands:
         "/saveclothing": "SaveClothing",
         "/loadclothing": "LoadClothing",
         "/threaten": "CoopExample",
-        "/roll": "RollDice"
+        "/roll": "RollDice",
+        "/timestamps": "ToggleChatTimestamps"
     }
 
 ## Numeric limits for the KI.


### PR DESCRIPTION
I tend to dislike chats without timestamps in MMOs. Especially in those that hide chat due to overlays or fade outs so when you see a message later, you wonder for how long you've missed it. In URU, this can happen a lot as well with how various circumstances hide the chat area, like using the Relto book or bookshelf. Simply being tabbed out for a moment is of course too a factor.

This adds a new /timestamps command that has two optional params
- Displayed time zone: Supported options are `ki`, `utc`, and `local`. `ki` is default.
- Displayed format: Allows a custom format for strftime. Default is `%H:%M`

<img width="784" height="453" alt="image" src="https://github.com/user-attachments/assets/70e32aef-dbfe-48e4-9e93-309bf80781db" />
