### PR TITLE
Change log date format to ISO with years

### DIFF
--- a/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
+++ b/Sources/Plasma/PubUtilLib/plStatusLog/plStatusLog.cpp
@@ -526,11 +526,11 @@ void plStatusLog::IPrintLineToFile(const ST::string& line)
         {
             if ( fFlags & kTimestamp )
             {
-                buf << '(' << plUnifiedTime::GetCurrent(plUnifiedTime::kLocal).Format("%m/%d %H:%M:%S") << ") ";
+                buf << '(' << plUnifiedTime::GetCurrent(plUnifiedTime::kLocal).Format("%Y-%m-%d %H:%M:%S") << ") ";
             }
             if ( fFlags & kTimestampGMT )
             {
-                buf << '(' << plUnifiedTime::GetCurrent().Format("%m/%d %H:%M:%S UTC") << ") ";
+                buf << '(' << plUnifiedTime::GetCurrent().Format("%Y-%m-%d %H:%M:%S UTC") << ") ";
             }
             if ( fFlags & kTimeInSeconds )
             {


### PR DESCRIPTION
Is this necessary for anything? No.
Is this free of opinions? No.
Does it bother me to have weird dates in logfiles? Yes. 😜

Shout if this would actually break anyone's workflow of parsing these, but I have my doubts anyone would parse them when they don't even include a year. If anything i expect this change to make potential parsing a lot easier for everyone.