### PR TITLE
Add debug backdoor to xLinkingBookGUIPopup

### DIFF
--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -63,8 +63,8 @@ from PlasmaKITypes import *
 from PlasmaNetConstants import *
 import xLinkingBookDefs
 from xPsnlVaultSDL import *
-import time
 import re
+from contextlib import contextmanager
 
 
 # define the attributes that will be entered in max
@@ -1020,10 +1020,8 @@ class xLinkingBookGUIPopup(ptModifier):
             bkIdx = id - kDebugTimerStartIdx
             defs = [x for x in xLinkingBookDefs.xAgeLinkingBooks]
             age = defs[bkIdx]
-            TargetAge.value = age
-            global stringAgeRequested
-            stringAgeRequested = age
-            self.IShowBookNoTreasure()
+            with self.OverrideTargetAge(age):
+                self.IShowBookNoTreasure()
             PtSaveScreenShot(f"{age}.jpg", PtGetDesktopWidth(), PtGetDesktopHeight())
 
     def GetOwnedAgeLink(self, age):
@@ -1219,5 +1217,17 @@ class xLinkingBookGUIPopup(ptModifier):
     def OnBackdoorMsg(self, target, param):
         if target == "xlinkingbookgui" and param == "debugall":
             # Start 1s interval timers to show every linking book and take a screenshot of it
+            # FIXME: Note that this will trigger on every linking book PFM in the age, which is not ideal but nothing we can easily fix right now.
+            # Recommended to not run this while in an age with multiple instances of this script.
             for idx, age in enumerate(xLinkingBookDefs.xAgeLinkingBooks):
                 PtAtTimeCallback(self.key, 1 + idx, kDebugTimerStartIdx + idx)
+
+    @contextmanager
+    def OverrideTargetAge(self, age: str):
+        global stringAgeRequested
+        prevTarget, prevRequested = TargetAge.value, stringAgeRequested
+        TargetAge.value, stringAgeRequested = age, age
+        try:
+            yield
+        finally:
+            TargetAge.value, stringAgeRequested = prevTarget, prevRequested

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -1028,10 +1028,12 @@ class xLinkingBookGUIPopup(ptModifier):
                     PtDebugPrint(f"xLinkPanelGUIPopup Showing Debug Panel for {age}")
                     with self.OverrideTargetAge(age):
                         self.IShowBookNoTreasure()
+                    PtGUICursorOff()
                 else:
                     # Take screenshot on odd timers.
                     PtSaveScreenShot(f"{age}.jpg", PtGetDesktopWidth(), PtGetDesktopHeight())
                     self.HideBook(0)
+                    PtGUICursorOn()
             finally:
                 # Start new timer unless we're done.
                 if id < kDebugTimerStartIdx + len(xLinkingBookDefs.xAgeLinkingBooks) * 2 - 1:

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -1014,15 +1014,32 @@ class xLinkingBookGUIPopup(ptModifier):
             cam = ptCamera()
             cam.enableFirstPersonOverride()
 
-        # Debug Timers for our backdoor
+        # Debug Timers for our backdoor, see bottom of file
         elif id >= kDebugTimerStartIdx:
-            self.HideBook(0)
-            bkIdx = id - kDebugTimerStartIdx
-            defs = [x for x in xLinkingBookDefs.xAgeLinkingBooks]
-            age = defs[bkIdx]
-            with self.OverrideTargetAge(age):
-                self.IShowBookNoTreasure()
-            PtSaveScreenShot(f"{age}.jpg", PtGetDesktopWidth(), PtGetDesktopHeight())
+            PtDebugPrint(f"xLinkPanelGUIPopup Debug Timer: {id}")
+            try:
+                # Wrap in try because we want to show all books even if one has errors.
+                # Get book index based on timer id
+                bkIdx = (id - kDebugTimerStartIdx) // 2
+                defs = [x for x in xLinkingBookDefs.xAgeLinkingBooks]
+                age = defs[bkIdx]
+                if id % 2 == 0:
+                    # Show book on even timers.
+                    self.HideBook(0)
+                    PtDebugPrint(f"xLinkPanelGUIPopup Showing Debug Panel for {age}")
+                    with self.OverrideTargetAge(age):
+                        self.IShowBookNoTreasure()
+                else:
+                    # Take screenshot on odd timers.
+                    PtSaveScreenShot(f"{age}.jpg", PtGetDesktopWidth(), PtGetDesktopHeight())
+            finally:
+                # Start new timer unless we're done.
+                if id < kDebugTimerStartIdx + len(xLinkingBookDefs.xAgeLinkingBooks) * 2 - 1:
+                    PtAtTimeCallback(self.key, 0.5, id + 1)
+                else:
+                    self.HideBook(0)
+                    PtSendKIMessage(kKIShowMiniKI, 0)
+                    PtSendKIMessage(kKILocalChatStatusMsg, "Done! Screenshots have been saved to the client folder.")
 
     def GetOwnedAgeLink(self, age):
         vault = ptAgeVault()
@@ -1214,20 +1231,30 @@ class xLinkingBookGUIPopup(ptModifier):
         linkMgr = ptNetLinkingMgr()
         linkMgr.linkToAge(als)
 
