### PR TITLE
Pull software vertex blending into its own helper

### DIFF
--- a/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp
@@ -87,6 +87,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plPipeline/hsG3DDeviceSelector.h"
 #include "plPipeline/plFogEnvironment.h"
 #include "plPipeline/plRenderTarget.h"
+#include "plPipeline/plSoftwareMeshSkinner.h"
 #include "plPipeline/plStatusLogDrawer.h"
 #include "plPipeline/hsWinRef.h"
 
@@ -173,57 +174,10 @@ static inline void inlCopy(uint8_t*& src, uint8_t*& dst)
     dst += sizeof(T);
 }
 
-static inline void inlCopy(const uint8_t*& src, uint8_t*& dst, size_t sz)
-{
-    memcpy(dst, src, sz);
-    src += sz;
-    dst += sz;
-}
-
-template<typename T>
-static inline const uint8_t* inlExtract(const uint8_t* src, T* val)
-{
-    const T* ptr = reinterpret_cast<const T*>(src);
-    *val = *ptr++;
-    return reinterpret_cast<const uint8_t*>(ptr);
-}
-
-template<>
-inline const uint8_t* inlExtract<hsPoint3>(const uint8_t* src, hsPoint3* val)
-{
-    const float* src_ptr = reinterpret_cast<const float*>(src);
-    float* dst_ptr = reinterpret_cast<float*>(val);
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr = 1.f;
-    return reinterpret_cast<const uint8_t*>(src_ptr);
-}
-
-template<>
-inline const uint8_t* inlExtract<hsVector3>(const uint8_t* src, hsVector3* val)
-{
-    const float* src_ptr = reinterpret_cast<const float*>(src);
-    float* dst_ptr = reinterpret_cast<float*>(val);
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr = 0.f;
-    return reinterpret_cast<const uint8_t*>(src_ptr);
-}
-
 template<typename T, size_t N>
 static inline void inlSkip(uint8_t*& src)
 {
     src += sizeof(T) * N;
-}
-
-template<typename T>
-static inline uint8_t* inlStuff(uint8_t* dst, const T* val)
-{
-    T* ptr = reinterpret_cast<T*>(dst);
-    *ptr++ = *val;
-    return reinterpret_cast<uint8_t*>(ptr);
 }
 
 inline DWORD F2DW( FLOAT f ) 
