### PR TITLE
Readd the mistakenly removed ercaOvenScope SDL.

### DIFF
--- a/Scripts/SDL/Ercana.sdl
+++ b/Scripts/SDL/Ercana.sdl
@@ -42,6 +42,14 @@
 #
 # State Description Language for Er'Cana
 
+STATEDESC ercaOvenScope
+{
+    VERSION 1
+    VAR INT   boolOperated[1]
+    VAR INT   OperatorID[1]
+
+}
+
 STATEDESC Ercana
 {
     VERSION 32


### PR DESCRIPTION
```
(08/17 23:59:12) cPythScope2 - Traceback (most recent call last):
(08/17 23:59:12)   File ".\python\ercaOvenScope.py", line 379, in OnNotify
(08/17 23:59:12)     self.IStartTelescope()
(08/17 23:59:12)   File ".\python\ercaOvenScope.py", line 496, in IStartTelescope
(08/17 23:59:12)     self.SDL["boolOperated"] = (1,)
(08/17 23:59:12)     ~~~~~~~~^^^^^^^^^^^^^^^^
(08/17 23:59:12) TypeError: 'NoneType' object does not support item assignment
```

[Whoopsie daisy.](https://github.com/H-uru/Plasma/commit/b1d127f124fddcf9468c45580935b23a8729ee12#diff-54878fd0ef140128ee73dfd53fb449fc088edf0a7506c6c5c481613fbeaf48d6L130)