+    # ALERT! ALERT! HAXCON 1
+    # Demons and Devils reside here, ready to attack and torment you.
+    # Do not proceed without a level 20 hackventuring party.
     def OnBackdoorMsg(self, target, param):
         if target == "xlinkingbookgui" and param == "debugall":
-            # Start 1s interval timers to show every linking book and take a screenshot of it
             # FIXME: Note that this will trigger on every linking book PFM in the age, which is not ideal but nothing we can easily fix right now.
-            # Recommended to not run this while in an age with multiple instances of this script.
-            for idx, age in enumerate(xLinkingBookDefs.xAgeLinkingBooks):
-                PtAtTimeCallback(self.key, 1 + idx, kDebugTimerStartIdx + idx)
+            # Recommended to not run this while in an age with multiple instances of this script. spyroom is my personal recommendation.
+            # We will now kick off a chain of timers for opening books and taking screenshots.
+            PtAtTimeCallback(self.key, 0.5, kDebugTimerStartIdx)
 
     @contextmanager
     def OverrideTargetAge(self, age: str):
         global stringAgeRequested
-        prevTarget, prevRequested = TargetAge.value, stringAgeRequested
+        global kGrsnTeamBook
+        prevTarget, prevRequested, prevRespVal, grsnTBTimer = TargetAge.value, stringAgeRequested, respLinkResponder.value, kGrsnTeamBook
         TargetAge.value, stringAgeRequested = age, age
+        respLinkResponder.value = [] # Because cleft forces a link, we have to override this one too...
+        if age == "grsnTeamRmPurple" or age == "grsnTeamRmYellow":
+            # Special stupid case for the team rooms because the main script runs a 5s timer to close an open linking book.
+            # Manually change the timer id to 0 so the callback won't trigger.
+            kGrsnTeamBook = 0
         try:
             yield
         finally:
             TargetAge.value, stringAgeRequested = prevTarget, prevRequested
+            respLinkResponder.value = prevRespVal
+            kGrsnTeamBook = grsnTBTimer

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -1025,19 +1025,18 @@ class xLinkingBookGUIPopup(ptModifier):
                 age = defs[bkIdx]
                 if id % 2 == 0:
                     # Show book on even timers.
-                    self.HideBook(0)
                     PtDebugPrint(f"xLinkPanelGUIPopup Showing Debug Panel for {age}")
                     with self.OverrideTargetAge(age):
                         self.IShowBookNoTreasure()
                 else:
                     # Take screenshot on odd timers.
                     PtSaveScreenShot(f"{age}.jpg", PtGetDesktopWidth(), PtGetDesktopHeight())
+                    self.HideBook(0)
             finally:
                 # Start new timer unless we're done.
                 if id < kDebugTimerStartIdx + len(xLinkingBookDefs.xAgeLinkingBooks) * 2 - 1:
                     PtAtTimeCallback(self.key, 0.5, id + 1)
                 else:
-                    self.HideBook(0)
                     PtSendKIMessage(kKIShowMiniKI, 0)
                     PtSendKIMessage(kKILocalChatStatusMsg, "Done! Screenshots have been saved to the client folder.")
 

--- a/Scripts/Python/xLinkingBookGUIPopup.py
+++ b/Scripts/Python/xLinkingBookGUIPopup.py
@@ -107,6 +107,7 @@ kFirstPersonEnableTime = 0.5
 
 pelletCaveGUID = None
 
+kDebugTimerStartIdx = 1000
 
 class xLinkingBookGUIPopup(ptModifier):
     "The Linking Book GUI Popup python code"
@@ -1013,6 +1014,17 @@ class xLinkingBookGUIPopup(ptModifier):
             cam = ptCamera()
             cam.enableFirstPersonOverride()
 
+        # Debug Timers for our backdoor
+        elif id >= kDebugTimerStartIdx:
+            self.HideBook(0)
+            bkIdx = id - kDebugTimerStartIdx
+            defs = [x for x in xLinkingBookDefs.xAgeLinkingBooks]
+            age = defs[bkIdx]
+            TargetAge.value = age
+            global stringAgeRequested
+            stringAgeRequested = age
+            self.IShowBookNoTreasure()
+            PtSaveScreenShot(f"{age}.jpg", PtGetDesktopWidth(), PtGetDesktopHeight())
 
     def GetOwnedAgeLink(self, age):
         vault = ptAgeVault()
@@ -1204,4 +1216,8 @@ class xLinkingBookGUIPopup(ptModifier):
         linkMgr = ptNetLinkingMgr()
         linkMgr.linkToAge(als)
 
-
+    def OnBackdoorMsg(self, target, param):
+        if target == "xlinkingbookgui" and param == "debugall":
+            # Start 1s interval timers to show every linking book and take a screenshot of it
+            for idx, age in enumerate(xLinkingBookDefs.xAgeLinkingBooks):
+                PtAtTimeCallback(self.key, 1 + idx, kDebugTimerStartIdx + idx)


### PR DESCRIPTION
Using `Python.Backdoor xlinkingbookgui debugall` in the console, timers in 1s offsets will be started to open all age entries in xLinkingBookDefs, display them, and take a screenshot to the client folder. This is a simple helper to facilitate checking the textures if changes to PRPs like BkBookImages are made.

Inspired by discussion and testing for https://github.com/H-uru/moul-assets/pull/289.