@@ -8585,9 +8539,9 @@ bool      plDXPipeline::ISoftwareVertexBlend(plDrawableSpans* drawable, const st
 
                         uint8_t* ptr = vRef->fOwner->GetVertBufferData(vRef->fIndex);
                         ptr += span.fVStartIdx * vRef->fOwner->GetVertexSize();
-                        IBlendVertsIntoBuffer( (plSpan*)&span,
+                        plSoftwareMeshSkinner::BlendVertBuffer(&span,
                                                 matrixPalette, span.fNumMatrices,
-                                                ptr, 
+                                                ptr,
                                                 vRef->fOwner->GetVertexFormat(), 
                                                 vRef->fOwner->GetVertexSize(), 
                                                 destPtr + span.fVStartIdx * vRef->fVertexSize, 
@@ -8732,166 +8686,6 @@ inline void inlTESTPOINT(const hsPoint3& destP,
     else if( destP.fZ > maxZ )
         maxZ = destP.fZ;
 }
-
-//// IBlendVertsIntoBuffer ////////////////////////////////////////////////////
-//  Given a pointer into a buffer of verts that have blending data in the D3D
-//  format, blends them into the destination buffer given without the blending
-//  info.
-
-#define SPLIT_SKIN_BUFFER(src, pt, vec) \
-    decltype(src) pt = &src[0];         \
-    decltype(src) vec = &src[4];        //
-
-#define SPLIT_SKIN_TRIPLES(src, pt, vec)                    \
-    hsPoint3* pt = reinterpret_cast<hsPoint3*>(&src[0]);    \
-    hsVector3* vec = reinterpret_cast<hsVector3*>(&src[4]); //
-
-static inline void ISkinVertexFPU(const hsMatrix44& xfm, float wgt,
-                                  const float* srcBuf, float* dstBuf)
-{
-    const float& m00 = xfm.fMap[0][0];
-    const float& m01 = xfm.fMap[0][1];
-    const float& m02 = xfm.fMap[0][2];
-    const float& m03 = xfm.fMap[0][3];
-    const float& m10 = xfm.fMap[1][0];
-    const float& m11 = xfm.fMap[1][1];
-    const float& m12 = xfm.fMap[1][2];
-    const float& m13 = xfm.fMap[1][3];
-    const float& m20 = xfm.fMap[2][0];
-    const float& m21 = xfm.fMap[2][1];
-    const float& m22 = xfm.fMap[2][2];
-    const float& m23 = xfm.fMap[2][3];
-
-    SPLIT_SKIN_BUFFER(srcBuf, pt_src, vec_src);
-    SPLIT_SKIN_BUFFER(dstBuf, pt_dst, vec_dst);
-
-    // position
-    {
-        const float& srcX = pt_src[0];
-        const float& srcY = pt_src[1];
-        const float& srcZ = pt_src[2];
-
-        pt_dst[0] += (srcX * m00 + srcY * m01 + srcZ * m02 + m03) * wgt;
-        pt_dst[1] += (srcX * m10 + srcY * m11 + srcZ * m12 + m13) * wgt;
-        pt_dst[2] += (srcX * m20 + srcY * m21 + srcZ * m22 + m23) * wgt;
-    }
-
-    // normal
-    {
-        const float& srcX = vec_src[0];
-        const float& srcY = vec_src[1];
-        const float& srcZ = vec_src[2];
-
-        vec_dst[0] += (srcX * m00 + srcY * m01 + srcZ * m02) * wgt;
-        vec_dst[1] += (srcX * m10 + srcY * m11 + srcZ * m12) * wgt;
-        vec_dst[2] += (srcX * m20 + srcY * m21 + srcZ * m22) * wgt;
-    }
-}
-
-#ifdef HAVE_SSE3
-static inline void ISkinDpSSE3(const float* src, float* dst, const __m128& mc0,
-                               const __m128& mc1, const __m128& mc2, const __m128& mwt)
-{
-    __m128 msr = _mm_load_ps(src);
-    __m128 _x  = _mm_mul_ps(_mm_mul_ps(mc0, msr), mwt);
-    __m128 _y  = _mm_mul_ps(_mm_mul_ps(mc1, msr), mwt);
-    __m128 _z  = _mm_mul_ps(_mm_mul_ps(mc2, msr), mwt);
-
-    __m128 hbuf1 = _mm_hadd_ps(_x, _y);
-    __m128 hbuf2 = _mm_hadd_ps(_z, _z);
-    hbuf1 = _mm_hadd_ps(hbuf1, hbuf2);
-    __m128 _dst = _mm_load_ps(dst);
-    _dst = _mm_add_ps(_dst, hbuf1);
-    _mm_store_ps(dst, _dst);
-}
-#endif // HAVE_SSE3
-
-static inline void ISkinVertexSSE3(const hsMatrix44& xfm, float wgt,
-                                   const float* srcBuf, float* dstBuf)
-{
-#ifdef HAVE_SSE3
-    __m128 mc0 = _mm_load_ps(xfm.fMap[0]);
-    __m128 mc1 = _mm_load_ps(xfm.fMap[1]);
-    __m128 mc2 = _mm_load_ps(xfm.fMap[2]);
-    __m128 mwt = _mm_set_ps1(wgt);
-
-    SPLIT_SKIN_BUFFER(srcBuf, pt_src, vec_src);
-    SPLIT_SKIN_BUFFER(dstBuf, pt_dst, vec_dst);
-
-    ISkinDpSSE3(pt_src, pt_dst, mc0, mc1, mc2, mwt);
-    ISkinDpSSE3(vec_src, vec_dst, mc0, mc1, mc2, mwt);
-#endif // HAVE_SSE3
-}
-
-typedef void(*skin_vert_ptr)(const hsMatrix44&, float, const float*, float*);
-
-template<skin_vert_ptr T>
-static void IBlendVertBuffer(plSpan* span, hsMatrix44* matrixPalette, int numMatrices,
-                             const uint8_t* src, uint8_t format, uint32_t srcStride,
-                             uint8_t* dest, uint32_t destStride, uint32_t count,
-                             uint16_t localUVWChans)
-{
-    alignas(32) float srcBuf[8]{};
-    SPLIT_SKIN_TRIPLES(srcBuf, srcPt, srcVec);
-
-    uint32_t indices;
-    float weights[4];
-
-    // Dropped support for localUVWChans at templatization of code
-    hsAssert(localUVWChans == 0, "support for skinned UVWs dropped. reimplement me?");
-    const size_t uvChanSize = plGBufferGroup::CalcNumUVs(format) * sizeof(float) * 3;
-    uint8_t numWeights = (format & plGBufferGroup::kSkinWeightMask) >> 4;
-
-    for (uint32_t i = 0; i < count; ++i) {
-        // Extract data
-        src = inlExtract<hsPoint3>(src, srcPt);
-
-        float weightSum = 0.f;
-        for (uint8_t j = 0; j < numWeights; ++j) {
-            src = inlExtract<float>(src, &weights[j]);
-            weightSum += weights[j];
-        }
-        weights[numWeights] = 1.f - weightSum;
-
-        if (format & plGBufferGroup::kSkinIndices)
-            src = inlExtract<uint32_t>(src, &indices);
-        else
-            indices = 1 << 8;
-        src = inlExtract<hsVector3>(src, srcVec);
-
-        // Destination buffers (float4 for SSE alignment)
-        alignas(32) float destBuf[8]{};
-        SPLIT_SKIN_TRIPLES(destBuf, destPt, destVec);
-
-        // Blend
-        for (uint32_t j = 0; j < numWeights + 1; ++j) {
-            if (weights[j])
-                T(matrixPalette[indices & 0xFF], weights[j], srcBuf, destBuf);
-            indices >>= 8;
-        }
-        // Probably don't really need to renormalize this. There errors are
-        // going to be subtle and "smooth".
-        /* hsFastMath::NormalizeAppr(destNorm); */
-
-        // Slam data into position now
-        dest = inlStuff<hsPoint3>(dest, reinterpret_cast<hsPoint3*>(destPt));
-        dest = inlStuff<hsVector3>(dest, reinterpret_cast<hsVector3*>(destVec));
-
-        // memcpy the colors and UVs
-        inlCopy(src, dest, sizeof(uint32_t) * 2 + uvChanSize);
-    }
-}
-
-// CPU-optimized functions requiring dispatch
-hsCpuFunctionDispatcher<plDXPipeline::blend_vert_buffer_ptr> plDXPipeline::blend_vert_buffer {
-    &IBlendVertBuffer<ISkinVertexFPU>,
-    nullptr,                                // SSE1
-    nullptr,                                // SSE2
-    &IBlendVertBuffer<ISkinVertexSSE3>
-};
-
-#undef SPLIT_SKIN_TRIPLES
-#undef SPLIT_SKIN_BUFFER
 
 // ISetPipeConsts //////////////////////////////////////////////////////////////////
 // A shader can request that the pipeline fill in certain constants that are indeterminate

--- a/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
+++ b/Sources/Plasma/FeatureLib/pfMetalPipeline/plMetalPipeline.cpp
@@ -74,6 +74,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 #include "plPipeline/plCubicRenderTarget.h"
 #include "plPipeline/plDebugText.h"
 #include "plPipeline/plDynamicEnvMap.h"
+#include "plPipeline/plSoftwareMeshSkinner.h"
 #include "plProfile.h"
 #include "plQuality.h"
 #include "plScene/plRenderRequest.h"
@@ -4011,66 +4012,6 @@ plMetalDevice* plMetalPipeline::GetMetalDevice()  const
     return &fDevice;
 }
 
-//// Local Static Stuff ///////////////////////////////////////////////////////
-
-// FIXME: CPU avatar stuff that should be evaluated once this moves onto the GPU.
-
-template <typename T>
-static inline void inlCopy(uint8_t*& src, uint8_t*& dst)
-{
-    T* src_ptr = reinterpret_cast<T*>(src);
-    T* dst_ptr = reinterpret_cast<T*>(dst);
-    *dst_ptr = *src_ptr;
-    src += sizeof(T);
-    dst += sizeof(T);
-}
-
-template <typename T>
-static inline const uint8_t* inlExtract(const uint8_t* src, T* val)
-{
-    const T* ptr = reinterpret_cast<const T*>(src);
-    *val = *ptr++;
-    return reinterpret_cast<const uint8_t*>(ptr);
-}
-
-template <>
-inline const uint8_t* inlExtract<hsPoint3>(const uint8_t* src, hsPoint3* val)
-{
-    const float* src_ptr = reinterpret_cast<const float*>(src);
-    float*       dst_ptr = reinterpret_cast<float*>(val);
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr = 1.f;
-    return reinterpret_cast<const uint8_t*>(src_ptr);
-}
-
-template <>
-inline const uint8_t* inlExtract<hsVector3>(const uint8_t* src, hsVector3* val)
-{
-    const float* src_ptr = reinterpret_cast<const float*>(src);
-    float*       dst_ptr = reinterpret_cast<float*>(val);
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr++ = *src_ptr++;
-    *dst_ptr = 0.f;
-    return reinterpret_cast<const uint8_t*>(src_ptr);
-}
-
-template <typename T, size_t N>
-static inline void inlSkip(uint8_t*& src)
-{
-    src += sizeof(T) * N;
-}
-
-template <typename T>
-static inline uint8_t* inlStuff(uint8_t* dst, const T* val)
-{
-    T* ptr = reinterpret_cast<T*>(dst);
-    *ptr++ = *val;
-    return reinterpret_cast<uint8_t*>(ptr);
-}
-
 //// ISoftwareVertexBlend ///////////////////////////////////////////////////////
 // Emulate matrix palette operations in software. The big difference between the hardware
 // and software versions is we only want to lock the vertex buffer once and blend all the
@@ -4144,7 +4085,7 @@ bool plMetalPipeline::ISoftwareVertexBlend(plDrawableSpans* drawable, const std:
 
                         uint8_t* ptr = vRef->fOwner->GetVertBufferData(vRef->fIndex);
                         ptr += span.fVStartIdx * vRef->fOwner->GetVertexSize();
-                        IBlendVertBuffer((plSpan*)&span,
+                        plSoftwareMeshSkinner::BlendVertBuffer(&span,
                                          matrixPalette, span.fNumMatrices,
                                          ptr,
                                          vRef->fOwner->GetVertexFormat(),
@@ -4170,76 +4111,6 @@ bool plMetalPipeline::ISoftwareVertexBlend(plDrawableSpans* drawable, const std:
     }
 
     return true;
-}
-
-//// IBlendVertsIntoBuffer ////////////////////////////////////////////////////
-//  Given a pointer into a buffer of verts that have blending data in the D3D
-//  format, blends them into the destination buffer given without the blending
-//  info.
-
-void plMetalPipeline::IBlendVertBuffer(plSpan* span, hsMatrix44* matrixPalette, int numMatrices,
-                                       const uint8_t* src, uint8_t format, uint32_t srcStride,
-                                       uint8_t* dest, uint32_t destStride, uint32_t count,
-                                       uint16_t localUVWChans)
-{
-    simd_float4      pt_buf = {0.f, 0.f, 0.f, 1.f};
-    simd_float4      vec_buf = {0.f, 0.f, 0.f, 0.f};
-    hsPoint3*  pt = reinterpret_cast<hsPoint3*>(&pt_buf);
-    hsVector3* vec = reinterpret_cast<hsVector3*>(&vec_buf);
-
-    uint32_t indices;
-    float    weights[4];
-
-    // Dropped support for localUVWChans at templatization of code
-    hsAssert(localUVWChans == 0, "support for skinned UVWs dropped. reimplement me?");
-    const size_t uvChanSize = plGBufferGroup::CalcNumUVs(format) * sizeof(float) * 3;
-    uint8_t      numWeights = (format & plGBufferGroup::kSkinWeightMask) >> 4;
-
-    for (uint32_t i = 0; i < count; ++i) {
-        // Extract data
-        src = inlExtract<hsPoint3>(src, pt);
-
-        float weightSum = 0.f;
-        for (uint8_t j = 0; j < numWeights; ++j) {
-            src = inlExtract<float>(src, &weights[j]);
-            weightSum += weights[j];
-        }
-        weights[numWeights] = 1.f - weightSum;
-
-        if (format & plGBufferGroup::kSkinIndices)
-            src = inlExtract<uint32_t>(src, &indices);
-        else
-            indices = 1 << 8;
-        src = inlExtract<hsVector3>(src, vec);
-
-        // Destination buffers (float4 for SSE alignment)
-        simd_float4 destNorm_buf = (simd_float4){0.f, 0.f, 0.f, 0.f};
-        simd_float4 destPt_buf = (simd_float4){0.f, 0.f, 0.f, 1.f};
-
-        // Blend
-        for (uint32_t j = 0; j < numWeights + 1; ++j) {
-            float weight = weights[j];
-            if (weight) {
-                const simd_float4x4& simdMatrix = hsMatrix2SIMD(matrixPalette[indices & 0xFF]);
-                // Note: This bit is different than GL/DirectX. It's using acclerate so this is also accelerated on ARM through NEON or maybe even the Neural Engine.
-                destPt_buf += simd_mul(pt_buf, simdMatrix) * weight;
-                destNorm_buf += simd_mul(vec_buf, simdMatrix) * weight;
-            }
-            // ISkinVertexSSE41(matrixPalette[indices & 0xFF], weights[j], pt_buf, destPt_buf, vec_buf, destNorm_buf);
-            indices >>= 8;
-        }
-        // Probably don't really need to renormalize this. There errors are
-        // going to be subtle and "smooth".
-        /* hsFastMath::NormalizeAppr(destNorm); */
-
-        // Slam data into position now
-        dest = inlStuff<hsPoint3>(dest, reinterpret_cast<hsPoint3*>(&destPt_buf));
-        dest = inlStuff<hsVector3>(dest, reinterpret_cast<hsVector3*>(&destNorm_buf));
-
-        // Jump past colors and UVws
-        dest += sizeof(uint32_t) * 2 + uvChanSize;
-        src += sizeof(uint32_t) * 2 + uvChanSize;
-    }
 }
 
 // Resource checking

--- a/Sources/Plasma/PubUtilLib/plPipeline/CMakeLists.txt
+++ b/Sources/Plasma/PubUtilLib/plPipeline/CMakeLists.txt
@@ -11,6 +11,7 @@ set(plPipeline_SOURCES
     plPipelineViewSettings.cpp
     plPlates.cpp
     plRenderTarget.cpp
+    plSoftwareMeshSkinner.cpp
     plStatusLogDrawer.cpp
     plTextFont.cpp
     plTransitionMgr.cpp
@@ -35,6 +36,7 @@ set(plPipeline_HEADERS
     plPipelineViewSettings.h
     plPlates.h
     plRenderTarget.h
+    plSoftwareMeshSkinner.h
     plStatusLogDrawer.h
     plStencil.h
     plTextFont.h
@@ -46,6 +48,7 @@ plasma_library(plPipeline
     SOURCES ${plPipeline_SOURCES} ${plPipeline_HEADERS}
     PRECOMPILED_HEADERS Pch.h
 )
+plasma_target_simd_sources(plPipeline SSE3 plSoftwareMeshSkinner.cpp)
 target_link_libraries(plPipeline
     PUBLIC
         CoreLib

--- a/Sources/Plasma/PubUtilLib/plPipeline/plSoftwareMeshSkinner.cpp
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plSoftwareMeshSkinner.cpp
@@ -1,0 +1,368 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+
+#include "plSoftwareMeshSkinner.h"
+
+#include "hsMatrix44.h"
+#include "plDrawable/plGBufferGroup.h"
+#include "plDrawable/plSpanTypes.h"
+
+#if !defined(__has_include)
+#   define __has_include(x) 0
+#endif
+
+template<typename T>
+static inline void inlCopy(uint8_t*& src, uint8_t*& dst)
+{
+    T* src_ptr = reinterpret_cast<T*>(src);
+    T* dst_ptr = reinterpret_cast<T*>(dst);
+    *dst_ptr = *src_ptr;
+    src += sizeof(T);
+    dst += sizeof(T);
+}
+
+static inline void inlCopy(const uint8_t*& src, uint8_t*& dst, size_t sz)
+{
+    memcpy(dst, src, sz);
+    src += sz;
+    dst += sz;
+}
+
+template<typename T>
+static inline const uint8_t* inlExtract(const uint8_t* src, T* val)
+{
+    const T* ptr = reinterpret_cast<const T*>(src);
+    *val = *ptr++;
+    return reinterpret_cast<const uint8_t*>(ptr);
+}
+
+template<>
+inline const uint8_t* inlExtract<hsPoint3>(const uint8_t* src, hsPoint3* val)
+{
+    const float* src_ptr = reinterpret_cast<const float*>(src);
+    float* dst_ptr = reinterpret_cast<float*>(val);
+    *dst_ptr++ = *src_ptr++;
+    *dst_ptr++ = *src_ptr++;
+    *dst_ptr++ = *src_ptr++;
+    *dst_ptr = 1.f;
+    return reinterpret_cast<const uint8_t*>(src_ptr);
+}
+
+template<>
+inline const uint8_t* inlExtract<hsVector3>(const uint8_t* src, hsVector3* val)
+{
+    const float* src_ptr = reinterpret_cast<const float*>(src);
+    float* dst_ptr = reinterpret_cast<float*>(val);
+    *dst_ptr++ = *src_ptr++;
+    *dst_ptr++ = *src_ptr++;
+    *dst_ptr++ = *src_ptr++;
+    *dst_ptr = 0.f;
+    return reinterpret_cast<const uint8_t*>(src_ptr);
+}
+
+template<typename T, size_t N>
+static inline void inlSkip(uint8_t*& src)
+{
+    src += sizeof(T) * N;
+}
+
+template<typename T>
+static inline uint8_t* inlStuff(uint8_t* dst, const T* val)
+{
+    T* ptr = reinterpret_cast<T*>(dst);
+    *ptr++ = *val;
+    return reinterpret_cast<uint8_t*>(ptr);
+}
+
+
+#if defined(HS_BUILD_FOR_APPLE) && __has_include(<simd/simd.h>)
+#   include <simd/simd.h>
+
+    static inline const matrix_float4x4 hsMatrix2SIMD(const hsMatrix44& src)
+    {
+        constexpr auto matrixSize = sizeof(matrix_float4x4);
+        if (src.fFlags & hsMatrix44::kIsIdent) {
+            return matrix_identity_float4x4;
+        }
+
+        simd_float4x4 dst;
+        memcpy(&dst, &src.fMap, matrixSize);
+        return dst;
+    }
+
+    void plSoftwareMeshSkinner::BlendVertBuffer(
+            const plSpan* span, hsMatrix44* matrixPalette, int numMatrices,
+            const uint8_t* src, uint8_t format, uint32_t srcStride,
+            uint8_t* dest, uint32_t destStride, uint32_t count,
+            uint16_t localUVWChans)
+    {
+        simd_float4 pt_buf = {0.f, 0.f, 0.f, 1.f};
+        simd_float4 vec_buf = {0.f, 0.f, 0.f, 0.f};
+
+        hsPoint3*  pt = reinterpret_cast<hsPoint3*>(&pt_buf);
+        hsVector3* vec = reinterpret_cast<hsVector3*>(&vec_buf);
+
+        uint32_t indices;
+        float    weights[4];
+
+        // Dropped support for localUVWChans at templatization of code
+        hsAssert(localUVWChans == 0, "support for skinned UVWs dropped. reimplement me?");
+
+        const size_t uvChanSize = plGBufferGroup::CalcNumUVs(format) * sizeof(float) * 3;
+        uint8_t      numWeights = (format & plGBufferGroup::kSkinWeightMask) >> 4;
+
+        for (uint32_t i = 0; i < count; ++i) {
+            // Extract data
+            src = inlExtract<hsPoint3>(src, pt);
+
+            float weightSum = 0.f;
+            for (uint8_t j = 0; j < numWeights; ++j) {
+                src = inlExtract<float>(src, &weights[j]);
+                weightSum += weights[j];
+            }
+            weights[numWeights] = 1.f - weightSum;
+
+            if (format & plGBufferGroup::kSkinIndices)
+                src = inlExtract<uint32_t>(src, &indices);
+            else
+                indices = 1 << 8;
+            src = inlExtract<hsVector3>(src, vec);
+
+            // Destination buffers (float4 for SSE alignment)
+            simd_float4 destNorm_buf = { 0.f, 0.f, 0.f, 0.f };
+            simd_float4 destPt_buf = { 0.f, 0.f, 0.f, 1.f };
+
+            // Blend
+            for (uint32_t j = 0; j < numWeights + 1; ++j) {
+                float weight = weights[j];
+                if (weight) {
+                    const simd_float4x4& simdMatrix = hsMatrix2SIMD(matrixPalette[indices & 0xFF]);
+
+                    // Note: This uses Accelerate.framework so this is also accelerated on ARM through NEON or maybe even the Neural Engine.
+                    destPt_buf += simd_mul(pt_buf, simdMatrix) * weight;
+                    destNorm_buf += simd_mul(vec_buf, simdMatrix) * weight;
+                }
+                indices >>= 8;
+            }
+
+            // Probably don't really need to renormalize this. There errors are
+            // going to be subtle and "smooth".
+            /* hsFastMath::NormalizeAppr(destNorm); */
+
+            // Slam data into position now
+            dest = inlStuff<hsPoint3>(dest, reinterpret_cast<hsPoint3*>(&destPt_buf));
+            dest = inlStuff<hsVector3>(dest, reinterpret_cast<hsVector3*>(&destNorm_buf));
+
+            // memcpy the colors and UVs
+            inlCopy(src, dest, sizeof(uint32_t) * 2 + uvChanSize);
+        }
+    }
+
+#else // HS_BUILD_FOR_APPLE && simd.h
+#   include "hsSIMD.h"
+
+    typedef void (*blend_vert_buffer_ptr)(const plSpan*, hsMatrix44*, int, const uint8_t*, uint8_t, uint32_t, uint8_t*, uint32_t, uint32_t, uint16_t);
+    typedef void (*skin_vert_ptr)(const hsMatrix44&, float, const float*, float*);
+
+#   define SPLIT_SKIN_BUFFER(src, pt, vec) \
+        decltype(src) pt = &src[0];         \
+        decltype(src) vec = &src[4];        //
+
+#   define SPLIT_SKIN_TRIPLES(src, pt, vec)                    \
+        hsPoint3* pt = reinterpret_cast<hsPoint3*>(&src[0]);    \
+        hsVector3* vec = reinterpret_cast<hsVector3*>(&src[4]); //
+
+    static inline void ISkinVertexFPU(const hsMatrix44& xfm, float wgt,
+                                  const float* srcBuf, float* dstBuf)
+    {
+        const float& m00 = xfm.fMap[0][0];
+        const float& m01 = xfm.fMap[0][1];
+        const float& m02 = xfm.fMap[0][2];
+        const float& m03 = xfm.fMap[0][3];
+        const float& m10 = xfm.fMap[1][0];
+        const float& m11 = xfm.fMap[1][1];
+        const float& m12 = xfm.fMap[1][2];
+        const float& m13 = xfm.fMap[1][3];
+        const float& m20 = xfm.fMap[2][0];
+        const float& m21 = xfm.fMap[2][1];
+        const float& m22 = xfm.fMap[2][2];
+        const float& m23 = xfm.fMap[2][3];
+
+        SPLIT_SKIN_BUFFER(srcBuf, pt_src, vec_src);
+        SPLIT_SKIN_BUFFER(dstBuf, pt_dst, vec_dst);
+
+        // position
+        {
+            const float& srcX = pt_src[0];
+            const float& srcY = pt_src[1];
+            const float& srcZ = pt_src[2];
+
+            pt_dst[0] += (srcX * m00 + srcY * m01 + srcZ * m02 + m03) * wgt;
+            pt_dst[1] += (srcX * m10 + srcY * m11 + srcZ * m12 + m13) * wgt;
+            pt_dst[2] += (srcX * m20 + srcY * m21 + srcZ * m22 + m23) * wgt;
+        }
+
+        // normal
+        {
+            const float& srcX = vec_src[0];
+            const float& srcY = vec_src[1];
+            const float& srcZ = vec_src[2];
+
+            vec_dst[0] += (srcX * m00 + srcY * m01 + srcZ * m02) * wgt;
+            vec_dst[1] += (srcX * m10 + srcY * m11 + srcZ * m12) * wgt;
+            vec_dst[2] += (srcX * m20 + srcY * m21 + srcZ * m22) * wgt;
+        }
+    }
+
+#   ifdef HAVE_SSE3
+    static inline void ISkinDpSSE3(const float* src, float* dst, const __m128& mc0,
+                                   const __m128& mc1, const __m128& mc2, const __m128& mwt)
+    {
+        __m128 msr = _mm_load_ps(src);
+        __m128 _x  = _mm_mul_ps(_mm_mul_ps(mc0, msr), mwt);
+        __m128 _y  = _mm_mul_ps(_mm_mul_ps(mc1, msr), mwt);
+        __m128 _z  = _mm_mul_ps(_mm_mul_ps(mc2, msr), mwt);
+
+        __m128 hbuf1 = _mm_hadd_ps(_x, _y);
+        __m128 hbuf2 = _mm_hadd_ps(_z, _z);
+        hbuf1 = _mm_hadd_ps(hbuf1, hbuf2);
+        __m128 _dst = _mm_load_ps(dst);
+        _dst = _mm_add_ps(_dst, hbuf1);
+        _mm_store_ps(dst, _dst);
+    }
+#   endif // HAVE_SSE3
+
+    static inline void ISkinVertexSSE3(const hsMatrix44& xfm, float wgt,
+                                       const float* srcBuf, float* dstBuf)
+    {
+#   ifdef HAVE_SSE3
+        __m128 mc0 = _mm_load_ps(xfm.fMap[0]);
+        __m128 mc1 = _mm_load_ps(xfm.fMap[1]);
+        __m128 mc2 = _mm_load_ps(xfm.fMap[2]);
+        __m128 mwt = _mm_set_ps1(wgt);
+
+        SPLIT_SKIN_BUFFER(srcBuf, pt_src, vec_src);
+        SPLIT_SKIN_BUFFER(dstBuf, pt_dst, vec_dst);
+
+        ISkinDpSSE3(pt_src, pt_dst, mc0, mc1, mc2, mwt);
+        ISkinDpSSE3(vec_src, vec_dst, mc0, mc1, mc2, mwt);
+#   endif // HAVE_SSE3
+    }
+
+    template<skin_vert_ptr T>
+    static void IBlendVertBuffer(const plSpan* span, hsMatrix44* matrixPalette, int numMatrices,
+                                 const uint8_t* src, uint8_t format, uint32_t srcStride,
+                                 uint8_t* dest, uint32_t destStride, uint32_t count,
+                                 uint16_t localUVWChans)
+    {
+        alignas(32) float srcBuf[8]{};
+        SPLIT_SKIN_TRIPLES(srcBuf, srcPt, srcVec);
+
+        uint32_t        indices;
+        float           weights[4];
+
+        // Dropped support for localUVWChans at templatization of code
+        hsAssert(localUVWChans == 0, "support for skinned UVWs dropped. reimplement me?");
+        const size_t uvChanSize = plGBufferGroup::CalcNumUVs(format) * sizeof(float) * 3;
+        uint8_t numWeights = (format & plGBufferGroup::kSkinWeightMask) >> 4;
+
+        for (uint32_t i = 0; i < count; ++i) {
+            // Extract data
+            src = inlExtract<hsPoint3>(src, srcPt);
+
+            float weightSum = 0.f;
+            for (uint8_t j = 0; j < numWeights; ++j) {
+                src = inlExtract<float>(src, &weights[j]);
+                weightSum += weights[j];
+            }
+            weights[numWeights] = 1.f - weightSum;
+
+            if (format & plGBufferGroup::kSkinIndices)
+                src = inlExtract<uint32_t>(src, &indices);
+            else
+                indices = 1 << 8;
+            src = inlExtract<hsVector3>(src, srcVec);
+
+            // Destination buffers (float4 for SSE alignment)
+            alignas(32) float destBuf[8]{};
+            SPLIT_SKIN_TRIPLES(destBuf, destPt, destVec);
+
+            // Blend
+            for (uint32_t j = 0; j < numWeights + 1; ++j) {
+                if (weights[j])
+                    T(matrixPalette[indices & 0xFF], weights[j], srcBuf, destBuf);
+                indices >>= 8;
+            }
+
+            // Probably don't really need to renormalize this. There errors are
+            // going to be subtle and "smooth".
+            /* hsFastMath::NormalizeAppr(destNorm); */
+
+            // Slam data into position now
+            dest = inlStuff<hsPoint3>(dest, reinterpret_cast<hsPoint3*>(destPt));
+            dest = inlStuff<hsVector3>(dest, reinterpret_cast<hsVector3*>(destVec));
+
+            // memcpy the colors and UVs
+            inlCopy(src, dest, sizeof(uint32_t) * 2 + uvChanSize);
+        }
+    }
+
+#   undef SPLIT_SKIN_TRIPLES
+#   undef SPLIT_SKIN_BUFFER
+
+    static hsCpuFunctionDispatcher<blend_vert_buffer_ptr> blend_vert_buffer {
+        &IBlendVertBuffer<ISkinVertexFPU>,
+        nullptr,                            // SSE1
+        nullptr,                            // SSE2
+        &IBlendVertBuffer<ISkinVertexSSE3>
+    };
+
+    void plSoftwareMeshSkinner::BlendVertBuffer(
+            const plSpan* span, hsMatrix44* matrixPalette, int numMatrices,
+            const uint8_t* src, uint8_t format, uint32_t srcStride,
+            uint8_t* dest, uint32_t destStride, uint32_t count,
+            uint16_t localUVWChans)
+    {
+        blend_vert_buffer.call(span, matrixPalette, numMatrices, src, format, srcStride, dest, destStride, count, localUVWChans);
+    }
+
+#endif // HS_BUILD_FOR_APPLE && simd.h

--- a/Sources/Plasma/PubUtilLib/plPipeline/plSoftwareMeshSkinner.h
+++ b/Sources/Plasma/PubUtilLib/plPipeline/plSoftwareMeshSkinner.h
@@ -1,0 +1,64 @@
+/*==LICENSE==*
+
+CyanWorlds.com Engine - MMOG client, server and tools
+Copyright (C) 2011  Cyan Worlds, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with any of RAD Game Tools Bink SDK, Autodesk 3ds Max SDK,
+NVIDIA PhysX SDK, Microsoft DirectX SDK, OpenSSL library, Independent
+JPEG Group JPEG library, Microsoft Windows Media SDK, or Apple QuickTime SDK
+(or a modified version of those libraries),
+containing parts covered by the terms of the Bink SDK EULA, 3ds Max EULA,
+PhysX SDK EULA, DirectX SDK EULA, OpenSSL and SSLeay licenses, IJG
+JPEG Library README, Windows Media SDK EULA, or QuickTime SDK EULA, the
+licensors of this Program grant you additional
+permission to convey the resulting work. Corresponding Source for a
+non-source form of such a combination shall include the source code for
+the parts of OpenSSL and IJG JPEG Library used as well as that of the covered
+work.
+
+You can contact Cyan Worlds, Inc. by email legal@cyan.com
+ or by snail mail at:
+      Cyan Worlds, Inc.
+      14617 N Newport Hwy
+      Mead, WA   99021
+
+*==LICENSE==*/
+#ifndef _plSoftwareMeshSkinner_inc_
+#define _plSoftwareMeshSkinner_inc_
+
+#include "HeadSpin.h"
+
+class plSpan;
+class hsMatrix44;
+
+namespace plSoftwareMeshSkinner
+{
+    /**
+     * Given a pointer into a buffer of verts that have blending data in the
+     * plVertCoder format, blends them into the destination buffer given
+     * without the blending info.
+     */
+    void BlendVertBuffer(const plSpan* span,
+            hsMatrix44* matrixPalette, int numMatrices,
+            const uint8_t* src, uint8_t format, uint32_t srcStride,
+            uint8_t* dest, uint32_t destStride, uint32_t count,
+            uint16_t localUVWChans);
+};
+
+#endif // _plSoftwareMeshSkinner_inc_


### PR DESCRIPTION
This includes a fix (https://github.com/H-uru/Plasma/pull/947 ported from DX to the macOS skinning implementation) for the avatar UV map not getting updated after morphs were changed in the closet.